### PR TITLE
docs: add performance results from testing with ella core tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use Ella Core where you need 5G connectivity: in a factory, a warehouse, a farm,
 ## Key features
 
 - **5G compliant**: Deploy Ella Core with 5G radios and devices. Ella Core's interfaces follow 3GPP standards.
-- **Performant Data Plane**: Achieve high throughput and low latency with an eBPF-based data plane.
+- **Performant Data Plane**: Achieve high throughput and low latency with an eBPF-based data plane. Ella Core delivers over 3.5 Gbps of throughput and less than 2 ms of latency.
 - **Lightweight**: Ella Core is a single binary with an embedded database, making it easy and quick to stand up. It requires as little as 2 CPU cores, 2GB of RAM, and 10GB of disk space. Forget specialized hardware; all you need to operate your 5G core network is a Linux system with four network interfaces.
 - **Intuitive User Experience**: Manage subscribers, radios, profiles, and operator information through a user-friendly web interface. Automate network operations with a complete REST API.
 - **Real-Time Observability**: Access detailed metrics and dashboards to monitor network health through the UI and the Prometheus-compliant API.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Use Ella Core where you need 5G connectivity: in a factory, a warehouse, a farm,
 ## Key features
 
 - **5G Compliant**: Deploy Ella Core with 5G radios and devices. Ella Core's interfaces follow 3GPP standards.
-- **Performant Data Plane**: Achieve high throughput and low latency with an eBPF-based data plane.
+- **Performant Data Plane**: Achieve high throughput and low latency with an eBPF-based data plane. Ella Core delivers over 3.5 Gbps of throughput and less than 2 ms of latency.
 - **Lightweight**: Ella Core is a single binary with an embedded database, making it easy and quick to stand up. It requires as little as 2 CPU cores, 2GB of RAM, and 10GB of disk space. Forget specialized hardware; all you need to operate your 5G core network is a Linux system with four network interfaces.
 - **Intuitive User Experience**: Manage subscribers, radios, profiles, and operator information through a user-friendly web interface. Automate network operations with a complete REST API.
 - **Real-Time Observability**: Access detailed metrics and dashboards to monitor network health through the UI and the Prometheus-compliant API.

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -14,7 +14,7 @@ The following table outlines the performance test results of Ella Core's data pl
 
 | Uplink (Gbps) | Downlink (Gbps) |
 | ------------- | --------------- |
-| 3.51          | 1.67            |
+| 3.05          | 1.31            |
 
 ### Latency
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -12,11 +12,9 @@ This reference document contains performance test results of Ella Core, covering
 
 The following table outlines the performance test results of Ella Core's data plane throughput:
 
-| Streams | Uplink (Gbps) | Downlink (Gbps) |
-| ------- | ------------- | --------------- |
-| 1       | 1.20          | 1.00            |
-| 10      | 1.48          | 1.22            |
-| 100     | 1.54          | 1.25            |
+| Uplink (Gbps) | Downlink (Gbps) |
+| ------------- | --------------- |
+| 3.51          | 1.67            |
 
 ### Latency
 
@@ -24,9 +22,9 @@ The following table outlines the performance test results of Ella Core's data pl
 
 | Average (ms) | Best (ms) | Worst (ms) | Standard Deviation (ms) |
 | ------------ | --------- | ---------- | ----------------------- |
-| 1.4          | 0.8       | 4.0        | 0.6                     |
+| 1.702        | 0.903     | 2.338      | 0.269                   |
 
-The value represents the round-trip-response times.
+The value represents the round-trip-response times from the UE to the router and back.
 
 ## PDU Session Support
 
@@ -44,7 +42,7 @@ We performed performance tests on a system with the following specifications:
 - **RAM**: 64GB
 - **Disk**: 1TB NVMe SSD
 
-We used the same virtualized environment outlined in the [Running an End-to-End 5G Network with Ella Core](../tutorials/end_to_end_network.md) tutorial, with the iPerf3 server running on the router virtual machine, and the iPerf3 client running on the radio virtual machine.
+We used the same virtualized environment outlined in the [Running an End-to-End 5G Network with Ella Core](../tutorials/end_to_end_network.md) tutorial, with the iPerf3 server running on the router virtual machine, and the iPerf3 client running on the radio virtual machine. We used [Ella Core Tester](https://github.com/ellanetworks/core-tester) as the UE and gNB simulator.
 
 !!! note
     We performed the performance tests in a virtualized environment. The results will likely improve in a bare-metal environment.
@@ -58,13 +56,15 @@ Test parameters:
 - **Version**: v3.16
 - **Protocol**: TCP
 - **Duration**: 30 seconds
+- **Streams**: 1
+- **MTU (upstream)**: 1424 bytes
+- **MTU (downstream)**: 1416 bytes
+- **Runs (average over)**: 5 
 
 #### Latency testing
 
-We performed latency tests using [mtr](https://manpages.ubuntu.com/manpages/focal/man8/mtr.8.html).
+We performed latency tests using ping.
 
 Test parameters:
 
-- **Version**: v0.95
-- **Protocol**: TCP
-- **Report Cycles**: 60
+- **Count**: 30


### PR DESCRIPTION
# Description

Add performance results from testing with [ella core tester](https://github.com/ellanetworks/core-tester) and iperf3

**Note**: I was able to get higher performance results, often over 3.50 Gbps (upstream) but I wasn't able to reproduce it consistently. I used the more conservative results.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
