### PR TITLE
chore: replace net.IP with netip.Addr

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/fs"
-	"net"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
@@ -160,30 +160,28 @@ func ReconcileKernelRouting(ctx context.Context, dbInstance *db.Database, kernel
 	}
 
 	for _, route := range expectedRoutes {
-		_, ipNetwork, err := net.ParseCIDR(route.Destination)
+		destPrefix, err := netip.ParsePrefix(route.Destination)
 		if err != nil {
 			return fmt.Errorf("couldn't parse destination: %v", err)
 		}
 
-		ipGateway := net.ParseIP(route.Gateway)
-		if ipGateway == nil || ipGateway.To4() == nil {
+		gwAddr, err := netip.ParseAddr(route.Gateway)
+		if err != nil || !gwAddr.Is4() {
 			return fmt.Errorf("invalid gateway: %v", route.Gateway)
 		}
-
-		ipGateway = ipGateway.To4()
 
 		kernelNetworkInterface, ok := interfaceDBKernelMap[route.Interface]
 		if !ok {
 			return fmt.Errorf("invalid interface: %v", route.Interface)
 		}
 
-		routeExists, err := kernelInt.RouteExists(ipNetwork, ipGateway, route.Metric, kernelNetworkInterface)
+		routeExists, err := kernelInt.RouteExists(destPrefix, gwAddr, route.Metric, kernelNetworkInterface)
 		if err != nil {
 			return fmt.Errorf("couldn't check if route exists: %v", err)
 		}
 
 		if !routeExists {
-			err := kernelInt.CreateRoute(ipNetwork, ipGateway, route.Metric, kernelNetworkInterface)
+			err := kernelInt.CreateRoute(destPrefix, gwAddr, route.Metric, kernelNetworkInterface)
 			if err != nil {
 				return fmt.Errorf("couldn't create route: %v", err)
 			}

--- a/internal/api/server/api_bgp.go
+++ b/internal/api/server/api_bgp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 
 	"github.com/ellanetworks/core/internal/bgp"
@@ -154,7 +155,7 @@ func UpdateBGPSettings(dbInstance *db.Database, bgpService *bgp.BGPService) http
 		}
 
 		if params.RouterID != "" {
-			if net.ParseIP(params.RouterID) == nil {
+			if _, err := netip.ParseAddr(params.RouterID); err != nil {
 				writeError(r.Context(), w, http.StatusBadRequest, "routerID must be a valid IPv4 address or empty", nil, logger.APILog)
 				return
 			}
@@ -398,7 +399,7 @@ func validatePeerParams(address string, remoteAS int, holdTime *int, importPrefi
 		return fmt.Errorf("address is required")
 	}
 
-	if ip := net.ParseIP(address); ip == nil || ip.To4() == nil {
+	if addr, err := netip.ParseAddr(address); err != nil || !addr.Is4() {
 		return fmt.Errorf("address must be a valid IPv4 address")
 	}
 
@@ -426,12 +427,12 @@ func validateImportPrefixes(prefixes []BGPImportPrefix) error {
 	}
 
 	for _, p := range prefixes {
-		_, ipNet, err := net.ParseCIDR(p.Prefix)
+		prefix, err := netip.ParsePrefix(p.Prefix)
 		if err != nil {
 			return fmt.Errorf("invalid prefix %q: must be valid CIDR notation", p.Prefix)
 		}
 
-		prefixLen, _ := ipNet.Mask.Size()
+		prefixLen := prefix.Bits()
 
 		if p.MaxLength < prefixLen || p.MaxLength > 32 {
 			return fmt.Errorf("invalid maxLength %d for prefix %q: must be between %d and 32", p.MaxLength, p.Prefix, prefixLen)
@@ -830,7 +831,7 @@ func buildRejectedPrefixes(ctx context.Context, dbInstance *db.Database, cfg con
 	dataNetworks, err := dbInstance.ListAllDataNetworks(ctx)
 	if err == nil {
 		for _, dn := range dataNetworks {
-			if _, _, parseErr := net.ParseCIDR(dn.IPPool); parseErr == nil {
+			if _, parseErr := netip.ParsePrefix(dn.IPPool); parseErr == nil {
 				filters = append(filters, RejectedPrefix{
 					Prefix:      dn.IPPool,
 					Source:      "data_network",
@@ -840,9 +841,9 @@ func buildRejectedPrefixes(ctx context.Context, dbInstance *db.Database, cfg con
 		}
 	}
 
-	if n3IP := net.ParseIP(cfg.Interfaces.N3.Address); n3IP != nil {
+	if n3Addr, err := netip.ParseAddr(cfg.Interfaces.N3.Address); err == nil {
 		filters = append(filters, RejectedPrefix{
-			Prefix:      n3IP.String() + "/32",
+			Prefix:      n3Addr.String() + "/32",
 			Source:      "interface",
 			Description: "N3 interface address",
 		})

--- a/internal/api/server/api_data_networks.go
+++ b/internal/api/server/api_data_networks.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/netip"
 	"regexp"
@@ -420,12 +419,13 @@ func isDataNetworkNameValid(name string) bool {
 }
 
 func isUeIPPoolValid(ueIPPool string) bool {
-	_, _, err := net.ParseCIDR(ueIPPool)
+	_, err := netip.ParsePrefix(ueIPPool)
 	return err == nil
 }
 
 func isValidDNS(dns string) bool {
-	return net.ParseIP(dns) != nil
+	_, err := netip.ParseAddr(dns)
+	return err == nil
 }
 
 func isValidMTU(mtu int32) bool {
@@ -524,12 +524,13 @@ func rebuildBGPFilter(ctx context.Context, dbInstance *db.Database, cfg config.C
 	}
 
 	uePools := collectUEPools(ctx, dbInstance)
-	filter := bgp.BuildRouteFilter(uePools, net.ParseIP(cfg.Interfaces.N3.Address), cfg.Interfaces.N6.Name)
+	n3Addr, _ := netip.ParseAddr(cfg.Interfaces.N3.Address)
+	filter := bgp.BuildRouteFilter(uePools, n3Addr, cfg.Interfaces.N6.Name)
 	bgpService.UpdateFilter(filter)
 }
 
 // collectUEPools returns the UE IP pool CIDRs from all data networks.
-func collectUEPools(ctx context.Context, dbInstance *db.Database) []*net.IPNet {
+func collectUEPools(ctx context.Context, dbInstance *db.Database) []netip.Prefix {
 	dataNetworks, err := dbInstance.ListAllDataNetworks(ctx)
 	if err != nil {
 		logger.APILog.Warn("failed to list data networks for BGP filter rebuild")
@@ -537,15 +538,15 @@ func collectUEPools(ctx context.Context, dbInstance *db.Database) []*net.IPNet {
 		return nil
 	}
 
-	var pools []*net.IPNet
+	var pools []netip.Prefix
 
 	for _, dn := range dataNetworks {
-		_, network, err := net.ParseCIDR(dn.IPPool)
+		prefix, err := netip.ParsePrefix(dn.IPPool)
 		if err != nil {
 			continue
 		}
 
-		pools = append(pools, network)
+		pools = append(pools, prefix)
 	}
 
 	return pools

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -32,11 +31,11 @@ const (
 
 type FakeKernel struct{}
 
-func (fk FakeKernel) CreateRoute(destination *net.IPNet, gateway net.IP, priority int, networkInterface kernel.NetworkInterface) error {
+func (fk FakeKernel) CreateRoute(destination netip.Prefix, gateway netip.Addr, priority int, networkInterface kernel.NetworkInterface) error {
 	return nil
 }
 
-func (fk FakeKernel) DeleteRoute(destination *net.IPNet, gateway net.IP, priority int, networkInterface kernel.NetworkInterface) error {
+func (fk FakeKernel) DeleteRoute(destination netip.Prefix, gateway netip.Addr, priority int, networkInterface kernel.NetworkInterface) error {
 	return nil
 }
 
@@ -44,7 +43,7 @@ func (fk FakeKernel) InterfaceExists(networkInterface kernel.NetworkInterface) (
 	return true, nil
 }
 
-func (fk FakeKernel) RouteExists(destination *net.IPNet, gateway net.IP, priority int, networkInterface kernel.NetworkInterface) (bool, error) {
+func (fk FakeKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, priority int, networkInterface kernel.NetworkInterface) (bool, error) {
 	return false, nil
 }
 
@@ -56,11 +55,11 @@ func (fk FakeKernel) IsIPForwardingEnabled() (bool, error) {
 	return true, nil
 }
 
-func (fk FakeKernel) ReplaceRoute(destination *net.IPNet, gateway net.IP, priority int, networkInterface kernel.NetworkInterface) error {
+func (fk FakeKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr, priority int, networkInterface kernel.NetworkInterface) error {
 	return nil
 }
 
-func (fk FakeKernel) ListRoutesByPriority(priority int, networkInterface kernel.NetworkInterface) ([]net.IPNet, error) {
+func (fk FakeKernel) ListRoutesByPriority(priority int, networkInterface kernel.NetworkInterface) ([]netip.Prefix, error) {
 	return nil, nil
 }
 

--- a/internal/api/server/api_policies.go
+++ b/internal/api/server/api_policies.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
+	"net/netip"
 	"slices"
 	"strconv"
 	"strings"
@@ -129,7 +129,7 @@ func validateRemotePrefix(prefix *string) error {
 		return nil
 	}
 
-	_, _, err := net.ParseCIDR(*prefix)
+	_, err := netip.ParsePrefix(*prefix)
 	if err != nil {
 		return fmt.Errorf("invalid CIDR: %w", err)
 	}

--- a/internal/api/server/api_routes.go
+++ b/internal/api/server/api_routes.go
@@ -3,8 +3,8 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 
 	"github.com/ellanetworks/core/internal/bgp"
@@ -48,14 +48,14 @@ const (
 
 // isRouteDestinationValid checks if the destination is in valid CIDR notation.
 func isRouteDestinationValid(dest string) bool {
-	_, _, err := net.ParseCIDR(dest)
+	_, err := netip.ParsePrefix(dest)
 	return err == nil
 }
 
 // isRouteGatewayValid checks if the gateway is a valid IP address.
 func isRouteGatewayValid(gateway string) bool {
-	ip := net.ParseIP(gateway)
-	return ip != nil
+	addr, err := netip.ParseAddr(gateway)
+	return err == nil && addr.Is4()
 }
 
 // interfaceDBMap maps the interface string to the db.NetworkInterface enum.
@@ -218,21 +218,19 @@ func CreateRoute(dbInstance *db.Database, kernelInt kernel.Kernel) http.Handler 
 			return
 		}
 
-		_, ipNetwork, err := net.ParseCIDR(createRouteParams.Destination)
+		destPrefix, err := netip.ParsePrefix(createRouteParams.Destination)
 		if err != nil {
 			writeError(r.Context(), w, http.StatusBadRequest, "Invalid destination format", err, logger.APILog)
 			return
 		}
 
-		ipGateway := net.ParseIP(createRouteParams.Gateway)
-		if ipGateway == nil || ipGateway.To4() == nil {
+		gwAddr, err := netip.ParseAddr(createRouteParams.Gateway)
+		if err != nil || !gwAddr.Is4() {
 			writeError(r.Context(), w, http.StatusBadRequest, "Invalid gateway format: expecting an IPv4 address", nil, logger.APILog)
 			return
 		}
 
-		ipGateway = ipGateway.To4()
-
-		routeExists, err := kernelInt.RouteExists(ipNetwork, ipGateway, createRouteParams.Metric, kernelNetworkInterface)
+		routeExists, err := kernelInt.RouteExists(destPrefix, gwAddr, createRouteParams.Metric, kernelNetworkInterface)
 		if err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to check if route exists", err, logger.APILog)
 			return
@@ -289,7 +287,7 @@ func CreateRoute(dbInstance *db.Database, kernelInt kernel.Kernel) http.Handler 
 			return
 		}
 
-		if err := kernelInt.CreateRoute(ipNetwork, ipGateway, createRouteParams.Metric, kernelNetworkInterface); err != nil {
+		if err := kernelInt.CreateRoute(destPrefix, gwAddr, createRouteParams.Metric, kernelNetworkInterface); err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create kernel route: "+err.Error(), nil, logger.APILog)
 			return
 		}
@@ -337,19 +335,17 @@ func DeleteRoute(dbInstance *db.Database, kernelInt kernel.Kernel) http.Handler 
 			return
 		}
 
-		_, ipNetwork, err := net.ParseCIDR(route.Destination)
+		destPrefix, err := netip.ParsePrefix(route.Destination)
 		if err != nil {
 			writeError(r.Context(), w, http.StatusBadRequest, "Invalid destination format: expecting CIDR notation.", err, logger.APILog)
 			return
 		}
 
-		gateway := net.ParseIP(route.Gateway)
-		if gateway == nil || gateway.To4() == nil {
+		gwAddr, err := netip.ParseAddr(route.Gateway)
+		if err != nil || !gwAddr.Is4() {
 			writeError(r.Context(), w, http.StatusBadRequest, "Invalid gateway format: expecting an IPv4 address", nil, logger.APILog)
 			return
 		}
-
-		gateway = gateway.To4()
 
 		tx, err := dbInstance.BeginTransaction(r.Context())
 		if err != nil {
@@ -378,7 +374,7 @@ func DeleteRoute(dbInstance *db.Database, kernelInt kernel.Kernel) http.Handler 
 			return
 		}
 
-		if err := kernelInt.DeleteRoute(ipNetwork, gateway, route.Metric, kernelInterface); err != nil {
+		if err := kernelInt.DeleteRoute(destPrefix, gwAddr, route.Metric, kernelInterface); err != nil {
 			logger.APILog.Warn("Failed to delete kernel route, proceeding with DB cleanup", zap.Error(err))
 		}
 

--- a/internal/bgp/filter.go
+++ b/internal/bgp/filter.go
@@ -1,17 +1,20 @@
 package bgp
 
-import "net"
+import (
+	"net"
+	"net/netip"
+)
 
 // RouteFilter holds hard-coded safety rejection prefixes.
 // Any received route that overlaps with a reject prefix is dropped
 // before per-peer prefix list evaluation.
 type RouteFilter struct {
-	RejectPrefixes []*net.IPNet
+	RejectPrefixes []netip.Prefix
 }
 
 // ImportPrefix represents a single import prefix list entry for a peer.
 type ImportPrefix struct {
-	Prefix    *net.IPNet
+	Prefix    netip.Prefix
 	MaxLength int
 }
 
@@ -20,16 +23,16 @@ type ImportPrefix struct {
 // rejected just because it contains a reject prefix — the kernel's
 // longest-prefix-match ensures traffic for reject prefixes still uses
 // more-specific local routes.
-func (f *RouteFilter) overlapsAny(route *net.IPNet) bool {
-	routeOnes, _ := route.Mask.Size()
+func (f *RouteFilter) overlapsAny(route netip.Prefix) bool {
+	routeBits := route.Bits()
 
 	for _, reject := range f.RejectPrefixes {
-		rejectOnes, _ := reject.Mask.Size()
+		rejectBits := reject.Bits()
 
 		// Route falls within (or equals) a reject prefix:
-		// the reject prefix contains the route's network address
+		// the reject prefix contains the route's address
 		// and the route is at least as specific.
-		if reject.Contains(route.IP) && routeOnes >= rejectOnes {
+		if reject.Contains(route.Addr()) && routeBits >= rejectBits {
 			return true
 		}
 	}
@@ -44,13 +47,13 @@ func (f *RouteFilter) overlapsAny(route *net.IPNet) bool {
 //   - The route's mask length is <= the entry's maxLength
 //
 // An empty entries list means "accept nothing".
-func matchesPrefixList(route *net.IPNet, entries []ImportPrefix) bool {
-	routeOnes, _ := route.Mask.Size()
+func matchesPrefixList(route netip.Prefix, entries []ImportPrefix) bool {
+	routeBits := route.Bits()
 
 	for _, e := range entries {
-		entryOnes, _ := e.Prefix.Mask.Size()
+		entryBits := e.Prefix.Bits()
 
-		if e.Prefix.Contains(route.IP) && routeOnes >= entryOnes && routeOnes <= e.MaxLength {
+		if e.Prefix.Contains(route.Addr()) && routeBits >= entryBits && routeBits <= e.MaxLength {
 			return true
 		}
 	}
@@ -62,22 +65,22 @@ func matchesPrefixList(route *net.IPNet, entries []ImportPrefix) bool {
 // hard-coded prefixes (link-local, multicast, loopback) to the caller-supplied
 // subnets (UE IP pools, interface addresses). These are always enforced
 // regardless of per-peer prefix list configuration.
-func BuildRejectPrefixes(subnets []*net.IPNet) []*net.IPNet {
+func BuildRejectPrefixes(subnets []netip.Prefix) []netip.Prefix {
 	hardCoded := []string{
 		"169.254.0.0/16", // link-local
 		"224.0.0.0/4",    // multicast
 		"127.0.0.0/8",    // loopback
 	}
 
-	var prefixes []*net.IPNet
+	var prefixes []netip.Prefix
 
 	for _, cidr := range hardCoded {
-		_, network, err := net.ParseCIDR(cidr)
+		p, err := netip.ParsePrefix(cidr)
 		if err != nil {
 			continue
 		}
 
-		prefixes = append(prefixes, network)
+		prefixes = append(prefixes, p)
 	}
 
 	prefixes = append(prefixes, subnets...)
@@ -91,18 +94,15 @@ func BuildRejectPrefixes(subnets []*net.IPNet) []*net.IPNet {
 //
 // Parameters:
 //   - uePools: UE IP pool CIDRs from all data networks
-//   - n3Addr: N3 interface IP address (added as /32), may be nil
+//   - n3Addr: N3 interface IP address (added as /32), may be invalid
 //   - n6IfName: N6 interface name (its IPv4 subnets are added)
-func BuildRouteFilter(uePools []*net.IPNet, n3Addr net.IP, n6IfName string) *RouteFilter {
-	var subnets []*net.IPNet
+func BuildRouteFilter(uePools []netip.Prefix, n3Addr netip.Addr, n6IfName string) *RouteFilter {
+	var subnets []netip.Prefix
 
 	subnets = append(subnets, uePools...)
 
-	if n3Addr != nil {
-		subnets = append(subnets, &net.IPNet{
-			IP:   n3Addr.To4(),
-			Mask: net.CIDRMask(32, 32),
-		})
+	if n3Addr.IsValid() {
+		subnets = append(subnets, netip.PrefixFrom(n3Addr, 32))
 	}
 
 	subnets = append(subnets, InterfaceIPv4Subnets(n6IfName)...)
@@ -112,7 +112,7 @@ func BuildRouteFilter(uePools []*net.IPNet, n3Addr net.IP, n6IfName string) *Rou
 
 // InterfaceIPv4Subnets returns the IPv4 subnets configured on the named
 // network interface.
-func InterfaceIPv4Subnets(ifName string) []*net.IPNet {
+func InterfaceIPv4Subnets(ifName string) []netip.Prefix {
 	iface, err := net.InterfaceByName(ifName)
 	if err != nil {
 		return nil
@@ -123,16 +123,16 @@ func InterfaceIPv4Subnets(ifName string) []*net.IPNet {
 		return nil
 	}
 
-	var subnets []*net.IPNet
+	var subnets []netip.Prefix
 
 	for _, addr := range addrs {
-		_, network, err := net.ParseCIDR(addr.String())
+		p, err := netip.ParsePrefix(addr.String())
 		if err != nil {
 			continue
 		}
 
-		if network.IP.To4() != nil {
-			subnets = append(subnets, network)
+		if p.Addr().Is4() {
+			subnets = append(subnets, p.Masked())
 		}
 	}
 

--- a/internal/bgp/filter_test.go
+++ b/internal/bgp/filter_test.go
@@ -1,38 +1,38 @@
 package bgp
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 )
 
-func mustParseCIDR(s string) *net.IPNet {
-	_, network, err := net.ParseCIDR(s)
+func mustParsePrefix(s string) netip.Prefix {
+	p, err := netip.ParsePrefix(s)
 	if err != nil {
 		panic(err)
 	}
 
-	return network
+	return p
 }
 
 func TestMatchesPrefixList_DefaultRouteOnly(t *testing.T) {
 	entries := []ImportPrefix{
-		{Prefix: mustParseCIDR("0.0.0.0/0"), MaxLength: 0},
+		{Prefix: mustParsePrefix("0.0.0.0/0"), MaxLength: 0},
 	}
 
 	// Exact match: default route
-	if !matchesPrefixList(mustParseCIDR("0.0.0.0/0"), entries) {
+	if !matchesPrefixList(mustParsePrefix("0.0.0.0/0"), entries) {
 		t.Fatal("expected default route to match")
 	}
 
 	// More specific route should not match (maxLength=0 means only /0)
-	if matchesPrefixList(mustParseCIDR("10.0.0.0/8"), entries) {
+	if matchesPrefixList(mustParsePrefix("10.0.0.0/8"), entries) {
 		t.Fatal("expected /8 to not match default-route-only entry")
 	}
 }
 
 func TestMatchesPrefixList_AcceptAll(t *testing.T) {
 	entries := []ImportPrefix{
-		{Prefix: mustParseCIDR("0.0.0.0/0"), MaxLength: 32},
+		{Prefix: mustParsePrefix("0.0.0.0/0"), MaxLength: 32},
 	}
 
 	testCases := []struct {
@@ -46,7 +46,7 @@ func TestMatchesPrefixList_AcceptAll(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := matchesPrefixList(mustParseCIDR(tc.prefix), entries)
+		got := matchesPrefixList(mustParsePrefix(tc.prefix), entries)
 		if got != tc.match {
 			t.Errorf("prefix %s: expected match=%v, got %v", tc.prefix, tc.match, got)
 		}
@@ -55,7 +55,7 @@ func TestMatchesPrefixList_AcceptAll(t *testing.T) {
 
 func TestMatchesPrefixList_CorporateSubnet(t *testing.T) {
 	entries := []ImportPrefix{
-		{Prefix: mustParseCIDR("10.100.0.0/16"), MaxLength: 24},
+		{Prefix: mustParsePrefix("10.100.0.0/16"), MaxLength: 24},
 	}
 
 	testCases := []struct {
@@ -75,7 +75,7 @@ func TestMatchesPrefixList_CorporateSubnet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := matchesPrefixList(mustParseCIDR(tc.prefix), entries)
+		got := matchesPrefixList(mustParsePrefix(tc.prefix), entries)
 		if got != tc.match {
 			t.Errorf("prefix %s: expected match=%v, got %v", tc.prefix, tc.match, got)
 		}
@@ -83,19 +83,19 @@ func TestMatchesPrefixList_CorporateSubnet(t *testing.T) {
 }
 
 func TestMatchesPrefixList_EmptyRejectsAll(t *testing.T) {
-	if matchesPrefixList(mustParseCIDR("0.0.0.0/0"), nil) {
+	if matchesPrefixList(mustParsePrefix("0.0.0.0/0"), nil) {
 		t.Fatal("empty prefix list should reject all routes")
 	}
 
-	if matchesPrefixList(mustParseCIDR("10.0.0.0/8"), []ImportPrefix{}) {
+	if matchesPrefixList(mustParsePrefix("10.0.0.0/8"), []ImportPrefix{}) {
 		t.Fatal("empty prefix list should reject all routes")
 	}
 }
 
 func TestMatchesPrefixList_MultipleEntries(t *testing.T) {
 	entries := []ImportPrefix{
-		{Prefix: mustParseCIDR("0.0.0.0/0"), MaxLength: 0},
-		{Prefix: mustParseCIDR("10.100.0.0/16"), MaxLength: 24},
+		{Prefix: mustParsePrefix("0.0.0.0/0"), MaxLength: 0},
+		{Prefix: mustParsePrefix("10.100.0.0/16"), MaxLength: 24},
 	}
 
 	testCases := []struct {
@@ -108,7 +108,7 @@ func TestMatchesPrefixList_MultipleEntries(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := matchesPrefixList(mustParseCIDR(tc.prefix), entries)
+		got := matchesPrefixList(mustParsePrefix(tc.prefix), entries)
 		if got != tc.match {
 			t.Errorf("prefix %s: expected match=%v, got %v", tc.prefix, tc.match, got)
 		}
@@ -117,8 +117,8 @@ func TestMatchesPrefixList_MultipleEntries(t *testing.T) {
 
 func TestOverlapsAny_UEPool(t *testing.T) {
 	filter := &RouteFilter{
-		RejectPrefixes: []*net.IPNet{
-			mustParseCIDR("10.45.0.0/16"),
+		RejectPrefixes: []netip.Prefix{
+			mustParsePrefix("10.45.0.0/16"),
 		},
 	}
 
@@ -136,7 +136,7 @@ func TestOverlapsAny_UEPool(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := filter.overlapsAny(mustParseCIDR(tc.prefix))
+		got := filter.overlapsAny(mustParsePrefix(tc.prefix))
 		if got != tc.overlap {
 			t.Errorf("prefix %s: expected overlap=%v, got %v", tc.prefix, tc.overlap, got)
 		}
@@ -163,7 +163,7 @@ func TestOverlapsAny_HardcodedRejections(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := filter.overlapsAny(mustParseCIDR(tc.prefix))
+		got := filter.overlapsAny(mustParsePrefix(tc.prefix))
 		if got != tc.overlap {
 			t.Errorf("prefix %s: expected overlap=%v, got %v", tc.prefix, tc.overlap, got)
 		}
@@ -171,9 +171,9 @@ func TestOverlapsAny_HardcodedRejections(t *testing.T) {
 }
 
 func TestBuildRejectPrefixes_IncludesAllSources(t *testing.T) {
-	subnets := []*net.IPNet{
-		mustParseCIDR("10.45.0.0/16"),
-		mustParseCIDR("192.168.1.0/24"),
+	subnets := []netip.Prefix{
+		mustParsePrefix("10.45.0.0/16"),
+		mustParsePrefix("192.168.1.0/24"),
 	}
 
 	prefixes := BuildRejectPrefixes(subnets)
@@ -186,11 +186,11 @@ func TestBuildRejectPrefixes_IncludesAllSources(t *testing.T) {
 	// Verify the UE pool is included
 	filter := &RouteFilter{RejectPrefixes: prefixes}
 
-	if !filter.overlapsAny(mustParseCIDR("10.45.1.0/24")) {
+	if !filter.overlapsAny(mustParsePrefix("10.45.1.0/24")) {
 		t.Fatal("expected UE pool subnet to be rejected")
 	}
 
-	if !filter.overlapsAny(mustParseCIDR("192.168.1.128/25")) {
+	if !filter.overlapsAny(mustParsePrefix("192.168.1.128/25")) {
 		t.Fatal("expected extra subnet to be rejected")
 	}
 }

--- a/internal/bgp/service.go
+++ b/internal/bgp/service.go
@@ -31,14 +31,14 @@ const MaxLearnedRoutesPerPeer = 1000
 
 // ownedPath tracks an advertised prefix and its owner.
 type ownedPath struct {
-	ip    net.IP
+	ip    netip.Addr
 	owner string
 }
 
 // learnedRoute tracks a BGP-learned route installed in the kernel.
 type learnedRoute struct {
-	prefix  net.IPNet
-	gateway net.IP
+	prefix  netip.Prefix
+	gateway netip.Addr
 	peer    string // peer address that advertised this route
 }
 
@@ -60,7 +60,7 @@ type BGPService struct {
 	settings    BGPSettings
 	peers       []BGPPeer
 	paths       map[string]ownedPath // keyed by IP string e.g. "10.45.0.3"
-	n6Addr      net.IP
+	n6Addr      netip.Addr
 	logger      *zap.Logger
 	listenPort  int32
 
@@ -114,8 +114,8 @@ func (b *BGPService) UpdateFilter(f *RouteFilter) {
 	for prefixStr, lr := range b.learnedRoutes {
 		dst := lr.prefix
 
-		if f.overlapsAny(&dst) {
-			err := b.kernel.DeleteRoute(&dst, lr.gateway, bgpRouteMetric, kernel.N6)
+		if f.overlapsAny(dst) {
+			err := b.kernel.DeleteRoute(dst, lr.gateway, bgpRouteMetric, kernel.N6)
 			if err != nil {
 				b.logger.Warn("failed to remove route rejected by updated filter",
 					zap.String("prefix", prefixStr), zap.Error(err))
@@ -134,7 +134,7 @@ func (b *BGPService) UpdateFilter(f *RouteFilter) {
 }
 
 // New creates a BGPService. Does not start the speaker.
-func New(n6Addr net.IP, logger *zap.Logger, opts ...Option) *BGPService {
+func New(n6Addr netip.Addr, logger *zap.Logger, opts ...Option) *BGPService {
 	b := &BGPService{
 		n6Addr:        n6Addr,
 		logger:        logger,
@@ -158,7 +158,7 @@ func (b *BGPService) SetListenPort(port int32) {
 // InjectLearnedRouteForTest adds a learned route to the in-memory map without
 // actually installing it in the kernel. Used by tests to set up state before
 // testing reconfiguration and cleanup methods.
-func (b *BGPService) InjectLearnedRouteForTest(prefix net.IPNet, gateway net.IP, peer string) {
+func (b *BGPService) InjectLearnedRouteForTest(prefix netip.Prefix, gateway netip.Addr, peer string) {
 	b.learnedMu.Lock()
 	defer b.learnedMu.Unlock()
 
@@ -258,8 +258,8 @@ func (b *BGPService) startLocked(ctx context.Context, settings BGPSettings, peer
 			b.paths = make(map[string]ownedPath, len(allocatedIPs))
 
 			for ipStr, subscriber := range allocatedIPs {
-				ip := net.ParseIP(ipStr)
-				if ip == nil {
+				ip, err := netip.ParseAddr(ipStr)
+				if err != nil {
 					continue
 				}
 
@@ -354,7 +354,7 @@ func (b *BGPService) Stop() error {
 
 // Announce adds a /32 route for the given IP to the BGP RIB.
 // It is a no-op if the service is not running or not advertising (NAT enabled).
-func (b *BGPService) Announce(ip net.IP, owner string) error {
+func (b *BGPService) Announce(ip netip.Addr, owner string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -373,7 +373,7 @@ func (b *BGPService) Announce(ip net.IP, owner string) error {
 
 // Withdraw removes a /32 route for the given IP from the BGP RIB.
 // It is a no-op if the service is not running or not advertising (NAT enabled).
-func (b *BGPService) Withdraw(ip net.IP) error {
+func (b *BGPService) Withdraw(ip netip.Addr) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -577,8 +577,8 @@ func (b *BGPService) SetAdvertising(advertising bool, allocatedIPs map[string]st
 		b.paths = make(map[string]ownedPath, len(allocatedIPs))
 
 		for ipStr, subscriber := range allocatedIPs {
-			ip := net.ParseIP(ipStr)
-			if ip == nil {
+			ip, err := netip.ParseAddr(ipStr)
+			if err != nil {
 				continue
 			}
 
@@ -647,32 +647,21 @@ func (b *BGPService) addPeer(ctx context.Context, s *gobgp.BgpServer, peer BGPPe
 	return s.AddPeer(ctx, &api.AddPeerRequest{Peer: p})
 }
 
-func buildPath(ip net.IP, nextHopAddr net.IP) (*apiutil.Path, error) {
-	ipv4 := ip.To4()
-	if ipv4 == nil {
+func buildPath(ip netip.Addr, nextHopAddr netip.Addr) (*apiutil.Path, error) {
+	if !ip.Is4() {
 		return nil, fmt.Errorf("only IPv4 addresses are supported, got: %s", ip.String())
 	}
 
-	addr, ok := netip.AddrFromSlice(ipv4)
-	if !ok {
-		return nil, fmt.Errorf("failed to convert IP to netip.Addr: %s", ip.String())
-	}
-
-	prefix := netip.PrefixFrom(addr, 32)
+	prefix := netip.PrefixFrom(ip, 32)
 
 	nlri, err := bgppacket.NewIPAddrPrefix(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create NLRI: %w", err)
 	}
 
-	nhAddr, ok := netip.AddrFromSlice(nextHopAddr.To4())
-	if !ok {
-		return nil, fmt.Errorf("failed to convert next-hop to netip.Addr: %s", nextHopAddr.String())
-	}
-
 	origin := bgppacket.NewPathAttributeOrigin(0) // IGP
 
-	nextHop, err := bgppacket.NewPathAttributeNextHop(nhAddr)
+	nextHop, err := bgppacket.NewPathAttributeNextHop(nextHopAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create next-hop attribute: %w", err)
 	}
@@ -685,7 +674,7 @@ func buildPath(ip net.IP, nextHopAddr net.IP) (*apiutil.Path, error) {
 }
 
 // announcePath adds a /32 route to the GoBGP RIB.
-func (b *BGPService) announcePath(s *gobgp.BgpServer, ip net.IP) error {
+func (b *BGPService) announcePath(s *gobgp.BgpServer, ip netip.Addr) error {
 	path, err := buildPath(ip, b.n6Addr)
 	if err != nil {
 		return err
@@ -699,7 +688,7 @@ func (b *BGPService) announcePath(s *gobgp.BgpServer, ip net.IP) error {
 }
 
 // withdrawPath removes a /32 route from the GoBGP RIB.
-func (b *BGPService) withdrawPath(s *gobgp.BgpServer, ip net.IP) error {
+func (b *BGPService) withdrawPath(s *gobgp.BgpServer, ip netip.Addr) error {
 	path, err := buildPath(ip, b.n6Addr)
 	if err != nil {
 		return err
@@ -783,12 +772,12 @@ func (b *BGPService) listRoutesLocked() ([]BGPRoute, error) {
 			// Only include locally-originated routes (those we announced).
 			// The global RIB may also contain routes learned from peers,
 			// which are not relevant to the advertised-routes view.
-			ip, _, _ := net.ParseCIDR(route.Prefix)
-			if ip == nil {
+			prefix, err := netip.ParsePrefix(route.Prefix)
+			if err != nil {
 				continue
 			}
 
-			owned, ok := b.paths[ip.String()]
+			owned, ok := b.paths[prefix.Addr().String()]
 			if !ok {
 				continue
 			}

--- a/internal/bgp/service_test.go
+++ b/internal/bgp/service_test.go
@@ -2,7 +2,7 @@ package bgp_test
 
 import (
 	"context"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/bgp"
@@ -12,7 +12,7 @@ import (
 func newTestService(t *testing.T) *bgp.BGPService {
 	t.Helper()
 
-	n6Addr := net.ParseIP("10.0.0.1")
+	n6Addr := netip.MustParseAddr("10.0.0.1")
 	logger := zap.NewNop()
 	svc := bgp.New(n6Addr, logger)
 	// Use ListenPort -1 to avoid binding to port 179 in tests
@@ -103,7 +103,7 @@ func TestAnnounceWithdraw(t *testing.T) {
 
 	defer func() { _ = svc.Stop() }()
 
-	ip := net.ParseIP("10.1.1.1")
+	ip := netip.MustParseAddr("10.1.1.1")
 
 	err = svc.Announce(ip, "001010000000001")
 	if err != nil {
@@ -150,12 +150,12 @@ func TestAnnounceWhenNotRunning(t *testing.T) {
 	svc := newTestService(t)
 
 	// Should be a no-op, not an error
-	err := svc.Announce(net.ParseIP("10.1.1.1"), "001010000000001")
+	err := svc.Announce(netip.MustParseAddr("10.1.1.1"), "001010000000001")
 	if err != nil {
 		t.Fatalf("Announce on non-running service should succeed (no-op), got: %v", err)
 	}
 
-	err = svc.Withdraw(net.ParseIP("10.1.1.1"))
+	err = svc.Withdraw(netip.MustParseAddr("10.1.1.1"))
 	if err != nil {
 		t.Fatalf("Withdraw on non-running service should succeed (no-op), got: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestAnnounceIPv6Rejected(t *testing.T) {
 
 	defer func() { _ = svc.Stop() }()
 
-	err = svc.Announce(net.ParseIP("::1"), "test")
+	err = svc.Announce(netip.MustParseAddr("::1"), "test")
 	if err == nil {
 		t.Fatal("expected error for IPv6 address")
 	}
@@ -490,10 +490,10 @@ func TestMultipleAnnounceWithdraw(t *testing.T) {
 
 	defer func() { _ = svc.Stop() }()
 
-	ips := []net.IP{
-		net.ParseIP("10.1.1.1"),
-		net.ParseIP("10.1.1.2"),
-		net.ParseIP("10.1.1.3"),
+	ips := []netip.Addr{
+		netip.MustParseAddr("10.1.1.1"),
+		netip.MustParseAddr("10.1.1.2"),
+		netip.MustParseAddr("10.1.1.3"),
 	}
 
 	for _, ip := range ips {
@@ -596,7 +596,7 @@ func TestAnnounceNoOpWhenNotAdvertising(t *testing.T) {
 	defer func() { _ = svc.Stop() }()
 
 	// Announce should be a no-op
-	err = svc.Announce(net.ParseIP("10.1.1.1"), "test")
+	err = svc.Announce(netip.MustParseAddr("10.1.1.1"), "test")
 	if err != nil {
 		t.Fatalf("Announce should succeed as no-op, got: %v", err)
 	}

--- a/internal/bgp/types.go
+++ b/internal/bgp/types.go
@@ -2,7 +2,7 @@ package bgp
 
 import (
 	"context"
-	"net"
+	"net/netip"
 )
 
 // BGPSettings holds the configuration for the BGP speaker.
@@ -65,8 +65,8 @@ type ImportPrefixStore interface {
 
 // BGPAnnouncer is the interface used by SMF to announce/withdraw routes.
 type BGPAnnouncer interface {
-	Announce(ip net.IP, owner string) error
-	Withdraw(ip net.IP) error
+	Announce(ip netip.Addr, owner string) error
+	Withdraw(ip netip.Addr) error
 	IsRunning() bool
 	IsAdvertising() bool
 }

--- a/internal/bgp/watcher.go
+++ b/internal/bgp/watcher.go
@@ -2,7 +2,6 @@ package bgp
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"time"
 
@@ -35,8 +34,8 @@ func (b *BGPService) handleBestPaths(ctx context.Context, paths []*apiutil.Path)
 // updating, or removing a kernel route.
 func (b *BGPService) handleSinglePath(ctx context.Context, path *apiutil.Path) {
 	// Extract prefix from NLRI.
-	prefix := extractPrefix(path)
-	if prefix == nil {
+	prefix, ok := extractPrefix(path)
+	if !ok {
 		return
 	}
 
@@ -57,14 +56,11 @@ func (b *BGPService) handleSinglePath(ctx context.Context, path *apiutil.Path) {
 		return
 	}
 
-	nextHopIP := nextHop.As4()
-	gwIP := net.IP(nextHopIP[:])
-
 	peerAddr := path.PeerAddress.String()
 
 	// Skip locally-originated routes (our own subscriber /32s).
 	b.mu.RLock()
-	_, isOwnedPath := b.paths[prefix.IP.String()]
+	_, isOwnedPath := b.paths[prefix.Addr().String()]
 	running := b.running
 	peers := b.peers
 	filter := b.filter // snapshot under lock so we can use it after RUnlock
@@ -79,9 +75,9 @@ func (b *BGPService) handleSinglePath(ctx context.Context, path *apiutil.Path) {
 	}
 
 	// Skip routes with our own next-hop (routing loop prevention).
-	if gwIP.Equal(b.n6Addr) {
+	if nextHop == b.n6Addr {
 		b.logger.Debug("skipping route with own next-hop",
-			zap.String("prefix", prefixStr), zap.String("nextHop", gwIP.String()))
+			zap.String("prefix", prefixStr), zap.String("nextHop", nextHop.String()))
 
 		return
 	}
@@ -141,7 +137,7 @@ func (b *BGPService) handleSinglePath(ctx context.Context, path *apiutil.Path) {
 	}
 
 	// Install or update the route in the kernel (still holding learnedMu).
-	err = b.kernel.ReplaceRoute(prefix, gwIP, bgpRouteMetric, kernel.N6)
+	err = b.kernel.ReplaceRoute(prefix, nextHop, bgpRouteMetric, kernel.N6)
 	if err != nil {
 		b.learnedMu.Unlock()
 
@@ -152,15 +148,15 @@ func (b *BGPService) handleSinglePath(ctx context.Context, path *apiutil.Path) {
 	}
 
 	b.learnedRoutes[prefixStr] = learnedRoute{
-		prefix:  *prefix,
-		gateway: gwIP,
+		prefix:  prefix,
+		gateway: nextHop,
 		peer:    peerAddr,
 	}
 	b.learnedMu.Unlock()
 
 	b.logger.Info("installed BGP route",
 		zap.String("prefix", prefixStr),
-		zap.String("nextHop", gwIP.String()),
+		zap.String("nextHop", nextHop.String()),
 		zap.String("peer", peerAddr),
 	)
 }
@@ -179,9 +175,7 @@ func (b *BGPService) handleWithdrawal(prefixStr string) {
 	delete(b.learnedRoutes, prefixStr)
 	b.learnedMu.Unlock()
 
-	dst := lr.prefix
-
-	err := b.kernel.DeleteRoute(&dst, lr.gateway, bgpRouteMetric, kernel.N6)
+	err := b.kernel.DeleteRoute(lr.prefix, lr.gateway, bgpRouteMetric, kernel.N6)
 	if err != nil {
 		b.logger.Warn("failed to remove withdrawn BGP route",
 			zap.String("prefix", prefixStr), zap.Error(err))
@@ -206,9 +200,9 @@ func (b *BGPService) cleanStaleRoutes() {
 	for i := range stale {
 		dst := stale[i]
 
-		// We don't know the original gateway, but DeleteRoute with a nil
+		// We don't know the original gateway, but DeleteRoute with an invalid
 		// gateway will match on destination + priority + interface.
-		err := b.kernel.DeleteRoute(&dst, nil, bgpRouteMetric, kernel.N6)
+		err := b.kernel.DeleteRoute(dst, netip.Addr{}, bgpRouteMetric, kernel.N6)
 		if err != nil {
 			b.logger.Warn("failed to remove stale BGP route",
 				zap.String("prefix", dst.String()), zap.Error(err))
@@ -230,7 +224,7 @@ func (b *BGPService) removeAllLearnedRoutes() {
 	for prefixStr, lr := range b.learnedRoutes {
 		dst := lr.prefix
 
-		err := b.kernel.DeleteRoute(&dst, lr.gateway, bgpRouteMetric, kernel.N6)
+		err := b.kernel.DeleteRoute(dst, lr.gateway, bgpRouteMetric, kernel.N6)
 		if err != nil {
 			b.logger.Warn("failed to remove learned BGP route on stop",
 				zap.String("prefix", prefixStr), zap.Error(err))
@@ -261,7 +255,7 @@ func (b *BGPService) removeLearnedRoutesForPeer(peerAddr string) {
 
 		dst := lr.prefix
 
-		err := b.kernel.DeleteRoute(&dst, lr.gateway, bgpRouteMetric, kernel.N6)
+		err := b.kernel.DeleteRoute(dst, lr.gateway, bgpRouteMetric, kernel.N6)
 		if err != nil {
 			b.logger.Warn("failed to remove learned BGP route for deleted peer",
 				zap.String("prefix", prefixStr), zap.String("peer", peerAddr), zap.Error(err))
@@ -296,8 +290,8 @@ func (b *BGPService) reEvaluateLearnedRoutes(ctx context.Context, peers []BGPPee
 		// Check safety filter first.
 		dst := lr.prefix
 
-		if b.filter.overlapsAny(&dst) {
-			err := b.kernel.DeleteRoute(&dst, lr.gateway, bgpRouteMetric, kernel.N6)
+		if b.filter.overlapsAny(dst) {
+			err := b.kernel.DeleteRoute(dst, lr.gateway, bgpRouteMetric, kernel.N6)
 			if err != nil {
 				b.logger.Warn("failed to remove route rejected by updated filter",
 					zap.String("prefix", prefixStr), zap.Error(err))
@@ -314,8 +308,8 @@ func (b *BGPService) reEvaluateLearnedRoutes(ctx context.Context, peers []BGPPee
 		peerID := findPeerID(peers, lr.peer)
 		entries := prefixCache[peerID]
 
-		if len(entries) == 0 || !matchesPrefixList(&dst, entries) {
-			err := b.kernel.DeleteRoute(&dst, lr.gateway, bgpRouteMetric, kernel.N6)
+		if len(entries) == 0 || !matchesPrefixList(dst, entries) {
+			err := b.kernel.DeleteRoute(dst, lr.gateway, bgpRouteMetric, kernel.N6)
 			if err != nil {
 				b.logger.Warn("failed to remove route no longer matching import policy",
 					zap.String("prefix", prefixStr), zap.Error(err))
@@ -363,8 +357,8 @@ func (b *BGPService) replayGlobalRIB(ctx context.Context, peers []BGPPeer) {
 				continue
 			}
 
-			prefix := extractPrefix(path)
-			if prefix == nil {
+			prefix, ok := extractPrefix(path)
+			if !ok {
 				continue
 			}
 
@@ -376,7 +370,7 @@ func (b *BGPService) replayGlobalRIB(ctx context.Context, peers []BGPPeer) {
 			}
 
 			// Skip locally-originated routes.
-			if _, owned := b.paths[prefix.IP.String()]; owned {
+			if _, owned := b.paths[prefix.Addr().String()]; owned {
 				continue
 			}
 
@@ -385,11 +379,8 @@ func (b *BGPService) replayGlobalRIB(ctx context.Context, peers []BGPPeer) {
 				continue
 			}
 
-			nextHopIP := nextHop.As4()
-			gwIP := net.IP(nextHopIP[:])
-
 			// Skip routes with our own next-hop.
-			if gwIP.Equal(b.n6Addr) {
+			if nextHop == b.n6Addr {
 				continue
 			}
 
@@ -415,7 +406,7 @@ func (b *BGPService) replayGlobalRIB(ctx context.Context, peers []BGPPeer) {
 				continue
 			}
 
-			err := b.kernel.ReplaceRoute(prefix, gwIP, bgpRouteMetric, kernel.N6)
+			err := b.kernel.ReplaceRoute(prefix, nextHop, bgpRouteMetric, kernel.N6)
 			if err != nil {
 				b.logger.Warn("failed to install route during RIB replay",
 					zap.String("prefix", prefixStr), zap.Error(err))
@@ -424,8 +415,8 @@ func (b *BGPService) replayGlobalRIB(ctx context.Context, peers []BGPPeer) {
 			}
 
 			b.learnedRoutes[prefixStr] = learnedRoute{
-				prefix:  *prefix,
-				gateway: gwIP,
+				prefix:  prefix,
+				gateway: nextHop,
 				peer:    peerAddr,
 			}
 
@@ -475,7 +466,7 @@ func (b *BGPService) loadImportPrefixes(ctx context.Context, peerID int) ([]Impo
 	entries := make([]ImportPrefix, 0, len(rawEntries))
 
 	for _, raw := range rawEntries {
-		_, network, err := net.ParseCIDR(raw.Prefix)
+		network, err := netip.ParsePrefix(raw.Prefix)
 		if err != nil {
 			b.logger.Warn("skipping invalid import prefix",
 				zap.String("prefix", raw.Prefix), zap.Error(err))
@@ -504,26 +495,17 @@ func findPeerID(peers []BGPPeer, address string) int {
 }
 
 // extractPrefix returns the route destination from a path's NLRI.
-func extractPrefix(path *apiutil.Path) *net.IPNet {
+func extractPrefix(path *apiutil.Path) (netip.Prefix, bool) {
 	if path.Nlri == nil {
-		return nil
+		return netip.Prefix{}, false
 	}
 
 	ipPrefix, ok := path.Nlri.(*bgppacket.IPAddrPrefix)
 	if !ok {
-		return nil
+		return netip.Prefix{}, false
 	}
 
-	prefix := ipPrefix.Prefix
-	addr := prefix.Addr()
-	bits := prefix.Bits()
-
-	ip := addr.As4()
-
-	return &net.IPNet{
-		IP:   net.IP(ip[:]),
-		Mask: net.CIDRMask(bits, 32),
-	}
+	return ipPrefix.Prefix, true
 }
 
 // extractNextHop returns the next-hop address from a path's attributes.

--- a/internal/bgp/watcher_test.go
+++ b/internal/bgp/watcher_test.go
@@ -2,7 +2,7 @@ package bgp_test
 
 import (
 	"context"
-	"net"
+	"net/netip"
 	"sync"
 	"testing"
 
@@ -16,7 +16,7 @@ type fakeKernel struct {
 	mu       sync.Mutex
 	replaced []fakeRoute
 	deleted  []fakeRoute
-	listed   []net.IPNet // routes returned by ListRoutesByPriority
+	listed   []netip.Prefix // routes returned by ListRoutesByPriority
 }
 
 type fakeRoute struct {
@@ -25,16 +25,16 @@ type fakeRoute struct {
 	priority    int
 }
 
-func (fk *fakeKernel) CreateRoute(dst *net.IPNet, gw net.IP, priority int, _ kernel.NetworkInterface) error {
+func (fk *fakeKernel) CreateRoute(dst netip.Prefix, gw netip.Addr, priority int, _ kernel.NetworkInterface) error {
 	return nil
 }
 
-func (fk *fakeKernel) DeleteRoute(dst *net.IPNet, gw net.IP, priority int, _ kernel.NetworkInterface) error {
+func (fk *fakeKernel) DeleteRoute(dst netip.Prefix, gw netip.Addr, priority int, _ kernel.NetworkInterface) error {
 	fk.mu.Lock()
 	defer fk.mu.Unlock()
 
 	gwStr := ""
-	if gw != nil {
+	if gw.IsValid() {
 		gwStr = gw.String()
 	}
 
@@ -47,7 +47,7 @@ func (fk *fakeKernel) DeleteRoute(dst *net.IPNet, gw net.IP, priority int, _ ker
 	return nil
 }
 
-func (fk *fakeKernel) ReplaceRoute(dst *net.IPNet, gw net.IP, priority int, _ kernel.NetworkInterface) error {
+func (fk *fakeKernel) ReplaceRoute(dst netip.Prefix, gw netip.Addr, priority int, _ kernel.NetworkInterface) error {
 	fk.mu.Lock()
 	defer fk.mu.Unlock()
 
@@ -60,7 +60,7 @@ func (fk *fakeKernel) ReplaceRoute(dst *net.IPNet, gw net.IP, priority int, _ ke
 	return nil
 }
 
-func (fk *fakeKernel) ListRoutesByPriority(priority int, _ kernel.NetworkInterface) ([]net.IPNet, error) {
+func (fk *fakeKernel) ListRoutesByPriority(priority int, _ kernel.NetworkInterface) ([]netip.Prefix, error) {
 	fk.mu.Lock()
 	defer fk.mu.Unlock()
 
@@ -68,7 +68,7 @@ func (fk *fakeKernel) ListRoutesByPriority(priority int, _ kernel.NetworkInterfa
 }
 
 func (fk *fakeKernel) InterfaceExists(_ kernel.NetworkInterface) (bool, error) { return true, nil }
-func (fk *fakeKernel) RouteExists(_ *net.IPNet, _ net.IP, _ int, _ kernel.NetworkInterface) (bool, error) {
+func (fk *fakeKernel) RouteExists(_ netip.Prefix, _ netip.Addr, _ int, _ kernel.NetworkInterface) (bool, error) {
 	return false, nil
 }
 
@@ -97,11 +97,11 @@ func TestGetLearnedRoutes_EmptyByDefault(t *testing.T) {
 }
 
 func TestCleanStaleRoutes(t *testing.T) {
-	_, n1, _ := net.ParseCIDR("0.0.0.0/0")
-	_, n2, _ := net.ParseCIDR("10.100.0.0/16")
+	n1 := netip.MustParsePrefix("0.0.0.0/0")
+	n2 := netip.MustParsePrefix("10.100.0.0/16")
 
 	fk := &fakeKernel{
-		listed: []net.IPNet{*n1, *n2},
+		listed: []netip.Prefix{n1, n2},
 	}
 
 	svc := newTestServiceWithLearning(t, fk, &fakeImportStore{})
@@ -189,7 +189,7 @@ func TestRouteLearningDisabledWithoutDeps(t *testing.T) {
 func newTestServiceWithLearning(t *testing.T, k kernel.Kernel, store bgp.ImportPrefixStore) *bgp.BGPService {
 	t.Helper()
 
-	n6Addr := net.ParseIP("10.0.0.1")
+	n6Addr := netip.MustParseAddr("10.0.0.1")
 	logger := zap.NewNop()
 
 	filter := &bgp.RouteFilter{
@@ -232,11 +232,11 @@ func TestReconfigurePeerRemovalCleansLearnedRoutes(t *testing.T) {
 	defer func() { _ = svc.Stop() }()
 
 	// Inject learned routes from both peers.
-	_, net1, _ := net.ParseCIDR("10.100.0.0/16")
-	_, net2, _ := net.ParseCIDR("10.200.0.0/16")
+	net1 := netip.MustParsePrefix("10.100.0.0/16")
+	net2 := netip.MustParsePrefix("10.200.0.0/16")
 
-	svc.InjectLearnedRouteForTest(*net1, net.ParseIP("192.168.1.1"), "192.168.1.1")
-	svc.InjectLearnedRouteForTest(*net2, net.ParseIP("192.168.1.2"), "192.168.1.2")
+	svc.InjectLearnedRouteForTest(net1, netip.MustParseAddr("192.168.1.1"), "192.168.1.1")
+	svc.InjectLearnedRouteForTest(net2, netip.MustParseAddr("192.168.1.2"), "192.168.1.2")
 
 	if len(svc.GetLearnedRoutes()) != 2 {
 		t.Fatalf("expected 2 learned routes, got %d", len(svc.GetLearnedRoutes()))
@@ -298,8 +298,8 @@ func TestReconfigureImportPolicyChangeRemovesRoutes(t *testing.T) {
 	defer func() { _ = svc.Stop() }()
 
 	// Inject a learned route.
-	_, net1, _ := net.ParseCIDR("10.100.0.0/16")
-	svc.InjectLearnedRouteForTest(*net1, net.ParseIP("192.168.1.1"), "192.168.1.1")
+	net1 := netip.MustParsePrefix("10.100.0.0/16")
+	svc.InjectLearnedRouteForTest(net1, netip.MustParseAddr("192.168.1.1"), "192.168.1.1")
 
 	if len(svc.GetLearnedRoutes()) != 1 {
 		t.Fatalf("expected 1 learned route, got %d", len(svc.GetLearnedRoutes()))
@@ -402,17 +402,17 @@ func TestUpdateFilterRemovesNewlyRejectedRoutes(t *testing.T) {
 	defer func() { _ = svc.Stop() }()
 
 	// Inject a learned route in 10.45.0.0/16 (not yet rejected).
-	_, net1, _ := net.ParseCIDR("10.45.0.5/32")
-	svc.InjectLearnedRouteForTest(*net1, net.ParseIP("192.168.1.1"), "192.168.1.1")
+	net1 := netip.MustParsePrefix("10.45.0.5/32")
+	svc.InjectLearnedRouteForTest(net1, netip.MustParseAddr("192.168.1.1"), "192.168.1.1")
 
 	if len(svc.GetLearnedRoutes()) != 1 {
 		t.Fatalf("expected 1 learned route, got %d", len(svc.GetLearnedRoutes()))
 	}
 
 	// Update the filter to reject 10.45.0.0/16 (new data network added).
-	_, uePool, _ := net.ParseCIDR("10.45.0.0/16")
+	uePool := netip.MustParsePrefix("10.45.0.0/16")
 	newFilter := &bgp.RouteFilter{
-		RejectPrefixes: bgp.BuildRejectPrefixes([]*net.IPNet{uePool}),
+		RejectPrefixes: bgp.BuildRejectPrefixes([]netip.Prefix{uePool}),
 	}
 
 	svc.UpdateFilter(newFilter)

--- a/internal/db/metrics.go
+++ b/internal/db/metrics.go
@@ -5,7 +5,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"os"
 
 	"github.com/ellanetworks/core/internal/logger"
@@ -107,24 +107,24 @@ func (db *Database) GetIPAddressesTotal() (int, error) {
 	for _, dn := range dataNetworks {
 		ipPool := dn.IPPool
 
-		_, ipNet, err := net.ParseCIDR(ipPool)
+		prefix, err := netip.ParsePrefix(ipPool)
 		if err != nil {
 			return 0, fmt.Errorf("invalid IP pool format '%s': %v", ipPool, err)
 		}
 
-		total += countIPsInCIDR(ipNet)
+		total += countIPsInPrefix(prefix)
 	}
 
 	return total, nil
 }
 
-func countIPsInCIDR(ipNet *net.IPNet) int {
-	ones, bits := ipNet.Mask.Size()
-	if bits-ones > 30 {
+func countIPsInPrefix(prefix netip.Prefix) int {
+	bits := prefix.Bits()
+	if 32-bits > 30 {
 		return int(^uint32(0))
 	}
 
-	return 1 << (bits - ones)
+	return 1 << (32 - bits)
 }
 
 func (db *Database) GetIPAddressesAllocated(ctx context.Context) (int, error) {

--- a/internal/kernel/neigh.go
+++ b/internal/kernel/neigh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net"
+	"net/netip"
 
 	"github.com/vishvananda/netlink"
 	"go.opentelemetry.io/otel"
@@ -17,7 +18,7 @@ var tracer = otel.Tracer("ella-core/kernel")
 
 // AddNeighbour adds the provided IP as a neighbour
 // on all links that have an address in the same subnet.
-func AddNeighbour(ctx context.Context, neigh net.IP) error {
+func AddNeighbour(ctx context.Context, neigh netip.Addr) error {
 	_, span := tracer.Start(
 		ctx,
 		"kernel/add_neighbour",
@@ -25,6 +26,8 @@ func AddNeighbour(ctx context.Context, neigh net.IP) error {
 			attribute.String("IP", neigh.String()),
 		))
 	defer span.End()
+
+	neighIP := neigh.AsSlice()
 
 	links, err := netlink.LinkList()
 	if err != nil {
@@ -40,8 +43,8 @@ func AddNeighbour(ctx context.Context, neigh net.IP) error {
 		}
 
 		for _, a := range addrs {
-			if a.Contains(neigh) {
-				err = addNeighbourForLink(neigh, l)
+			if a.Contains(neighIP) {
+				err = addNeighbourForLink(neighIP, l)
 				if err != nil {
 					return fmt.Errorf("could not add neighbour for link: %v", err)
 				}

--- a/internal/kernel/routes.go
+++ b/internal/kernel/routes.go
@@ -3,6 +3,7 @@ package kernel
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 
 	"github.com/ellanetworks/core/internal/logger"
@@ -24,12 +25,12 @@ const (
 type Kernel interface {
 	EnableIPForwarding() error
 	IsIPForwardingEnabled() (bool, error)
-	CreateRoute(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) error
-	DeleteRoute(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) error
-	ReplaceRoute(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) error
-	ListRoutesByPriority(priority int, ifKey NetworkInterface) ([]net.IPNet, error)
+	CreateRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error
+	DeleteRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error
+	ReplaceRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error
+	ListRoutesByPriority(priority int, ifKey NetworkInterface) ([]netip.Prefix, error)
 	InterfaceExists(ifKey NetworkInterface) (bool, error)
-	RouteExists(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) (bool, error)
+	RouteExists(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) (bool, error)
 	EnsureGatewaysOnInterfaceInNeighTable(ifKey NetworkInterface) error
 }
 
@@ -49,8 +50,25 @@ func NewRealKernel(n3Interface, n6Interface string) *RealKernel {
 	}
 }
 
+// prefixToIPNet converts a netip.Prefix to a *net.IPNet for netlink.
+func prefixToIPNet(p netip.Prefix) *net.IPNet {
+	return &net.IPNet{
+		IP:   p.Masked().Addr().AsSlice(),
+		Mask: net.CIDRMask(p.Bits(), 32),
+	}
+}
+
+// addrToNetIP converts a netip.Addr to a net.IP for netlink.
+func addrToNetIP(a netip.Addr) net.IP {
+	if !a.IsValid() {
+		return nil
+	}
+
+	return a.AsSlice()
+}
+
 // CreateRoute adds a route to the kernel for the interface defined by ifKey.
-func (rk *RealKernel) CreateRoute(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) error {
+func (rk *RealKernel) CreateRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error {
 	interfaceName, ok := rk.ifMapping[ifKey]
 	if !ok {
 		return fmt.Errorf("invalid interface key: %v", ifKey)
@@ -62,8 +80,8 @@ func (rk *RealKernel) CreateRoute(destination *net.IPNet, gateway net.IP, priori
 	}
 
 	nlRoute := netlink.Route{
-		Dst:       destination,
-		Gw:        gateway,
+		Dst:       prefixToIPNet(destination),
+		Gw:        addrToNetIP(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -76,11 +94,11 @@ func (rk *RealKernel) CreateRoute(destination *net.IPNet, gateway net.IP, priori
 	logger.EllaLog.Debug("Added route", zap.String("destination", destination.String()), zap.String("gateway", gateway.String()), zap.Int("priority", priority), zap.String("interface", interfaceName))
 
 	// Tells the kernel that the gateway is in use, and ARP requests should be sent out
-	return addNeighbourForLink(gateway, link)
+	return addNeighbourForLink(addrToNetIP(gateway), link)
 }
 
 // DeleteRoute removes a route from the kernel for the interface defined by ifKey.
-func (rk *RealKernel) DeleteRoute(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) error {
+func (rk *RealKernel) DeleteRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error {
 	interfaceName, ok := rk.ifMapping[ifKey]
 	if !ok {
 		return fmt.Errorf("invalid interface key: %v", ifKey)
@@ -92,8 +110,8 @@ func (rk *RealKernel) DeleteRoute(destination *net.IPNet, gateway net.IP, priori
 	}
 
 	nlRoute := netlink.Route{
-		Dst:       destination,
-		Gw:        gateway,
+		Dst:       prefixToIPNet(destination),
+		Gw:        addrToNetIP(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -109,7 +127,7 @@ func (rk *RealKernel) DeleteRoute(destination *net.IPNet, gateway net.IP, priori
 // ReplaceRoute creates or updates a route in the kernel for the interface defined by ifKey.
 // Unlike CreateRoute, this is idempotent — it will update an existing route with the same
 // destination and priority rather than returning an error.
-func (rk *RealKernel) ReplaceRoute(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) error {
+func (rk *RealKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error {
 	interfaceName, ok := rk.ifMapping[ifKey]
 	if !ok {
 		return fmt.Errorf("invalid interface key: %v", ifKey)
@@ -121,8 +139,8 @@ func (rk *RealKernel) ReplaceRoute(destination *net.IPNet, gateway net.IP, prior
 	}
 
 	nlRoute := netlink.Route{
-		Dst:       destination,
-		Gw:        gateway,
+		Dst:       prefixToIPNet(destination),
+		Gw:        addrToNetIP(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -134,12 +152,12 @@ func (rk *RealKernel) ReplaceRoute(destination *net.IPNet, gateway net.IP, prior
 
 	logger.EllaLog.Debug("Replaced route", zap.String("destination", destination.String()), zap.String("gateway", gateway.String()), zap.Int("priority", priority), zap.String("interface", interfaceName))
 
-	return addNeighbourForLink(gateway, link)
+	return addNeighbourForLink(addrToNetIP(gateway), link)
 }
 
 // ListRoutesByPriority returns all route destinations with the given priority (metric)
 // on the interface defined by ifKey.
-func (rk *RealKernel) ListRoutesByPriority(priority int, ifKey NetworkInterface) ([]net.IPNet, error) {
+func (rk *RealKernel) ListRoutesByPriority(priority int, ifKey NetworkInterface) ([]netip.Prefix, error) {
 	interfaceName, ok := rk.ifMapping[ifKey]
 	if !ok {
 		return nil, fmt.Errorf("invalid interface key: %v", ifKey)
@@ -160,11 +178,17 @@ func (rk *RealKernel) ListRoutesByPriority(priority int, ifKey NetworkInterface)
 		return nil, fmt.Errorf("failed to list routes: %v", err)
 	}
 
-	var result []net.IPNet
+	var result []netip.Prefix
 
 	for _, r := range routes {
 		if r.Priority == priority && r.Dst != nil {
-			result = append(result, *r.Dst)
+			addr, ok := netip.AddrFromSlice(r.Dst.IP)
+			if !ok {
+				continue
+			}
+
+			ones, _ := r.Dst.Mask.Size()
+			result = append(result, netip.PrefixFrom(addr, ones))
 		}
 	}
 
@@ -191,7 +215,7 @@ func (rk *RealKernel) InterfaceExists(ifKey NetworkInterface) (bool, error) {
 }
 
 // RouteExists checks if a route exists for the interface defined by ifKey.
-func (rk *RealKernel) RouteExists(destination *net.IPNet, gateway net.IP, priority int, ifKey NetworkInterface) (bool, error) {
+func (rk *RealKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) (bool, error) {
 	interfaceName, ok := rk.ifMapping[ifKey]
 	if !ok {
 		return false, fmt.Errorf("invalid interface key: %v", ifKey)
@@ -203,8 +227,8 @@ func (rk *RealKernel) RouteExists(destination *net.IPNet, gateway net.IP, priori
 	}
 
 	nlRoute := netlink.Route{
-		Dst:       destination,
-		Gw:        gateway,
+		Dst:       prefixToIPNet(destination),
+		Gw:        addrToNetIP(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -136,7 +136,9 @@ func (s *SMF) CreateSmContext(ctx context.Context, supi etsi.SUPI, pduSessionID 
 
 	span.AddEvent("session_accepted")
 
-	s.announceRoute(pduAddress, smContext.Supi.IMSI())
+	if addr, ok := netip.AddrFromSlice(pduAddress.To4()); ok {
+		s.announceRoute(addr, smContext.Supi.IMSI())
+	}
 
 	success = true
 

--- a/internal/smf/release.go
+++ b/internal/smf/release.go
@@ -41,7 +41,7 @@ func (s *SMF) ReleaseSmContext(ctx context.Context, smContextRef string) error {
 		if releaseErr != nil {
 			logger.SmfLog.Warn("release UE IP address failed", zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
 		} else if released.IsValid() {
-			s.withdrawRoute(released.AsSlice())
+			s.withdrawRoute(released)
 		}
 	}
 

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -79,8 +79,8 @@ type UPFClient interface {
 
 // BGPAnnouncer is the interface used by the SMF to announce/withdraw subscriber routes.
 type BGPAnnouncer interface {
-	Announce(ip net.IP, owner string) error
-	Withdraw(ip net.IP) error
+	Announce(ip netip.Addr, owner string) error
+	Withdraw(ip netip.Addr) error
 	IsRunning() bool
 	IsAdvertising() bool
 }
@@ -244,7 +244,7 @@ func (s *SMF) RemoveSession(ctx context.Context, ref string) {
 		if err != nil {
 			logger.SmfLog.Error("release UE IP-Address failed", zap.Error(err), zap.String("smContextRef", ref))
 		} else if released.IsValid() {
-			s.withdrawRoute(released.AsSlice())
+			s.withdrawRoute(released)
 		}
 	}
 
@@ -351,12 +351,10 @@ func (s *SMF) NewURR() (*URR, error) {
 	}, nil
 }
 
-// announceRoute advertises a /32 route for the given UE IP via BGP,
-// tagged with the subscriber IMSI as owner.
-// announceRoute announces a /32 route for the given UE IP via BGP.
+// announceRoute advertises a /32 route for the given UE IP via BGP.
 // It is a no-op if no BGP announcer is configured or it is not advertising
 // (BGP not running, or NAT enabled).
-func (s *SMF) announceRoute(ip net.IP, owner string) {
+func (s *SMF) announceRoute(ip netip.Addr, owner string) {
 	if s.bgp == nil || !s.bgp.IsAdvertising() {
 		return
 	}
@@ -369,7 +367,7 @@ func (s *SMF) announceRoute(ip net.IP, owner string) {
 // withdrawRoute removes a /32 route for the given UE IP from BGP.
 // It is a no-op if no BGP announcer is configured or it is not advertising
 // (BGP not running, or NAT enabled).
-func (s *SMF) withdrawRoute(ip net.IP) {
+func (s *SMF) withdrawRoute(ip netip.Addr) {
 	if s.bgp == nil || !s.bgp.IsAdvertising() {
 		return
 	}

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -614,7 +614,7 @@ type fakeBGP struct {
 	withdrawErr error
 }
 
-func (f *fakeBGP) Announce(ip net.IP, owner string) error {
+func (f *fakeBGP) Announce(ip netip.Addr, owner string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -624,7 +624,7 @@ func (f *fakeBGP) Announce(ip net.IP, owner string) error {
 	return f.announceErr
 }
 
-func (f *fakeBGP) Withdraw(ip net.IP) error {
+func (f *fakeBGP) Withdraw(ip netip.Addr) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -91,7 +91,7 @@ func (s *SMF) handleUpdateN1Msg(ctx context.Context, n1Msg []byte, smContext *SM
 				logger.WithTrace(ctx, logger.SmfLog).Warn("release UE IP address failed during PDU session release, continuing teardown",
 					zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn))
 			} else if released.IsValid() {
-				s.withdrawRoute(released.AsSlice())
+				s.withdrawRoute(released)
 			}
 		}
 

--- a/internal/upf/engine/establish_session.go
+++ b/internal/upf/engine/establish_session.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"net"
 	"net/netip"
 
 	"github.com/ellanetworks/core/internal/kernel"
@@ -243,9 +242,9 @@ func addRemoteIPToNeigh(ctx context.Context, remoteIP uint32) {
 		return
 	}
 
-	ipBytes := make([]byte, 4)
-	binary.NativeEndian.PutUint32(ipBytes, remoteIP)
-	ip := net.IP(ipBytes)
+	var b [4]byte
+	binary.NativeEndian.PutUint32(b[:], remoteIP)
+	ip := netip.AddrFrom4(b)
 
 	if err := kernel.AddNeighbour(ctx, ip); err != nil {
 		logger.UpfLog.Warn("could not add gnb IP to neighbour list", logger.IPAddress(ip.String()), zap.Error(err))

--- a/internal/upf/engine/flow_reporter.go
+++ b/internal/upf/engine/flow_reporter.go
@@ -6,7 +6,7 @@ package engine
 import (
 	"encoding/binary"
 	"fmt"
-	"net"
+	"net/netip"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -38,11 +38,11 @@ func mustGetBootTime() time.Time {
 	return bootTime
 }
 
-func int2ip(nn uint32) net.IP {
-	ip := make(net.IP, 4)
-	binary.NativeEndian.PutUint32(ip, nn)
+func int2ip(nn uint32) netip.Addr {
+	var b [4]byte
+	binary.NativeEndian.PutUint32(b[:], nn)
 
-	return ip
+	return netip.AddrFrom4(b)
 }
 
 func u16NtoHS(n uint16) uint16 {

--- a/internal/upf/engine/flow_reporter_test.go
+++ b/internal/upf/engine/flow_reporter_test.go
@@ -5,7 +5,7 @@ package engine_test
 
 import (
 	"encoding/binary"
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -16,10 +16,11 @@ import (
 // Helper function to convert IP address to uint32 format used by eBPF
 // The actual implementation uses binary.NativeEndian.PutUint32(), so we reverse it
 func makeIPUint32(b0, b1, b2, b3 byte) uint32 {
-	// Create a net.IP from the bytes
-	ip := net.IPv4(b0, b1, b2, b3)
+	addr := netip.AddrFrom4([4]byte{b0, b1, b2, b3})
 	// Convert to uint32 using NativeEndian (matching the actual int2ip function behavior)
-	return binary.NativeEndian.Uint32(ip.To4())
+	b := addr.As4()
+
+	return binary.NativeEndian.Uint32(b[:])
 }
 
 // Helper function to convert port from host byte order to network byte order

--- a/internal/upf/engine/sdf_handlers.go
+++ b/internal/upf/engine/sdf_handlers.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"encoding/binary"
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/upf/ebpf"
@@ -31,10 +31,18 @@ func updateFiltersRule(rule models.FilterRule) ebpf.SdfRule {
 	}
 
 	if rule.RemotePrefix != "" {
-		_, ipnet, err := net.ParseCIDR(rule.RemotePrefix)
+		prefix, err := netip.ParsePrefix(rule.RemotePrefix)
 		if err == nil {
-			sdfRule.RemoteIP = binary.BigEndian.Uint32(ipnet.IP.To4())
-			sdfRule.RemoteMask = binary.BigEndian.Uint32(ipnet.Mask)
+			addr4 := prefix.Masked().Addr().As4()
+			sdfRule.RemoteIP = binary.BigEndian.Uint32(addr4[:])
+			bits := prefix.Bits()
+
+			mask := uint32(0)
+			if bits > 0 {
+				mask = ^uint32(0) << (32 - bits)
+			}
+
+			sdfRule.RemoteMask = mask
 		}
 	}
 

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -594,7 +594,7 @@ func (u *UPF) listenForMissingNeighbours() {
 			continue
 		}
 
-		if err := kernel.AddNeighbour(u.ctx, ip.AsSlice()); err != nil {
+		if err := kernel.AddNeighbour(u.ctx, ip); err != nil {
 			logger.UpfLog.Warn("could not add neighbour", zap.String("destination", ip.String()), zap.Error(err))
 			continue
 		}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"sync"
 	"time"
@@ -130,13 +130,19 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		return fmt.Errorf("couldn't get N6 interface IP: %w", err)
 	}
 
+	n6Addr, err := netip.ParseAddr(n6IP)
+	if err != nil {
+		return fmt.Errorf("couldn't parse N6 IP %q: %w", n6IP, err)
+	}
+
 	realKernel := kernel.NewRealKernel(cfg.Interfaces.N3.Name, cfg.Interfaces.N6.Name)
 
 	uePools := collectUEPools(ctx, dbInstance)
-	routeFilter := bgp.BuildRouteFilter(uePools, net.ParseIP(cfg.Interfaces.N3.Address), cfg.Interfaces.N6.Name)
+	n3Addr, _ := netip.ParseAddr(cfg.Interfaces.N3.Address)
+	routeFilter := bgp.BuildRouteFilter(uePools, n3Addr, cfg.Interfaces.N6.Name)
 	importStore := &bgpImportPrefixAdapter{db: dbInstance}
 
-	bgpService := bgp.New(net.ParseIP(n6IP), logger.EllaLog,
+	bgpService := bgp.New(n6Addr, logger.EllaLog,
 		bgp.WithKernel(realKernel),
 		bgp.WithImportPrefixStore(importStore),
 		bgp.WithRouteFilter(routeFilter),
@@ -454,7 +460,7 @@ func (a *bgpImportPrefixAdapter) ListImportPrefixes(ctx context.Context, peerID 
 }
 
 // collectUEPools returns the UE IP pool CIDRs from all data networks.
-func collectUEPools(ctx context.Context, dbInstance *db.Database) []*net.IPNet {
+func collectUEPools(ctx context.Context, dbInstance *db.Database) []netip.Prefix {
 	dataNetworks, err := dbInstance.ListAllDataNetworks(ctx)
 	if err != nil {
 		logger.EllaLog.Warn("failed to list data networks for BGP filter", zap.Error(err))
@@ -462,15 +468,15 @@ func collectUEPools(ctx context.Context, dbInstance *db.Database) []*net.IPNet {
 		return nil
 	}
 
-	var pools []*net.IPNet
+	var pools []netip.Prefix
 
 	for _, dn := range dataNetworks {
-		_, network, err := net.ParseCIDR(dn.IPPool)
+		prefix, err := netip.ParsePrefix(dn.IPPool)
 		if err != nil {
 			continue
 		}
 
-		pools = append(pools, network)
+		pools = append(pools, prefix)
 	}
 
 	return pools


### PR DESCRIPTION
# Description

`netip.Addr` is the recommended type since Go 1.18. It is an immutable, comparable, zero-allocation value type that eliminates the 4-vs-16-byte ambiguity bug class inherent in `net.IP`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
