### PR TITLE
feat: Include AmfUe state in support bundle

### DIFF
--- a/internal/amf/context/export.go
+++ b/internal/amf/context/export.go
@@ -1,0 +1,385 @@
+// Copyright 2026 Ella Networks
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"context"
+	"time"
+
+	"github.com/ellanetworks/core/internal/models"
+	smfcontext "github.com/ellanetworks/core/internal/smf/context"
+)
+
+// AmfUeExport is the JSON-serializable export of a single UE's AMF state.
+type AmfUeExport struct {
+	Identity      UEIdentityExport            `json:"identity"`
+	State         UEStateExport               `json:"state"`
+	Security      UESecurityExport            `json:"security"`
+	Location      UELocationExport            `json:"location"`
+	Subscription  UESubscriptionExport        `json:"subscription"`
+	PDUSessions   map[string]PDUSessionExport `json:"pdu_sessions"`
+	Registration  UERegistrationExport        `json:"registration"`
+	Timers        UETimersExport              `json:"timers"`
+	LastActivity  UELastActivityExport        `json:"last_activity"`
+	RANConnection *RANConnectionExport        `json:"ran_connection,omitempty"`
+}
+
+// UEIdentityExport contains the identifiers for a UE.
+type UEIdentityExport struct {
+	Supi    string        `json:"supi"`
+	Pei     string        `json:"pei,omitempty"`
+	PlmnID  models.PlmnID `json:"plmn_id"`
+	Guti    string        `json:"guti,omitempty"`
+	OldGuti string        `json:"old_guti,omitempty"`
+	Tmsi    string        `json:"tmsi,omitempty"`
+	OldTmsi string        `json:"old_tmsi,omitempty"`
+	Suci    string        `json:"suci,omitempty"`
+}
+
+// UEStateExport contains the current GMM and procedure state of a UE.
+type UEStateExport struct {
+	GMMState                 string `json:"gmm_state"`
+	OngoingProcedure         string `json:"ongoing_procedure"`
+	SecurityContextAvailable bool   `json:"security_context_available"`
+	MacFailed                bool   `json:"mac_failed"`
+}
+
+// UESecurityExport contains non-sensitive security context info for a UE.
+type UESecurityExport struct {
+	CipheringAlgorithm string       `json:"ciphering_algorithm,omitempty"`
+	IntegrityAlgorithm string       `json:"integrity_algorithm,omitempty"`
+	NgKsi              models.NgKsi `json:"ng_ksi"`
+}
+
+// UELocationExport contains location information for a UE.
+type UELocationExport struct {
+	Current          models.UserLocation `json:"current"`
+	Tai              models.Tai          `json:"tai"`
+	Timezone         string              `json:"timezone,omitempty"`
+	RegistrationArea []models.Tai        `json:"registration_area"`
+}
+
+// UESubscriptionExport contains subscription data for a UE.
+type UESubscriptionExport struct {
+	AllowedNssai *models.Snssai `json:"allowed_nssai,omitempty"`
+	Ambr         *models.Ambr   `json:"ambr,omitempty"`
+}
+
+// PDUSessionExport contains the export of a single PDU session.
+type PDUSessionExport struct {
+	Ref                            string               `json:"ref"`
+	Snssai                         *models.Snssai       `json:"snssai,omitempty"`
+	Inactive                       bool                 `json:"inactive"`
+	DNN                            string               `json:"dnn,omitempty"`
+	PDUSessionReleaseDueToDupPduID bool                 `json:"release_due_to_dup_id,omitempty"`
+	PolicyData                     *models.SmPolicyData `json:"policy_data,omitempty"`
+	Tunnel                         *TunnelExport        `json:"tunnel,omitempty"`
+	PFCPLocalSEID                  *uint64              `json:"pfcp_local_seid,omitempty"`
+}
+
+// TunnelExport contains the AN tunnel endpoint information for a PDU session.
+type TunnelExport struct {
+	ANIPAddress string `json:"an_ip_address,omitempty"`
+	ANTEID      uint32 `json:"an_teid,omitempty"`
+}
+
+// UERegistrationExport contains registration procedure information for a UE.
+type UERegistrationExport struct {
+	Type                 uint8 `json:"type"`
+	IdentityTypeUsed     uint8 `json:"identity_type_used"`
+	Retransmission       bool  `json:"retransmission"`
+	AuthFailureSyncTimes int   `json:"auth_failure_sync_times"`
+}
+
+// TimerStatusExport contains the status of a single 3GPP timer.
+type TimerStatusExport struct {
+	Active      bool  `json:"active"`
+	ExpireCount int32 `json:"expire_count,omitempty"`
+	MaxRetries  int32 `json:"max_retries,omitempty"`
+}
+
+// UETimersExport contains the status of all 3GPP timers for a UE.
+type UETimersExport struct {
+	T3512ValueSeconds   int64             `json:"t3512_value_seconds"`
+	T3502ValueSeconds   int64             `json:"t3502_value_seconds"`
+	T3513Paging         TimerStatusExport `json:"t3513_paging"`
+	T3565Notification   TimerStatusExport `json:"t3565_notification"`
+	T3560Auth           TimerStatusExport `json:"t3560_auth"`
+	T3550Registration   TimerStatusExport `json:"t3550_registration"`
+	T3555ConfigUpdate   TimerStatusExport `json:"t3555_config_update"`
+	T3522Deregistration TimerStatusExport `json:"t3522_deregistration"`
+	MobileReachable     TimerStatusExport `json:"mobile_reachable"`
+	ImplicitDereg       TimerStatusExport `json:"implicit_deregistration"`
+}
+
+// UELastActivityExport contains the last-seen activity info for a UE.
+type UELastActivityExport struct {
+	Timestamp time.Time `json:"timestamp"`
+	RadioNode string    `json:"radio_node,omitempty"`
+}
+
+// RANConnectionExport contains a lightweight summary of the RAN UE connection.
+type RANConnectionExport struct {
+	RanUeNgapID int64      `json:"ran_ue_ngap_id"`
+	AmfUeNgapID int64      `json:"amf_ue_ngap_id"`
+	RanTai      models.Tai `json:"ran_tai"`
+	RadioName   string     `json:"radio_name,omitempty"`
+}
+
+// copyPtr returns a shallow copy of the value pointed to by src, or nil if src is nil.
+func copyPtr[T any](src *T) *T {
+	if src == nil {
+		return nil
+	}
+
+	cp := *src
+
+	return &cp
+}
+
+// copyUserLocation returns a copy of a UserLocation with each pointer field
+// independently owned, preventing aliasing with the source struct.
+func copyUserLocation(loc models.UserLocation) models.UserLocation {
+	out := loc
+
+	out.NrLocation = copyPtr(loc.NrLocation)
+	if out.NrLocation != nil {
+		out.NrLocation.Tai = copyPtr(loc.NrLocation.Tai)
+		if out.NrLocation.Tai != nil {
+			out.NrLocation.Tai.PlmnID = copyPtr(loc.NrLocation.Tai.PlmnID)
+		}
+
+		out.NrLocation.Ncgi = copyPtr(loc.NrLocation.Ncgi)
+		if out.NrLocation.Ncgi != nil {
+			out.NrLocation.Ncgi.PlmnID = copyPtr(loc.NrLocation.Ncgi.PlmnID)
+		}
+
+		out.NrLocation.UeLocationTimestamp = copyPtr(loc.NrLocation.UeLocationTimestamp)
+	}
+
+	out.EutraLocation = copyPtr(loc.EutraLocation)
+	if out.EutraLocation != nil {
+		out.EutraLocation.Tai = copyPtr(loc.EutraLocation.Tai)
+		if out.EutraLocation.Tai != nil {
+			out.EutraLocation.Tai.PlmnID = copyPtr(loc.EutraLocation.Tai.PlmnID)
+		}
+
+		out.EutraLocation.Ecgi = copyPtr(loc.EutraLocation.Ecgi)
+		if out.EutraLocation.Ecgi != nil {
+			out.EutraLocation.Ecgi.PlmnID = copyPtr(loc.EutraLocation.Ecgi.PlmnID)
+		}
+
+		out.EutraLocation.UeLocationTimestamp = copyPtr(loc.EutraLocation.UeLocationTimestamp)
+	}
+
+	out.N3gaLocation = copyPtr(loc.N3gaLocation)
+	if out.N3gaLocation != nil {
+		out.N3gaLocation.N3gppTai = copyPtr(loc.N3gaLocation.N3gppTai)
+		if out.N3gaLocation.N3gppTai != nil {
+			out.N3gaLocation.N3gppTai.PlmnID = copyPtr(loc.N3gaLocation.N3gppTai.PlmnID)
+		}
+	}
+
+	return out
+}
+
+// copySmPolicyData returns a copy of a SmPolicyData pointer, or nil if src is nil.
+func copySmPolicyData(src *models.SmPolicyData) *models.SmPolicyData {
+	if src == nil {
+		return nil
+	}
+
+	cp := *src
+	cp.Ambr = copyPtr(src.Ambr)
+
+	cp.QosData = copyPtr(src.QosData)
+	if cp.QosData != nil {
+		cp.QosData.Arp = copyPtr(src.QosData.Arp)
+	}
+
+	return &cp
+}
+
+// timerStatus returns a TimerStatusExport for the given timer. Safe to call with nil.
+func timerStatus(t *Timer) TimerStatusExport {
+	if t == nil {
+		return TimerStatusExport{Active: false}
+	}
+
+	return TimerStatusExport{
+		Active:      t.IsActive(),
+		ExpireCount: t.ExpireTimes(),
+		MaxRetries:  t.MaxRetryTimes(),
+	}
+}
+
+// ExportUEs returns a snapshot of all current UEs in the AMF context.
+// It acquires the AMF lock to get the list of UEs, then acquires
+// locks per-UE and calls into the SMF singleton for PDU session
+// details. Safe to call concurrently with normal AMF operation.
+func ExportUEs(_ context.Context) ([]AmfUeExport, error) {
+	amf := AMFSelf()
+	amf.Mutex.Lock()
+
+	ues := make([]*AmfUe, 0, len(amf.UEs))
+	for _, ue := range amf.UEs {
+		ues = append(ues, ue)
+	}
+
+	amf.Mutex.Unlock()
+
+	exports := make([]AmfUeExport, 0, len(ues))
+	for _, ue := range ues {
+		exports = append(exports, exportAmfUe(ue))
+	}
+
+	return exports, nil
+}
+
+// smContextCopy is a local copy of AMF SmContext fields used to avoid holding the UE lock while querying SMF.
+type smContextCopy struct {
+	ref      string
+	snssai   *models.Snssai
+	inactive bool
+}
+
+// exportAmfUe builds an AmfUeExport for a single UE.
+// It acquires ue.Mutex to copy scalar fields, then queries SMF outside the lock.
+func exportAmfUe(ue *AmfUe) AmfUeExport {
+	ue.Mutex.Lock()
+
+	// Copy all scalar fields while holding the lock.
+	export := AmfUeExport{
+		Identity: UEIdentityExport{
+			Supi:    ue.Supi.String(),
+			Pei:     ue.Pei,
+			PlmnID:  ue.PlmnID,
+			Guti:    ue.Guti.String(),
+			OldGuti: ue.OldGuti.String(),
+			Tmsi:    ue.Tmsi.String(),
+			OldTmsi: ue.OldTmsi.String(),
+			Suci:    ue.Suci,
+		},
+		State: UEStateExport{
+			GMMState:                 string(ue.State),
+			OngoingProcedure:         string(ue.OnGoing),
+			SecurityContextAvailable: ue.SecurityContextAvailable,
+			MacFailed:                ue.MacFailed,
+		},
+		Security: UESecurityExport{
+			CipheringAlgorithm: ue.cipheringAlgName(),
+			IntegrityAlgorithm: ue.integrityAlgName(),
+			NgKsi:              ue.NgKsi,
+		},
+		Location: UELocationExport{
+			Current:          copyUserLocation(ue.Location),
+			Tai:              ue.Tai,
+			Timezone:         ue.TimeZone,
+			RegistrationArea: append([]models.Tai(nil), ue.RegistrationArea...),
+		},
+		Subscription: UESubscriptionExport{
+			AllowedNssai: copyPtr(ue.AllowedNssai),
+			Ambr:         copyPtr(ue.Ambr),
+		},
+		Registration: UERegistrationExport{
+			Type:                 ue.RegistrationType5GS,
+			IdentityTypeUsed:     ue.IdentityTypeUsedForRegistration,
+			Retransmission:       ue.RetransmissionOfInitialNASMsg,
+			AuthFailureSyncTimes: ue.AuthFailureCauseSynchFailureTimes,
+		},
+		Timers: UETimersExport{
+			T3512ValueSeconds:   int64(ue.T3512Value / time.Second),
+			T3502ValueSeconds:   int64(ue.T3502Value / time.Second),
+			T3513Paging:         timerStatus(ue.T3513),
+			T3565Notification:   timerStatus(ue.T3565),
+			T3560Auth:           timerStatus(ue.T3560),
+			T3550Registration:   timerStatus(ue.T3550),
+			T3555ConfigUpdate:   timerStatus(ue.T3555),
+			T3522Deregistration: timerStatus(ue.T3522),
+			MobileReachable:     timerStatus(ue.mobileReachableTimer),
+			ImplicitDereg:       timerStatus(ue.implicitDeregistrationTimer),
+		},
+		LastActivity: UELastActivityExport{
+			Timestamp: ue.LastSeenAt,
+			RadioNode: ue.LastSeenRadio,
+		},
+	}
+
+	// Copy SmContextList refs while holding the UE lock.
+	smCopies := make([]smContextCopy, 0, len(ue.SmContextList))
+	for _, sc := range ue.SmContextList {
+		smCopies = append(smCopies, smContextCopy{
+			ref:      sc.Ref,
+			snssai:   copyPtr(sc.Snssai),
+			inactive: sc.PduSessionInactive,
+		})
+	}
+
+	// Capture RAN UE info while holding the UE lock.
+	if ue.RanUe != nil {
+		rc := &RANConnectionExport{
+			RanUeNgapID: ue.RanUe.RanUeNgapID,
+			AmfUeNgapID: ue.RanUe.AmfUeNgapID,
+			RanTai:      ue.RanUe.Tai,
+		}
+		if ue.RanUe.Radio != nil {
+			rc.RadioName = ue.RanUe.Radio.Name
+		}
+
+		export.RANConnection = rc
+	}
+
+	ue.Mutex.Unlock()
+
+	// Build PDU sessions OUTSIDE the UE lock to avoid holding two locks simultaneously.
+	export.PDUSessions = buildPDUSessions(smCopies)
+
+	return export
+}
+
+// buildPDUSessions enriches AMF SmContext copies with SMF context data.
+func buildPDUSessions(copies []smContextCopy) map[string]PDUSessionExport {
+	result := make(map[string]PDUSessionExport, len(copies))
+	smf := smfcontext.SMFSelf()
+
+	for _, sc := range copies {
+		pdu := PDUSessionExport{
+			Ref:      sc.ref,
+			Snssai:   sc.snssai,
+			Inactive: sc.inactive,
+		}
+
+		smCtx := smf.GetSMContext(sc.ref)
+		if smCtx != nil {
+			smCtx.Mutex.Lock()
+			pdu.DNN = smCtx.Dnn
+			pdu.PDUSessionReleaseDueToDupPduID = smCtx.PDUSessionReleaseDueToDupPduID
+
+			pdu.PolicyData = copySmPolicyData(smCtx.PolicyData)
+			if smCtx.Tunnel != nil {
+				ipStr := ""
+				if smCtx.Tunnel.ANInformation.IPAddress != nil {
+					ipStr = smCtx.Tunnel.ANInformation.IPAddress.String()
+				}
+
+				pdu.Tunnel = &TunnelExport{
+					ANIPAddress: ipStr,
+					ANTEID:      smCtx.Tunnel.ANInformation.TEID,
+				}
+			}
+
+			if smCtx.PFCPContext != nil {
+				seid := smCtx.PFCPContext.LocalSEID
+				pdu.PFCPLocalSEID = &seid
+			}
+
+			smCtx.Mutex.Unlock()
+		}
+
+		result[sc.ref] = pdu
+	}
+
+	return result
+}

--- a/internal/amf/context/export_test.go
+++ b/internal/amf/context/export_test.go
@@ -1,0 +1,577 @@
+// Copyright 2026 Ella Networks
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/etsi"
+	amfcontext "github.com/ellanetworks/core/internal/amf/context"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/free5gc/nas/security"
+	"go.uber.org/zap"
+)
+
+func addTestUE(t *testing.T, imsi string, setup func(*amfcontext.AmfUe)) *amfcontext.AmfUe {
+	t.Helper()
+
+	supi, err := etsi.NewSUPIFromIMSI(imsi)
+	if err != nil {
+		t.Fatalf("invalid IMSI %q: %v", imsi, err)
+	}
+
+	ue := amfcontext.NewAmfUe()
+	ue.Supi = supi
+	ue.Log = zap.NewNop()
+
+	setup(ue)
+
+	if err := amfcontext.AMFSelf().AddAmfUeToUePool(ue); err != nil {
+		t.Fatalf("AddAmfUeToUePool: %v", err)
+	}
+
+	t.Cleanup(func() {
+		amf := amfcontext.AMFSelf()
+		amf.Mutex.Lock()
+		delete(amf.UEs, supi)
+		amf.Mutex.Unlock()
+	})
+
+	return ue
+}
+
+func exportAndMarshal(t *testing.T) []map[string]any {
+	t.Helper()
+
+	exports, err := amfcontext.ExportUEs(context.Background())
+	if err != nil {
+		t.Fatalf("ExportUEs: %v", err)
+	}
+
+	b, err := json.Marshal(exports)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	return result
+}
+
+func jsonMap(t *testing.T, m map[string]any, key string) map[string]any {
+	t.Helper()
+
+	v, ok := m[key]
+	if !ok {
+		t.Fatalf("missing key %q in JSON", key)
+	}
+
+	sub, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("key %q is not a JSON object, got %T", key, v)
+	}
+
+	return sub
+}
+
+func TestExportUEsEmpty(t *testing.T) {
+	exports, err := amfcontext.ExportUEs(context.Background())
+	if err != nil {
+		t.Fatalf("ExportUEs returned unexpected error: %v", err)
+	}
+
+	if exports == nil {
+		t.Fatal("expected non-nil slice, got nil")
+	}
+}
+
+func TestExportJSON_MinimalUE(t *testing.T) {
+	addTestUE(t, "001010000000001", func(ue *amfcontext.AmfUe) {})
+
+	result := exportAndMarshal(t)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 UE in result, got %d", len(result))
+	}
+
+	ueExport := result[0]
+
+	identity := jsonMap(t, ueExport, "identity")
+	if supi, ok := identity["supi"].(string); !ok || supi != "imsi-001010000000001" {
+		t.Fatalf("expected identity.supi to be 'imsi-001010000000001', got %v", identity["supi"])
+	}
+
+	state := jsonMap(t, ueExport, "state")
+	if gmmState, ok := state["gmm_state"].(string); !ok || gmmState != "Deregistered" {
+		t.Fatalf("expected state.gmm_state to be 'Deregistered', got %v", state["gmm_state"])
+	}
+
+	if ongoingProc, ok := state["ongoing_procedure"].(string); !ok || ongoingProc != "Nothing" {
+		t.Fatalf("expected state.ongoing_procedure to be 'Nothing', got %v", state["ongoing_procedure"])
+	}
+
+	if secCtx, ok := state["security_context_available"].(bool); !ok || secCtx != false {
+		t.Fatalf("expected state.security_context_available to be false, got %v", state["security_context_available"])
+	}
+
+	if macFailed, ok := state["mac_failed"].(bool); !ok || macFailed != false {
+		t.Fatalf("expected state.mac_failed to be false, got %v", state["mac_failed"])
+	}
+
+	if _, ok := ueExport["ran_connection"]; ok {
+		t.Fatal("expected ran_connection to be absent")
+	}
+
+	subscription := jsonMap(t, ueExport, "subscription")
+	if _, ok := subscription["allowed_nssai"]; ok {
+		t.Fatal("expected subscription.allowed_nssai to be absent")
+	}
+
+	if _, ok := subscription["ambr"]; ok {
+		t.Fatal("expected subscription.ambr to be absent")
+	}
+
+	security := jsonMap(t, ueExport, "security")
+	if cipherAlg, ok := security["ciphering_algorithm"].(string); !ok || cipherAlg != "NEA0" {
+		t.Fatalf("expected security.ciphering_algorithm to be 'NEA0', got %v", security["ciphering_algorithm"])
+	}
+
+	if integrityAlg, ok := security["integrity_algorithm"].(string); !ok || integrityAlg != "NIA0" {
+		t.Fatalf("expected security.integrity_algorithm to be 'NIA0', got %v", security["integrity_algorithm"])
+	}
+
+	if _, ok := identity["pei"]; ok {
+		t.Fatal("expected identity.pei to be absent")
+	}
+
+	location := jsonMap(t, ueExport, "location")
+	if _, ok := location["timezone"]; ok {
+		t.Fatal("expected location.timezone to be absent")
+	}
+
+	lastActivity := jsonMap(t, ueExport, "last_activity")
+	if _, ok := lastActivity["radio_node"]; ok {
+		t.Fatal("expected last_activity.radio_node to be absent")
+	}
+
+	pduSessions, ok := ueExport["pdu_sessions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pdu_sessions to be a map, got %T", ueExport["pdu_sessions"])
+	}
+
+	if len(pduSessions) != 0 {
+		t.Fatalf("expected pdu_sessions to be empty, got %d entries", len(pduSessions))
+	}
+
+	timers := jsonMap(t, ueExport, "timers")
+	if t3512, ok := timers["t3512_value_seconds"].(float64); !ok || t3512 != 0 {
+		t.Fatalf("expected timers.t3512_value_seconds to be 0, got %v", timers["t3512_value_seconds"])
+	}
+
+	if t3502, ok := timers["t3502_value_seconds"].(float64); !ok || t3502 != 0 {
+		t.Fatalf("expected timers.t3502_value_seconds to be 0, got %v", timers["t3502_value_seconds"])
+	}
+
+	timerNames := []string{"t3513_paging", "t3565_notification", "t3560_auth", "t3550_registration", "t3555_config_update", "t3522_deregistration", "mobile_reachable", "implicit_deregistration"}
+	for _, timerName := range timerNames {
+		timerObj := jsonMap(t, timers, timerName)
+		if active, ok := timerObj["active"].(bool); !ok || active != false {
+			t.Fatalf("expected timers.%s.active to be false, got %v", timerName, timerObj["active"])
+		}
+	}
+}
+
+func TestExportJSON_FullyPopulatedUE(t *testing.T) {
+	now := time.Now()
+	ue := addTestUE(t, "001010000000002", func(ue *amfcontext.AmfUe) {
+		ue.Pei = "imei-123456789012345"
+		ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
+		ue.Suci = "suci-0-001-01-0000-0-0-0000000001"
+		ue.State = amfcontext.Registered
+		ue.OnGoing = amfcontext.OnGoingProcedureNothing
+		ue.SecurityContextAvailable = true
+		ue.CipheringAlg = security.AlgCiphering128NEA2
+		ue.IntegrityAlg = security.AlgIntegrity128NIA2
+		ue.NgKsi = models.NgKsi{Ksi: 1}
+		ue.Location = models.UserLocation{
+			NrLocation: &models.NrLocation{
+				Tai:                      &models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
+				Ncgi:                     &models.Ncgi{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, NrCellID: "000000001"},
+				AgeOfLocationInformation: 5,
+				UeLocationTimestamp:      &now,
+			},
+		}
+		ue.Tai = models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}
+		ue.TimeZone = "+09:00"
+		ue.RegistrationArea = []models.Tai{
+			{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
+			{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000002"},
+		}
+		ue.AllowedNssai = &models.Snssai{Sst: 1, Sd: "000001"}
+		ue.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "2000000"}
+		ue.SmContextList[5] = &amfcontext.SmContext{
+			Ref:    "imsi-001010000000002-5",
+			Snssai: &models.Snssai{Sst: 1, Sd: "000001"},
+		}
+		radio := &amfcontext.Radio{Name: "gNB-001", RanUEs: make(map[int64]*amfcontext.RanUe), Log: zap.NewNop()}
+		ue.RanUe = &amfcontext.RanUe{
+			RanUeNgapID: 42,
+			AmfUeNgapID: 100,
+			Tai:         models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
+			Radio:       radio,
+			Log:         zap.NewNop(),
+		}
+		ue.T3513 = amfcontext.NewTimer(1*time.Hour, 3, func(_ int32) {}, func() {})
+		ue.T3512Value = 3600 * time.Second
+		ue.T3502Value = 720 * time.Second
+		ue.LastSeenAt = time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+		ue.LastSeenRadio = "gNB-001"
+		ue.RegistrationType5GS = 1
+		ue.IdentityTypeUsedForRegistration = 1
+		ue.RetransmissionOfInitialNASMsg = true
+		ue.AuthFailureCauseSynchFailureTimes = 2
+	})
+
+	t.Cleanup(func() {
+		ue.T3513.Stop()
+	})
+
+	result := exportAndMarshal(t)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 UE in result, got %d", len(result))
+	}
+
+	ueExport := result[0]
+
+	identity := jsonMap(t, ueExport, "identity")
+	if supi, ok := identity["supi"].(string); !ok || supi != "imsi-001010000000002" {
+		t.Fatalf("expected identity.supi to be 'imsi-001010000000002', got %v", identity["supi"])
+	}
+
+	if pei, ok := identity["pei"].(string); !ok || pei != "imei-123456789012345" {
+		t.Fatalf("expected identity.pei to be 'imei-123456789012345', got %v", identity["pei"])
+	}
+
+	if suci, ok := identity["suci"].(string); !ok || suci != "suci-0-001-01-0000-0-0-0000000001" {
+		t.Fatalf("expected identity.suci to be 'suci-0-001-01-0000-0-0-0000000001', got %v", identity["suci"])
+	}
+
+	plmnID := jsonMap(t, identity, "plmn_id")
+	if mcc, ok := plmnID["Mcc"].(string); !ok || mcc != "001" {
+		t.Fatalf("expected identity.plmn_id.Mcc to be '001', got %v", plmnID["Mcc"])
+	}
+
+	if mnc, ok := plmnID["Mnc"].(string); !ok || mnc != "01" {
+		t.Fatalf("expected identity.plmn_id.Mnc to be '01', got %v", plmnID["Mnc"])
+	}
+
+	state := jsonMap(t, ueExport, "state")
+	if gmmState, ok := state["gmm_state"].(string); !ok || gmmState != "Registered" {
+		t.Fatalf("expected state.gmm_state to be 'Registered', got %v", state["gmm_state"])
+	}
+
+	if secCtx, ok := state["security_context_available"].(bool); !ok || secCtx != true {
+		t.Fatalf("expected state.security_context_available to be true, got %v", state["security_context_available"])
+	}
+
+	if macFailed, ok := state["mac_failed"].(bool); !ok || macFailed != false {
+		t.Fatalf("expected state.mac_failed to be false, got %v", state["mac_failed"])
+	}
+
+	if ongoingProc, ok := state["ongoing_procedure"].(string); !ok || ongoingProc != "Nothing" {
+		t.Fatalf("expected state.ongoing_procedure to be 'Nothing', got %v", state["ongoing_procedure"])
+	}
+
+	security := jsonMap(t, ueExport, "security")
+	if cipherAlg, ok := security["ciphering_algorithm"].(string); !ok || cipherAlg != "NEA2" {
+		t.Fatalf("expected security.ciphering_algorithm to be 'NEA2', got %v", security["ciphering_algorithm"])
+	}
+
+	if integrityAlg, ok := security["integrity_algorithm"].(string); !ok || integrityAlg != "NIA2" {
+		t.Fatalf("expected security.integrity_algorithm to be 'NIA2', got %v", security["integrity_algorithm"])
+	}
+
+	ngKsi := jsonMap(t, security, "ng_ksi")
+	if ksi, ok := ngKsi["Ksi"].(float64); !ok || ksi != 1 {
+		t.Fatalf("expected security.ng_ksi.Ksi to be 1, got %v", ngKsi["Ksi"])
+	}
+
+	location := jsonMap(t, ueExport, "location")
+	if timezone, ok := location["timezone"].(string); !ok || timezone != "+09:00" {
+		t.Fatalf("expected location.timezone to be '+09:00', got %v", location["timezone"])
+	}
+
+	registrationArea, ok := location["registration_area"].([]any)
+	if !ok {
+		t.Fatalf("expected location.registration_area to be a slice, got %T", location["registration_area"])
+	}
+
+	if len(registrationArea) != 2 {
+		t.Fatalf("expected location.registration_area to have 2 entries, got %d", len(registrationArea))
+	}
+
+	currentLoc := jsonMap(t, location, "current")
+	if _, ok := currentLoc["NrLocation"]; !ok {
+		t.Fatal("expected location.current.NrLocation to be present")
+	}
+
+	subscription := jsonMap(t, ueExport, "subscription")
+
+	allowedNssai := jsonMap(t, subscription, "allowed_nssai")
+	if sst, ok := allowedNssai["Sst"].(float64); !ok || sst != 1 {
+		t.Fatalf("expected subscription.allowed_nssai.Sst to be 1, got %v", allowedNssai["Sst"])
+	}
+
+	if sd, ok := allowedNssai["Sd"].(string); !ok || sd != "000001" {
+		t.Fatalf("expected subscription.allowed_nssai.Sd to be '000001', got %v", allowedNssai["Sd"])
+	}
+
+	ambr := jsonMap(t, subscription, "ambr")
+	if uplink, ok := ambr["Uplink"].(string); !ok || uplink != "1000000" {
+		t.Fatalf("expected subscription.ambr.Uplink to be '1000000', got %v", ambr["Uplink"])
+	}
+
+	if downlink, ok := ambr["Downlink"].(string); !ok || downlink != "2000000" {
+		t.Fatalf("expected subscription.ambr.Downlink to be '2000000', got %v", ambr["Downlink"])
+	}
+
+	ranConn := jsonMap(t, ueExport, "ran_connection")
+	if ranUeNgapID, ok := ranConn["ran_ue_ngap_id"].(float64); !ok || ranUeNgapID != 42 {
+		t.Fatalf("expected ran_connection.ran_ue_ngap_id to be 42, got %v", ranConn["ran_ue_ngap_id"])
+	}
+
+	if amfUeNgapID, ok := ranConn["amf_ue_ngap_id"].(float64); !ok || amfUeNgapID != 100 {
+		t.Fatalf("expected ran_connection.amf_ue_ngap_id to be 100, got %v", ranConn["amf_ue_ngap_id"])
+	}
+
+	if radioName, ok := ranConn["radio_name"].(string); !ok || radioName != "gNB-001" {
+		t.Fatalf("expected ran_connection.radio_name to be 'gNB-001', got %v", ranConn["radio_name"])
+	}
+
+	timers := jsonMap(t, ueExport, "timers")
+	if t3512, ok := timers["t3512_value_seconds"].(float64); !ok || t3512 != 3600 {
+		t.Fatalf("expected timers.t3512_value_seconds to be 3600, got %v", timers["t3512_value_seconds"])
+	}
+
+	if t3502, ok := timers["t3502_value_seconds"].(float64); !ok || t3502 != 720 {
+		t.Fatalf("expected timers.t3502_value_seconds to be 720, got %v", timers["t3502_value_seconds"])
+	}
+
+	t3513 := jsonMap(t, timers, "t3513_paging")
+	if active, ok := t3513["active"].(bool); !ok || active != true {
+		t.Fatalf("expected timers.t3513_paging.active to be true, got %v", t3513["active"])
+	}
+
+	if maxRetries, ok := t3513["max_retries"].(float64); !ok || maxRetries != 3 {
+		t.Fatalf("expected timers.t3513_paging.max_retries to be 3, got %v", t3513["max_retries"])
+	}
+
+	pduSessions, ok := ueExport["pdu_sessions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pdu_sessions to be a map, got %T", ueExport["pdu_sessions"])
+	}
+
+	pduSession, ok := pduSessions["imsi-001010000000002-5"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pdu_sessions['imsi-001010000000002-5'] to be a map, got %T", pduSessions["imsi-001010000000002-5"])
+	}
+
+	if ref, ok := pduSession["ref"].(string); !ok || ref != "imsi-001010000000002-5" {
+		t.Fatalf("expected pdu_sessions entry ref to be 'imsi-001010000000002-5', got %v", pduSession["ref"])
+	}
+
+	if _, ok := pduSession["snssai"]; !ok {
+		t.Fatal("expected pdu_sessions entry snssai to be present")
+	}
+
+	registration := jsonMap(t, ueExport, "registration")
+	if regType, ok := registration["type"].(float64); !ok || regType != 1 {
+		t.Fatalf("expected registration.type to be 1, got %v", registration["type"])
+	}
+
+	if identityType, ok := registration["identity_type_used"].(float64); !ok || identityType != 1 {
+		t.Fatalf("expected registration.identity_type_used to be 1, got %v", registration["identity_type_used"])
+	}
+
+	if retransmission, ok := registration["retransmission"].(bool); !ok || retransmission != true {
+		t.Fatalf("expected registration.retransmission to be true, got %v", registration["retransmission"])
+	}
+
+	if authFailureSyncTimes, ok := registration["auth_failure_sync_times"].(float64); !ok || authFailureSyncTimes != 2 {
+		t.Fatalf("expected registration.auth_failure_sync_times to be 2, got %v", registration["auth_failure_sync_times"])
+	}
+
+	lastActivity := jsonMap(t, ueExport, "last_activity")
+	if radioNode, ok := lastActivity["radio_node"].(string); !ok || radioNode != "gNB-001" {
+		t.Fatalf("expected last_activity.radio_node to be 'gNB-001', got %v", lastActivity["radio_node"])
+	}
+
+	if _, ok := lastActivity["timestamp"]; !ok {
+		t.Fatal("expected last_activity.timestamp to be present")
+	}
+}
+
+func TestExportJSON_NilTimers(t *testing.T) {
+	addTestUE(t, "001010000000003", func(ue *amfcontext.AmfUe) {})
+
+	result := exportAndMarshal(t)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 UE in result, got %d", len(result))
+	}
+
+	ueExport := result[0]
+
+	timers := jsonMap(t, ueExport, "timers")
+
+	timerNames := []string{"t3513_paging", "t3565_notification", "t3560_auth", "t3550_registration", "t3555_config_update", "t3522_deregistration", "mobile_reachable", "implicit_deregistration"}
+	for _, timerName := range timerNames {
+		timerObj := jsonMap(t, timers, timerName)
+		if active, ok := timerObj["active"].(bool); !ok || active != false {
+			t.Fatalf("expected timers.%s.active to be false, got %v", timerName, timerObj["active"])
+		}
+
+		if _, ok := timerObj["expire_count"]; ok {
+			t.Fatalf("expected timers.%s.expire_count to be absent", timerName)
+		}
+
+		if _, ok := timerObj["max_retries"]; ok {
+			t.Fatalf("expected timers.%s.max_retries to be absent", timerName)
+		}
+	}
+}
+
+func TestExportJSON_NilRanUe(t *testing.T) {
+	addTestUE(t, "001010000000004", func(ue *amfcontext.AmfUe) {
+		ue.RanUe = nil
+	})
+
+	result := exportAndMarshal(t)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 UE in result, got %d", len(result))
+	}
+
+	ueExport := result[0]
+
+	if _, ok := ueExport["ran_connection"]; ok {
+		t.Fatal("expected ran_connection to be absent")
+	}
+}
+
+func TestExportJSON_EmptySmContextList(t *testing.T) {
+	addTestUE(t, "001010000000005", func(ue *amfcontext.AmfUe) {})
+
+	result := exportAndMarshal(t)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 UE in result, got %d", len(result))
+	}
+
+	ueExport := result[0]
+
+	pduSessions, ok := ueExport["pdu_sessions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pdu_sessions to be a map, got %T", ueExport["pdu_sessions"])
+	}
+
+	if len(pduSessions) != 0 {
+		t.Fatalf("expected pdu_sessions to be empty, got %d entries", len(pduSessions))
+	}
+}
+
+func TestExportJSON_NilLocationPointers(t *testing.T) {
+	addTestUE(t, "001010000000006", func(ue *amfcontext.AmfUe) {})
+
+	result := exportAndMarshal(t)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 UE in result, got %d", len(result))
+	}
+
+	ueExport := result[0]
+
+	location := jsonMap(t, ueExport, "location")
+	current := jsonMap(t, location, "current")
+
+	if nrLoc := current["NrLocation"]; nrLoc != nil {
+		t.Fatalf("expected location.current.NrLocation to be nil, got %v", nrLoc)
+	}
+
+	if eutraLoc := current["EutraLocation"]; eutraLoc != nil {
+		t.Fatalf("expected location.current.EutraLocation to be nil, got %v", eutraLoc)
+	}
+
+	if n3gaLoc := current["N3gaLocation"]; n3gaLoc != nil {
+		t.Fatalf("expected location.current.N3gaLocation to be nil, got %v", n3gaLoc)
+	}
+}
+
+func TestExportJSON_PDUSessionNilSMFContext(t *testing.T) {
+	addTestUE(t, "001010000000007", func(ue *amfcontext.AmfUe) {
+		ue.SmContextList[1] = &amfcontext.SmContext{
+			Ref:                "nonexistent-ref",
+			Snssai:             &models.Snssai{Sst: 1, Sd: "000001"},
+			PduSessionInactive: true,
+		}
+	})
+
+	result := exportAndMarshal(t)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 UE in result, got %d", len(result))
+	}
+
+	ueExport := result[0]
+
+	pduSessions, ok := ueExport["pdu_sessions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pdu_sessions to be a map, got %T", ueExport["pdu_sessions"])
+	}
+
+	pduSession, ok := pduSessions["nonexistent-ref"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pdu_sessions['nonexistent-ref'] to be a map, got %T", pduSessions["nonexistent-ref"])
+	}
+
+	if ref, ok := pduSession["ref"].(string); !ok || ref != "nonexistent-ref" {
+		t.Fatalf("expected ref to be 'nonexistent-ref', got %v", pduSession["ref"])
+	}
+
+	if inactive, ok := pduSession["inactive"].(bool); !ok || inactive != true {
+		t.Fatalf("expected inactive to be true, got %v", pduSession["inactive"])
+	}
+
+	if _, ok := pduSession["snssai"]; !ok {
+		t.Fatal("expected snssai to be present")
+	}
+
+	if _, ok := pduSession["dnn"]; ok {
+		t.Fatal("expected dnn to be absent")
+	}
+
+	if _, ok := pduSession["policy_data"]; ok {
+		t.Fatal("expected policy_data to be absent")
+	}
+
+	if _, ok := pduSession["tunnel"]; ok {
+		t.Fatal("expected tunnel to be absent")
+	}
+
+	if _, ok := pduSession["pfcp_local_seid"]; ok {
+		t.Fatal("expected pfcp_local_seid to be absent")
+	}
+
+	if _, ok := pduSession["release_due_to_dup_id"]; ok {
+		t.Fatal("expected release_due_to_dup_id to be absent")
+	}
+}

--- a/internal/amf/context/timer.go
+++ b/internal/amf/context/timer.go
@@ -16,6 +16,7 @@ type Timer struct {
 	expireTimes   int32 // accessed atomically
 	maxRetryTimes int32 // accessed atomically
 	done          chan bool
+	active        int32 // 1 = active, 0 = stopped; accessed atomically
 }
 
 // NewTimer will return a Timer struct and create a goroutine. Then it calls expiredFunc every time interval d until
@@ -26,6 +27,7 @@ func NewTimer(d time.Duration, maxRetryTimes int32, expiredFunc func(expireTimes
 	t := &Timer{}
 	atomic.StoreInt32(&t.expireTimes, 0)
 	atomic.StoreInt32(&t.maxRetryTimes, maxRetryTimes)
+	atomic.StoreInt32(&t.active, 1)
 	t.done = make(chan bool, 1)
 	t.ticker = time.NewTicker(d)
 
@@ -40,7 +42,9 @@ func NewTimer(d time.Duration, maxRetryTimes int32, expiredFunc func(expireTimes
 				atomic.AddInt32(&t.expireTimes, 1)
 
 				if t.ExpireTimes() > t.MaxRetryTimes() {
+					atomic.StoreInt32(&t.active, 0)
 					cancelFunc()
+
 					return
 				} else {
 					expiredFunc(t.ExpireTimes())
@@ -62,9 +66,16 @@ func (t *Timer) ExpireTimes() int32 {
 	return atomic.LoadInt32(&t.expireTimes)
 }
 
+// IsActive returns true if the timer has not been stopped.
+func (t *Timer) IsActive() bool {
+	return atomic.LoadInt32(&t.active) == 1
+}
+
 // Stop turns off the timer, after Stop, no more timeout event will be triggered. User should call Stop() only once
 // otherwise it may hang on writing to done channel
 func (t *Timer) Stop() {
+	atomic.StoreInt32(&t.active, 0)
+
 	t.done <- true
 
 	close(t.done)

--- a/internal/amf/context/timer_test.go
+++ b/internal/amf/context/timer_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Ella Networks
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package context_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/amf/context"
+)
+
+func TestTimerIsActiveNewTimer(t *testing.T) {
+	timer := context.NewTimer(1*time.Hour, 1, func(_ int32) {}, func() {})
+	defer timer.Stop()
+
+	if !timer.IsActive() {
+		t.Fatal("expected new timer to be active, got inactive")
+	}
+}
+
+func TestTimerIsActiveAfterStop(t *testing.T) {
+	timer := context.NewTimer(1*time.Hour, 1, func(_ int32) {}, func() {})
+	timer.Stop()
+
+	if timer.IsActive() {
+		t.Fatal("expected stopped timer to be inactive, got active")
+	}
+}
+
+func TestTimerIsActiveAutoStop(t *testing.T) {
+	done := make(chan struct{})
+	timer := context.NewTimer(10*time.Millisecond, 1, func(_ int32) {}, func() {
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timer did not auto-stop within timeout")
+	}
+
+	// Give the goroutine time to set active=0 before we check
+	time.Sleep(20 * time.Millisecond)
+
+	if timer.IsActive() {
+		t.Fatal("expected auto-stopped timer to be inactive, got active")
+	}
+}

--- a/internal/supportbundle/generator.go
+++ b/internal/supportbundle/generator.go
@@ -35,6 +35,10 @@ var ConfigProvider func(ctx context.Context) ([]byte, error)
 // BPF objects are not available.
 var BpfDumper func(ctx context.Context, tw *tar.Writer) error
 
+// AMFDumper, when set, is called during support bundle generation to collect
+// live AMF/SMF UE state. Returns a JSON-serializable value or nil.
+var AMFDumper func(ctx context.Context) (any, error)
+
 // GenerateSupportBundleFromData writes a minimal support bundle containing the
 // provided redacted data as db.json into the writer as a gzipped tar archive.
 // This avoids import cycles: callers (e.g. internal/db) should fetch and redact
@@ -169,6 +173,25 @@ func GenerateSupportBundleFromData(ctx context.Context, data map[string]any, w i
 				if _, werr2 := tw.Write(errBs); werr2 != nil {
 					logger.APILog.Warn("failed to write bpf error file to tar", zap.Error(werr2))
 				}
+			}
+		}
+	}
+
+	// Attempt to dump live AMF UE state if a dumper is installed. This is
+	// best-effort: failures are logged but do not abort bundle creation.
+	if AMFDumper != nil {
+		amfData, err := AMFDumper(ctx)
+		if err != nil {
+			logger.APILog.Warn("amf ue dump failed", zap.Error(err))
+
+			errBs := []byte(err.Error())
+			_ = writeFile("amf_ues_error.txt", errBs)
+		} else if amfData != nil {
+			amfJSON, err := json.MarshalIndent(amfData, "", "  ")
+			if err != nil {
+				logger.APILog.Warn("failed to marshal amf_ues.json", zap.Error(err))
+			} else {
+				_ = writeFile("amf_ues.json", amfJSON)
 			}
 		}
 	}

--- a/internal/supportbundle/generator_test.go
+++ b/internal/supportbundle/generator_test.go
@@ -106,3 +106,103 @@ func TestGenerateSupportBundleFromData(t *testing.T) {
 		t.Fatalf("db.json not found in archive")
 	}
 }
+
+func TestGenerateSupportBundleFromData_AMFUesSeparateFile(t *testing.T) {
+	// Set AMFDumper to return test data.
+	origDumper := AMFDumper
+
+	defer func() { AMFDumper = origDumper }()
+
+	AMFDumper = func(ctx context.Context) (any, error) {
+		return []map[string]any{
+			{"supi": "imsi-001010000000099", "state": "Registered"},
+		}, nil
+	}
+
+	captured := time.Now().UTC().Format(time.RFC3339)
+	data := map[string]any{
+		"bundle_metadata": map[string]any{"version": "1.0", "captured_at": captured},
+		"subscribers":     []any{},
+	}
+
+	var buf bytes.Buffer
+	if err := GenerateSupportBundleFromData(context.Background(), data, &buf); err != nil {
+		t.Fatalf("GenerateSupportBundleFromData failed: %v", err)
+	}
+
+	gr, err := gzip.NewReader(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+
+	defer func() { _ = gr.Close() }()
+
+	tr := tar.NewReader(gr)
+	foundDBJSON := false
+	foundAMFUes := false
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("tar.Next: %v", err)
+		}
+
+		switch hdr.Name {
+		case "db.json":
+			foundDBJSON = true
+
+			b, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatalf("read db.json: %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("unmarshal db.json: %v", err)
+			}
+
+			// db.json must NOT contain amf_ues
+			if _, ok := got["amf_ues"]; ok {
+				t.Fatalf("db.json should not contain amf_ues key")
+			}
+
+		case "amf_ues.json":
+			foundAMFUes = true
+
+			b, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatalf("read amf_ues.json: %v", err)
+			}
+
+			var got []any
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("unmarshal amf_ues.json: %v", err)
+			}
+
+			if len(got) != 1 {
+				t.Fatalf("expected 1 AMF UE entry, got %d", len(got))
+			}
+
+			entry, ok := got[0].(map[string]any)
+			if !ok {
+				t.Fatalf("amf_ues entry wrong type: %T", got[0])
+			}
+
+			if supi, ok := entry["supi"].(string); !ok || supi != "imsi-001010000000099" {
+				t.Fatalf("unexpected supi: %#v", entry["supi"])
+			}
+		}
+	}
+
+	if !foundDBJSON {
+		t.Fatalf("db.json not found in archive")
+	}
+
+	if !foundAMFUes {
+		t.Fatalf("amf_ues.json not found in archive")
+	}
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
+	amfcontext "github.com/ellanetworks/core/internal/amf/context"
 	"github.com/ellanetworks/core/internal/api"
 	"github.com/ellanetworks/core/internal/api/server"
 	"github.com/ellanetworks/core/internal/ausf"
@@ -179,6 +180,10 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 
 	if err := amf.Start(ctx, dbInstance, cfg.Interfaces.N2.Address, cfg.Interfaces.N2.Port, &pdusession.EllaSmfSbi{}); err != nil {
 		return fmt.Errorf("couldn't start AMF: %w", err)
+	}
+
+	supportbundle.AMFDumper = func(ctx context.Context) (any, error) {
+		return amfcontext.ExportUEs(ctx)
 	}
 
 	defer func() {


### PR DESCRIPTION
# Description

This PR adds the state of all the `AmfUe`s to the support bundle. It includes details about PDU sessions by querying the SMF and some details from the RAN by inspecting the `RanUe` struct.

We explicitly ignore sensitive information like key material.

This makes the support bundle file larger, reaching ~160Kb on a core with 1000 active subscribers.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
