### PR TITLE
fix: backup on systems without /tmp dir

### DIFF
--- a/internal/api/server/api_backup.go
+++ b/internal/api/server/api_backup.go
@@ -21,7 +21,7 @@ func Backup(dbInstance *db.Database) http.HandlerFunc {
 			return
 		}
 
-		tempFile, err := os.CreateTemp("", "backup_*.db")
+		tempFile, err := os.CreateTemp(dbInstance.Dir(), "backup_*.db")
 		if err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create temp backup file", err, logger.APILog)
 			return

--- a/internal/api/server/api_restore.go
+++ b/internal/api/server/api_restore.go
@@ -42,7 +42,7 @@ func Restore(dbInstance *db.Database) http.HandlerFunc {
 			}
 		}()
 
-		tempFile, err := os.CreateTemp("", "restore_*.db")
+		tempFile, err := os.CreateTemp(dbInstance.Dir(), "restore_*.db")
 		if err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create temporary file", err, logger.APILog)
 			return

--- a/internal/db/restore.go
+++ b/internal/db/restore.go
@@ -41,10 +41,15 @@ func validateSQLiteFile(ctx context.Context, path string) error {
 	return nil
 }
 
+// Dir returns the parent directory of the database file.
+func (db *Database) Dir() string {
+	return filepath.Dir(db.filepath)
+}
+
 // dbDirRoot opens the database's parent directory as an os.Root, scoping
 // all file access to that directory and preventing path traversal.
 func (db *Database) dbDirRoot() (*os.Root, error) {
-	return os.OpenRoot(filepath.Dir(db.filepath))
+	return os.OpenRoot(db.Dir())
 }
 
 // rollbackFromSafetyCopy restores the original database from the safety copy


### PR DESCRIPTION
# Description

Backup did not work on systems that did not have a `/tmp` directory like the distroless container image we publish. Since Ella Core already relies on a directory for the db, here we use the same directory for storing temp files. This is cleaner and more robust than assuming there's a `/tmp` directory.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
