### PR TITLE
fix: Set default MTU for standard Ethernet

### DIFF
--- a/ui/components/CreateDataNetworkModal.tsx
+++ b/ui/components/CreateDataNetworkModal.tsx
@@ -62,7 +62,7 @@ const CreateDataNetworkModal: React.FC<CreateDataNetworkModalProps> = ({
     name: "",
     ipPool: "10.45.0.0/22",
     dns: "8.8.8.8",
-    mtu: 1500,
+    mtu: 1456,
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});


### PR DESCRIPTION
# Description

The default MTU when creating a DNN in Ella Core was set to 1500. It is not a good default, because in most deployment, the MTU of the underlying infrastructure will most likely be 1500, unless jumbo frames are configured.

The UE traffic will be encapsulated in a GTP tunnel, so we need to subtract the corresponding header length from the standard MTU. This would consist of a IP header of 20 bytes, a UDP header of 8 bytes, and a GTP header of 16 bytes. This gives a MTU of 1456.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
