### PR TITLE
fix: only build service area info if am policy is not nil

### DIFF
--- a/internal/amf/ngap/message/forward_ie.go
+++ b/internal/amf/ngap/message/forward_ie.go
@@ -148,7 +148,7 @@ func BuildIEMobilityRestrictionList(ue *context.AmfUe) ngapType.MobilityRestrict
 		}
 	}
 
-	if ue.AmPolicyAssociation.ServAreaRes != nil {
+	if ue.AmPolicyAssociation != nil && ue.AmPolicyAssociation.ServAreaRes != nil {
 		mobilityRestrictionList.ServiceAreaInformation = new(ngapType.ServiceAreaInformation)
 		serviceAreaInformation := mobilityRestrictionList.ServiceAreaInformation
 


### PR DESCRIPTION
# Description

We fix a nil-pointer error where we were building the service area information with content that we didn't check we had access to.

Fixes #735 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
