### PR TITLE
chore: set max number of resources

### DIFF
--- a/client/logs_test.go
+++ b/client/logs_test.go
@@ -1,0 +1,165 @@
+package client_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+func TestListAuditLogs_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`[{"id": 1, "timestamp": "2023-10-01T12:00:00Z", "level": "info", "actor": "admin@ellanetworks.com", "action": "login", "ip": "1.2.3.4", "details": "User logged in"}]`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	auditLogs, err := clientObj.ListAuditLogs()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(auditLogs) != 1 {
+		t.Fatalf("expected 1 audit log, got %d", len(auditLogs))
+	}
+
+	if auditLogs[0].ID != 1 {
+		t.Fatalf("expected audit log ID 1, got %d", auditLogs[0].ID)
+	}
+
+	if auditLogs[0].Timestamp != "2023-10-01T12:00:00Z" {
+		t.Fatalf("expected timestamp '2023-10-01T12:00:00Z', got '%s'", auditLogs[0].Timestamp)
+	}
+
+	if auditLogs[0].Level != "info" {
+		t.Fatalf("expected level 'info', got '%s'", auditLogs[0].Level)
+	}
+
+	if auditLogs[0].Actor != "admin@ellanetworks.com" {
+		t.Fatalf("expected actor 'admin@ellanetworks.com', got '%s'", auditLogs[0].Actor)
+	}
+
+	if auditLogs[0].Action != "login" {
+		t.Fatalf("expected action 'login', got '%s'", auditLogs[0].Action)
+	}
+
+	if auditLogs[0].IP != "1.2.3.4" {
+		t.Fatalf("expected IP '1.2.3.4', got '%s'", auditLogs[0].IP)
+	}
+
+	if auditLogs[0].Details != "User logged in" {
+		t.Fatalf("expected details 'User logged in', got '%s'", auditLogs[0].Details)
+	}
+}
+
+func TestListAuditLogs_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 500,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Internal server error"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	_, err := clientObj.ListAuditLogs()
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestGetAuditLogRetentionPolicy_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"days": 30}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	policy, err := clientObj.GetAuditLogRetentionPolicy()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if policy.Days != 30 {
+		t.Fatalf("expected retention days 30, got %d", policy.Days)
+	}
+}
+
+func TestGetAuditLogRetentionPolicy_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 500,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Internal server error"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	_, err := clientObj.GetAuditLogRetentionPolicy()
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestUpdateAuditLogRetentionPolicy_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Audit log retention policy updated successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	updateOpts := &client.UpdateAuditLogsRetentionPolicyOptions{
+		Days: 60,
+	}
+	err := clientObj.UpdateAuditLogRetentionPolicy(updateOpts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestUpdateAuditLogRetentionPolicy_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 400,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Invalid request body"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	updateOpts := &client.UpdateAuditLogsRetentionPolicyOptions{
+		Days: -10,
+	}
+	err := clientObj.UpdateAuditLogRetentionPolicy(updateOpts)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}

--- a/internal/api/server/api_operator.go
+++ b/internal/api/server/api_operator.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	MaxSupportedTACs = 12
+)
+
 type UpdateOperatorSliceParams struct {
 	Sst int `json:"sst,omitempty"`
 	Sd  int `json:"sd,omitempty"`
@@ -308,8 +312,14 @@ func UpdateOperatorTracking(dbInstance *db.Database) http.Handler {
 			writeError(w, http.StatusBadRequest, "Invalid request data", err, logger.APILog)
 			return
 		}
+
 		if len(params.SupportedTacs) == 0 {
 			writeError(w, http.StatusBadRequest, "supportedTacs is missing", nil, logger.APILog)
+			return
+		}
+
+		if len(params.SupportedTacs) > MaxSupportedTACs {
+			writeError(w, http.StatusBadRequest, "Too many supported TACs. Maximum is "+strconv.Itoa(MaxSupportedTACs), nil, logger.APILog)
 			return
 		}
 

--- a/internal/api/server/api_operator_test.go
+++ b/internal/api/server/api_operator_test.go
@@ -624,6 +624,14 @@ func TestUpdateOperatorTrackingInvalidInput(t *testing.T) {
 			supportedTacs: []string{"00"},
 			error:         "Invalid TAC format. Must be a 3-digit number",
 		},
+		{
+			testName: "Too many TACs",
+			supportedTacs: []string{
+				"001", "002", "003", "004", "005", "006", "007", "008",
+				"009", "010", "011", "012", "013", "014", "015", "016",
+			},
+			error: "Too many supported TACs. Maximum is 12",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/internal/api/server/api_policies.go
+++ b/internal/api/server/api_policies.go
@@ -37,6 +37,10 @@ const (
 	DeletePolicyAction = "delete_policy"
 )
 
+const (
+	MaxNumPolicies = 12
+)
+
 func isPolicyNameValid(name string) bool {
 	return len(name) > 0 && len(name) < 256
 }
@@ -180,6 +184,17 @@ func CreatePolicy(dbInstance *db.Database) http.Handler {
 
 		if _, err := dbInstance.GetPolicy(r.Context(), createPolicyParams.Name); err == nil {
 			writeError(w, http.StatusBadRequest, "Policy already exists", nil, logger.APILog)
+			return
+		}
+
+		numPolicies, err := dbInstance.NumPolicies(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to retrieve policies", err, logger.APILog)
+			return
+		}
+
+		if numPolicies >= MaxNumPolicies {
+			writeError(w, http.StatusBadRequest, "Maximum number of policies reached ("+strconv.Itoa(MaxNumPolicies)+")", nil, logger.APILog)
 			return
 		}
 

--- a/internal/api/server/api_users.go
+++ b/internal/api/server/api_users.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/mail"
+	"strconv"
 	"strings"
 
 	"github.com/ellanetworks/core/internal/db"
@@ -40,6 +41,10 @@ const (
 	UpdateUserAction         = "update_user"
 	DeleteUserAction         = "delete_user"
 	UpdateUserPasswordAction = "update_user_password"
+)
+
+const (
+	MaxNumUsers = 50
 )
 
 func isValidEmail(email string) bool {
@@ -172,6 +177,11 @@ func CreateUser(dbInstance *db.Database) http.Handler {
 				writeError(w, http.StatusBadRequest, "First user must be an admin", errors.New("first user must be admin"), logger.APILog)
 				return
 			}
+		}
+
+		if numUsers >= MaxNumUsers {
+			writeError(w, http.StatusBadRequest, "Maximum number of users reached ("+strconv.Itoa(MaxNumUsers)+")", nil, logger.APILog)
+			return
 		}
 
 		dbUser := &db.User{


### PR DESCRIPTION
# Description

We set max number of resources for each user-created resources. For security reasons, we want to avoid the possibility of creating an unmanageable number of resources. Here we set what I think is reasonable for most private networks. If these limits turn out to be too low, we can always increase them later. But having no limits is risky.
- Subscribers: 1000
- Data Networks: 12
- Policies: 12
- Users: 50
- Supported TACs: 12
- Routes: 12

We also add log management to go client.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
