### PR TITLE
fix: add CNAME file to docs root dir

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.ellanetworks.com

--- a/docs/reference/tls.md
+++ b/docs/reference/tls.md
@@ -4,7 +4,7 @@ description: Reference for TLS.
 
 # TLS
 
-Ella Core uses TLS to secure its API and the web interface. The use of TLS is mandatory. Ella core will not start if the TLS configuration is missing or invalid.
+Ella Core uses TLS to secure its API and web interface. The use of TLS is mandatory, Ella Core will not start if the TLS configuration is missing or invalid.
 
 ## Configuration
 
@@ -12,7 +12,7 @@ The TLS configuration is defined in the [configuration file](config_file.md).
 
 ## Default Certificate
 
-When installing the Ella Core snap, a self-signed certificate is generated and stored in the snap's common directory. The certificate is valid for 1 year. Users can replace the certificate and key at any time by updating the respective files in the common directory. 
+When installing the Ella Core snap, a self-signed certificate is generated and stored in the snap's common directory. The certificate is valid for 365 days. Users can replace the certificate and key at any time by updating the respective files in the common directory. 
 
 ## Considerations for Production
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Ella Core Documentation
 site_url: https://docs.ellanetworks.com/
+docs_dir: docs
 theme:
   name: material
   logo: images/logo.png


### PR DESCRIPTION
# Description

Add CNAME file to docs root dir so that the CNAME configuration persists.  This fixes an issue where the custom domain configuration would be overwritten on every push to main.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
