### PR TITLE
chore: fix incorrect conversion between integer types

### DIFF
--- a/internal/smf/qos/qos_flow.go
+++ b/internal/smf/qos/qos_flow.go
@@ -174,7 +174,7 @@ func GetBitRate(sBitRate string) (val uint16, unit uint8) {
 	sl := strings.Fields(sBitRate)
 
 	// rate
-	if rate, err := strconv.Atoi(sl[0]); err != nil {
+	if rate, err := strconv.ParseUint(sl[0], 10, 16); err != nil {
 		log.Printf("invalid bit rate [%v]", sBitRate)
 	} else {
 		val = uint16(rate)

--- a/internal/smf/qos/qos_rule.go
+++ b/internal/smf/qos/qos_rule.go
@@ -492,7 +492,7 @@ func BuildPFCompProtocolId(val string) (*PacketFilterComponent, uint8) {
 		ComponentValue: make([]byte, 1),
 	}
 
-	if pfcVal, err := strconv.Atoi(val); err == nil {
+	if pfcVal, err := strconv.ParseUint(val, 10, 32); err == nil {
 		bs := make([]byte, 4)
 		binary.BigEndian.PutUint32(bs, uint32(pfcVal))
 		pfc.ComponentValue = []byte{bs[3]}

--- a/internal/upf/core/sdf_filter_parser.go
+++ b/internal/upf/core/sdf_filter_parser.go
@@ -89,8 +89,8 @@ func ParseCidrIp(ipStr, maskStr string) (ebpf.IpWMask, error) {
 		}
 		mask := net.CIDRMask(8*len(ip), 8*len(ip))
 		if maskStr != "" {
-			if maskUint, err := strconv.ParseUint(maskStr, 10, 64); err == nil {
-				mask = net.CIDRMask(int(maskUint), 8*len(ip))
+			if maskInt, err := strconv.ParseInt(maskStr, 10, 32); err == nil {
+				mask = net.CIDRMask(int(maskInt), 8*len(ip))
 				ip = ip.Mask(mask)
 			} else {
 				return ebpf.IpWMask{}, fmt.Errorf("Bad IP mask formatting.")

--- a/internal/util/flowdesc/flowdesc.go
+++ b/internal/util/flowdesc/flowdesc.go
@@ -345,7 +345,7 @@ func Decode(s string) (*IPFilterRule, error) {
 	if parts[ptr] == "ip" {
 		r.proto = ProtocolNumberAny
 	} else {
-		if proto, err := strconv.Atoi(parts[ptr]); err != nil {
+		if proto, err := strconv.ParseUint(parts[ptr], 10, 8); err != nil {
 			return nil, flowDescErrorf("parse proto failed: %s", err)
 		} else {
 			protoNumber = uint8(proto)


### PR DESCRIPTION
Fixes [https://github.com/ellanetworks/core/security/code-scanning/34](https://github.com/ellanetworks/core/security/code-scanning/34)

To fix the problem, we need to ensure that the integer value parsed from the string fits within the bounds of the `uint8` type before performing the conversion. This can be achieved by using `strconv.ParseUint` with a bit size of 8, which directly parses the string into a `uint8` value and ensures it is within the valid range.

- Replace the use of `strconv.Atoi` with `strconv.ParseUint` specifying a bit size of 8.
- Update the code to handle the returned `uint64` type from `strconv.ParseUint` and convert it to `uint8`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
