### PR TITLE
fix: set SCTP PPID with network endianness

### DIFF
--- a/internal/amf/ngap/service/service.go
+++ b/internal/amf/ngap/service/service.go
@@ -91,7 +91,7 @@ func listenAndServe(addr *sctp.SCTPAddr, handler NGAPHandler) {
 			logger.AmfLog.Debug("Get default sent param", zap.Any("info", info))
 		}
 
-		info.PPID = ngap.PPID
+		info.PPID = nativeToNetworkEndianness32(ngap.PPID)
 		if err := newConn.SetDefaultSentParam(info); err != nil {
 			logger.AmfLog.Error("Set default sent param error", zap.Error(err))
 			if err = newConn.Close(); err != nil {
@@ -210,4 +210,10 @@ func networkToNativeEndianness32(value uint32) uint32 {
 	var b [4]byte
 	binary.BigEndian.PutUint32(b[:], value)
 	return binary.NativeEndian.Uint32(b[:])
+}
+
+func nativeToNetworkEndianness32(value uint32) uint32 {
+	var b [4]byte
+	binary.NativeEndian.PutUint32(b[:], value)
+	return binary.BigEndian.Uint32(b[:])
 }


### PR DESCRIPTION
# Description

On Linux, the syscall for SYS_SETSOCKOPT expects the PPID field in network byte order (big-endian), but Ella Core passed it in host order (generally little-endian), so the kernel stored and sent `1006632960` instead of `60`. Now we convert native to network endianness in order to always pass in the value in the expected endianness. 

Fixes #759 

## Screenshots

<img width="1836" height="1354" alt="image" src="https://github.com/user-attachments/assets/a9859971-7efa-481a-9997-fbae46aa5f54" />


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
