### PR TITLE
feat: add ability for non-admin users to change their password

### DIFF
--- a/internal/api/server/authorization_middleware.go
+++ b/internal/api/server/authorization_middleware.go
@@ -21,7 +21,7 @@ var PermissionsByRole = map[RoleID][]string{
 	RoleAdmin: {"*"},
 
 	RoleReadOnly: {
-		PermReadMyUser,
+		PermReadMyUser, PermUpdateMyUserPassword,
 		PermReadOperator, PermGetOperatorSlice, PermGetOperatorTracking,
 		PermListSubscribers, PermReadSubscriber,
 		PermListDataNetworks, PermReadDataNetwork,
@@ -31,7 +31,7 @@ var PermissionsByRole = map[RoleID][]string{
 	},
 
 	RoleNetworkManager: {
-		PermReadUser, PermReadMyUser,
+		PermReadUser, PermReadMyUser, PermUpdateMyUserPassword,
 		PermReadOperator, PermUpdateOperatorSlice, PermGetOperatorSlice, PermUpdateOperatorTracking, PermGetOperatorTracking,
 		PermListDataNetworks, PermCreateDataNetwork, PermUpdateDataNetwork, PermReadDataNetwork, PermDeleteDataNetwork,
 		PermListSubscribers, PermCreateSubscriber, PermUpdateSubscriber, PermReadSubscriber, PermDeleteSubscriber,
@@ -43,13 +43,14 @@ var PermissionsByRole = map[RoleID][]string{
 
 const (
 	// User permissions
-	PermListUsers          = "user:list"
-	PermCreateUser         = "user:create"
-	PermUpdateUser         = "user:update"
-	PermUpdateUserPassword = "user:update_password"
-	PermReadUser           = "user:read"
-	PermDeleteUser         = "user:delete"
-	PermReadMyUser         = "user:read_my_user"
+	PermListUsers            = "user:list"
+	PermCreateUser           = "user:create"
+	PermUpdateUser           = "user:update"
+	PermUpdateUserPassword   = "user:update_password"
+	PermReadUser             = "user:read"
+	PermDeleteUser           = "user:delete"
+	PermReadMyUser           = "user:read_my_user"
+	PermUpdateMyUserPassword = "user:update_my_user_password"
 
 	// Data Network permissions
 	PermListDataNetworks  = "data_network:list"

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -25,6 +25,7 @@ func NewHandler(dbInstance *db.Database, kernel kernel.Kernel, jwtSecret []byte,
 
 	// Users (Authenticated except for first user creation)
 	mux.HandleFunc("GET /api/v1/users/me", Authenticate(jwtSecret, GetLoggedInUser(dbInstance)).ServeHTTP)
+	mux.HandleFunc("PUT /api/v1/users/me/password", Authenticate(jwtSecret, RequirePermission(PermUpdateMyUserPassword, jwtSecret, UpdateMyUserPassword(dbInstance))).ServeHTTP)
 	mux.HandleFunc("GET /api/v1/users", Authenticate(jwtSecret, RequirePermission(PermListUsers, jwtSecret, ListUsers(dbInstance))).ServeHTTP)
 	mux.HandleFunc("POST /api/v1/users", RequirePermissionOrFirstUser(PermCreateUser, dbInstance, jwtSecret, CreateUser(dbInstance)).ServeHTTP)
 	mux.HandleFunc("PUT /api/v1/users/{email}", Authenticate(jwtSecret, RequirePermission(PermUpdateUser, jwtSecret, UpdateUser(dbInstance))).ServeHTTP)

--- a/ui/app/(core)/profile/page.tsx
+++ b/ui/app/(core)/profile/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import { useCookies } from "react-cookie";
-import EditUserPasswordModal from "@/components/EditUserPasswordModal";
+import EditMyUserPasswordModal from "@/components/EditMyUserPasswordModal";
 import { getLoggedInUser } from "@/queries/users";
 import { useAuth } from "@/contexts/AuthContext";
 import { User } from "@/types/types";
@@ -51,9 +51,6 @@ export default function Profile() {
 
   const [loggedInUser, setLoggedInUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const [editPasswordData, setEditPasswordData] = useState<{
-    email: string;
-  } | null>(null);
 
   const fetchUser = useCallback(async () => {
     try {
@@ -74,7 +71,6 @@ export default function Profile() {
 
   const handleEditPasswordClick = (user: User | null) => {
     if (!user) return;
-    setEditPasswordData({ email: user.email });
     setEditPasswordModalOpen(true);
   };
 
@@ -201,11 +197,10 @@ export default function Profile() {
       </Grid>
 
       {isEditPasswordModalOpen && (
-        <EditUserPasswordModal
+        <EditMyUserPasswordModal
           open
           onClose={() => setEditPasswordModalOpen(false)}
           onSuccess={handlePasswordSuccess}
-          initialData={editPasswordData || { email: "" }}
         />
       )}
     </Box>

--- a/ui/components/EditMyUserPasswordModal.tsx
+++ b/ui/components/EditMyUserPasswordModal.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Alert,
+  Collapse,
+} from "@mui/material";
+import { updateMyUserPassword } from "@/queries/users";
+import { useRouter } from "next/navigation";
+import { useCookies } from "react-cookie";
+
+interface EditMyUserPasswordModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+interface FormValues {
+  password: string;
+}
+
+const EditMyUserPasswordModal: React.FC<EditMyUserPasswordModalProps> = ({
+  open,
+  onClose,
+  onSuccess,
+}) => {
+  const router = useRouter();
+  const [cookies] = useCookies(["user_token"]);
+
+  if (!cookies.user_token) {
+    router.push("/login");
+  }
+
+  const [formValues, setFormValues] = useState<FormValues>({
+    password: "",
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [alert, setAlert] = useState<{ message: string }>({ message: "" });
+
+  useEffect(() => {
+    if (open) {
+      setFormValues({
+        password: "",
+      });
+      setErrors({});
+    }
+  }, [open]);
+
+  const handleChange = (field: keyof FormValues, value: string) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setAlert({ message: "" });
+
+    try {
+      await updateMyUserPassword(
+        cookies.user_token,
+        formValues.password,
+      );
+      onClose();
+      onSuccess();
+    } catch (error: unknown) {
+      let errorMessage = "Unknown error occurred.";
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      setAlert({ message: `Failed to update user: ${errorMessage}` });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="edit-user-modal-title"
+      aria-describedby="edit-user-modal-description"
+    >
+      <DialogTitle>Change My Password</DialogTitle>
+      <DialogContent dividers>
+        <Collapse in={!!alert.message}>
+          <Alert
+            onClose={() => setAlert({ message: "" })}
+            sx={{ mb: 2 }}
+            severity="error"
+          >
+            {alert.message}
+          </Alert>
+        </Collapse>
+        <TextField
+          fullWidth
+          label="New Password"
+          type="password"
+          value={formValues.password}
+          onChange={(e) => handleChange("password", e.target.value)}
+          error={!!errors.password}
+          helperText={errors.password}
+          margin="normal"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="success"
+          onClick={handleSubmit}
+          disabled={loading}
+        >
+          {loading ? "Updating..." : "Update"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default EditMyUserPasswordModal;

--- a/ui/queries/users.tsx
+++ b/ui/queries/users.tsx
@@ -132,6 +132,40 @@ export const updateUserPassword = async (
   return respData.result;
 };
 
+export const updateMyUserPassword = async (
+  authToken: string,
+  password: string,
+) => {
+  const userData = {
+    password: password,
+  };
+
+  const response = await fetch(`/api/v1/users/me/password`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + authToken,
+    },
+    body: JSON.stringify(userData),
+  });
+  let respData;
+  try {
+    respData = await response.json();
+  } catch {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
+    );
+  }
+
+  return respData.result;
+};
+
 export const updateUser = async (
   authToken: string,
   email: string,


### PR DESCRIPTION
# Description

- [x] Add new api endpoint for users to change their own password
- [x] Use that endpoint in the UI's profile page

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
