### PR TITLE
feat: create session on initialization and separate endpoint from user creation

### DIFF
--- a/client/initialize.go
+++ b/client/initialize.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+)
+
+type InitializeOptions struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+func (c *Client) Initialize(ctx context.Context, opts *InitializeOptions) error {
+	payload := struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}{
+		Email:    opts.Email,
+		Password: opts.Password,
+	}
+
+	var body bytes.Buffer
+
+	err := json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "api/v1/init",
+		Body:   &body,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/client/initialize_test.go
+++ b/client/initialize_test.go
@@ -1,0 +1,60 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+func TestInitialize_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "System initialized successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+	initializeOpts := &client.InitializeOptions{
+		Email:    "user@example.com",
+		Password: "secret",
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.Initialize(ctx, initializeOpts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestInitialize_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 400,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Invalid email"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+	initializeOpts := &client.InitializeOptions{
+		Email:    "invalid-email",
+		Password: "secret",
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.Initialize(ctx, initializeOpts)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}

--- a/docs/reference/api/initialize.md
+++ b/docs/reference/api/initialize.md
@@ -1,0 +1,30 @@
+---
+description: RESTful API reference for initializing Ella Core.
+---
+
+# Initialize
+
+This section describes the RESTful API for initializing Ella Core. Initialization consists of creating the first admin user. This user can then create other users and manage the system.
+
+## Initialize the System
+
+This path initializes the system by creating the first admin user. This endpoint can only be called if no users exist in the system.
+
+| Method | Path            |
+| ------ | --------------- |
+| POST   | `/api/v1/init` |
+
+### Parameters
+
+- `email` (string): The email of the user.
+- `password` (string): The password of the user.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "message": "System initialized successfully"
+    }
+}
+```

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -41,7 +41,7 @@ This path returns the list of system users.
 
 ## Create a User
 
-This path creates a new system user. The first user can be created without authentication.
+This path creates a new system user.
 
 | Method | Path            |
 | ------ | --------------- |

--- a/docs/tutorials/end_to_end_network.md
+++ b/docs/tutorials/end_to_end_network.md
@@ -118,11 +118,7 @@ In the Initialization page, create the first user with the following credentials
 - Email: `admin@ellanetworks.com`
 - Password: `admin`
 
-After creating the user, you will be redirected to the login page. Use the credentials you just created to log in.
-
-You will be redirected to the dashboard.
-
-Ella Core is now initialized and ready to be used.
+Ella Core is now initialized and ready to be used. You will be redirected to the dashboard.
 
 ### 2.4 Configure your private network
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -103,12 +103,9 @@ On the Initialization page, create the first user with the following credentials
 - Email: `admin@ellanetworks.com`
 - Password: `admin`
 
-After creating the user, Ella Core will redirect you to the Login page. Use the credentials you just created to log in.
-
-Ella Core should redirect you to the dashboard.
+After creating the user, Ella Core will redirect you to the dashboard.
 
 ![Dashboard](../images/dashboard.png){ align=center }
-
 
 !!! success
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -40,24 +40,14 @@ type ConfigureEllaCoreOpts struct {
 }
 
 func configureEllaCore(ctx context.Context, opts *ConfigureEllaCoreOpts) (*client.Subscriber, error) {
-	createUserOpts := &client.CreateUserOptions{
+	initializeOpts := &client.InitializeOptions{
 		Email:    "admin@ellanetworks.com",
 		Password: "admin",
-		RoleID:   client.RoleAdmin,
 	}
-	err := opts.client.CreateUser(ctx, createUserOpts)
+
+	err := opts.client.Initialize(ctx, initializeOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %v", err)
-	}
-
-	loginOpts := &client.LoginOptions{
-		Email:    "admin@ellanetworks.com",
-		Password: "admin",
-	}
-
-	err = opts.client.Login(ctx, loginOpts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to login: %v", err)
 	}
 
 	err = opts.client.Refresh(ctx)

--- a/internal/api/server/api_audit_logs_test.go
+++ b/internal/api/server/api_audit_logs_test.go
@@ -138,7 +138,7 @@ func TestAPIAuditLogs(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -160,12 +160,12 @@ func TestAPIAuditLogs(t *testing.T) {
 		t.Fatalf("unexpected error :%q", response.Error)
 	}
 
-	if response.Result.Items[0].Actor != "" {
-		t.Fatalf("expected second audit log actor to be '', got %s", response.Result.Items[0].Actor)
+	if response.Result.Items[0].Actor != FirstUserEmail {
+		t.Fatalf("expected first audit log actor to be '%s', got %s", FirstUserEmail, response.Result.Items[0].Actor)
 	}
 
 	if response.Result.Items[0].Action != "initialize" {
-		t.Fatalf("expected second audit log action to be '%s', got %s", "initialize", response.Result.Items[0].Action)
+		t.Fatalf("expected first audit log action to be '%s', got %s", "initialize", response.Result.Items[0].Action)
 	}
 }
 
@@ -179,7 +179,7 @@ func TestAPIAuditLogsPagination_LargeDataSet(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -316,7 +316,7 @@ func TestAPIAuditLogRetentionPolicyEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -389,7 +389,7 @@ func TestUpdateAuditLogRetentionPolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_audit_logs_test.go
+++ b/internal/api/server/api_audit_logs_test.go
@@ -138,7 +138,7 @@ func TestAPIAuditLogs(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -164,8 +164,8 @@ func TestAPIAuditLogs(t *testing.T) {
 		t.Fatalf("expected second audit log actor to be '', got %s", response.Result.Items[0].Actor)
 	}
 
-	if response.Result.Items[0].Action != "create_user" {
-		t.Fatalf("expected second audit log action to be '%s', got %s", "create_user", response.Result.Items[0].Action)
+	if response.Result.Items[0].Action != "initialize" {
+		t.Fatalf("expected second audit log action to be '%s', got %s", "initialize", response.Result.Items[0].Action)
 	}
 }
 
@@ -179,7 +179,7 @@ func TestAPIAuditLogsPagination_LargeDataSet(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -301,7 +301,7 @@ func TestAPIAuditLogsPagination_LargeDataSet(t *testing.T) {
 		t.Fatalf("expected first audit log details to be correct, got %s", response.Result.Items[0].Details)
 	}
 
-	if response.Result.Items[9].Details != "User created user: my.user123@ellanetworks.com with role: 1" {
+	if response.Result.Items[9].Details != "System initialized with first user my.user123@ellanetworks.com" {
 		t.Fatalf("expected last audit log details to be correct, got %s", response.Result.Items[9].Details)
 	}
 }
@@ -316,7 +316,7 @@ func TestAPIAuditLogRetentionPolicyEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -389,7 +389,7 @@ func TestUpdateAuditLogRetentionPolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_auth_test.go
+++ b/internal/api/server/api_auth_test.go
@@ -128,13 +128,12 @@ func TestLoginEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	t.Run("1. Create Admin user", func(t *testing.T) {
-		user := &CreateUserParams{
+	t.Run("1. Initialize", func(t *testing.T) {
+		initParams := &InitializeParams{
 			Email:    FirstUserEmail,
 			Password: "password123",
-			RoleID:   RoleAdmin,
 		}
-		statusCode, _, err := createUser(ts.URL, client, "", user)
+		statusCode, _, err := initializeAPI(ts.URL, client, initParams)
 		if err != nil {
 			t.Fatalf("couldn't create admin user: %s", err)
 		}
@@ -268,7 +267,7 @@ func TestAuthAPITokenEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	adminToken, err := createFirstUserAndLogin(ts.URL, client)
+	adminToken, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -375,7 +374,7 @@ func TestRolesEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	adminToken, err := createFirstUserAndLogin(ts.URL, client)
+	adminToken, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -547,12 +546,11 @@ func TestLookupToken(t *testing.T) {
 	client := ts.Client()
 
 	t.Run("Lookup valid token", func(t *testing.T) {
-		createUserParams := &CreateUserParams{
+		initializeParams := &InitializeParams{
 			Email:    FirstUserEmail,
 			Password: "password123",
-			RoleID:   RoleAdmin,
 		}
-		statusCode, _, err := createUser(ts.URL, client, "", createUserParams)
+		statusCode, _, err := initializeAPI(ts.URL, client, initializeParams)
 		if err != nil {
 			t.Fatalf("couldn't create admin user: %s", err)
 		}

--- a/internal/api/server/api_auth_test.go
+++ b/internal/api/server/api_auth_test.go
@@ -133,7 +133,7 @@ func TestLoginEndToEnd(t *testing.T) {
 			Email:    FirstUserEmail,
 			Password: "password123",
 		}
-		statusCode, _, err := initializeAPI(ts.URL, client, initParams)
+		statusCode, _, err := initialize(ts.URL, client, initParams)
 		if err != nil {
 			t.Fatalf("couldn't create admin user: %s", err)
 		}
@@ -267,7 +267,7 @@ func TestAuthAPITokenEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	adminToken, err := initialize(ts.URL, client)
+	adminToken, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -374,7 +374,7 @@ func TestRolesEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	adminToken, err := initialize(ts.URL, client)
+	adminToken, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -550,7 +550,7 @@ func TestLookupToken(t *testing.T) {
 			Email:    FirstUserEmail,
 			Password: "password123",
 		}
-		statusCode, _, err := initializeAPI(ts.URL, client, initializeParams)
+		statusCode, _, err := initialize(ts.URL, client, initializeParams)
 		if err != nil {
 			t.Fatalf("couldn't create admin user: %s", err)
 		}

--- a/internal/api/server/api_backup_test.go
+++ b/internal/api/server/api_backup_test.go
@@ -41,7 +41,7 @@ func TestBackupEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	client := ts.Client()
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_backup_test.go
+++ b/internal/api/server/api_backup_test.go
@@ -41,7 +41,7 @@ func TestBackupEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	client := ts.Client()
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_data_networks_test.go
+++ b/internal/api/server/api_data_networks_test.go
@@ -203,7 +203,7 @@ func TestAPIDataNetworksEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -416,7 +416,7 @@ func TestCreateDataNetworkInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -542,7 +542,7 @@ func TestCreateTooManyDataNetworks(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_data_networks_test.go
+++ b/internal/api/server/api_data_networks_test.go
@@ -203,7 +203,7 @@ func TestAPIDataNetworksEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -416,7 +416,7 @@ func TestCreateDataNetworkInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -542,7 +542,7 @@ func TestCreateTooManyDataNetworks(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -3,12 +3,14 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"strings"
 
 	"github.com/ellanetworks/core/internal/api/server"
 	"github.com/ellanetworks/core/internal/db"
@@ -97,16 +99,62 @@ func setupServer(filepath string) (*httptest.Server, []byte, error) {
 	return ts, jwtSecret, nil
 }
 
-func createFirstUserAndLogin(url string, client *http.Client) (string, error) {
-	user := &CreateUserParams{
+type InitializeResponseResult struct {
+	Message string `json:"message"`
+}
+
+type InitializeResponse struct {
+	Result InitializeResponseResult `json:"result"`
+	Error  string                   `json:"error,omitempty"`
+}
+
+type InitializeParams struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+func initializeAPI(url string, client *http.Client, data *InitializeParams) (int, *InitializeResponse, error) {
+	body, err := json.Marshal(data)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url+"/api/v1/init", strings.NewReader(string(body)))
+	if err != nil {
+		return 0, nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return res.StatusCode, nil, err
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	var initResponse InitializeResponse
+
+	if err := json.NewDecoder(res.Body).Decode(&initResponse); err != nil {
+		return res.StatusCode, nil, err
+	}
+
+	return res.StatusCode, &initResponse, nil
+}
+
+func initialize(url string, client *http.Client) (string, error) {
+	initParams := &InitializeParams{
 		Email:    FirstUserEmail,
 		Password: "password123",
-		RoleID:   RoleAdmin,
 	}
-	statusCode, _, err := createUser(url, client, "", user)
+
+	statusCode, _, err := initializeAPI(url, client, initParams)
 	if err != nil {
 		return "", fmt.Errorf("couldn't create user: %s", err)
 	}
+
 	if statusCode != http.StatusCreated {
 		return "", fmt.Errorf("expected status %d, got %d", http.StatusCreated, statusCode)
 	}

--- a/internal/api/server/api_initialize.go
+++ b/internal/api/server/api_initialize.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/logger"
+)
+
+type InitializeParams struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+const (
+	InitializeAction = "initialize"
+)
+
+func Initialize(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var newUser InitializeParams
+
+		if err := json.NewDecoder(r.Body).Decode(&newUser); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid request data", err, logger.APILog)
+			return
+		}
+
+		if newUser.Email == "" {
+			writeError(w, http.StatusBadRequest, "email is missing", errors.New("missing email"), logger.APILog)
+			return
+		}
+
+		if newUser.Password == "" {
+			writeError(w, http.StatusBadRequest, "password is missing", errors.New("missing password"), logger.APILog)
+			return
+		}
+
+		if !isValidEmail(newUser.Email) {
+			writeError(w, http.StatusBadRequest, "Invalid email format", errors.New("bad format"), logger.APILog)
+			return
+		}
+
+		numUsers, err := dbInstance.CountUsers(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to count users", err, logger.APILog)
+			return
+		}
+
+		if numUsers != 0 {
+			writeError(w, http.StatusForbidden, "System already initialized", errors.New("users already exist"), logger.APILog)
+			return
+		}
+
+		hashedPassword, err := hashPassword(newUser.Password)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to hash password", err, logger.APILog)
+			return
+		}
+
+		dbUser := &db.User{
+			Email:          newUser.Email,
+			HashedPassword: hashedPassword,
+			RoleID:         db.RoleAdmin,
+		}
+
+		if err := dbInstance.CreateUser(r.Context(), dbUser); err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to create user", err, logger.APILog)
+			return
+		}
+
+		writeResponse(w, SuccessResponse{Message: "System initialized successfully"}, http.StatusCreated, logger.APILog)
+
+		logger.LogAuditEvent(
+			InitializeAction,
+			"",
+			getClientIP(r),
+			fmt.Sprintf("System initialized with first user %s", newUser.Email),
+		)
+	})
+}

--- a/internal/api/server/api_initialize_test.go
+++ b/internal/api/server/api_initialize_test.go
@@ -1,0 +1,70 @@
+package server_test
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitializeInvalidInput(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+	ts, _, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer ts.Close()
+	client := ts.Client()
+
+	tests := []struct {
+		email    string
+		password string
+		error    string
+	}{
+		{
+			email:    strings.Repeat("a", 257),
+			password: Password,
+			error:    "Invalid email format",
+		},
+		{
+			email:    "abcdef",
+			password: Password,
+			error:    "Invalid email format",
+		},
+		{
+			email:    "abcdef@",
+			password: Password,
+			error:    "Invalid email format",
+		},
+		{
+			email:    "abcdef@gmail.",
+			password: Password,
+			error:    "Invalid email format",
+		},
+		{
+			email:    "abcd@ef@ellanetworks.com",
+			password: Password,
+			error:    "Invalid email format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.email, func(t *testing.T) {
+			initializeParams := &InitializeParams{
+				Email:    tt.email,
+				Password: tt.password,
+			}
+			statusCode, response, err := initializeAPI(ts.URL, client, initializeParams)
+			if err != nil {
+				t.Fatalf("couldn't create user: %s", err)
+			}
+			if statusCode != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
+			}
+			if response.Error != tt.error {
+				t.Fatalf("expected error %q, got %q", tt.error, response.Error)
+			}
+		})
+	}
+}

--- a/internal/api/server/api_nat_test.go
+++ b/internal/api/server/api_nat_test.go
@@ -110,7 +110,7 @@ func TestApiNATInfoEndToEnd(t *testing.T) {
 
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_nat_test.go
+++ b/internal/api/server/api_nat_test.go
@@ -110,7 +110,7 @@ func TestApiNATInfoEndToEnd(t *testing.T) {
 
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_operator_test.go
+++ b/internal/api/server/api_operator_test.go
@@ -315,7 +315,7 @@ func TestApiOperatorEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -538,7 +538,7 @@ func TestUpdateOperatorSliceInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -604,7 +604,7 @@ func TestUpdateOperatorTrackingInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -662,7 +662,7 @@ func TestUpdateOperatorIDInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -741,7 +741,7 @@ func TestUpdateOperatorCodeInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_operator_test.go
+++ b/internal/api/server/api_operator_test.go
@@ -315,7 +315,7 @@ func TestApiOperatorEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -538,7 +538,7 @@ func TestUpdateOperatorSliceInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -604,7 +604,7 @@ func TestUpdateOperatorTrackingInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -662,7 +662,7 @@ func TestUpdateOperatorIDInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -741,7 +741,7 @@ func TestUpdateOperatorCodeInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_policies_test.go
+++ b/internal/api/server/api_policies_test.go
@@ -202,7 +202,7 @@ func TestAPIPoliciesEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -444,7 +444,7 @@ func TestCreatePolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -625,7 +625,7 @@ func TestCreateTooManyPolicies(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_policies_test.go
+++ b/internal/api/server/api_policies_test.go
@@ -202,7 +202,7 @@ func TestAPIPoliciesEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -444,7 +444,7 @@ func TestCreatePolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -625,7 +625,7 @@ func TestCreateTooManyPolicies(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_radio_logs_test.go
+++ b/internal/api/server/api_radio_logs_test.go
@@ -140,7 +140,7 @@ func TestAPIRadioLogs(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -185,7 +185,7 @@ func TestAPIRadioLogRetentionPolicyEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -258,7 +258,7 @@ func TestUpdateRadioLogRetentionPolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_radio_logs_test.go
+++ b/internal/api/server/api_radio_logs_test.go
@@ -140,7 +140,7 @@ func TestAPIRadioLogs(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -185,7 +185,7 @@ func TestAPIRadioLogRetentionPolicyEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -258,7 +258,7 @@ func TestUpdateRadioLogRetentionPolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_radios_test.go
+++ b/internal/api/server/api_radios_test.go
@@ -92,7 +92,7 @@ func TestListRadios(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_radios_test.go
+++ b/internal/api/server/api_radios_test.go
@@ -92,7 +92,7 @@ func TestListRadios(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_restore_test.go
+++ b/internal/api/server/api_restore_test.go
@@ -87,7 +87,7 @@ func TestRestoreEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	client := ts.Client()
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_restore_test.go
+++ b/internal/api/server/api_restore_test.go
@@ -87,7 +87,7 @@ func TestRestoreEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	client := ts.Client()
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_routes_test.go
+++ b/internal/api/server/api_routes_test.go
@@ -173,7 +173,7 @@ func TestAPIRoutesEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -322,7 +322,7 @@ func TestCreateRouteInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -410,7 +410,7 @@ func TestCreateTooManyRoutes(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_routes_test.go
+++ b/internal/api/server/api_routes_test.go
@@ -173,7 +173,7 @@ func TestAPIRoutesEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -322,7 +322,7 @@ func TestCreateRouteInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -410,7 +410,7 @@ func TestCreateTooManyRoutes(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_subscriber_logs_test.go
+++ b/internal/api/server/api_subscriber_logs_test.go
@@ -140,7 +140,7 @@ func TestAPISubscriberLogs(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -185,7 +185,7 @@ func TestAPISubscriberLogRetentionPolicyEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -258,7 +258,7 @@ func TestUpdateSubscriberLogRetentionPolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_subscriber_logs_test.go
+++ b/internal/api/server/api_subscriber_logs_test.go
@@ -140,7 +140,7 @@ func TestAPISubscriberLogs(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -185,7 +185,7 @@ func TestAPISubscriberLogRetentionPolicyEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -258,7 +258,7 @@ func TestUpdateSubscriberLogRetentionPolicyInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -183,7 +183,7 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -397,7 +397,7 @@ func TestCreateSubscriberInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -489,7 +489,7 @@ func TestCreateTooManySubscribers(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -183,7 +183,7 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -397,7 +397,7 @@ func TestCreateSubscriberInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -489,7 +489,7 @@ func TestCreateTooManySubscribers(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_users.go
+++ b/internal/api/server/api_users.go
@@ -241,13 +241,6 @@ func CreateUser(dbInstance *db.Database) http.Handler {
 			return
 		}
 
-		if numUsers == 0 {
-			if newUser.RoleID != RoleAdmin {
-				writeError(w, http.StatusBadRequest, "First user must be an admin", errors.New("first user must be admin"), logger.APILog)
-				return
-			}
-		}
-
 		if numUsers >= MaxNumUsers {
 			writeError(w, http.StatusBadRequest, "Maximum number of users reached ("+strconv.Itoa(MaxNumUsers)+")", nil, logger.APILog)
 			return

--- a/internal/api/server/api_users.go
+++ b/internal/api/server/api_users.go
@@ -252,7 +252,8 @@ func CreateUser(dbInstance *db.Database) http.Handler {
 			RoleID:         db.RoleID(newUser.RoleID),
 		}
 
-		if err := dbInstance.CreateUser(r.Context(), dbUser); err != nil {
+		_, err = dbInstance.CreateUser(r.Context(), dbUser)
+		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Failed to create user", err, logger.APILog)
 			return
 		}

--- a/internal/api/server/api_users_test.go
+++ b/internal/api/server/api_users_test.go
@@ -451,7 +451,7 @@ func TestAPIUsersEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -621,7 +621,7 @@ func TestNonAdminUpdateUserPassword(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	adminToken, err := createFirstUserAndLogin(ts.URL, client)
+	adminToken, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -696,36 +696,6 @@ func TestNonAdminUpdateUserPassword(t *testing.T) {
 	}
 }
 
-func TestAPIUsersFirstUserNonAdmin(t *testing.T) {
-	tempDir := t.TempDir()
-	dbPath := filepath.Join(tempDir, "db.sqlite3")
-	ts, _, err := setupServer(dbPath)
-	if err != nil {
-		t.Fatalf("couldn't create test server: %s", err)
-	}
-	defer ts.Close()
-	client := ts.Client()
-
-	createUserParams := &CreateUserParams{
-		Email:    Email,
-		Password: Password,
-		RoleID:   RoleReadOnly,
-	}
-
-	statusCode, response, err := createUser(ts.URL, client, "", createUserParams)
-	if err != nil {
-		t.Fatalf("couldn't create user: %s", err)
-	}
-
-	if statusCode != http.StatusBadRequest {
-		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
-	}
-
-	if response.Error != "First user must be an admin" {
-		t.Fatalf("unexpected error :%q", response.Error)
-	}
-}
-
 func TestCreateUserInvalidInput(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
@@ -736,7 +706,7 @@ func TestCreateUserInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -803,7 +773,7 @@ func TestCreateTooManyUsers(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -857,7 +827,7 @@ func TestCreateAPIToken(t *testing.T) {
 
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -929,7 +899,7 @@ func TestCreateAPITokenInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -986,7 +956,7 @@ func TestListUsersPagination(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := createFirstUserAndLogin(ts.URL, client)
+	token, err := initialize(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/api_users_test.go
+++ b/internal/api/server/api_users_test.go
@@ -451,7 +451,7 @@ func TestAPIUsersEndToEnd(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -621,7 +621,7 @@ func TestNonAdminUpdateUserPassword(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	adminToken, err := initialize(ts.URL, client)
+	adminToken, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -706,7 +706,7 @@ func TestCreateUserInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -773,7 +773,7 @@ func TestCreateTooManyUsers(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -827,7 +827,7 @@ func TestCreateAPIToken(t *testing.T) {
 
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -899,7 +899,7 @@ func TestCreateAPITokenInvalidInput(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}
@@ -956,7 +956,7 @@ func TestListUsersPagination(t *testing.T) {
 	defer ts.Close()
 	client := ts.Client()
 
-	token, err := initialize(ts.URL, client)
+	token, err := initializeAndRefresh(ts.URL, client)
 	if err != nil {
 		t.Fatalf("couldn't create first user and login: %s", err)
 	}

--- a/internal/api/server/authentication_middleware.go
+++ b/internal/api/server/authentication_middleware.go
@@ -100,16 +100,6 @@ func putIdentity(ctx context.Context, id int, email string, role RoleID) context
 	return ctx
 }
 
-// authorize checks if a role has a permission.
-func authorize(role RoleID, perm string) bool {
-	for _, p := range PermissionsByRole[role] {
-		if p == "*" || p == perm {
-			return true
-		}
-	}
-	return false
-}
-
 func Authenticate(jwtSecret []byte, store *db.Database, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		uid, email, role, err := authenticateRequest(r, jwtSecret, store)

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -30,7 +30,7 @@ func NewHandler(dbInstance *db.Database, upf UPFReloader, kernel kernel.Kernel, 
 	mux.HandleFunc("POST /api/v1/auth/lookup-token", LookupToken(dbInstance, jwtSecret).ServeHTTP)
 
 	// Initialization (Unauthenticated)
-	mux.HandleFunc("POST /api/v1/init", Initialize(dbInstance).ServeHTTP)
+	mux.HandleFunc("POST /api/v1/init", Initialize(dbInstance, secureCookie).ServeHTTP)
 
 	// Users (Authenticated except for first user creation)
 	mux.HandleFunc("GET /api/v1/users/me", Authenticate(jwtSecret, dbInstance, GetLoggedInUser(dbInstance)).ServeHTTP)

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -29,6 +29,9 @@ func NewHandler(dbInstance *db.Database, upf UPFReloader, kernel kernel.Kernel, 
 	mux.HandleFunc("POST /api/v1/auth/logout", Logout(dbInstance, secureCookie).ServeHTTP)
 	mux.HandleFunc("POST /api/v1/auth/lookup-token", LookupToken(dbInstance, jwtSecret).ServeHTTP)
 
+	// Initialization (Unauthenticated)
+	mux.HandleFunc("POST /api/v1/init", Initialize(dbInstance).ServeHTTP)
+
 	// Users (Authenticated except for first user creation)
 	mux.HandleFunc("GET /api/v1/users/me", Authenticate(jwtSecret, dbInstance, GetLoggedInUser(dbInstance)).ServeHTTP)
 	mux.HandleFunc("PUT /api/v1/users/me/password", Authenticate(jwtSecret, dbInstance, RequirePermission(PermUpdateMyUserPassword, jwtSecret, UpdateMyUserPassword(dbInstance))).ServeHTTP)
@@ -36,7 +39,7 @@ func NewHandler(dbInstance *db.Database, upf UPFReloader, kernel kernel.Kernel, 
 	mux.HandleFunc("POST /api/v1/users/me/api-tokens", Authenticate(jwtSecret, dbInstance, RequirePermission(PermCreateMyAPIToken, jwtSecret, CreateMyAPIToken(dbInstance))).ServeHTTP)
 	mux.HandleFunc("DELETE /api/v1/users/me/api-tokens/", Authenticate(jwtSecret, dbInstance, RequirePermission(PermDeleteMyAPIToken, jwtSecret, DeleteMyAPIToken(dbInstance))).ServeHTTP)
 	mux.HandleFunc("GET /api/v1/users", Authenticate(jwtSecret, dbInstance, RequirePermission(PermListUsers, jwtSecret, ListUsers(dbInstance))).ServeHTTP)
-	mux.HandleFunc("POST /api/v1/users", RequirePermissionOrFirstUser(PermCreateUser, dbInstance, jwtSecret, CreateUser(dbInstance)).ServeHTTP)
+	mux.HandleFunc("POST /api/v1/users", Authenticate(jwtSecret, dbInstance, RequirePermission(PermCreateUser, jwtSecret, CreateUser(dbInstance))).ServeHTTP)
 	mux.HandleFunc("PUT /api/v1/users/{email}", Authenticate(jwtSecret, dbInstance, RequirePermission(PermUpdateUser, jwtSecret, UpdateUser(dbInstance))).ServeHTTP)
 	mux.HandleFunc("PUT /api/v1/users/{email}/password", Authenticate(jwtSecret, dbInstance, RequirePermission(PermUpdateUserPassword, jwtSecret, UpdateUserPassword(dbInstance))).ServeHTTP)
 	mux.HandleFunc("GET /api/v1/users/{email}", Authenticate(jwtSecret, dbInstance, RequirePermission(PermReadUser, jwtSecret, GetUser(dbInstance))).ServeHTTP)

--- a/internal/db/api_tokens_test.go
+++ b/internal/db/api_tokens_test.go
@@ -27,7 +27,8 @@ func TestDBAPITokensEndToEnd(t *testing.T) {
 		Email:  "abc@ellanetworks.com",
 		RoleID: db.RoleAdmin,
 	}
-	err = database.CreateUser(context.Background(), user)
+
+	_, err = database.CreateUser(context.Background(), user)
 	if err != nil {
 		t.Fatalf("Couldn't create user: %s", err)
 	}

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -39,10 +39,9 @@ const (
 type RoleID int
 
 const (
-	RoleAdmin                RoleID = 0
-	RoleCertificateManager   RoleID = 1
-	RoleCertificateRequestor RoleID = 2
-	RoleReadOnly             RoleID = 3
+	RoleAdmin          RoleID = 1
+	RoleReadOnly       RoleID = 2
+	RoleNetworkManager RoleID = 3
 )
 
 type User struct {

--- a/internal/db/users_test.go
+++ b/internal/db/users_test.go
@@ -40,9 +40,14 @@ func TestDBUsersEndToEnd(t *testing.T) {
 		Email:          "my.user123@ellanetworks.com",
 		HashedPassword: "my-hashed-password",
 	}
-	err = database.CreateUser(context.Background(), user)
+
+	userID, err := database.CreateUser(context.Background(), user)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
+	}
+
+	if userID == 0 {
+		t.Fatalf("Expected user ID to be non-zero after creation")
 	}
 
 	res, total, err = database.ListUsersPage(context.Background(), 1, 10)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,17 +53,18 @@ nav:
     - reference/index.md
     - API:
       - reference/api/index.md
-      - Backup: reference/api/backup.md
       - Authentication: reference/api/auth.md
+      - Backup: reference/api/backup.md
+      - Initialization: reference/api/initialize.md
+      - Logs: reference/api/logs.md
       - Metrics: reference/api/metrics.md
-      - Operator: reference/api/operator.md
       - Networking: reference/api/networking.md
+      - Operator: reference/api/operator.md
       - Policies: reference/api/policies.md
       - Radios: reference/api/radios.md
       - Restore: reference/api/restore.md
       - Status: reference/api/status.md
       - Subscribers: reference/api/subscribers.md
-      - Logs: reference/api/logs.md
       - Users: reference/api/users.md
     - Configuration File: reference/config_file.md
     - Production Hardening: reference/production_hardening.md

--- a/ui/app/(auth)/initialize/page.tsx
+++ b/ui/app/(auth)/initialize/page.tsx
@@ -10,7 +10,7 @@ import {
   Alert,
   CircularProgress,
 } from "@mui/material";
-import { createUser, RoleID } from "@/queries/users";
+import { initialize } from "@/queries/initialize";
 import { getStatus } from "@/queries/status";
 
 const InitializePage = () => {
@@ -45,7 +45,7 @@ const InitializePage = () => {
     setError(null);
 
     try {
-      await createUser("", email, RoleID.Admin, password);
+      await initialize(email, password);
       router.push("/login");
     } catch (err) {
       const error = err as Error;

--- a/ui/app/(auth)/initialize/page.tsx
+++ b/ui/app/(auth)/initialize/page.tsx
@@ -26,7 +26,7 @@ const InitializePage = () => {
       try {
         const status = await getStatus();
         if (status?.initialized) {
-          router.push("/login");
+          router.push("/dashboard");
         } else {
           setCheckingInitialization(false);
         }

--- a/ui/queries/initialize.tsx
+++ b/ui/queries/initialize.tsx
@@ -1,9 +1,6 @@
 import { HTTPStatus } from "@/queries/utils";
 
-export const initialize = async (
-  email: string,
-  password: string,
-) => {
+export const initialize = async (email: string, password: string) => {
   const initData = {
     email: email,
     password: password,

--- a/ui/queries/initialize.tsx
+++ b/ui/queries/initialize.tsx
@@ -1,0 +1,35 @@
+import { HTTPStatus } from "@/queries/utils";
+
+export const initialize = async (
+  email: string,
+  password: string,
+) => {
+  const initData = {
+    email: email,
+    password: password,
+  };
+
+  const response = await fetch(`/api/v1/init`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(initData),
+  });
+  let respData;
+  try {
+    respData = await response.json();
+  } catch {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
+    );
+  }
+
+  return respData.result;
+};


### PR DESCRIPTION
# Description

After initializing Ella Core we had to login with the same credentials used to initialize. This second step was always superfluous and unnecessarily increased the number of actions needed to get started with Ella Core. Here we separate initialization from user creation and automatically create a session on initialization. In addition to the better UX, this change cleans up the weird logic we had around auth for creating users.

- [x] Add a separate `POST /api/v1/init` for initializing the system
- [x] Create session and set cookie on initialization
- [x] Update tests
- [x] Update client
- [x] Update docs

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
