### PR TITLE
feat: improve card layout in operator and backup pages [ui]

### DIFF
--- a/ui/app/(core)/backup-restore/page.tsx
+++ b/ui/app/(core)/backup-restore/page.tsx
@@ -1,11 +1,28 @@
 "use client";
 import React, { useState } from "react";
-import { Box, Typography, Button, Alert, Collapse } from "@mui/material";
+import {
+  Box,
+  Typography,
+  Button,
+  Alert,
+  Collapse,
+  Card,
+  CardHeader,
+  CardContent,
+} from "@mui/material";
 import { backup, restore } from "@/queries/backup";
 import { useCookies } from "react-cookie";
 import Grid from "@mui/material/Grid";
 
 const MAX_WIDTH = 1400;
+
+const headerStyles = {
+  backgroundColor: "#F5F5F5",
+  color: "#000000ff",
+  borderTopLeftRadius: 12,
+  borderTopRightRadius: 12,
+  "& .MuiCardHeader-title": { color: "#000000ff" },
+};
 
 const BackupRestore = () => {
   const [cookies] = useCookies(["user_token"]);
@@ -14,7 +31,7 @@ const BackupRestore = () => {
     severity: "success" | "error" | null;
   }>({ message: "", severity: null });
 
-  const descriptionText =
+  const pageDescription =
     "Create and download a full backup of Ella Core, or restore from a .backup file. Take regular backups to ensure you can recover your data in case of a hardware failure or data loss.";
 
   const handleCreate = async () => {
@@ -105,65 +122,91 @@ const BackupRestore = () => {
       >
         <Typography variant="h4">Backup & Restore</Typography>
         <Typography variant="body1" color="text.secondary">
-          {descriptionText}
+          {pageDescription}
         </Typography>
       </Box>
 
       <Box sx={{ width: "100%", maxWidth: MAX_WIDTH, px: { xs: 2, sm: 4 } }}>
         <Grid container spacing={4} justifyContent="flex-start">
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Box
+            <Card
               sx={{
-                border: "1px solid",
-                borderColor: "divider",
-                borderRadius: 2,
-                p: 3,
-                textAlign: "center",
                 height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                borderRadius: 3, // 12px
+                boxShadow: 2,
               }}
             >
-              <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
-                Create a Backup
-              </Typography>
-              <Button
-                variant="contained"
-                color="success"
-                onClick={handleCreate}
-                sx={{ px: 3 }}
+              <CardHeader title="Create a Backup" sx={headerStyles} />
+              <CardContent
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 1.5,
+                  flexGrow: 1,
+                }}
               >
-                Create
-              </Button>
-            </Box>
+                <Typography variant="body2" color="text.secondary">
+                  Generate and download a snapshot of your Ella Core
+                  configuration and data. You can then use this file to restore
+                  your system if needed.
+                </Typography>
+
+                <Box sx={{ flexGrow: 1 }} />
+                <Box sx={{ display: "flex", justifyContent: "center" }}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleCreate}
+                  >
+                    Create Backup
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
           </Grid>
+
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Box
+            <Card
               sx={{
-                border: "1px solid",
-                borderColor: "divider",
-                borderRadius: 2,
-                p: 3,
-                textAlign: "center",
                 height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                borderRadius: 3,
+                boxShadow: 2,
               }}
             >
-              <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
-                Restore a Backup
-              </Typography>
-              <Button
-                variant="contained"
-                component="label"
-                color="success"
-                sx={{ px: 3 }}
+              <CardHeader title="Restore a Backup" sx={headerStyles} />
+              <CardContent
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 1.5,
+                  flexGrow: 1,
+                }}
               >
-                Upload File
-                <input
-                  type="file"
-                  hidden
-                  accept=".backup"
-                  onChange={handleRestore}
-                />
-              </Button>
-            </Box>
+                <Typography variant="body2" color="text.secondary">
+                  Upload a previously created backup file to restore Ella Core
+                  to a previous state. Be aware that this action will overwrite
+                  your current configuration and data.
+                </Typography>
+
+                <Box sx={{ flexGrow: 1 }} />
+
+                <Box sx={{ display: "flex", justifyContent: "center" }}>
+                  <Button variant="contained" component="label" color="primary">
+                    Upload File
+                    <input
+                      type="file"
+                      hidden
+                      accept=".backup"
+                      onChange={handleRestore}
+                    />
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
           </Grid>
         </Grid>
       </Box>

--- a/ui/app/(core)/data-networks/page.tsx
+++ b/ui/app/(core)/data-networks/page.tsx
@@ -106,7 +106,7 @@ const DataNetworkPage = () => {
   };
 
   const descriptionText =
-    "Manage the IP networks used by your subscribers. Data Network Names (DNNs) are used to identify different networks, and each network can have its own IP pool, DNS settings, and MTU size. The DNN must be configured on the subscriber device to connect to the correct network.";
+    "Manage the IP networks used by your subscribers. Data Network Names (DNNs) are used to identify different networks, and must be configured on the subscriber device to connect to the correct network.";
 
   return (
     <Box

--- a/ui/app/(core)/operator/page.tsx
+++ b/ui/app/(core)/operator/page.tsx
@@ -137,6 +137,15 @@ const Operator = () => {
     }
   };
 
+  const headerStyles = {
+    backgroundColor: "#F5F5F5",
+    color: "#000000ff",
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    "& .MuiCardHeader-title": { color: "#000000ff" },
+    "& .MuiIconButton-root": { color: "#000000ff" },
+  };
+
   const descriptionText =
     "Review and configure your operator identifiers and core settings.";
 
@@ -175,11 +184,11 @@ const Operator = () => {
               flexDirection: "column",
               borderRadius: 3,
               boxShadow: 2,
-              p: 1,
             }}
           >
             <CardHeader
               title="Operator ID"
+              sx={headerStyles}
               action={
                 canEdit && (
                   <IconButton
@@ -226,11 +235,11 @@ const Operator = () => {
               flexDirection: "column",
               borderRadius: 3,
               boxShadow: 2,
-              p: 1,
             }}
           >
             <CardHeader
               title="Operator Code"
+              sx={headerStyles}
               action={
                 canEdit && (
                   <IconButton
@@ -265,11 +274,11 @@ const Operator = () => {
               flexDirection: "column",
               borderRadius: 3,
               boxShadow: 2,
-              p: 1,
             }}
           >
             <CardHeader
               title="Tracking Information"
+              sx={headerStyles}
               action={
                 canEdit && (
                   <IconButton
@@ -311,11 +320,11 @@ const Operator = () => {
               flexDirection: "column",
               borderRadius: 3,
               boxShadow: 2,
-              p: 1,
             }}
           >
             <CardHeader
               title="Slice Information"
+              sx={headerStyles}
               action={
                 canEdit && (
                   <IconButton
@@ -362,11 +371,11 @@ const Operator = () => {
               flexDirection: "column",
               borderRadius: 3,
               boxShadow: 2,
-              p: 1,
             }}
           >
             <CardHeader
               title="Home Network Information"
+              sx={headerStyles}
               action={
                 canEdit && (
                   <IconButton


### PR DESCRIPTION
# Description

Improve card layout in:
- Operator page
- Backup & Restore page

## Screenshots

<img width="2523" height="1060" alt="image" src="https://github.com/user-attachments/assets/62970882-2265-4a22-9d97-23f00057306f" />

<img width="2523" height="1060" alt="image" src="https://github.com/user-attachments/assets/ab4f4320-2a19-4d44-9667-a9cccccf27d7" />


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
