### PR TITLE
fix: remove deregistration initiated state

### DIFF
--- a/internal/amf/context/amf_ue.go
+++ b/internal/amf/context/amf_ue.go
@@ -46,12 +46,11 @@ const (
 
 // GMM state for UE
 const (
-	Deregistered            StateType = "Deregistered"
-	DeregistrationInitiated StateType = "DeregistrationInitiated"
-	Authentication          StateType = "Authentication"
-	SecurityMode            StateType = "SecurityMode"
-	ContextSetup            StateType = "ContextSetup"
-	Registered              StateType = "Registered"
+	Deregistered   StateType = "Deregistered"
+	Authentication StateType = "Authentication"
+	SecurityMode   StateType = "SecurityMode"
+	ContextSetup   StateType = "ContextSetup"
+	Registered     StateType = "Registered"
 )
 
 type AmfUe struct {

--- a/internal/amf/nas/gmm/handle_deregistration_accept.go
+++ b/internal/amf/nas/gmm/handle_deregistration_accept.go
@@ -18,10 +18,6 @@ func handleDeregistrationAccept(ctx ctxt.Context, ue *context.AmfUe) error {
 	ctx, span := tracer.Start(ctx, "AMF NAS HandleDeregistrationAccept")
 	defer span.End()
 
-	if ue.State.Current() != context.DeregistrationInitiated {
-		return fmt.Errorf("state mismatch: receive Deregistration Accept message in state %s", ue.State.Current())
-	}
-
 	if ue.T3522 != nil {
 		ue.T3522.Stop()
 		ue.T3522 = nil // clear the timer

--- a/internal/amf/nas/gmm/handle_deregistration_request.go
+++ b/internal/amf/nas/gmm/handle_deregistration_request.go
@@ -35,7 +35,7 @@ func handleDeregistrationRequestUEOriginatingDeregistration(ctx ctxt.Context, ue
 		return fmt.Errorf("gmm message is nil")
 	}
 
-	ue.State.Set(context.DeregistrationInitiated)
+	ue.State.Set(context.Deregistered)
 
 	targetDeregistrationAccessType := msg.DeregistrationRequestUEOriginatingDeregistration.GetAccessType()
 

--- a/internal/amf/nas/gmm/handle_registration_request.go
+++ b/internal/amf/nas/gmm/handle_registration_request.go
@@ -239,6 +239,8 @@ func handleRegistrationRequest(ctx ctxt.Context, ue *context.AmfUe, msg *nas.Gmm
 		ue.State.Set(context.Deregistered)
 		ue.Log.Info("state reset to Deregistered")
 		return nil
+	default:
+		return fmt.Errorf("state mismatch: receive Registration Request message in state %s", ue.State.Current())
 	}
 
 	return nil


### PR DESCRIPTION
# Description

There was a condition where UE's could get stuck in a "Deregistration Initiated" state. Here we simply get rid of that state because it bears no other utility than getting stuck.

This PR should address #907, but none of my UE's at home trigger this specific bug. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
