### PR TITLE
feat: Update rules in realtime

### DIFF
--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -73,7 +73,13 @@ func (dummyFS) Open(name string) (fs.File, error) {
 	return nil, fs.ErrNotExist
 }
 
-type FakeUPF struct{}
+type FakeUPF struct {
+	calledFilters *[]struct {
+		policyID  int64
+		direction models.Direction
+		rules     []models.FilterRule
+	}
+}
 
 func (f FakeUPF) ReloadNAT(natEnabled bool) error {
 	return nil
@@ -84,6 +90,16 @@ func (f FakeUPF) ReloadFlowAccounting(flowAccountingEnabled bool) error {
 }
 
 func (f FakeUPF) UpdateAdvertisedN3Address(ip net.IP) {
+}
+
+func (f FakeUPF) UpdateFilters(policyID int64, direction models.Direction, rules []models.FilterRule) error {
+	*f.calledFilters = append(*f.calledFilters, struct {
+		policyID  int64
+		direction models.Direction
+		rules     []models.FilterRule
+	}{policyID: policyID, direction: direction, rules: rules})
+
+	return nil
 }
 
 // testEnv holds the components created by setupServer.
@@ -132,6 +148,56 @@ func setupServer(filepath string) (testEnv, error) {
 
 	amfInstance := amf.New(testdb, nil, nil)
 	ts := httptest.NewTLSServer(server.NewHandler(testdb, cfg, fakeUPF, fakeKernel, jwtSecret, false, dummyfs, smfInstance, amfInstance, nil, nil))
+
+	supportbundle.ConfigProvider = func(ctx context.Context) ([]byte, error) {
+		return []byte("fake test config"), nil
+	}
+
+	return testEnv{
+		Server:    ts,
+		JWTSecret: jwtSecret,
+		DB:        testdb,
+		SMF:       smfInstance,
+		AMF:       amfInstance,
+	}, nil
+}
+
+func setupServerWithUPF(filepath string, upf server.UPFUpdater) (testEnv, error) {
+	testdb, err := db.NewDatabase(context.Background(), filepath)
+	if err != nil {
+		return testEnv{}, err
+	}
+
+	logger.SetDb(testdb)
+
+	// Initialize SMF context with test stubs
+	smfInstance := smf.New(&fakeSessionStore{}, &fakeUPFClient{}, &fakeAMFCallback{})
+
+	jwtSecret := server.NewJWTSecret([]byte("testsecret"))
+	fakeKernel := FakeKernel{}
+	dummyfs := dummyFS{}
+
+	cfg := config.Config{
+		Interfaces: config.Interfaces{
+			N2: config.N2Interface{
+				Address: "12.12.12.12",
+				Port:    2152,
+			},
+			N3: config.N3Interface{
+				Name:    "eth0",
+				Address: "13.13.13.13",
+			},
+			N6: config.N6Interface{
+				Name: "eth1",
+			},
+			API: config.APIInterface{
+				Port: 8443,
+			},
+		},
+	}
+
+	amfInstance := amf.New(testdb, nil, nil)
+	ts := httptest.NewTLSServer(server.NewHandler(testdb, cfg, upf, fakeKernel, jwtSecret, false, dummyfs, smfInstance, amfInstance, nil, nil))
 
 	supportbundle.ConfigProvider = func(ctx context.Context) ([]byte, error) {
 		return []byte("fake test config"), nil
@@ -259,12 +325,12 @@ func (f *fakeUPFClient) DeleteSession(ctx context.Context, localSEID, remoteSEID
 	return nil
 }
 
-func (f *fakeUPFClient) UpdateFilters(ctx context.Context, req *smf.FilterUpdateRequest) (*smf.FilterUpdateResponse, error) {
-	return nil, fmt.Errorf("not implemented in test")
+func (f *fakeUPFClient) UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
+	return nil
 }
 
-func (f *fakeUPFClient) ReleaseFilter(ctx context.Context, index uint32) error {
-	return nil
+func (f *fakeUPFClient) GetFilterIndex(ctx context.Context, policyID int64, direction models.Direction) (uint32, error) {
+	return 0, nil
 }
 
 type fakeAMFCallback struct{}

--- a/internal/api/server/api_policies.go
+++ b/internal/api/server/api_policies.go
@@ -13,10 +13,15 @@ import (
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"go.uber.org/zap"
 )
 
-const MaxNumNetworkRulesPerDirection = 12
+const (
+	MaxNumNetworkRulesPerDirection = 12
+	DirectionUplink                = "uplink"
+	DirectionDownlink              = "downlink"
+)
 
 type PolicyRule struct {
 	Description  string  `json:"description"`
@@ -78,11 +83,6 @@ const (
 	CreatePolicyAction = "create_policy"
 	UpdatePolicyAction = "update_policy"
 	DeletePolicyAction = "delete_policy"
-)
-
-const (
-	DirectionUplink   = "uplink"
-	DirectionDownlink = "downlink"
 )
 
 const (
@@ -378,6 +378,31 @@ func getPolicyRulesForPolicy(ctx context.Context, dbInstance *db.Database, polic
 	return policyRules, nil
 }
 
+func convertNetworkRulesToFilterRules(rules []*db.NetworkRule, direction string) []models.FilterRule {
+	filterRules := make([]models.FilterRule, 0, len(rules))
+	for _, rule := range rules {
+		if rule.Direction != direction {
+			continue
+		}
+
+		filterRule := models.FilterRule{
+			RemotePrefix: "",
+			Protocol:     rule.Protocol,
+			PortLow:      rule.PortLow,
+			PortHigh:     rule.PortHigh,
+			Action:       models.ActionFromString(rule.Action),
+		}
+
+		if rule.RemotePrefix != nil {
+			filterRule.RemotePrefix = *rule.RemotePrefix
+		}
+
+		filterRules = append(filterRules, filterRule)
+	}
+
+	return filterRules
+}
+
 func GetPolicy(dbInstance *db.Database) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
@@ -611,7 +636,7 @@ func CreatePolicy(dbInstance *db.Database) http.Handler {
 	})
 }
 
-func UpdatePolicy(dbInstance *db.Database) http.Handler {
+func UpdatePolicy(dbInstance *db.Database, filterUpdater UPFUpdater) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		email, ok := r.Context().Value(contextKeyEmail).(string)
 		if !ok {
@@ -724,6 +749,36 @@ func UpdatePolicy(dbInstance *db.Database) http.Handler {
 		}
 
 		committed = true
+
+		if filterUpdater != nil {
+			rules, err := dbInstance.ListRulesForPolicy(r.Context(), int64(policy.ID))
+			if err != nil {
+				logger.APILog.Warn("Failed to fetch updated rules for filter update",
+					zap.String("policyName", policyName),
+					zap.Error(err),
+				)
+			} else {
+				uplinkRules := convertNetworkRulesToFilterRules(rules, DirectionUplink)
+				if len(uplinkRules) > 0 {
+					if err := filterUpdater.UpdateFilters(int64(policy.ID), models.DirectionUplink, uplinkRules); err != nil {
+						logger.APILog.Warn("Failed to update uplink filters",
+							zap.String("policyName", policyName),
+							zap.Error(err),
+						)
+					}
+				}
+
+				downlinkRules := convertNetworkRulesToFilterRules(rules, DirectionDownlink)
+				if len(downlinkRules) > 0 {
+					if err := filterUpdater.UpdateFilters(int64(policy.ID), models.DirectionDownlink, downlinkRules); err != nil {
+						logger.APILog.Warn("Failed to update downlink filters",
+							zap.String("policyName", policyName),
+							zap.Error(err),
+						)
+					}
+				}
+			}
+		}
 
 		writeResponse(r.Context(), w, SuccessResponse{Message: "Policy updated successfully"}, http.StatusOK, logger.APILog)
 		logger.LogAuditEvent(r.Context(), UpdatePolicyAction, email, getClientIP(r), "User updated policy: "+policyName)

--- a/internal/api/server/api_policies_test.go
+++ b/internal/api/server/api_policies_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
 )
 
 const (
@@ -1155,5 +1157,180 @@ func TestCreatePolicyOnePolicyPerProfile(t *testing.T) {
 
 	if statusCode != http.StatusConflict {
 		t.Fatalf("Expected status %d for 1-policy-per-profile limit, got %d", http.StatusConflict, statusCode)
+	}
+}
+
+// TestUpdatePolicyCallsUpdateFilters verifies that UpdatePolicy handler
+// calls UpdateFilters when policy rules are updated.
+func TestUpdatePolicyCallsUpdateFilters(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	var calledFilters []struct {
+		policyID  int64
+		direction models.Direction
+		rules     []models.FilterRule
+	}
+
+	fakeUPF := &FakeUPF{
+		calledFilters: &calledFilters,
+	}
+
+	env, err := setupServerWithUPF(dbPath, fakeUPF)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize and login: %s", err)
+	}
+
+	// Create the data network first.
+	_, _, err = createDataNetwork(env.Server.URL, client, token, &CreateDataNetworkParams{
+		Name: DataNetworkName, MTU: MTU, IPPool: IPPool, DNS: DNS,
+	})
+	if err != nil {
+		t.Fatalf("couldn't create data network: %s", err)
+	}
+
+	// Create a profile for the policy.
+	_, _, err = createProfile(env.Server.URL, client, token, &CreateProfileParams{
+		Name: "update-rules-profile", UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "100 Mbps",
+	})
+	if err != nil {
+		t.Fatalf("couldn't create profile: %s", err)
+	}
+
+	// Create a policy without rules initially.
+	_, _, err = createPolicy(env.Server.URL, client, token, &CreatePolicyParams{
+		Name:                "filter-test-policy",
+		ProfileName:         "update-rules-profile",
+		SliceName:           DefaultSliceName,
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkName:     DataNetworkName,
+	})
+	if err != nil {
+		t.Fatalf("couldn't create policy: %s", err)
+	}
+
+	// Update the policy with rules.
+	cidr := "10.0.0.0/8"
+	uplinkRule := PolicyRule{
+		Description:  "Allow traffic to 10.0.0.0/8",
+		RemotePrefix: &cidr,
+		Protocol:     6,
+		PortLow:      443,
+		PortHigh:     443,
+		Action:       "allow",
+	}
+
+	downlinkRule := PolicyRule{
+		Description:  "Allow traffic from 10.0.0.0/8",
+		RemotePrefix: &cidr,
+		Protocol:     6,
+		PortLow:      443,
+		PortHigh:     443,
+		Action:       "deny",
+	}
+
+	statusCode, updateResp, err := editPolicy(env.Server.URL, client, "filter-test-policy", token, &UpdatePolicyParams{
+		ProfileName:         "update-rules-profile",
+		SliceName:           DefaultSliceName,
+		SessionAmbrUplink:   "200 Mbps",
+		SessionAmbrDownlink: "200 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkName:     DataNetworkName,
+		Rules: &PolicyRules{
+			Uplink:   []PolicyRule{uplinkRule},
+			Downlink: []PolicyRule{downlinkRule},
+		},
+	})
+	if err != nil {
+		t.Fatalf("couldn't update policy: %s", err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got %d (error: %s)", http.StatusOK, statusCode, updateResp.Error)
+	}
+
+	// Verify UpdateFilters was called for both uplink and downlink
+	if len(*fakeUPF.calledFilters) != 2 {
+		t.Fatalf("expected UpdateFilters to be called 2 times (uplink + downlink), got %d calls", len(*fakeUPF.calledFilters))
+	}
+
+	// Verify uplink call
+	foundUplink := false
+
+	for _, call := range *fakeUPF.calledFilters {
+		if call.direction == models.DirectionUplink {
+			foundUplink = true
+
+			if len(call.rules) != 1 {
+				t.Fatalf("expected uplink rules count 1, got %d", len(call.rules))
+			}
+
+			if call.rules[0].Action != models.Allow {
+				t.Fatalf("expected uplink action Allow, got %v", call.rules[0].Action)
+			}
+		}
+	}
+
+	if !foundUplink {
+		t.Fatal("expected UpdateFilters call for uplink direction")
+	}
+
+	// Verify downlink call
+	foundDownlink := false
+
+	for _, call := range *fakeUPF.calledFilters {
+		if call.direction == models.DirectionDownlink {
+			foundDownlink = true
+
+			if len(call.rules) != 1 {
+				t.Fatalf("expected downlink rules count 1, got %d", len(call.rules))
+			}
+
+			if call.rules[0].Action != models.Deny {
+				t.Fatalf("expected downlink action Deny, got %v", call.rules[0].Action)
+			}
+		}
+	}
+
+	if !foundDownlink {
+		t.Fatal("expected UpdateFilters call for downlink direction")
+	}
+
+	// Verify the rules were updated in the database.
+	_, getResp, err := getPolicy(env.Server.URL, client, token, "filter-test-policy")
+	if err != nil {
+		t.Fatalf("couldn't get policy after update: %s", err)
+	}
+
+	if getResp.Result.Rules == nil {
+		t.Fatal("expected rules to exist after update, got none")
+	}
+
+	if len(getResp.Result.Rules.Uplink) != 1 {
+		t.Fatalf("expected 1 uplink rule, got %d", len(getResp.Result.Rules.Uplink))
+	}
+
+	if len(getResp.Result.Rules.Downlink) != 1 {
+		t.Fatalf("expected 1 downlink rule, got %d", len(getResp.Result.Rules.Downlink))
+	}
+
+	if getResp.Result.Rules.Uplink[0].Action != "allow" {
+		t.Fatalf("expected uplink rule action 'allow', got %q", getResp.Result.Rules.Uplink[0].Action)
+	}
+
+	if getResp.Result.Rules.Downlink[0].Action != "deny" {
+		t.Fatalf("expected downlink rule action 'deny', got %q", getResp.Result.Rules.Downlink[0].Action)
 	}
 }

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/kernel"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/smf"
 	"go.uber.org/zap"
 )
@@ -20,6 +21,7 @@ type UPFUpdater interface {
 	ReloadNAT(natEnabled bool) error
 	ReloadFlowAccounting(flowAccountingEnabled bool) error
 	UpdateAdvertisedN3Address(net.IP)
+	UpdateFilters(policyID int64, direction models.Direction, rules []models.FilterRule) error
 }
 
 func NewHandler(dbInstance *db.Database, cfg config.Config, upf UPFUpdater, kernel kernel.Kernel, jwtSecret *JWTSecret, secureCookie bool, embedFS fs.FS, sessions smf.SessionQuerier, amfInstance *amf.AMF, bgpService *bgp.BGPService, registerExtraRoutes func(mux *http.ServeMux)) http.Handler {
@@ -81,7 +83,7 @@ func NewHandler(dbInstance *db.Database, cfg config.Config, upf UPFUpdater, kern
 	// Policies (Authenticated)
 	mux.HandleFunc("GET /api/v1/policies", Authenticate(jwtSecret, dbInstance, Authorize(PermListPolicies, ListPolicies(dbInstance))).ServeHTTP)
 	mux.HandleFunc("POST /api/v1/policies", Authenticate(jwtSecret, dbInstance, Authorize(PermCreatePolicy, CreatePolicy(dbInstance))).ServeHTTP)
-	mux.HandleFunc("PUT /api/v1/policies/{name}", Authenticate(jwtSecret, dbInstance, Authorize(PermUpdatePolicy, UpdatePolicy(dbInstance))).ServeHTTP)
+	mux.HandleFunc("PUT /api/v1/policies/{name}", Authenticate(jwtSecret, dbInstance, Authorize(PermUpdatePolicy, UpdatePolicy(dbInstance, upf))).ServeHTTP)
 	mux.HandleFunc("GET /api/v1/policies/{name}", Authenticate(jwtSecret, dbInstance, Authorize(PermReadPolicy, GetPolicy(dbInstance))).ServeHTTP)
 	mux.HandleFunc("DELETE /api/v1/policies/{name}", Authenticate(jwtSecret, dbInstance, Authorize(PermDeletePolicy, DeletePolicy(dbInstance))).ServeHTTP)
 

--- a/internal/models/filter_rule.go
+++ b/internal/models/filter_rule.go
@@ -1,0 +1,66 @@
+package models
+
+import "fmt"
+
+// Direction represents the traffic direction for a network rule or filter.
+type Direction int
+
+const (
+	DirectionUplink   Direction = iota // "uplink": traffic from UE to network
+	DirectionDownlink                  // "downlink": traffic from network to UE
+)
+
+func (d Direction) String() string {
+	switch d {
+	case DirectionUplink:
+		return "uplink"
+	case DirectionDownlink:
+		return "downlink"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseDirection converts a direction string to a Direction value.
+// Returns an error if the string is not a valid direction.
+func ParseDirection(s string) (Direction, error) {
+	switch s {
+	case "uplink":
+		return DirectionUplink, nil
+	case "downlink":
+		return DirectionDownlink, nil
+	default:
+		return 0, fmt.Errorf("unknown direction %q: must be \"uplink\" or \"downlink\"", s)
+	}
+}
+
+type Action int
+
+const (
+	Allow Action = iota
+	Deny
+)
+
+func (a Action) String() string {
+	if a == Allow {
+		return "allow"
+	}
+
+	return "deny"
+}
+
+func ActionFromString(s string) Action {
+	if s == "deny" {
+		return Deny
+	}
+
+	return Allow
+}
+
+type FilterRule struct {
+	RemotePrefix string // CIDR notation; "" = any
+	Protocol     int32  // 0 = any (maps to SdfProtoAny)
+	PortLow      int32
+	PortHigh     int32
+	Action       Action
+}

--- a/internal/pfcp_dispatcher/pfcp.go
+++ b/internal/pfcp_dispatcher/pfcp.go
@@ -6,6 +6,7 @@ package pfcp_dispatcher
 import (
 	"context"
 
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/wmnsk/go-pfcp/message"
 )
 
@@ -29,6 +30,9 @@ type UPF interface {
 	HandlePfcpSessionEstablishmentRequest(context.Context, *message.SessionEstablishmentRequest) (*message.SessionEstablishmentResponse, error)
 	HandlePfcpSessionDeletionRequest(context.Context, *message.SessionDeletionRequest) (*message.SessionDeletionResponse, error)
 	HandlePfcpSessionModificationRequest(context.Context, *message.SessionModificationRequest) (*message.SessionModificationResponse, error)
+
+	UpdateFilters(context.Context, int64, models.Direction, []models.FilterRule) error
+	GetFilterIndex(context.Context, int64, models.Direction) (uint32, error)
 }
 
 type SMF interface {

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -30,6 +30,16 @@ func netipToIP(addr netip.Addr) net.IP {
 	return net.IP(b[:])
 }
 
+func hasRulesForDirection(rules []*ResolvedNetworkRule, dir models.Direction) bool {
+	for _, v := range rules {
+		if v.Direction == dir {
+			return true
+		}
+	}
+
+	return false
+}
+
 // CreateSmContext creates a new PDU session. It decodes the NAS message, retrieves the
 // subscriber policy and DNN info, allocates an IP, creates the data path, sends
 // PFCP rules to the UPF, and delivers the accept/reject to the AMF.
@@ -349,45 +359,31 @@ func (s *SMF) sendPFCPRules(ctx context.Context, smContext *SMContext) error {
 	filterIndexByPDRID := make(map[uint16]uint32)
 
 	if smContext.PFCPContext.RemoteSEID == 0 && smContext.PolicyData != nil {
-		uplinkRules := filterByDirection(smContext.PolicyData.NetworkRules, DirectionUplink)
-		if len(uplinkRules) > 0 {
-			uplinkResp, err := s.upf.UpdateFilters(ctx, &FilterUpdateRequest{
-				PolicyID:  smContext.PolicyData.PolicyID,
-				Direction: DirectionUplink,
-				Rules:     uplinkRules,
-			})
-			if err != nil {
+		if hasRulesForDirection(smContext.PolicyData.NetworkRules, models.DirectionUplink) {
+			idx, err := s.upf.GetFilterIndex(ctx, smContext.PolicyData.PolicyID, models.DirectionUplink)
+			if err == nil {
+				if dataPath.UpLinkTunnel != nil && dataPath.UpLinkTunnel.PDR != nil {
+					dataPath.UpLinkTunnel.PDR.FilterMapIndex = idx
+					filterIndexByPDRID[dataPath.UpLinkTunnel.PDR.PDRID] = idx
+				}
+			} else {
 				span.RecordError(err)
-				span.SetStatus(codes.Error, "failed to update uplink filters")
-
-				return fmt.Errorf("failed to update uplink filters: %v", err)
-			}
-
-			smContext.UplinkFilterIndex = uplinkResp.FilterMapIndex
-			if dataPath.UpLinkTunnel != nil && dataPath.UpLinkTunnel.PDR != nil {
-				dataPath.UpLinkTunnel.PDR.FilterMapIndex = uplinkResp.FilterMapIndex
-				filterIndexByPDRID[dataPath.UpLinkTunnel.PDR.PDRID] = uplinkResp.FilterMapIndex
+				span.SetStatus(codes.Error, "failed to get uplink filter index")
+				logger.WithTrace(ctx, logger.SmfLog).Warn("Failed to get uplink filter index", zap.Error(err))
 			}
 		}
 
-		downlinkRules := filterByDirection(smContext.PolicyData.NetworkRules, DirectionDownlink)
-		if len(downlinkRules) > 0 {
-			downlinkResp, err := s.upf.UpdateFilters(ctx, &FilterUpdateRequest{
-				PolicyID:  smContext.PolicyData.PolicyID,
-				Direction: DirectionDownlink,
-				Rules:     downlinkRules,
-			})
-			if err != nil {
+		if hasRulesForDirection(smContext.PolicyData.NetworkRules, models.DirectionDownlink) {
+			idx, err := s.upf.GetFilterIndex(ctx, smContext.PolicyData.PolicyID, models.DirectionDownlink)
+			if err == nil {
+				if dataPath.DownLinkTunnel != nil && dataPath.DownLinkTunnel.PDR != nil {
+					dataPath.DownLinkTunnel.PDR.FilterMapIndex = idx
+					filterIndexByPDRID[dataPath.DownLinkTunnel.PDR.PDRID] = idx
+				}
+			} else {
 				span.RecordError(err)
-				span.SetStatus(codes.Error, "failed to update downlink filters")
-
-				return fmt.Errorf("failed to update downlink filters: %v", err)
-			}
-
-			smContext.DownlinkFilterIndex = downlinkResp.FilterMapIndex
-			if dataPath.DownLinkTunnel != nil && dataPath.DownLinkTunnel.PDR != nil {
-				dataPath.DownLinkTunnel.PDR.FilterMapIndex = downlinkResp.FilterMapIndex
-				filterIndexByPDRID[dataPath.DownLinkTunnel.PDR.PDRID] = downlinkResp.FilterMapIndex
+				span.SetStatus(codes.Error, "failed to get downlink filter index")
+				logger.WithTrace(ctx, logger.SmfLog).Debug("Failed to get downlink filter index", zap.Error(err))
 			}
 		}
 	}

--- a/internal/smf/pfcp_handler.go
+++ b/internal/smf/pfcp_handler.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/pfcp_dispatcher"
 	"github.com/ellanetworks/core/internal/smf/ngap"
 	"github.com/wmnsk/go-pfcp/ie"
@@ -129,7 +130,7 @@ func (s *SMF) SendFlowReport(ctx context.Context, req *pfcp_dispatcher.FlowRepor
 		EndTime:         req.EndTime,
 	}
 
-	dir, err := ParseDirection(req.Direction)
+	dir, err := models.ParseDirection(req.Direction)
 	if err != nil {
 		return fmt.Errorf("invalid direction in flow report: %w", err)
 	}

--- a/internal/smf/policy_fetch_test.go
+++ b/internal/smf/policy_fetch_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
-	"github.com/ellanetworks/core/internal/smf"
 	"github.com/ellanetworks/core/pkg/runtime"
 )
 
@@ -156,7 +155,7 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 		if r.Description == "rule-1" {
 			rule1Found = true
 
-			if r.Direction != smf.DirectionUplink {
+			if r.Direction != models.DirectionUplink {
 				t.Fatalf("rule-1 expected direction uplink, got %s", r.Direction)
 			}
 
@@ -188,7 +187,7 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 		if r.Description == "rule-2" {
 			rule2Found = true
 
-			if r.Direction != smf.DirectionDownlink {
+			if r.Direction != models.DirectionDownlink {
 				t.Fatalf("rule-2 expected direction downlink, got %s", r.Direction)
 			}
 

--- a/internal/smf/release.go
+++ b/internal/smf/release.go
@@ -67,20 +67,6 @@ func (s *SMF) releaseTunnel(ctx context.Context, smContext *SMContext) error {
 
 	smContext.Tunnel.DataPath.DeactivateTunnelAndPDR(s)
 
-	if smContext.UplinkFilterIndex != 0 {
-		err := s.upf.ReleaseFilter(ctx, smContext.UplinkFilterIndex)
-		if err != nil {
-			logger.SmfLog.Warn("couldn't release uplink filters", zap.Uint32("UplinkFilterIndex", smContext.UplinkFilterIndex), zap.Error(err))
-		}
-	}
-
-	if smContext.DownlinkFilterIndex != 0 {
-		err := s.upf.ReleaseFilter(ctx, smContext.DownlinkFilterIndex)
-		if err != nil {
-			logger.SmfLog.Warn("couldn't release downlink filters", zap.Uint32("DownlinkFilterIndex", smContext.DownlinkFilterIndex), zap.Error(err))
-		}
-	}
-
 	if smContext.PFCPContext == nil {
 		smContext.Tunnel = nil
 		return nil

--- a/internal/smf/sm_context.go
+++ b/internal/smf/sm_context.go
@@ -40,8 +40,6 @@ type SMContext struct {
 	PDUSessionID                   uint8
 	PDUAddress                     net.IP
 	PDUSessionReleaseDueToDupPduID bool
-	UplinkFilterIndex              uint32
-	DownlinkFilterIndex            uint32
 }
 
 func CanonicalName(identifier etsi.SUPI, pduSessID uint8) string {

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -61,8 +61,9 @@ type UPFClient interface {
 	EstablishSession(ctx context.Context, req *PFCPEstablishmentRequest) (*PFCPEstablishmentResponse, error)
 	ModifySession(ctx context.Context, req *PFCPModificationRequest) error
 	DeleteSession(ctx context.Context, localSEID, remoteSEID uint64) error
-	UpdateFilters(ctx context.Context, req *FilterUpdateRequest) (*FilterUpdateResponse, error)
-	ReleaseFilter(ctx context.Context, index uint32) error
+
+	UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error
+	GetFilterIndex(ctx context.Context, policyID int64, direction models.Direction) (uint32, error)
 }
 
 // BGPAnnouncer is the interface used by the SMF to announce/withdraw subscriber routes.
@@ -86,62 +87,17 @@ type AMFCallback interface {
 	N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error
 }
 
-// Direction represents the traffic direction for a network rule or filter.
-type Direction int
-
-const (
-	DirectionUplink   Direction = iota // "uplink": traffic from UE to network
-	DirectionDownlink                  // "downlink": traffic from network to UE
-)
-
-// String returns the canonical string representation of a Direction.
-func (d Direction) String() string {
-	switch d {
-	case DirectionUplink:
-		return "uplink"
-	case DirectionDownlink:
-		return "downlink"
-	default:
-		return "unknown"
-	}
-}
-
-// ParseDirection converts a direction string to a Direction value.
-// Returns an error if the string is not a valid direction.
-func ParseDirection(s string) (Direction, error) {
-	switch s {
-	case "uplink":
-		return DirectionUplink, nil
-	case "downlink":
-		return DirectionDownlink, nil
-	default:
-		return 0, fmt.Errorf("unknown direction %q: must be \"uplink\" or \"downlink\"", s)
-	}
-}
-
 // ResolvedNetworkRule represents a network rule attached to a policy for PDI/SDF filtering.
 type ResolvedNetworkRule struct {
 	Description  string
 	PolicyID     int64
-	Direction    Direction
+	Direction    models.Direction
 	RemotePrefix *string
 	Protocol     int32
 	PortLow      int32
 	PortHigh     int32
 	Action       string
 	Precedence   int32
-}
-
-// FilterUpdateRequest contains the parameters for updating filters on the UPF.
-type FilterUpdateRequest struct {
-	PolicyID  int64
-	Direction Direction
-	Rules     []*ResolvedNetworkRule
-}
-
-// FilterUpdateResponse contains the result of a filter update.
-type FilterUpdateResponse struct {
-	FilterMapIndex uint32
 }
 
 // Policy contains the QoS parameters and network rules the SMF needs for a session.
@@ -170,7 +126,7 @@ type FlowReport struct {
 	Bytes           uint64
 	StartTime       string
 	EndTime         string
-	Direction       Direction
+	Direction       models.Direction
 }
 
 // PFCPEstablishmentRequest contains the parameters for creating a PFCP session.
@@ -494,16 +450,4 @@ func (s *SMF) RemoveQER(qer *QER) {
 // RemoveURR frees a URR ID.
 func (s *SMF) RemoveURR(urr *URR) {
 	s.urrIDs.FreeID(int64(urr.URRID))
-}
-
-func filterByDirection(rules []*ResolvedNetworkRule, direction Direction) []*ResolvedNetworkRule {
-	out := make([]*ResolvedNetworkRule, 0)
-
-	for _, r := range rules {
-		if r.Direction == direction {
-			out = append(out, r)
-		}
-	}
-
-	return out
 }

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -133,18 +133,12 @@ func (f *fakeUPF) DeleteSession(_ context.Context, localSEID, remoteSEID uint64)
 	return f.err
 }
 
-func (f *fakeUPF) UpdateFilters(_ context.Context, req *smf.FilterUpdateRequest) (*smf.FilterUpdateResponse, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	return &smf.FilterUpdateResponse{FilterMapIndex: 0}, f.err
+func (f *fakeUPF) UpdateFilters(_ context.Context, _ int64, _ models.Direction, _ []models.FilterRule) error {
+	return nil
 }
 
-func (f *fakeUPF) ReleaseFilter(_ context.Context, index uint32) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	return f.err
+func (f *fakeUPF) GetFilterIndex(_ context.Context, _ int64, _ models.Direction) (uint32, error) {
+	return 0, nil
 }
 
 type fakeAMF struct {

--- a/internal/upf/core/pfcp_connection.go
+++ b/internal/upf/core/pfcp_connection.go
@@ -2,20 +2,20 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"net"
 	"sync"
 
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/upf/ebpf"
+	"go.uber.org/zap"
 )
 
 var connection *PfcpConnection
-
-type filterEntry struct {
-	index    uint32
-	refcount int
-}
 
 type PfcpConnection struct {
 	mu sync.Mutex
@@ -29,7 +29,7 @@ type PfcpConnection struct {
 	FteIDResourceManager *FteIDResourceManager
 	SdfIndexAllocator    *SdfIndexAllocator
 	filterMu             sync.Mutex
-	filtersByKey         map[string]*filterEntry
+	filtersByKey         map[string]uint32
 }
 
 func (pc *PfcpConnection) ListSessions() map[uint64]*Session {
@@ -68,11 +68,89 @@ func (pc *PfcpConnection) AddSession(seid uint64, session *Session) {
 	pc.sessions[seid] = session
 }
 
-func (pc *PfcpConnection) SetBPFObjects(bpfObjects *ebpf.BpfObjects) {
+func (pc *PfcpConnection) SetBPFObjects(bpfObjects *ebpf.BpfObjects, dbInstance *db.Database) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 
 	pc.BpfObjects = bpfObjects
+
+	if dbInstance != nil {
+		if err := pc.InitializeFiltersFromDB(dbInstance); err != nil {
+			logger.WithTrace(context.Background(), logger.DBLog).Warn(
+				"failed to initialize filters from DB",
+				zap.Error(err),
+			)
+		}
+	}
+}
+
+func (pc *PfcpConnection) InitializeFiltersFromDB(dbInstance *db.Database) error {
+	ctx := context.Background()
+
+	policies, _, err := dbInstance.ListPoliciesPage(ctx, 1, 1000)
+	if err != nil {
+		logger.WithTrace(ctx, logger.DBLog).Error("failed to list policies", zap.Error(err))
+		return nil
+	}
+
+	for _, policy := range policies {
+		rules, err := dbInstance.ListRulesForPolicy(ctx, int64(policy.ID))
+		if err != nil {
+			logger.WithTrace(ctx, logger.DBLog).Error(
+				"failed to list rules for policy",
+				zap.Int("policyID", policy.ID),
+				zap.Error(err),
+			)
+
+			continue
+		}
+
+		uplinkRules := make([]models.FilterRule, 0)
+		downlinkRules := make([]models.FilterRule, 0)
+
+		for _, rule := range rules {
+			filterRule := models.FilterRule{
+				RemotePrefix: "",
+				Protocol:     rule.Protocol,
+				PortLow:      rule.PortLow,
+				PortHigh:     rule.PortHigh,
+				Action:       models.ActionFromString(rule.Action),
+			}
+
+			if rule.RemotePrefix != nil {
+				filterRule.RemotePrefix = *rule.RemotePrefix
+			}
+
+			switch rule.Direction {
+			case "uplink":
+				uplinkRules = append(uplinkRules, filterRule)
+			case "downlink":
+				downlinkRules = append(downlinkRules, filterRule)
+			}
+		}
+
+		if len(uplinkRules) > 0 {
+			if err := UpdateFilters(pc, int64(policy.ID), "uplink", uplinkRules); err != nil {
+				logger.WithTrace(ctx, logger.DBLog).Error(
+					"failed to update uplink filters",
+					zap.Int("policyID", policy.ID),
+					zap.Error(err),
+				)
+			}
+		}
+
+		if len(downlinkRules) > 0 {
+			if err := UpdateFilters(pc, int64(policy.ID), "downlink", downlinkRules); err != nil {
+				logger.WithTrace(ctx, logger.DBLog).Error(
+					"failed to update downlink filters",
+					zap.Int("policyID", policy.ID),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (pc *PfcpConnection) GetAdvertisedN3Address() net.IP {
@@ -114,7 +192,7 @@ func CreatePfcpConnection(addr string, nodeID string, n3Ip string, advertisedN3I
 		BpfObjects:           bpfObjects,
 		FteIDResourceManager: resourceManager,
 		SdfIndexAllocator:    NewSdfIndexAllocator(ebpf.MaxSdfFilters),
-		filtersByKey:         make(map[string]*filterEntry),
+		filtersByKey:         make(map[string]uint32),
 	}
 
 	return connection, nil

--- a/internal/upf/core/pfcp_session_handlers.go
+++ b/internal/upf/core/pfcp_session_handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/kernel"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/upf/ebpf"
 	"github.com/wmnsk/go-pfcp/ie"
 	"github.com/wmnsk/go-pfcp/message"
@@ -39,6 +40,29 @@ func (u UpfPfcpHandler) HandlePfcpSessionDeletionRequest(ctx context.Context, ms
 
 func (u UpfPfcpHandler) HandlePfcpSessionModificationRequest(ctx context.Context, msg *message.SessionModificationRequest) (*message.SessionModificationResponse, error) {
 	return HandlePfcpSessionModificationRequest(ctx, msg, nil)
+}
+
+func (u UpfPfcpHandler) UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
+	conn := GetConnection()
+	if conn == nil {
+		return fmt.Errorf("no PFCP connection available")
+	}
+
+	return UpdateFilters(conn, policyID, direction.String(), rules)
+}
+
+func (u UpfPfcpHandler) GetFilterIndex(ctx context.Context, policyID int64, direction models.Direction) (uint32, error) {
+	conn := GetConnection()
+	if conn == nil {
+		return 0, fmt.Errorf("no PFCP connection available")
+	}
+
+	idx, ok := GetFilterIndex(policyID, direction.String())
+	if !ok {
+		return 0, fmt.Errorf("filter not found for policy %d, direction %s", policyID, direction.String())
+	}
+
+	return idx, nil
 }
 
 func HandlePfcpSessionEstablishmentRequest(ctx context.Context, msg *message.SessionEstablishmentRequest, filterIndexByPDRID map[uint16]uint32) (*message.SessionEstablishmentResponse, error) {

--- a/internal/upf/core/sdf_handlers.go
+++ b/internal/upf/core/sdf_handlers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/ellanetworks/core/internal/smf"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/upf/ebpf"
 )
 
@@ -25,34 +25,45 @@ func StringToAction(a string) Action {
 	return Allow
 }
 
-// UpdateFilterRule is a DTO carrying the fields needed to build a BPF sdf_rule.
-type UpdateFilterRule struct {
-	RemotePrefix string // CIDR notation; "" = any
-	Protocol     int32  // 0 = any (maps to SdfProtoAny)
-	PortLow      int32
-	PortHigh     int32
-	Action       Action
-}
+// updateFiltersRule converts a FilterRule to an internal Action for BPF operations
+func updateFiltersRule(rule models.FilterRule) ebpf.SdfRule {
+	sdfRule := ebpf.SdfRule{
+		Protocol: ebpf.SdfProtoAny,
+		Action:   ebpf.SdfActionAllow,
+	}
+	if rule.Protocol != 0 {
+		sdfRule.Protocol = uint8(rule.Protocol)
+	}
 
-// UpdateFiltersRequest is the input to UpdateFilters.
-type UpdateFiltersRequest struct {
-	PolicyID  int64
-	Direction smf.Direction
-	Rules     []UpdateFilterRule
-}
+	if rule.Action == models.Deny {
+		sdfRule.Action = ebpf.SdfActionDeny
+	}
 
-// UpdateFiltersResponse is the output of UpdateFilters.
-type UpdateFiltersResponse struct {
-	FilterMapIndex uint32
+	if rule.RemotePrefix != "" {
+		_, ipnet, err := net.ParseCIDR(rule.RemotePrefix)
+		if err == nil {
+			sdfRule.RemoteIP = binary.BigEndian.Uint32(ipnet.IP.To4())
+			sdfRule.RemoteMask = binary.BigEndian.Uint32(ipnet.Mask)
+		}
+	}
+
+	sdfRule.PortLow = uint16(rule.PortLow)
+	sdfRule.PortHigh = uint16(rule.PortHigh)
+
+	return sdfRule
 }
 
 // UpdateFilters allocates or refreshes a sdf_filters BPF array slot for the
 // given (PolicyID, Direction) pair. It is idempotent: concurrent calls for the
-// same key return the same index and update the BPF slot in place.
-func UpdateFilters(conn *PfcpConnection, req UpdateFiltersRequest) (*UpdateFiltersResponse, error) {
-	key := fmt.Sprintf("%d:%s", req.PolicyID, req.Direction)
+// same key update the BPF slot in place.
+func UpdateFilters(conn *PfcpConnection, policyID int64, direction string, rules []models.FilterRule) error {
+	key := fmt.Sprintf("%d:%s", policyID, direction)
 
-	sdfRules := resolveSdfRules(req.Rules)
+	sdfRules := make([]ebpf.SdfRule, 0, len(rules))
+	for _, r := range rules {
+		sdfRules = append(sdfRules, updateFiltersRule(r))
+	}
+
 	list := ebpf.SdfFilterList{NumRules: uint8(len(sdfRules))}
 	copy(list.Rules[:len(sdfRules)], sdfRules)
 
@@ -60,90 +71,44 @@ func UpdateFilters(conn *PfcpConnection, req UpdateFiltersRequest) (*UpdateFilte
 	defer conn.filterMu.Unlock()
 
 	if entry, ok := conn.filtersByKey[key]; ok {
-		// Update BPF slot in place; increment refcount.
-		if err := conn.BpfObjects.PutSdfFilterList(entry.index, list); err != nil {
-			return nil, fmt.Errorf("update sdf filter list: %w", err)
+		// Update BPF slot in place (skip if BPF objects not available - test mode)
+		if conn.BpfObjects != nil {
+			if err := conn.BpfObjects.PutSdfFilterList(entry, list); err != nil {
+				return fmt.Errorf("update sdf filter list: %w", err)
+			}
 		}
 
-		entry.refcount++
-
-		return &UpdateFiltersResponse{FilterMapIndex: entry.index}, nil
+		return nil
 	}
 
-	// Allocate a new slot.
 	idx, err := conn.SdfIndexAllocator.Allocate()
 	if err != nil {
-		return nil, fmt.Errorf("allocate sdf filter index: %w", err)
+		return fmt.Errorf("allocate sdf filter index: %w", err)
 	}
 
 	if err := conn.BpfObjects.PutSdfFilterList(idx, list); err != nil {
 		conn.SdfIndexAllocator.Release(idx)
-		return nil, fmt.Errorf("write sdf filter list: %w", err)
+		return fmt.Errorf("write sdf filter list: %w", err)
 	}
 
-	conn.filtersByKey[key] = &filterEntry{index: idx, refcount: 1}
+	conn.filtersByKey[key] = idx
 
-	return &UpdateFiltersResponse{FilterMapIndex: idx}, nil
+	return nil
 }
 
-// ReleaseFilter decrements the refcount for the given index and frees the
-// BPF slot when it reaches zero.
-func ReleaseFilter(conn *PfcpConnection, index uint32) error {
-	if index == ebpf.NoFilterIndex {
-		return nil
+// GetFilterIndex retrieves the BPF sdf_filters map index for a given (PolicyID, Direction) pair.
+// Returns the index and true if found, or 0 and false if not allocated.
+func GetFilterIndex(policyID int64, direction string) (uint32, bool) {
+	conn := GetConnection()
+	if conn == nil {
+		return 0, false
 	}
 
 	conn.filterMu.Lock()
 	defer conn.filterMu.Unlock()
 
-	for key, entry := range conn.filtersByKey {
-		if entry.index != index {
-			continue
-		}
+	key := fmt.Sprintf("%d:%s", policyID, direction)
+	idx, ok := conn.filtersByKey[key]
 
-		entry.refcount--
-		if entry.refcount <= 0 {
-			if err := conn.BpfObjects.DeleteSdfFilterList(index); err != nil {
-				return fmt.Errorf("zero sdf filter list: %w", err)
-			}
-
-			conn.SdfIndexAllocator.Release(index)
-			delete(conn.filtersByKey, key)
-		}
-
-		return nil
-	}
-
-	return nil // index not found; no-op
-}
-
-func resolveSdfRules(rules []UpdateFilterRule) []ebpf.SdfRule {
-	out := make([]ebpf.SdfRule, 0, len(rules))
-	for _, r := range rules {
-		rule := ebpf.SdfRule{
-			Protocol: ebpf.SdfProtoAny,
-			Action:   ebpf.SdfActionAllow,
-		}
-		if r.Protocol != 0 {
-			rule.Protocol = uint8(r.Protocol)
-		}
-
-		if r.Action == Deny {
-			rule.Action = ebpf.SdfActionDeny
-		}
-
-		if r.RemotePrefix != "" {
-			_, ipnet, err := net.ParseCIDR(r.RemotePrefix)
-			if err == nil {
-				rule.RemoteIP = binary.BigEndian.Uint32(ipnet.IP.To4())
-				rule.RemoteMask = binary.BigEndian.Uint32(ipnet.Mask)
-			}
-		}
-
-		rule.PortLow = uint16(r.PortLow)
-		rule.PortHigh = uint16(r.PortHigh)
-		out = append(out, rule)
-	}
-
-	return out
+	return idx, ok
 }

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ellanetworks/core/internal/config"
 	"github.com/ellanetworks/core/internal/kernel"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/pfcp_dispatcher"
 	"github.com/ellanetworks/core/internal/upf/core"
 	"github.com/ellanetworks/core/internal/upf/ebpf"
@@ -224,6 +225,29 @@ func (u *UPF) Close(ctx context.Context) {
 
 func (u *UPF) UpdateAdvertisedN3Address(newN3Addr net.IP) {
 	u.pfcpConn.SetAdvertisedN3Address(newN3Addr)
+}
+
+func (u *UPF) UpdateFilters(policyID int64, direction models.Direction, rules []models.FilterRule) error {
+	conn := core.GetConnection()
+	if conn == nil {
+		return fmt.Errorf("no PFCP connection available")
+	}
+
+	return core.UpdateFilters(conn, policyID, direction.String(), rules)
+}
+
+func (u *UPF) GetFilterIndex(policyID int64, direction models.Direction) (uint32, error) {
+	conn := core.GetConnection()
+	if conn == nil {
+		return 0, fmt.Errorf("no PFCP connection available")
+	}
+
+	idx, ok := core.GetFilterIndex(policyID, direction.String())
+	if !ok {
+		return 0, fmt.Errorf("filter not found for policy %d, direction %s", policyID, direction.String())
+	}
+
+	return idx, nil
 }
 
 func (u *UPF) ReloadNAT(masquerade bool) error {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -212,6 +212,12 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		return fmt.Errorf("couldn't start UPF: %w", err)
 	}
 
+	// Initialize SDF filters from database
+	conn := upf_pfcp.GetConnection()
+	if conn != nil && dbInstance != nil {
+		conn.SetBPFObjects(conn.BpfObjects, dbInstance)
+	}
+
 	// Wire supportbundle BPF dumper to dump live BPF maps from the UPF process.
 	// The closure captures the live BPF objects via the PFCP connection stored
 	// in the UPF core package. If the UPF hasn't initialized BPF objects, the

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -180,7 +180,7 @@ func (a *smfDBAdapter) GetSessionPolicy(ctx context.Context, imsi string, snssai
 
 	resolvedRules := make([]*smf.ResolvedNetworkRule, len(dbRules))
 	for i, dbRule := range dbRules {
-		dir, err := smf.ParseDirection(dbRule.Direction)
+		dir, err := models.ParseDirection(dbRule.Direction)
 		if err != nil {
 			return nil, fmt.Errorf("invalid direction for rule %d: %w", dbRule.ID, err)
 		}
@@ -374,40 +374,12 @@ func (a *smfUPFAdapter) DeleteSession(ctx context.Context, localSEID, remoteSEID
 	return nil
 }
 
-func (a *smfUPFAdapter) UpdateFilters(ctx context.Context, req *smf.FilterUpdateRequest) (*smf.FilterUpdateResponse, error) {
-	rules := make([]upf_pfcp.UpdateFilterRule, 0, len(req.Rules))
-	for _, r := range req.Rules {
-		remote := ""
-		if r.RemotePrefix != nil {
-			remote = *r.RemotePrefix
-		}
-
-		rules = append(rules, upf_pfcp.UpdateFilterRule{
-			RemotePrefix: remote,
-			Protocol:     r.Protocol,
-			PortLow:      r.PortLow,
-			PortHigh:     r.PortHigh,
-			Action:       upf_pfcp.StringToAction(r.Action),
-		})
-	}
-
-	conn := upf_pfcp.GetConnection()
-
-	resp, err := upf_pfcp.UpdateFilters(conn, upf_pfcp.UpdateFiltersRequest{
-		PolicyID:  req.PolicyID,
-		Direction: req.Direction,
-		Rules:     rules,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &smf.FilterUpdateResponse{FilterMapIndex: resp.FilterMapIndex}, nil
+func (a *smfUPFAdapter) UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
+	return a.dispatcher.UPF.UpdateFilters(ctx, policyID, direction, rules)
 }
 
-func (a *smfUPFAdapter) ReleaseFilter(ctx context.Context, index uint32) error {
-	conn := upf_pfcp.GetConnection()
-	return upf_pfcp.ReleaseFilter(conn, index)
+func (a *smfUPFAdapter) GetFilterIndex(ctx context.Context, policyID int64, direction models.Direction) (uint32, error) {
+	return a.dispatcher.UPF.GetFilterIndex(ctx, policyID, direction)
 }
 
 func findFTEID(createdPDRIEs []*ie.IE) (*ie.FTEIDFields, error) {


### PR DESCRIPTION
# Description

This PR refactors the network rules handling introduced in #1189.

The original implementation followed some parts of the 3GPP specs, making loading the rules in the UPF an SMF task linked to session creation and modification. This made any changes to the rules by the user not apply immediately to on-going sessions.

We could fix it one of 2 ways.

1. Leaning more into the 3GPP specs, having the policies update trigger a session update in the SMF
2. Ignore the 3GPP specs and load the rules directly in the UPF

This PR uses option 2. In the case of Ella Core, the whole core network lives in a single binary. The PFCP communication would have increased complexity, and we already have some features like flow accounting that do not use PFCP at all.

With this design, the rules are loaded in the eBPF map at startup, and whenever a change to them is done through the API. When a session is created, the map index for the relevant rule lists are looked up and added to the PDR.

With this PR, rule changes are applied immediately to all sessions using the same policy. 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
