### PR TITLE
fix: use local n3 address in far info

### DIFF
--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -63,7 +63,7 @@ func (f FakeUPF) Reload(natEnabled bool) error {
 	return nil
 }
 
-func (f FakeUPF) UpdateN3Address(ip net.IP) {
+func (f FakeUPF) UpdateAdvertisedN3Address(ip net.IP) {
 }
 
 func setupServer(filepath string) (*httptest.Server, []byte, *db.Database, error) {

--- a/internal/api/server/api_interfaces.go
+++ b/internal/api/server/api_interfaces.go
@@ -130,7 +130,7 @@ func UpdateN3Interface(dbInstance *db.Database, upf UPFUpdater, cfg config.Confi
 			n3Address = cfg.Interfaces.N3.Address
 		}
 
-		upf.UpdateN3Address(net.ParseIP(n3Address))
+		upf.UpdateAdvertisedN3Address(net.ParseIP(n3Address))
 
 		logger.APILog.Info("N3 interface updated", zap.String("n3_address", n3Address))
 

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -14,7 +14,7 @@ import (
 
 type UPFUpdater interface {
 	Reload(natEnabled bool) error
-	UpdateN3Address(net.IP)
+	UpdateAdvertisedN3Address(net.IP)
 }
 
 func NewHandler(dbInstance *db.Database, cfg config.Config, upf UPFUpdater, kernel kernel.Kernel, jwtSecret []byte, secureCookie bool, embedFS fs.FS, registerExtraRoutes func(mux *http.ServeMux)) http.Handler {

--- a/internal/upf/core/pfcp_connection.go
+++ b/internal/upf/core/pfcp_connection.go
@@ -16,6 +16,7 @@ type PfcpConnection struct {
 	nodeID               string
 	nodeAddrV4           net.IP
 	n3Address            net.IP
+	advertisedN3Address  net.IP
 	bpfObjects           *ebpf.BpfObjects
 	FteIDResourceManager *FteIDResourceManager
 }
@@ -24,28 +25,35 @@ func (pc *PfcpConnection) SetBPFObjects(bpfObjects *ebpf.BpfObjects) {
 	pc.bpfObjects = bpfObjects
 }
 
-func (pc *PfcpConnection) GetN3Address() net.IP {
-	return pc.n3Address
+func (pc *PfcpConnection) GetAdvertisedN3Address() net.IP {
+	return pc.advertisedN3Address
 }
 
-func (pc *PfcpConnection) SetN3Address(newN3Addr net.IP) {
-	pc.n3Address = newN3Addr
+func (pc *PfcpConnection) SetAdvertisedN3Address(newN3Addr net.IP) {
+	pc.advertisedN3Address = newN3Addr
 }
 
-func CreatePfcpConnection(addr string, nodeID string, n3Ip string, smfAddress string, bpfObjects *ebpf.BpfObjects, resourceManager *FteIDResourceManager) (*PfcpConnection, error) {
+func CreatePfcpConnection(addr string, nodeID string, n3Ip string, advertisedN3Ip string, smfAddress string, bpfObjects *ebpf.BpfObjects, resourceManager *FteIDResourceManager) (*PfcpConnection, error) {
 	addrV4 := net.ParseIP(addr)
 	if addrV4 == nil {
 		return nil, fmt.Errorf("failed to parse IP address ID: %s", addr)
 	}
+
 	n3Addr := net.ParseIP(n3Ip)
 	if n3Addr == nil {
 		return nil, fmt.Errorf("failed to parse N3 IP address ID: %s", n3Ip)
+	}
+
+	advertisedN3Addr := net.ParseIP(advertisedN3Ip)
+	if advertisedN3Addr == nil {
+		return nil, fmt.Errorf("failed to parse advertised N3 IP address ID: %s", advertisedN3Ip)
 	}
 
 	connection = &PfcpConnection{
 		nodeID:               nodeID,
 		nodeAddrV4:           addrV4,
 		n3Address:            n3Addr,
+		advertisedN3Address:  advertisedN3Addr,
 		bpfObjects:           bpfObjects,
 		FteIDResourceManager: resourceManager,
 		SmfAddress:           smfAddress,

--- a/internal/upf/core/pfcp_session_handlers.go
+++ b/internal/upf/core/pfcp_session_handlers.go
@@ -117,7 +117,7 @@ func HandlePfcpSessionEstablishmentRequest(ctx context.Context, msg *message.Ses
 		ie.NewFSEID(localSEID, cloneIP(conn.nodeAddrV4), nil),
 	}
 
-	pdrIEs := processCreatedPDRs(createdPDRs, cloneIP(conn.n3Address))
+	pdrIEs := processCreatedPDRs(createdPDRs, cloneIP(conn.advertisedN3Address))
 	additionalIEs = append(additionalIEs, pdrIEs...)
 
 	estResp := message.NewSessionEstablishmentResponse(0, 0, remoteSEID.SEID, msg.Sequence(), 0, additionalIEs...)
@@ -346,7 +346,7 @@ func HandlePfcpSessionModificationRequest(ctx context.Context, msg *message.Sess
 		newIeNodeID(conn.nodeID),
 	}
 
-	pdrIEs := processCreatedPDRs(createdPDRs, conn.n3Address)
+	pdrIEs := processCreatedPDRs(createdPDRs, conn.advertisedN3Address)
 	additionalIEs = append(additionalIEs, pdrIEs...)
 
 	modResp := message.NewSessionModificationResponse(0, 0, session.RemoteSEID, msg.Sequence(), 0, additionalIEs...)

--- a/internal/upf/core/pfcp_session_handlers_test.go
+++ b/internal/upf/core/pfcp_session_handlers_test.go
@@ -31,6 +31,7 @@ func TestHandlePfcpSessionModificationRequestCauseNoEstablishedPFCPAssociation(t
 		"1.2.3.4",
 		"nodeId",
 		"2.3.4.5",
+		"2.3.4.5",
 		"1.1.1.1",
 		nil,
 		nil,
@@ -73,6 +74,7 @@ func TestHandlePfcpSessionModificationRequestCauseSessionContextNotFound(t *test
 	conn, err := core.CreatePfcpConnection(
 		"1.2.3.4",
 		"nodeId",
+		"2.3.4.5",
 		"2.3.4.5",
 		"1.1.1.1",
 		nil,
@@ -119,6 +121,7 @@ func TestHandlePfcpSessionDeletionRequestCauseRequestAccepted(t *testing.T) {
 	conn, err := core.CreatePfcpConnection(
 		"1.2.3.4",
 		"nodeId",
+		"2.3.4.5",
 		"2.3.4.5",
 		"1.1.1.1",
 		nil,
@@ -169,6 +172,7 @@ func TestHandlePfcpSessionDeletionRequestCauseNoEstablishedPFCPAssociation(t *te
 		"1.2.3.4",
 		"nodeId",
 		"2.3.4.5",
+		"2.3.4.5",
 		"1.1.1.1",
 		nil,
 		nil,
@@ -211,6 +215,7 @@ func TestHandlePfcpSessionDeletionRequestCauseSessionContextNotFound(t *testing.
 	conn, err := core.CreatePfcpConnection(
 		"1.2.3.4",
 		"nodeId",
+		"2.3.4.5",
 		"2.3.4.5",
 		"1.1.1.1",
 		nil,
@@ -257,6 +262,7 @@ func TestHandlePfcpSessionModificationRequestCauseRequestAccepted(t *testing.T) 
 	conn, err := core.CreatePfcpConnection(
 		"1.2.3.4",
 		"nodeId",
+		"2.3.4.5",
 		"2.3.4.5",
 		"1.1.1.1",
 		nil,

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -37,7 +37,7 @@ type UPF struct {
 	gcCancel context.CancelFunc
 }
 
-func Start(ctx context.Context, n3Interface config.N3Interface, n3Address string, n6Interface config.N6Interface, xdpAttachMode string, masquerade bool) (*UPF, error) {
+func Start(ctx context.Context, n3Interface config.N3Interface, n3Address string, advertisedN3Address string, n6Interface config.N6Interface, xdpAttachMode string, masquerade bool) (*UPF, error) {
 	var n3Vlan uint32
 	var n6Vlan uint32
 
@@ -107,7 +107,7 @@ func Start(ctx context.Context, n3Interface config.N3Interface, n3Address string
 		return nil, fmt.Errorf("failed to create Resource Manager: %w", err)
 	}
 
-	pfcpConn, err := core.CreatePfcpConnection(PfcpAddress, PfcpNodeID, n3Address, SmfAddress, bpfObjects, resourceManager)
+	pfcpConn, err := core.CreatePfcpConnection(PfcpAddress, PfcpNodeID, n3Address, advertisedN3Address, SmfAddress, bpfObjects, resourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PFCP connection: %w", err)
 	}
@@ -154,8 +154,8 @@ func (u *UPF) Close() {
 	logger.UpfLog.Info("UPF resources released")
 }
 
-func (u *UPF) UpdateN3Address(newN3Addr net.IP) {
-	u.pfcpConn.SetN3Address(newN3Addr)
+func (u *UPF) UpdateAdvertisedN3Address(newN3Addr net.IP) {
+	u.pfcpConn.SetAdvertisedN3Address(newN3Addr)
 }
 
 func (u *UPF) Reload(masquerade bool) error {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -100,12 +100,13 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		return fmt.Errorf("couldn't get N3 external address: %w", err)
 	}
 
+	advertisedN3Address := n3Address
 	if n3Settings != nil && n3Settings.ExternalAddress != "" {
-		n3Address = n3Settings.ExternalAddress
-		logger.EllaLog.Debug("Using N3 external address from N3 settings", zap.String("n3_external_address", n3Address))
+		advertisedN3Address = n3Settings.ExternalAddress
+		logger.EllaLog.Debug("Using N3 external address from N3 settings", zap.String("n3_external_address", advertisedN3Address))
 	}
 
-	upfInstance, err := upf.Start(ctx, cfg.Interfaces.N3, n3Address, cfg.Interfaces.N6, cfg.XDP.AttachMode, isNATEnabled)
+	upfInstance, err := upf.Start(ctx, cfg.Interfaces.N3, n3Address, advertisedN3Address, cfg.Interfaces.N6, cfg.XDP.AttachMode, isNATEnabled)
 	if err != nil {
 		return fmt.Errorf("couldn't start UPF: %w", err)
 	}


### PR DESCRIPTION
# Description

In #815, we added support for defining an external address for N3. However, as identified in a comment in #727, Ella Core now used the advertised IP address as the source IP of GTP-U packets. The N3 IP address was used for two things:
1. Include in PDR responses
2. Write FAR maps

The first behavior was intended, but not the second. Ella Core should re-write packets by setting the source IP as the local n3 address, not the advertised one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
