### PR TITLE
fix: Properly convert network endianness to native endianness

### DIFF
--- a/internal/amf/ngap/service/service.go
+++ b/internal/amf/ngap/service/service.go
@@ -8,9 +8,9 @@ package service
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
-	"math/bits"
 	"net"
 	"sync"
 	"syscall"
@@ -191,7 +191,7 @@ func handleConnection(conn *sctp.SCTPConn, bufsize uint32, handler NGAPHandler) 
 				logger.AmfLog.Warn("Received sctp notification but not handled", zap.Any("type", notification.Type()))
 			}
 		} else {
-			if info == nil || info.PPID != bits.ReverseBytes32(ngap.PPID) {
+			if info == nil || networkToNativeEndianness32(info.PPID) != ngap.PPID {
 				logger.AmfLog.Warn("Received SCTP PPID != 60, discard this packet")
 				continue
 			}
@@ -199,4 +199,12 @@ func handleConnection(conn *sctp.SCTPConn, bufsize uint32, handler NGAPHandler) 
 			handler.HandleMessage(context.Background(), conn, buf[:n])
 		}
 	}
+}
+
+// Takes a uint32 in Network Byte Order and returns
+// in in Native Byte Order
+func networkToNativeEndianness32(value uint32) uint32 {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], value)
+	return binary.NativeEndian.Uint32(b[:])
 }


### PR DESCRIPTION
# Description

#667 introduced code to convert the endianness of a value in NGAP handling. The implementation was flawed as it assumes that the native endianness will always be Little Endian. While it is the case for most common architectures, it is not a guarantee.

This PR fixes this issue by instead converting the value received from the network, that will always be in Big Endian, as that is the network byte order standard. It then converts it to the native byte order, ensuring that this will work on any architecture.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
