### PR TITLE
fix: release session when deleting subscriber

### DIFF
--- a/internal/amf/deregister/deregister.go
+++ b/internal/amf/deregister/deregister.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf/context"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/smf/pdusession"
 	"go.uber.org/zap"
 )
 
@@ -16,6 +17,17 @@ func DeregisterSubscriber(ctx ctxt.Context, supi string) error {
 		logger.AmfLog.Debug("UE with SUPI %s not found", zap.String("supi", supi))
 		return nil
 	}
+
+	ue.SmContextList.Range(func(key, value any) bool {
+		smContext := value.(*context.SmContext)
+		err := pdusession.ReleaseSmContext(ctx, smContext.SmContextRef())
+		if err != nil {
+			ue.GmmLog.Error("Release SmContext Error", zap.Error(err))
+		} else {
+			ue.GmmLog.Info("Release SmContext Success", zap.String("smContextRef", smContext.SmContextRef()))
+		}
+		return true
+	})
 
 	ue.Remove()
 


### PR DESCRIPTION
# Description

Whenever a subscriber is deleted, its session is now removed from the SMF and the GTP tunnel is torn down. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
