### PR TITLE
fix: only start 1 goroutine for collecting connection tracking garbage

### DIFF
--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -153,10 +153,6 @@ func Start(ctx context.Context, n3Interface config.N3Interface, n3Address string
 		upf.startGC()
 	}
 
-	if masquerade {
-		go upf.collectCollectionTrackingGarbage(ctx)
-	}
-
 	return upf, nil
 }
 


### PR DESCRIPTION
# Description

We were creating two identical goroutine for collecting connection tracking garbage. Here we remove one of the two.

## Screenshot

I identified this issue when I was looking at a [Parca](https://github.com/parca-dev/parca) CPU profile of Ella Core.

Here you can see the two independent instances of connection tracking garbage collection (the two flames on the left).

<img width="2111" height="862" alt="image" src="https://github.com/user-attachments/assets/326c8e1a-c265-4501-b34e-7addceb5cd86" />
 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
