### PR TITLE
chore: Test handling of Mobile Identity Contents

### DIFF
--- a/internal/amf/context/amf.go
+++ b/internal/amf/context/amf.go
@@ -117,13 +117,13 @@ type SecurityAlgorithm struct {
 	CipheringOrder []uint8 // slice of security.AlgCipheringXXX
 }
 
-func allocateTMSI() (int32, error) {
+func allocateTMSI() (uint32, error) {
 	val, err := tmsiGenerator.Allocate()
 	if err != nil {
-		return -1, fmt.Errorf("could not allocate TMSI: %v", err)
+		return 0, fmt.Errorf("could not allocate TMSI: %v", err)
 	}
 
-	return int32(val), nil
+	return uint32(val), nil
 }
 
 func allocateAmfUeNgapID() (int64, error) {

--- a/internal/amf/context/amf_ue.go
+++ b/internal/amf/context/amf_ue.go
@@ -66,8 +66,8 @@ type AmfUe struct {
 	Suci    string
 	Supi    string
 	Pei     string
-	Tmsi    int32
-	OldTmsi int32
+	Tmsi    uint32
+	OldTmsi uint32
 	Guti    string
 	OldGuti string
 	/* User Location*/

--- a/internal/amf/nas/gmm/common.go
+++ b/internal/amf/nas/gmm/common.go
@@ -5,6 +5,10 @@ import (
 )
 
 func plmnIDStringToModels(plmnIDStr string) models.PlmnID {
+	if len(plmnIDStr) < 5 {
+		return models.PlmnID{}
+	}
+
 	return models.PlmnID{
 		Mcc: plmnIDStr[:3],
 		Mnc: plmnIDStr[3:],

--- a/internal/amf/nas/gmm/handle_identity_response_test.go
+++ b/internal/amf/nas/gmm/handle_identity_response_test.go
@@ -1,0 +1,216 @@
+package gmm
+
+import (
+	"fmt"
+	"testing"
+
+	amfContext "github.com/ellanetworks/core/internal/amf/context"
+	"github.com/free5gc/nas/nasMessage"
+)
+
+type UpdateInputs struct {
+	name         string
+	ue           *amfContext.AmfUe
+	mi           []uint8
+	expected_err error
+	validate_ue  func(ue *amfContext.AmfUe) error
+}
+
+func emptyValidation(ue *amfContext.AmfUe) error {
+	return nil
+}
+
+func TestUpdateUeIdentity(t *testing.T) {
+	testcases := []UpdateInputs{
+		{
+			"NIL UE",
+			nil,
+			[]uint8{},
+			fmt.Errorf("AmfUe is nil"),
+			emptyValidation,
+		},
+		{
+			"Empty mobileIdentityContents",
+			&amfContext.AmfUe{},
+			[]uint8{},
+			fmt.Errorf("mobile identity is empty"),
+			emptyValidation,
+		},
+		{
+			"Unknown type is ignored",
+			&amfContext.AmfUe{},
+			[]uint8{0xFF},
+			nil,
+			emptyValidation,
+		},
+		{
+			"Invalid SUCI sets empty SUCI and PLMN",
+			&amfContext.AmfUe{},
+			[]uint8{nasMessage.MobileIdentity5GSTypeSuci},
+			nil,
+			func(ue *amfContext.AmfUe) error {
+				if ue.Suci != "" || ue.PlmnID.Mcc != "" || ue.PlmnID.Mnc != "" {
+					return fmt.Errorf("SUCI and PLMN should be empty, got %s, %s%s", ue.Suci, ue.PlmnID.Mcc, ue.PlmnID.Mnc)
+				}
+
+				return nil
+			},
+		},
+		{
+			"Valid SUCI sets SUCI and PLMN",
+			&amfContext.AmfUe{},
+			[]uint8{nasMessage.MobileIdentity5GSTypeSuci, 0x00, 0xf1, 0x10, 0x10, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			nil,
+			func(ue *amfContext.AmfUe) error {
+				if ue.Suci != "suci-0-001-01-0110-0-1-00000000000000000010" || ue.PlmnID.Mcc != "001" || ue.PlmnID.Mnc != "01" {
+					return fmt.Errorf("SUCI and PLMN should not be empty, got %s, %s%s", ue.Suci, ue.PlmnID.Mcc, ue.PlmnID.Mnc)
+				}
+
+				return nil
+			},
+		},
+		{
+			"Invalid GUTI sets empty GUTI",
+			&amfContext.AmfUe{Guti: "oldguti", MacFailed: false},
+			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0},
+			fmt.Errorf("UE sent invalid GUTI"),
+			emptyValidation,
+		},
+		{
+			"GUTI with MacFailed returns error",
+			&amfContext.AmfUe{MacFailed: true},
+			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0x10, 0x1f, 0, 0, 1, 0, 0, 0, 1},
+			fmt.Errorf("NAS message integrity check failed"),
+			emptyValidation,
+		},
+		{
+			"Valid GUTI matches UE GUTI",
+			&amfContext.AmfUe{MacFailed: false, Guti: "00101cafe01deadbeef"},
+			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0xf1, 0x10, 0xCA, 0xFE, 1, 0xDE, 0xAD, 0xBE, 0xEF},
+			nil,
+			emptyValidation,
+		},
+		{
+			"Valid GUTI matches UE old GUTI",
+			&amfContext.AmfUe{MacFailed: false, Guti: "00101cafe02f00df00d", OldGuti: "00101cafe01deadbeef"},
+			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0xf1, 0x10, 0xCA, 0xFE, 1, 0xDE, 0xAD, 0xBE, 0xEF},
+			nil,
+			emptyValidation,
+		},
+		{
+			"Valid GUTI does not match AMF state",
+			&amfContext.AmfUe{MacFailed: false, Guti: "00101cafe02f00df00d", OldGuti: "00101cafe0112345678"},
+			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0xf1, 0x10, 0xCA, 0xFE, 1, 0xDE, 0xAD, 0xBE, 0xEF},
+			fmt.Errorf("UE sent unknown GUTI"),
+			emptyValidation,
+		},
+		{
+			"5G-S-TMSI with MacFailed returns error",
+			&amfContext.AmfUe{MacFailed: true},
+			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0x00, 0x12, 0x34, 0x56, 0x78, 0x90},
+			fmt.Errorf("NAS message integrity check failed"),
+			emptyValidation,
+		},
+		{
+			"5G-S-TMSI maximum value matches",
+			&amfContext.AmfUe{MacFailed: false, Tmsi: 0xFFFFFFFF},
+			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			nil,
+			emptyValidation,
+		},
+		{
+			"5G-S-TMSI too long returns error",
+			&amfContext.AmfUe{MacFailed: false},
+			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			fmt.Errorf("wrong length for TMSI"),
+			emptyValidation,
+		},
+		{
+			"5G-S-TMSI too short returns error",
+			&amfContext.AmfUe{MacFailed: false},
+			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFF, 0xFF, 0x01},
+			fmt.Errorf("wrong length for TMSI"),
+			emptyValidation,
+		},
+		{
+			"Valid 5G-S-TMSI matches UE TMSI",
+			&amfContext.AmfUe{MacFailed: false, Tmsi: uint32(0x1A345678)},
+			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFE, 0x01, 0x1A, 0x34, 0x56, 0x78},
+			nil,
+			emptyValidation,
+		},
+		{
+			"Valid 5G-S-TMSI matches UE old TMSI",
+			&amfContext.AmfUe{MacFailed: false, Tmsi: uint32(0x22234567), OldTmsi: uint32(0x1A345678)},
+			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFE, 0x01, 0x1A, 0x34, 0x56, 0x78},
+			nil,
+			emptyValidation,
+		},
+		{
+			"Valid 5G-S-TMSI does not match AMF state",
+			&amfContext.AmfUe{MacFailed: false, Tmsi: uint32(0x22234567), OldTmsi: uint32(0x5FFF5555)},
+			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFE, 0x01, 0x1A, 0x34, 0x56, 0x78},
+			fmt.Errorf("UE sent unknown TMSI"),
+			emptyValidation,
+		},
+		{
+			"IMEI with MacFailed returns error",
+			&amfContext.AmfUe{MacFailed: true},
+			[]uint8{nasMessage.MobileIdentity5GSTypeImei + 0x08 + 0x40, 0x09, 0x51, 0x24, 0x30, 0x32, 0x57, 0x81},
+			fmt.Errorf("NAS message integrity check failed"),
+			emptyValidation,
+		},
+		{
+			"Valid IMEI sets PEI",
+			&amfContext.AmfUe{MacFailed: false},
+			[]uint8{nasMessage.MobileIdentity5GSTypeImei + 0x08 + 0x40, 0x09, 0x51, 0x24, 0x30, 0x32, 0x57, 0x81},
+			nil,
+			func(ue *amfContext.AmfUe) error {
+				expected := "imei-490154203237518"
+				if ue.Pei != expected {
+					return fmt.Errorf("PEI should be %s, got %s", expected, ue.Pei)
+				}
+
+				return nil
+			},
+		},
+		{
+			"IMEISV with MacFailed returns error",
+			&amfContext.AmfUe{MacFailed: true},
+			[]uint8{nasMessage.MobileIdentity5GSTypeImeisv + 0x30, 0x25, 0x90, 0x09, 0x10, 0x67, 0x41, 0x28, 0xF3},
+			fmt.Errorf("NAS message integrity check failed"),
+			emptyValidation,
+		},
+		{
+			"Valid IMEISV sets PEI",
+			&amfContext.AmfUe{MacFailed: false},
+			[]uint8{nasMessage.MobileIdentity5GSTypeImeisv + 0x30, 0x25, 0x90, 0x09, 0x10, 0x67, 0x41, 0x28, 0xF3},
+			nil,
+			func(ue *amfContext.AmfUe) error {
+				expected := "imeisv-3520990017614823"
+				if ue.Pei != expected {
+					return fmt.Errorf("PEI should be %s, got %s", expected, ue.Pei)
+				}
+
+				return nil
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := updateUEIdentity(tc.ue, tc.mi)
+
+			if tc.expected_err == nil && err != nil {
+				t.Fatalf("expected error to be nil, got %v", err)
+			} else if tc.expected_err != nil && err == nil {
+				t.Fatalf("expected an error but error was nil")
+			} else if tc.expected_err != nil && err != nil && err.Error() != tc.expected_err.Error() {
+				t.Fatalf("expected error to be %v, got %v", tc.expected_err, err)
+			}
+
+			if err = tc.validate_ue(tc.ue); err != nil {
+				t.Fatalf("validating updated UE failed: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR adds unit tests for the handling of Mobile Identity Contents in `updateUEIdentity`. When adding those tests, I identified a couple of bugs that I also fixed. To make sure that those changes can be easily reverted, I am opening this PR right away to make the changes focused.

The bugs addressed in this PRs are:

- A badly formatted PLMN in the Mobile Identity contents IE could crash the server
- The TMSI was stored as a int32, and it should be a uint32
- The length of the provided TMSI was not checked
- The parsing of the TMSI could safely handle numbers that did not have letters when represented in hexadecimal
- The GUTI or TMSI sent by the UE was overwriting the context in the AMF, blindly trusting the value sent by the UE. Because those values are assigned by the AMF, there is no reason to set them in the UE context.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
