### PR TITLE
chore: include ueransim config files in integration tests 

### DIFF
--- a/integration/compose/ueransim/compose.yaml
+++ b/integration/compose/ueransim/compose.yaml
@@ -107,7 +107,7 @@ configs:
 
 services:
   ella-core:
-    image: ghcr.io/ellanetworks/ella-core:v0.4.0
+    image: ella-core:latest
     configs:
       - source: ella_config
         target: /core.yaml


### PR DESCRIPTION
# Description

In our ueransim integration tests we used the ueransim's config files (`ue.yaml` and `gnb.yaml`) that were part of the [container image](https://github.com/ellanetworks/test-rocks/tree/main/ueransim) we build for ueransim. While using these pre-configured files is great in tutorials as it hides the configuration details form the users, it's quite useful in integration tests to know exactly what we are testing. Here we explicitly use the files part of the docker-compose file we build. This makes it easy to change a parameter and validate its consequence.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
