### PR TITLE
fix: provide independent identitities to grpc services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tim-ywliu/event v0.1.0
 	github.com/urfave/cli v1.22.15
-	github.com/yeastengine/config5g v0.0.0-20240623153504-fc7633181713
+	github.com/yeastengine/config5g v0.0.0-20240624120332-b75c495fdf84
 	go.mongodb.org/mongo-driver v1.11.7
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3k
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
-github.com/yeastengine/config5g v0.0.0-20240623153504-fc7633181713 h1:qPLGRfWV89BoyuutCQoqkbK7ICmqRrSv5vBA4ir6i+4=
-github.com/yeastengine/config5g v0.0.0-20240623153504-fc7633181713/go.mod h1:gDqmRwmsY5npZ4dKLtuJIXn2NmiW4IFub4pH2vQzZqc=
+github.com/yeastengine/config5g v0.0.0-20240624120332-b75c495fdf84 h1:+TISbsSYtnGeDlEXX+hu3ZXuzFmDkOOWpu9/cRH7ANw=
+github.com/yeastengine/config5g v0.0.0-20240624120332-b75c495fdf84/go.mod h1:gDqmRwmsY5npZ4dKLtuJIXn2NmiW4IFub4pH2vQzZqc=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=

--- a/internal/amf/service/init.go
+++ b/internal/amf/service/init.go
@@ -140,7 +140,7 @@ func (amf *AMF) Initialize(c *cli.Context) error {
 		factory.AmfConfig.Configuration.SupportTAIList = nil
 		factory.AmfConfig.Configuration.PlmnSupportList = nil
 		initLog.Infoln("Reading Amf related configuration from ROC")
-		client := gClient.ConnectToConfigServer(factory.AmfConfig.Configuration.WebuiUri)
+		client := gClient.ConnectToConfigServer(factory.AmfConfig.Configuration.WebuiUri, "amf")
 		configChannel := client.PublishOnConfigChange(true)
 		go amf.UpdateConfig(configChannel)
 	} else {

--- a/internal/ausf/service/init.go
+++ b/internal/ausf/service/init.go
@@ -97,7 +97,7 @@ func (ausf *AUSF) Initialize(c *cli.Context) error {
 	roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 	if roc == "true" {
 		initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-		commChannel := client.ConfigWatcher(factory.AusfConfig.Configuration.WebuiUri)
+		commChannel := client.ConfigWatcher(factory.AusfConfig.Configuration.WebuiUri, "ausf")
 		go ausf.updateConfig(commChannel)
 	} else {
 		go func() {

--- a/internal/nrf/factory/factory.go
+++ b/internal/nrf/factory/factory.go
@@ -42,7 +42,7 @@ func InitConfigFactory(f string) error {
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-			commChannel := client.ConfigWatcher(NrfConfig.Configuration.WebuiUri)
+			commChannel := client.ConfigWatcher(NrfConfig.Configuration.WebuiUri, "nrf")
 			ManagedByConfigPod = true
 			go NrfConfig.updateConfig(commChannel)
 		}

--- a/internal/nssf/factory/factory.go
+++ b/internal/nssf/factory/factory.go
@@ -40,7 +40,7 @@ func InitConfigFactory(f string) error {
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			logger.CfgLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-			commChannel := client.ConfigWatcher(NssfConfig.Configuration.WebuiUri)
+			commChannel := client.ConfigWatcher(NssfConfig.Configuration.WebuiUri, "nssf")
 			go NssfConfig.updateConfig(commChannel)
 		} else {
 			go func() {

--- a/internal/pcf/service/init.go
+++ b/internal/pcf/service/init.go
@@ -107,7 +107,7 @@ func (pcf *PCF) Initialize(c *cli.Context) error {
 	roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 	if roc == "true" {
 		initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-		gClient := client.ConnectToConfigServer(factory.PcfConfig.Configuration.WebuiUri)
+		gClient := client.ConnectToConfigServer(factory.PcfConfig.Configuration.WebuiUri, "pcf")
 		commChannel := gClient.PublishOnConfigChange(true)
 		go pcf.updateConfig(commChannel)
 	} else {

--- a/internal/smf/factory/factory.go
+++ b/internal/smf/factory/factory.go
@@ -44,7 +44,7 @@ func InitConfigFactory(f string) error {
 
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
-			gClient := client.ConnectToConfigServer(SmfConfig.Configuration.WebuiUri)
+			gClient := client.ConnectToConfigServer(SmfConfig.Configuration.WebuiUri, "smf")
 			commChannel := gClient.PublishOnConfigChange(false)
 			go SmfConfig.updateConfig(commChannel)
 		}

--- a/internal/udm/service/init.go
+++ b/internal/udm/service/init.go
@@ -100,7 +100,7 @@ func (udm *UDM) Initialize(c *cli.Context) error {
 	roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 	if roc == "true" {
 		initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-		commChannel := client.ConfigWatcher(factory.UdmConfig.Configuration.WebuiUri)
+		commChannel := client.ConfigWatcher(factory.UdmConfig.Configuration.WebuiUri, "udm")
 		go udm.updateConfig(commChannel)
 	} else {
 		go func() {

--- a/internal/udr/factory/factory.go
+++ b/internal/udr/factory/factory.go
@@ -56,7 +56,7 @@ func InitConfigFactory(f string) error {
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-			commChannel := client.ConfigWatcher(UdrConfig.Configuration.WebuiUri)
+			commChannel := client.ConfigWatcher(UdrConfig.Configuration.WebuiUri, "udr")
 			ConfigUpdateDbTrigger = make(chan *UpdateDb, 10)
 			go UdrConfig.updateConfig(commChannel, ConfigUpdateDbTrigger)
 		} else {


### PR DESCRIPTION
# Description

Provide independent identitities to grpc services. In the long run we simply want to get rid of GRPC and the independent webui service. 

Fixes #58 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
