### PR TITLE
fix: handle inner NAS message container in registration request

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -46,7 +46,7 @@ func Start(dbInstance *db.Database, n2Address string, n2Port int) error {
 	}
 	self.TimeZone = nasConvert.GetTimeZone(time.Now())
 	self.T3502Value = 720
-	self.T3512Value = 30 // TO DO: revert before merging
+	self.T3512Value = 3600
 	self.T3513Cfg = context.TimerValue{
 		Enable:        true,
 		ExpireTime:    6 * time.Second,


### PR DESCRIPTION
# Description

Given an existing UE NAS security context, the UE may send a Registration Request with the actual (ciphered) request carried in the NAS message container. When that's the case, Ella Core decrypts this container and processes the inner registration request instead of the outer one.

Fixes #907 

## Reference
- TS 24.501: https://www.etsi.org/deliver/etsi_ts/124500_124599/124501/16.05.01_60/ts_124501v160501p.pdf

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
