### PR TITLE
fix: purge ue regardless of its state upon deletion

### DIFF
--- a/internal/amf/deregister/deregister.go
+++ b/internal/amf/deregister/deregister.go
@@ -2,13 +2,9 @@ package deregister
 
 import (
 	ctxt "context"
-	"fmt"
 
 	"github.com/ellanetworks/core/internal/amf/context"
-	"github.com/ellanetworks/core/internal/amf/gmm"
 	"github.com/ellanetworks/core/internal/logger"
-	"github.com/ellanetworks/core/internal/models"
-	"github.com/ellanetworks/core/internal/util/fsm"
 	"go.uber.org/zap"
 )
 
@@ -21,21 +17,7 @@ func DeregisterSubscriber(ctx ctxt.Context, supi string) error {
 		return nil
 	}
 
-	ueFsmState := ue.State[models.AccessType3GPPAccess].Current()
-	switch ueFsmState {
-	case context.Deregistered:
-		logger.AmfLog.Info("Removing the UE", zap.String("supi", ue.Supi))
-		ue.Remove()
-	case context.Registered:
-		logger.AmfLog.Info("Deregistration triggered for the UE", zap.String("supi", ue.Supi))
-		err := gmm.GmmFSM.SendEvent(ctx, ue.State[models.AccessType3GPPAccess], gmm.NwInitiatedDeregistrationEvent, fsm.ArgsType{
-			gmm.ArgAmfUe:      ue,
-			gmm.ArgAccessType: models.AccessType3GPPAccess,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to send deregistration event: %w", err)
-		}
-	}
+	ue.Remove()
 
 	return nil
 }


### PR DESCRIPTION
# Description

Depending on the UE state, when we deleted it via the UI/API, it was sometimes possible for it to remain in memory. Here we take a more drastic approach and completely get rid of the UE regardless of its state upon deletion. 

TO DO:
- Ensure both SMF context get removed
- Ensure GTP tunnel is removed

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
