### PR TITLE
fix: use correct type for SD in API client

### DIFF
--- a/client/operator.go
+++ b/client/operator.go
@@ -12,8 +12,8 @@ type GetOperatorIDResponse struct {
 }
 
 type GetOperatorSliceResponse struct {
-	Sst int `json:"sst,omitempty"`
-	Sd  int `json:"sd,omitempty"`
+	Sst int    `json:"sst,omitempty"`
+	Sd  string `json:"sd,omitempty"`
 }
 
 type GetOperatorTrackingResponse struct {


### PR DESCRIPTION
# Description

We fix an issue where the API client expected an int as the SD but the actual API returns a string. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
