### PR TITLE
chore: replace KB with MB to represent DB size in dashboard [ui]

### DIFF
--- a/ui/app/(core)/dashboard/page.tsx
+++ b/ui/app/(core)/dashboard/page.tsx
@@ -213,7 +213,8 @@ const Dashboard = () => {
       pduSessions: pduSessions ?? null,
       memoryUsageMB:
         memBytes == null ? null : Math.round(memBytes / (1024 * 1024)),
-      databaseSizeMB: dbBytes == null ? null : Math.round(dbBytes / (1024 * 1024)),
+      databaseSizeMB:
+        dbBytes == null ? null : Math.round(dbBytes / (1024 * 1024)),
       routines: goGoroutines ?? null,
       allocatedIPs: allocIPs == null ? null : Math.round(allocIPs),
       totalIPs: totalIPsV == null ? null : Math.round(totalIPsV),


### PR DESCRIPTION
# Description

We used to represent the database size in KB in the UI dashboard. Typical deployments have database sizes in MB, making the value unnecessarily large (xx xxx). Now we use KB instead of MB.

## Screenshots

**Before**
<img width="3803" height="1877" alt="image" src="https://github.com/user-attachments/assets/e00cd29a-6579-481c-9bff-3ca97ec31bd4" />

**After**
<img width="3803" height="1877" alt="image" src="https://github.com/user-attachments/assets/7c6f0865-5dc3-4c02-b6b5-79eaa0015acf" />

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
