### PR TITLE
fix: allocate GUTI during registration accept

### DIFF
--- a/internal/amf/context/context.go
+++ b/internal/amf/context/context.go
@@ -114,15 +114,6 @@ func (context *AMFContext) AllocateAmfUeNgapID() (int64, error) {
 	return val, nil
 }
 
-func (context *AMFContext) AllocateGutiToUe(ctx ctxt.Context, ue *AmfUe) {
-	guamis := GetServedGuamiList(ctx)
-	servedGuami := guamis[0]
-	ue.Tmsi = context.TmsiAllocate()
-	plmnID := servedGuami.PlmnID.Mcc + servedGuami.PlmnID.Mnc
-	tmsiStr := fmt.Sprintf("%08x", ue.Tmsi)
-	ue.Guti = plmnID + servedGuami.AmfID + tmsiStr
-}
-
 func (context *AMFContext) ReAllocateGutiToUe(ctx ctxt.Context, ue *AmfUe) {
 	guamis := GetServedGuamiList(ctx)
 	servedGuami := guamis[0]
@@ -174,8 +165,6 @@ func (context *AMFContext) NewAmfUe(ctx ctxt.Context, supi string) *AmfUe {
 	if supi != "" {
 		context.AddAmfUeToUePool(&ue, supi)
 	}
-
-	// context.AllocateGutiToUe(ctx, &ue)
 
 	return &ue
 }

--- a/internal/amf/gmm/handler.go
+++ b/internal/amf/gmm/handler.go
@@ -396,7 +396,6 @@ func HandleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, anType model
 	// MacFailed is set if plain Registration Request message received with GUTI/SUCI or
 	// integrity protected Registration Reguest message received but mac verification Failed
 	if ue.MacFailed {
-		amfSelf.ReAllocateGutiToUe(ctx, ue)
 		ue.SecurityContextAvailable = false
 	}
 


### PR DESCRIPTION
# Description

Ella Core would generate a GUTI early, then store the UE's GUTI sent as part of the registration request, and send that same GUTI as part of the Registration Accept message. Instead, now Ella Core allocates the GUTI during the registration (initial or periodic) and send that GUTI regardless of what the UE initially provided.  

Fixes #716 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
