### PR TITLE
feat: add ability to edit usage data retention [ui]

### DIFF
--- a/ui/components/EditUsageRetentionPolicyModal.tsx
+++ b/ui/components/EditUsageRetentionPolicyModal.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  DialogContentText,
+  TextField,
+  Button,
+  Alert,
+  Collapse,
+} from "@mui/material";
+import {
+  updateUsageRetentionPolicy,
+  type UsageRetentionPolicy,
+} from "@/queries/usage";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+
+interface EditUsageRetentionPolicyModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  initialData: UsageRetentionPolicy;
+}
+
+const EditUsageRetentionPolicyModal: React.FC<
+  EditUsageRetentionPolicyModalProps
+> = ({ open, onClose, onSuccess, initialData }) => {
+  const router = useRouter();
+  const { accessToken, authReady } = useAuth();
+
+  if (!authReady || !accessToken) {
+    router.push("/login");
+  }
+
+  const [formValues, setFormValues] = useState(initialData);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [alert, setAlert] = useState<{ message: string }>({ message: "" });
+
+  useEffect(() => {
+    if (open) {
+      setFormValues({
+        days: initialData.days,
+      });
+      setErrors({});
+    }
+  }, [open, initialData]);
+
+  const handleChange = (field: string, value: string | number) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async () => {
+    if (!accessToken) return;
+    setLoading(true);
+    setAlert({ message: "" });
+
+    try {
+      await updateUsageRetentionPolicy(accessToken, formValues.days);
+      onClose();
+      onSuccess();
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error occurred.";
+      setAlert({
+        message: `Failed to update usage retention policy: ${errorMessage}`,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="edit-usage-retention-policy-modal-title"
+      aria-describedby="edit-usage-retention-policy-modal-description"
+    >
+      <DialogTitle>Edit Usage Retention Policy</DialogTitle>
+      <DialogContent dividers>
+        <Collapse in={!!alert.message}>
+          <Alert
+            onClose={() => setAlert({ message: "" })}
+            sx={{ mb: 2 }}
+            severity="error"
+          >
+            {alert.message}
+          </Alert>
+        </Collapse>
+        <DialogContentText>
+          Set the number of days to retain usage data. After this period, data
+          will be automatically deleted.
+        </DialogContentText>
+        <TextField
+          fullWidth
+          type="number"
+          label="Days"
+          value={formValues.days}
+          onChange={(e) => handleChange("days", Number(e.target.value))}
+          error={!!errors.days}
+          helperText={errors.days}
+          margin="normal"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="success"
+          onClick={handleSubmit}
+          disabled={loading}
+        >
+          {loading ? "Updating..." : "Update"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default EditUsageRetentionPolicyModal;

--- a/ui/queries/usage.tsx
+++ b/ui/queries/usage.tsx
@@ -8,6 +8,10 @@ export type SubscriberUsage = {
 
 export type UsageResult = Array<Record<string, SubscriberUsage>>;
 
+export type UsageRetentionPolicy = {
+  days: number;
+};
+
 export async function getUsage(
   authToken: string,
   start: string,
@@ -52,3 +56,57 @@ export async function getUsage(
 
   return json.result;
 }
+
+export const getUsageRetentionPolicy = async (authToken: string) => {
+  const response = await fetch(`/api/v1/subscriber-usage/retention`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + authToken,
+    },
+  });
+  let respData;
+  try {
+    respData = await response.json();
+  } catch {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
+    );
+  }
+
+  return respData.result;
+};
+
+export const updateUsageRetentionPolicy = async (
+  authToken: string,
+  days: number,
+) => {
+  const response = await fetch(`/api/v1/subscriber-usage/retention`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + authToken,
+    },
+    body: JSON.stringify({ days: days }),
+  });
+
+  if (!response.ok) {
+    let respData;
+    try {
+      respData = await response.json();
+    } catch {
+      throw new Error(
+        `${response.status}: ${HTTPStatus(response.status)}. ${response.statusText}`,
+      );
+    }
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData?.error || "Unknown error"}`,
+    );
+  }
+};


### PR DESCRIPTION
# Description

Usage data can be modified via the API and here we add the ability to do the same via the UI.

## Screenshots

<img width="3840" height="1453" alt="image" src="https://github.com/user-attachments/assets/e36ffb3d-1ca6-48a1-8e4f-8765ed596095" />


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
