### PR TITLE
fix: Follow Prometheus best practices for metrics naming

### DIFF
--- a/docs/reference/api/metrics.md
+++ b/docs/reference/api/metrics.md
@@ -22,10 +22,10 @@ None
 # HELP app_database_storage_bytes The total storage used by the database in bytes. This is the size of the database file on disk.
 # TYPE app_database_storage_bytes gauge
 app_database_storage_bytes 28672
-# HELP app_ip_addresses_allocated The total number of IP addresses currently allocated to subscribers
-# TYPE app_ip_addresses_allocated gauge
-app_ip_addresses_allocated 0
-# HELP app_ip_addresses_total The total number of IP addresses allocated to subscribers
+# HELP app_ip_addresses_allocated_total The total number of IP addresses currently allocated to subscribers
+# TYPE app_ip_addresses_allocated_total gauge
+app_ip_addresses_allocated_total 0
+# HELP app_ip_addresses_total The total number of IP addresses available for subscribers
 # TYPE app_ip_addresses_total gauge
 app_ip_addresses_total 65792
 # HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -15,16 +15,16 @@ These metrics are used to monitor the performance of the Go runtime and garbage 
 These metrics are used to monitor the health of the system and the performance of the network. These metrics start with the `app_` prefix. The following custom metrics are exposed by Ella Core:
 
 - `app_database_storage_bytes`: The total storage used by the database in bytes. This is the size of the database file on disk.
-- `app_ip_addresses_allocated`: The total number of IP addresses currently allocated to subscribers.
-- `app_ip_addresses_total`: The total number of IP addresses allocated to subscribers.
-- `app_pdu_sessions`: Number of PDU sessions currently in Ella Core.
+- `app_ip_addresses_allocated_total`: The total number of IP addresses currently allocated to subscribers.
+- `app_ip_addresses_total`: The total number of IP addresses available for subscribers.
+- `app_pdu_sessions_total`: Number of PDU sessions currently in Ella Core.
 - `app_uplink_bytes`: The total number of bytes transmitted in the uplink direction (N3 -> N6). This value includes the Ethernet header. 
 - `app_downlink_bytes`: The total number of bytes transmitted in the downlink direction (N6 -> N3). This value includes the Ethernet header.
-- `app_n3_xdp_drop`: The total number of dropped packets (n3).
-- `app_n3_xdp_pass`: The total number of passed packets (n3).
-- `app_n3_xdp_tx`: The total number of transmitted packets (n3).
-- `app_n3_xdp_redirect`: The total number of redirected packets (n3).
-- `app_n6_xdp_drop`: The total number of dropped packets (n6).
-- `app_n6_xdp_pass`: The total number of passed packets (n6).
-- `app_n6_xdp_tx`: The total number of transmitted packets (n6).
-- `app_n6_xdp_redirect`: The total number of redirected packets (n6).
+- `app_n3_xdp_drop_total`: The total number of dropped packets (n3).
+- `app_n3_xdp_pass_total`: The total number of passed packets (n3).
+- `app_n3_xdp_tx_total`: The total number of transmitted packets (n3).
+- `app_n3_xdp_redirect_total`: The total number of redirected packets (n3).
+- `app_n6_xdp_drop_total`: The total number of dropped packets (n6).
+- `app_n6_xdp_pass_total`: The total number of passed packets (n6).
+- `app_n6_xdp_tx_total`: The total number of transmitted packets (n6).
+- `app_n6_xdp_redirect_total`: The total number of redirected packets (n6).

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -50,7 +50,7 @@ func RegisterDatabaseMetrics(db *db.Database) {
 
 	IPAddressesTotal = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "app_ip_addresses_total",
-		Help: "The total number of IP addresses allocated to subscribers",
+		Help: "The total number of IP addresses available for subscribers",
 	}, func() float64 {
 		total, err := db.GetIPAddressesTotal()
 		if err != nil {
@@ -61,7 +61,7 @@ func RegisterDatabaseMetrics(db *db.Database) {
 	})
 
 	IPAddressesAllocated = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "app_ip_addresses_allocated",
+		Name: "app_ip_addresses_allocated_total",
 		Help: "The total number of IP addresses currently allocated to subscribers",
 	}, func() float64 {
 		allocated, err := db.GetIPAddressesAllocated(context.Background())
@@ -78,8 +78,8 @@ func RegisterDatabaseMetrics(db *db.Database) {
 }
 
 func RegisterSmfMetrics() {
-	PduSessions = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_pdu_sessions",
+	PduSessions = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "app_pdu_sessions_total",
 		Help: "Number of PDU sessions currently in Ella",
 	}, func() float64 {
 		return float64(smfStats.GetPDUSessionCount())
@@ -91,70 +91,70 @@ func RegisterSmfMetrics() {
 func RegisterUPFMetrics(stats *ebpf.UpfXdpActionStatistic) {
 	// Metrics for the app_xdp_statistic (xdp_action)
 	UpfN3XdpAborted = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n3_xdp_aborted",
+		Name: "app_n3_xdp_aborted_total",
 		Help: "The total number of aborted packets (n3)",
 	}, func() float64 {
 		return float64(stats.GetN3Aborted())
 	})
 
 	UpfN3XdpDrop = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n3_xdp_drop",
+		Name: "app_n3_xdp_drop_total",
 		Help: "The total number of dropped packets (n3)",
 	}, func() float64 {
 		return float64(stats.GetN3Drop())
 	})
 
 	UpfN3XdpPass = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n3_xdp_pass",
+		Name: "app_n3_xdp_pass_total",
 		Help: "The total number of passed packets (n3)",
 	}, func() float64 {
 		return float64(stats.GetN3Pass())
 	})
 
 	UpfN3XdpTx = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n3_xdp_tx",
+		Name: "app_n3_xdp_tx_total",
 		Help: "The total number of transmitted packets (n3)",
 	}, func() float64 {
 		return float64(stats.GetN3Tx())
 	})
 
 	UpfN3XdpRedirect = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n3_xdp_redirect",
+		Name: "app_n3_xdp_redirect_total",
 		Help: "The total number of redirected packets (n3)",
 	}, func() float64 {
 		return float64(stats.GetN3Redirect())
 	})
 
 	UpfN6XdpAborted = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n6_xdp_aborted",
+		Name: "app_n6_xdp_aborted_total",
 		Help: "The total number of aborted packets (n6)",
 	}, func() float64 {
 		return float64(stats.GetN6Aborted())
 	})
 
 	UpfN6XdpDrop = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n6_xdp_drop",
+		Name: "app_n6_xdp_drop_total",
 		Help: "The total number of dropped packets (n6)",
 	}, func() float64 {
 		return float64(stats.GetN6Drop())
 	})
 
 	UpfN6XdpPass = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n6_xdp_pass",
+		Name: "app_n6_xdp_pass_total",
 		Help: "The total number of passed packets (n6)",
 	}, func() float64 {
 		return float64(stats.GetN3Pass())
 	})
 
 	UpfN6XdpTx = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n6_xdp_tx",
+		Name: "app_n6_xdp_tx_total",
 		Help: "The total number of transmitted packets (n6)",
 	}, func() float64 {
 		return float64(stats.GetN6Tx())
 	})
 
 	UpfN6XdpRedirect = prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Name: "app_n6_xdp_redirect",
+		Name: "app_n6_xdp_redirect_total",
 		Help: "The total number of redirected packets (n6)",
 	}, func() float64 {
 		return float64(stats.GetN6Redirect())

--- a/ui/app/(core)/dashboard/page.tsx
+++ b/ui/app/(core)/dashboard/page.tsx
@@ -193,16 +193,16 @@ const Dashboard = () => {
       return Number.isFinite(n) ? n : null;
     };
 
-    const pduSessions = getValue("app_pdu_sessions ");
+    const pduSessions = getValue("app_pdu_sessions_total ");
     const memBytes = getValue("go_memstats_alloc_bytes ");
     const goGoroutines = getValue("go_goroutines ");
     const dbBytes = getValue("app_database_storage_bytes ");
-    const allocIPs = getValue("app_ip_addresses_allocated ");
+    const allocIPs = getValue("app_ip_addresses_allocated_total ");
     const totalIPsV = getValue("app_ip_addresses_total ");
     const ulBytes = getValue("app_uplink_bytes ");
     const dlBytes = getValue("app_downlink_bytes ");
-    const n3Drop = getValue("app_n3_xdp_drop ");
-    const n6Drop = getValue("app_n6_xdp_drop ");
+    const n3Drop = getValue("app_n3_xdp_drop_total ");
+    const n6Drop = getValue("app_n6_xdp_drop_total ");
     const startTime = getValue("process_start_time_seconds ");
 
     return {


### PR DESCRIPTION
# Description

This PR updates the metrics name to follow the best practices laid out here: https://prometheus.io/docs/practices/naming/.

It also changes the metric for the amount of current PDU sessions to a `Gauge`, as it can go down.

The documentation is updated to reflect the changes.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
