### PR TITLE
feat: lower default subnet to /22

### DIFF
--- a/client/data_networks_test.go
+++ b/client/data_networks_test.go
@@ -24,7 +24,7 @@ func TestCreateDataNetwork_Success(t *testing.T) {
 
 	createDataNetworkOpts := &client.CreateDataNetworkOptions{
 		Name:   "testDataNetwork",
-		IPPool: "10.45.0.0/16",
+		IPPool: "10.45.0.0/22",
 		DNS:    "8.8.8.8",
 		Mtu:    1400,
 	}
@@ -69,7 +69,7 @@ func TestGetDataNetwork_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"name": "my-data-network", "ip_pool": "1.2.3.0/24"}`),
+			Result:     []byte(`{"name": "my-data-network", "ip_pool": "1.2.3.0/22"}`),
 		},
 		err: nil,
 	}
@@ -93,8 +93,8 @@ func TestGetDataNetwork_Success(t *testing.T) {
 		t.Fatalf("expected ID %v, got %v", name, dataNetwork.Name)
 	}
 
-	if dataNetwork.IPPool != "1.2.3.0/24" {
-		t.Fatalf("expected ID %v, got %v", "1.2.3.0/24", dataNetwork.IPPool)
+	if dataNetwork.IPPool != "1.2.3.0/22" {
+		t.Fatalf("expected ID %v, got %v", "1.2.3.0/22", dataNetwork.IPPool)
 	}
 }
 
@@ -182,7 +182,7 @@ func TestListDataNetworks_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"items": [{"name": "data-network-1", "ip_pool": "1.2.3.0/24"}], "page": 1, "per_page": 10, "total_count": 1}`),
+			Result:     []byte(`{"items": [{"name": "data-network-1", "ip_pool": "1.2.3.0/22"}], "page": 1, "per_page": 10, "total_count": 1}`),
 		},
 		err: nil,
 	}

--- a/docs/tutorials/end_to_end_network.md
+++ b/docs/tutorials/end_to_end_network.md
@@ -223,7 +223,7 @@ You should see a new interface `uesimtun0` with the UE's IP address:
        valid_lft forever preferred_lft forever
 3: uesimtun0: <POINTOPOINT,PROMISC,NOTRAILERS,UP,LOWER_UP> mtu 1400 qdisc fq_codel state UNKNOWN group default qlen 500
     link/none
-    inet 10.45.0.1/16 scope global uesimtun0
+    inet 10.45.0.1/22 scope global uesimtun0
        valid_lft forever preferred_lft forever
     inet6 fe80::a331:940b:f57a:da80/64 scope link stable-privacy
        valid_lft forever preferred_lft forever

--- a/integration/compose/core-tester/compose.yaml
+++ b/integration/compose/core-tester/compose.yaml
@@ -67,7 +67,7 @@ services:
       - /bin/bash
       - -lc
       - >
-        ip route add 10.45.0.0/16 dev n6 via 10.6.0.2;
+        ip route add 10.45.0.0/22 dev n6 via 10.6.0.2;
         trap : TERM INT;
         python3 /responder.py 34242 & wait
     restart: unless-stopped

--- a/integration/compose/ueransim/compose.yaml
+++ b/integration/compose/ueransim/compose.yaml
@@ -154,7 +154,7 @@ services:
       - /bin/bash
       - -lc
       - >
-        ip route add 10.45.0.0/16 dev n6 via 10.6.0.2;
+        ip route add 10.45.0.0/22 dev n6 via 10.6.0.2;
         trap : TERM INT;
         python3 /responder.py 34242 & wait
     restart: unless-stopped

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -60,7 +60,7 @@ var (
 // Initial Data network values
 const (
 	InitialDataNetworkName   = "internet"
-	InitialDataNetworkIPPool = "10.45.0.0/16"
+	InitialDataNetworkIPPool = "10.45.0.0/22"
 	InitialDataNetworkDNS    = "8.8.8.8"
 	InitialDataNetworkMTU    = 1400
 )

--- a/internal/db/metrics_test.go
+++ b/internal/db/metrics_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	DefaultDNIPPool = "10.45.0.0/16"
+	DefaultDNIPPool = "10.45.0.0/22"
 )
 
 func TestDatabaseMetrics(t *testing.T) {

--- a/ui/components/CreateDataNetworkModal.tsx
+++ b/ui/components/CreateDataNetworkModal.tsx
@@ -36,7 +36,7 @@ const schema = yup.object().shape({
     .string()
     .matches(
       /^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\/\d{1,2}$/,
-      "Must be a valid IP pool (e.g., 10.45.0.0/16)",
+      "Must be a valid IP pool (e.g., 10.45.0.0/22)",
     )
     .required("IP Pool is required"),
   dns: yup
@@ -60,7 +60,7 @@ const CreateDataNetworkModal: React.FC<CreateDataNetworkModalProps> = ({
 
   const [formValues, setFormValues] = useState({
     name: "",
-    ipPool: "10.45.0.0/16",
+    ipPool: "10.45.0.0/22",
     dns: "8.8.8.8",
     mtu: 1500,
   });


### PR DESCRIPTION
# Description

The default data network subnet was a `/16` (65,536 addresses) which is unnecessarily high for the number of supported subscribers (1000). Here we lower it to a `/22` (1,024 addresses).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
