### PR TITLE
fix: validate smcontext is not nil during update sm context request

### DIFF
--- a/internal/smf/pdusession/api_individual_sm_context.go
+++ b/internal/smf/pdusession/api_individual_sm_context.go
@@ -46,13 +46,18 @@ func UpdateSmContext(ctx ctxt.Context, smContextRef string, updateSmContextReque
 	}
 
 	smContext := context.GetSMContext(smContextRef)
+	if smContext == nil {
+		return nil, fmt.Errorf("sm context not found: %s", smContextRef)
+	}
 
 	rsp, err := producer.HandlePDUSessionSMContextUpdate(ctx, updateSmContextRequest, smContext)
 	if err != nil {
 		return rsp, fmt.Errorf("error updating pdu session: %v ", err.Error())
 	}
+
 	if rsp == nil {
 		return nil, fmt.Errorf("response is nil")
 	}
+
 	return rsp, nil
 }


### PR DESCRIPTION
# Description

Validate smcontext is not nil during update sm context request. This fixes a nil-pointer type issue. See referenced issue for stack trace.

Fixes #728

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
