### PR TITLE
chore: add database UNIQUE constraints to subscriber, data network and policy names

### DIFF
--- a/internal/api/server/authentication_middleware.go
+++ b/internal/api/server/authentication_middleware.go
@@ -96,7 +96,7 @@ func authenticateRequest(r *http.Request, jwtSecret []byte, store *db.Database) 
 	}
 
 	// JWT path
-	cl, err := getClaimsFromJWT(r.Context(), token, jwtSecret)
+	cl, err := getClaimsFromJWT(token, jwtSecret)
 	if err != nil {
 		return 0, "", 0, err
 	}
@@ -124,7 +124,7 @@ func Authenticate(jwtSecret []byte, store *db.Database, next http.Handler) http.
 	})
 }
 
-func getClaimsFromJWT(ctx context.Context, bearerToken string, jwtSecret []byte) (*claims, error) {
+func getClaimsFromJWT(bearerToken string, jwtSecret []byte) (*claims, error) {
 	claims := claims{}
 	token, err := jwt.ParseWithClaims(bearerToken, &claims, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+var ErrAlreadyExists = errors.New("already exists")
+
+func isUniqueNameError(err error) bool {
+	var se sqlite3.Error
+	if errors.As(err, &se) {
+		return se.ExtendedCode == sqlite3.ErrConstraintUnique
+	}
+
+	return false
+}


### PR DESCRIPTION
# Description

This PR includes a couple of changes that make API queries slightly more efficient. We remove unnecessary existence check prior to creating Subscribers, Data Networks, and Policies. We replace those checks with a SQL `UNIQUE` constraint. This reduces the total number of database calls and makes API calls slightly quicker.

This PR also adds a span to capture the amount of time taken by authentication, which can be substantial.

Both those changes were helped by the use of Tracing. 

## Screenshots

<img width="3836" height="623" alt="image" src="https://github.com/user-attachments/assets/b4694718-1922-4c51-92c3-8eab9d332d42" />
 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
