### PR TITLE
feat: add free chip in header and copyright footer [ui]

### DIFF
--- a/ui/components/DrawerLayout.tsx
+++ b/ui/components/DrawerLayout.tsx
@@ -44,6 +44,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 import IconButton from "@mui/material/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
+import Footer from "@/components/Footer";
 
 const drawerWidth = 250;
 
@@ -129,10 +130,13 @@ export default function DrawerLayout({
             Ella Core
           </Typography>
           <Chip
-            label={role}
-            color={"warning"}
-            variant="outlined"
-            sx={{ ml: 2 }}
+            label={"free"}
+            variant="filled"
+            sx={{
+              ml: 2,
+              color: "text.primary",
+              backgroundColor: "#F5F5F5",
+            }}
           />
         </Toolbar>
       </AppBar>
@@ -371,12 +375,16 @@ export default function DrawerLayout({
         component="main"
         sx={{
           flexGrow: 1,
-          p: 3,
           ml: isMobile ? 0 : `${drawerWidth}px`,
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          p: 3,
         }}
       >
         <Toolbar />
-        {children}
+        <Box sx={{ flexGrow: 1 }}>{children}</Box>
+        <Footer />
       </Box>
     </Box>
   );

--- a/ui/components/Footer.tsx
+++ b/ui/components/Footer.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Box, Container, Typography } from "@mui/material";
+
+export default function Footer() {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        mt: "auto",
+        borderTop: 1,
+        borderColor: "divider",
+        py: 2,
+        bgcolor: "background.paper",
+      }}
+    >
+      <Container maxWidth="lg">
+        <Typography variant="body2" color="text.secondary">
+          © 2025 Ella Networks Inc.
+        </Typography>
+      </Container>
+    </Box>
+  );
+}


### PR DESCRIPTION
# Description

- Add `free` chip in header
- Add a footer with the copyright information. Later we will add link to website and possibly other resources.

## Screenshots

<img width="2475" height="804" alt="image" src="https://github.com/user-attachments/assets/1cba73b6-7ed9-43cb-bbb5-84fa6db98953" />

<img width="2475" height="804" alt="image" src="https://github.com/user-attachments/assets/f16bb59c-e92a-4f30-b477-f5ee73031b63" />

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
