### PR TITLE
fix: Add gateways from routes on relevant interfaces to neighbours

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -131,6 +131,12 @@ func ReconcileKernelRouting(dbInstance *db.Database, kernelInt kernel.Kernel) er
 			}
 		}
 	}
+	for _, netIf := range interfaceDBKernelMap {
+		err := kernelInt.EnsureGatewaysOnInterfaceInNeighTable(netIf)
+		if err != nil {
+			logger.APILog.Warn("failed to ensure gateways are in neighbour table for interface", zap.Any("interface", netIf), zap.Error(err))
+		}
+	}
 	logger.APILog.Debug("Routes reconciled")
 	return nil
 }

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -46,6 +46,10 @@ func (fk FakeKernel) IsIPForwardingEnabled() (bool, error) {
 	return true, nil
 }
 
+func (fk FakeKernel) EnsureGatewaysOnInterfaceInNeighTable(ifKey kernel.NetworkInterface) error {
+	return nil
+}
+
 type dummyFS struct{}
 
 func (dummyFS) Open(name string) (fs.File, error) {


### PR DESCRIPTION
# Description

Because we use XDP for the UPF pipeline, packets are routed without the usual kernel involvment. This means that the kernel will not send the ARP requests to the gateways that are necessary for routing to work from the UPF traffic. External intervention was necessary, either from network traffic or administrative actions.

This commit makes Ella Core add the gateways to the neighbour table with the `use` flag, ensuring the kernel will run the required ARP requests in the background.

We first add the gateway to the neighbour table anytime we create a route, ensuring that routes added from the interface will work immediately.

We also inspect all routes with gateways on N3 and N6, and try to add those gateways to the neighbour table during the route reconciliation process. This will cover all relevant routes that are not managed directly by Ella Core, for example routes received through DHCP.

fixes #729 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
