### PR TITLE
fix: return early if too many data networks

### DIFF
--- a/internal/api/server/api_data_networks.go
+++ b/internal/api/server/api_data_networks.go
@@ -208,7 +208,8 @@ func CreateDataNetwork(dbInstance *db.Database) http.Handler {
 		}
 
 		if numDataNetworks >= MaxNumDataNetworks {
-			writeError(w, http.StatusBadRequest, "Maximum number of data networks reached ("+strconv.Itoa(MaxNumPolicies)+")", nil, logger.APILog)
+			writeError(w, http.StatusBadRequest, "Maximum number of data networks reached ("+strconv.Itoa(MaxNumDataNetworks)+")", nil, logger.APILog)
+			return
 		}
 
 		dbDataNetwork := &db.DataNetwork{


### PR DESCRIPTION
# Description

If someone tried to create a data network after the max had been reached, Ella Core would return an error but still create the Data network. Now we return early, as it is the case with the other resources.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
