### PR TITLE
fix: reject NGAP messages from radios before NG Setup

### DIFF
--- a/internal/amf/ngap/dispatcher.go
+++ b/internal/amf/ngap/dispatcher.go
@@ -129,6 +129,14 @@ func Dispatch(ctx context.Context, amfInstance *amf.AMF, conn *sctp.SCTPConn, ms
 		return
 	}
 
+	// TS 38.413 §10.4: NG Setup must be the first NGAP procedure after
+	// the TNL association is established. Reject anything else.
+	if ran.RanID == nil {
+		ran.Log.Error("Received NGAP message before NG Setup, dropping", zap.String("messageType", messageType))
+
+		return
+	}
+
 	dispatchNgapMsg(ctx, amfInstance, ran, pdu)
 }
 

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -9,34 +9,10 @@ import (
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/ngap/ngapConvert"
-	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
 )
 
 func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.InitialUEMessage) {
-	// TS 38.413 §10.4 logical error case 2: InitialUEMessage before NGSetup.
-	if ran.RanID == nil {
-		criticalityDiagnostics := (&decode.Report{
-			ProcedureCode:        ngapType.ProcedureCodeInitialUEMessage,
-			TriggeringMessage:    ngapType.TriggeringMessagePresentInitiatingMessage,
-			ProcedureCriticality: ngapType.CriticalityPresentIgnore,
-		}).ToCriticalityDiagnostics()
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentProtocol,
-			Protocol: &ngapType.CauseProtocol{
-				Value: ngapType.CauseProtocolPresentMessageNotCompatibleWithReceiverState,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, &criticalityDiagnostics)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-			return
-		}
-
-		return
-	}
-
 	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
 	if ranUe != nil {
 		// gNB reused a RAN UE NGAP ID before completing the previous

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -17,42 +17,7 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/aper"
-	"github.com/free5gc/ngap/ngapType"
 )
-
-func TestHandleInitialUEMessage_NoRanID_SendsErrorIndication(t *testing.T) {
-	ran := newTestRadio()
-	amfInstance := newTestAMF()
-
-	ngap.HandleInitialUEMessage(context.Background(), amfInstance, ran, decode.InitialUEMessage{})
-
-	sender, ok := ran.NGAPSender.(*FakeNGAPSender)
-	if !ok {
-		t.Fatalf("ran.NGAPSender is %T, want *FakeNGAPSender", ran.NGAPSender)
-	}
-
-	if got := len(sender.SentErrorIndications); got != 1 {
-		t.Fatalf("len(SentErrorIndications) = %d, want 1", got)
-	}
-
-	ei := sender.SentErrorIndications[0]
-	if ei.Cause == nil {
-		t.Fatal("ErrorIndication.Cause is nil")
-	}
-
-	if ei.Cause.Present != ngapType.CausePresentProtocol {
-		t.Errorf("cause.Present = %d, want CausePresentProtocol", ei.Cause.Present)
-	}
-
-	if ei.Cause.Protocol == nil ||
-		ei.Cause.Protocol.Value != ngapType.CauseProtocolPresentMessageNotCompatibleWithReceiverState {
-		t.Errorf("cause.Protocol = %+v, want MessageNotCompatibleWithReceiverState", ei.Cause.Protocol)
-	}
-
-	if ei.CriticalityDiagnostics == nil {
-		t.Error("CriticalityDiagnostics is nil")
-	}
-}
 
 func TestHandleInitialUEMessage_CreatesNewRanUe(t *testing.T) {
 	fakeNAS := &FakeNASHandler{}

--- a/internal/amf/ngap/handle_ng_setup_request.go
+++ b/internal/amf/ngap/handle_ng_setup_request.go
@@ -14,8 +14,6 @@ import (
 )
 
 func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.NGSetupRequest) {
-	ran.SetRanID(msg.GlobalRANNodeID.Raw())
-
 	if msg.RANNodeName != "" {
 		ran.Name = msg.RANNodeName
 
@@ -105,6 +103,11 @@ func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		logger.WithTrace(ctx, ran.Log).Error("Could not list operator SNSSAI", zap.Error(err))
 		return
 	}
+
+	// Set RanID only after all validation passes — this gates the
+	// dispatcher guard (ran.RanID != nil) that protects all other
+	// NGAP handlers (TS 38.413 §10.4).
+	ran.SetRanID(msg.GlobalRANNodeID.Raw())
 
 	err = ran.NGAPSender.SendNGSetupResponse(ctx, operatorInfo.Guami, snssaiList, amfInstance.Name, amfInstance.RelativeCapacity)
 	if err != nil {

--- a/internal/amf/ngap/handle_ng_setup_request_test.go
+++ b/internal/amf/ngap/handle_ng_setup_request_test.go
@@ -227,6 +227,10 @@ func TestHandleNGSetupRequest_NGSetupFailure_gNodeBDoesntSupportAnyTAC(t *testin
 	if cause.Misc.Value != ngapType.CauseMiscPresentUnspecified {
 		t.Errorf("expected Cause Miscellaneous Value to be CauseMiscPresentUnspecified, but got %v", cause.Misc.Value)
 	}
+
+	if ran.RanID != nil {
+		t.Error("RanID should remain nil after failed NG Setup")
+	}
 }
 
 func TestHandleNGSetupRequest_NGSetupFailure_gNodeBSupportsDifferentTAC(t *testing.T) {
@@ -279,6 +283,10 @@ func TestHandleNGSetupRequest_NGSetupFailure_gNodeBSupportsDifferentTAC(t *testi
 
 	if cause.Misc.Value != ngapType.CauseMiscPresentUnknownPLMN {
 		t.Errorf("expected Cause Miscellaneous Value to be CauseMiscPresentUnknownPLMN, but got %v", cause.Misc.Value)
+	}
+
+	if ran.RanID != nil {
+		t.Error("RanID should remain nil after failed NG Setup")
 	}
 }
 
@@ -354,6 +362,10 @@ func TestHandleNGSetupRequest_NGSetupResponse(t *testing.T) {
 
 	if response.AmfRelativeCapacity != 0xff {
 		t.Errorf("expected AmfRelativeCapacity to be 0xff, but got %d", response.AmfRelativeCapacity)
+	}
+
+	if ran.RanID == nil {
+		t.Fatal("RanID should be set after successful NG Setup")
 	}
 
 	// Verify ran.SupportedTAIs was populated from the request


### PR DESCRIPTION
# Description

Only the NGAP handler for initial ue message validated that there was a ran ID available before handling the message. Now Ella Core rejects any NGAP message before NG Setup.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
