### PR TITLE
chore: combine subscriber usage endpoints and differentiate via group_by query param

### DIFF
--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -59,8 +59,7 @@ func NewHandler(dbInstance *db.Database, cfg config.Config, upf UPFUpdater, kern
 	mux.HandleFunc("GET /api/v1/subscriber-usage/retention", Authenticate(jwtSecret, dbInstance, RequirePermission(PermGetSubscriberUsageRetentionPolicy, jwtSecret, GetSubscriberUsageRetentionPolicy(dbInstance))).ServeHTTP)
 	mux.HandleFunc("PUT /api/v1/subscriber-usage/retention", Authenticate(jwtSecret, dbInstance, RequirePermission(PermSetSubscriberUsageRetentionPolicy, jwtSecret, UpdateSubscriberUsageRetentionPolicy(dbInstance))).ServeHTTP)
 	mux.HandleFunc("DELETE /api/v1/subscriber-usage", Authenticate(jwtSecret, dbInstance, RequirePermission(PermClearSubscriberUsage, jwtSecret, ClearSubscriberUsage(dbInstance))).ServeHTTP)
-	mux.HandleFunc("GET /api/v1/subscriber-usage/per-day", Authenticate(jwtSecret, dbInstance, RequirePermission(PermGetSubscriberUsage, jwtSecret, GetSubscriberUsagePerDay(dbInstance))).ServeHTTP)
-	mux.HandleFunc("GET /api/v1/subscriber-usage/per-subscriber", Authenticate(jwtSecret, dbInstance, RequirePermission(PermGetSubscriberUsage, jwtSecret, GetSubscriberUsagePerSubscriber(dbInstance))).ServeHTTP)
+	mux.HandleFunc("GET /api/v1/subscriber-usage", Authenticate(jwtSecret, dbInstance, RequirePermission(PermGetSubscriberUsage, jwtSecret, GetSubscriberUsage(dbInstance))).ServeHTTP)
 
 	// Policies (Authenticated)
 	mux.HandleFunc("GET /api/v1/policies", Authenticate(jwtSecret, dbInstance, RequirePermission(PermListPolicies, jwtSecret, ListPolicies(dbInstance))).ServeHTTP)

--- a/ui/app/(core)/usage/page.tsx
+++ b/ui/app/(core)/usage/page.tsx
@@ -18,12 +18,7 @@ import {
   type GridPaginationModel,
 } from "@mui/x-data-grid";
 import { BarChart } from "@mui/x-charts/BarChart";
-import {
-  getUsagePerSubscriber,
-  type UsagePerSubscriberResult,
-  getUsagePerDay,
-  type UsagePerDayResult,
-} from "@/queries/usage";
+import { getUsage, type UsageResult } from "@/queries/usage";
 import { useAuth } from "@/contexts/AuthContext";
 import { useQuery } from "@tanstack/react-query";
 
@@ -106,7 +101,7 @@ const SubscriberUsage = () => {
   const {
     data: usagePerSubscriberData,
     isLoading: isUsagePerSubscriberLoading,
-  } = useQuery<UsagePerSubscriberResult>({
+  } = useQuery<UsageResult>({
     queryKey: [
       "usagePerSubscriber",
       accessToken,
@@ -115,11 +110,12 @@ const SubscriberUsage = () => {
       selectedSubscriber,
     ],
     queryFn: async () => {
-      return getUsagePerSubscriber(
+      return getUsage(
         accessToken || "",
         startDate,
         endDate,
         selectedSubscriber,
+        "subscriber",
       );
     },
     enabled: !!accessToken && !!startDate && !!endDate,
@@ -165,7 +161,7 @@ const SubscriberUsage = () => {
   );
 
   const { data: usagePerDayData, isLoading: isUsagePerDayLoading } =
-    useQuery<UsagePerDayResult>({
+    useQuery<UsageResult>({
       queryKey: [
         "usagePerDay",
         accessToken,
@@ -174,11 +170,12 @@ const SubscriberUsage = () => {
         selectedSubscriber,
       ],
       queryFn: async () => {
-        return getUsagePerDay(
+        return getUsage(
           accessToken || "",
           startDate,
           endDate,
           selectedSubscriber,
+          "day",
         );
       },
       enabled: !!accessToken && !!startDate && !!endDate,

--- a/ui/queries/usage.tsx
+++ b/ui/queries/usage.tsx
@@ -6,14 +6,15 @@ export type SubscriberUsage = {
   total_bytes: number;
 };
 
-export type UsagePerDayResult = Array<Record<string, SubscriberUsage>>;
+export type UsageResult = Array<Record<string, SubscriberUsage>>;
 
-export async function getUsagePerDay(
+export async function getUsage(
   authToken: string,
   start: string,
   end: string,
   subscriber: string,
-): Promise<UsagePerDayResult> {
+  groupBy: "day" | "subscriber",
+): Promise<UsageResult> {
   const params = new URLSearchParams({
     start,
     end,
@@ -24,7 +25,7 @@ export async function getUsagePerDay(
   }
 
   const response = await fetch(
-    `/api/v1/subscriber-usage/per-day?${params.toString()}`,
+    `/api/v1/subscriber-usage?group_by=${groupBy}&${params.toString()}`,
     {
       method: "GET",
       headers: {
@@ -34,53 +35,7 @@ export async function getUsagePerDay(
     },
   );
 
-  let json: { result: UsagePerDayResult; error?: string };
-  try {
-    json = await response.json();
-  } catch {
-    throw new Error(
-      `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
-    );
-  }
-
-  if (!response.ok) {
-    throw new Error(
-      `${response.status}: ${HTTPStatus(response.status)}. ${json?.error || "Unknown error"}`,
-    );
-  }
-
-  return json.result;
-}
-
-export type UsagePerSubscriberResult = Array<Record<string, SubscriberUsage>>;
-
-export async function getUsagePerSubscriber(
-  authToken: string,
-  start: string,
-  end: string,
-  subscriber: string,
-): Promise<UsagePerSubscriberResult> {
-  const params = new URLSearchParams({
-    start,
-    end,
-  });
-
-  if (subscriber.trim() !== "") {
-    params.set("subscriber", subscriber);
-  }
-
-  const response = await fetch(
-    `/api/v1/subscriber-usage/per-subscriber?${params.toString()}`,
-    {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + authToken,
-      },
-    },
-  );
-
-  let json: { result: UsagePerSubscriberResult; error?: string };
+  let json: { result: UsageResult; error?: string };
   try {
     json = await response.json();
   } catch {


### PR DESCRIPTION
# Description

Combine subscriber usage endpoints and differentiate via `group_by` query param.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
