### PR TITLE
fix: always remove ue context upon subscriber deletion

### DIFF
--- a/internal/amf/deregister/deregister.go
+++ b/internal/amf/deregister/deregister.go
@@ -2,13 +2,9 @@ package deregister
 
 import (
 	ctxt "context"
-	"fmt"
 
 	"github.com/ellanetworks/core/internal/amf/context"
-	"github.com/ellanetworks/core/internal/amf/gmm"
 	"github.com/ellanetworks/core/internal/logger"
-	"github.com/ellanetworks/core/internal/models"
-	"github.com/ellanetworks/core/internal/util/fsm"
 	"go.uber.org/zap"
 )
 
@@ -21,21 +17,9 @@ func DeregisterSubscriber(ctx ctxt.Context, supi string) error {
 		return nil
 	}
 
-	ueFsmState := ue.State[models.AccessType3GPPAccess].Current()
-	switch ueFsmState {
-	case context.Deregistered:
-		logger.AmfLog.Info("Removing the UE", zap.String("supi", ue.Supi))
-		ue.Remove()
-	case context.Registered:
-		logger.AmfLog.Info("Deregistration triggered for the UE", zap.String("supi", ue.Supi))
-		err := gmm.GmmFSM.SendEvent(ctx, ue.State[models.AccessType3GPPAccess], gmm.NwInitiatedDeregistrationEvent, fsm.ArgsType{
-			gmm.ArgAmfUe:      ue,
-			gmm.ArgAccessType: models.AccessType3GPPAccess,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to send deregistration event: %w", err)
-		}
-	}
+	ue.Remove()
+
+	logger.AmfLog.Info("removed ue context", zap.String("supi", supi))
 
 	return nil
 }

--- a/internal/amf/gmm/message/send.go
+++ b/internal/amf/gmm/message/send.go
@@ -77,6 +77,10 @@ func SendIdentityRequest(ue *context.RanUe, typeOfIdentity uint8) error {
 }
 
 func SendAuthenticationRequest(ue *context.RanUe) error {
+	if ue == nil {
+		return fmt.Errorf("ue is nil")
+	}
+
 	amfUe := ue.AmfUe
 	if amfUe == nil {
 		return fmt.Errorf("amf ue is nil")
@@ -177,6 +181,10 @@ func SendServiceReject(ue *context.RanUe, pDUSessionStatus *[16]bool, cause uint
 // T3502: This IE may be included to indicate a value for timer T3502 during the initial registration
 // eapMessage: if the REGISTRATION REJECT message is used to convey EAP-failure message
 func SendRegistrationReject(ue *context.RanUe, cause5GMM uint8, eapMessage string) error {
+	if ue == nil {
+		return fmt.Errorf("ue is nil")
+	}
+
 	nasMsg, err := BuildRegistrationReject(ue.AmfUe, cause5GMM, eapMessage)
 	if err != nil {
 		return fmt.Errorf("error building registration reject: %s", err.Error())


### PR DESCRIPTION
# Description

It was possible to bring Ella Core to a state where it kept its UE context after deletion. When users delete a subscriber, we now get rid of the memory UE context regardless of any external event. 

We also add validations to avoid possible nil-context crashes.

Both these fixes are outcomes of validating Ella Core with [Ella Core Tester.](https://github.com/ellanetworks/core-tester)  

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
