### PR TITLE
fix: Use Via instead of Gw in Netlink

### DIFF
--- a/internal/kernel/routes.go
+++ b/internal/kernel/routes.go
@@ -67,6 +67,22 @@ func addrToNetIP(a netip.Addr) net.IP {
 	return a.AsSlice()
 }
 
+// addrToVia converts a netip.Addr to a netlink.Via for netlink.
+func addrToVia(a netip.Addr) *netlink.Via {
+	if !a.IsValid() {
+		return nil
+	}
+
+    family := netlink.FAMILY_V4
+    if a.Is6() {
+        family = netlink.FAMILY_V6
+    }
+    return &netlink.Via{
+        AddrFamily: family,
+        Addr:       net.IP(a.AsSlice()),
+    }
+}
+
 // CreateRoute adds a route to the kernel for the interface defined by ifKey.
 func (rk *RealKernel) CreateRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error {
 	interfaceName, ok := rk.ifMapping[ifKey]
@@ -81,7 +97,7 @@ func (rk *RealKernel) CreateRoute(destination netip.Prefix, gateway netip.Addr, 
 
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Gw:        addrToNetIP(gateway),
+		Via:       addrToVia(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -111,7 +127,7 @@ func (rk *RealKernel) DeleteRoute(destination netip.Prefix, gateway netip.Addr, 
 
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Gw:        addrToNetIP(gateway),
+		Via:       addrToVia(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -140,7 +156,7 @@ func (rk *RealKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr,
 
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Gw:        addrToNetIP(gateway),
+		Via:       addrToVia(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,

--- a/internal/kernel/routes.go
+++ b/internal/kernel/routes.go
@@ -92,20 +92,30 @@ func addrToNetIP(a netip.Addr) net.IP {
 	return a.AsSlice()
 }
 
-// addrToVia converts a netip.Addr to a netlink.Via for netlink.
-func addrToVia(a netip.Addr) *netlink.Via {
-	if !a.IsValid() {
-		return nil
+// gwOrVia builds the gateway/via fields for a route.
+// When the destination and gateway families match, it uses Gw (RTA_GATEWAY).
+// When they differ (e.g. IPv4 dst + IPv6 gw), it uses Via (RTA_VIA) since
+// RTA_GATEWAY requires family matching in the kernel.
+func gwOrVia(destination netip.Prefix, gateway netip.Addr) (net.IP, *netlink.Via) {
+	if !gateway.IsValid() {
+		return nil, nil
+	}
+
+	dstIs4 := destination.Addr().Is4()
+	gwIs4 := gateway.Is4()
+
+	if dstIs4 == gwIs4 {
+		return addrToNetIP(gateway), nil
 	}
 
 	family := netlink.FAMILY_V4
-	if a.Is6() {
+	if gateway.Is6() {
 		family = netlink.FAMILY_V6
 	}
 
-	return &netlink.Via{
+	return nil, &netlink.Via{
 		AddrFamily: family,
-		Addr:       net.IP(a.AsSlice()),
+		Addr:       net.IP(gateway.AsSlice()),
 	}
 }
 
@@ -121,23 +131,37 @@ func (rk *RealKernel) CreateRoute(destination netip.Prefix, gateway netip.Addr, 
 		return fmt.Errorf("failed to find network interface %q: %v", interfaceName, err)
 	}
 
+	gw, via := gwOrVia(destination, gateway)
+
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Via:       addrToVia(gateway),
+		Gw:        gw,
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
 		Protocol:  rtProtoElla,
 	}
+	if via != nil {
+		nlRoute.Via = via
+	}
 
 	if err := netlink.RouteAdd(&nlRoute); err != nil {
+		logger.EllaLog.Debug("failed to add route", zap.Any("nlRoute", nlRoute))
 		return fmt.Errorf("failed to add route: %v", err)
 	}
 
 	logger.EllaLog.Debug("Added route", zap.String("destination", destination.String()), zap.String("gateway", gateway.String()), zap.Int("priority", priority), zap.String("interface", interfaceName))
 
 	// Tells the kernel that the gateway is in use, and ARP requests should be sent out
-	return addNeighbourForLink(addrToNetIP(gateway), link)
+	if gw != nil {
+		return addNeighbourForLink(gw, link)
+	}
+
+	if via != nil {
+		return addNeighbourForLink(via.Addr, link)
+	}
+
+	return nil
 }
 
 // DeleteRoute removes a route from the kernel for the interface defined by ifKey.
@@ -154,13 +178,18 @@ func (rk *RealKernel) DeleteRoute(destination netip.Prefix, gateway netip.Addr, 
 		return fmt.Errorf("failed to find network interface %q: %v", interfaceName, err)
 	}
 
+	gw, via := gwOrVia(destination, gateway)
+
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Via:       addrToVia(gateway),
+		Gw:        gw,
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
 		Protocol:  rtProtoElla,
+	}
+	if via != nil {
+		nlRoute.Via = via
 	}
 
 	if err := netlink.RouteDel(&nlRoute); err != nil {
@@ -184,13 +213,18 @@ func (rk *RealKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr,
 		return fmt.Errorf("failed to find network interface %q: %v", interfaceName, err)
 	}
 
+	gw, via := gwOrVia(destination, gateway)
+
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Via:       addrToVia(gateway),
+		Gw:        gw,
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
 		Protocol:  rtProtoElla,
+	}
+	if via != nil {
+		nlRoute.Via = via
 	}
 
 	if err := netlink.RouteReplace(&nlRoute); err != nil {
@@ -199,7 +233,15 @@ func (rk *RealKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr,
 
 	logger.EllaLog.Debug("Replaced route", zap.String("destination", destination.String()), zap.String("gateway", gateway.String()), zap.Int("priority", priority), zap.String("interface", interfaceName))
 
-	return addNeighbourForLink(addrToNetIP(gateway), link)
+	if gw != nil {
+		return addNeighbourForLink(gw, link)
+	}
+
+	if via != nil {
+		return addNeighbourForLink(via.Addr, link)
+	}
+
+	return nil
 }
 
 // ListRoutesByPriority returns Ella-owned route destinations with the given
@@ -295,7 +337,17 @@ func (rk *RealKernel) ListManagedRoutes(ifKey NetworkInterface) ([]ManagedRoute,
 		}
 
 		ones, _ := r.Dst.Mask.Size()
-		gw, _ := netip.AddrFromSlice(r.Gw)
+
+		var gw netip.Addr
+		if r.Gw != nil {
+			gw, _ = netip.AddrFromSlice(r.Gw)
+		} else if r.Via != nil {
+			if via, ok := r.Via.(*netlink.Via); ok {
+				if viaAddr, ok := netip.AddrFromSlice(via.Addr); ok {
+					gw = viaAddr
+				}
+			}
+		}
 
 		result = append(result, ManagedRoute{
 			Destination: netip.PrefixFrom(dstAddr, ones),
@@ -353,7 +405,7 @@ func (rk *RealKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, 
 		af = unix.AF_INET6
 	}
 
-	expectedVia := addrToVia(gateway)
+	_, expectedVia := gwOrVia(destination, gateway)
 
 	routes, err := netlink.RouteListFiltered(af, &nlRoute, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PROTOCOL)
 	if err != nil {
@@ -361,7 +413,13 @@ func (rk *RealKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, 
 	}
 
 	for _, r := range routes {
-		if r.Via != nil && r.Via.Equal(expectedVia) {
+		if r.Gw != nil {
+			if gw, ok := netip.AddrFromSlice(r.Gw); ok && gw == gateway {
+				return true, nil
+			}
+		}
+
+		if expectedVia != nil && r.Via != nil && r.Via.Equal(expectedVia) {
 			return true, nil
 		}
 	}
@@ -488,6 +546,15 @@ func (rk *RealKernel) EnsureGatewaysOnInterfaceInNeighTable(ifKey NetworkInterfa
 			err := addNeighbourForLink(route.Gw, link)
 			if err != nil {
 				logger.EllaLog.Warn("failed to add gateway to neighbour list, arp may need to be triggered manually", zap.String("gateway", route.Gw.String()), zap.Error(err))
+			}
+		}
+
+		if route.Via != nil {
+			if via, ok := route.Via.(*netlink.Via); ok {
+				err := addNeighbourForLink(via.Addr, link)
+				if err != nil {
+					logger.EllaLog.Warn("failed to add gateway to neighbour list, arp may need to be triggered manually", zap.String("gateway", via.Addr.String()), zap.Error(err))
+				}
 			}
 		}
 	}

--- a/internal/kernel/routes.go
+++ b/internal/kernel/routes.go
@@ -98,14 +98,15 @@ func addrToVia(a netip.Addr) *netlink.Via {
 		return nil
 	}
 
-    family := netlink.FAMILY_V4
-    if a.Is6() {
-        family = netlink.FAMILY_V6
-    }
-    return &netlink.Via{
-        AddrFamily: family,
-        Addr:       net.IP(a.AsSlice()),
-    }
+	family := netlink.FAMILY_V4
+	if a.Is6() {
+		family = netlink.FAMILY_V6
+	}
+
+	return &netlink.Via{
+		AddrFamily: family,
+		Addr:       net.IP(a.AsSlice()),
+	}
 }
 
 // CreateRoute adds a route to the kernel for the interface defined by ifKey.
@@ -341,7 +342,6 @@ func (rk *RealKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, 
 
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Gw:        addrToNetIP(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -353,13 +353,17 @@ func (rk *RealKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, 
 		af = unix.AF_INET6
 	}
 
-	routes, err := netlink.RouteListFiltered(af, &nlRoute, netlink.RT_FILTER_DST|netlink.RT_FILTER_GW|netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PROTOCOL)
+	expectedVia := addrToVia(gateway)
+
+	routes, err := netlink.RouteListFiltered(af, &nlRoute, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PROTOCOL)
 	if err != nil {
 		return false, fmt.Errorf("failed to list routes: %v", err)
 	}
 
-	if len(routes) > 0 {
-		return true, nil
+	for _, r := range routes {
+		if r.Via != nil && r.Via.Equal(expectedVia) {
+			return true, nil
+		}
 	}
 
 	return false, nil

--- a/internal/kernel/routes.go
+++ b/internal/kernel/routes.go
@@ -92,6 +92,22 @@ func addrToNetIP(a netip.Addr) net.IP {
 	return a.AsSlice()
 }
 
+// addrToVia converts a netip.Addr to a netlink.Via for netlink.
+func addrToVia(a netip.Addr) *netlink.Via {
+	if !a.IsValid() {
+		return nil
+	}
+
+    family := netlink.FAMILY_V4
+    if a.Is6() {
+        family = netlink.FAMILY_V6
+    }
+    return &netlink.Via{
+        AddrFamily: family,
+        Addr:       net.IP(a.AsSlice()),
+    }
+}
+
 // CreateRoute adds a route to the kernel for the interface defined by ifKey.
 func (rk *RealKernel) CreateRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error {
 	interfaceName, ok := rk.ifMapping[ifKey]
@@ -106,7 +122,7 @@ func (rk *RealKernel) CreateRoute(destination netip.Prefix, gateway netip.Addr, 
 
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Gw:        addrToNetIP(gateway),
+		Via:       addrToVia(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -139,7 +155,7 @@ func (rk *RealKernel) DeleteRoute(destination netip.Prefix, gateway netip.Addr, 
 
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Gw:        addrToNetIP(gateway),
+		Via:       addrToVia(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,
@@ -169,7 +185,7 @@ func (rk *RealKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr,
 
 	nlRoute := netlink.Route{
 		Dst:       prefixToIPNet(destination),
-		Gw:        addrToNetIP(gateway),
+		Via:       addrToVia(gateway),
 		LinkIndex: link.Attrs().Index,
 		Priority:  priority,
 		Table:     unix.RT_TABLE_MAIN,

--- a/internal/kernel/routes_test.go
+++ b/internal/kernel/routes_test.go
@@ -1,0 +1,71 @@
+package kernel
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestAddrToVia(t *testing.T) {
+	// IPv4 address → FAMILY_V4
+	v4 := netip.MustParseAddr("192.168.1.1")
+
+	via := addrToVia(v4)
+	if via == nil {
+		t.Fatal("expected non-nil Via for valid IPv4 address")
+	}
+
+	if via.AddrFamily != netlink.FAMILY_V4 {
+		t.Errorf("expected FAMILY_V4, got %d", via.AddrFamily)
+	}
+
+	if len(via.Addr) != 4 {
+		t.Errorf("expected 4-byte address, got %d", len(via.Addr))
+	}
+
+	// IPv6 address → FAMILY_V6
+	v6 := netip.MustParseAddr("2001:db8::1")
+
+	via = addrToVia(v6)
+	if via == nil {
+		t.Fatal("expected non-nil Via for valid IPv6 address")
+	}
+
+	if via.AddrFamily != netlink.FAMILY_V6 {
+		t.Errorf("expected FAMILY_V6, got %d", via.AddrFamily)
+	}
+
+	if len(via.Addr) != 16 {
+		t.Errorf("expected 16-byte address, got %d", len(via.Addr))
+	}
+
+	// Invalid address → nil
+	if addrToVia(netip.Addr{}) != nil {
+		t.Error("expected nil for invalid address")
+	}
+}
+
+func TestPrefixToIPNet(t *testing.T) {
+	p := netip.MustParsePrefix("10.0.0.0/24")
+
+	ipNet := prefixToIPNet(p)
+	if ipNet.String() != "10.0.0.0/24" {
+		t.Errorf("got %q, want %q", ipNet.String(), "10.0.0.0/24")
+	}
+
+	p6 := netip.MustParsePrefix("2001:db8::/32")
+
+	ipNet = prefixToIPNet(p6)
+	if ipNet.String() != "2001:db8::/32" {
+		t.Errorf("got %q, want %q", ipNet.String(), "2001:db8::/32")
+	}
+
+	// /0 prefix
+	zero := netip.MustParsePrefix("0.0.0.0/0")
+
+	ipNet = prefixToIPNet(zero)
+	if ipNet.String() != "0.0.0.0/0" {
+		t.Errorf("got %q, want %q", ipNet.String(), "0.0.0.0/0")
+	}
+}

--- a/internal/kernel/routes_test.go
+++ b/internal/kernel/routes_test.go
@@ -7,29 +7,46 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func TestAddrToVia(t *testing.T) {
-	// IPv4 address → FAMILY_V4
+func TestGwOrVia_SameFamily(t *testing.T) {
+	// IPv4 dst + IPv4 gw → Gw set, Via nil
 	v4 := netip.MustParseAddr("192.168.1.1")
+	p4 := netip.MustParsePrefix("10.0.0.0/24")
 
-	via := addrToVia(v4)
-	if via == nil {
-		t.Fatal("expected non-nil Via for valid IPv4 address")
+	gw, via := gwOrVia(p4, v4)
+	if gw == nil {
+		t.Fatal("expected non-nil Gw for matching families")
 	}
 
-	if via.AddrFamily != netlink.FAMILY_V4 {
-		t.Errorf("expected FAMILY_V4, got %d", via.AddrFamily)
+	if via != nil {
+		t.Error("expected nil Via for matching families")
 	}
 
-	if len(via.Addr) != 4 {
-		t.Errorf("expected 4-byte address, got %d", len(via.Addr))
-	}
-
-	// IPv6 address → FAMILY_V6
+	// IPv6 dst + IPv6 gw → Gw set, Via nil
 	v6 := netip.MustParseAddr("2001:db8::1")
+	p6 := netip.MustParsePrefix("2001:db8::/32")
 
-	via = addrToVia(v6)
+	gw, via = gwOrVia(p6, v6)
+	if gw == nil {
+		t.Fatal("expected non-nil Gw for matching families")
+	}
+
+	if via != nil {
+		t.Error("expected nil Via for matching families")
+	}
+}
+
+func TestGwOrVia_MixedFamily(t *testing.T) {
+	// IPv4 dst + IPv6 gw → Gw nil, Via with FAMILY_V6
+	v6 := netip.MustParseAddr("2001:db8::1")
+	p4 := netip.MustParsePrefix("10.0.0.0/24")
+
+	gw, via := gwOrVia(p4, v6)
+	if gw != nil {
+		t.Error("expected nil Gw for mismatched families")
+	}
+
 	if via == nil {
-		t.Fatal("expected non-nil Via for valid IPv6 address")
+		t.Fatal("expected non-nil Via for mismatched families")
 	}
 
 	if via.AddrFamily != netlink.FAMILY_V6 {
@@ -40,9 +57,38 @@ func TestAddrToVia(t *testing.T) {
 		t.Errorf("expected 16-byte address, got %d", len(via.Addr))
 	}
 
-	// Invalid address → nil
-	if addrToVia(netip.Addr{}) != nil {
-		t.Error("expected nil for invalid address")
+	// IPv6 dst + IPv4 gw → Gw nil, Via with FAMILY_V4
+	v4 := netip.MustParseAddr("192.168.1.1")
+	p6 := netip.MustParsePrefix("2001:db8::/32")
+
+	gw, via = gwOrVia(p6, v4)
+	if gw != nil {
+		t.Error("expected nil Gw for mismatched families")
+	}
+
+	if via == nil {
+		t.Fatal("expected non-nil Via for mismatched families")
+	}
+
+	if via.AddrFamily != netlink.FAMILY_V4 {
+		t.Errorf("expected FAMILY_V4, got %d", via.AddrFamily)
+	}
+
+	if len(via.Addr) != 4 {
+		t.Errorf("expected 4-byte address, got %d", len(via.Addr))
+	}
+}
+
+func TestGwOrVia_Invalid(t *testing.T) {
+	p4 := netip.MustParsePrefix("10.0.0.0/24")
+
+	gw, via := gwOrVia(p4, netip.Addr{})
+	if gw != nil {
+		t.Error("expected nil Gw for invalid address")
+	}
+
+	if via != nil {
+		t.Error("expected nil Via for invalid address")
 	}
 }
 


### PR DESCRIPTION
# Description

Via is a more modern (kernel ~5.0+) route attribute which includes an address family, rather than Gateway, which must match the route address family. 

Resolves #1236 - tested with BIRD3 with a valid IPv6 next-hop

Once again, not sure about tests for this one. 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
