### PR TITLE
fix: send authentication request after setting t3560 timer

### DIFF
--- a/internal/amf/gmm/message/send.go
+++ b/internal/amf/gmm/message/send.go
@@ -91,11 +91,6 @@ func SendAuthenticationRequest(ue *context.RanUe) error {
 		return fmt.Errorf("error building authentication request: %s", err.Error())
 	}
 
-	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
-	if err != nil {
-		return fmt.Errorf("error sending downlink NAS transport message: %s", err.Error())
-	}
-
 	if context.AMFSelf().T3560Cfg.Enable {
 		cfg := context.AMFSelf().T3560Cfg
 		amfUe.T3560 = context.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
@@ -109,6 +104,11 @@ func SendAuthenticationRequest(ue *context.RanUe) error {
 			amfUe.GmmLog.Warn("T3560 Expires, abort authentication procedure & ongoing 5GMM procedure", zap.Any("expireTimes", cfg.MaxRetryTimes))
 			amfUe.Remove()
 		})
+	}
+
+	err = ngap_message.SendDownlinkNasTransport(ue, nasMsg, nil)
+	if err != nil {
+		return fmt.Errorf("error sending downlink NAS transport message: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
# Description

In rare cases where the UE responds ultra quickly to the core, it was possible for the UE to send the authentication response before the core could even set the t3560 timer. This situation resulted in the timer not being stopped when the core received the response and for further unnecessary authentication requests to be sent. Here we set the timer right before sending the authentication request to avoid this issue.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
