### PR TITLE
chore: stabilize, speed up, and instrument IP allocation

### DIFF
--- a/internal/db/metrics_test.go
+++ b/internal/db/metrics_test.go
@@ -50,10 +50,13 @@ func TestDatabaseMetrics(t *testing.T) {
 		}
 	}
 
+	ip1 := "10.45.0.2"
+	ip2 := "10.0.0.3"
+
 	subscribers := []db.Subscriber{
-		{Imsi: "001", IPAddress: "10.45.0.2", PolicyID: 1},
-		{Imsi: "002", IPAddress: "10.0.0.3", PolicyID: 2},
-		{Imsi: "003", IPAddress: "", PolicyID: 1},
+		{Imsi: "001", IPAddress: &ip1, PolicyID: 1},
+		{Imsi: "002", IPAddress: &ip2, PolicyID: 2},
+		{Imsi: "003", IPAddress: nil, PolicyID: 1},
 	}
 	for _, subscriber := range subscribers {
 		err := database.CreateSubscriber(context.Background(), &subscriber)

--- a/internal/db/subscribers.go
+++ b/internal/db/subscribers.go
@@ -51,13 +51,13 @@ const (
 )
 
 type Subscriber struct {
-	ID             int    `db:"id"`
-	Imsi           string `db:"imsi"`
-	IPAddress      string `db:"ipAddress"`
-	SequenceNumber string `db:"sequenceNumber"`
-	PermanentKey   string `db:"permanentKey"`
-	Opc            string `db:"opc"`
-	PolicyID       int    `db:"policyID"`
+	ID             int     `db:"id"`
+	Imsi           string  `db:"imsi"`
+	IPAddress      *string `db:"ipAddress"`
+	SequenceNumber string  `db:"sequenceNumber"`
+	PermanentKey   string  `db:"permanentKey"`
+	Opc            string  `db:"opc"`
+	PolicyID       int     `db:"policyID"`
 }
 
 func (db *Database) ListSubscribersPage(ctx context.Context, page int, perPage int) ([]Subscriber, int, error) {
@@ -390,10 +390,10 @@ func (db *Database) AllocateIP(ctx context.Context, imsi string) (net.IP, error)
 		ipStr := ip.String()
 
 		var existing Subscriber
-		err = db.conn.Query(ctx, checkStmt, Subscriber{IPAddress: ipStr}).Get(&existing)
+		err = db.conn.Query(ctx, checkStmt, Subscriber{IPAddress: &ipStr}).Get(&existing)
 		if err == sql.ErrNoRows {
 			// IP is not allocated, assign it to the subscriber
-			subscriber.IPAddress = ipStr
+			subscriber.IPAddress = &ipStr
 
 			stmt, err := sqlair.Prepare(fmt.Sprintf(allocateIPStmt, SubscribersTableName), Subscriber{})
 			if err != nil {
@@ -419,7 +419,7 @@ func (db *Database) releaseIP(ctx context.Context, imsi string) error {
 		return fmt.Errorf("failed to get subscriber: %v", err)
 	}
 
-	if subscriber.IPAddress == "" {
+	if subscriber.IPAddress == nil {
 		return nil
 	}
 

--- a/internal/db/subscribers_test.go
+++ b/internal/db/subscribers_test.go
@@ -188,8 +188,8 @@ func TestIPAllocationAndRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't retrieve subscriber: %s", err)
 	}
-	if retrievedSubscriber.IPAddress != allocatedIP.String() {
-		t.Fatalf("IP address in database %s does not match allocated IP %s", retrievedSubscriber.IPAddress, allocatedIP.String())
+	if *retrievedSubscriber.IPAddress != allocatedIP.String() {
+		t.Fatalf("IP address in database %s does not match allocated IP %s", *retrievedSubscriber.IPAddress, allocatedIP.String())
 	}
 
 	// Step 5: Release the IP
@@ -203,7 +203,7 @@ func TestIPAllocationAndRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't retrieve subscriber after release: %s", err)
 	}
-	if retrievedSubscriber.IPAddress != "" {
+	if retrievedSubscriber.IPAddress != nil {
 		t.Fatalf("IP address was not cleared from the database after release")
 	}
 
@@ -343,12 +343,13 @@ func TestCountSubscribersWithIP(t *testing.T) {
 		t.Fatalf("Expected 0 subscribers with IP, but got %d", count)
 	}
 
+	ip := "192.168.1.2"
 	subscriber1 := &db.Subscriber{
 		Imsi:           "001010100007487",
 		SequenceNumber: "123456",
 		PermanentKey:   "123456",
 		Opc:            "123456",
-		IPAddress:      "192.168.1.2",
+		IPAddress:      &ip,
 	}
 	err = database.CreateSubscriber(context.Background(), subscriber1)
 	if err != nil {
@@ -375,12 +376,13 @@ func TestCountSubscribersWithIP(t *testing.T) {
 		t.Fatalf("Expected 1 subscriber with IP, but got %d", count)
 	}
 
+	ip = "192.168.1.3"
 	subscriber3 := &db.Subscriber{
 		Imsi:           "001010100007489",
 		SequenceNumber: "123458",
 		PermanentKey:   "123458",
 		Opc:            "123458",
-		IPAddress:      "192.168.1.3",
+		IPAddress:      &ip,
 	}
 	err = database.CreateSubscriber(context.Background(), subscriber3)
 	if err != nil {


### PR DESCRIPTION
# Description

This PR improves IP allocation:
- Add unique constraint on subscriber IP at DB level
- Add span to better differentiate parts of allocating IP addresses
- Move prepare statement out of loop to speed IP allocation

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
