### PR TITLE
feat: auto-refresh subscriber and data network status [ui]

### DIFF
--- a/ui/app/(core)/backup-restore/page.tsx
+++ b/ui/app/(core)/backup-restore/page.tsx
@@ -94,7 +94,6 @@ const BackupRestore = () => {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        minHeight: "100vh",
       }}
     >
       <Box sx={{ width: "100%", maxWidth: MAX_WIDTH, px: { xs: 2, sm: 4 } }}>


### PR DESCRIPTION
# Description

Auto refresh status so that users don't have to refresh the page to see that a subscriber went from Inactive to Active or vice-versa.

- [x] Auto-refresh subscriber page
- [x] Auto-refresh data network page
- [x] Adapt footer in backup/restore page to not require scrolling

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
