### PR TITLE
feat: allow user specified opc

### DIFF
--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -11,6 +11,7 @@ type CreateSubscriberOptions struct {
 	Key            string `json:"key"`
 	SequenceNumber string `json:"sequenceNumber"`
 	ProfileName    string `json:"profileName"`
+	OPc            string `json:"opc,omitempty"`
 }
 
 type GetSubscriberOptions struct {

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -10,7 +10,6 @@ This section describes the RESTful API for managing network subscribers. Network
 
 This path returns the list of network subscribers.
 
-
 | Method | Path                  |
 | ------ | --------------------- |
 | GET    | `/api/v1/subscribers` |
@@ -50,9 +49,7 @@ This path creates a new network subscriber.
 - `key` (string): The key of the subscriber. Must be a 32-character hexadecimal string.
 - `sequenceNumber` (string): The sequence number of the subscriber. Must be a 6-byte hexadecimal string.
 - `ProfileName` (string): The profile name of the subscriber. Must be the name of an existing profile.
-
-!!! note
-    The `opc` parameter is generated automatically using the Operator Code (OP) and the `key` parameter.
+- `opc` (optional string): The operator code of the subscriber. If not provided, it will be generated automatically using the Operator Code (OP) and the `key` parameter.
 
 ### Sample Response
 

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -43,6 +43,7 @@ type GetSubscriberResponse struct {
 type CreateSubscriberParams struct {
 	Imsi           string `json:"imsi"`
 	Key            string `json:"key"`
+	Opc            string `json:"opc,omitempty"`
 	SequenceNumber string `json:"sequenceNumber"`
 	ProfileName    string `json:"profileName"`
 }
@@ -301,6 +302,57 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 		}
 		if response.Error != "Subscriber not found" {
 			t.Fatalf("expected error %q, got %q", "Subscriber not found", response.Error)
+		}
+	})
+
+	t.Run("8. Create subscriber (with opc)", func(t *testing.T) {
+		createSubscriberParams := &CreateSubscriberParams{
+			Imsi:           Imsi,
+			Key:            Key,
+			Opc:            Opc,
+			SequenceNumber: SequenceNumber,
+			ProfileName:    ProfileName,
+		}
+		statusCode, response, err := createSubscriber(ts.URL, client, token, createSubscriberParams)
+		if err != nil {
+			t.Fatalf("couldn't create subscriber: %s", err)
+		}
+		if statusCode != http.StatusCreated {
+			t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+		}
+		if response.Error != "" {
+			t.Fatalf("unexpected error :%q", response.Error)
+		}
+		if response.Result.Message != "Subscriber created successfully" {
+			t.Fatalf("expected message 'Subscriber created successfully', got %q", response.Result.Message)
+		}
+	})
+
+	t.Run("9. Get subscriber - with opc", func(t *testing.T) {
+		statusCode, response, err := getSubscriber(ts.URL, client, token, Imsi)
+		if err != nil {
+			t.Fatalf("couldn't get subscriber: %s", err)
+		}
+		if statusCode != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, statusCode)
+		}
+		if response.Result.Imsi != Imsi {
+			t.Fatalf("expected imsi %s, got %s", Imsi, response.Result.Imsi)
+		}
+		if response.Result.OPc != Opc {
+			t.Fatalf("expected opc %s, got %s", Opc, response.Result.OPc)
+		}
+		if response.Result.Key != Key {
+			t.Fatalf("expected key %s, got %s", Key, response.Result.Key)
+		}
+		if response.Result.SequenceNumber != SequenceNumber {
+			t.Fatalf("expected sequenceNumber %s, got %s", SequenceNumber, response.Result.SequenceNumber)
+		}
+		if response.Result.ProfileName != ProfileName {
+			t.Fatalf("expected profileName %s, got %s", ProfileName, response.Result.ProfileName)
+		}
+		if response.Error != "" {
+			t.Fatalf("unexpected error :%q", response.Error)
 		}
 	})
 }

--- a/ui/components/CreateSubscriberModal.tsx
+++ b/ui/components/CreateSubscriberModal.tsx
@@ -11,7 +11,9 @@ import {
     Alert,
     Collapse,
     MenuItem,
+    FormControlLabel,
     Select,
+    Checkbox,
     InputLabel,
     FormControl,
     FormGroup,
@@ -48,6 +50,10 @@ const schema = yup.object().shape({
     profileName: yup
         .string()
         .required("Profile Name is required."),
+    opc: yup
+        .string()
+        .matches(/^[0-9a-fA-F]{32}$/, "Key must be a 32-character hexadecimal string.")
+        .notRequired(),
 });
 
 const CreateSubscriberModal: React.FC<CreateSubscriberModalProps> = ({ open, onClose, onSuccess }) => {
@@ -60,6 +66,7 @@ const CreateSubscriberModal: React.FC<CreateSubscriberModalProps> = ({ open, onC
     const [formValues, setFormValues] = useState({
         msin: "",
         key: "",
+        opc: "",
         sequenceNumber: "000000000022", // Default value
         profileName: "",
     });
@@ -72,6 +79,7 @@ const CreateSubscriberModal: React.FC<CreateSubscriberModalProps> = ({ open, onC
     const [isValid, setIsValid] = useState(false);
     const [loading, setLoading] = useState(false);
     const [alert, setAlert] = useState<{ message: string }>({ message: "" });
+    const [customOPC, setCustomOPC] = useState(false);
 
     useEffect(() => {
         const fetchOperatorAndProfiles = async () => {
@@ -156,7 +164,8 @@ const CreateSubscriberModal: React.FC<CreateSubscriberModalProps> = ({ open, onC
                 imsi,
                 formValues.key,
                 formValues.sequenceNumber,
-                formValues.profileName
+                formValues.profileName,
+                formValues.opc
             );
             onClose();
             onSuccess();
@@ -292,6 +301,31 @@ const CreateSubscriberModal: React.FC<CreateSubscriberModalProps> = ({ open, onC
                         </Typography>
                     )}
                 </FormControl>
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={customOPC}
+                            onChange={(e) => {
+                                setCustomOPC(e.target.checked);
+                                if (!e.target.checked) {
+                                    handleChange("opc", "");
+                                }
+                            }}
+                        />
+                    }
+                    label="Provide custom OPC"
+                />
+                {customOPC && (
+                    <TextField
+                        fullWidth
+                        label="OPC (optional)"
+                        value={formValues.opc}
+                        onChange={(e) => handleChange("opc", e.target.value)}
+                        onBlur={() => handleBlur("opc")}
+                        margin="normal"
+                        helperText="Leave blank to use centrally managed OP"
+                    />
+                )}
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose} >

--- a/ui/queries/subscribers.tsx
+++ b/ui/queries/subscribers.tsx
@@ -44,12 +44,13 @@ export const getSubscriber = async (authToken: string, imsi: string) => {
   return respData.result;
 };
 
-export const createSubscriber = async (authToken: string, imsi: string, key: string, sequenceNumber: string, profileName: string) => {
+export const createSubscriber = async (authToken: string, imsi: string, key: string, sequenceNumber: string, profileName: string, opc: string) => {
   const subscriberData = {
     imsi,
     key,
     sequenceNumber,
     profileName,
+    opc
   };
 
   const response = await fetch(`/api/v1/subscribers`, {


### PR DESCRIPTION
# Description

Ella Core manages Operator Code (OP) centrally. When users create a subscriber, they provide a Key, and Ella Core uses that key and its central OP to generate the OPc. 

Some SIM vendors come with a pre-written OPc and Key. If users want to use those SIM cards, they would have to re-write them with the OPc provided by Ella Core, making the process of emitting cards more tedious than necessary.

Here we add the ability for users to specify the OPc of their choice. This is an optional feature, if users don't select it, Ella Core will generate the OPc.

Fixes #518 

## Screenshots
![image](https://github.com/user-attachments/assets/842e75e0-8e54-443a-9e07-85b38179783f)
![image](https://github.com/user-attachments/assets/241fe09b-37d0-4abd-8906-53a949884aee)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
