### PR TITLE
feat: add backup and restore functions to Go API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![ella-core](https://snapcraft.io/ella-core/badge.svg)](https://snapcraft.io/ella-core)
 
-Ella Core is a 5G mobile core network designed for private deployments. It consolidates the complexity of traditional 5G networks into a single application, offering simplicity, reliability, and security.
+Ella Core is a 5G core designed for private networks. It consolidates the complexity of traditional 5G networks into a single application, offering simplicity, reliability, and security.
 
 Typical mobile networks are expensive, complex, and inadequate for private deployments. They require a team of experts to deploy, maintain, and operate. Open source alternatives are often incomplete, difficult to use, and geared towards research and development. Ella Core is an open-source, production-geared solution that simplifies the deployment and operation of private mobile networks.
 
@@ -20,9 +20,10 @@ Use Ella Core where you need 5G connectivity: in a factory, a warehouse, a farm,
 - **Performant Data Plane**: Achieve high throughput and low latency with an eBPF-based data plane. Ella Core delivers over 10 Gbps of throughput and less than 1.2 ms of latency.
 - **Lightweight**: Ella Core is a single binary with an embedded database, making it easy and quick to stand up. It requires as little as 2 CPU cores, 2GB of RAM, and 10GB of disk space. Forget specialized hardware; all you need to operate your 5G core network is a Linux system with a network interface.
 - **Intuitive User Experience**: Manage subscribers, radios, data networks, policies, and operator information through a user-friendly web interface. Automate network operations with a complete REST API.
-- **Real-Time Observability**: Access detailed metrics, traces, and dashboards to monitor network health through the UI, the Prometheus-compliant API, or an OpenTelemetry collector.
-- **Backup and Restore**: Backup and restore the network configuration and data.
-- **Audit Logs**: Keep track of all operations performed on the network.
+- **Real-Time Observability**: Access logs, metrics, traces, profiles, and dashboards to monitor network health through the UI, the Prometheus-compliant API, or an OpenTelemetry collector.
+- **Backup and Restore**: Backup and restore your data in 1 click.
+- **Audit Logs**: At any moment, keep track of who did what and when on your network.
+- **Open Source**: Ella Core is open source and available under the Apache 2.0 license.
 
 ## Quick Links
 

--- a/client/auth.go
+++ b/client/auth.go
@@ -16,7 +16,6 @@ type RefreshResponseResult struct {
 }
 
 // Login authenticates the user with the provided email and password.
-// It stores the token in the client for future requests.
 func (c *Client) Login(ctx context.Context, opts *LoginOptions) error {
 	payload := struct {
 		Email    string `json:"email"`
@@ -51,6 +50,8 @@ func (c *Client) Login(ctx context.Context, opts *LoginOptions) error {
 	return nil
 }
 
+// Refresh refreshes the authentication token.
+// It stores the new token in the client.
 func (c *Client) Refresh(ctx context.Context) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",

--- a/client/backup.go
+++ b/client/backup.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+)
+
+type CreateBackupParams struct {
+	Path string
+}
+
+type RestoreBackupParams struct {
+	Path string
+}
+
+// CreateBackup creates a backup and saves it to the specified path.
+func (c *Client) CreateBackup(ctx context.Context, p *CreateBackupParams) error {
+	if p == nil {
+		return fmt.Errorf("CreateBackupParams is nil")
+	}
+
+	if p.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	resp, err := c.Requester.Do(ctx, &RequestOptions{
+		Type:   RawRequest,
+		Method: "POST",
+		Path:   "api/v1/backup",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create backup: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	out, err := os.Create(p.Path)
+	if err != nil {
+		return fmt.Errorf("failed to create backup file: %w", err)
+	}
+
+	defer func() {
+		_ = out.Close()
+	}()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to write backup to file: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) RestoreBackup(ctx context.Context, p *RestoreBackupParams) error {
+	if p == nil || p.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	f, err := os.Open(p.Path)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+
+	// Stream multipart to the pipe.
+	go func() {
+		defer func() {
+			_ = pw.Close()
+		}()
+
+		part, err := mw.CreateFormFile("backup", filepath.Base(p.Path)) // must match r.FormFile("backup")
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+
+		if _, err := io.Copy(part, f); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+
+		if err := mw.Close(); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+	}()
+
+	resp, err := c.Requester.Do(ctx, &RequestOptions{
+		Type:   RawRequest,
+		Method: "POST",
+		Path:   "api/v1/restore",
+		Headers: map[string]string{
+			"Content-Type": mw.FormDataContentType(),
+		},
+		Body: pr,
+	})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	return nil
+}

--- a/client/backup_test.go
+++ b/client/backup_test.go
@@ -1,0 +1,134 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+func TestCreateBackup_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpPath := filepath.Join(tmpDir, "ella_core.backup")
+
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Backup created successfully"}`),
+			Body:       io.NopCloser(strings.NewReader("backup data")),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	createBackupOpts := &client.CreateBackupParams{
+		Path: tmpPath,
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.CreateBackup(ctx, createBackupOpts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestCreateBackup_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 400,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Invalid Path"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+	createBackupOpts := &client.CreateBackupParams{
+		Path: "invalid/path",
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.CreateBackup(ctx, createBackupOpts)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestRestoreBackup_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpPath := filepath.Join(tmpDir, "ella_core.backup")
+
+	err := os.WriteFile(tmpPath, []byte("backup data"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write temp backup file: %v", err)
+	}
+
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Backup restored successfully"}`),
+			Body:       io.NopCloser(strings.NewReader("")),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	restoreBackupOpts := &client.RestoreBackupParams{
+		Path: tmpPath,
+	}
+
+	ctx := context.Background()
+
+	err = clientObj.RestoreBackup(ctx, restoreBackupOpts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestRestoreBackup_Failure(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpPath := filepath.Join(tmpDir, "ella_core.backup")
+
+	err := os.WriteFile(tmpPath, []byte("backup data"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write temp backup file: %v", err)
+	}
+
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 500,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Restore failed"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	restoreBackupOpts := &client.RestoreBackupParams{
+		Path: tmpPath,
+	}
+
+	ctx := context.Background()
+
+	err = clientObj.RestoreBackup(ctx, restoreBackupOpts)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -86,14 +86,17 @@ type Client struct {
 	token     string
 }
 
+// GetToken returns the current API token.
 func (c *Client) GetToken() string {
 	return c.token
 }
 
+// SetToken sets the API token to be used for authentication.
 func (c *Client) SetToken(token string) {
 	c.token = token
 }
 
+// New creates a new Client using the provided configuration.
 func New(config *Config) (*Client, error) {
 	if config == nil {
 		config = &Config{}

--- a/client/data_networks.go
+++ b/client/data_networks.go
@@ -37,6 +37,7 @@ type ListDataNetworksResponse struct {
 	TotalCount int           `json:"total_count"`
 }
 
+// CreateDataNetwork creates a new data network with the provided options.
 func (c *Client) CreateDataNetwork(ctx context.Context, opts *CreateDataNetworkOptions) error {
 	payload := struct {
 		Name   string `json:"name"`
@@ -70,6 +71,7 @@ func (c *Client) CreateDataNetwork(ctx context.Context, opts *CreateDataNetworkO
 	return nil
 }
 
+// GetDataNetwork retrieves the details of a data network by name.
 func (c *Client) GetDataNetwork(ctx context.Context, opts *GetDataNetworkOptions) (*DataNetwork, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -90,6 +92,7 @@ func (c *Client) GetDataNetwork(ctx context.Context, opts *GetDataNetworkOptions
 	return &dataNetworkResponse, nil
 }
 
+// DeleteDataNetwork deletes a data network by name.
 func (c *Client) DeleteDataNetwork(ctx context.Context, opts *DeleteDataNetworkOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -103,6 +106,7 @@ func (c *Client) DeleteDataNetwork(ctx context.Context, opts *DeleteDataNetworkO
 	return nil
 }
 
+// ListDataNetworks lists all data networks with pagination support.
 func (c *Client) ListDataNetworks(ctx context.Context, p *ListParams) (*ListDataNetworksResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/initialize.go
+++ b/client/initialize.go
@@ -11,6 +11,7 @@ type InitializeOptions struct {
 	Password string `json:"password"`
 }
 
+// Initialize initializes the client with the provided options.
 func (c *Client) Initialize(ctx context.Context, opts *InitializeOptions) error {
 	payload := struct {
 		Email    string `json:"email"`

--- a/client/logs.go
+++ b/client/logs.go
@@ -33,6 +33,7 @@ type ListAuditLogsResponse struct {
 	TotalCount int        `json:"total_count"`
 }
 
+// ListAuditLogs retrieves a paginated list of audit logs.
 func (c *Client) ListAuditLogs(ctx context.Context, p *ListParams) (*ListAuditLogsResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -57,6 +58,7 @@ func (c *Client) ListAuditLogs(ctx context.Context, p *ListParams) (*ListAuditLo
 	return &auditLogs, nil
 }
 
+// GetAuditLogRetentionPolicy retrieves the current audit log retention policy.
 func (c *Client) GetAuditLogRetentionPolicy(ctx context.Context) (*GetAuditLogsRetentionPolicy, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -77,6 +79,7 @@ func (c *Client) GetAuditLogRetentionPolicy(ctx context.Context) (*GetAuditLogsR
 	return &policy, nil
 }
 
+// UpdateAuditLogRetentionPolicy updates the audit log retention policy.
 func (c *Client) UpdateAuditLogRetentionPolicy(ctx context.Context, opts *UpdateAuditLogsRetentionPolicyOptions) error {
 	payload := struct {
 		Days int `json:"days"`

--- a/client/nat.go
+++ b/client/nat.go
@@ -14,6 +14,7 @@ type UpdateNATInfoOptions struct {
 	Enabled bool `json:"enabled"`
 }
 
+// GetNATInfo retrieves the current Network Address Translation (NAT) configuration.
 func (c *Client) GetNATInfo(ctx context.Context) (*GetNATInfoResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -34,6 +35,7 @@ func (c *Client) GetNATInfo(ctx context.Context) (*GetNATInfoResponse, error) {
 	return &natInfoResponse, nil
 }
 
+// UpdateNATInfo updates the Network Address Translation (NAT) configuration.
 func (c *Client) UpdateNATInfo(ctx context.Context, opts *UpdateNATInfoOptions) error {
 	var body bytes.Buffer
 

--- a/client/operator.go
+++ b/client/operator.go
@@ -49,6 +49,7 @@ type UpdateOperatorHomeNetworkOptions struct {
 	PrivateKey string
 }
 
+// GetOperator retrieves the current operator configuration.
 func (c *Client) GetOperator(ctx context.Context) (*Operator, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -69,6 +70,7 @@ func (c *Client) GetOperator(ctx context.Context) (*Operator, error) {
 	return &operatorResponse, nil
 }
 
+// UpdateOperatorID updates the operator's Mobile Country Code (MCC) and Mobile Network Code (MNC).
 func (c *Client) UpdateOperatorID(ctx context.Context, opts *UpdateOperatorIDOptions) error {
 	payload := struct {
 		Mcc string `json:"mcc"`
@@ -98,6 +100,7 @@ func (c *Client) UpdateOperatorID(ctx context.Context, opts *UpdateOperatorIDOpt
 	return nil
 }
 
+// UpdateOperatorSlice updates the operator's slice information.
 func (c *Client) UpdateOperatorSlice(ctx context.Context, opts *UpdateOperatorSliceOptions) error {
 	payload := struct {
 		Sst int    `json:"sst"`
@@ -127,6 +130,7 @@ func (c *Client) UpdateOperatorSlice(ctx context.Context, opts *UpdateOperatorSl
 	return nil
 }
 
+// UpdateOperatorTracking updates the operator's tracking information (supported TACs).
 func (c *Client) UpdateOperatorTracking(ctx context.Context, opts *UpdateOperatorTrackingOptions) error {
 	payload := struct {
 		SupportedTacs []string `json:"supportedTacs"`
@@ -154,6 +158,7 @@ func (c *Client) UpdateOperatorTracking(ctx context.Context, opts *UpdateOperato
 	return nil
 }
 
+// UpdateOperatorHomeNetwork updates the operator's home network information (private key).
 func (c *Client) UpdateOperatorHomeNetwork(ctx context.Context, opts *UpdateOperatorHomeNetworkOptions) error {
 	payload := struct {
 		PrivateKey string `json:"privateKey"`

--- a/client/policies.go
+++ b/client/policies.go
@@ -41,6 +41,7 @@ type ListPoliciesResponse struct {
 	TotalCount int      `json:"total_count"`
 }
 
+// CreatePolicy creates a new policy with the provided options.
 func (c *Client) CreatePolicy(ctx context.Context, opts *CreatePolicyOptions) error {
 	payload := struct {
 		Name            string `json:"name"`
@@ -78,6 +79,7 @@ func (c *Client) CreatePolicy(ctx context.Context, opts *CreatePolicyOptions) er
 	return nil
 }
 
+// GetPolicy retrieves a policy by name.
 func (c *Client) GetPolicy(ctx context.Context, opts *GetPolicyOptions) (*Policy, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -98,6 +100,7 @@ func (c *Client) GetPolicy(ctx context.Context, opts *GetPolicyOptions) (*Policy
 	return &policyResponse, nil
 }
 
+// DeletePolicy deletes a policy by name.
 func (c *Client) DeletePolicy(ctx context.Context, opts *DeletePolicyOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -111,6 +114,7 @@ func (c *Client) DeletePolicy(ctx context.Context, opts *DeletePolicyOptions) er
 	return nil
 }
 
+// ListPolicies lists policies with pagination.
 func (c *Client) ListPolicies(ctx context.Context, p *ListParams) (*ListPoliciesResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/radios.go
+++ b/client/radios.go
@@ -87,6 +87,7 @@ type RadioEventContent struct {
 	Raw     string `json:"raw"`
 }
 
+// GetRadio retrieves a radio by name.
 func (c *Client) GetRadio(ctx context.Context, opts *GetRadioOptions) (*Radio, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -107,6 +108,7 @@ func (c *Client) GetRadio(ctx context.Context, opts *GetRadioOptions) (*Radio, e
 	return &radioResponse, nil
 }
 
+// ListRadios lists radios with pagination.
 func (c *Client) ListRadios(ctx context.Context, p *ListParams) (*ListRadiosResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -131,6 +133,7 @@ func (c *Client) ListRadios(ctx context.Context, p *ListParams) (*ListRadiosResp
 	return &radios, nil
 }
 
+// ListRadioEvents lists radio events with filtering and pagination.
 func (c *Client) ListRadioEvents(ctx context.Context, p *ListRadioEventsParams) (*ListRadioEventsResponse, error) {
 	query := url.Values{}
 	if p.Page != 0 {
@@ -181,6 +184,7 @@ func (c *Client) ListRadioEvents(ctx context.Context, p *ListRadioEventsParams) 
 	return &radioEvents, nil
 }
 
+// ClearRadioEvents clears all radio events. Events will be permanently deleted.
 func (c *Client) ClearRadioEvents(ctx context.Context) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -194,6 +198,7 @@ func (c *Client) ClearRadioEvents(ctx context.Context) error {
 	return nil
 }
 
+// GetRadioEventRetentionPolicy retrieves the current radio event retention policy.
 func (c *Client) GetRadioEventRetentionPolicy(ctx context.Context) (*GetRadioEventsRetentionPolicy, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -214,6 +219,7 @@ func (c *Client) GetRadioEventRetentionPolicy(ctx context.Context) (*GetRadioEve
 	return &policy, nil
 }
 
+// UpdateRadioEventRetentionPolicy updates the radio event retention policy.
 func (c *Client) UpdateRadioEventRetentionPolicy(ctx context.Context, opts *UpdateRadioEventsRetentionPolicyOptions) error {
 	payload := struct {
 		Days int `json:"days"`
@@ -241,6 +247,7 @@ func (c *Client) UpdateRadioEventRetentionPolicy(ctx context.Context, opts *Upda
 	return nil
 }
 
+// GetRadioEvent retrieves a radio event by ID.
 func (c *Client) GetRadioEvent(ctx context.Context, id int) (*RadioEventContent, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/routes.go
+++ b/client/routes.go
@@ -38,6 +38,7 @@ type ListRoutesResponse struct {
 	TotalCount int     `json:"total_count"`
 }
 
+// CreateRoute creates a new route with the provided options. The route will be added to the system's underlying kernel routing table.
 func (c *Client) CreateRoute(ctx context.Context, opts *CreateRouteOptions) error {
 	payload := struct {
 		Destination string `json:"destination"`
@@ -71,6 +72,7 @@ func (c *Client) CreateRoute(ctx context.Context, opts *CreateRouteOptions) erro
 	return nil
 }
 
+// GetRoute retrieves a route by ID.
 func (c *Client) GetRoute(ctx context.Context, opts *GetRouteOptions) (*Route, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -91,6 +93,7 @@ func (c *Client) GetRoute(ctx context.Context, opts *GetRouteOptions) (*Route, e
 	return &routeResponse, nil
 }
 
+// DeleteRoute deletes a route by ID.
 func (c *Client) DeleteRoute(ctx context.Context, opts *DeleteRouteOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -104,6 +107,7 @@ func (c *Client) DeleteRoute(ctx context.Context, opts *DeleteRouteOptions) erro
 	return nil
 }
 
+// ListRoutes lists routes with pagination.
 func (c *Client) ListRoutes(ctx context.Context, p *ListParams) (*ListRoutesResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/status.go
+++ b/client/status.go
@@ -7,6 +7,7 @@ type Status struct {
 	Initialized bool   `json:"initialized"`
 }
 
+// GetStatus retrieves the current status of the system.
 func (c *Client) GetStatus(ctx context.Context) (*Status, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -49,6 +49,7 @@ type ListSubscribersResponse struct {
 	TotalCount int          `json:"total_count"`
 }
 
+// CreateSubscriber creates a new subscriber with the provided options.
 func (c *Client) CreateSubscriber(ctx context.Context, opts *CreateSubscriberOptions) error {
 	payload := struct {
 		Imsi           string `json:"imsi"`
@@ -84,6 +85,7 @@ func (c *Client) CreateSubscriber(ctx context.Context, opts *CreateSubscriberOpt
 	return nil
 }
 
+// GetSubscriber retrieves a subscriber by ID.
 func (c *Client) GetSubscriber(ctx context.Context, opts *GetSubscriberOptions) (*Subscriber, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -104,6 +106,7 @@ func (c *Client) GetSubscriber(ctx context.Context, opts *GetSubscriberOptions) 
 	return &subscriberResponse, nil
 }
 
+// DeleteSubscriber deletes a subscriber by ID.
 func (c *Client) DeleteSubscriber(ctx context.Context, opts *DeleteSubscriberOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -117,8 +120,7 @@ func (c *Client) DeleteSubscriber(ctx context.Context, opts *DeleteSubscriberOpt
 	return nil
 }
 
-// http://127.0.0.1:5002/api/v1/subscribers?page=1&per_page=25
-
+// ListSubscribers lists subscribers with pagination.
 func (c *Client) ListSubscribers(ctx context.Context, p *ListParams) (*ListSubscribersResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/usage.go
+++ b/client/usage.go
@@ -30,6 +30,7 @@ type ListUsageParams struct {
 	Subscriber string `json:"subscriber"`
 }
 
+// ListUsage retrieves subscriber usage data based on the provided parameters.
 func (c *Client) ListUsage(ctx context.Context, p *ListUsageParams) (*ListUsageResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -56,6 +57,7 @@ func (c *Client) ListUsage(ctx context.Context, p *ListUsageParams) (*ListUsageR
 	return &usage, nil
 }
 
+// GetUsageRetentionPolicy retrieves the current usage retention policy.
 func (c *Client) GetUsageRetentionPolicy(ctx context.Context) (*GetUsageRetentionPolicy, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -76,6 +78,7 @@ func (c *Client) GetUsageRetentionPolicy(ctx context.Context) (*GetUsageRetentio
 	return &policy, nil
 }
 
+// UpdateUsageRetentionPolicy updates the usage retention policy with the provided options.
 func (c *Client) UpdateUsageRetentionPolicy(ctx context.Context, opts *UpdateUsageRetentionPolicyOptions) error {
 	payload := struct {
 		Days int `json:"days"`

--- a/client/users.go
+++ b/client/users.go
@@ -60,6 +60,7 @@ type ListAPITokensResponse struct {
 	TotalCount int        `json:"total_count"`
 }
 
+// ListUsers lists users with pagination.
 func (c *Client) ListUsers(ctx context.Context, p *ListParams) (*ListUsersResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -84,6 +85,7 @@ func (c *Client) ListUsers(ctx context.Context, p *ListParams) (*ListUsersRespon
 	return &users, nil
 }
 
+// CreateUser creates a new user with the provided options.
 func (c *Client) CreateUser(ctx context.Context, opts *CreateUserOptions) error {
 	payload := struct {
 		Email    string `json:"email"`
@@ -115,6 +117,7 @@ func (c *Client) CreateUser(ctx context.Context, opts *CreateUserOptions) error 
 	return nil
 }
 
+// DeleteUser deletes a user by email.
 func (c *Client) DeleteUser(ctx context.Context, opts *DeleteUserOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -128,6 +131,7 @@ func (c *Client) DeleteUser(ctx context.Context, opts *DeleteUserOptions) error 
 	return nil
 }
 
+// CreateMyAPIToken creates a new API token for the authenticated user.
 func (c *Client) CreateMyAPIToken(ctx context.Context, opts *CreateAPITokenOptions) (*CreateAPITokenResponse, error) {
 	payload := struct {
 		Name   string `json:"name"`
@@ -164,6 +168,7 @@ func (c *Client) CreateMyAPIToken(ctx context.Context, opts *CreateAPITokenOptio
 	return &tokenResponse, nil
 }
 
+// ListMyAPITokens lists API tokens for the authenticated user with pagination.
 func (c *Client) ListMyAPITokens(ctx context.Context, p *ListParams) (*ListAPITokensResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -188,6 +193,7 @@ func (c *Client) ListMyAPITokens(ctx context.Context, p *ListParams) (*ListAPITo
 	return &tokens, nil
 }
 
+// DeleteMyAPIToken deletes an API token for the authenticated user by token ID.
 func (c *Client) DeleteMyAPIToken(ctx context.Context, tokenID string) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ description: A 5G mobile core network for private deployments - easy to operate,
   <img src="images/summary.svg" alt="Ella Core Logo" />
 </p>
 
-**Ella Core** is an open-source 5G mobile core network built for private deployments. It simplifies the complexity of traditional 5G networks into a single, easy-to-operate solution that is reliable and secure.
+**Ella Core** is a 5G core designed for private networks. It simplifies the complexity of traditional 5G networks into a single, easy-to-operate solution that is reliable and secure.
 
 Use Ella Core where you need 5G connectivity: in a factory, a warehouse, a farm, a stadium, a ship, a military base, or a remote location.
 
@@ -18,9 +18,10 @@ Use Ella Core where you need 5G connectivity: in a factory, a warehouse, a farm,
 - **Performant Data Plane**: Achieve high throughput and low latency with an eBPF-based data plane. Ella Core delivers over 10 Gbps of throughput and less than 1.2 ms of latency.
 - **Lightweight**: Ella Core is a single binary with an embedded database, making it easy and quick to stand up. It requires as little as 2 CPU cores, 2GB of RAM, and 10GB of disk space. Forget specialized hardware; all you need to operate your 5G core network is a Linux system with a network interface.
 - **Intuitive User Experience**: Manage subscribers, radios, data networks, policies, and operator information through a user-friendly web interface. Automate network operations with a complete REST API.
-- **Real-Time Observability**: Access detailed metrics, traces, and dashboards to monitor network health through the UI, the Prometheus-compliant API, or an OpenTelemetry collector.
-- **Backup and Restore**: Backup and restore the network configuration and data.
-- **Audit Logs**: Keep track of all operations performed on the network.
+- **Real-Time Observability**: Access logs, metrics, traces, profiles, and dashboards to monitor network health through the UI, the Prometheus-compliant API, or an OpenTelemetry collector.
+- **Backup and Restore**: Backup and restore your data in 1 click.
+- **Audit Logs**: At any moment, keep track of who did what and when on your network.
+- **Open Source**: Ella Core is open source and available under the Apache 2.0 license.
 
 ## In this documentation
 


### PR DESCRIPTION
# Description

Here we expose the ability to perform backups and restores via the Golang API client. The client leverages the HTTP API `/backup` and `/restore` endpoints.

This PR also adds description to public functions in the API client. Those descriptions will be visible on the client documentation at [https://pkg.go.dev/github.com/ellanetworks/core/client](https://pkg.go.dev/github.com/ellanetworks/core/client).

## Example

```go
package main

import (
	"context"
	"log"

	"github.com/ellanetworks/core/client"
)

func main() {
	clientConfig := &client.Config{
		BaseURL:  "https://127.0.0.1:5002",
		APIToken: "ellacore_J1g05MJIDo31_CxVwej8feZE4Z4B2pZRLGXdN",
	}

	ella, err := client.New(clientConfig)
	if err != nil {
		log.Println("Failed to create client:", err)
	}

	ctx := context.Background()

	err = ella.CreateBackup(ctx, &client.CreateBackupParams{
		Path: "ella_core.backup",
	})
	if err != nil {
		log.Fatalf("Failed to create backup: %v", err)
	}

	log.Println("Backup completed successfully")

	err = ella.RestoreBackup(ctx, &client.RestoreBackupParams{
		Path: "ella_core.backup",
	})
	if err != nil {
		log.Fatalf("Failed to restore backup: %v", err)
	}

	log.Println("Restore completed successfully")
}
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
