### PR TITLE
chore: improve error handling in amf

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -151,7 +151,10 @@ func Terminate() {
 	unavailableGuamiList := message.BuildUnavailableGUAMIList(guamiList)
 	amfSelf.AmfRanPool.Range(func(key, value interface{}) bool {
 		ran := value.(*context.AmfRan)
-		message.SendAMFStatusIndication(ran, unavailableGuamiList)
+		err := message.SendAMFStatusIndication(ran, unavailableGuamiList)
+		if err != nil {
+			logger.AmfLog.Errorf("failed to send AMF Status Indication to RAN: %+v", err)
+		}
 		return true
 	})
 

--- a/internal/amf/gmm/message/send.go
+++ b/internal/amf/gmm/message/send.go
@@ -79,8 +79,6 @@ func SendAuthenticationRequest(ue *context.RanUe) {
 		return
 	}
 
-	amfUe.GmmLog.Infof("Send Authentication Request")
-
 	if amfUe.AuthenticationCtx == nil {
 		amfUe.GmmLog.Error("Authentication Context of UE is nil")
 		return
@@ -95,7 +93,7 @@ func SendAuthenticationRequest(ue *context.RanUe) {
 	if err != nil {
 		amfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
 	}
-	amfUe.GmmLog.Infof("sent authentication request")
+	amfUe.GmmLog.Infof("sent authentication request to UE")
 
 	if context.AMFSelf().T3560Cfg.Enable {
 		cfg := context.AMFSelf().T3560Cfg
@@ -106,7 +104,7 @@ func SendAuthenticationRequest(ue *context.RanUe) {
 				amfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
 				return
 			}
-			amfUe.GmmLog.Infof("sent authentication request")
+			amfUe.GmmLog.Infof("sent authentication request to UE")
 		}, func() {
 			amfUe.GmmLog.Warnf("T3560 Expires %d times, abort authentication procedure & ongoing 5GMM procedure",
 				cfg.MaxRetryTimes)

--- a/internal/amf/gmm/message/send.go
+++ b/internal/amf/gmm/message/send.go
@@ -19,23 +19,23 @@ import (
 func SendDLNASTransport(ue *context.RanUe, payloadContainerType uint8, nasPdu []byte,
 	pduSessionId int32, cause uint8, backOffTimerUint *uint8, backOffTimer uint8,
 ) {
-	ue.AmfUe.GmmLog.Info("Send DL NAS Transport")
 	var causePtr *uint8
 	if cause != 0 {
 		causePtr = &cause
 	}
-	nasMsg, err := BuildDLNASTransport(ue.AmfUe, payloadContainerType, nasPdu,
-		uint8(pduSessionId), causePtr, backOffTimerUint, backOffTimer)
+	nasMsg, err := BuildDLNASTransport(ue.AmfUe, payloadContainerType, nasPdu, uint8(pduSessionId), causePtr, backOffTimerUint, backOffTimer)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent downlink NAS transport message")
 }
 
 func SendNotification(ue *context.RanUe, nasMsg []byte) {
-	ue.AmfUe.GmmLog.Info("Send Notification")
-
 	amfUe := ue.AmfUe
 	if amfUe == nil {
 		ue.AmfUe.GmmLog.Error("AmfUe is nil")
@@ -46,7 +46,12 @@ func SendNotification(ue *context.RanUe, nasMsg []byte) {
 		cfg := context.AMFSelf().T3565Cfg
 		amfUe.T3565 = context.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.GmmLog.Warnf("T3565 expires, retransmit Notification (retry: %d)", expireTimes)
-			ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			err := ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			if err != nil {
+				amfUe.GmmLog.Errorf("could not send notification: %s", err.Error())
+				return
+			}
+			amfUe.GmmLog.Infof("sent notification")
 		}, func() {
 			amfUe.GmmLog.Warnf("T3565 Expires %d times, abort notification procedure", cfg.MaxRetryTimes)
 			amfUe.T3565 = nil // clear the timer
@@ -55,14 +60,16 @@ func SendNotification(ue *context.RanUe, nasMsg []byte) {
 }
 
 func SendIdentityRequest(ue *context.RanUe, typeOfIdentity uint8) {
-	ue.AmfUe.GmmLog.Info("Send Identity Request")
-
 	nasMsg, err := BuildIdentityRequest(typeOfIdentity)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent identity request")
 }
 
 func SendAuthenticationRequest(ue *context.RanUe) {
@@ -84,13 +91,22 @@ func SendAuthenticationRequest(ue *context.RanUe) {
 		amfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		amfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	amfUe.GmmLog.Infof("sent authentication request")
 
 	if context.AMFSelf().T3560Cfg.Enable {
 		cfg := context.AMFSelf().T3560Cfg
 		amfUe.T3560 = context.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.GmmLog.Warnf("T3560 expires, retransmit Authentication Request (retry: %d)", expireTimes)
-			ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			err := ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			if err != nil {
+				amfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+				return
+			}
+			amfUe.GmmLog.Infof("sent authentication request")
 		}, func() {
 			amfUe.GmmLog.Warnf("T3560 Expires %d times, abort authentication procedure & ongoing 5GMM procedure",
 				cfg.MaxRetryTimes)
@@ -102,25 +118,29 @@ func SendAuthenticationRequest(ue *context.RanUe) {
 func SendServiceAccept(ue *context.RanUe, pDUSessionStatus *[16]bool, reactivationResult *[16]bool,
 	errPduSessionId, errCause []uint8,
 ) {
-	ue.AmfUe.GmmLog.Info("Send Service Accept")
-
 	nasMsg, err := BuildServiceAccept(ue.AmfUe, pDUSessionStatus, reactivationResult, errPduSessionId, errCause)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent service accept")
 }
 
 func SendAuthenticationReject(ue *context.RanUe, eapMsg string) {
-	ue.AmfUe.GmmLog.Info("Send Authentication Reject")
-
 	nasMsg, err := BuildAuthenticationReject(ue.AmfUe, eapMsg)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent authentication reject")
 }
 
 func SendAuthenticationResult(ue *context.RanUe, eapSuccess bool, eapMsg string) {
@@ -128,52 +148,59 @@ func SendAuthenticationResult(ue *context.RanUe, eapSuccess bool, eapMsg string)
 		logger.AmfLog.Errorf("AmfUe is nil")
 		return
 	}
-
-	ue.AmfUe.GmmLog.Info("Send Authentication Result")
-
 	nasMsg, err := BuildAuthenticationResult(ue.AmfUe, eapSuccess, eapMsg)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent authentication result")
 }
 
 func SendServiceReject(ue *context.RanUe, pDUSessionStatus *[16]bool, cause uint8) {
-	ue.AmfUe.GmmLog.Info("Send Service Reject")
-
 	nasMsg, err := BuildServiceReject(pDUSessionStatus, cause)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent service reject")
 }
 
 // T3502: This IE may be included to indicate a value for timer T3502 during the initial registration
 // eapMessage: if the REGISTRATION REJECT message is used to convey EAP-failure message
 func SendRegistrationReject(ue *context.RanUe, cause5GMM uint8, eapMessage string) {
-	ue.AmfUe.GmmLog.Info("Send Registration Reject")
-
 	nasMsg, err := BuildRegistrationReject(ue.AmfUe, cause5GMM, eapMessage)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent registration reject")
 }
 
 // eapSuccess: only used when authType is EAP-AKA', set the value to false if authType is not EAP-AKA'
 // eapMessage: only used when authType is EAP-AKA', set the value to "" if authType is not EAP-AKA'
 func SendSecurityModeCommand(ue *context.RanUe, eapSuccess bool, eapMessage string) {
-	ue.AmfUe.GmmLog.Info("Send Security Mode Command")
-
 	nasMsg, err := BuildSecurityModeCommand(ue.AmfUe, eapSuccess, eapMessage)
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent security mode command")
 
 	amfUe := ue.AmfUe
 
@@ -181,7 +208,12 @@ func SendSecurityModeCommand(ue *context.RanUe, eapSuccess bool, eapMessage stri
 		cfg := context.AMFSelf().T3560Cfg
 		amfUe.T3560 = context.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.GmmLog.Warnf("T3560 expires, retransmit Security Mode Command (retry: %d)", expireTimes)
-			ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			if err != nil {
+				amfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+				return
+			}
+			amfUe.GmmLog.Infof("sent security mode command")
 		}, func() {
 			amfUe.GmmLog.Warnf("T3560 Expires %d times, abort security mode control procedure", cfg.MaxRetryTimes)
 			amfUe.Remove()
@@ -190,9 +222,6 @@ func SendSecurityModeCommand(ue *context.RanUe, eapSuccess bool, eapMessage stri
 }
 
 func SendDeregistrationRequest(ue *context.RanUe, accessType uint8, reRegistrationRequired bool, cause5GMM uint8) {
-	ue.AmfUe.GmmLog.Info("Send Deregistration Request")
-
-	// setting accesstype
 	ue.AmfUe.DeregistrationTargetAccessType = accessType
 
 	nasMsg, err := BuildDeregistrationRequest(ue, accessType, reRegistrationRequired, cause5GMM)
@@ -200,7 +229,11 @@ func SendDeregistrationRequest(ue *context.RanUe, accessType uint8, reRegistrati
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent deregistration request")
 
 	amfUe := ue.AmfUe
 
@@ -208,7 +241,12 @@ func SendDeregistrationRequest(ue *context.RanUe, accessType uint8, reRegistrati
 		cfg := context.AMFSelf().T3522Cfg
 		amfUe.T3522 = context.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.GmmLog.Warnf("T3522 expires, retransmit Deregistration Request (retry: %d)", expireTimes)
-			ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+			if err != nil {
+				amfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+				return
+			}
+			amfUe.GmmLog.Infof("sent deregistration request")
 		}, func() {
 			amfUe.GmmLog.Warnf("T3522 Expires %d times, abort deregistration procedure", cfg.MaxRetryTimes)
 			amfUe.T3522 = nil // clear the timer
@@ -232,14 +270,16 @@ func SendDeregistrationRequest(ue *context.RanUe, accessType uint8, reRegistrati
 }
 
 func SendDeregistrationAccept(ue *context.RanUe) {
-	ue.AmfUe.GmmLog.Info("Send Deregistration Accept")
-
 	nasMsg, err := BuildDeregistrationAccept()
 	if err != nil {
 		ue.AmfUe.GmmLog.Error(err.Error())
 		return
 	}
-	ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		ue.AmfUe.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+	}
+	ue.AmfUe.GmmLog.Infof("sent deregistration accept")
 }
 
 func SendRegistrationAccept(
@@ -257,9 +297,17 @@ func SendRegistrationAccept(
 	}
 
 	if ue.RanUe[anType].UeContextRequest {
-		ngap_message.SendInitialContextSetupRequest(ue, anType, nasMsg, pduSessionResourceSetupList, nil, nil, nil)
+		err = ngap_message.SendInitialContextSetupRequest(ue, anType, nasMsg, pduSessionResourceSetupList, nil, nil, nil)
+		if err != nil {
+			ue.GmmLog.Errorf("could not send initial context setup request: %s", err.Error())
+		}
+		ue.GmmLog.Infof("sent initial context setup request")
 	} else {
-		ngap_message.SendDownlinkNasTransport(ue.RanUe[models.AccessType__3_GPP_ACCESS], nasMsg, nil)
+		err = ngap_message.SendDownlinkNasTransport(ue.RanUe[models.AccessType__3_GPP_ACCESS], nasMsg, nil)
+		if err != nil {
+			ue.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+		}
+		ue.GmmLog.Infof("sent registration accept")
 	}
 
 	if context.AMFSelf().T3550Cfg.Enable {
@@ -270,10 +318,18 @@ func SendRegistrationAccept(
 				ue.T3550 = nil
 			} else {
 				if ue.RanUe[anType].UeContextRequest && !ue.RanUe[anType].RecvdInitialContextSetupResponse {
-					ngap_message.SendInitialContextSetupRequest(ue, anType, nasMsg, pduSessionResourceSetupList, nil, nil, nil)
+					err = ngap_message.SendInitialContextSetupRequest(ue, anType, nasMsg, pduSessionResourceSetupList, nil, nil, nil)
+					if err != nil {
+						ue.GmmLog.Errorf("could not send initial context setup request: %s", err.Error())
+					}
+					ue.GmmLog.Infof("sent initial context setup request")
 				} else {
 					ue.GmmLog.Warnf("T3550 expires, retransmit Registration Accept (retry: %d)", expireTimes)
-					ngap_message.SendDownlinkNasTransport(ue.RanUe[anType], nasMsg, nil)
+					err = ngap_message.SendDownlinkNasTransport(ue.RanUe[anType], nasMsg, nil)
+					if err != nil {
+						ue.GmmLog.Errorf("could not send downlink NAS transport message: %s", err.Error())
+					}
+					ue.GmmLog.Infof("sent registration accept")
 				}
 			}
 		}, func() {

--- a/internal/amf/ngap/dispatcher.go
+++ b/internal/amf/ngap/dispatcher.go
@@ -24,8 +24,8 @@ func Dispatch(conn net.Conn, msg []byte) {
 
 	ran, ok := amfSelf.AmfRanFindByConn(conn)
 	if !ok {
-		logger.AmfLog.Infof("Create a new NG connection for: %s", conn.RemoteAddr().String())
 		ran = amfSelf.NewAmfRan(conn)
+		logger.AmfLog.Infof("added a new radio: %s", conn.RemoteAddr().String())
 	}
 
 	if len(msg) == 0 {

--- a/internal/amf/ngap/handler.go
+++ b/internal/amf/ngap/handler.go
@@ -495,7 +495,7 @@ func HandleNGSetupRequest(ran *context.AmfRan, message *ngapType.NGAPPDU) {
 		logger.AmfLog.Error("ran is nil")
 		return
 	}
-	ran.Log.Infof("received NG-Setup Request from: %s", ran.Name)
+	ran.Log.Infof("received NG Setup Request from: %s", ran.Name)
 	if message == nil {
 		ran.Log.Error("NGAP Message is nil")
 		return
@@ -589,7 +589,7 @@ func HandleNGSetupRequest(ran *context.AmfRan, message *ngapType.NGAPPDU) {
 	}
 
 	if len(ran.SupportedTAList) == 0 {
-		ran.Log.Warn("NG-Setup failure: No supported TA exist in NG-Setup request")
+		ran.Log.Warn("NG Setup failure: No supported TA exist in NG Setup request")
 		cause.Present = ngapType.CausePresentMisc
 		cause.Misc = &ngapType.CauseMisc{
 			Value: ngapType.CauseMiscPresentUnspecified,
@@ -637,7 +637,7 @@ func HandleNGSetupRequest(ran *context.AmfRan, message *ngapType.NGAPPDU) {
 			ran.Log.Errorf("error sending NG Setup Failure: %+v", err)
 			return
 		}
-		ran.Log.Infof("sent NG Setup Failure")
+		ran.Log.Infof("sent NG Setup failure with cause: %+v", cause)
 	}
 }
 

--- a/internal/amf/ngap/message/build.go
+++ b/internal/amf/ngap/message/build.go
@@ -203,9 +203,7 @@ func BuildNGSetupFailure(cause ngapType.Cause) ([]byte, error) {
 	return ngap.Encoder(pdu)
 }
 
-func BuildNGResetAcknowledge(partOfNGInterface *ngapType.UEAssociatedLogicalNGConnectionList,
-	criticalityDiagnostics *ngapType.CriticalityDiagnostics,
-) ([]byte, error) {
+func BuildNGResetAcknowledge(partOfNGInterface *ngapType.UEAssociatedLogicalNGConnectionList) ([]byte, error) {
 	var pdu ngapType.NGAPPDU
 
 	pdu.Present = ngapType.NGAPPDUPresentSuccessfulOutcome
@@ -250,19 +248,6 @@ func BuildNGResetAcknowledge(partOfNGInterface *ngapType.UEAssociatedLogicalNGCo
 
 			uEAssociatedLogicalNGConnectionList.List = append(uEAssociatedLogicalNGConnectionList.List, uEAssociatedLogicalNGConnectionItem)
 		}
-
-		nGResetAcknowledgeIEs.List = append(nGResetAcknowledgeIEs.List, ie)
-	}
-
-	// Criticality Diagnostics (optional)
-	if criticalityDiagnostics != nil {
-		ie := ngapType.NGResetAcknowledgeIEs{}
-		ie.Id.Value = ngapType.ProtocolIEIDCriticalityDiagnostics
-		ie.Criticality.Value = ngapType.CriticalityPresentIgnore
-		ie.Value.Present = ngapType.NGResetAcknowledgeIEsPresentCriticalityDiagnostics
-		ie.Value.CriticalityDiagnostics = new(ngapType.CriticalityDiagnostics)
-
-		ie.Value.CriticalityDiagnostics = criticalityDiagnostics
 
 		nGResetAcknowledgeIEs.List = append(nGResetAcknowledgeIEs.List, ie)
 	}

--- a/internal/amf/ngap/service/service.go
+++ b/internal/amf/ngap/service/service.go
@@ -130,7 +130,7 @@ func listenAndServe(addr *sctp.SCTPAddr, handler NGAPHandler) {
 			logger.AmfLog.Debugf("Set read timeout: %+v", readTimeout)
 		}
 
-		logger.AmfLog.Infof("[AMF] SCTP Accept from: %s", newConn.RemoteAddr().String())
+		logger.AmfLog.Infof("new connection from %s", newConn.RemoteAddr())
 		connections.Store(newConn, newConn)
 
 		go handleConnection(newConn, readBufSize, handler)

--- a/internal/amf/producer/n1n2message.go
+++ b/internal/amf/producer/n1n2message.go
@@ -130,7 +130,11 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string, n1n2Message
 			}
 			if n2Info == nil {
 				ue.ProducerLog.Debug("Forward N1 Message to UE")
-				ngap_message.SendDownlinkNasTransport(ue.RanUe[anType], nasPdu, nil)
+				err := ngap_message.SendDownlinkNasTransport(ue.RanUe[anType], nasPdu, nil)
+				if err != nil {
+					return nil, fmt.Errorf("send downlink nas transport error: %v", err)
+				}
+				ue.ProducerLog.Infof("sent downlink nas transport to UE")
 				n1n2MessageTransferRspData = new(models.N1N2MessageTransferRspData)
 				n1n2MessageTransferRspData.Cause = models.N1N2MessageTransferCause_N1_N2_TRANSFER_INITIATED
 				return n1n2MessageTransferRspData, nil
@@ -148,13 +152,20 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string, n1n2Message
 				}
 				if ue.RanUe[anType].SentInitialContextSetupRequest {
 					list := ngapType.PDUSessionResourceSetupListSUReq{}
-
 					ngap_message.AppendPDUSessionResourceSetupListSUReq(&list, smInfo.PduSessionId, omecSnssai, nasPdu, n2Info)
-					ngap_message.SendPDUSessionResourceSetupRequest(ue.RanUe[anType], nil, list)
+					err := ngap_message.SendPDUSessionResourceSetupRequest(ue.RanUe[anType], nil, list)
+					if err != nil {
+						return nil, fmt.Errorf("send pdu session resource setup request error: %v", err)
+					}
+					ue.ProducerLog.Infof("sent pdu session resource setup request to UE")
 				} else {
 					list := ngapType.PDUSessionResourceSetupListCxtReq{}
 					ngap_message.AppendPDUSessionResourceSetupListCxtReq(&list, smInfo.PduSessionId, omecSnssai, nasPdu, n2Info)
-					ngap_message.SendInitialContextSetupRequest(ue, anType, nil, &list, nil, nil, nil)
+					err := ngap_message.SendInitialContextSetupRequest(ue, anType, nil, &list, nil, nil, nil)
+					if err != nil {
+						return nil, fmt.Errorf("send initial context setup request error: %v", err)
+					}
+					ue.ProducerLog.Infof("sent initial context setup request to UE")
 					ue.RanUe[anType].SentInitialContextSetupRequest = true
 				}
 				n1n2MessageTransferRspData = new(models.N1N2MessageTransferRspData)
@@ -165,7 +176,11 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string, n1n2Message
 				ue.ProducerLog.Debugln("AMF Transfer NGAP PDU Session Resource Modify Request from SMF")
 				list := ngapType.PDUSessionResourceModifyListModReq{}
 				ngap_message.AppendPDUSessionResourceModifyListModReq(&list, smInfo.PduSessionId, nasPdu, n2Info)
-				ngap_message.SendPDUSessionResourceModifyRequest(ue.RanUe[anType], list)
+				err := ngap_message.SendPDUSessionResourceModifyRequest(ue.RanUe[anType], list)
+				if err != nil {
+					return nil, fmt.Errorf("send pdu session resource modify request error: %v", err)
+				}
+				ue.ProducerLog.Infof("sent pdu session resource modify request to UE")
 				n1n2MessageTransferRspData = new(models.N1N2MessageTransferRspData)
 				n1n2MessageTransferRspData.Cause = models.N1N2MessageTransferCause_N1_N2_TRANSFER_INITIATED
 				// context.StoreContextInDB(ue)
@@ -174,7 +189,11 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string, n1n2Message
 				ue.ProducerLog.Debugln("AMF Transfer NGAP PDU Session Resource Release Command from SMF")
 				list := ngapType.PDUSessionResourceToReleaseListRelCmd{}
 				ngap_message.AppendPDUSessionResourceToReleaseListRelCmd(&list, smInfo.PduSessionId, n2Info)
-				ngap_message.SendPDUSessionResourceReleaseCommand(ue.RanUe[anType], nasPdu, list)
+				err := ngap_message.SendPDUSessionResourceReleaseCommand(ue.RanUe[anType], nasPdu, list)
+				if err != nil {
+					return nil, fmt.Errorf("send pdu session resource release command error: %v", err)
+				}
+				ue.ProducerLog.Infof("sent pdu session resource release command to UE")
 				n1n2MessageTransferRspData = new(models.N1N2MessageTransferRspData)
 				n1n2MessageTransferRspData.Cause = models.N1N2MessageTransferCause_N1_N2_TRANSFER_INITIATED
 				// context.StoreContextInDB(ue)
@@ -229,7 +248,10 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string, n1n2Message
 			if err != nil {
 				return n1n2MessageTransferRspData, fmt.Errorf("build paging error: %v", err)
 			}
-			ngap_message.SendPaging(ue, pkg)
+			err = ngap_message.SendPaging(ue, pkg)
+			if err != nil {
+				return n1n2MessageTransferRspData, fmt.Errorf("send paging error: %v", err)
+			}
 		}
 		return n1n2MessageTransferRspData, nil
 	} else {
@@ -276,7 +298,10 @@ func N1N2MessageTransferProcedure(ueContextID string, reqUri string, n1n2Message
 			if err != nil {
 				return n1n2MessageTransferRspData, fmt.Errorf("build paging error: %v", err)
 			}
-			ngap_message.SendPaging(ue, pkg)
+			err = ngap_message.SendPaging(ue, pkg)
+			if err != nil {
+				return n1n2MessageTransferRspData, fmt.Errorf("send paging error: %v", err)
+			}
 			return n1n2MessageTransferRspData, nil
 		}
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -100,6 +100,6 @@ func ReconcileKernelRouting(dbInstance *db.Database, kernelInt kernel.Kernel) er
 			}
 		}
 	}
-	logger.APILog.Infoln("routes reconciled")
+	logger.APILog.Debugln("routes reconciled")
 	return nil
 }

--- a/internal/ausf/ue_authentication.go
+++ b/internal/ausf/ue_authentication.go
@@ -53,7 +53,7 @@ func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationIn
 
 	authInfoResult, err := udm.CreateAuthData(authInfoReq, supiOrSuci)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAuthData failed: %s", err.Error())
+		return nil, fmt.Errorf("failed to create auth data: %s", err)
 	}
 
 	ueid := authInfoResult.Supi


### PR DESCRIPTION
# Description

We keep on improving error handling in the AMF code. Specifically sending ngap messages return errors when there's an issue with the send operation (instead of logging) and the caller decides what to do with the error. There's still a long way to go in terms of improving error handling, but this is a step in the right direction. Next step is to do the same for the GMM code.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
