### PR TITLE
fix: panic in authentication NAS message missing IEs

### DIFF
--- a/internal/amf/nas/gmm/handle_authentication_failure.go
+++ b/internal/amf/nas/gmm/handle_authentication_failure.go
@@ -75,6 +75,10 @@ func handleAuthenticationFailure(ctx context.Context, amf *amfContext.AMF, ue *a
 			return nil
 		}
 
+		if msg.AuthenticationFailureParameter == nil {
+			return fmt.Errorf("missing AuthenticationFailureParameter IE for SynchFailure")
+		}
+
 		auts := msg.GetAuthenticationFailureParameter()
 		resynchronizationInfo := &models.ResynchronizationInfo{
 			Auts: hex.EncodeToString(auts[:]),

--- a/internal/amf/nas/gmm/handle_authentication_failure_test.go
+++ b/internal/amf/nas/gmm/handle_authentication_failure_test.go
@@ -397,3 +397,25 @@ func TestHandleAuthenticationFailure_SynchFailure_SecondTime_DeregistersAndSends
 		t.Fatalf("expected AuthenticationReject message, got: %v", nm.GmmHeader.GetMessageType())
 	}
 }
+
+func TestHandleAuthenticationFailure_SynchFailure_NilAuthenticationFailureParameter(t *testing.T) {
+	amfSelf := amfContext.AMFSelf()
+	amfSelf.Smf = &FakeSmf{}
+
+	ue, _, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.State = amfContext.Authentication
+	ue.AuthFailureCauseSynchFailureTimes = 0
+
+	// Build message with SynchFailure cause but nil AuthenticationFailureParameter
+	msg := buildTestAuthenticationFailureMessage(nasMessage.Cause5GMMSynchFailure, nil)
+
+	// This must not panic — before the fix it caused a nil pointer dereference
+	err = handleAuthenticationFailure(t.Context(), &amfContext.AMF{}, ue, msg)
+	if err == nil {
+		t.Fatal("expected error when AuthenticationFailureParameter is nil, got nil")
+	}
+}

--- a/internal/amf/nas/gmm/handle_authentication_response.go
+++ b/internal/amf/nas/gmm/handle_authentication_response.go
@@ -29,6 +29,10 @@ func handleAuthenticationResponse(ctx context.Context, amf *amfContext.AMF, ue *
 		return fmt.Errorf("ue Authentication Context is nil")
 	}
 
+	if msg.AuthenticationResponseParameter == nil {
+		return fmt.Errorf("missing AuthenticationResponseParameter IE")
+	}
+
 	resStar := msg.GetRES()
 
 	// Calculate HRES* (TS 33.501 Annex A.5)

--- a/internal/amf/nas/gmm/handle_authentication_response_test.go
+++ b/internal/amf/nas/gmm/handle_authentication_response_test.go
@@ -17,6 +17,22 @@ import (
 	"github.com/free5gc/nas/security"
 )
 
+func TestHandleAuthenticationResponse_NilAuthenticationResponseParameter(t *testing.T) {
+	ue := &amfContext.AmfUe{
+		State:             amfContext.Authentication,
+		AuthenticationCtx: &models.Av5gAka{Rand: "DEADBEEF"},
+	}
+
+	msg := &nasMessage.AuthenticationResponse{
+		AuthenticationResponseParameter: nil,
+	}
+
+	err := handleAuthenticationResponse(context.TODO(), &amfContext.AMF{}, ue, msg)
+	if err == nil {
+		t.Fatal("expected error when AuthenticationResponseParameter is nil, got nil")
+	}
+}
+
 func TestHandleAuthenticationResponse_PreconditionErrors(t *testing.T) {
 	type TestCase struct {
 		name string


### PR DESCRIPTION
# Description

Ella Core panic via NAS Authentication Response/Failure with missing IE.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
