### PR TITLE
docs: add Baicells and Vankom to list of commercial radios

### DIFF
--- a/docs/reference/supported_5g_equipment.md
+++ b/docs/reference/supported_5g_equipment.md
@@ -4,18 +4,21 @@ description: Reference for supported 5G radios and user equipment (UE).
 
 # Supported 5G Equipment
 
+Ella Core's N2 and N3 interfaces follow 3GPP standards. This means that any radio and user equipment (UE) that follows the same standards should be compatible with Ella Core.
+
+> Some integrations were validated by third-party vendors, partners, or the open-source community.
+
 ## Radios
-
-Ella Core's N2 and N3 interfaces follow the 3GPP standards. This means that any radio that follows the same standards should be compatible with Ella Core.
-
-Ella Core has been tested with the following radios and simulators:
 
 ### Commercial Radios
 
 - **[CableFree 5G Small Cell](https://www.cablefree.net/5g-lte/5g-small-cell-base-station-radios/)**
+- **[Baicells Stellar 227](https://baicells.com/Product/Details?id=17aaad9c-190a-4acc-bb91-1d5695e01167#description)**
+- **[Vankom VKScell-g3](https://www.vankom.com/nps-scell-en/)**
 
-### Open RAN Radios
+### Open RAN Radios & SDR Platforms
 
+- **[Ettus Research USRP](https://www.ettus.com/all-products/)**
 - **[OpenAirInterface 5G RAN](https://openairinterface.org/)**
 - **[srsRAN 5G](https://www.srslte.com/5g)**
 
@@ -26,8 +29,6 @@ Ella Core has been tested with the following radios and simulators:
 
 ## User Equipment
 
-Ella Core has been tested with a variety of 5G user equipment and should work with most standard-compliant devices. The following devices have been confirmed to work with Ella Core:
-
 ### iOS Devices
 
 - **iPhone 16**
@@ -37,6 +38,8 @@ Ella Core has been tested with a variety of 5G user equipment and should work wi
 - **Crosscall CORE-Z5**
 - **Motorola G73 5G**
 - **Motorola Moto G 5G (2024)**
+- **OnePlus Nord 2 CE 5G**
+- **Huawei P40 5G**
 
 ### Simulators
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,6 @@ nav:
     - User Plane Packet processing with eBPF: explanation/user_plane_packet_processing_with_ebpf.md
     - Obtaining a PLMN ID for a Private Network: explanation/obtaining_plmn_id.md
     - Managing SIM Cards: explanation/managing_sim_cards.md
-  - Website: https://ellanetworks.com/
 plugins:
   - search
   - glightbox


### PR DESCRIPTION
# Description

Vicente Llarena from [Somorrostro](https://www.somorrostro.com/) reported validating Ella Core with multiple gNodeBs (Baicells Stellar 227, Vankom VKScell-g3 and Ettus B210 with srsRAN) and UEs (OnePlus Nord2 CE 5G and Huawei P40 5G). Here we add those to the list of supported equipment.

We also add a disclaimer that some integrations were validated by third-party vendors, partners, or the open-source community.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
