### PR TITLE
fix: race between amf and smf accessing policy data

### DIFF
--- a/internal/smf/activate.go
+++ b/internal/smf/activate.go
@@ -32,6 +32,14 @@ func (s *SMF) ActivateSmContext(ctx context.Context, smContextRef string) ([]byt
 	smContext.Mutex.Lock()
 	defer smContext.Mutex.Unlock()
 
+	if smContext.Tunnel == nil || smContext.Tunnel.DataPath == nil || smContext.Tunnel.DataPath.UpLinkTunnel == nil {
+		return nil, fmt.Errorf("session %s has no active tunnel", smContextRef)
+	}
+
+	if smContext.PolicyData == nil {
+		return nil, fmt.Errorf("session %s has no policy data", smContextRef)
+	}
+
 	n2Buf, err := ngap.BuildPDUSessionResourceSetupRequestTransfer(&smContext.PolicyData.Ambr, &smContext.PolicyData.QosData, smContext.Tunnel.DataPath.UpLinkTunnel.TEID, smContext.Tunnel.DataPath.UpLinkTunnel.N3IP)
 	if err != nil {
 		return nil, fmt.Errorf("build PDUSession Resource Setup Request Transfer Error: %v", err)

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -440,6 +440,8 @@ func (s *SMF) sendPduSessionEstablishmentAccept(
 		return fmt.Errorf("build PDUSessionResourceSetupRequestTransfer failed: %v", err)
 	}
 
+	smContext.SetPolicyData(policy)
+
 	err = s.amf.TransferN1N2(ctx, smContext.Supi, smContext.PDUSessionID, smContext.Snssai, n1Msg, n2Msg)
 	if err != nil {
 		span.RecordError(err)
@@ -449,8 +451,6 @@ func (s *SMF) sendPduSessionEstablishmentAccept(
 	}
 
 	logger.WithTrace(ctx, logger.SmfLog).Debug("Sent n1 n2 transfer request", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
-
-	smContext.SetPolicyData(policy)
 
 	return nil
 }


### PR DESCRIPTION
# Description

This PR fixes a race condition: the smf would set its policy data after notifying the amf of it which would sometimes result in nil pointer.

## Logs

```
2026-03-28 08:01:22.759	/home/protectli/core/internal/amf/ngap/service/service.go:106 +0x2e5
2026-03-28 08:01:22.759created by github.com/ellanetworks/core/internal/amf/ngap/service.(*Server).acceptLoop in goroutine 146
2026-03-28 08:01:22.759	/home/protectli/core/internal/amf/ngap/service/service.go:171 +0x6e6
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/ngap.HandleUplinkNasTransport({0x1915d28, 0x21ba34915e30}, 0x21ba349a6140, 0x21ba3487d4a0, 0x0?)
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/nas/gmm.HandleGmmMessage({0x1915d28?, 0x21ba34cfc840?}, 0x21ba349d2200?, 0x21ba346e2180?, 0x2?)
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/nas/gmm/context_setup.go:26 +0x153
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/nas/handler.go:83 +0xb07
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/nas/gmm/handler.go:19 +0x3e
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/ngap/service.(*Server).serveConn(0x21ba346cd570, {0x1915eb0, 0x21ba34826fc0}, 0x21ba35492360)
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/nas/gmm.securityMode({0x1915d28, 0x21ba34cfc840}, 0x21ba349a6140, 0x21ba3480c008)
2026-03-28 08:01:22.758github.com/ellanetworks/core/pkg/runtime.Start.func7({0x1915eb0?, 0x21ba34826fc0?}, 0x20000?, {0x21ba347dd340?, 0x1?, 0x1?})
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/ngap/handle_uplink_nas_transport.go:96 +0x312
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/nas/gmm/handle_registration_request.go:235 +0x629
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/nas.HandleNAS({0x1915d28, 0x21ba34915e30}, 0x21ba349a6140, 0x21ba34ba80a0, {0x21ba34c38c40?, 0x1?, 0x0?})
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/nas/gmm/security_mode.go:24 +0x43b
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/ngap/dispatcher.go:108 +0x117d
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/ngap.dispatchNgapMsg({0x1915d28, 0x21ba34915e30}, 0x21ba349a6140, 0x21ba3487d4a0, 0x21ba34567d60)
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/ngap/dispatcher.go:151 +0x3a5
2026-03-28 08:01:22.758	/home/protectli/core/pkg/runtime/runtime.go:282 +0x35
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/nas/gmm.handleRegistrationRequest({0x1915d28, 0x21ba34cfc840}, 0x21ba349a6140, 0x21ba3480c008, 0x21ba34be1e00)
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/ngap.Dispatch({0x1915eb0, 0x21ba34826fc0}, 0x21ba349a6140, 0x21ba35492360, {0x21ba347dd340, 0x68, 0x68})
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/nas/gmm.contextSetup({0x1915d28?, 0x21ba34cfcf30?}, 0x21ba349a6140, 0x21ba3480c008, 0x21ba34699d40)
2026-03-28 08:01:22.758	/home/protectli/core/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go:111 +0x1d08
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/amf/nas/gmm.HandleMobilityAndPeriodicRegistrationUpdating({0x1915d28, 0x21ba34cfd1a0}, 0x21ba349a6140, 0x21ba3480c008)
2026-03-28 08:01:22.758	/home/protectli/core/internal/smf/activate.go:35 +0x3e8
2026-03-28 08:01:22.758github.com/ellanetworks/core/internal/smf.(*SMF).ActivateSmContext(0x21ba346a2210, {0x1915d28, 0x21ba34cfd1a0}, {0x21ba3475cba0, 0x16})
2026-03-28 08:01:22.758go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x21ba34ae8000, {0x0, 0x0, 0x21ba34af1c20?})
2026-03-28 08:01:22.758go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x21ba34ccc000, {0x0, 0x0, 0x21ba34af1c20?})
2026-03-28 08:01:22.758	/home/protectli/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.1.linux-amd64/src/runtime/panic.go:860 +0x13a
2026-03-28 08:01:22.758panic({0x14185c0?, 0x256a830?})
2026-03-28 08:01:22.758	/home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.42.0/trace/span.go:528 +0xc7b
2026-03-28 08:01:22.758go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x21ba34c6b860, {0x0, 0x0, 0x21ba34af1c20?})
2026-03-28 08:01:22.758	/home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.42.0/trace/span.go:478 +0x1b
2026-03-28 08:01:22.758go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
2026-03-28 08:01:22.758go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x21ba34b2b680, {0x0, 0x0, 0x21ba34af1c20?})
2026-03-28 08:01:22.758	/home/protectli/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.1.linux-amd64/src/runtime/panic.go:860 +0x13a
2026-03-28 08:01:22.758panic({0x14185c0?, 0x256a830?})
2026-03-28 08:01:22.758	/home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.42.0/trace/span.go:528 +0xc7b
2026-03-28 08:01:22.758go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x21ba34b2b2c0, {0x0, 0x0, 0x21ba34af1c20?})
2026-03-28 08:01:22.758	/home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.42.0/trace/span.go:478 +0x1b
2026-03-28 08:01:22.758go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
2026-03-28 08:01:22.758goroutine 261046 [running]:
2026-03-28 08:01:22.758[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xae8fc8]
2026-03-28 08:01:22.758panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
