### PR TITLE
fix: Fix segfaults when SCTP connection is closed uncleanly by the remote peer

### DIFF
--- a/internal/amf/ngap/dispatcher.go
+++ b/internal/amf/ngap/dispatcher.go
@@ -90,10 +90,17 @@ func DispatchNgapMsg(conn net.Conn, ran *context.AmfRan, pdu *ngapType.NGAPPDU) 
 		procName = "UnknownProcedure"
 	}
 
+	peerAddr := conn.RemoteAddr()
+	var peerAddrStr string
+	if peerAddr != nil {
+		peerAddrStr = peerAddr.String()
+	} else {
+		peerAddrStr = ""
+	}
 	spanName := fmt.Sprintf("AMF NGAP %s", procName)
 	ctx, span := tracer.Start(ctxt.Background(), spanName,
 		trace.WithAttributes(
-			attribute.String("net.peer", conn.RemoteAddr().String()),
+			attribute.String("net.peer", peerAddrStr),
 			attribute.String("ngap.pdu_present", fmt.Sprintf("%d", pdu.Present)),
 			attribute.String("ngap.procedureCode", procName),
 		),

--- a/internal/amf/ngap/service/service.go
+++ b/internal/amf/ngap/service/service.go
@@ -178,8 +178,11 @@ func handleConnection(conn *sctp.SCTPConn, bufsize uint32, handler NGAPHandler) 
 			case syscall.EINTR:
 				logger.AmfLog.Debug("SCTPRead", zap.Error(err))
 				continue
+			case syscall.EINVAL:
+				logger.AmfLog.Error("Couldn't handle remotely closed connection", zap.Error(err))
+				return
 			default:
-				logger.AmfLog.Error("Handle connection error", zap.Error(err), zap.String("address", conn.RemoteAddr().String()))
+				logger.AmfLog.Error("Handle connection error", zap.Error(err))
 				return
 			}
 		}


### PR DESCRIPTION
# Description

When a gnb disconnects uncleanly from the core, like when using a simulator and using `ctrl-c`, the core often crashed with a segfault, due to a nil pointer dereference when trying to read the remote address. This small PR fixes the 2 instances I observed of this happening, ensuring the core stays up in such cases.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
