### PR TITLE
fix: dont default to null security algorithms

### DIFF
--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -521,15 +521,12 @@ func (ue *AmfUe) UpdateNH() error {
 	return nil
 }
 
-func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) {
-	ue.CipheringAlg = security.AlgCiphering128NEA0
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-
+func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) error {
 	if ue.UESecurityCapability == nil {
-		logger.AmfLog.Warn("AMF UE Security Capability is not available, using null encryption (NEA0) and null integrity (NIA0)")
-		return
+		return fmt.Errorf("UE security capability not available, cannot negotiate NAS security algorithms")
 	}
 
+	intFound := false
 	ueSupported := uint8(0)
 
 	for _, intAlg := range intOrder {
@@ -546,10 +543,17 @@ func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) {
 
 		if ueSupported == 1 {
 			ue.IntegrityAlg = intAlg
+			intFound = true
+
 			break
 		}
 	}
 
+	if !intFound {
+		return fmt.Errorf("no common NAS integrity algorithm found")
+	}
+
+	encFound := false
 	ueSupported = uint8(0)
 
 	for _, encAlg := range encOrder {
@@ -566,9 +570,17 @@ func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) {
 
 		if ueSupported == 1 {
 			ue.CipheringAlg = encAlg
+			encFound = true
+
 			break
 		}
 	}
+
+	if !encFound {
+		return fmt.Errorf("no common NAS ciphering algorithm found")
+	}
+
+	return nil
 }
 
 // this is clearing the transient data of registration request, this is called entrypoint of Deregistration and Registration state

--- a/internal/amf/amf_ue_test.go
+++ b/internal/amf/amf_ue_test.go
@@ -4,10 +4,13 @@ package amf_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/nas/security"
 )
 
@@ -188,6 +191,167 @@ func TestIsAllowedNssai(t *testing.T) {
 			got := ue.IsAllowedNssai(tc.target)
 			if got != tc.expected {
 				t.Fatalf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+// makeUESecCap creates a UESecurityCapability with the given 5G integrity and ciphering bits set.
+func makeUESecCap(ia0, ia1, ia2, ia3, ea0, ea1, ea2, ea3 uint8) *nasType.UESecurityCapability {
+	ueCap := &nasType.UESecurityCapability{
+		Iei:    nasMessage.RegistrationRequestUESecurityCapabilityType,
+		Len:    2,
+		Buffer: []uint8{0x00, 0x00},
+	}
+	ueCap.SetIA0_5G(ia0)
+	ueCap.SetIA1_128_5G(ia1)
+	ueCap.SetIA2_128_5G(ia2)
+	ueCap.SetIA3_128_5G(ia3)
+	ueCap.SetEA0_5G(ea0)
+	ueCap.SetEA1_128_5G(ea1)
+	ueCap.SetEA2_128_5G(ea2)
+	ueCap.SetEA3_128_5G(ea3)
+
+	return ueCap
+}
+
+func TestSelectSecurityAlg(t *testing.T) {
+	tests := []struct {
+		name       string
+		cap        *nasType.UESecurityCapability
+		intOrder   []uint8
+		encOrder   []uint8
+		wantErr    string
+		wantIntAlg uint8
+		wantEncAlg uint8
+	}{
+		{
+			name:    "nil UE security capability",
+			cap:     nil,
+			wantErr: "UE security capability not available",
+		},
+		{
+			name:     "no common integrity algorithm",
+			cap:      makeUESecCap(0, 0, 1, 0, 1, 1, 1, 1),
+			intOrder: []uint8{security.AlgIntegrity128NIA1},
+			encOrder: []uint8{security.AlgCiphering128NEA0},
+			wantErr:  "no common NAS integrity algorithm found",
+		},
+		{
+			name:     "no common ciphering algorithm",
+			cap:      makeUESecCap(1, 1, 1, 1, 0, 0, 1, 0),
+			intOrder: []uint8{security.AlgIntegrity128NIA1},
+			encOrder: []uint8{security.AlgCiphering128NEA1},
+			wantErr:  "no common NAS ciphering algorithm found",
+		},
+		{
+			name:       "selects highest priority integrity and ciphering",
+			cap:        makeUESecCap(1, 1, 1, 0, 1, 1, 1, 0),
+			intOrder:   []uint8{security.AlgIntegrity128NIA2, security.AlgIntegrity128NIA1},
+			encOrder:   []uint8{security.AlgCiphering128NEA2, security.AlgCiphering128NEA1},
+			wantIntAlg: security.AlgIntegrity128NIA2,
+			wantEncAlg: security.AlgCiphering128NEA2,
+		},
+		{
+			name:       "falls back to second choice when first not supported",
+			cap:        makeUESecCap(0, 1, 0, 0, 0, 0, 1, 0),
+			intOrder:   []uint8{security.AlgIntegrity128NIA2, security.AlgIntegrity128NIA1},
+			encOrder:   []uint8{security.AlgCiphering128NEA1, security.AlgCiphering128NEA2},
+			wantIntAlg: security.AlgIntegrity128NIA1,
+			wantEncAlg: security.AlgCiphering128NEA2,
+		},
+		{
+			name:       "NIA0 and NEA0 selected when explicitly in preference order",
+			cap:        makeUESecCap(1, 0, 0, 0, 1, 0, 0, 0),
+			intOrder:   []uint8{security.AlgIntegrity128NIA0},
+			encOrder:   []uint8{security.AlgCiphering128NEA0},
+			wantIntAlg: security.AlgIntegrity128NIA0,
+			wantEncAlg: security.AlgCiphering128NEA0,
+		},
+		{
+			name:       "NIA0 not selected when not in preference order even if UE supports it",
+			cap:        makeUESecCap(1, 1, 1, 1, 1, 1, 1, 1),
+			intOrder:   []uint8{security.AlgIntegrity128NIA2, security.AlgIntegrity128NIA1},
+			encOrder:   []uint8{security.AlgCiphering128NEA2, security.AlgCiphering128NEA1},
+			wantIntAlg: security.AlgIntegrity128NIA2,
+			wantEncAlg: security.AlgCiphering128NEA2,
+		},
+		{
+			name:       "single algorithm match NIA1 NEA1",
+			cap:        makeUESecCap(0, 1, 0, 0, 0, 1, 0, 0),
+			intOrder:   []uint8{security.AlgIntegrity128NIA1},
+			encOrder:   []uint8{security.AlgCiphering128NEA1},
+			wantIntAlg: security.AlgIntegrity128NIA1,
+			wantEncAlg: security.AlgCiphering128NEA1,
+		},
+		{
+			name:       "NIA3 NEA3 only",
+			cap:        makeUESecCap(0, 0, 0, 1, 0, 0, 0, 1),
+			intOrder:   []uint8{security.AlgIntegrity128NIA3},
+			encOrder:   []uint8{security.AlgCiphering128NEA3},
+			wantIntAlg: security.AlgIntegrity128NIA3,
+			wantEncAlg: security.AlgCiphering128NEA3,
+		},
+		{
+			name:     "empty preference lists",
+			cap:      makeUESecCap(1, 1, 1, 1, 1, 1, 1, 1),
+			intOrder: []uint8{},
+			encOrder: []uint8{},
+			wantErr:  "no common NAS integrity algorithm found",
+		},
+		{
+			name:     "integrity matches but empty ciphering preference",
+			cap:      makeUESecCap(0, 1, 0, 0, 1, 1, 1, 1),
+			intOrder: []uint8{security.AlgIntegrity128NIA1},
+			encOrder: []uint8{},
+			wantErr:  "no common NAS ciphering algorithm found",
+		},
+		{
+			name:       "operator preference order is respected: NIA1 before NIA2",
+			cap:        makeUESecCap(0, 1, 1, 0, 0, 1, 1, 0),
+			intOrder:   []uint8{security.AlgIntegrity128NIA1, security.AlgIntegrity128NIA2},
+			encOrder:   []uint8{security.AlgCiphering128NEA1, security.AlgCiphering128NEA2},
+			wantIntAlg: security.AlgIntegrity128NIA1,
+			wantEncAlg: security.AlgCiphering128NEA1,
+		},
+		{
+			name:       "operator preference order is respected: NIA2 before NIA1",
+			cap:        makeUESecCap(0, 1, 1, 0, 0, 1, 1, 0),
+			intOrder:   []uint8{security.AlgIntegrity128NIA2, security.AlgIntegrity128NIA1},
+			encOrder:   []uint8{security.AlgCiphering128NEA2, security.AlgCiphering128NEA1},
+			wantIntAlg: security.AlgIntegrity128NIA2,
+			wantEncAlg: security.AlgCiphering128NEA2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ue := &amf.AmfUe{UESecurityCapability: tc.cap}
+
+			err := ue.SelectSecurityAlg(tc.intOrder, tc.encOrder)
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if ue.IntegrityAlg != tc.wantIntAlg {
+				t.Errorf("IntegrityAlg: got %d, want %d", ue.IntegrityAlg, tc.wantIntAlg)
+			}
+
+			if ue.CipheringAlg != tc.wantEncAlg {
+				t.Errorf("CipheringAlg: got %d, want %d", ue.CipheringAlg, tc.wantEncAlg)
 			}
 		})
 	}

--- a/internal/amf/nas/gmm/handle_authentication_response_test.go
+++ b/internal/amf/nas/gmm/handle_authentication_response_test.go
@@ -332,12 +332,8 @@ func TestHandleAuthenticationResponse_DeriveKamf_Success(t *testing.T) {
 	}
 	ue.UESecurityCapability.SetEA0_5G(1)
 	ue.UESecurityCapability.SetEA1_128_5G(1)
-	ue.UESecurityCapability.SetEA2_128_5G(1)
-	ue.UESecurityCapability.SetEA2_128_5G(0)
 	ue.UESecurityCapability.SetIA0_5G(1)
 	ue.UESecurityCapability.SetIA1_128_5G(1)
-	ue.UESecurityCapability.SetIA2_128_5G(1)
-	ue.UESecurityCapability.SetIA2_128_5G(0)
 
 	err = handleAuthenticationResponse(t.Context(), amfInstance, ue, &nasMessage.AuthenticationResponse{AuthenticationResponseParameter: &nasType.AuthenticationResponseParameter{}})
 	if err != nil {

--- a/internal/amf/nas/gmm/handle_authentication_response_test.go
+++ b/internal/amf/nas/gmm/handle_authentication_response_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/free5gc/nas"
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/nas/nasType"
-	"github.com/free5gc/nas/security"
 )
 
 func TestHandleAuthenticationResponse_NilAuthenticationResponseParameter(t *testing.T) {
@@ -304,6 +303,8 @@ func TestHandleAuthenticationResponse_DeriveKamf_Success(t *testing.T) {
 			Mcc:           "001",
 			Mnc:           "01",
 			SupportedTACs: "[\"1\"]",
+			Integrity:     `["NIA1","NIA0"]`,
+			Ciphering:     `["NEA1","NEA0"]`,
 		},
 	}, &FakeAusf{
 		AvKgAka: &ausf.AuthResult{
@@ -359,13 +360,9 @@ func TestHandleAuthenticationResponse_DeriveKamf_Success(t *testing.T) {
 		t.Fatalf("expected a protected with new 5g NAS security context NAS message, got: %v", nm.SecurityHeaderType)
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
-		t.Fatalf("could not decrypt NAS message: %v", err)
-	}
-
 	err = nm.PlainNasDecode(&payload)
 	if err != nil {
-		t.Fatalf("could not decode ciphered NAS message: %v", err)
+		t.Fatalf("could not decode NAS message: %v", err)
 	}
 
 	if nm.GmmHeader.GetMessageType() != nas.MsgTypeSecurityModeCommand {

--- a/internal/amf/nas/gmm/handle_service_request_test.go
+++ b/internal/amf/nas/gmm/handle_service_request_test.go
@@ -1470,12 +1470,6 @@ func TestHandleServiceRequest_OutOfRangePduSessionID_UplinkDataStatus(t *testing
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("handleServiceRequest panicked with out-of-range PDU session ID: %v", r)
-		}
-	}()
-
 	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
 	if err != nil {
 		t.Logf("handleServiceRequest returned error (acceptable): %v", err)
@@ -1535,12 +1529,6 @@ func TestHandleServiceRequest_OutOfRangePduSessionID_PDUSessionStatus(t *testing
 	// Ensure PDUSessionStatus is set in the inner message (it is by default in
 	// buildTestServiceRequestCiphered). The panic occurs when iterating SmContextList
 	// and indexing into the [16]bool psiArray with pduSessionID >= 16.
-
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("handleServiceRequest panicked with out-of-range PDU session ID: %v", r)
-		}
-	}()
 
 	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
 	if err != nil {

--- a/internal/amf/nas/gmm/handle_ul_nas_transport_test.go
+++ b/internal/amf/nas/gmm/handle_ul_nas_transport_test.go
@@ -1238,12 +1238,5 @@ func TestTransport5GSMMessage_NoSmContext_NilRequestType_Panic(t *testing.T) {
 
 	amfInstance := amf.New(&FakeDBInstance{}, nil, &FakeSmf{})
 
-	// This should NOT panic — it should return an error gracefully
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("transport5GSMMessage panicked with nil RequestType (no SM context): %v", r)
-		}
-	}()
-
 	_ = transport5GSMMessage(t.Context(), amfInstance, ue, msg)
 }

--- a/internal/amf/nas/gmm/security_mode.go
+++ b/internal/amf/nas/gmm/security_mode.go
@@ -29,7 +29,10 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) erro
 		return fmt.Errorf("error getting security algorithms: %v", err)
 	}
 
-	ue.SelectSecurityAlg(integrityOrder, cipheringOrder)
+	err = ue.SelectSecurityAlg(integrityOrder, cipheringOrder)
+	if err != nil {
+		return fmt.Errorf("NAS security algorithm negotiation failed: %v", err)
+	}
 
 	err = ue.DerivateAlgKey()
 	if err != nil {

--- a/internal/amf/nas/handler_test.go
+++ b/internal/amf/nas/handler_test.go
@@ -22,12 +22,10 @@ func TestHandleNAS_ShortIntegrityProtectedPayload(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	ue := &amf.RanUe{} // AmfUe is nil, so HandleNAS enters fetchUeContextWithMobileIdentity
 
-	assertNoPanic(t, "HandleNAS(short integrity-protected payload)", func() {
-		err := HandleNAS(context.Background(), amfInstance, ue, shortPayload)
-		if err == nil {
-			t.Fatal("expected error for short integrity-protected payload, got nil")
-		}
-	})
+	err := HandleNAS(context.Background(), amfInstance, ue, shortPayload)
+	if err == nil {
+		t.Fatal("expected error for short integrity-protected payload, got nil")
+	}
 }
 
 func TestHandleNAS_NilPayload(t *testing.T) {
@@ -44,12 +42,10 @@ func TestHandleNAS_SingleBytePayload(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	ue := &amf.RanUe{}
 
-	assertNoPanic(t, "HandleNAS(single-byte payload)", func() {
-		err := HandleNAS(context.Background(), amfInstance, ue, []byte{0x7e})
-		if err == nil {
-			t.Fatal("expected error for single-byte payload, got nil")
-		}
-	})
+	err := HandleNAS(context.Background(), amfInstance, ue, []byte{0x7e})
+	if err == nil {
+		t.Fatal("expected error for single-byte payload, got nil")
+	}
 }
 
 func TestHandleNAS_IntegrityProtectedPayloadExactly6Bytes(t *testing.T) {
@@ -59,23 +55,8 @@ func TestHandleNAS_IntegrityProtectedPayloadExactly6Bytes(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	ue := &amf.RanUe{}
 
-	assertNoPanic(t, "HandleNAS(6-byte integrity-protected payload)", func() {
-		err := HandleNAS(context.Background(), amfInstance, ue, payload)
-		if err == nil {
-			t.Fatal("expected error for 6-byte integrity-protected payload, got nil")
-		}
-	})
-}
-
-// assertNoPanic runs fn and fails the test if it panics.
-func assertNoPanic(t *testing.T, name string, fn func()) {
-	t.Helper()
-
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("%s panicked: %v", name, r)
-		}
-	}()
-
-	fn()
+	err := HandleNAS(context.Background(), amfInstance, ue, payload)
+	if err == nil {
+		t.Fatal("expected error for 6-byte integrity-protected payload, got nil")
+	}
 }

--- a/internal/amf/ngap/send/send.go
+++ b/internal/amf/ngap/send/send.go
@@ -48,8 +48,14 @@ func (s *RealNGAPSender) SendToRan(ctx context.Context, packet []byte, msgType N
 		return fmt.Errorf("ran conn is nil")
 	}
 
-	if s.Conn.RemoteAddr() == nil {
-		return fmt.Errorf("ran address is nil")
+	localAddr := s.Conn.LocalAddr()
+	if localAddr == nil {
+		return fmt.Errorf("ran local address is nil")
+	}
+
+	remoteAddr := s.Conn.RemoteAddr()
+	if remoteAddr == nil {
+		return fmt.Errorf("ran remote address is nil")
 	}
 
 	info := sctp.SndRcvInfo{
@@ -65,8 +71,8 @@ func (s *RealNGAPSender) SendToRan(ctx context.Context, packet []byte, msgType N
 		logger.NGAPNetworkProtocol,
 		string(msgType),
 		logger.DirectionOutbound,
-		s.Conn.LocalAddr().String(),
-		s.Conn.RemoteAddr().String(),
+		localAddr.String(),
+		remoteAddr.String(),
 		s.RadioName,
 		packet,
 	)

--- a/internal/amf/ngap/send/send.go
+++ b/internal/amf/ngap/send/send.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 )
 
 var tracer = otel.Tracer("ella-core/amf/ngap/send")
@@ -40,13 +39,6 @@ func (s *RealNGAPSender) SendToRan(ctx context.Context, packet []byte, msgType N
 	if err != nil {
 		return fmt.Errorf("could not determine SCTP stream ID from NGAP message type (%s): %s", msgType, err.Error())
 	}
-
-	defer func() {
-		err := recover()
-		if err != nil {
-			logger.AmfLog.Warn("could not send to ran", zap.Any("error", err))
-		}
-	}()
 
 	if len(packet) == 0 {
 		return fmt.Errorf("packet len is 0")

--- a/internal/api/server/api_operator_test.go
+++ b/internal/api/server/api_operator_test.go
@@ -685,7 +685,7 @@ func TestUpdateOperatorNASSecurity(t *testing.T) {
 			t.Fatalf("expected status %d, got %d", http.StatusOK, statusCode)
 		}
 
-		expectedCiphering := []string{"NEA2", "NEA1", "NEA0"}
+		expectedCiphering := []string{"NEA2", "NEA1"}
 		if len(response.Result.NASSecurity.Ciphering) != len(expectedCiphering) {
 			t.Fatalf("expected %d ciphering algorithms, got %d", len(expectedCiphering), len(response.Result.NASSecurity.Ciphering))
 		}
@@ -696,7 +696,7 @@ func TestUpdateOperatorNASSecurity(t *testing.T) {
 			}
 		}
 
-		expectedIntegrity := []string{"NIA2", "NIA1", "NIA0"}
+		expectedIntegrity := []string{"NIA2", "NIA1"}
 		if len(response.Result.NASSecurity.Integrity) != len(expectedIntegrity) {
 			t.Fatalf("expected %d integrity algorithms, got %d", len(expectedIntegrity), len(response.Result.NASSecurity.Integrity))
 		}

--- a/internal/db/migration_v2.go
+++ b/internal/db/migration_v2.go
@@ -16,13 +16,13 @@ import (
 func migrateV2(ctx context.Context, tx *sql.Tx) error {
 	// 1. Add NAS security algorithm configuration columns to operator.
 	_, err := tx.ExecContext(ctx,
-		fmt.Sprintf("ALTER TABLE %s ADD COLUMN ciphering TEXT NOT NULL DEFAULT '[\"NEA2\",\"NEA1\",\"NEA0\"]'", OperatorTableName))
+		fmt.Sprintf("ALTER TABLE %s ADD COLUMN ciphering TEXT NOT NULL DEFAULT '[\"NEA2\",\"NEA1\"]'", OperatorTableName))
 	if err != nil {
 		return fmt.Errorf("failed to add ciphering column: %w", err)
 	}
 
 	_, err = tx.ExecContext(ctx,
-		fmt.Sprintf("ALTER TABLE %s ADD COLUMN integrity TEXT NOT NULL DEFAULT '[\"NIA2\",\"NIA1\",\"NIA0\"]'", OperatorTableName))
+		fmt.Sprintf("ALTER TABLE %s ADD COLUMN integrity TEXT NOT NULL DEFAULT '[\"NIA2\",\"NIA1\"]'", OperatorTableName))
 	if err != nil {
 		return fmt.Errorf("failed to add integrity column: %w", err)
 	}

--- a/internal/db/migration_v7.go
+++ b/internal/db/migration_v7.go
@@ -246,8 +246,8 @@ func migrateV7(ctx context.Context, tx *sql.Tx) error {
 			mnc           TEXT NOT NULL,
 			operatorCode  TEXT NOT NULL,
 			supportedTACs TEXT DEFAULT '[]',
-			ciphering     TEXT NOT NULL DEFAULT '["NEA2","NEA1","NEA0"]',
-			integrity     TEXT NOT NULL DEFAULT '["NIA2","NIA1","NIA0"]',
+			ciphering     TEXT NOT NULL DEFAULT '["NEA2","NEA1"]',
+			integrity     TEXT NOT NULL DEFAULT '["NIA2","NIA1"]',
 			spnFullName   TEXT NOT NULL DEFAULT 'Ella Networks',
 			spnShortName  TEXT NOT NULL DEFAULT 'Ella'
 		)`, OperatorTableName))

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -530,11 +530,11 @@ func TestMigrateV2_AddsColumns(t *testing.T) {
 		t.Fatalf("failed to query new columns: %v", err)
 	}
 
-	if want := `["NEA2","NEA1","NEA0"]`; ciphering != want {
+	if want := `["NEA2","NEA1"]`; ciphering != want {
 		t.Errorf("ciphering = %q, want %q", ciphering, want)
 	}
 
-	if want := `["NIA2","NIA1","NIA0"]`; integrity != want {
+	if want := `["NIA2","NIA1"]`; integrity != want {
 		t.Errorf("integrity = %q, want %q", integrity, want)
 	}
 

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -8,8 +8,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
-	sdkresource "go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
@@ -22,7 +22,7 @@ type TelemetryConfig struct {
 }
 
 // InitTracer sets up a global TracerProvider based on the given configuration.
-func InitTracer(ctx context.Context, cfg TelemetryConfig) (*sdktrace.TracerProvider, error) {
+func InitTracer(ctx context.Context, cfg TelemetryConfig) (*trace.TracerProvider, error) {
 	exp, err := otlptracegrpc.New(ctx,
 		otlptracegrpc.WithEndpoint(cfg.OTLPEndpoint),
 		otlptracegrpc.WithInsecure(),
@@ -31,12 +31,12 @@ func InitTracer(ctx context.Context, cfg TelemetryConfig) (*sdktrace.TracerProvi
 		return nil, fmt.Errorf("failed to create OTLP exporter: %w", err)
 	}
 
-	sampler := sdktrace.AlwaysSample()
+	sampler := trace.AlwaysSample()
 
-	res, err := sdkresource.New(ctx,
-		sdkresource.WithHost(),
-		sdkresource.WithProcess(),
-		sdkresource.WithAttributes(
+	res, err := resource.New(ctx,
+		resource.WithHost(),
+		resource.WithProcess(),
+		resource.WithAttributes(
 			semconv.ServiceName(cfg.ServiceName),
 			semconv.ServiceVersion(cfg.ServiceVersion),
 			attribute.String("service.revision", cfg.ServiceRevision),
@@ -46,10 +46,10 @@ func InitTracer(ctx context.Context, cfg TelemetryConfig) (*sdktrace.TracerProvi
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sampler),
-		sdktrace.WithBatcher(exp),
-		sdktrace.WithResource(res),
+	tp := trace.NewTracerProvider(
+		trace.WithSampler(sampler),
+		trace.WithBatcher(exp),
+		trace.WithResource(res),
 	)
 
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
# Description

Remove null algorithms from default set of supported algorithms. Null algorithms can still be used as an intentional operator configuration change.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
