### PR TITLE
chore: use bare container base

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,5 +1,5 @@
 name: ella-core
-base: ubuntu@24.04
+base: bare
 build-base: ubuntu@24.04
 adopt-info: core-release-data
 summary: Ella Core is a secure, reliable, and easy to operate mobile network.

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -24,6 +24,8 @@ parts:
     build-snaps:
       - go/1.24/stable
       - node/22/stable
+    stage-packages:
+      - libc6_libs
     override-build: |
       npm install --prefix ui
       npm run build --prefix ui


### PR DESCRIPTION
# Description

Replace the `ubuntu@24.04` base with `bare` alongside the chiseled libc6. This change brings the container image size from 138MB to 83.1MB, a 40% reduction! This image reduction makes the installation process faster and reduces the attack surface. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
