### PR TITLE
chore: dont try adding 0.0.0.0 to neighbors

### DIFF
--- a/internal/upf/ebpf/pdr.go
+++ b/internal/upf/ebpf/pdr.go
@@ -186,6 +186,10 @@ func ToN3N6EntrypointPdrInfo(defaultPdr PdrInfo) N3N6EntrypointPdrInfo {
 }
 
 func addRemoteIPToNeigh(ctx context.Context, remoteIP uint32) {
+	if remoteIP == 0 {
+		return
+	}
+
 	ip_bytes := make([]byte, 4)
 	binary.NativeEndian.PutUint32(ip_bytes, remoteIP)
 	ip := net.IP(ip_bytes)


### PR DESCRIPTION
# Description

On session establishment, the downlink FAR is created with Action = Drop and the remote IP is 0. Ella Core would try to add this `0.0.0.0` address to its neighbor list which wouldn't succeed. This is not a huge issue and would result in a warning log, but this syscall could be avoided. Here we return early when the neighbor is `0.0.0.0`.

```
2026-03-05 14:09:56.866WARN{"level":"warn","ts":"2026-03-05T14:09:56.864-0500","caller":"ebpf/pdr.go:194","msg":"could not add gnb IP to neighbour list","component":"UPF","IP":"0.0.0.0","error":"could not add neighbour"}
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
