### PR TITLE
fix: use next available IP on collision

### DIFF
--- a/internal/db/subscribers.go
+++ b/internal/db/subscribers.go
@@ -402,6 +402,10 @@ func (db *Database) AllocateIP(ctx context.Context, imsi string) (net.IP, error)
 
 			err = db.conn.Query(ctx, stmt, subscriber).Run()
 			if err != nil {
+				if isUniqueNameError(err) {
+					logger.DBLog.Warn("IP address collision during allocation, retrying", zap.String("ip", ipStr))
+					continue
+				}
 				return nil, fmt.Errorf("failed to allocate IP: %v", err)
 			}
 


### PR DESCRIPTION
# Description

Whenever there is a collision when choosing an IP address for the UE, Ella Core would return out preventing the initial registration from completing. Now Ella Core moves on with the next IP available. 

This issue can only be observed when running registrations with many UE's in parallel, like in our integration tests. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
