### PR TITLE
fix: Make rules prefix optional again

### DIFF
--- a/ui/src/components/PolicyRulesModal.tsx
+++ b/ui/src/components/PolicyRulesModal.tsx
@@ -97,9 +97,13 @@ const schema = yup.object().shape({
     .required("Action is required"),
   remotePrefix: yup
     .string()
-    .matches(
-      /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/,
+    .test(
+      "cidr-or-empty",
       "Must be valid CIDR format (e.g., 192.168.0.0/24)",
+      (val) => {
+        if (!val || val.trim() === "") return true; // allow empty (optional field)
+        return /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/.test(val);
+      },
     ),
   protocol: yup
     .string()


### PR DESCRIPTION
# Description

PR #1202 broke the handling of the option prefix field in the rules modal. The field was still marked optional, but leaving it empty would make the `Create` button do nothing at all. No errors were shown to the user.

This PR fixes the issue by allowing leaving the prefix field empty to mean `0.0.0.0/0`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
