### PR TITLE
docs: add Motorola Moto G 5G (2024) to list of validated UEs

### DIFF
--- a/docs/reference/supported_5g_equipment.md
+++ b/docs/reference/supported_5g_equipment.md
@@ -36,6 +36,7 @@ Ella Core has been tested with a variety of 5G user equipment and should work wi
 
 - **Crosscall CORE-Z5**
 - **Motorola G73 5G**
+- **Motorola Moto G 5G (2024)**
 
 ### Simulators
 


### PR DESCRIPTION
# Description

I just received my Motorola Moto G 5G (2024) in the mail and it works just fine with Ella Core. Here we add the device to the list of validated UEs.

Note: I had to go into the Android Engineering Settings and set the Preferred network type to "NR Only" ( Dial `*#*#4636#*#*` -> Phone Information > Set Prefered Network Type)

## Screenshots

![image](https://github.com/user-attachments/assets/71b5bf2e-b6dc-4872-b4a1-e24435137b65)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
