### PR TITLE
chore: add workflow permission to ui-lint

### DIFF
--- a/.github/workflows/ui-lint.yaml
+++ b/.github/workflows/ui-lint.yaml
@@ -3,6 +3,9 @@ name: UI Lint
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   ui-lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/ellanetworks/core/security/code-scanning/82](https://github.com/ellanetworks/core/security/code-scanning/82)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the least privilege required for the workflow. Since the workflow only performs linting and formatting checks, it does not require write permissions. The `contents: read` permission is sufficient.

The `permissions` block should be added at the root level of the workflow file, ensuring it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
