### PR TITLE
fix: clean BPF stats on shutdown

### DIFF
--- a/internal/upf/ebpf/objects.go
+++ b/internal/upf/ebpf/objects.go
@@ -147,10 +147,12 @@ func (bpfObjects *BpfObjects) unpinMaps() {
 	if err := bpfObjects.PdrsDownlinkIp6.Unpin(); err != nil {
 		logger.UpfLog.Warn("failed to unpin pdrs_downlink_ip6 map, state could be left behind: %v", zap.Error(err))
 	}
-	if err := bpfObjects.N3N6EntrypointMaps.DownlinkStatistics.Unpin(); err != nil {
+
+	if err := bpfObjects.DownlinkStatistics.Unpin(); err != nil {
 		logger.UpfLog.Warn("failed to unpin downlink_statistics map, state could be left behind: %v", zap.Error(err))
 	}
-	if err := bpfObjects.N3N6EntrypointMaps.UplinkStatistics.Unpin(); err != nil {
+
+	if err := bpfObjects.UplinkStatistics.Unpin(); err != nil {
 		logger.UpfLog.Warn("failed to unpin uplink_statistics map, state could be left behind: %v", zap.Error(err))
 	}
 }


### PR DESCRIPTION
# Description

On shutdown we only unpin some maps, but were keeping uplink/downlink statistics. Now we unpin those maps as well.

Fixes #927 .

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
