### PR TITLE
fix: only allow operator to be initialized once

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -18,6 +18,10 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
+const (
+	ReqsPerSec = 100 // Number of requests per second allowed per IP (Rate Limiting)
+)
+
 // interfaceDBKernelMap maps the interface string to the kernel.NetworkInterface enum.
 var interfaceDBKernelMap = map[db.NetworkInterface]kernel.NetworkInterface{
 	db.N3: kernel.N3,
@@ -49,7 +53,7 @@ func Start(dbInstance *db.Database, port int, scheme Scheme, certFile string, ke
 		return fmt.Errorf("couldn't generate jwt secret: %v", err)
 	}
 	kernelInt := kernel.NewRealKernel(n3Interface, n6Interface)
-	router := server.NewHandler(dbInstance, kernelInt, jwtSecret, server.ReleaseMode, tracingEnabled)
+	router := server.NewHandler(dbInstance, kernelInt, jwtSecret, ReqsPerSec, tracingEnabled)
 
 	// Start the HTTP server in a goroutine.
 	go func() {

--- a/internal/api/server/api_auth_test.go
+++ b/internal/api/server/api_auth_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ellanetworks/core/internal/api/server"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -88,7 +87,7 @@ func lookupToken(url string, client *http.Client, token string) (int, *LoookupTo
 func TestLoginEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, jwtSecret, err := setupServer(dbPath, server.TestMode)
+	ts, jwtSecret, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -217,7 +216,7 @@ func TestLoginEndToEnd(t *testing.T) {
 func TestRolesEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -369,7 +368,7 @@ func TestRolesEndToEnd(t *testing.T) {
 func TestLookupToken(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_backup_test.go
+++ b/internal/api/server/api_backup_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 func backup(url string, client *http.Client, token string) (int, []byte, error) {
@@ -36,7 +34,7 @@ func backup(url string, client *http.Client, token string) (int, []byte, error) 
 func TestBackupEndpoint(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/ellanetworks/core/internal/kernel"
 )
 
+const (
+	ReqsPerSec = 9999 // High number to avoid rate limiting in tests
+)
+
 var initialOperator = db.Operator{
 	Mcc:                   "001",
 	Mnc:                   "01",
@@ -48,14 +52,14 @@ func (fk FakeKernel) IsIPForwardingEnabled() (bool, error) {
 	return true, nil
 }
 
-func setupServer(filepath string, mode server.Mode) (*httptest.Server, []byte, error) {
+func setupServer(filepath string, reqsPerSec int) (*httptest.Server, []byte, error) {
 	testdb, err := db.NewDatabase(filepath, initialOperator)
 	if err != nil {
 		return nil, nil, err
 	}
 	jwtSecret := []byte("testsecret")
 	fakeKernel := FakeKernel{}
-	ts := httptest.NewTLSServer(server.NewHandler(testdb, fakeKernel, jwtSecret, mode, false))
+	ts := httptest.NewTLSServer(server.NewHandler(testdb, fakeKernel, jwtSecret, reqsPerSec, false))
 	return ts, jwtSecret, nil
 }
 

--- a/internal/api/server/api_operator_test.go
+++ b/internal/api/server/api_operator_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 const (
@@ -310,7 +308,7 @@ func updateOperatorCode(url string, client *http.Client, token string, data *Upd
 func TestApiOperatorEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -533,7 +531,7 @@ func TestApiOperatorEndToEnd(t *testing.T) {
 func TestUpdateOperatorSliceInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -599,7 +597,7 @@ func TestUpdateOperatorSliceInvalidInput(t *testing.T) {
 func TestUpdateOperatorTrackingInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -649,7 +647,7 @@ func TestUpdateOperatorTrackingInvalidInput(t *testing.T) {
 func TestUpdateOperatorIDInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -728,7 +726,7 @@ func TestUpdateOperatorIDInvalidInput(t *testing.T) {
 func TestUpdateOperatorCodeInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_profiles_test.go
+++ b/internal/api/server/api_profiles_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 const (
@@ -198,7 +196,7 @@ func deleteProfile(url string, client *http.Client, token, name string) (int, *D
 func TestAPIProfilesEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -430,7 +428,7 @@ func TestAPIProfilesEndToEnd(t *testing.T) {
 func TestCreateProfileInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_radios_test.go
+++ b/internal/api/server/api_radios_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	amfContext "github.com/ellanetworks/core/internal/amf/context"
-	"github.com/ellanetworks/core/internal/api/server"
 	"github.com/ellanetworks/core/internal/models"
 )
 
@@ -78,7 +77,7 @@ func listRadios(url string, client *http.Client, token string) (int, *ListRadios
 func TestListRadios(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_restore_test.go
+++ b/internal/api/server/api_restore_test.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 type RestoreResponseResult struct {
@@ -82,7 +80,7 @@ func TestRestoreEndpoint(t *testing.T) {
 		t.Fatalf("failed to create dummy backup file: %s", err)
 	}
 
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_routes_test.go
+++ b/internal/api/server/api_routes_test.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 const (
@@ -161,7 +159,7 @@ func deleteRoute(url string, client *http.Client, token string, id int64) (int, 
 func TestAPIRoutesEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -310,7 +308,7 @@ func TestAPIRoutesEndToEnd(t *testing.T) {
 func TestCreateRouteInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_status_test.go
+++ b/internal/api/server/api_status_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 type GetStatusResponseResult struct {
@@ -46,7 +44,7 @@ func getStatus(url string, client *http.Client) (int, *GetStatusResponse, error)
 func TestStatusEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 const (
@@ -164,7 +162,7 @@ func deleteSubscriber(url string, client *http.Client, token string, imsi string
 func TestSubscribersApiEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -360,7 +358,7 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 func TestCreateSubscriberInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/api_users_test.go
+++ b/internal/api/server/api_users_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 const (
@@ -234,7 +232,7 @@ func deleteUser(url string, client *http.Client, token string, name string) (int
 func TestAPIUsersEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -404,7 +402,7 @@ func TestAPIUsersEndToEnd(t *testing.T) {
 func TestCreateUserInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/benchmark_test.go
+++ b/internal/api/server/benchmark_test.go
@@ -4,14 +4,12 @@ import (
 	"net/http"
 	"path/filepath"
 	"testing"
-
-	"github.com/ellanetworks/core/internal/api/server"
 )
 
 func BenchmarkLoginHandler(b *testing.B) {
 	tempDir := b.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.TestMode)
+	ts, _, err := setupServer(dbPath, ReqsPerSec)
 	if err != nil {
 		b.Fatalf("couldn't create test server: %s", err)
 	}

--- a/internal/api/server/rate_limiter_middleware.go
+++ b/internal/api/server/rate_limiter_middleware.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	NumRequests     = 100
+	NumRequests     = 200
 	RequestsPerTime = time.Second
 )
 
@@ -32,8 +32,7 @@ func getVisitor(ip string) *rate.Limiter {
 
 	v, exists := visitors[ip]
 	if !exists {
-		every := rate.Every(RequestsPerTime)
-		limiter := rate.NewLimiter(every, NumRequests)
+		limiter := rate.NewLimiter(rate.Limit(NumRequests), NumRequests)
 		visitors[ip] = &Visitor{limiter: limiter, lastSeen: time.Now()}
 		return limiter
 	}

--- a/internal/api/server/rate_limiter_middleware.go
+++ b/internal/api/server/rate_limiter_middleware.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	NumRequests     = 100
 	RequestsPerTime = time.Second
 )
 
@@ -26,13 +25,13 @@ var (
 )
 
 // getVisitor retrieves the rate limiter for a given IP, or creates a new one if none exists.
-func getVisitor(ip string) *rate.Limiter {
+func getVisitor(ip string, reqsPerSec int) *rate.Limiter {
 	mu.Lock()
 	defer mu.Unlock()
 
 	v, exists := visitors[ip]
 	if !exists {
-		limiter := rate.NewLimiter(rate.Limit(NumRequests), NumRequests)
+		limiter := rate.NewLimiter(rate.Limit(reqsPerSec), reqsPerSec)
 		visitors[ip] = &Visitor{limiter: limiter, lastSeen: time.Now()}
 		return limiter
 	}
@@ -55,10 +54,10 @@ func cleanupVisitors() {
 }
 
 // RateLimitMiddleware is a Gin middleware that rate limits incoming requests based on the client IP.
-func RateLimitMiddleware(next http.Handler) http.Handler {
+func RateLimitMiddleware(next http.Handler, reqsPerSec int) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := getClientIP(r)
-		limiter := getVisitor(ip)
+		limiter := getVisitor(ip, reqsPerSec)
 		if !limiter.Allow() {
 			writeError(w, http.StatusTooManyRequests, "Rate limit exceeded", fmt.Errorf("rate limit exceeded for IP %s", ip), logger.APILog)
 			return

--- a/internal/api/server/rate_limiter_middleware.go
+++ b/internal/api/server/rate_limiter_middleware.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	NumRequests     = 200
+	NumRequests     = 100
 	RequestsPerTime = time.Second
 )
 

--- a/internal/api/server/rate_limiter_middleware_test.go
+++ b/internal/api/server/rate_limiter_middleware_test.go
@@ -36,7 +36,7 @@ func TestRateLimiterMiddleware(t *testing.T) {
 	var rateLimitCount int32
 
 	// Fire many concurrent requests.
-	totalRequests := 200
+	totalRequests := 300
 	wg.Add(totalRequests)
 	for i := 0; i < totalRequests; i++ {
 		go func() {
@@ -61,8 +61,8 @@ func TestRateLimiterMiddleware(t *testing.T) {
 	}
 	wg.Wait()
 
-	if successCount < 100 {
-		t.Fatalf("expected at least 100 successful logins, got %d", successCount)
+	if successCount < 200 {
+		t.Fatalf("expected at least 200 successful logins, got %d", successCount)
 	}
 	if rateLimitCount == 0 {
 		t.Fatalf("expected at least one rate limited response, got %d", rateLimitCount)

--- a/internal/api/server/rate_limiter_middleware_test.go
+++ b/internal/api/server/rate_limiter_middleware_test.go
@@ -10,10 +10,14 @@ import (
 	"github.com/ellanetworks/core/internal/api/server"
 )
 
+const (
+	NumRequests = 5 // Number of requests per second allowed per IP (Rate Limiting
+)
+
 func TestRateLimiterMiddleware(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath, server.ReleaseMode)
+	ts, _, err := setupServer(dbPath, NumRequests)
 	if err != nil {
 		t.Fatalf("couldn't create test server: %s", err)
 	}
@@ -36,7 +40,7 @@ func TestRateLimiterMiddleware(t *testing.T) {
 	var rateLimitCount int32
 
 	// Fire many concurrent requests.
-	totalRequests := 300
+	totalRequests := 100
 	wg.Add(totalRequests)
 	for i := 0; i < totalRequests; i++ {
 		go func() {
@@ -61,8 +65,8 @@ func TestRateLimiterMiddleware(t *testing.T) {
 	}
 	wg.Wait()
 
-	if successCount < 100 {
-		t.Fatalf("expected at least 100 successful logins, got %d", successCount)
+	if successCount < 5 {
+		t.Fatalf("expected at least 5 successful logins, got %d", successCount)
 	}
 	if rateLimitCount == 0 {
 		t.Fatalf("expected at least one rate limited response, got %d", rateLimitCount)

--- a/internal/api/server/rate_limiter_middleware_test.go
+++ b/internal/api/server/rate_limiter_middleware_test.go
@@ -61,8 +61,8 @@ func TestRateLimiterMiddleware(t *testing.T) {
 	}
 	wg.Wait()
 
-	if successCount < 200 {
-		t.Fatalf("expected at least 200 successful logins, got %d", successCount)
+	if successCount < 100 {
+		t.Fatalf("expected at least 100 successful logins, got %d", successCount)
 	}
 	if rateLimitCount == 0 {
 		t.Fatalf("expected at least one rate limited response, got %d", rateLimitCount)

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -9,14 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type Mode string
-
-const (
-	TestMode    Mode = "test"
-	ReleaseMode Mode = "release"
-)
-
-func NewHandler(dbInstance *db.Database, kernel kernel.Kernel, jwtSecret []byte, mode Mode, tracingEnabled bool) http.Handler {
+func NewHandler(dbInstance *db.Database, kernel kernel.Kernel, jwtSecret []byte, reqsPerSec int, tracingEnabled bool) http.Handler {
 	mux := http.NewServeMux()
 
 	// Status (Unauthenticated)
@@ -90,9 +83,7 @@ func NewHandler(dbInstance *db.Database, kernel kernel.Kernel, jwtSecret []byte,
 	if tracingEnabled {
 		handler = TracingMiddleware("ella-core/api", handler)
 	}
-	if mode != TestMode {
-		handler = RateLimitMiddleware(handler)
-	}
+	handler = RateLimitMiddleware(handler, reqsPerSec)
 
 	return handler
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -81,8 +81,10 @@ func NewDatabase(databasePath string, initialOperator Operator) (*Database, erro
 	db.operatorTable = OperatorTableName
 	db.usersTable = UsersTableName
 
-	if err := db.InitializeOperator(context.Background(), initialOperator); err != nil {
-		return nil, fmt.Errorf("failed to initialize network configuration: %v", err)
+	if !db.IsOperatorInitialized() {
+		if err := db.InitializeOperator(context.Background(), initialOperator); err != nil {
+			return nil, fmt.Errorf("failed to initialize network configuration: %v", err)
+		}
 	}
 
 	logger.DBLog.Info("Database Initialized")

--- a/internal/smf/context/upf.go
+++ b/internal/smf/context/upf.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/util/idgenerator"
-	"github.com/google/uuid"
 	"github.com/omec-project/nas/nasMessage"
 )
 
@@ -47,7 +46,6 @@ type UPF struct {
 	qerIDGenerator *idgenerator.IDGenerator
 
 	NodeID NodeID
-	uuid   uuid.UUID
 
 	// lock
 	UpfLock sync.RWMutex
@@ -70,7 +68,6 @@ func (i *UPFInterfaceInfo) IP(pduSessType uint8) (net.IP, error) {
 
 func NewUPF(nodeID *NodeID, dnn string) (upf *UPF) {
 	upf = new(UPF)
-	upf.uuid = uuid.New()
 	upf.NodeID = *nodeID
 	upf.pdrIDGenerator = idgenerator.NewGenerator(1, math.MaxUint16)
 	upf.farIDGenerator = idgenerator.NewGenerator(1, math.MaxUint32)

--- a/internal/smf/qos/qos_rule_test.go
+++ b/internal/smf/qos/qos_rule_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ellanetworks/core/internal/smf/qos"
 )
 
+// This test is flaky because the order of rules from BuildQosRules is not guaranteed since it uses maps.
 func TestBuildQosRules(t *testing.T) {
 	// make SM Policy Decision
 	smPolicyDecision := &models.SmPolicyDecision{}


### PR DESCRIPTION
# Description

This PR includes these 2 fixes:
- Only allow operator to be initialized once
- Allow 100 requests per second in rate-limiter

Fixes #590 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
