### PR TITLE
docs: update api reference to session cookie and refresh token

### DIFF
--- a/docs/reference/api/auth.md
+++ b/docs/reference/api/auth.md
@@ -8,7 +8,7 @@ This section describes the RESTful API for system user authentication.
 
 ## Login
 
-This path returns a token that can be used to authenticate with Ella Core.
+This path logs the user in and sets an httpOnly session cookie valid for 30 days.
 
 | Method | Path                 |
 | ------ | -------------------- |
@@ -18,6 +18,31 @@ This path returns a token that can be used to authenticate with Ella Core.
 
 - `email` (string): The email to authenticate with.
 - `password` (string): The password to authenticate with.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "message": "Login successful"
+    }
+}
+```
+
+## Refresh
+
+This path validates the current session cookie and returns a new JWT token. This token can then be used to authenticate future requests by sending it in the `Authorization` header using the `Bearer <token>` scheme. This token is valid for 15 minutes.
+
+| Method | Path                 |
+| ------ | -------------------- |
+| POST   | `/api/v1/auth/refresh` |
+
+!!! warning
+    Avoid relying on refresh tokens for API access since they require regular renewals. Instead, use [API tokens](users.md#create-an-api-token) which offer explicit expiry settings and can be manually revoked.
+
+### Parameters
+
+None
 
 ### Sample Response
 


### PR DESCRIPTION
# Description

We recently updated Ella Core's authentication approach to leverage session cookies and refresh tokens but we hadn't updated the API reference. Here we update the API reference and warn users against using refresh tokens for API access, they should use API tokens instead.

Fixes #737

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
