### PR TITLE
feat: make TLS optional on the API interface

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -31,7 +31,11 @@ const (
 )
 
 func startNetwork(dbInstance *db.Database, cfg config.Config) error {
-	err := api.Start(dbInstance, cfg.Interfaces.API.Port, cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key, cfg.Interfaces.N3.Name, cfg.Interfaces.N6.Name)
+	scheme := api.HTTPS
+	if cfg.Interfaces.API.TLS.Cert == "" || cfg.Interfaces.API.TLS.Key == "" {
+		scheme = api.HTTP
+	}
+	err := api.Start(dbInstance, cfg.Interfaces.API.Port, scheme, cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key, cfg.Interfaces.N3.Name, cfg.Interfaces.N6.Name)
 	if err != nil {
 		return err
 	}

--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -31,9 +31,9 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
     - `api` (object): The configuration for the api interface.
         - `name` (string): The name of the network interface.
         - `port` (int): The port to listen on.
-        - `tls` (object): The TLS configuration.
-            - `cert` (string): The path to the TLS certificate file.
-            - `key` (string): The path to the TLS key file.
+        - `tls` (object): The TLS configuration (optional).
+            - `cert` (string): The path to the TLS certificate file (optional).
+            - `key` (string): The path to the TLS key file (optional).
 - `xdp` (object): The XDP configuration.
     - `attach-mode` (string): The XDP attach mode. Options are `native` and `generic`. `native` is the most performant option and only works on supported drivers.
 

--- a/docs/reference/tls.md
+++ b/docs/reference/tls.md
@@ -4,7 +4,7 @@ description: Reference for TLS.
 
 # TLS
 
-Ella Core uses TLS to secure its API and web interface. The use of TLS is mandatory, Ella Core will not start if the TLS configuration is missing or invalid.
+Ella Core uses TLS to secure its API and web interface. Although TLS is optional, it is highly recommended.
 
 ## Configuration
 
@@ -12,11 +12,11 @@ The TLS configuration is defined in the [configuration file](config_file.md).
 
 ## Default Certificate
 
-When installing the Ella Core snap, a self-signed certificate is generated and stored in the snap's common directory. The certificate is valid for 365 days. Users can replace the certificate and key at any time by updating the respective files in the common directory. 
+When installing the Ella Core snap, a self-signed certificate is generated and stored in the snap's `common` directory. The certificate is valid for 365 days. Users can replace the certificate and key at any time by updating the respective files in the `common` directory.
 
 ## Considerations for Production
 
-It is highly recommended to replace the self-signed certificate with one issued by a trusted Certificate Authority (CA) for production deployments.
+For production deployments, it is highly recommended that the self-signed certificate be replaced with one issued by a trusted Certificate Authority (CA).
 
 Ensure that the private key is stored securely and that access is restricted to authorized personnel only.
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,100 @@
+// start_integration_test.go
+package api
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/kernel"
+)
+
+// initialOperator is used to initialize a test database.
+var initialOperator = db.Operator{
+	Mcc:                   "001",
+	Mnc:                   "01",
+	OperatorCode:          "0123456789ABCDEF0123456789ABCDEF",
+	Sst:                   1,
+	Sd:                    1056816,
+	SupportedTACs:         `["001"]`,
+	HomeNetworkPrivateKey: "c09c17bddf23357f614f492075b970d825767718114f59554ce2f345cf8c4b6a",
+}
+
+// freePort finds an available port on localhost.
+func freePort(t *testing.T) int {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func TestStartServerStandup(t *testing.T) {
+	// Override routeReconciler to a no-op to avoid actual route reconciliation.
+	origReconciler := routeReconciler
+	routeReconciler = func(dbInstance *db.Database, kernelInt kernel.Kernel) error {
+		return nil
+	}
+	defer func() { routeReconciler = origReconciler }()
+
+	// Use HTTP scheme for testing.
+	scheme := HTTP
+
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+	testdb, err := db.NewDatabase(dbPath, initialOperator)
+	if err != nil {
+		t.Fatalf("NewDatabase returned error: %v", err)
+	}
+
+	port := freePort(t)
+	// For HTTP, these cert/key files are unused.
+	certFile := "dummy_cert.pem"
+	keyFile := "dummy_key.pem"
+	n3Interface := "eth0"
+	n6Interface := "eth1"
+
+	// Start the server in a separate goroutine.
+	if err := Start(testdb, port, scheme, certFile, keyFile, n3Interface, n6Interface); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	// Poll the server until it responds or timeout occurs.
+	baseURL := "http://127.0.0.1:" + strconv.Itoa(port)
+	client := &http.Client{}
+	var resp *http.Response
+	var lastErr error
+	timeout := time.Now().Add(5 * time.Second)
+	for time.Now().Before(timeout) {
+		req, reqErr := http.NewRequestWithContext(context.Background(), "GET", baseURL+"/", nil)
+		if reqErr != nil {
+			lastErr = reqErr
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		resp, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("failed to reach server: %v", lastErr)
+	}
+	defer resp.Body.Close()
+
+	// Read and log the response.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	t.Logf("Server is up. Response status: %s, body: %s", resp.Status, string(body))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,19 +254,17 @@ func Validate(filePath string) (Config, error) {
 	if c.Interfaces.API.Port == 0 {
 		return Config{}, errors.New("interfaces.api.port is empty")
 	}
-	if c.Interfaces.API.TLS.Cert == "" {
-		return Config{}, fmt.Errorf("interfaces.api.tls.cert is empty")
+	if c.Interfaces.API.TLS.Cert != "" {
+		if _, err := os.Stat(c.Interfaces.API.TLS.Cert); os.IsNotExist(err) {
+			return Config{}, fmt.Errorf("cert file %s does not exist", c.Interfaces.API.TLS.Cert)
+		}
+		config.Interfaces.API.TLS.Cert = c.Interfaces.API.TLS.Cert
 	}
-	if c.Interfaces.API.TLS.Key == "" {
-		return Config{}, fmt.Errorf("interfaces.api.tls.key is empty")
-	}
-
-	if _, err := os.Stat(c.Interfaces.API.TLS.Cert); os.IsNotExist(err) {
-		return Config{}, fmt.Errorf("cert file %s does not exist", c.Interfaces.API.TLS.Cert)
-	}
-
-	if _, err := os.Stat(c.Interfaces.API.TLS.Key); os.IsNotExist(err) {
-		return Config{}, fmt.Errorf("key file %s does not exist", c.Interfaces.API.TLS.Key)
+	if c.Interfaces.API.TLS.Key != "" {
+		if _, err := os.Stat(c.Interfaces.API.TLS.Key); os.IsNotExist(err) {
+			return Config{}, fmt.Errorf("key file %s does not exist", c.Interfaces.API.TLS.Key)
+		}
+		config.Interfaces.API.TLS.Key = c.Interfaces.API.TLS.Key
 	}
 
 	if c.XDP == (XDPYaml{}) {
@@ -298,8 +296,6 @@ func Validate(filePath string) (Config, error) {
 	config.Interfaces.N6.Name = c.Interfaces.N6.Name
 	config.Interfaces.API.Name = c.Interfaces.API.Name
 	config.Interfaces.API.Port = c.Interfaces.API.Port
-	config.Interfaces.API.TLS.Cert = c.Interfaces.API.TLS.Cert
-	config.Interfaces.API.TLS.Key = c.Interfaces.API.TLS.Key
 	config.XDP.AttachMode = c.XDP.AttachMode
 	return config, nil
 }

--- a/internal/config/testdata/valid_no_tls.yaml
+++ b/internal/config/testdata/valid_no_tls.yaml
@@ -1,0 +1,22 @@
+logging:
+  system:
+    level: "info"
+    output: "file"
+    path: "/var/log/ella_system.log"
+  audit:
+    output: "stdout"
+db:
+  path: "test"
+interfaces:
+  n2:
+    name: "enp2s0"
+    port: 38412
+  n3: 
+    name: "enp3s0"
+  n6:
+    name: "enp6s0"
+  api:
+    name: "enp0s8"
+    port: 5002
+xdp:
+  attach-mode: "native"


### PR DESCRIPTION
# Description

Users who use ingresses or service meshes often prefer to have TLS terminated prior to reaching the workload. For those use-cases, it makes sense to start Ella Core without TLS. For any other use case, TLS remains strongly recommended. Here we make the use of TLS optional.

Fixes #500 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
