### PR TITLE
fix: use pre-computed interface name when address is used in config file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -445,9 +445,8 @@ var GetInterfaceNameFunc = func(address string) (string, error) {
 var GetVLANConfigForInterfaceFunc = func(name string) (*VlanConfig, error) {
 	link, err := netlink.LinkByName(name)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get link for interface %s: %w", name, err)
+		return nil, err
 	}
-
 	if link.Type() == "vlan" {
 		vlanLink := link.(*netlink.Vlan)
 		parentLink, err := netlink.LinkByIndex(vlanLink.ParentIndex)


### PR DESCRIPTION
# Description

Whenever the address was used to specify n3 in the config file, we would still use the interface name from the config file (empty) to validate whether there was a VLAN on the interface. Here we leverage the if name that was computed from the address instead.

Fixes #811 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
