### PR TITLE
fix: validate DNN is not empty

### DIFF
--- a/internal/amf/gmm/handler.go
+++ b/internal/amf/gmm/handler.go
@@ -207,7 +207,7 @@ func transport5GSMMessage(ctx ctxt.Context, ue *context.AmfUe, anType models.Acc
 				}
 			}
 
-			if ulNasTransport.DNN != nil {
+			if ulNasTransport.DNN != nil && ulNasTransport.DNN.GetLen() > 0 {
 				dnn = string(ulNasTransport.DNN.GetDNN())
 			} else {
 				// if user's subscription context obtained from UDM does not contain the default DNN for the,

--- a/internal/decoder/nas/pdu_session_establishment_accept.go
+++ b/internal/decoder/nas/pdu_session_establishment_accept.go
@@ -96,7 +96,7 @@ func buildPDUSessionEstablishmentAccept(msg *nasMessage.PDUSessionEstablishmentA
 		estAcc.ExtendedProtocolConfigurationOptions = buildExtendedProtocolConfigurationOptions(msg.ExtendedProtocolConfigurationOptions)
 	}
 
-	if msg.DNN != nil {
+	if msg.DNN != nil && msg.DNN.GetLen() > 0 {
 		dnn := string(msg.DNN.GetDNN())
 		estAcc.DNN = &dnn
 	}

--- a/internal/decoder/nas/ul_nas_transport.go
+++ b/internal/decoder/nas/ul_nas_transport.go
@@ -65,7 +65,7 @@ func buildULNASTransport(msg *nasMessage.ULNASTransport) *ULNASTransport {
 		ulNasTransport.SNSSAI = &snssai
 	}
 
-	if msg.DNN != nil {
+	if msg.DNN != nil && msg.DNN.GetLen() > 0 {
 		dnn := string(msg.DNN.GetDNN())
 		ulNasTransport.DNN = &dnn
 	}


### PR DESCRIPTION
# Description

According to #773, some UE's send an empty DNN in the its PDU Session Establishment Request.  While I was not able to reproduce this issue with the phone I had on hand (Crosscall Core Z5) nor with a simulator, even when removing the DNN config, I was able to write a short test that resulted in the same error:

```go
func TestGetDNN_ZeroLength(t *testing.T) {
	ulNasTransport := &nasMessage.ULNASTransport{}

	ulNasTransport.DNN = new(nasType.DNN)

	ulNasTransport.DNN.SetDNN([]uint8{})
	ulNasTransport.DNN.SetLen(0)

	ulNasTransport.DNN.GetDNN()
}
```

Fixes #773 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
