### PR TITLE
fix: avoid nil pointer when GnbID is nil

### DIFF
--- a/internal/amf/ngap/handle_uplink_ran_configuration_transfer.go
+++ b/internal/amf/ngap/handle_uplink_ran_configuration_transfer.go
@@ -34,7 +34,7 @@ func HandleUplinkRanConfigurationTransfer(ctx context.Context, amf *amfContext.A
 
 	targetRanNodeID := util.RanIDToModels(sONConfigurationTransferUL.TargetRANNodeID.GlobalRANNodeID)
 
-	if targetRanNodeID.GNbID.GNBValue != "" {
+	if targetRanNodeID.GNbID != nil && targetRanNodeID.GNbID.GNBValue != "" {
 		ran.Log.Debug("targetRanID", zap.String("targetRanID", targetRanNodeID.GNbID.GNBValue))
 	}
 

--- a/internal/api/server/api_radios.go
+++ b/internal/api/server/api_radios.go
@@ -101,9 +101,14 @@ func ListRadios() http.HandlerFunc {
 				radioAddress = radio.Conn.RemoteAddr().String()
 			}
 
+			radioID := ""
+			if radio.RanID.GNbID != nil {
+				radioID = radio.RanID.GNbID.GNBValue
+			}
+
 			newRadio := Radio{
 				Name:          radio.Name,
-				ID:            radio.RanID.GNbID.GNBValue,
+				ID:            radioID,
 				Address:       radioAddress,
 				SupportedTAIs: supportedTais,
 			}
@@ -143,9 +148,14 @@ func GetRadio() http.HandlerFunc {
 					radioAddress = radio.Conn.RemoteAddr().String()
 				}
 
+				radioID := ""
+				if radio.RanID.GNbID != nil {
+					radioID = radio.RanID.GNbID.GNBValue
+				}
+
 				result := Radio{
 					Name:          radio.Name,
-					ID:            radio.RanID.GNbID.GNBValue,
+					ID:            radioID,
 					Address:       radioAddress,
 					SupportedTAIs: supportedTais,
 				}


### PR DESCRIPTION
# Description

Avoid nil pointer error in the edge case where the gnb ID is nil.

Logs:

```
2026/01/28 14:49:46 http: panic serving 192.168.40.6:45932: runtime error: invalid memory address or nil pointer dereference
goroutine 1283 [running]:
net/http.(*conn).serve.func1()
	/snap/go/11045/src/net/http/server.go:1943 +0xb4
panic({0xf89760?, 0x1f817a0?})
	/snap/go/11045/src/runtime/panic.go:783 +0x120
github.com/ellanetworks/core/internal/api/server.NewHandler.ListRadios.func147({0x1782c40, 0x40000ccc40}, 0xffff97ad0108?)
	/home/raspberrypi/core/internal/api/server/api_radios.go:101 +0x1ec
net/http.HandlerFunc.ServeHTTP(0x400037cd80?, {0x1782c40?, 0x40000ccc40?}, 0x400025aa00?)
	/snap/go/11045/src/net/http/server.go:2322 +0x38
github.com/ellanetworks/core/internal/api/server.NewHandler.Authorize.func148({0x1782c40, 0x40000ccc40}, 0x400025aa00)
	/home/raspberrypi/core/internal/api/server/authorization_middleware.go:142 +0x128
net/http.HandlerFunc.ServeHTTP(0x400025a8c0?, {0x1782c40?, 0x40000ccc40?}, 0x400022e4f8?)
	/snap/go/11045/src/net/http/server.go:2322 +0x38
github.com/ellanetworks/core/internal/api/server.NewHandler.Authenticate.func149({0x1782c40, 0x40000ccc40}, 0x400025a8c0)
	/home/raspberrypi/core/internal/api/server/authentication_middleware.go:155 +0x164
net/http.HandlerFunc.ServeHTTP(0x114b9b3?, {0x1782c40?, 0x40000ccc40?}, 0xffff97810d28?)
	/snap/go/11045/src/net/http/server.go:2322 +0x38
net/http.HandlerFunc.ServeHTTP(0x4000222000?, {0x1782c40?, 0x40000ccc40?}, 0x0?)
	/snap/go/11045/src/net/http/server.go:2322 +0x38
net/http.(*ServeMux).ServeHTTP(0x40000b8c04?, {0x1782c40, 0x40000ccc40}, 0x400025a8c0)
	/snap/go/11045/src/net/http/server.go:2861 +0x190
github.com/ellanetworks/core/internal/api/server.NewHandler.MetricsMiddleware.func183({0x1782b80, 0x400021c690}, 0x400025a8c0)
	/home/raspberrypi/core/internal/api/server/metrics_middleware.go:49 +0xc4
net/http.HandlerFunc.ServeHTTP(0x400037c8a0?, {0x1782b80?, 0x400021c690?}, 0x47d9bc?)
	/snap/go/11045/src/net/http/server.go:2322 +0x38
golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP({{0x1779ae0?, 0x40003cb560?}, 0x400036e000?}, {0x1782b80, 0x400021c690}, 0x400025a8c0)
	/home/raspberrypi/go/pkg/mod/golang.org/x/net@v0.49.0/http2/h2c/h2c.go:125 +0x474
net/http.serverHandler.ServeHTTP({0x4000232740?}, {0x1782b80?, 0x400021c690?}, 0x6?)
	/snap/go/11045/src/net/http/server.go:3340 +0xb0
net/http.(*conn).serve(0x4000534b40, {0x1784f98, 0x40002ba750})
	/snap/go/11045/src/net/http/server.go:2109 +0x528
created by net/http.(*Server).Serve in goroutine 11
	/snap/go/11045/src/net/http/server.go:3493 +0x384

```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
