### PR TITLE
fix: use correct network events link in dashboard [UI]

### DIFF
--- a/ui/app/(core)/dashboard/page.tsx
+++ b/ui/app/(core)/dashboard/page.tsx
@@ -458,7 +458,7 @@ const Dashboard = () => {
             title={
               <Box
                 component={Link}
-                href="/events"
+                href="/radios?tab=events"
                 sx={{
                   textDecoration: "none",
                   color: "inherit",


### PR DESCRIPTION
# Description

When I moved the events from its own page to the radios page I forgot to update the link in the dashboard. Here's the fix.

Fixes #908 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
