### PR TITLE
fix: set cookie on http connections

### DIFF
--- a/ui/app/(auth)/login/page.tsx
+++ b/ui/app/(auth)/login/page.tsx
@@ -52,7 +52,6 @@ const LoginPage = () => {
             if (result?.token) {
                 setCookie("user_token", result.token, {
                     sameSite: true,
-                    secure: true,
                     expires: new Date(new Date().getTime() + 60 * 60 * 1000), // 1 hour expiry
                 });
 


### PR DESCRIPTION
# Description

Since we now allow users to run Ella Core in `http` mode, we should also allow the UI to set cookies in non secure environments. Here we remove the `secure` from the setCookie call.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
