### PR TITLE
fix: allow empty opc in create subscriber modal

### DIFF
--- a/ui/components/CreateSubscriberModal.tsx
+++ b/ui/components/CreateSubscriberModal.tsx
@@ -52,7 +52,10 @@ const schema = yup.object().shape({
         .required("Profile Name is required."),
     opc: yup
         .string()
-        .matches(/^[0-9a-fA-F]{32}$/, "Key must be a 32-character hexadecimal string.")
+        .matches(
+            /(^$)|(^[0-9a-fA-F]{32}$)/,
+            "OPC must be either empty or a 32-character hexadecimal string."
+        )
         .notRequired(),
 });
 


### PR DESCRIPTION
# Description

Allow empty opc in create subscriber modal

Fixes #535 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
