### PR TITLE
fix: open empty create modals

### DIFF
--- a/ui/app/(core)/audit-logs/page.tsx
+++ b/ui/app/(core)/audit-logs/page.tsx
@@ -227,13 +227,15 @@ const AuditLog = () => {
         initialData={retentionPolicy || { days: 30 }}
       />
 
-      <DeleteConfirmationModal
-        open={isConfirmationOpen}
-        onClose={() => setConfirmationOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirm Deletion"
-        description={`Are you sure you want to delete all audit logs? This action cannot be undone.`}
-      />
+      {isConfirmationOpen && (
+        <DeleteConfirmationModal
+          open
+          onClose={() => setConfirmationOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          title="Confirm Deletion"
+          description={`Are you sure you want to delete all audit logs? This action cannot be undone.`}
+        />
+      )}
     </Box>
   );
 };

--- a/ui/app/(core)/data-networks/page.tsx
+++ b/ui/app/(core)/data-networks/page.tsx
@@ -248,32 +248,37 @@ const DataNetworkPage = () => {
           </Box>
         </>
       )}
-
-      <CreateDataNetworkModal
-        open={isCreateModalOpen}
-        onClose={handleCloseCreateModal}
-        onSuccess={refetch}
-      />
-      <EditDataNetworkModal
-        open={isEditModalOpen}
-        onClose={() => setEditModalOpen(false)}
-        onSuccess={refetch}
-        initialData={
-          editData || {
-            name: "",
-            ipPool: "",
-            dns: "",
-            mtu: 1500,
+      {isCreateModalOpen && (
+        <CreateDataNetworkModal
+          open
+          onClose={handleCloseCreateModal}
+          onSuccess={refetch}
+        />
+      )}
+      {isEditModalOpen && (
+        <EditDataNetworkModal
+          open
+          onClose={() => setEditModalOpen(false)}
+          onSuccess={refetch}
+          initialData={
+            editData || {
+              name: "",
+              ipPool: "",
+              dns: "",
+              mtu: 1500,
+            }
           }
-        }
-      />
-      <DeleteConfirmationModal
-        open={isConfirmationOpen}
-        onClose={() => setConfirmationOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirm Deletion"
-        description={`Are you sure you want to delete the data network "${selectedDataNetwork}"? This action cannot be undone.`}
-      />
+        />
+      )}
+      {isConfirmationOpen && (
+        <DeleteConfirmationModal
+          open
+          onClose={() => setConfirmationOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          title="Confirm Deletion"
+          description={`Are you sure you want to delete the data network "${selectedDataNetwork}"? This action cannot be undone.`}
+        />
+      )}
     </Box>
   );
 };

--- a/ui/app/(core)/operator/page.tsx
+++ b/ui/app/(core)/operator/page.tsx
@@ -442,34 +442,44 @@ const Operator = () => {
         </Grid>
       </Grid>
 
-      <EditOperatorIdModal
-        open={isEditOperatorIdModalOpen}
-        onClose={handleEditOperatorIdModalClose}
-        onSuccess={handleEditOperatorIdSuccess}
-        initialData={operator?.id || { mcc: "", mnc: "" }}
-      />
-      <EditOperatorCodeModal
-        open={isEditOperatorCodeModalOpen}
-        onClose={handleEditOperatorCodeModalClose}
-        onSuccess={handleEditOperatorCodeSuccess}
-      />
-      <EditOperatorTrackingModal
-        open={isEditOperatorTrackingModalOpen}
-        onClose={handleEditOperatorTrackingModalClose}
-        onSuccess={handleEditOperatorTrackingSuccess}
-        initialData={operator?.tracking || { supportedTacs: [""] }}
-      />
-      <EditOperatorSliceModal
-        open={isEditOperatorSliceModalOpen}
-        onClose={handleEditOperatorSliceModalClose}
-        onSuccess={handleEditOperatorSliceSuccess}
-        initialData={operator?.slice || { sst: 0, sd: 0 }}
-      />
-      <EditOperatorHomeNetworkModal
-        open={isEditOperatorHomeNetworkModalOpen}
-        onClose={handleEditOperatorHomeNetworkModalClose}
-        onSuccess={handleEditOperatorHomeNetworkSuccess}
-      />
+      {isEditOperatorIdModalOpen && (
+        <EditOperatorIdModal
+          open
+          onClose={handleEditOperatorIdModalClose}
+          onSuccess={handleEditOperatorIdSuccess}
+          initialData={operator?.id || { mcc: "", mnc: "" }}
+        />
+      )}
+      {isEditOperatorCodeModalOpen && (
+        <EditOperatorCodeModal
+          open
+          onClose={handleEditOperatorCodeModalClose}
+          onSuccess={handleEditOperatorCodeSuccess}
+        />
+      )}
+      {isEditOperatorTrackingModalOpen && (
+        <EditOperatorTrackingModal
+          open
+          onClose={handleEditOperatorTrackingModalClose}
+          onSuccess={handleEditOperatorTrackingSuccess}
+          initialData={operator?.tracking || { supportedTacs: [""] }}
+        />
+      )}
+      {isEditOperatorSliceModalOpen && (
+        <EditOperatorSliceModal
+          open
+          onClose={handleEditOperatorSliceModalClose}
+          onSuccess={handleEditOperatorSliceSuccess}
+          initialData={operator?.slice || { sst: 0, sd: 0 }}
+        />
+      )}
+      {isEditOperatorHomeNetworkModalOpen && (
+        <EditOperatorHomeNetworkModal
+          open
+          onClose={handleEditOperatorHomeNetworkModalClose}
+          onSuccess={handleEditOperatorHomeNetworkSuccess}
+        />
+      )}
     </Box>
   );
 };

--- a/ui/app/(core)/policies/page.tsx
+++ b/ui/app/(core)/policies/page.tsx
@@ -235,33 +235,39 @@ const PolicyPage = () => {
         </>
       )}
 
-      <CreatePolicyModal
-        open={isCreateModalOpen}
-        onClose={() => setCreateModalOpen(false)}
-        onSuccess={fetchPolicies}
-      />
-      <EditPolicyModal
-        open={isEditModalOpen}
-        onClose={() => setEditModalOpen(false)}
-        onSuccess={fetchPolicies}
-        initialData={
-          editData || {
-            name: "",
-            bitrateUp: "100 Mbps",
-            bitrateDown: "100 Mbps",
-            fiveQi: 1,
-            priorityLevel: 1,
-            dataNetworkName: "",
+      {isCreateModalOpen && (
+        <CreatePolicyModal
+          open
+          onClose={() => setCreateModalOpen(false)}
+          onSuccess={fetchPolicies}
+        />
+      )}
+      {isEditModalOpen && (
+        <EditPolicyModal
+          open
+          onClose={() => setEditModalOpen(false)}
+          onSuccess={fetchPolicies}
+          initialData={
+            editData || {
+              name: "",
+              bitrateUp: "100 Mbps",
+              bitrateDown: "100 Mbps",
+              fiveQi: 1,
+              priorityLevel: 1,
+              dataNetworkName: "",
+            }
           }
-        }
-      />
-      <DeleteConfirmationModal
-        open={isConfirmationOpen}
-        onClose={() => setConfirmationOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirm Deletion"
-        description={`Are you sure you want to delete the policy "${selectedPolicy}"? This action cannot be undone.`}
-      />
+        />
+      )}
+      {isConfirmationOpen && (
+        <DeleteConfirmationModal
+          open
+          onClose={() => setConfirmationOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          title="Confirm Deletion"
+          description={`Are you sure you want to delete the policy "${selectedPolicy}"? This action cannot be undone.`}
+        />
+      )}
     </Box>
   );
 };

--- a/ui/app/(core)/routes/page.tsx
+++ b/ui/app/(core)/routes/page.tsx
@@ -231,19 +231,22 @@ const RoutePage = () => {
           </Box>
         </>
       )}
-
-      <CreateRouteModal
-        open={isCreateModalOpen}
-        onClose={() => setCreateModalOpen(false)}
-        onSuccess={fetchRoutes}
-      />
-      <DeleteConfirmationModal
-        open={isConfirmationOpen}
-        onClose={() => setConfirmationOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirm Deletion"
-        description={`Are you sure you want to delete the route "${selectedRoute}"? This action cannot be undone.`}
-      />
+      {isCreateModalOpen && (
+        <CreateRouteModal
+          open
+          onClose={() => setCreateModalOpen(false)}
+          onSuccess={fetchRoutes}
+        />
+      )}
+      {isConfirmationOpen && (
+        <DeleteConfirmationModal
+          open
+          onClose={() => setConfirmationOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          title="Confirm Deletion"
+          description={`Are you sure you want to delete the route "${selectedRoute}"? This action cannot be undone.`}
+        />
+      )}
     </Box>
   );
 };

--- a/ui/app/(core)/subscribers/page.tsx
+++ b/ui/app/(core)/subscribers/page.tsx
@@ -370,30 +370,37 @@ const SubscriberPage = () => {
           </Box>
         </>
       )}
-
-      <ViewSubscriberModal
-        open={isViewModalOpen}
-        onClose={handleCloseViewModal}
-        imsi={selectedSubscriber || ""}
-      />
-      <CreateSubscriberModal
-        open={isCreateModalOpen}
-        onClose={handleCloseCreateModal}
-        onSuccess={refetch}
-      />
-      <EditSubscriberModal
-        open={isEditModalOpen}
-        onClose={() => setEditModalOpen(false)}
-        onSuccess={refetch}
-        initialData={editData || { imsi: "", policyName: "" }}
-      />
-      <DeleteConfirmationModal
-        open={isConfirmationOpen}
-        onClose={() => setConfirmationOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirm Deletion"
-        description={`Are you sure you want to delete the subscriber "${selectedSubscriber}"? This action cannot be undone.`}
-      />
+      {isViewModalOpen && (
+        <ViewSubscriberModal
+          open
+          onClose={handleCloseViewModal}
+          imsi={selectedSubscriber || ""}
+        />
+      )}
+      {isCreateModalOpen && (
+        <CreateSubscriberModal
+          open
+          onClose={handleCloseCreateModal}
+          onSuccess={refetch}
+        />
+      )}
+      {isEditModalOpen && (
+        <EditSubscriberModal
+          open
+          onClose={() => setEditModalOpen(false)}
+          onSuccess={refetch}
+          initialData={editData || { imsi: "", policyName: "" }}
+        />
+      )}
+      {isConfirmationOpen && (
+        <DeleteConfirmationModal
+          open
+          onClose={() => setConfirmationOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          title="Confirm Deletion"
+          description={`Are you sure you want to delete the subscriber "${selectedSubscriber}"? This action cannot be undone.`}
+        />
+      )}
     </Box>
   );
 };

--- a/ui/app/(core)/users/page.tsx
+++ b/ui/app/(core)/users/page.tsx
@@ -240,30 +240,38 @@ const UserPage = () => {
         </>
       )}
 
-      <CreateUserModal
-        open={isCreateModalOpen}
-        onClose={() => setCreateModalOpen(false)}
-        onSuccess={fetchUsers}
-      />
-      <EditUserModal
-        open={isEditModalOpen}
-        onClose={() => setEditModalOpen(false)}
-        onSuccess={fetchUsers}
-        initialData={editData || { email: "", roleID: RoleID.ReadOnly }}
-      />
-      <EditUserPasswordModal
-        open={isEditPasswordModalOpen}
-        onClose={() => setEditPasswordModalOpen(false)}
-        onSuccess={fetchUsers}
-        initialData={editPasswordData || { email: "" }}
-      />
-      <DeleteConfirmationModal
-        open={isConfirmationOpen}
-        onClose={() => setConfirmationOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirm Deletion"
-        description={`Are you sure you want to delete the user "${selectedUser}"? This action cannot be undone.`}
-      />
+      {isCreateModalOpen && (
+        <CreateUserModal
+          open
+          onClose={() => setCreateModalOpen(false)}
+          onSuccess={fetchUsers}
+        />
+      )}
+      {isEditModalOpen && (
+        <EditUserModal
+          open
+          onClose={() => setEditModalOpen(false)}
+          onSuccess={fetchUsers}
+          initialData={editData || { email: "", roleID: RoleID.ReadOnly }}
+        />
+      )}
+      {isEditPasswordModalOpen && (
+        <EditUserPasswordModal
+          open
+          onClose={() => setEditPasswordModalOpen(false)}
+          onSuccess={fetchUsers}
+          initialData={editPasswordData || { email: "" }}
+        />
+      )}
+      {isConfirmationOpen && (
+        <DeleteConfirmationModal
+          open
+          onClose={() => setConfirmationOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          title="Confirm Deletion"
+          description={`Are you sure you want to delete the user "${selectedUser}"? This action cannot be undone.`}
+        />
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
# Description

When you create a resource (ex. subscriber) for a second time in a row, the modal was pre-filled with the content of the previous creation. We don’t want that, the Create modal should be empty.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
