### PR TITLE
fix: TOCTOU race in AmfUe.RanUe()

### DIFF
--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -63,7 +63,7 @@ type SmContext struct {
 }
 
 type AmfUe struct {
-	Mutex sync.Mutex
+	Mutex sync.RWMutex
 
 	/* Gmm State */
 	state StateType
@@ -159,12 +159,20 @@ func NewAmfUe() *AmfUe {
 }
 
 // RanUe returns the currently attached RanUe, or nil.
+// The read is synchronized via ue.Mutex so the returned pointer is a
+// consistent snapshot.  Callers must capture the result in a local
+// variable and reuse it — never call RanUe() twice in the same
+// code path, as the underlying pointer may change between calls.
 func (ue *AmfUe) RanUe() *RanUe {
 	if ue == nil {
 		return nil
 	}
 
-	return ue.ranUe
+	ue.Mutex.RLock()
+	r := ue.ranUe
+	ue.Mutex.RUnlock()
+
+	return r
 }
 
 func (ue *AmfUe) GetState() StateType {

--- a/internal/amf/nas/gmm/authentication_procedure.go
+++ b/internal/amf/nas/gmm/authentication_procedure.go
@@ -31,11 +31,16 @@ func authenticationProcedure(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 	ctx, span := tracer.Start(ctx, "nas/authentication_procedure")
 	defer span.End()
 
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return false, fmt.Errorf("ue is not connected to RAN")
+	}
+
 	if !identityVerification(ue) {
 		// Request UE's SUCI by sending identity request
 		ue.Log.Debug("UE has no SUCI / SUPI - send identity request to UE")
 
-		err := message.SendIdentityRequest(ctx, ue.RanUe(), nasMessage.MobileIdentity5GSTypeSuci)
+		err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeSuci)
 		if err != nil {
 			return false, fmt.Errorf("error sending identity request: %v", err)
 		}
@@ -64,7 +69,7 @@ func authenticationProcedure(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 
 	ue.ABBA = []uint8{0x00, 0x00} // set ABBA value as described at TS 33.501 Annex A.7.1
 
-	err = message.SendAuthenticationRequest(ctx, amfInstance, ue.RanUe())
+	err = message.SendAuthenticationRequest(ctx, amfInstance, ranUe)
 	if err != nil {
 		return false, fmt.Errorf("error sending authentication request: %v", err)
 	}

--- a/internal/amf/nas/gmm/handle_authentication_failure.go
+++ b/internal/amf/nas/gmm/handle_authentication_failure.go
@@ -16,6 +16,11 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		return fmt.Errorf("state mismatch: receive Authentication Failure message in state %s", state)
 	}
 
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ue is not connected to RAN")
+	}
+
 	if ue.T3560 != nil {
 		ue.T3560.Stop()
 		ue.T3560 = nil // clear the timer
@@ -26,7 +31,7 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		ue.Log.Warn("Authentication Failure Cause: Mac Failure")
 		ue.Deregister(ctx)
 
-		err := message.SendAuthenticationReject(ctx, ue.RanUe())
+		err := message.SendAuthenticationReject(ctx, ranUe)
 		if err != nil {
 			return fmt.Errorf("error sending GMM authentication reject: %v", err)
 		}
@@ -36,7 +41,7 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		ue.Log.Warn("Authentication Failure Cause: Non-5G Authentication Unacceptable")
 		ue.Deregister(ctx)
 
-		err := message.SendAuthenticationReject(ctx, ue.RanUe())
+		err := message.SendAuthenticationReject(ctx, ranUe)
 		if err != nil {
 			return fmt.Errorf("error sending GMM authentication reject: %v", err)
 		}
@@ -48,7 +53,7 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		ue.Log.Warn("Select new NgKsi")
 		ue.NgKsi.Ksi = nextNgKsi(ue.NgKsi.Ksi)
 
-		err := message.SendAuthenticationRequest(ctx, amfInstance, ue.RanUe())
+		err := message.SendAuthenticationRequest(ctx, amfInstance, ranUe)
 		if err != nil {
 			return fmt.Errorf("send authentication request error: %s", err)
 		}
@@ -62,7 +67,7 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 			ue.Log.Warn("2 consecutive Synch Failure, terminate authentication procedure")
 			ue.Deregister(ctx)
 
-			err := message.SendAuthenticationReject(ctx, ue.RanUe())
+			err := message.SendAuthenticationReject(ctx, ranUe)
 			if err != nil {
 				return fmt.Errorf("error sending GMM authentication reject: %v", err)
 			}
@@ -87,7 +92,7 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		ue.AuthenticationCtx = response
 		ue.ABBA = []uint8{0x00, 0x00}
 
-		err = message.SendAuthenticationRequest(ctx, amfInstance, ue.RanUe())
+		err = message.SendAuthenticationRequest(ctx, amfInstance, ranUe)
 		if err != nil {
 			return fmt.Errorf("send authentication request error: %s", err)
 		}

--- a/internal/amf/nas/gmm/handle_authentication_response.go
+++ b/internal/amf/nas/gmm/handle_authentication_response.go
@@ -20,6 +20,11 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 		return fmt.Errorf("state mismatch: receive Authentication Response message in state %s", state)
 	}
 
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ue is not connected to RAN")
+	}
+
 	if ue.T3560 != nil {
 		ue.T3560.Stop()
 		ue.T3560 = nil // clear the timer
@@ -50,7 +55,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 		ue.Log.Error("HRES* Validation Failure")
 
 		if ue.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
-			err := message.SendIdentityRequest(ctx, ue.RanUe(), nasMessage.MobileIdentity5GSTypeSuci)
+			err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeSuci)
 			if err != nil {
 				return fmt.Errorf("send identity request error: %s", err)
 			}
@@ -62,7 +67,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 
 		defer ue.Deregister(ctx)
 
-		err := message.SendAuthenticationReject(ctx, ue.RanUe())
+		err := message.SendAuthenticationReject(ctx, ranUe)
 		if err != nil {
 			return fmt.Errorf("error sending GMM authentication reject: %v", err)
 		}
@@ -75,7 +80,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 		logger.WithTrace(ctx, logger.AmfLog).Error("5G AKA Confirmation Request Procedure failed", zap.Error(err))
 
 		if ue.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
-			err := message.SendIdentityRequest(ctx, ue.RanUe(), nasMessage.MobileIdentity5GSTypeSuci)
+			err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeSuci)
 			if err != nil {
 				return fmt.Errorf("send identity request error: %s", err)
 			}
@@ -87,7 +92,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 
 		defer ue.Deregister(ctx)
 
-		err := message.SendAuthenticationReject(ctx, ue.RanUe())
+		err := message.SendAuthenticationReject(ctx, ranUe)
 		if err != nil {
 			return fmt.Errorf("error sending GMM authentication reject: %v", err)
 		}

--- a/internal/amf/nas/gmm/handle_authentication_response_test.go
+++ b/internal/amf/nas/gmm/handle_authentication_response_test.go
@@ -17,7 +17,11 @@ import (
 )
 
 func TestHandleAuthenticationResponse_NilAuthenticationResponseParameter(t *testing.T) {
-	ue := amf.NewAmfUe()
+	ue, _, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
 	ue.ForceState(amf.Authentication)
 	ue.AuthenticationCtx = &ausf.AuthResult{Rand: "DEADBEEF"}
 
@@ -25,7 +29,7 @@ func TestHandleAuthenticationResponse_NilAuthenticationResponseParameter(t *test
 		AuthenticationResponseParameter: nil,
 	}
 
-	err := handleAuthenticationResponse(context.TODO(), amf.New(nil, nil, nil), ue, msg)
+	err = handleAuthenticationResponse(context.TODO(), amf.New(nil, nil, nil), ue, msg)
 	if err == nil {
 		t.Fatal("expected error when AuthenticationResponseParameter is nil, got nil")
 	}
@@ -51,7 +55,11 @@ func TestHandleAuthenticationResponse_PreconditionErrors(t *testing.T) {
 		{
 			"nil authentication context",
 			func() *amf.AmfUe {
-				ue := amf.NewAmfUe()
+				ue, _, err := buildUeAndRadio()
+				if err != nil {
+					panic(err)
+				}
+
 				ue.ForceState(amf.Authentication)
 
 				return ue
@@ -61,7 +69,11 @@ func TestHandleAuthenticationResponse_PreconditionErrors(t *testing.T) {
 		{
 			"invalid rand in UE context",
 			func() *amf.AmfUe {
-				ue := amf.NewAmfUe()
+				ue, _, err := buildUeAndRadio()
+				if err != nil {
+					panic(err)
+				}
+
 				ue.ForceState(amf.Authentication)
 				ue.AuthenticationCtx = &ausf.AuthResult{Rand: "Not hex"}
 

--- a/internal/amf/nas/gmm/handle_deregistration_accept.go
+++ b/internal/amf/nas/gmm/handle_deregistration_accept.go
@@ -18,14 +18,15 @@ func handleDeregistrationAccept(ctx context.Context, ue *amf.AmfUe) error {
 
 	defer ue.Deregister(ctx)
 
-	if ue.RanUe() == nil {
+	ranUe := ue.RanUe()
+	if ranUe == nil {
 		logger.WithTrace(ctx, logger.AmfLog).Warn("RanUe is nil, cannot send UE Context Release Command", logger.SUPI(ue.Supi.String()))
 		return nil
 	}
 
-	ue.RanUe().ReleaseAction = amf.UeContextReleaseDueToNwInitiatedDeregistraion
+	ranUe.ReleaseAction = amf.UeContextReleaseDueToNwInitiatedDeregistraion
 
-	err := ue.RanUe().SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
+	err := ranUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
 	if err != nil {
 		return fmt.Errorf("error sending ue context release command: %v", err)
 	}

--- a/internal/amf/nas/gmm/handle_deregistration_request.go
+++ b/internal/amf/nas/gmm/handle_deregistration_request.go
@@ -19,14 +19,15 @@ func handleDeregistrationRequestUEOriginatingDeregistration(ctx context.Context,
 
 	defer ue.Deregister(ctx)
 
-	if ue.RanUe() == nil {
+	ranUe := ue.RanUe()
+	if ranUe == nil {
 		logger.WithTrace(ctx, logger.AmfLog).Warn("RanUe is nil, cannot send UE Context Release Command", logger.SUPI(ue.Supi.String()))
 		return nil
 	}
 
 	// if Deregistration type is not switch-off, send Deregistration Accept
 	if msg.GetSwitchOff() == 0 {
-		err := message.SendDeregistrationAccept(ctx, ue.RanUe())
+		err := message.SendDeregistrationAccept(ctx, ranUe)
 		if err != nil {
 			return fmt.Errorf("error sending deregistration accept: %v", err)
 		}
@@ -40,9 +41,9 @@ func handleDeregistrationRequestUEOriginatingDeregistration(ctx context.Context,
 		return nil
 	}
 
-	ue.RanUe().ReleaseAction = amf.UeContextReleaseUeContext
+	ranUe.ReleaseAction = amf.UeContextReleaseUeContext
 
-	err := ue.RanUe().SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
+	err := ranUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
 	if err != nil {
 		return fmt.Errorf("error sending ue context release command: %v", err)
 	}

--- a/internal/amf/nas/gmm/handle_registration_complete.go
+++ b/internal/amf/nas/gmm/handle_registration_complete.go
@@ -37,9 +37,14 @@ func handleRegistrationComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 	shouldRelease := !forPending && !udsHasPending && !hasActiveSessions
 
 	if shouldRelease {
-		ue.RanUe().ReleaseAction = amf.UeContextN2NormalRelease
+		ranUe := ue.RanUe()
+		if ranUe == nil {
+			return fmt.Errorf("ue is not connected to RAN")
+		}
 
-		err := ue.RanUe().SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
+		ranUe.ReleaseAction = amf.UeContextN2NormalRelease
+
+		err := ranUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 		if err != nil {
 			return fmt.Errorf("error sending ue context release command: %v", err)
 		}

--- a/internal/amf/nas/gmm/handle_registration_request.go
+++ b/internal/amf/nas/gmm/handle_registration_request.go
@@ -42,7 +42,8 @@ const (
 
 // Handle cleartext IEs of Registration Request, which cleattext IEs defined in TS 24.501 4.4.6
 func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, registrationRequest *nasMessage.RegistrationRequest) error {
-	if ue.RanUe() == nil {
+	ranUe := ue.RanUe()
+	if ranUe == nil {
 		return fmt.Errorf("RanUe is nil")
 	}
 
@@ -76,7 +77,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		if err != nil {
 			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
 
-			err1 := message.SendRegistrationReject(ctx, ue.RanUe(), nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
+			err1 := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 			if err1 != nil {
 				return fmt.Errorf("error sending registration reject after error decrypting: %v", err1)
 			}
@@ -89,7 +90,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		if err := m.GmmMessageDecode(&contents); err != nil {
 			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
 
-			err1 := message.SendRegistrationReject(ctx, ue.RanUe(), nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
+			err1 := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 			if err1 != nil {
 				return fmt.Errorf("error sending registration reject after error decoding: %v", err1)
 			}
@@ -170,14 +171,14 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	}
 
 	// Copy UserLocation from ranUe
-	ue.Location = ue.RanUe().Location
-	ue.Tai = ue.RanUe().Tai
+	ue.Location = ranUe.Location
+	ue.Tai = ranUe.Tai
 
 	// Check TAI
 	if !amf.InTaiList(ue.Tai, operatorInfo.Tais) {
 		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
 
-		err := message.SendRegistrationReject(ctx, ue.RanUe(), nasMessage.Cause5GMMTrackingAreaNotAllowed)
+		err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMTrackingAreaNotAllowed)
 		if err != nil {
 			return fmt.Errorf("error sending registration reject: %v", err)
 		}
@@ -188,7 +189,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	if ue.RegistrationType5GS == nasMessage.RegistrationType5GSInitialRegistration && registrationRequest.UESecurityCapability == nil {
 		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
 
-		err := message.SendRegistrationReject(ctx, ue.RanUe(), nasMessage.Cause5GMMProtocolErrorUnspecified)
+		err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
 		if err != nil {
 			return fmt.Errorf("error sending registration reject: %v", err)
 		}
@@ -222,7 +223,12 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
 
-			err := message.SendRegistrationReject(ctx, ue.RanUe(), nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
+			ranUe := ue.RanUe()
+			if ranUe == nil {
+				return fmt.Errorf("ue is not connected to RAN")
+			}
+
+			err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 			if err != nil {
 				return fmt.Errorf("error sending registration reject: %v", err)
 			}

--- a/internal/amf/nas/gmm/handle_security_mode_reject.go
+++ b/internal/amf/nas/gmm/handle_security_mode_reject.go
@@ -25,9 +25,15 @@ func handleSecurityModeReject(ctx context.Context, ue *amf.AmfUe, msg *nasMessag
 	ue.Log.Error("UE rejected the security mode command, abort the ongoing procedure", logger.Cause(nasMessage.Cause5GMMToString(msg.GetCauseValue())), logger.SUPI(ue.Supi.String()))
 
 	ue.SecurityContextAvailable = false
-	ue.RanUe().ReleaseAction = amf.UeContextReleaseUeContext
 
-	err := ue.RanUe().SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ue is not connected to RAN")
+	}
+
+	ranUe.ReleaseAction = amf.UeContextReleaseUeContext
+
+	err := ranUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 	if err != nil {
 		return fmt.Errorf("error sending ue context release command: %v", err)
 	}

--- a/internal/amf/nas/gmm/handle_service_request.go
+++ b/internal/amf/nas/gmm/handle_service_request.go
@@ -39,6 +39,7 @@ func serviceTypeToString(serviceType uint8) string {
 func sendServiceAccept(
 	ctx context.Context,
 	ue *amf.AmfUe,
+	ranUe *amf.RanUe,
 	ctxList ngapType.PDUSessionResourceSetupListCxtReq,
 	suList ngapType.PDUSessionResourceSetupListSUReq,
 	pDUSessionStatus *[16]bool,
@@ -47,7 +48,7 @@ func sendServiceAccept(
 	errCause []uint8,
 	supportedGUAMI *models.Guami,
 ) error {
-	if ue.RanUe().UeContextRequest {
+	if ranUe.UeContextRequest {
 		// update Kgnb/Kn3iwf
 		err := ue.UpdateSecurityContext()
 		if err != nil {
@@ -59,9 +60,9 @@ func sendServiceAccept(
 			return fmt.Errorf("error building service accept message: %v", err)
 		}
 
-		ue.RanUe().SentInitialContextSetupRequest = true
+		ranUe.SentInitialContextSetupRequest = true
 
-		err = ue.RanUe().SendInitialContextSetupRequest(
+		err = ranUe.SendInitialContextSetupRequest(
 			ctx,
 			ue.Ambr.Uplink,
 			ue.Ambr.Downlink,
@@ -86,7 +87,7 @@ func sendServiceAccept(
 			return fmt.Errorf("error building service accept message: %v", err)
 		}
 
-		err = ue.RanUe().SendPDUSessionResourceSetupRequest(
+		err = ranUe.SendPDUSessionResourceSetupRequest(
 			ctx,
 			ue.Ambr.Uplink,
 			ue.Ambr.Downlink,
@@ -99,7 +100,7 @@ func sendServiceAccept(
 
 		ue.Log.Info("sent service accept")
 	} else {
-		err := message.SendServiceAccept(ctx, ue.RanUe(), pDUSessionStatus, reactivationResult, errPduSessionID, errCause)
+		err := message.SendServiceAccept(ctx, ranUe, pDUSessionStatus, reactivationResult, errPduSessionID, errCause)
 		if err != nil {
 			return fmt.Errorf("error sending service accept: %v", err)
 		}
@@ -112,25 +113,33 @@ func sendServiceAccept(
 
 // TS 24501 5.6.1
 func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.ServiceRequest) error {
+	// Validate state before accessing RanUe — state checks are cheap and
+	// independent of the RAN connection.
+	state := ue.GetState()
+	if state != amf.Deregistered && state != amf.Registered {
+		return fmt.Errorf("state mismatch: receive Service Request message in state %s", state)
+	}
+
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ue is not connected to RAN")
+	}
+
 	// TS 24.501 5.6.1.1: reject service request from deregistered UE
-	if ue.GetState() == amf.Deregistered {
-		err := message.SendServiceReject(ctx, ue.RanUe(), nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
+	if state == amf.Deregistered {
+		err := message.SendServiceReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 		if err != nil {
 			return fmt.Errorf("error sending service reject: %v", err)
 		}
 
-		ue.RanUe().ReleaseAction = amf.UeContextN2NormalRelease
+		ranUe.ReleaseAction = amf.UeContextN2NormalRelease
 
-		err = ue.RanUe().SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
+		err = ranUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 		if err != nil {
 			return fmt.Errorf("error sending ue context release command: %v", err)
 		}
 
 		return nil
-	}
-
-	if ue.GetState() != amf.Registered {
-		return fmt.Errorf("state mismatch: receive Service Request message in state %s", ue.GetState())
 	}
 
 	if ue.T3513 != nil {
@@ -187,15 +196,16 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		ue.Log.Warn("No security context", logger.SUPI(ue.Supi.String()))
 		ue.SecurityContextAvailable = false
 
-		err := message.SendServiceReject(ctx, ue.RanUe(), nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
+		err := message.SendServiceReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 		if err != nil {
 			return fmt.Errorf("error sending service reject: %v", err)
 		}
 
 		ue.Log.Info("sent service reject")
-		ue.RanUe().ReleaseAction = amf.UeContextN2NormalRelease
 
-		err = ue.RanUe().SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
+		ranUe.ReleaseAction = amf.UeContextN2NormalRelease
+
+		err = ranUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 		if err != nil {
 			return fmt.Errorf("error sending ue context release command: %v", err)
 		}
@@ -227,7 +237,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 	}
 
 	if serviceType == nasMessage.ServiceTypeSignalling {
-		err := sendServiceAccept(ctx, ue, ctxList, suList, nil, nil, nil, nil, operatorInfo.Guami)
+		err := sendServiceAccept(ctx, ue, ranUe, ctxList, suList, nil, nil, nil, nil, operatorInfo.Guami)
 		return err
 	}
 
@@ -267,7 +277,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 						errPduSessionID = append(errPduSessionID, pduSessionID)
 						cause := nasMessage.Cause5GMMProtocolErrorUnspecified
 						errCause = append(errCause, cause)
-					} else if ue.RanUe().UeContextRequest {
+					} else if ranUe.UeContextRequest {
 						send.AppendPDUSessionResourceSetupListCxtReq(&ctxList, pduSessionID, smContext.Snssai, nil, binaryDataN2SmInformation)
 					} else {
 						send.AppendPDUSessionResourceSetupListSUReq(&suList, pduSessionID, smContext.Snssai, nil, binaryDataN2SmInformation)
@@ -309,12 +319,12 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 
 			// Paging was triggered for downlink signaling only
 			if n2Info == nil && n1Msg != nil {
-				err := sendServiceAccept(ctx, ue, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
+				err := sendServiceAccept(ctx, ue, ranUe, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
 				if err != nil {
 					return fmt.Errorf("error sending service accept: %v", err)
 				}
 
-				err = message.SendDLNASTransport(ctx, ue.RanUe(), nasMessage.PayloadContainerTypeN1SMInfo, n1Msg, requestData.PduSessionID, 0)
+				err = message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, n1Msg, requestData.PduSessionID, 0)
 				if err != nil {
 					return fmt.Errorf("error sending downlink nas transport message: %v", err)
 				}
@@ -340,7 +350,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 					}
 				}
 
-				if ue.RanUe().UeContextRequest {
+				if ranUe.UeContextRequest {
 					send.AppendPDUSessionResourceSetupListCxtReq(&ctxList, requestData.PduSessionID, requestData.SNssai, nasPdu, n2Info)
 				} else {
 					send.AppendPDUSessionResourceSetupListSUReq(&suList, requestData.PduSessionID, requestData.SNssai, nasPdu, n2Info)
@@ -348,13 +358,13 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 
 				ue.Log.Debug("sending service accept")
 
-				err := sendServiceAccept(ctx, ue, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
+				err := sendServiceAccept(ctx, ue, ranUe, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
 				if err != nil {
 					return fmt.Errorf("error sending service accept: %v", err)
 				}
 			}
 		} else {
-			err := sendServiceAccept(ctx, ue, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
+			err := sendServiceAccept(ctx, ue, ranUe, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
 			if err != nil {
 				return fmt.Errorf("error sending service accept: %v", err)
 			}
@@ -368,7 +378,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		message.SendConfigurationUpdateCommand(ctx, amfInstance, ue, true)
 
 	case nasMessage.ServiceTypeData:
-		err := sendServiceAccept(ctx, ue, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
+		err := sendServiceAccept(ctx, ue, ranUe, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami)
 		if err != nil {
 			return fmt.Errorf("error sending service accept: %v", err)
 		}

--- a/internal/amf/nas/gmm/handle_ul_nas_transport.go
+++ b/internal/amf/nas/gmm/handle_ul_nas_transport.go
@@ -24,7 +24,8 @@ func forward5GSMMessageToSMF(
 	smContextRef string,
 	smMessage []byte,
 ) error {
-	if ue.RanUe() == nil {
+	ranUe := ue.RanUe()
+	if ranUe == nil {
 		return fmt.Errorf("RAN UE context is nil, cannot forward 5GSM message to SMF")
 	}
 
@@ -60,7 +61,7 @@ func forward5GSMMessageToSMF(
 		list := ngapType.PDUSessionResourceToReleaseListRelCmd{}
 		send.AppendPDUSessionResourceToReleaseListRelCmd(&list, pduSessionID, response.N2Msg)
 
-		err := ue.RanUe().SendPDUSessionResourceReleaseCommand(ctx, n1Msg, list)
+		err := ranUe.SendPDUSessionResourceReleaseCommand(ctx, n1Msg, list)
 		if err != nil {
 			return fmt.Errorf("error sending pdu session resource release command: %s", err)
 		}
@@ -71,7 +72,7 @@ func forward5GSMMessageToSMF(
 	}
 
 	if n1Msg != nil {
-		err := ue.RanUe().SendDownlinkNasTransport(ctx, n1Msg, nil)
+		err := ranUe.SendDownlinkNasTransport(ctx, n1Msg, nil)
 		if err != nil {
 			return fmt.Errorf("error sending downlink nas transport: %s", err)
 		}
@@ -96,6 +97,11 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		return fmt.Errorf("invalid PDU session ID %d: must be in range 1-15 per TS 24.501", pduSessionID)
 	}
 
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("RAN UE context is nil, cannot transport 5GSM message")
+	}
+
 	if ulNasTransport.OldPDUSessionID != nil {
 		return fmt.Errorf("old pdu session id is not supported")
 	}
@@ -111,7 +117,7 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		case nasMessage.ULNASTransportRequestTypeExistingEmergencyPduSession:
 			ue.Log.Warn("Emergency PDU Session is not supported")
 
-			err := message.SendDLNASTransport(ctx, ue.RanUe(), nasMessage.PayloadContainerTypeN1SMInfo, smMessage, pduSessionID, nasMessage.Cause5GMMPayloadWasNotForwarded)
+			err := message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, smMessage, pduSessionID, nasMessage.Cause5GMMPayloadWasNotForwarded)
 			if err != nil {
 				return fmt.Errorf("error sending downlink nas transport: %s", err)
 			}
@@ -165,7 +171,7 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 			list := ngapType.PDUSessionResourceToReleaseListRelCmd{}
 			send.AppendPDUSessionResourceToReleaseListRelCmd(&list, pduSessionID, n2Rsp)
 
-			err = ue.RanUe().SendPDUSessionResourceReleaseCommand(ctx, nil, list)
+			err = ranUe.SendPDUSessionResourceReleaseCommand(ctx, nil, list)
 			if err != nil {
 				return fmt.Errorf("error sending pdu session resource release command: %s", err)
 			}
@@ -180,7 +186,7 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 
 			ue.Log.Error("S-NSSAI is not allowed for access type", zap.Any("snssai", smContext.Snssai), zap.Uint8("pduSessionID", pduSessionID))
 
-			err := message.SendDLNASTransport(ctx, ue.RanUe(), nasMessage.PayloadContainerTypeN1SMInfo, smMessage, pduSessionID, nasMessage.Cause5GMMPayloadWasNotForwarded)
+			err := message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, smMessage, pduSessionID, nasMessage.Cause5GMMPayloadWasNotForwarded)
 			if err != nil {
 				return fmt.Errorf("error sending downlink nas transport: %s", err)
 			}
@@ -237,7 +243,7 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 			}
 
 			if errResponse != nil {
-				err := message.SendDLNASTransport(ctx, ue.RanUe(), nasMessage.PayloadContainerTypeN1SMInfo, errResponse, pduSessionID, 0)
+				err := message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, errResponse, pduSessionID, 0)
 				if err != nil {
 					return fmt.Errorf("error sending downlink nas transport: %s", err)
 				}
@@ -254,7 +260,7 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		case nasMessage.ULNASTransportRequestTypeModificationRequest:
 			fallthrough
 		case nasMessage.ULNASTransportRequestTypeExistingPduSession:
-			err := message.SendDLNASTransport(ctx, ue.RanUe(), nasMessage.PayloadContainerTypeN1SMInfo, smMessage, pduSessionID, nasMessage.Cause5GMMPayloadWasNotForwarded)
+			err := message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, smMessage, pduSessionID, nasMessage.Cause5GMMPayloadWasNotForwarded)
 			if err != nil {
 				return fmt.Errorf("error sending downlink nas transport: %s", err)
 			}

--- a/internal/amf/nas/gmm/message/send.go
+++ b/internal/amf/nas/gmm/message/send.go
@@ -339,10 +339,15 @@ func SendRegistrationAccept(
 		return fmt.Errorf("error building registration accept: %s", err.Error())
 	}
 
-	if ue.RanUe().UeContextRequest {
-		ue.RanUe().SentInitialContextSetupRequest = true
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ranUe is nil")
+	}
 
-		err = ue.RanUe().SendInitialContextSetupRequest(
+	if ranUe.UeContextRequest {
+		ranUe.SentInitialContextSetupRequest = true
+
+		err = ranUe.SendInitialContextSetupRequest(
 			ctx,
 			ue.Ambr.Uplink,
 			ue.Ambr.Downlink,
@@ -362,7 +367,7 @@ func SendRegistrationAccept(
 
 		ue.Log.Info("Sent NGAP initial context setup request")
 	} else {
-		err = ue.RanUe().SendDownlinkNasTransport(ctx, nasMsg, nil)
+		err = ranUe.SendDownlinkNasTransport(ctx, nasMsg, nil)
 		if err != nil {
 			return fmt.Errorf("error sending downlink NAS transport message: %s", err.Error())
 		}
@@ -373,12 +378,13 @@ func SendRegistrationAccept(
 	if amfInstance.T3550Cfg.Enable {
 		cfg := amfInstance.T3550Cfg
 		ue.T3550 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
-			if ue.RanUe() == nil {
+			retryRanUe := ue.RanUe()
+			if retryRanUe == nil {
 				ue.Log.Warn("[NAS] UE Context released, abort retransmission of Registration Accept")
 				ue.T3550 = nil
 			} else {
-				if ue.RanUe().UeContextRequest && !ue.RanUe().RecvdInitialContextSetupResponse {
-					err = ue.RanUe().SendInitialContextSetupRequest(
+				if retryRanUe.UeContextRequest && !retryRanUe.RecvdInitialContextSetupResponse {
+					err = retryRanUe.SendInitialContextSetupRequest(
 						context.Background(),
 						ue.Ambr.Uplink,
 						ue.Ambr.Downlink,
@@ -396,12 +402,13 @@ func SendRegistrationAccept(
 						ue.Log.Error("could not send initial context setup request", zap.Error(err))
 					}
 
-					ue.RanUe().SentInitialContextSetupRequest = true
+					retryRanUe.SentInitialContextSetupRequest = true
+
 					ue.Log.Info("Sent NGAP initial context setup request")
 				} else {
 					ue.Log.Warn("T3550 expires, retransmit Registration Accept", zap.Any("expireTimes", expireTimes))
 
-					err = ue.RanUe().SendDownlinkNasTransport(context.Background(), nasMsg, nil)
+					err = retryRanUe.SendDownlinkNasTransport(context.Background(), nasMsg, nil)
 					if err != nil {
 						ue.Log.Error("could not send downlink NAS transport message", zap.Error(err))
 					}
@@ -434,7 +441,8 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *amf.AMF, a
 	)
 	defer span.End()
 
-	if amfUe.RanUe() == nil {
+	ranUe := amfUe.RanUe()
+	if ranUe == nil {
 		amfUe.Log.Error("cannot SendConfigurationUpdateCommand: RanUe is nil")
 		return
 	}
@@ -459,7 +467,7 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *amf.AMF, a
 		return
 	}
 
-	err = amfUe.RanUe().SendDownlinkNasTransport(ctx, nasMsg, mobilityRestrictionList)
+	err = ranUe.SendDownlinkNasTransport(ctx, nasMsg, mobilityRestrictionList)
 	if err != nil {
 		amfUe.Log.Error("could not send configuration update command", zap.Error(err))
 		return
@@ -472,19 +480,20 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *amf.AMF, a
 		amfUe.T3555 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.Log.Warn("timer T3555 expired, retransmit Configuration Update Command", zap.Int32("retry", expireTimes))
 
-			if amfUe.RanUe() == nil {
+			retryRanUe := amfUe.RanUe()
+			if retryRanUe == nil {
 				amfUe.Log.Warn("UE Context released, abort retransmission of Configuration Update Command")
 				amfUe.T3555 = nil
 
 				return
 			}
 
-			if amfUe.RanUe().Radio == nil {
+			if retryRanUe.Radio == nil {
 				amfUe.Log.Warn("Radio is nil, abort retransmission of Configuration Update Command")
 				return
 			}
 
-			err = amfUe.RanUe().SendDownlinkNasTransport(context.Background(), nasMsg, mobilityRestrictionList)
+			err = retryRanUe.SendDownlinkNasTransport(context.Background(), nasMsg, mobilityRestrictionList)
 			if err != nil {
 				amfUe.Log.Error("could not send configuration update command", zap.Error(err))
 			}

--- a/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
@@ -16,6 +16,11 @@ import (
 func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) error {
 	ue.Log.Debug("Handle MobilityAndPeriodicRegistrationUpdating")
 
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ue is not connected to RAN")
+	}
+
 	err := ue.DerivateAnKey()
 	if err != nil {
 		return fmt.Errorf("error deriving AnKey: %v", err)
@@ -39,7 +44,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		if ue.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
 			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
 
-			err := message.SendRegistrationReject(ctx, ue.RanUe(), nasMessage.Cause5GMMProtocolErrorUnspecified)
+			err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
 			if err != nil {
 				return fmt.Errorf("error sending registration reject: %v", err)
 			}
@@ -65,7 +70,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	if len(ue.Pei) == 0 {
 		ue.Log.Debug("The UE did not provide PEI")
 
-		err := message.SendIdentityRequest(ctx, ue.RanUe(), nasMessage.MobileIdentity5GSTypeImei)
+		err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeImei)
 		if err != nil {
 			return fmt.Errorf("error sending identity request: %v", err)
 		}
@@ -107,7 +112,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 						cause := nasMessage.Cause5GMMProtocolErrorUnspecified
 						errCause = append(errCause, cause)
 					} else {
-						if ue.RanUe().UeContextRequest {
+						if ranUe.UeContextRequest {
 							send.AppendPDUSessionResourceSetupListCxtReq(&ctxList, pduSessionID,
 								smContext.Snssai, nil, binaryDataN2SmInformation)
 						} else {
@@ -163,7 +168,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
 
-					err = ue.RanUe().SendPDUSessionResourceSetupRequest(
+					err = ranUe.SendPDUSessionResourceSetupRequest(
 						ctx,
 						ue.Ambr.Uplink,
 						ue.Ambr.Downlink,
@@ -186,7 +191,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					ue.Log.Info("Sent GMM registration accept")
 				}
 
-				err := message.SendDLNASTransport(ctx, ue.RanUe(), nasMessage.PayloadContainerTypeN1SMInfo, n1Msg, requestData.PduSessionID, 0)
+				err := message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, n1Msg, requestData.PduSessionID, 0)
 				if err != nil {
 					return fmt.Errorf("error sending downlink nas transport message: %v", err)
 				}
@@ -220,7 +225,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 	ue.AllocateRegistrationArea(operatorInfo.Tais)
 
-	if ue.RanUe().UeContextRequest {
+	if ranUe.UeContextRequest {
 		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
 
 		err := message.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, &ctxList, operatorInfo.SupportedPLMN, operatorInfo.Guami)
@@ -240,7 +245,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		if len(suList.List) != 0 {
 			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
 
-			err := ue.RanUe().SendPDUSessionResourceSetupRequest(
+			err := ranUe.SendPDUSessionResourceSetupRequest(
 				ctx,
 				ue.Ambr.Uplink,
 				ue.Ambr.Downlink,
@@ -255,7 +260,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		} else {
 			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
 
-			err := ue.RanUe().SendDownlinkNasTransport(ctx, nasPdu, nil)
+			err := ranUe.SendDownlinkNasTransport(ctx, nasPdu, nil)
 			if err != nil {
 				return fmt.Errorf("error sending downlink nas transport: %v", err)
 			}

--- a/internal/amf/nas/gmm/security_mode.go
+++ b/internal/amf/nas/gmm/security_mode.go
@@ -36,7 +36,12 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) erro
 		return fmt.Errorf("error deriving algorithm key: %v", err)
 	}
 
-	err = message.SendSecurityModeCommand(ctx, amfInstance, ue.RanUe())
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ue is not connected to RAN")
+	}
+
+	err = message.SendSecurityModeCommand(ctx, amfInstance, ranUe)
 	if err != nil {
 		return fmt.Errorf("error sending security mode command: %v", err)
 	}

--- a/internal/amf/producer/n1n2message.go
+++ b/internal/amf/producer/n1n2message.go
@@ -41,7 +41,8 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 		return fmt.Errorf("ue context not found")
 	}
 
-	if ue.RanUe() == nil {
+	ranUe := ue.RanUe()
+	if ranUe == nil {
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
@@ -52,12 +53,12 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 
 	ue.Log.Debug("AMF Transfer NGAP PDU Session Resource Setup Request from SMF")
 
-	if ue.RanUe().SentInitialContextSetupRequest {
+	if ranUe.SentInitialContextSetupRequest {
 		list := ngapType.PDUSessionResourceSetupListSUReq{}
 
 		send.AppendPDUSessionResourceSetupListSUReq(&list, req.PduSessionID, req.SNssai, nasPdu, req.BinaryDataN2Information)
 
-		err := ue.RanUe().SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
+		err := ranUe.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
 		if err != nil {
 			return fmt.Errorf("send pdu session resource setup request error: %v", err)
 		}
@@ -76,7 +77,7 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 
 	send.AppendPDUSessionResourceSetupListCxtReq(&list, req.PduSessionID, req.SNssai, nasPdu, req.BinaryDataN2Information)
 
-	err = ue.RanUe().SendInitialContextSetupRequest(
+	err = ranUe.SendInitialContextSetupRequest(
 		ctx,
 		ue.Ambr.Uplink,
 		ue.Ambr.Downlink,
@@ -95,7 +96,8 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 	}
 
 	ue.Log.Info("Sent NGAP initial context setup request to UE")
-	ue.RanUe().SentInitialContextSetupRequest = true
+
+	ranUe.SentInitialContextSetupRequest = true
 
 	return nil
 }
@@ -125,14 +127,15 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 		return fmt.Errorf("temporary reject handover ongoing")
 	}
 
-	if ue.RanUe() != nil {
+	ranUe := ue.RanUe()
+	if ranUe != nil {
 		ue.Log.Debug("AMF Transfer NGAP PDU Session Resource Setup Request from SMF")
 
-		if ue.RanUe().SentInitialContextSetupRequest {
+		if ranUe.SentInitialContextSetupRequest {
 			list := ngapType.PDUSessionResourceSetupListSUReq{}
 			send.AppendPDUSessionResourceSetupListSUReq(&list, req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 
-			err := ue.RanUe().SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
+			err := ranUe.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
 			if err != nil {
 				return fmt.Errorf("send pdu session resource setup request error: %v", err)
 			}
@@ -150,7 +153,7 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 		list := ngapType.PDUSessionResourceSetupListCxtReq{}
 		send.AppendPDUSessionResourceSetupListCxtReq(&list, req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 
-		err = ue.RanUe().SendInitialContextSetupRequest(
+		err = ranUe.SendInitialContextSetupRequest(
 			ctx,
 			ue.Ambr.Uplink,
 			ue.Ambr.Downlink,
@@ -169,7 +172,8 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 		}
 
 		ue.Log.Info("Sent NGAP initial context setup request to UE")
-		ue.RanUe().SentInitialContextSetupRequest = true
+
+		ranUe.SentInitialContextSetupRequest = true
 
 		return nil
 	}
@@ -218,7 +222,8 @@ func TransferN1Msg(ctx context.Context, amfInstance *amf.AMF, supi etsi.SUPI, n1
 		return fmt.Errorf("ue context not found")
 	}
 
-	if ue.RanUe() == nil {
+	ranUe := ue.RanUe()
+	if ranUe == nil {
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
@@ -227,7 +232,7 @@ func TransferN1Msg(ctx context.Context, amfInstance *amf.AMF, supi etsi.SUPI, n1
 		return fmt.Errorf("build DL NAS Transport error: %v", err)
 	}
 
-	err = ue.RanUe().SendDownlinkNasTransport(ctx, nasPdu, nil)
+	err = ranUe.SendDownlinkNasTransport(ctx, nasPdu, nil)
 	if err != nil {
 		return fmt.Errorf("send downlink nas transport error: %v", err)
 	}

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -36,8 +36,10 @@ const (
 // RanUe represents one UE's radio-level state on a single Radio.
 // It has no mutex of its own. It is protected either by the owning Radio's
 // single SCTP goroutine, or by AmfUe.Mutex when accessed via AmfUe.RanUe().
-// After obtaining a RanUe from a Radio lookup, acquire the AmfUe's Mutex
-// before reading or writing any AmfUe fields.
+//
+// AmfUe.RanUe() acquires a read-lock internally and returns a consistent
+// snapshot. Callers must capture the returned pointer in a local variable
+// and reuse it — never call RanUe() twice in the same code path.
 type RanUe struct {
 	RanUeNgapID                      int64
 	AmfUeNgapID                      int64


### PR DESCRIPTION
# Description

AmfUe.RanUe() was not thread-safe. It read ue.ranUe without any lock, while AttachRanUe/DetachRanUe wrote under ue.Mutex. Combined with callers calling RanUe() multiple times (check-then-use), this created TOCTOU races where the pointer could become nil between calls.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
