### PR TITLE
fix: release mutex after removing SM context

### DIFF
--- a/internal/smf/context/smf.go
+++ b/internal/smf/context/smf.go
@@ -234,19 +234,20 @@ func (smf *SMF) GetPDUSessionCount() int {
 
 func (smf *SMF) RemoveSMContext(ctx context.Context, ref string) {
 	smf.Mutex.Lock()
-	defer smf.Mutex.Unlock()
 
 	smContext, ok := smf.smContextPool[ref]
 	if !ok {
+		smf.Mutex.Unlock()
 		return
 	}
+
+	delete(smf.smContextPool, ref)
+	smf.Mutex.Unlock()
 
 	err := smf.ReleaseUeIPAddr(ctx, smContext.Supi)
 	if err != nil {
 		logger.SmfLog.Error("release UE IP-Address failed", zap.Error(err), zap.String("smContextRef", ref))
 	}
-
-	delete(smf.smContextPool, ref)
 
 	logger.SmfLog.Info("SM Context removed", zap.String("smContextRef", ref))
 }


### PR DESCRIPTION
# Description

Remove SM Context held the lock for an unnecessarily long period. Here we release the mutex right after it's not needed anymore. This lock seemed to have caused intermittent tests timeout like the one referenced below. While the fix is the correct thing to do, it's hard to be certain that it is the precise root cause.

## Reference
- https://github.com/ellanetworks/core/actions/runs/23262267204/job/67634561688 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
