### PR TITLE
chore(ui): handle copy public key error

### DIFF
--- a/ui/src/pages/Operator.tsx
+++ b/ui/src/pages/Operator.tsx
@@ -114,10 +114,20 @@ const Operator = () => {
     );
   };
 
-  const handleCopyPublicKey = () => {
-    if (operator?.homeNetwork.publicKey) {
-      navigator.clipboard.writeText(operator.homeNetwork.publicKey);
+  const handleCopyPublicKey = async () => {
+    if (!operator?.homeNetwork.publicKey) return;
+    if (!navigator.clipboard) {
+      showSnackbar(
+        "Clipboard API not available. Please use HTTPS or try a different browser.",
+        "error",
+      );
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(operator.homeNetwork.publicKey);
       showSnackbar("Copied to clipboard.", "success");
+    } catch {
+      showSnackbar("Failed to copy public key.", "error");
     }
   };
 


### PR DESCRIPTION
# Description

When copying the home network public key to clipboard is not available (when not using `https`), Ella Core now displays a snackbar alert, just like it does for subscriber provisioning details.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
