### PR TITLE
fix: reorder ue context release

### DIFF
--- a/internal/amf/nas/gmm/handle_deregistration_request.go
+++ b/internal/amf/nas/gmm/handle_deregistration_request.go
@@ -17,7 +17,7 @@ func handleDeregistrationRequestUEOriginatingDeregistration(ctx context.Context,
 		return fmt.Errorf("state mismatch: receive Deregistration Request (UE Originating Deregistration) message in state %s", ue.State)
 	}
 
-	ue.Deregister()
+	defer ue.Deregister()
 
 	if ue.RanUe == nil {
 		logger.WithTrace(ctx, logger.AmfLog).Warn("RanUe is nil, cannot send UE Context Release Command", logger.SUPI(ue.Supi.String()))

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -151,23 +151,28 @@ func HandleUEContextReleaseRequest(ctx context.Context, amf *amfContext.AMF, ran
 			}
 		} else {
 			logger.WithTrace(ctx, ranUe.Log).Info("Ue Context in Non GMM-Registered")
-			amfUe.Mutex.Lock()
-
-			for _, smContext := range amfUe.SmContextList {
-				err := pdusession.ReleaseSmContext(ctx, smContext.Ref)
-				if err != nil {
-					logger.WithTrace(ctx, ranUe.Log).Error("error sending release sm context request", zap.Error(err))
-				}
-			}
-
-			amfUe.Mutex.Unlock()
-
 			ranUe.ReleaseAction = amfContext.UeContextReleaseUeContext
 
 			err := ran.NGAPSender.SendUEContextReleaseCommand(ctx, ranUe.AmfUeNgapID, ranUe.RanUeNgapID, causeGroup, causeValue)
 			if err != nil {
 				logger.WithTrace(ctx, ranUe.Log).Error("error sending ue context release command", zap.Error(err))
 				return
+			}
+
+			amfUe.Mutex.Lock()
+
+			smContextRefs := make([]string, 0, len(amfUe.SmContextList))
+			for _, smContext := range amfUe.SmContextList {
+				smContextRefs = append(smContextRefs, smContext.Ref)
+			}
+
+			amfUe.Mutex.Unlock()
+
+			for _, smContextRef := range smContextRefs {
+				err := pdusession.ReleaseSmContext(ctx, smContextRef)
+				if err != nil {
+					logger.WithTrace(ctx, ranUe.Log).Error("error sending release sm context request", zap.Error(err))
+				}
 			}
 
 			return


### PR DESCRIPTION
# Description

Reorders deregistration handling so the Ella Core sends UEContextReleaseCommand before session release work, preventing NGAP UE release from being blocked by backend teardown.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
