### PR TITLE
chore: dont log entire n1 sm message

### DIFF
--- a/internal/smf/pdusession/handle_update_sm_context_n1_msg.go
+++ b/internal/smf/pdusession/handle_update_sm_context_n1_msg.go
@@ -66,7 +66,7 @@ func handleUpdateN1Msg(ctx context.Context, n1Msg []byte, smContext *smfContext.
 		return nil, false, fmt.Errorf("error decoding N1SmMessage: %v", err)
 	}
 
-	logger.SmfLog.Debug("Update SM Context Request N1SmMessage", zap.Any("N1SmMessage", m), zap.String("supi", smContext.Supi), zap.Uint8("pduSessionID", smContext.PDUSessionID))
+	logger.SmfLog.Debug("Update SM Context Request N1SmMessage", zap.String("supi", smContext.Supi), zap.Uint8("pduSessionID", smContext.PDUSessionID))
 
 	switch m.GsmHeader.GetMessageType() {
 	case nas.MsgTypePDUSessionReleaseRequest:


### PR DESCRIPTION
# Description

There's no reason to log the entire N1 msg and using zap.Any unnecessary allocates memory. In my small deployment, this specific call takes 4.31% of memory allocations.

<img width="2843" height="1221" alt="image" src="https://github.com/user-attachments/assets/e422e4db-b94f-4e64-8ff7-b67daf09fe87" />


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
