### PR TITLE
fix: show alert when using clipboard copy over non-secure connection

### DIFF
--- a/docs/how_to/install.md
+++ b/docs/how_to/install.md
@@ -93,7 +93,8 @@ You can install Ella Core on Linux or on Kubernetes.
     ```shell
     sudo snap install go --channel=1.24/stable --classic
     sudo snap install node --channel=20/stable --classic
-    sudo apt install clang llvm gcc-multilib libbpf-dev
+    sudo apt update
+    sudo apt -y install clang llvm gcc-multilib libbpf-dev
     ```
 
     ### Steps
@@ -130,9 +131,9 @@ You can install Ella Core on Linux or on Kubernetes.
     Edit the configuration file at `core.yaml` to configure the network interfaces.
 
     Start the service:
-  
+
     ```shell
-    ./main --config core.yaml
+    sudo ./main --config core.yaml
     ```
 
     Navigate to `https://localhost:5002` to access the Ella UI.

--- a/ui/components/ViewSubscriberModal.tsx
+++ b/ui/components/ViewSubscriberModal.tsx
@@ -76,6 +76,12 @@ const ViewSubscriberModal: React.FC<ViewSubscriberModalProps> = ({
     }, [imsi, open, cookies.user_token]);
 
     const handleCopy = async (value: string, label: string) => {
+        if (!navigator.clipboard) {
+            console.error(`Clipboard API not available.`);
+            setAlert({ message: `Clipboard API not available. Please use HTTPS or try a different browser.` });
+            return;
+        }
+
         try {
             await navigator.clipboard.writeText(value);
             setAlert({ message: `${label} copied to clipboard!` });


### PR DESCRIPTION
# Description

The Clipboard API is only available over HTTPS. Here we make it clearer why the copy behavior doesn't work.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
