### PR TITLE
chore: fix incorrect conversion between integer types

### DIFF
--- a/internal/smf/qos/qos_rule.go
+++ b/internal/smf/qos/qos_rule.go
@@ -180,7 +180,7 @@ func btou(b bool) uint8 {
 }
 
 func GetQosRuleIdFromPccRuleId(pccRuleId string) uint8 {
-	if id, err := strconv.Atoi(pccRuleId); err != nil {
+	if id, err := strconv.ParseUint(pccRuleId, 10, 8); err != nil {
 		return 0
 	} else {
 		return uint8(id)
@@ -211,7 +211,7 @@ func GetPacketFilterFromFlowInfo(flowInfo *models.FlowInformation) PacketFilter 
 }
 
 func GetPfId(ids string) uint8 {
-	if id, err := strconv.Atoi(ids); err != nil {
+	if id, err := strconv.ParseUint(ids, 10, 8); err != nil {
 		return 0
 	} else {
 		return (uint8(id) & PacketFilterIdBitmask)


### PR DESCRIPTION
Fixes [https://github.com/ellanetworks/core/security/code-scanning/28](https://github.com/ellanetworks/core/security/code-scanning/28)

To fix the problem, we need to ensure that the integer value parsed from the string is within the valid range for `uint8` before performing the conversion. This can be done by using `strconv.ParseUint` with a specified bit size of 8, which directly parses the string into a `uint8` value. This approach avoids the need for manual bounds checking and ensures that the parsed value is within the valid range for `uint8`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
