### PR TITLE
feat: display subscriber events in API/UI

### DIFF
--- a/internal/amf/gmm/handler.go
+++ b/internal/amf/gmm/handler.go
@@ -478,6 +478,16 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 		ue.GmmLog.Debug("PEI", zap.String("imeisv", imeisv))
 	}
 
+	logger.LogSubscriberEvent(
+		logger.SubscriberRegistrationRequest,
+		ue.Supi,
+		zap.String("ran", ue.RanUe[anType].Ran.Name),
+		zap.String("guti", ue.Guti),
+		zap.String("suci", ue.Suci),
+		zap.String("pei", ue.Pei),
+		zap.String("plmnID", ue.PlmnID.Mcc+ue.PlmnID.Mnc),
+	)
+
 	// NgKsi: TS 24.501 9.11.3.32
 	switch registrationRequest.NgksiAndRegistrationType5GS.GetTSC() {
 	case nasMessage.TypeOfSecurityContextFlagNative:

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -59,7 +59,11 @@ func setupServer(filepath string) (*httptest.Server, []byte, error) {
 
 	auditWriter := testdb.AuditWriteFunc(context.Background())
 
+	subscriberWriter := testdb.SubscriberWriteFunc(context.Background())
+
 	logger.SetAuditDBWriter(auditWriter)
+
+	logger.SetSubscriberDBWriter(subscriberWriter)
 
 	jwtSecret := []byte("testsecret")
 	fakeKernel := FakeKernel{}

--- a/internal/api/server/api_subscriber_logs.go
+++ b/internal/api/server/api_subscriber_logs.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/logger"
+)
+
+const (
+	UpdateSubscriberLogRetentionPolicyAction = "update_subscriber_log_retention_policy"
+)
+
+type GetSubscriberLogResponse struct {
+	ID        int    `json:"id"`
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	IMSI      string `json:"imsi"`
+	Event     string `json:"event"`
+	Details   string `json:"details"`
+}
+
+type GetSubscriberLogsRetentionPolicyResponse struct {
+	Days int `json:"days"`
+}
+
+type UpdateSubscriberLogsRetentionPolicyParams struct {
+	Days int `json:"days"`
+}
+
+func GetSubscriberLogRetentionPolicy(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		policyDays, err := dbInstance.GetLogRetentionPolicy(ctx, db.CategorySubscriberLogs)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to retrieve subscriber log retention policy", err, logger.APILog)
+			return
+		}
+
+		response := GetSubscriberLogsRetentionPolicyResponse{Days: policyDays}
+		writeResponse(w, response, http.StatusOK, logger.APILog)
+	})
+}
+
+func UpdateSubscriberLogRetentionPolicy(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		email, ok := r.Context().Value(contextKeyEmail).(string)
+		if !ok {
+			writeError(w, http.StatusInternalServerError, "Failed to get email", errors.New("missing email in context"), logger.APILog)
+			return
+		}
+
+		var params UpdateSubscriberLogsRetentionPolicyParams
+		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid request body", err, logger.APILog)
+			return
+		}
+
+		if params.Days < 1 {
+			writeError(w, http.StatusBadRequest, "retention days must be greater than 0", nil, logger.APILog)
+			return
+		}
+
+		updatedPolicy := &db.LogRetentionPolicy{
+			Category: db.CategorySubscriberLogs,
+			Days:     params.Days,
+		}
+
+		if err := dbInstance.SetLogRetentionPolicy(r.Context(), updatedPolicy); err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to update subscriber log retention policy", err, logger.APILog)
+			return
+		}
+
+		writeResponse(w, SuccessResponse{Message: "Subscriber log retention policy updated successfully"}, http.StatusOK, logger.APILog)
+		logger.LogAuditEvent(UpdateSubscriberLogRetentionPolicyAction, email, getClientIP(r), fmt.Sprintf("User updated subscriber log retention policy to %d days", params.Days))
+	})
+}
+
+func ListSubscriberLogs(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logs, err := dbInstance.ListSubscriberLogs(ctx)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to retrieve subscriber logs", err, logger.APILog)
+			return
+		}
+
+		response := make([]GetSubscriberLogResponse, len(logs))
+		for i, log := range logs {
+			response[i] = GetSubscriberLogResponse{
+				ID:        log.ID,
+				Timestamp: log.Timestamp,
+				Level:     log.Level,
+				IMSI:      log.IMSI,
+				Event:     log.Event,
+				Details:   log.Details,
+			}
+		}
+
+		writeResponse(w, response, http.StatusOK, logger.APILog)
+	})
+}

--- a/internal/api/server/authorization_middleware.go
+++ b/internal/api/server/authorization_middleware.go
@@ -104,7 +104,11 @@ const (
 	PermGetAuditLogRetentionPolicy = "audit_logs:get_retention"
 	PermSetAuditLogRetentionPolicy = "audit_logs:set_retention"
 	PermListAuditLogs              = "audit_logs:list"
-	PermDeleteAuditLogs            = "audit_logs:delete"
+
+	// Subscriber Log permissions
+	PermGetSubscriberLogRetentionPolicy = "subscriber_logs:get_retention"
+	PermSetSubscriberLogRetentionPolicy = "subscriber_logs:set_retention"
+	PermListSubscriberLogs              = "subscriber_logs:list"
 )
 
 func RequirePermissionOrFirstUser(permission string, database *db.Database, jwtSecret []byte, next http.Handler) http.Handler {

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -87,6 +87,11 @@ func NewHandler(dbInstance *db.Database, kernel kernel.Kernel, jwtSecret []byte,
 	mux.HandleFunc("PUT /api/v1/logs/audit/retention", Authenticate(jwtSecret, dbInstance, RequirePermission(PermSetAuditLogRetentionPolicy, jwtSecret, UpdateAuditLogRetentionPolicy(dbInstance))).ServeHTTP)
 	mux.HandleFunc("GET /api/v1/logs/audit", Authenticate(jwtSecret, dbInstance, RequirePermission(PermListAuditLogs, jwtSecret, ListAuditLogs(dbInstance))).ServeHTTP)
 
+	// Subscriber Logs (Authenticated)
+	mux.HandleFunc("GET /api/v1/logs/subscriber/retention", Authenticate(jwtSecret, dbInstance, RequirePermission(PermGetSubscriberLogRetentionPolicy, jwtSecret, GetSubscriberLogRetentionPolicy(dbInstance))).ServeHTTP)
+	mux.HandleFunc("PUT /api/v1/logs/subscriber/retention", Authenticate(jwtSecret, dbInstance, RequirePermission(PermSetSubscriberLogRetentionPolicy, jwtSecret, UpdateSubscriberLogRetentionPolicy(dbInstance))).ServeHTTP)
+	mux.HandleFunc("GET /api/v1/logs/subscriber", Authenticate(jwtSecret, dbInstance, RequirePermission(PermListSubscriberLogs, jwtSecret, ListSubscriberLogs(dbInstance))).ServeHTTP)
+
 	// Fallback to UI
 	frontendHandler, err := newFrontendFileServer(embedFS)
 	if err != nil {

--- a/internal/db/log_retention_policies.go
+++ b/internal/db/log_retention_policies.go
@@ -33,7 +33,8 @@ ON CONFLICT(category) DO UPDATE SET retention_days = excluded.retention_days
 type LogCategory string
 
 const (
-	CategoryAuditLogs LogCategory = "audit"
+	CategoryAuditLogs      LogCategory = "audit"
+	CategorySubscriberLogs LogCategory = "subscriber"
 )
 
 type LogRetentionPolicy struct {
@@ -79,7 +80,7 @@ func (db *Database) GetLogRetentionPolicy(ctx context.Context, category LogCateg
 }
 
 // Ensure that we have a row for the Audit Log retention policy.
-func (db *Database) IsLogRetentionPolicyInitialized(ctx context.Context) bool {
+func (db *Database) IsLogRetentionPolicyInitialized(ctx context.Context, category LogCategory) bool {
 	operation := "SELECT"
 	target := LogRetentionPolicyTableName
 	spanName := fmt.Sprintf("%s %s", operation, target)
@@ -95,7 +96,7 @@ func (db *Database) IsLogRetentionPolicyInitialized(ctx context.Context) bool {
 		attribute.String("db.collection", target),
 	)
 
-	row := LogRetentionPolicy{Category: CategoryAuditLogs}
+	row := LogRetentionPolicy{Category: category}
 	q, err := sqlair.Prepare(stmt, LogRetentionPolicy{})
 	if err != nil {
 		span.RecordError(err)

--- a/internal/db/subscriber_logs.go
+++ b/internal/db/subscriber_logs.go
@@ -1,0 +1,186 @@
+// Copyright 2024 Ella Networks
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/canonical/sqlair"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const SubscriberLogsTableName = "subscriber_logs"
+
+// Structured table (no raw blob). Keep strings NOT NULL with empty defaults to avoid NullString hassle.
+const QueryCreateSubscriberLogsTable = `
+	CREATE TABLE IF NOT EXISTS %s (
+		id         INTEGER PRIMARY KEY AUTOINCREMENT,
+		timestamp  TEXT NOT NULL,                      -- RFC3339
+		level      TEXT NOT NULL,                      -- info|warn|error...
+		imsi      TEXT NOT NULL DEFAULT '',
+		event     TEXT NOT NULL,
+		details    TEXT NOT NULL DEFAULT ''
+);`
+
+const (
+	insertSubscriberLogStmt     = "INSERT INTO %s (timestamp, level, imsi, event, details) VALUES ($SubscriberLog.timestamp, $SubscriberLog.level, $SubscriberLog.imsi, $SubscriberLog.event, $SubscriberLog.details)"
+	listSubscriberLogsStmt      = "SELECT &SubscriberLog.* FROM %s ORDER BY id DESC"
+	deleteOldSubscriberLogsStmt = "DELETE FROM %s WHERE timestamp < $cutoffArgs.cutoff"
+)
+
+type SubscriberLog struct {
+	ID        int    `db:"id"`
+	Timestamp string `db:"timestamp"` // store as RFC3339 string; parse in API layer if needed
+	Level     string `db:"level"`
+	IMSI      string `db:"imsi"`
+	Event     string `db:"event"`
+	Details   string `db:"details"` // JSON or plain text (we store a string)
+}
+
+type zapSubscriberJSON struct {
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	IMSI      string `json:"imsi"`
+	Event     string `json:"event"`
+	Details   string `json:"details"` // could be string or object in the future
+}
+
+func (db *Database) SubscriberWriteFunc(ctx context.Context) func([]byte) error {
+	return func(b []byte) error {
+		return db.InsertSubscriberLogJSON(ctx, b)
+	}
+}
+
+// InsertSubscriberLogJSON parses the zap JSON and inserts a structured row.
+func (db *Database) InsertSubscriberLogJSON(ctx context.Context, raw []byte) error {
+	const operation = "INSERT"
+	const target = SubscriberLogsTableName
+	spanName := fmt.Sprintf("%s %s", operation, target)
+
+	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	query := fmt.Sprintf(insertSubscriberLogStmt, db.subscriberLogsTable)
+	span.SetAttributes(
+		semconv.DBSystemSqlite,
+		semconv.DBStatementKey.String(query),
+		semconv.DBOperationKey.String(operation),
+		attribute.String("db.collection", target),
+	)
+
+	// Parse incoming JSON
+	var z zapSubscriberJSON
+	if err := json.Unmarshal(raw, &z); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "unmarshal failed")
+		return err
+	}
+
+	row := SubscriberLog{
+		Timestamp: z.Timestamp,
+		Level:     z.Level,
+		IMSI:      z.IMSI,
+		Event:     z.Event,
+		Details:   z.Details,
+	}
+
+	stmt, err := sqlair.Prepare(query, SubscriberLog{})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "prepare failed")
+		return err
+	}
+	if err := db.conn.Query(ctx, stmt, row).Run(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "execution failed")
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return nil
+}
+
+func (db *Database) ListSubscriberLogs(ctx context.Context) ([]SubscriberLog, error) {
+	const operation = "SELECT"
+	const target = SubscriberLogsTableName
+	spanName := fmt.Sprintf("%s %s", operation, target)
+
+	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	stmt := fmt.Sprintf(listSubscriberLogsStmt, db.subscriberLogsTable)
+	span.SetAttributes(
+		semconv.DBSystemSqlite,
+		semconv.DBStatementKey.String(stmt),
+		semconv.DBOperationKey.String(operation),
+		attribute.String("db.collection", target),
+	)
+
+	q, err := sqlair.Prepare(stmt, SubscriberLog{})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "prepare failed")
+		return nil, err
+	}
+
+	var logs []SubscriberLog
+	if err := db.conn.Query(ctx, q).GetAll(&logs); err != nil {
+		if err == sql.ErrNoRows {
+			span.SetStatus(codes.Ok, "no rows")
+			return nil, nil
+		}
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "query failed")
+		return nil, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return logs, nil
+}
+
+// DeleteOldSubscriberLogs removes logs older than the specified retention period in days.
+func (db *Database) DeleteOldSubscriberLogs(ctx context.Context, days int) error {
+	const operation = "DELETE"
+	const target = SubscriberLogsTableName
+	spanName := fmt.Sprintf("%s %s (retention)", operation, target)
+
+	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	// Compute UTC cutoff so string comparison works lexicographically for RFC3339
+	cutoff := time.Now().AddDate(0, 0, -days).UTC().Format(time.RFC3339)
+
+	stmtStr := fmt.Sprintf(deleteOldSubscriberLogsStmt, db.subscriberLogsTable)
+	span.SetAttributes(
+		semconv.DBSystemSqlite,
+		semconv.DBStatementKey.String(stmtStr),
+		semconv.DBOperationKey.String(operation),
+		attribute.String("db.collection", target),
+		attribute.Int("retention.days", days),
+		attribute.String("retention.cutoff", cutoff),
+	)
+
+	stmt, err := sqlair.Prepare(stmtStr, cutoffArgs{})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "prepare failed")
+		return err
+	}
+
+	args := cutoffArgs{Cutoff: cutoff}
+	if err := db.conn.Query(ctx, stmt, args).Run(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "execution failed")
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return nil
+}

--- a/ui/app/(core)/audit-logs/page.tsx
+++ b/ui/app/(core)/audit-logs/page.tsx
@@ -7,13 +7,11 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import {
   listAuditLogs,
-  deleteAuditLogs,
   getAuditLogRetentionPolicy,
 } from "@/queries/audit_logs";
 import { useCookies } from "react-cookie";
 import { useAuth } from "@/contexts/AuthContext";
 import EditAuditLogRetentionPolicyModal from "@/components/EditAuditLogRetentionPolicyModal";
-import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
 import { AuditLogRetentionPolicy } from "@/types/types";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 
@@ -40,7 +38,6 @@ const AuditLog = () => {
     message: "",
     severity: null,
   });
-  const [isConfirmationOpen, setConfirmationOpen] = useState(false);
   const [isEditModalOpen, setEditModalOpen] = useState(false);
 
   const theme = useTheme();
@@ -72,25 +69,6 @@ const AuditLog = () => {
       console.error("Error fetching audit log retention policy:", error);
     }
   }, [cookies.user_token]);
-
-  const handleDeleteConfirm = async () => {
-    setConfirmationOpen(false);
-    try {
-      await deleteAuditLogs(cookies.user_token);
-      setAlert({
-        message: `Audit Logs deleted successfully!`,
-        severity: "success",
-      });
-      fetchAuditLogs();
-    } catch (error) {
-      setAlert({
-        message: `Failed to delete Audit Logs": ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`,
-        severity: "error",
-      });
-    }
-  };
 
   const fetchAuditLogs = useCallback(async () => {
     try {
@@ -226,16 +204,6 @@ const AuditLog = () => {
         }}
         initialData={retentionPolicy || { days: 30 }}
       />
-
-      {isConfirmationOpen && (
-        <DeleteConfirmationModal
-          open
-          onClose={() => setConfirmationOpen(false)}
-          onConfirm={handleDeleteConfirm}
-          title="Confirm Deletion"
-          description={`Are you sure you want to delete all audit logs? This action cannot be undone.`}
-        />
-      )}
     </Box>
   );
 };

--- a/ui/app/(core)/events/page.tsx
+++ b/ui/app/(core)/events/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, Typography, Alert, Button, Collapse } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import {
+  listSubscriberLogs,
+  getSubscriberLogRetentionPolicy,
+} from "@/queries/subscriber_logs";
+import { useCookies } from "react-cookie";
+import { useAuth } from "@/contexts/AuthContext";
+import EditSubscriberLogRetentionPolicyModal from "@/components/EditSubscriberLogRetentionPolicyModal";
+import { SubscriberLogRetentionPolicy } from "@/types/types";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+interface SubscriberLogData {
+  id: string;
+  timestamp: string;
+  level: string;
+  imsi: string;
+  event: string;
+  ip: string;
+  details: string;
+}
+
+const MAX_WIDTH = 1400;
+
+const Events = () => {
+  const { role } = useAuth();
+  const [cookies] = useCookies(["user_token"]);
+  const [subscriberLogs, setSubscriberLogs] = useState<SubscriberLogData[]>([]);
+  const [alert, setAlert] = useState<{
+    message: string;
+    severity: "success" | "error" | null;
+  }>({
+    message: "",
+    severity: null,
+  });
+  const [isEditModalOpen, setEditModalOpen] = useState(false);
+
+  const theme = useTheme();
+  const isSmDown = useMediaQuery(theme.breakpoints.down("sm"));
+  const canEdit = role === "Admin";
+
+  const outerTheme = useTheme();
+  const gridTheme = React.useMemo(
+    () =>
+      createTheme(outerTheme, {
+        palette: {
+          DataGrid: { headerBg: "#F5F5F5" },
+        },
+      }),
+    [outerTheme],
+  );
+
+  const [retentionPolicy, setRetentionPolicy] =
+    useState<SubscriberLogRetentionPolicy | null>(null);
+
+  const descriptionText = "Review subscriber events in Ella Core.";
+
+  const fetchRetentionPolicy = useCallback(async () => {
+    try {
+      const data = await getSubscriberLogRetentionPolicy(cookies.user_token);
+      setRetentionPolicy(data);
+    } catch (error) {
+      console.error("Error fetching subscriber log retention policy:", error);
+    }
+  }, [cookies.user_token]);
+
+  const fetchSubscriberLogs = useCallback(async () => {
+    try {
+      const data = await listSubscriberLogs(cookies.user_token);
+      setSubscriberLogs(data);
+    } catch (error) {
+      console.error("Error fetching subscriber logs:", error);
+    }
+  }, [cookies.user_token]);
+
+  useEffect(() => {
+    fetchSubscriberLogs();
+    fetchRetentionPolicy();
+  }, [fetchSubscriberLogs, fetchRetentionPolicy]);
+
+  const columns: GridColDef[] = useMemo(
+    () => [
+      { field: "timestamp", headerName: "Timestamp", flex: 1, minWidth: 220 },
+      { field: "imsi", headerName: "IMSI", flex: 1, minWidth: 250 },
+      { field: "event", headerName: "Event", flex: 1, minWidth: 200 },
+      { field: "details", headerName: "Details", flex: 2, minWidth: 350 },
+    ],
+    [],
+  );
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        pt: 6,
+        pb: 4,
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: MAX_WIDTH, px: { xs: 2, sm: 4 } }}>
+        <Collapse in={!!alert.message}>
+          <Alert
+            severity={alert.severity || "success"}
+            onClose={() => setAlert({ message: "", severity: null })}
+            sx={{ mb: 2 }}
+          >
+            {alert.message}
+          </Alert>
+        </Collapse>
+      </Box>
+
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: MAX_WIDTH,
+          px: { xs: 2, sm: 4 },
+          mb: 3,
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+        }}
+      >
+        <Typography variant="h4">Subscriber Events</Typography>
+
+        <Typography variant="body1" color="text.secondary">
+          {descriptionText}
+        </Typography>
+
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          {canEdit && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={() => setEditModalOpen(true)}
+              sx={{ minWidth: 140 }}
+            >
+              Edit Retention
+            </Button>
+          )}
+
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ ml: "auto" }}
+          >
+            Retention: <strong>{retentionPolicy?.days ?? "…"}</strong> days
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box sx={{ width: "100%", maxWidth: MAX_WIDTH, px: { xs: 2, sm: 4 } }}>
+        <ThemeProvider theme={gridTheme}>
+          <DataGrid
+            rows={subscriberLogs}
+            columns={columns}
+            getRowId={(row) => row.id}
+            showToolbar={true}
+            initialState={{
+              sorting: { sortModel: [{ field: "timestamp", sort: "desc" }] },
+            }}
+            disableRowSelectionOnClick
+            columnVisibilityModel={{
+              id: !isSmDown,
+            }}
+            sx={{
+              width: "100%",
+              border: 1,
+              borderColor: "divider",
+              "& .MuiDataGrid-cell": {
+                borderBottom: "1px solid",
+                borderColor: "divider",
+              },
+              "& .MuiDataGrid-columnHeaders": {
+                borderBottom: "1px solid",
+                borderColor: "divider",
+              },
+              "& .MuiDataGrid-footerContainer": {
+                borderTop: "1px solid",
+                borderColor: "divider",
+              },
+              "& .MuiDataGrid-columnHeaderTitle": { fontWeight: "bold" },
+            }}
+          />
+        </ThemeProvider>
+      </Box>
+
+      <EditSubscriberLogRetentionPolicyModal
+        open={isEditModalOpen}
+        onClose={() => setEditModalOpen(false)}
+        onSuccess={() => {
+          fetchRetentionPolicy();
+          setAlert({
+            message: "Retention policy updated!",
+            severity: "success",
+          });
+        }}
+        initialData={retentionPolicy || { days: 30 }}
+      />
+    </Box>
+  );
+};
+
+export default Events;

--- a/ui/components/DrawerLayout.tsx
+++ b/ui/components/DrawerLayout.tsx
@@ -27,6 +27,7 @@ import {
   Sensors as SensorsIcon,
   Groups as GroupsIcon,
   Dashboard as DashboardIcon,
+  Feed as FeedIcon,
   Router as RouterIcon,
   Logout as LogoutIcon,
   AccountCircle as AccountCircleIcon,
@@ -179,6 +180,20 @@ export default function DrawerLayout({
                   <DashboardIcon color="primary" />
                 </ListItemIcon>
                 <ListItemText primary="Dashboard" />
+              </ListItemButton>
+            </ListItem>
+
+            <ListItem disablePadding>
+              <ListItemButton
+                component={Link}
+                href="/events"
+                selected={pathname === "/events"}
+                onClick={handleNavClick}
+              >
+                <ListItemIcon>
+                  <FeedIcon color="primary" />
+                </ListItemIcon>
+                <ListItemText primary="Events" />
               </ListItemButton>
             </ListItem>
 

--- a/ui/components/EditSubscriberLogRetentionPolicyModal.tsx
+++ b/ui/components/EditSubscriberLogRetentionPolicyModal.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  DialogContentText,
+  TextField,
+  Button,
+  Alert,
+  Collapse,
+} from "@mui/material";
+import { updateSubscriberLogRetentionPolicy } from "@/queries/subscriber_logs";
+import { useRouter } from "next/navigation";
+import { useCookies } from "react-cookie";
+import { SubscriberLogRetentionPolicy } from "@/types/types";
+
+interface EditSubscriberLogRetentionPolicyModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  initialData: SubscriberLogRetentionPolicy;
+}
+
+const EditSubscriberLogRetentionPolicyModal: React.FC<
+  EditSubscriberLogRetentionPolicyModalProps
+> = ({ open, onClose, onSuccess, initialData }) => {
+  const router = useRouter();
+  const [cookies, ,] = useCookies(["user_token"]);
+
+  if (!cookies.user_token) {
+    router.push("/login");
+  }
+
+  const [formValues, setFormValues] = useState(initialData);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [alert, setAlert] = useState<{ message: string }>({ message: "" });
+
+  useEffect(() => {
+    if (open) {
+      setFormValues({
+        days: initialData.days,
+      });
+      setErrors({});
+    }
+  }, [open, initialData]);
+
+  const handleChange = (field: string, value: string | number) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setAlert({ message: "" });
+
+    try {
+      await updateSubscriberLogRetentionPolicy(
+        cookies.user_token,
+        formValues.days,
+      );
+      onClose();
+      onSuccess();
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error occurred.";
+      setAlert({
+        message: `Failed to update subscriber log retention policy: ${errorMessage}`,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="edit-subscriber-log-retention-policy-modal-title"
+      aria-describedby="edit-subscriber-log-retention-policy-modal-description"
+    >
+      <DialogTitle>Edit Subscriber Log Retention Policy</DialogTitle>
+      <DialogContent dividers>
+        <Collapse in={!!alert.message}>
+          <Alert
+            onClose={() => setAlert({ message: "" })}
+            sx={{ mb: 2 }}
+            severity="error"
+          >
+            {alert.message}
+          </Alert>
+        </Collapse>
+        <DialogContentText>
+          Set the number of days to retain subscriber logs. After this period,
+          logs will be automatically deleted.
+        </DialogContentText>
+        <TextField
+          fullWidth
+          type="number"
+          label="Days"
+          value={formValues.days}
+          onChange={(e) => handleChange("days", Number(e.target.value))}
+          error={!!errors.days}
+          helperText={errors.days}
+          margin="normal"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="success"
+          onClick={handleSubmit}
+          disabled={loading}
+        >
+          {loading ? "Updating..." : "Update"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default EditSubscriberLogRetentionPolicyModal;

--- a/ui/queries/audit_logs.tsx
+++ b/ui/queries/audit_logs.tsx
@@ -26,30 +26,6 @@ export const listAuditLogs = async (authToken: string) => {
   return respData.result;
 };
 
-export const deleteAuditLogs = async (authToken: string) => {
-  const response = await fetch(`/api/v1/logs/audit`, {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: "Bearer " + authToken,
-    },
-  });
-
-  if (!response.ok) {
-    let respData;
-    try {
-      respData = await response.json();
-    } catch {
-      throw new Error(
-        `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
-      );
-    }
-    throw new Error(
-      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
-    );
-  }
-};
-
 export const getAuditLogRetentionPolicy = async (authToken: string) => {
   const response = await fetch(`/api/v1/logs/audit/retention`, {
     method: "GET",

--- a/ui/queries/subscriber_logs.tsx
+++ b/ui/queries/subscriber_logs.tsx
@@ -1,0 +1,81 @@
+import { HTTPStatus } from "@/queries/utils";
+
+export const listSubscriberLogs = async (authToken: string) => {
+  const response = await fetch(`/api/v1/logs/subscriber`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + authToken,
+    },
+  });
+  let respData;
+  try {
+    respData = await response.json();
+  } catch {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
+    );
+  }
+
+  return respData.result;
+};
+
+export const getSubscriberLogRetentionPolicy = async (authToken: string) => {
+  const response = await fetch(`/api/v1/logs/subscriber/retention`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + authToken,
+    },
+  });
+  let respData;
+  try {
+    respData = await response.json();
+  } catch {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
+    );
+  }
+
+  return respData.result;
+};
+
+export const updateSubscriberLogRetentionPolicy = async (
+  authToken: string,
+  days: number,
+) => {
+  const response = await fetch(`/api/v1/logs/subscriber/retention`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + authToken,
+    },
+    body: JSON.stringify({ days: days }),
+  });
+
+  if (!response.ok) {
+    let respData;
+    try {
+      respData = await response.json();
+    } catch {
+      throw new Error(
+        `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
+      );
+    }
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
+    );
+  }
+};

--- a/ui/types/types.ts
+++ b/ui/types/types.ts
@@ -60,6 +60,18 @@ export type AuditLogRetentionPolicy = {
   days: number;
 };
 
+export type SubscriberLogRetentionPolicy = {
+  days: number;
+};
+
+export type SubscriberLog = {
+  id: number;
+  timestamp: string;
+  imsi: string;
+  event: string;
+  details: string;
+};
+
 export const roleIDToLabel = (role: RoleID): string => {
   switch (role) {
     case RoleID.Admin:


### PR DESCRIPTION
# Description

Add the ability to view subscriber events in both the API and UI. This is quite useful to troubleshoot network related events without having to check in the system logs.

To do:
- [x] Add DB table for subscriber logs 
- [x] Add backend API's to get subscriber logs
- [x] Emit subscriber logs

## Future work

In the future we will also want to add Radio events. In the UI this will be reflected with the use of tabs for both "Subscribers" and "Radios". 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
