### PR TITLE
fix: nil pointer when remote addr is nil

### DIFF
--- a/internal/api/server/api_radios.go
+++ b/internal/api/server/api_radios.go
@@ -97,8 +97,11 @@ func ListRadios() http.HandlerFunc {
 			supportedTais := convertRadioTaiToReturnTai(radio.SupportedTAIs)
 
 			radioAddress := ""
+
 			if radio.Conn != nil {
-				radioAddress = radio.Conn.RemoteAddr().String()
+				if addr := radio.Conn.RemoteAddr(); addr != nil {
+					radioAddress = addr.String()
+				}
 			}
 
 			radioID := ""
@@ -144,8 +147,11 @@ func GetRadio() http.HandlerFunc {
 				supportedTais := convertRadioTaiToReturnTai(radio.SupportedTAIs)
 
 				radioAddress := ""
+
 				if radio.Conn != nil {
-					radioAddress = radio.Conn.RemoteAddr().String()
+					if addr := radio.Conn.RemoteAddr(); addr != nil {
+						radioAddress = addr.String()
+					}
 				}
 
 				radioID := ""


### PR DESCRIPTION
# Description

`radio.Conn.RemoteAddr()` can return nil even when `radio.Conn` itself is not nil. Here we make sure not to panic when that's the case.

Logs

```
Jan 29 08:28:30 raspberrypi main[58264]: 2026/01/29 08:28:30 http: panic serving 192.168.40.6:60532: runtime error: invalid memory address or nil pointer dereference
Jan 29 08:28:30 raspberrypi main[58264]: goroutine 244 [running]:
Jan 29 08:28:30 raspberrypi main[58264]: net/http.(*conn).serve.func1()
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:1943 +0xb4
Jan 29 08:28:30 raspberrypi main[58264]: panic({0xf88780?, 0x1f817a0?})
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/runtime/panic.go:783 +0x120
Jan 29 08:28:30 raspberrypi main[58264]: github.com/ellanetworks/core/internal/api/server.NewHandler.ListRadios.func147({0x1781c60, 0x4000314040}, 0xffffbcae0108?)
Jan 29 08:28:30 raspberrypi main[58264]:         /home/raspberrypi/core/internal/api/server/api_radios.go:101 +0x1ec
Jan 29 08:28:30 raspberrypi main[58264]: net/http.HandlerFunc.ServeHTTP(0x400020c3f0?, {0x1781c60?, 0x4000314040?}, 0x400021e280?)
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:2322 +0x38
Jan 29 08:28:30 raspberrypi main[58264]: github.com/ellanetworks/core/internal/api/server.NewHandler.Authorize.func148({0x1781c60, 0x4000314040}, 0x400021e280)
Jan 29 08:28:30 raspberrypi main[58264]:         /home/raspberrypi/core/internal/api/server/authorization_middleware.go:142 +0x128
Jan 29 08:28:30 raspberrypi main[58264]: net/http.HandlerFunc.ServeHTTP(0x400021e140?, {0x1781c60?, 0x4000314040?}, 0x400022e180?)
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:2322 +0x38
Jan 29 08:28:30 raspberrypi main[58264]: github.com/ellanetworks/core/internal/api/server.NewHandler.Authenticate.func149({0x1781c60, 0x4000314040}, 0x400021e140)
Jan 29 08:28:30 raspberrypi main[58264]:         /home/raspberrypi/core/internal/api/server/authentication_middleware.go:155 +0x164
Jan 29 08:28:30 raspberrypi main[58264]: net/http.HandlerFunc.ServeHTTP(0xffffbcae0108?, {0x1781c60?, 0x4000314040?}, 0xffff745f0dc8?)
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:2322 +0x38
Jan 29 08:28:30 raspberrypi main[58264]: net/http.HandlerFunc.ServeHTTP(0x4000132000?, {0x1781c60?, 0x4000314040?}, 0x0?)
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:2322 +0x38
Jan 29 08:28:30 raspberrypi main[58264]: net/http.(*ServeMux).ServeHTTP(0x40003ac7c4?, {0x1781c60, 0x4000314040}, 0x400021e140)
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:2861 +0x190
Jan 29 08:28:30 raspberrypi main[58264]: github.com/ellanetworks/core/internal/api/server.NewHandler.MetricsMiddleware.func183({0x1781ba0, 0x400027e000}, 0x400021e140)
Jan 29 08:28:30 raspberrypi main[58264]:         /home/raspberrypi/core/internal/api/server/metrics_middleware.go:49 +0xc4
Jan 29 08:28:30 raspberrypi main[58264]: net/http.HandlerFunc.ServeHTTP(0x400020c150?, {0x1781ba0?, 0x400027e000?}, 0x0?)
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:2322 +0x38
Jan 29 08:28:30 raspberrypi main[58264]: golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP({{0x1778b00?, 0x4000481530?}, 0x4000548000?}, {0x1781ba0, 0x400027e000}, 0x400021e140)
Jan 29 08:28:30 raspberrypi main[58264]:         /home/raspberrypi/go/pkg/mod/golang.org/x/net@v0.49.0/http2/h2c/h2c.go:125 +0x474
Jan 29 08:28:30 raspberrypi main[58264]: net/http.serverHandler.ServeHTTP({0x40003d2000?}, {0x1781ba0?, 0x400027e000?}, 0x6?)
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:3340 +0xb0
Jan 29 08:28:30 raspberrypi main[58264]: net/http.(*conn).serve(0x40001ae6c0, {0x1783fb8, 0x40001fc690})
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:2109 +0x528
Jan 29 08:28:30 raspberrypi main[58264]: created by net/http.(*Server).Serve in goroutine 27
Jan 29 08:28:30 raspberrypi main[58264]:         /snap/go/11045/src/net/http/server.go:3493 +0x384

```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
