### PR TITLE
chore: fix incorrect conversion between integer types

### DIFF
--- a/internal/smf/qos/qos_rule.go
+++ b/internal/smf/qos/qos_rule.go
@@ -448,8 +448,12 @@ func buildPFCompPort(local bool, val string) (*PacketFilterComponent, uint8) {
 	}
 
 	if port, err := strconv.Atoi(val); err == nil {
-		port16 := uint16(port)
-		pfc.ComponentValue = []byte{byte(port16 >> 8), byte(port16 & 0xff)}
+		if port >= 0 && port <= math.MaxUint16 {
+			port16 := uint16(port)
+			pfc.ComponentValue = []byte{byte(port16 >> 8), byte(port16 & 0xff)}
+		} else {
+			return nil, 0
+		}
 	}
 	return pfc, 3
 }


### PR DESCRIPTION
Fixes [https://github.com/ellanetworks/core/security/code-scanning/29](https://github.com/ellanetworks/core/security/code-scanning/29)

To fix the problem, we need to ensure that the integer parsed from the string is within the valid range for `uint16` before performing the conversion. This can be done by adding a bounds check after parsing the integer. If the parsed integer is within the range of `0` to `65535`, we can safely convert it to `uint16`. Otherwise, we should handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
