### PR TITLE
chore!: remove backup/restore permissions from network manager

### DIFF
--- a/internal/api/server/authorization_middleware.go
+++ b/internal/api/server/authorization_middleware.go
@@ -47,7 +47,7 @@ var PermissionsByRole = map[RoleID][]string{
 		PermGetFlowAccountingInfo, PermUpdateFlowAccountingInfo,
 		PermListRadioEvents, PermGetRadioEventRetentionPolicy, PermSetRadioEventRetentionPolicy, PermClearRadioEvents, PermGetRadioEvent,
 		PermGetFlowReportsRetentionPolicy, PermSetFlowReportsRetentionPolicy, PermListFlowReports, PermClearFlowReports,
-		PermBackup, PermRestore, PermSupportBundle,
+		PermSupportBundle,
 	},
 }
 


### PR DESCRIPTION
# Description

Network Managers should not have the ability to backup and restore the DB as it has obvious security and reliability consequences. Here we leave this responsibility only to admins.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
