### PR TITLE
fix: add check that pdu session exists before checking for ip

### DIFF
--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -109,6 +109,9 @@ func ListSubscribers(dbInstance *db.Database) http.Handler {
 			smfSessions := smfContext.PDUSessionsByIMSI(dbSubscriber.Imsi)
 
 			for _, session := range smfSessions {
+				if session.PDUAddress == nil {
+					continue
+				}
 				subscriberSessions = append(subscriberSessions, SubscriberSession{
 					IPAddress: session.PDUAddress.IP.String(),
 				})
@@ -158,6 +161,9 @@ func GetSubscriber(dbInstance *db.Database) http.Handler {
 		smfSessions := smfContext.PDUSessionsByIMSI(dbSubscriber.Imsi)
 
 		for _, session := range smfSessions {
+			if session.PDUAddress == nil {
+				continue
+			}
 			subscriberSessions = append(subscriberSessions, SubscriberSession{
 				IPAddress: session.PDUAddress.IP.String(),
 			})


### PR DESCRIPTION
# Description

We had a bug where we assumed that the PDUAddress was necessarily non-nil in the PDU session returned by the SMF. This condition was triggered whenever the UE's SD was incorrect. 

## Logs

```
2025-08-22T11:40:25Z ella-core.cored[30293]: 2025-08-22T11:40:25.285Z	ERROR	gmm/sm.go:104	Error handling UL NASTransport	{"component": "AMF", "error": "error sending sm context request: create sm context request error: failed to create SM Context: error retrieving DNN information: expected sd 000001, got 102030"}
2025-08-22T11:40:28Z ella-core.cored[30293]: 2025/08/22 11:40:28 http2: panic serving 192.168.40.6:44774: runtime error: invalid memory address or nil pointer dereference
2025-08-22T11:40:28Z ella-core.cored[30293]: goroutine 236 [running]:
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.(*http2serverConn).runHandler.func1()
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/h2_bundle.go:6522 +0x13e
2025-08-22T11:40:28Z ella-core.cored[30293]: panic({0x1100dc0?, 0x1f86640?})
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/runtime/panic.go:792 +0x132
2025-08-22T11:40:28Z ella-core.cored[30293]: github.com/ellanetworks/core/internal/api/server.NewHandler.ListSubscribers.func35({0x16f65c8, 0xc000122168}, 0x121f640?)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/build/ella-core/parts/core/build/internal/api/server/api_subscribers.go:113 +0x5a8
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.HandlerFunc.ServeHTTP(0xc0003f0a20?, {0x16f65c8?, 0xc000122168?}, 0xc00059e500?)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/server.go:2294 +0x29
2025-08-22T11:40:28Z ella-core.cored[30293]: github.com/ellanetworks/core/internal/api/server.NewHandler.RequirePermission.func36({0x16f65c8, 0xc000122168}, 0xc00059e500)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/build/ella-core/parts/core/build/internal/api/server/authorization_middleware.go:159 +0x14a
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.HandlerFunc.ServeHTTP(0xc00059e280?, {0x16f65c8?, 0xc000122168?}, 0xc0001503c0?)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/server.go:2294 +0x29
2025-08-22T11:40:28Z ella-core.cored[30293]: github.com/ellanetworks/core/internal/api/server.NewHandler.Authenticate.func37({0x16f65c8, 0xc000122168}, 0xc00059e280)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/build/ella-core/parts/core/build/internal/api/server/authentication_middleware.go:122 +0x19e
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.HandlerFunc.ServeHTTP(0x4fbbf3?, {0x16f65c8?, 0xc000122168?}, 0xc00071a800?)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/server.go:2294 +0x29
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.HandlerFunc.ServeHTTP(0xc0001ca240?, {0x16f65c8?, 0xc000122168?}, 0xc0003f03c0?)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/server.go:2294 +0x29
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.(*ServeMux).ServeHTTP(0xc0003f03c0?, {0x16f65c8, 0xc000122168}, 0xc00059e280)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/server.go:2822 +0x1c4
2025-08-22T11:40:28Z ella-core.cored[30293]: golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP({{0x16ecea0?, 0xc0001ca240?}, 0xc0000b62a0?}, {0x16f65c8, 0xc000122168}, 0xc00059e280)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/root/go/pkg/mod/golang.org/x/net@v0.43.0/http2/h2c/h2c.go:125 +0x673
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.serverHandler.ServeHTTP({0x62ca77?}, {0x16f65c8?, 0xc000122168?}, 0x2589b00?)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/server.go:3301 +0x8e
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.initALPNRequest.ServeHTTP({{0x16f9408?, 0xc00003e6c0?}, 0xc00002ee08?, {0xc0000d0000?}}, {0x16f65c8, 0xc000122168}, 0xc00059e280)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/server.go:3974 +0x231
2025-08-22T11:40:28Z ella-core.cored[30293]: net/http.(*http2serverConn).runHandler(0x2589b00?, 0x0?, 0x0?, 0x0?)
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/h2_bundle.go:6529 +0xf5
2025-08-22T11:40:28Z ella-core.cored[30293]: created by net/http.(*http2serverConn).scheduleHandler in goroutine 69
2025-08-22T11:40:28Z ella-core.cored[30293]: 	/snap/go/10938/src/net/http/h2_bundle.go:6463 +0x21d
```
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
