### PR TITLE
docs: add revision to how-to install from source guide

### DIFF
--- a/docs/how_to/install.md
+++ b/docs/how_to/install.md
@@ -59,7 +59,8 @@ Ensure your system meets the [requirements](../reference/system_reqs.md). Then, 
     Build Ella Core:
 
     ```shell
-    go build cmd/core/main.go
+    REVISION=`git rev-parse HEAD`
+    go build -ldflags "-X github.com/ellanetworks/core/version.GitCommit=${REVISION}" ./cmd/core/main.go
     ```
 
     Configure Ella Core:


### PR DESCRIPTION
# Description

In #743 we added the revision as one of the fields in Ella Core's status. This requires building the binary with a certain `ldflag`. Here we add this information to the how-to install from source guide so that users building from source also get the revision in their builds.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
