### PR TITLE
feat!: Handle IPv6 IPs for API

### DIFF
--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -23,16 +23,16 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
 - `interfaces` (object): The network interfaces configuration.
     - `n2` (object): The configuration for the n2 interface. This interface should be connected to the radios.
         - `name` (string): The name of the network interface (optional: either name or address must be provided).
-        - `address` (string): The address to listen on (optional: either name or address must be provided).
+        - `address` (string): The address to listen on. Currently only IPv4 is supported (optional: either name or address must be provided).
         - `port` (int): The port to listen on.
     - `n3` (object): The configuration for the n3 interface. This interface should be connected to the radios.
         - `name` (string): The name of the network interface (optional: either name or address must be provided).
-        - `address` (string): The address to listen on (optional: either name or address must be provided).
+        - `address` (string): The address to listen on. Currently only IPv4 is supported (optional: either name or address must be provided).
     - `n6` (object): The configuration for the n6 interface. This interface should be connected to the internet.
         - `name` (string): The name of the network interface.
     - `api` (object): The configuration for the api interface.
-        - `name` (string): The name of the network interface (optional: either name or address must be provided).
-        - `address` (string): The address to listen on (optional: either name or address must be provided).
+        - `name` (string): The name of the network interface to listen on (optional: either name or address must be provided). When set, the server listens on all addresses (`0.0.0.0`) but uses `SO_BINDTODEVICE` to restrict incoming traffic to this interface. Use this when you want to bind to a device without pinning to a specific IP address.
+        - `address` (string): The IP address to listen on. Supports both IPv4 and IPv6 addresses (optional: either name or address must be provided). When set, the server binds to this specific address.
         - `port` (int): The port to listen on.
         - `tls` (object): The TLS configuration (optional).
             - `cert` (string): The path to the TLS certificate file (optional).
@@ -78,3 +78,24 @@ telemetry:
   enabled: true
   otlp-endpoint: "localhost:4317"
 ```
+
+## IPv6 Support
+
+Ella Core supports IPv6 addresses for the management interface (`api`). The following example demonstrates using an IPv6 address:
+
+```yaml
+interfaces:
+  n2:
+    address: "22.22.22.2"
+    port: 38412
+  n3:
+    name: "ens5"
+  n6:
+    name: "ens3"
+  api:
+    address: "2001:db8::2"
+    port: 5002
+```
+
+!!! note
+    IPv6 support is currently limited to the management interfaces (`api`). The subscriber data interfaces (`n3` and `n6`) and radio interface (`n2`) currently only support IPv4 addresses.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,8 +5,11 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/netip"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
@@ -72,7 +75,10 @@ func Start(ctx context.Context, dbInstance *db.Database, cfg config.Config, upf 
 		RegisterExtraRoutes: registerExtraRoutes,
 	})
 
-	httpAddr := fmt.Sprintf("%s:%d", cfg.Interfaces.API.Address, cfg.Interfaces.API.Port)
+	httpAddr := fmt.Sprintf(":%s", strconv.Itoa(cfg.Interfaces.API.Port))
+	if cfg.Interfaces.API.Address != "" {
+		httpAddr = net.JoinHostPort(cfg.Interfaces.API.Address, strconv.Itoa(cfg.Interfaces.API.Port))
+	}
 
 	h2Server := &http2.Server{
 		IdleTimeout: 120 * time.Second,
@@ -88,8 +94,43 @@ func Start(ctx context.Context, dbInstance *db.Database, cfg config.Config, upf 
 	go func() {
 		var serveErr error
 
+		var ln net.Listener
+
+		if cfg.Interfaces.API.Name != "" {
+			lc := net.ListenConfig{
+				Control: func(network, address string, c syscall.RawConn) error {
+					var setSockOptErr error
+
+					if err := c.Control(func(fd uintptr) {
+						setSockOptErr = syscall.SetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, cfg.Interfaces.API.Name)
+					}); err != nil {
+						return err
+					}
+
+					return setSockOptErr
+				},
+			}
+
+			ln, serveErr = lc.Listen(ctx, "tcp", httpAddr)
+			if serveErr != nil {
+				logger.APILog.Fatal("couldn't create listener", zap.Error(serveErr))
+				return
+			}
+		}
+
+		logFields := []zap.Field{
+			zap.String("scheme", string(scheme)),
+			zap.String("address", httpAddr),
+		}
+		if cfg.Interfaces.API.Name != "" {
+			logFields = append(logFields, zap.String("interface", cfg.Interfaces.API.Name))
+		}
+
+		logger.APILog.Info("API server started", logFields...)
+
 		if scheme == HTTPS {
 			srv.Handler = router
+
 			srv.TLSConfig = &tls.Config{
 				MinVersion: tls.VersionTLS12,
 				CipherSuites: []uint16{
@@ -106,18 +147,24 @@ func Start(ctx context.Context, dbInstance *db.Database, cfg config.Config, upf 
 					tls.CurveP384,
 				},
 			}
-			serveErr = srv.ListenAndServeTLS(cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key)
+			if ln != nil {
+				serveErr = srv.ServeTLS(ln, cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key)
+			} else {
+				serveErr = srv.ListenAndServeTLS(cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key)
+			}
 		} else {
 			srv.Handler = h2c.NewHandler(router, h2Server)
-			serveErr = srv.ListenAndServe()
+			if ln != nil {
+				serveErr = srv.Serve(ln)
+			} else {
+				serveErr = srv.ListenAndServe()
+			}
 		}
 
 		if serveErr != nil && serveErr != http.ErrServerClosed {
 			logger.APILog.Fatal("couldn't start API server", zap.Error(serveErr))
 		}
 	}()
-
-	logger.APILog.Info("API server started", zap.String("scheme", string(scheme)), zap.String("address", fmt.Sprintf("%s://%s:%d", scheme, cfg.Interfaces.API.Address, cfg.Interfaces.API.Port)))
 
 	// Reconcile routes on startup and every 5 minutes.
 	reconcile := routeReconciler // capture to avoid racing with test teardown

--- a/internal/api/server/api_interfaces.go
+++ b/internal/api/server/api_interfaces.go
@@ -34,8 +34,8 @@ type N6Interface struct {
 }
 
 type APIInterface struct {
-	Address string `json:"address"`
-	Port    int    `json:"port"`
+	Addresses []string `json:"addresses"`
+	Port      int      `json:"port"`
 }
 
 type NetworkInterfaces struct {
@@ -61,6 +61,20 @@ func ListNetworkInterfaces(dbInstance *db.Database, cfg config.Config) http.Hand
 			return
 		}
 
+		var apiAddresses []string
+
+		if cfg.Interfaces.API.Name != "" {
+			ips, err := config.GetInterfaceIPs(cfg.Interfaces.API.Name)
+			if err != nil {
+				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get API interface IPs", err, logger.APILog)
+				return
+			}
+
+			apiAddresses = ips
+		} else if cfg.Interfaces.API.Address != "" {
+			apiAddresses = []string{cfg.Interfaces.API.Address}
+		}
+
 		resp := &NetworkInterfaces{
 			N2: N2Interface{
 				Address: cfg.Interfaces.N2.Address,
@@ -75,8 +89,8 @@ func ListNetworkInterfaces(dbInstance *db.Database, cfg config.Config) http.Hand
 				Name: cfg.Interfaces.N6.Name,
 			},
 			API: APIInterface{
-				Address: cfg.Interfaces.API.Address,
-				Port:    cfg.Interfaces.API.Port,
+				Addresses: apiAddresses,
+				Port:      cfg.Interfaces.API.Port,
 			},
 		}
 

--- a/internal/api/server/api_interfaces_test.go
+++ b/internal/api/server/api_interfaces_test.go
@@ -25,8 +25,8 @@ type N6Interface struct {
 }
 
 type APIInterface struct {
-	Address string `json:"address"`
-	Port    int    `json:"port"`
+	Addresses []string `json:"addresses"`
+	Port      int      `json:"port"`
 }
 
 type NetworkInterfaces struct {
@@ -176,8 +176,8 @@ func TestNetworkInteraces_EndToEnd(t *testing.T) {
 			t.Fatalf("unexpected N6 interface name: %s", resp.Result.N6.Name)
 		}
 
-		if resp.Result.API.Address != "" {
-			t.Fatalf("unexpected API interface address: %s", resp.Result.API.Address)
+		if len(resp.Result.API.Addresses) != 0 {
+			t.Fatalf("unexpected API interface addresses: %v", resp.Result.API.Addresses)
 		}
 
 		if resp.Result.API.Port != 8443 {

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -4311,11 +4311,13 @@ components:
     APIInterface:
       type: object
       properties:
-        address:
-          type: string
+        addresses:
+          type: array
+          items:
+            type: string
         port:
           type: integer
-      required: [address, port]
+      required: [addresses, port]
 
     NetworkInterfaces:
       type: object

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,16 @@ const (
 	AttachModeGeneric = "generic"
 )
 
+// AddressFamily specifies which IP address family to return when resolving an interface IP.
+type AddressFamily int
+
+const (
+	// IPv4 filters for IPv4-only addresses.
+	IPv4 AddressFamily = iota
+	// AnyFamily accepts any address family, preferring non-link-local IPv6 over IPv4.
+	AnyFamily
+)
+
 const (
 	LoggingSystemOutputStdout = "stdout"
 	LoggingSystemOutputFile   = "file"
@@ -128,6 +138,7 @@ type N6Interface struct {
 }
 
 type APIInterface struct {
+	Name    string
 	Address string
 	Port    int
 	TLS     TLS
@@ -248,7 +259,7 @@ func Validate(filePath string) (Config, error) {
 		return Config{}, errors.New("interfaces.n2 is empty")
 	}
 
-	_, n2Address, err := getInterfaceNameAndAddress(c.Interfaces.N2.Name, c.Interfaces.N2.Address)
+	_, n2Address, err := getInterfaceNameAndAddress(c.Interfaces.N2.Name, c.Interfaces.N2.Address, IPv4)
 	if err != nil {
 		return Config{}, fmt.Errorf("interfaces.n2: %w", err)
 	}
@@ -257,7 +268,7 @@ func Validate(filePath string) (Config, error) {
 		return Config{}, errors.New("interfaces.n3 is empty")
 	}
 
-	n3InterfaceName, n3Address, err := getInterfaceNameAndAddress(c.Interfaces.N3.Name, c.Interfaces.N3.Address)
+	n3InterfaceName, n3Address, err := getInterfaceNameAndAddress(c.Interfaces.N3.Name, c.Interfaces.N3.Address, IPv4)
 	if err != nil {
 		return Config{}, fmt.Errorf("interfaces.n3: %w", err)
 	}
@@ -274,7 +285,7 @@ func Validate(filePath string) (Config, error) {
 		return Config{}, errors.New("interfaces.api is empty")
 	}
 
-	_, apiAddress, err := getInterfaceNameAndAddress(c.Interfaces.API.Name, c.Interfaces.API.Address)
+	apiInterfaceName, apiAddress, err := getInterfaceNameAndAddress(c.Interfaces.API.Name, c.Interfaces.API.Address, AnyFamily)
 	if err != nil {
 		return Config{}, fmt.Errorf("interfaces.api: %w", err)
 	}
@@ -337,8 +348,14 @@ func Validate(filePath string) (Config, error) {
 	config.Interfaces.N2.Port = c.Interfaces.N2.Port
 	config.Interfaces.N3.Name = n3InterfaceName
 	config.Interfaces.N3.Address = n3Address
+
 	config.Interfaces.N6.Name = c.Interfaces.N6.Name
-	config.Interfaces.API.Address = apiAddress
+	if c.Interfaces.API.Name != "" {
+		config.Interfaces.API.Name = apiInterfaceName
+	} else {
+		config.Interfaces.API.Address = apiAddress
+	}
+
 	config.Interfaces.API.Port = c.Interfaces.API.Port
 	config.XDP.AttachMode = c.XDP.AttachMode
 	config.Telemetry.OTLPEndpoint = c.Telemetry.OTLPEndpoint
@@ -347,7 +364,7 @@ func Validate(filePath string) (Config, error) {
 	return config, nil
 }
 
-func getInterfaceNameAndAddress(interfaceName string, address string) (string, string, error) {
+func getInterfaceNameAndAddress(interfaceName string, address string, family AddressFamily) (string, string, error) {
 	if interfaceName != "" && address != "" {
 		return "", "", errors.New("interface name and address cannot be both set")
 	}
@@ -362,9 +379,9 @@ func getInterfaceNameAndAddress(interfaceName string, address string) (string, s
 			return "", "", fmt.Errorf("interface name %s does not exist on the host: %w", interfaceName, err)
 		}
 
-		computedAddress, err := GetInterfaceIP(interfaceName)
+		computedAddress, err := GetInterfaceIP(interfaceName, family)
 		if err != nil {
-			return "", "", fmt.Errorf("cannot get IPv4 address for interface %s: %w", interfaceName, err)
+			return "", "", fmt.Errorf("cannot get IP address for interface %s: %w", interfaceName, err)
 		}
 
 		return interfaceName, computedAddress, nil
@@ -377,7 +394,7 @@ func getInterfaceNameAndAddress(interfaceName string, address string) (string, s
 
 		computedInterfaceName, err := GetInterfaceName(address)
 		if err != nil {
-			return "", "", fmt.Errorf("cannot get interface name for IP address  %s: %w", address, err)
+			return "", "", fmt.Errorf("cannot get interface name for IP address %s: %w", address, err)
 		}
 
 		return computedInterfaceName, address, nil
@@ -399,7 +416,7 @@ var CheckInterfaceExistsFunc = func(name string) (bool, error) {
 	return true, nil
 }
 
-var GetInterfaceIPFunc = func(name string) (string, error) {
+var GetInterfaceIPFunc = func(name string, family AddressFamily) (string, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
 		return "", err
@@ -410,15 +427,32 @@ var GetInterfaceIPFunc = func(name string) (string, error) {
 		return "", err
 	}
 
+	var ipv4Fallback string
+
 	for _, addr := range addresses {
 		if ip, _, err := net.ParseCIDR(addr.String()); err == nil {
-			if ip.To4() != nil {
-				return ip.String(), nil
+			switch family {
+			case IPv4:
+				if ip.To4() != nil {
+					return ip.String(), nil
+				}
+			case AnyFamily:
+				if ip.To4() == nil && !ip.IsLinkLocalUnicast() {
+					return ip.String(), nil
+				}
+
+				if ip.To4() != nil && ipv4Fallback == "" {
+					ipv4Fallback = ip.String()
+				}
 			}
 		}
 	}
 
-	return "", errors.New("no valid IPv4 address found")
+	if family == AnyFamily && ipv4Fallback != "" {
+		return ipv4Fallback, nil
+	}
+
+	return "", errors.New("no valid IP address found")
 }
 
 var GetInterfaceNameFunc = func(address string) (string, error) {
@@ -471,8 +505,8 @@ var GetVLANConfigForInterfaceFunc = func(name string) (*VlanConfig, error) {
 	return nil, nil
 }
 
-func GetInterfaceIP(name string) (string, error) {
-	return GetInterfaceIPFunc(name)
+func GetInterfaceIP(name string, family AddressFamily) (string, error) {
+	return GetInterfaceIPFunc(name, family)
 }
 
 func InterfaceExists(name string) (bool, error) {
@@ -481,4 +515,32 @@ func InterfaceExists(name string) (bool, error) {
 
 func GetInterfaceName(address string) (string, error) {
 	return GetInterfaceNameFunc(address)
+}
+
+var GetInterfaceIPsFunc = func(name string) ([]string, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []string
+
+	for _, addr := range addresses {
+		if ip, _, err := net.ParseCIDR(addr.String()); err == nil {
+			if !ip.IsLinkLocalUnicast() && !ip.IsLoopback() {
+				ips = append(ips, ip.String())
+			}
+		}
+	}
+
+	return ips, nil
+}
+
+func GetInterfaceIPs(name string) ([]string, error) {
+	return GetInterfaceIPsFunc(name)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,129 +11,170 @@ import (
 )
 
 const (
-	InterfaceIP   = "1.2.3.4"
 	InterfaceName = "enp3s0"
 )
 
 func TestValidConfigSuccess(t *testing.T) {
-	tempCertFile, err := os.CreateTemp("", "ella_cert_*.pem")
-	if err != nil {
-		t.Fatalf("Failed to create temp cert file: %s", err)
+	testcases := []struct {
+		name    string
+		n2n3IP  string
+		apiIP   string
+		apiName string
+		file    string
+	}{
+		{
+			name:   "IPv4",
+			n2n3IP: "1.2.3.4",
+			apiIP:  "1.2.3.4",
+			file:   "testdata/valid.yaml",
+		},
+		{
+			name:   "IPv6",
+			n2n3IP: "10.0.0.1",
+			apiIP:  "fc42:dead:beef::1",
+			file:   "testdata/valid_v6.yaml",
+		},
+		{
+			name:    "IPv6-Interface",
+			n2n3IP:  "10.0.0.1",
+			apiIP:   "2001:db8::1",
+			apiName: "eth0",
+			file:    "testdata/valid_v6_iface.yaml",
+		},
 	}
 
-	defer func() {
-		if err := os.Remove(tempCertFile.Name()); err != nil {
-			t.Fatalf("Failed to remove temp key file: %v", err)
-		}
-	}()
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempCertFile, err := os.CreateTemp("", "ella_cert_*.pem")
+			if err != nil {
+				t.Fatalf("Failed to create temp cert file: %s", err)
+			}
 
-	tempKeyFile, err := os.CreateTemp("", "ella_key_*.pem")
-	if err != nil {
-		t.Fatalf("Failed to create temp key file: %s", err)
-	}
+			defer func() {
+				if err := os.Remove(tempCertFile.Name()); err != nil {
+					t.Fatalf("Failed to remove temp key file: %v", err)
+				}
+			}()
 
-	defer func() {
-		if err := os.Remove(tempKeyFile.Name()); err != nil {
-			t.Fatalf("Failed to remove temp key file: %v", err)
-		}
-	}()
+			tempKeyFile, err := os.CreateTemp("", "ella_key_*.pem")
+			if err != nil {
+				t.Fatalf("Failed to create temp key file: %s", err)
+			}
 
-	if _, err := tempCertFile.WriteString("dummy cert data"); err != nil {
-		t.Fatalf("Failed to write to temp cert file: %s", err)
-	}
+			defer func() {
+				if err := os.Remove(tempKeyFile.Name()); err != nil {
+					t.Fatalf("Failed to remove temp key file: %v", err)
+				}
+			}()
 
-	if _, err := tempKeyFile.WriteString("dummy key data"); err != nil {
-		t.Fatalf("Failed to write to temp key file: %s", err)
-	}
+			if err := os.WriteFile(tempCertFile.Name(), []byte("dummy cert data"), 0o644); err != nil {
+				t.Fatalf("Failed to write to temp cert file: %s", err)
+			}
 
-	defer func() {
-		if err := tempCertFile.Close(); err != nil {
-			t.Fatalf("Faile to close temp cert file: %v", err)
-		}
-	}()
+			if err := os.WriteFile(tempKeyFile.Name(), []byte("dummy key data"), 0o644); err != nil {
+				t.Fatalf("Failed to write to temp key file: %s", err)
+			}
 
-	defer func() {
-		if err := tempKeyFile.Close(); err != nil {
-			t.Fatalf("Faile to close temp key file: %v", err)
-		}
-	}()
+			defer func() {
+				if err := tempCertFile.Close(); err != nil {
+					t.Fatalf("Faile to close temp cert file: %v", err)
+				}
+			}()
 
-	config.CheckInterfaceExistsFunc = func(name string) (bool, error) {
-		return true, nil
-	}
+			defer func() {
+				if err := tempKeyFile.Close(); err != nil {
+					t.Fatalf("Faile to close temp key file: %v", err)
+				}
+			}()
 
-	config.GetInterfaceIPFunc = func(name string) (string, error) {
-		return InterfaceIP, nil
-	}
-	config.GetVLANConfigForInterfaceFunc = func(name string) (*config.VlanConfig, error) {
-		return nil, nil
-	}
+			config.CheckInterfaceExistsFunc = func(name string) (bool, error) {
+				return true, nil
+			}
 
-	// Update the config file to use the temporary cert and key paths
-	confFilePath := "testdata/valid.yaml"
+			config.GetInterfaceIPFunc = func(name string, family config.AddressFamily) (string, error) {
+				if family == config.AnyFamily {
+					return tc.apiIP, nil
+				}
 
-	originalContent, err := os.ReadFile(confFilePath)
-	if err != nil {
-		t.Fatalf("Failed to read config file: %s", err)
-	}
+				return tc.n2n3IP, nil
+			}
+			config.GetInterfaceNameFunc = func(address string) (string, error) {
+				return "eth0", nil
+			}
+			config.GetVLANConfigForInterfaceFunc = func(name string) (*config.VlanConfig, error) {
+				return nil, nil
+			}
 
-	updatedContent := strings.ReplaceAll(string(originalContent), "/etc/ella/cert.pem", tempCertFile.Name())
-	updatedContent = strings.ReplaceAll(updatedContent, "/etc/ella/key.pem", tempKeyFile.Name())
+			originalContent, err := os.ReadFile(tc.file)
+			if err != nil {
+				t.Fatalf("Failed to read config file: %s", err)
+			}
 
-	err = os.WriteFile(confFilePath, []byte(updatedContent), os.FileMode(0o600))
-	if err != nil {
-		t.Fatalf("Failed to update config file: %s", err)
-	}
+			updatedContent := strings.ReplaceAll(string(originalContent), "/etc/ella/cert.pem", tempCertFile.Name())
+			updatedContent = strings.ReplaceAll(updatedContent, "/etc/ella/key.pem", tempKeyFile.Name())
 
-	defer func() {
-		if err := os.WriteFile(confFilePath, originalContent, os.FileMode(0o600)); err != nil {
-			t.Fatalf("Failed to close database: %v", err)
-		}
-	}()
+			err = os.WriteFile(tc.file, []byte(updatedContent), os.FileMode(0o600))
+			if err != nil {
+				t.Fatalf("Failed to update config file: %s", err)
+			}
 
-	conf, err := config.Validate(confFilePath)
-	if err != nil {
-		t.Fatalf("Error occurred: %s", err)
-	}
+			defer func() {
+				if err := os.WriteFile(tc.file, originalContent, os.FileMode(0o600)); err != nil {
+					t.Fatalf("Failed to close database: %v", err)
+				}
+			}()
 
-	if conf.Interfaces.N2.Address != "1.2.3.4" {
-		t.Fatalf("N2 interface address was not configured correctly")
-	}
+			conf, err := config.Validate(tc.file)
+			if err != nil {
+				t.Fatalf("Error occurred: %s", err)
+			}
 
-	if conf.Interfaces.N2.Port != 38412 {
-		t.Fatalf("N2 port was not configured correctly")
-	}
+			if conf.Interfaces.N2.Address != tc.n2n3IP {
+				t.Fatalf("N2 interface address was not configured correctly")
+			}
 
-	if conf.Interfaces.N3.Name != "enp3s0" {
-		t.Fatalf("N3 interface was not configured correctly")
-	}
+			if conf.Interfaces.N2.Port != 38412 {
+				t.Fatalf("N2 port was not configured correctly")
+			}
 
-	if conf.Interfaces.N3.Address != "1.2.3.4" {
-		t.Fatalf("N3 interface address was not configured correctly")
-	}
+			if conf.Interfaces.N3.Name != "enp3s0" {
+				t.Fatalf("N3 interface was not configured correctly")
+			}
 
-	if conf.Interfaces.N6.Name != "enp6s0" {
-		t.Fatalf("N6 interface was not configured correctly")
-	}
+			if conf.Interfaces.N3.Address != tc.n2n3IP {
+				t.Fatalf("N3 interface address was not configured correctly")
+			}
 
-	if conf.Interfaces.API.Address != "1.2.3.4" {
-		t.Fatalf("API interface was not configured correctly")
-	}
+			if conf.Interfaces.N6.Name != "enp6s0" {
+				t.Fatalf("N6 interface was not configured correctly")
+			}
 
-	if conf.Interfaces.API.Port != 5002 {
-		t.Fatalf("API port was not configured correctly")
-	}
+			if tc.apiName != "" {
+				if conf.Interfaces.API.Name != tc.apiName {
+					t.Fatalf("API interface name was not configured correctly, expected: %s, got %s", tc.apiName, conf.Interfaces.API.Name)
+				}
+			} else {
+				if conf.Interfaces.API.Address != tc.apiIP {
+					t.Fatalf("API interface was not configured correctly, expected: %s, got %s", tc.apiIP, conf.Interfaces.API.Address)
+				}
+			}
 
-	if conf.Interfaces.API.TLS.Cert != tempCertFile.Name() {
-		t.Fatalf("TLS cert was not configured correctly")
-	}
+			if conf.Interfaces.API.Port != 5002 {
+				t.Fatalf("API port was not configured correctly")
+			}
 
-	if conf.Interfaces.API.TLS.Key != tempKeyFile.Name() {
-		t.Fatalf("TLS key was not configured correctly")
-	}
+			if conf.Interfaces.API.TLS.Cert != tempCertFile.Name() {
+				t.Fatalf("TLS cert was not configured correctly")
+			}
 
-	if conf.DB.Path != "test" {
-		t.Fatalf("Database path was not configured correctly")
+			if conf.Interfaces.API.TLS.Key != tempKeyFile.Name() {
+				t.Fatalf("TLS key was not configured correctly")
+			}
+
+			if conf.DB.Path != "test" {
+				t.Fatalf("Database path was not configured correctly")
+			}
+		})
 	}
 }
 
@@ -217,6 +258,7 @@ func TestBadConfigFail(t *testing.T) {
 		{"no db", "testdata/invalid_no_db.yaml", "db is empty"},
 		{"invalid yaml", "testdata/invalid_yaml.yaml", "cannot unmarshal config file"},
 		{"n2 missing both name and address", "testdata/invalid_both_name_and_address.yaml", "interfaces.n2: interface name and address cannot be both set"},
+		{"invalid ip address", "testdata/invalid_ip.yaml", "is not a valid IP address"},
 	}
 
 	for _, tc := range cases {

--- a/internal/config/testdata/invalid_ip.yaml
+++ b/internal/config/testdata/invalid_ip.yaml
@@ -1,0 +1,25 @@
+logging:
+  system:
+    level: "info"
+    output: "file"
+    path: "/var/log/ella_system.log"
+  audit:
+    output: "stdout"
+db:
+  path: "test"
+interfaces:
+  n2:
+    address: "not.a.valid.ip.address"
+    port: 38412
+  n3:
+    name: "enp3s0"
+  n6:
+    name: "enp6s0"
+  api:
+    address: "1.2.3.4"
+    port: 5002
+    tls:
+      cert: "/etc/ella/cert.pem"
+      key: "/etc/ella/key.pem"
+xdp:
+  attach-mode: "native"

--- a/internal/config/testdata/valid_v6.yaml
+++ b/internal/config/testdata/valid_v6.yaml
@@ -1,0 +1,25 @@
+logging:
+  system:
+    level: "info"
+    output: "file"
+    path: "/var/log/ella_system.log"
+  audit:
+    output: "stdout"
+db:
+  path: "test"
+interfaces:
+  n2:
+    name: "enp2s0"
+    port: 38412
+  n3:
+    name: "enp3s0"
+  n6:
+    name: "enp6s0"
+  api:
+    address: "fc42:dead:beef::1"
+    port: 5002
+    tls:
+      cert: "/etc/ella/cert.pem"
+      key: "/etc/ella/key.pem"
+xdp:
+  attach-mode: "native"

--- a/internal/config/testdata/valid_v6_iface.yaml
+++ b/internal/config/testdata/valid_v6_iface.yaml
@@ -1,0 +1,25 @@
+logging:
+  system:
+    level: "info"
+    output: "file"
+    path: "/var/log/ella_system.log"
+  audit:
+    output: "stdout"
+db:
+  path: "test"
+interfaces:
+  n2:
+    name: "enp2s0"
+    port: 38412
+  n3:
+    name: "enp3s0"
+  n6:
+    name: "enp6s0"
+  api:
+    name: "eth0"
+    port: 5002
+    tls:
+      cert: "/etc/ella/cert.pem"
+      key: "/etc/ella/key.pem"
+xdp:
+  attach-mode: "native"

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -125,7 +125,7 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 	}
 
 	// Initialize BGP service
-	n6IP, err := config.GetInterfaceIPFunc(cfg.Interfaces.N6.Name)
+	n6IP, err := config.GetInterfaceIPFunc(cfg.Interfaces.N6.Name, config.IPv4)
 	if err != nil {
 		return fmt.Errorf("couldn't get N6 interface IP: %w", err)
 	}

--- a/ui/src/pages/networking/InterfacesTab.tsx
+++ b/ui/src/pages/networking/InterfacesTab.tsx
@@ -209,9 +209,18 @@ export default function InterfacesTab() {
                 <Typography variant="subtitle1">API</Typography>
                 <Chip label="Management" size="small" />
               </Stack>
-              <Typography variant="body2" color="text.secondary">
-                Address: <strong>{interfacesInfo.api?.address ?? "—"}</strong>
-              </Typography>
+              {interfacesInfo.api?.addresses &&
+              interfacesInfo.api.addresses.length > 0 ? (
+                interfacesInfo.api.addresses.map((addr) => (
+                  <Typography key={addr} variant="body2" color="text.secondary">
+                    Address: <strong>{addr}</strong>
+                  </Typography>
+                ))
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  Address: <strong>—</strong>
+                </Typography>
+              )}
               <Typography variant="body2" color="text.secondary">
                 Port: <strong>{interfacesInfo.api?.port ?? "—"}</strong>
               </Typography>

--- a/ui/src/queries/interfaces.tsx
+++ b/ui/src/queries/interfaces.tsx
@@ -14,7 +14,7 @@ export type InterfacesInfo = {
     vlan?: VlanInfo;
   };
   n6?: { name?: string; vlan?: VlanInfo };
-  api?: { address?: string; port?: number };
+  api?: { addresses?: string[]; port?: number };
 };
 
 export const getInterfaces = async (


### PR DESCRIPTION
# Description

**Breaking API change: /api/v1/interfaces now returns a list of addresses**

We now support IPv6 for the API interface. The user can either specify an IPv6 address in the configuration file, or specify an interface name. When a user specifies an interface name, we do the expected thing an bind to the interface instead of a specific address. For that reason, we also modify the API for interfaces to return a list of addresses, as it is very common in IPv6 to have multiple addresses on an interface.

With this change, the UI and API are reachable through IPv6. I also validated that the otlp endpoint can be specified with an IPv6 address.

There is also a small change in the UI to support multiple addresses on an interface:

<img width="3695" height="1453" alt="2026-04-09-191750_3695x1453_scrot" src="https://github.com/user-attachments/assets/3aae0a4f-7c92-46eb-8c30-e89d5de1c5ec" />

_Note the address bar in the screenshot above_

This addresses a small portion of #1227 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
