### PR TITLE
docs: reduce logging level on srsRAN

### DIFF
--- a/docs/how_to/co_host_with_srsran.md
+++ b/docs/how_to/co_host_with_srsran.md
@@ -130,13 +130,11 @@ cell_cfg:
 
 log:
   filename: /tmp/gnb.log
-  all_level: info
+  all_level: warning
 
 pcap:
-  mac_enable: enable
-  mac_filename: /tmp/gnb_mac.pcap
-  ngap_enable: enable
-  ngap_filename: /tmp/gnb_ngap.pcap
+  mac_enable: disable
+  ngap_enable: disable
 ```
 
 Start srsRAN in the `n3ns` namespace:


### PR DESCRIPTION
# Description

srsRAN produces **a ton** of info-level logs consuming precious CPU time. Here we reduce the srsRAN logging level to `warning` to get a more stable deployment on a Raspberry Pi.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
