### PR TITLE
fix: release TEID if error applying PDR

### DIFF
--- a/internal/upf/core/pfcp_session_handlers.go
+++ b/internal/upf/core/pfcp_session_handlers.go
@@ -166,6 +166,7 @@ func HandlePfcpSessionEstablishmentRequest(ctx context.Context, msg *message.Ses
 				if spdrInfo.Allocated {
 					pdrContext.FteIDResourceManager.ReleaseTEID(pdrContext.Session.SEID)
 				}
+
 				return fmt.Errorf("couldn't apply PDR: %s", err.Error())
 			}
 
@@ -480,6 +481,7 @@ func HandlePfcpSessionModificationRequest(ctx context.Context, msg *message.Sess
 				if spdrInfo.Allocated {
 					pdrContext.FteIDResourceManager.ReleaseTEID(pdrContext.Session.SEID)
 				}
+
 				return fmt.Errorf("couldn't apply PDR: %s", err.Error())
 			}
 
@@ -507,6 +509,7 @@ func HandlePfcpSessionModificationRequest(ctx context.Context, msg *message.Sess
 				if spdrInfo.Allocated {
 					pdrContext.FteIDResourceManager.ReleaseTEID(pdrContext.Session.SEID)
 				}
+
 				return fmt.Errorf("couldn't apply PDR: %s", err.Error())
 			}
 


### PR DESCRIPTION
# Description

ExtractPDR calls AllocateTEID (removing the TEID from the free list) before applyPDR is called. If applyPDR fails — for any reason — the code returned the error immediately without calling ReleaseTEID, permanently leaking that TEID slot.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
