### PR TITLE
fix: delete db entry even if kernel route cant be deleted

### DIFF
--- a/internal/api/server/api_routes.go
+++ b/internal/api/server/api_routes.go
@@ -360,8 +360,7 @@ func DeleteRoute(dbInstance *db.Database, kernelInt kernel.Kernel) http.Handler 
 		}
 
 		if err := kernelInt.DeleteRoute(ipNetwork, gateway, route.Metric, kernelInterface); err != nil {
-			writeError(w, http.StatusInternalServerError, "Failed to delete kernel route", err, logger.APILog)
-			return
+			logger.APILog.Warn("Failed to delete kernel route, proceeding with DB cleanup", zap.Error(err))
 		}
 
 		if err := tx.Commit(); err != nil {


### PR DESCRIPTION
# Description

If the kernel route is deleted outside of Ella Core and the user tried to delete it via the UI/API, they would get a 500 error. Here we delete the route from the DB even if there's an issue trying to delete the kernel route.

Fixes #1014 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
