### PR TITLE
fix: replace OnGoing with procedure registry for concurrent procedure tracking

### DIFF
--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
@@ -26,15 +27,6 @@ import (
 	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/nas/security"
 	"go.uber.org/zap"
-)
-
-type OnGoingProcedure string
-
-const (
-	OnGoingProcedureNothing      OnGoingProcedure = "Nothing"
-	OnGoingProcedurePaging       OnGoingProcedure = "Paging"
-	OnGoingProcedureN2Handover   OnGoingProcedure = "N2Handover"
-	OnGoingProcedureRegistration OnGoingProcedure = "Registration"
 )
 
 type StateType string
@@ -95,7 +87,7 @@ type AmfUe struct {
 	N1N2Message                       *models.N1N2MessageTransferRequest
 	SmContextList                     map[uint8]*SmContext // Key: pdu session id
 	ranUe                             *RanUe
-	OnGoing                           OnGoingProcedure
+	Procedures                        *procedure.Registry
 	UeRadioCapability                 string // OCTET string
 
 	/* context related to Paging */
@@ -149,7 +141,7 @@ func NewAmfUe() *AmfUe {
 	return &AmfUe{
 		state:            Deregistered,
 		RegistrationArea: make([]models.Tai, 0),
-		OnGoing:          OnGoingProcedureNothing,
+		Procedures:       procedure.NewRegistry(logger.AmfLog),
 		SmContextList:    make(map[uint8]*SmContext),
 	}
 }
@@ -596,23 +588,17 @@ func (ue *AmfUe) ClearRegistrationRequestData() {
 	}
 
 	ue.RetransmissionOfInitialNASMsg = false
-	ue.OnGoing = OnGoingProcedureNothing
+
+	// Clear any active procedures — this is a registration boundary.
+	for _, t := range ue.Procedures.ActiveTypes() {
+		ue.Procedures.End(procedure.Type(t))
+	}
 }
 
 func (ue *AmfUe) ClearRegistrationData(ctx context.Context) {
 	ue.releaseSmContexts(ctx)
 
 	ue.SmContextList = make(map[uint8]*SmContext)
-}
-
-func (ue *AmfUe) SetOnGoing(onGoing OnGoingProcedure) {
-	prevOnGoing := ue.OnGoing
-	ue.OnGoing = onGoing
-	ue.Log.Debug("set ongoing procedure", zap.Any("ongoingProcedure", onGoing), zap.Any("previousOnGoingProcedure", prevOnGoing))
-}
-
-func (ue *AmfUe) GetOnGoing() OnGoingProcedure {
-	return ue.OnGoing
 }
 
 func (ue *AmfUe) CreateSmContext(pduSessionID uint8, ref string, snssai *models.Snssai) error {

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -41,10 +41,10 @@ type UEIdentityExport struct {
 
 // UEStateExport contains the current GMM and procedure state of a UE.
 type UEStateExport struct {
-	GMMState                 string `json:"gmm_state"`
-	OngoingProcedure         string `json:"ongoing_procedure"`
-	SecurityContextAvailable bool   `json:"security_context_available"`
-	MacFailed                bool   `json:"mac_failed"`
+	GMMState                 string   `json:"gmm_state"`
+	OngoingProcedures        []string `json:"ongoing_procedures"`
+	SecurityContextAvailable bool     `json:"security_context_available"`
+	MacFailed                bool     `json:"mac_failed"`
 }
 
 // UESecurityExport contains non-sensitive security context info for a UE.
@@ -319,7 +319,7 @@ func (amf *AMF) exportAmfUe(ue *AmfUe) AmfUeExport {
 		},
 		State: UEStateExport{
 			GMMState:                 string(ue.state),
-			OngoingProcedure:         string(ue.OnGoing),
+			OngoingProcedures:        ue.Procedures.ActiveTypes(),
 			SecurityContextAvailable: ue.SecurityContextAvailable,
 			MacFailed:                ue.MacFailed,
 		},

--- a/internal/amf/export_test.go
+++ b/internal/amf/export_test.go
@@ -114,8 +114,10 @@ func TestExportJSON_MinimalUE(t *testing.T) {
 		t.Fatalf("expected state.gmm_state to be 'Deregistered', got %v", state["gmm_state"])
 	}
 
-	if ongoingProc, ok := state["ongoing_procedure"].(string); !ok || ongoingProc != "Nothing" {
-		t.Fatalf("expected state.ongoing_procedure to be 'Nothing', got %v", state["ongoing_procedure"])
+	if ongoingProcs, ok := state["ongoing_procedures"]; ok && ongoingProcs != nil {
+		if arr, ok := ongoingProcs.([]interface{}); ok && len(arr) != 0 {
+			t.Fatalf("expected state.ongoing_procedures to be empty, got %v", ongoingProcs)
+		}
 	}
 
 	if secCtx, ok := state["security_context_available"].(bool); !ok || secCtx != false {
@@ -192,7 +194,6 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 		ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 		ue.Suci = "suci-0-001-01-0000-0-0-0000000001"
 		ue.ForceState(amf.Registered)
-		ue.OnGoing = amf.OnGoingProcedureNothing
 		ue.SecurityContextAvailable = true
 		ue.CipheringAlg = security.AlgCiphering128NEA2
 		ue.IntegrityAlg = security.AlgIntegrity128NIA2
@@ -283,8 +284,10 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 		t.Fatalf("expected state.mac_failed to be false, got %v", state["mac_failed"])
 	}
 
-	if ongoingProc, ok := state["ongoing_procedure"].(string); !ok || ongoingProc != "Nothing" {
-		t.Fatalf("expected state.ongoing_procedure to be 'Nothing', got %v", state["ongoing_procedure"])
+	if ongoingProcs, ok := state["ongoing_procedures"]; ok && ongoingProcs != nil {
+		if arr, ok := ongoingProcs.([]interface{}); ok && len(arr) != 0 {
+			t.Fatalf("expected state.ongoing_procedures to be empty, got %v", ongoingProcs)
+		}
 	}
 
 	security := jsonMap(t, ueExport, "security")

--- a/internal/amf/nas/gmm/handle_registration_complete_test.go
+++ b/internal/amf/nas/gmm/handle_registration_complete_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/nas"
@@ -61,7 +62,10 @@ func setupRegistrationCompleteUE(t *testing.T) (*amf.AmfUe, *FakeNGAPSender) {
 	ue.RanUe().UeContextRequest = true
 	ue.RanUe().RecvdInitialContextSetupResponse = true
 	ue.RetransmissionOfInitialNASMsg = true
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
 
 	return ue, ngapSender
 }
@@ -300,7 +304,7 @@ func checkUERegistrationDataIsCleared(ue *amf.AmfUe) error {
 		return fmt.Errorf("retransmission of initial NAS msg should be false")
 	}
 
-	if ue.GetOnGoing() != amf.OnGoingProcedureNothing {
+	if ue.Procedures.Active(procedure.Paging) {
 		return fmt.Errorf("ongoing should be nothing")
 	}
 

--- a/internal/amf/nas/gmm/handle_registration_request.go
+++ b/internal/amf/nas/gmm/handle_registration_request.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/nas/gmm/message"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/nas"
@@ -54,7 +55,15 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		ue.SecurityContextAvailable = false
 	}
 
-	ue.SetOnGoing(amf.OnGoingProcedureRegistration)
+	// Supersession: cancel any active N2 Handover before starting Registration.
+	if ue.Procedures.Active(procedure.N2Handover) {
+		_ = ue.Procedures.Cancel(ctx, procedure.N2Handover)
+	}
+
+	_, err := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.Registration})
+	if err != nil {
+		ue.Log.Warn("failed to begin registration procedure", zap.Error(err))
+	}
 
 	if ue.T3513 != nil {
 		ue.T3513.Stop()
@@ -286,6 +295,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 			ue.T3560 = nil
 		}
 
+		ue.Procedures.End(procedure.SecurityMode)
 		ue.Deregister(ctx)
 
 		return HandleGmmMessage(ctx, amfInstance, ue, msg)

--- a/internal/amf/nas/gmm/handle_security_mode_complete.go
+++ b/internal/amf/nas/gmm/handle_security_mode_complete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/free5gc/nas"
 	"github.com/free5gc/nas/nasConvert"
 	"github.com/free5gc/nas/nasMessage"
@@ -24,6 +25,8 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		ue.T3560.Stop()
 		ue.T3560 = nil // clear the timer
 	}
+
+	ue.Procedures.End(procedure.SecurityMode)
 
 	if ue.SecurityContextIsValid() {
 		err := ue.UpdateSecurityContext()

--- a/internal/amf/nas/gmm/handle_security_mode_reject.go
+++ b/internal/amf/nas/gmm/handle_security_mode_reject.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/ngap/ngapType"
@@ -21,6 +22,8 @@ func handleSecurityModeReject(ctx context.Context, ue *amf.AmfUe, msg *nasMessag
 		ue.T3560.Stop()
 		ue.T3560 = nil // clear the timer
 	}
+
+	ue.Procedures.End(procedure.SecurityMode)
 
 	ue.Log.Error("UE rejected the security mode command, abort the ongoing procedure", logger.Cause(nasMessage.Cause5GMMToString(msg.GetCauseValue())), logger.SUPI(ue.Supi.String()))
 

--- a/internal/amf/nas/gmm/handle_service_request.go
+++ b/internal/amf/nas/gmm/handle_service_request.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/nas/gmm/message"
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/nas"
@@ -153,10 +154,8 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 	}
 
 	// Set No ongoing
-	if procedure := ue.GetOnGoing(); procedure == amf.OnGoingProcedurePaging {
-		ue.SetOnGoing(amf.OnGoingProcedureNothing)
-	} else if procedure != amf.OnGoingProcedureNothing {
-		ue.Log.Warn("UE should not in OnGoing", zap.Any("procedure", procedure))
+	if ue.Procedures.Active(procedure.Paging) {
+		ue.Procedures.End(procedure.Paging)
 	}
 
 	// TS 24.501 8.2.6.21: if the UE is sending a REGISTRATION REQUEST message as an initial NAS message,

--- a/internal/amf/nas/gmm/handle_service_request_test.go
+++ b/internal/amf/nas/gmm/handle_service_request_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
@@ -342,8 +343,11 @@ func TestHandleServiceRequest_ServiceTypeSignaling_ServiceAccept(t *testing.T) {
 	ue.ForceState(amf.Registered)
 	ue.SecurityContextAvailable = true
 	ue.MacFailed = false
+
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
 
 	m := buildTestServiceRequest()
 
@@ -377,7 +381,7 @@ func TestHandleServiceRequest_ServiceTypeSignaling_ServiceAccept(t *testing.T) {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
-	if ue.GetOnGoing() != amf.OnGoingProcedureNothing {
+	if ue.Procedures.Active(procedure.Paging) {
 		t.Fatalf("expected paging procedure to be completed")
 	}
 }
@@ -572,7 +576,10 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
+
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
@@ -664,7 +671,10 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_NoPDUSession
 	}
 
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
+
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceState(amf.Registered)
 	ue.Guti = mustTestGuti("001", "01", "cafe42", 0x00000001)
@@ -725,8 +735,12 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
+
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
+
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
@@ -856,8 +870,12 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
+
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
+
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
@@ -992,8 +1010,12 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
+
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
+
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
@@ -1136,8 +1158,12 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
+
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
+
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
@@ -1269,8 +1295,12 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
+
 	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
+
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti

--- a/internal/amf/nas/gmm/message/send.go
+++ b/internal/amf/nas/gmm/message/send.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/ngap/ngapType"
 	"go.opentelemetry.io/otel"
@@ -277,6 +278,7 @@ func SendSecurityModeCommand(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 			amfUe.Log.Info("sent security mode command")
 		}, func() {
 			amfUe.Log.Warn("T3560 Expires, abort security mode control procedure", zap.Any("expireTimes", cfg.MaxRetryTimes))
+			amfUe.Procedures.End(procedure.SecurityMode)
 			amfInstance.DeregisterAndRemoveAMFUE(context.Background(), amfUe)
 		})
 	}

--- a/internal/amf/nas/gmm/security_mode.go
+++ b/internal/amf/nas/gmm/security_mode.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/nas/gmm/message"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 )
 
@@ -44,8 +45,14 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) erro
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
+	if _, beginErr := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.SecurityMode}); beginErr != nil {
+		return fmt.Errorf("security mode blocked by conflict: %w", beginErr)
+	}
+
 	err = message.SendSecurityModeCommand(ctx, amfInstance, ranUe)
 	if err != nil {
+		ue.Procedures.End(procedure.SecurityMode)
+
 		return fmt.Errorf("error sending security mode command: %v", err)
 	}
 

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
@@ -51,6 +52,11 @@ func HandleHandoverCancel(ctx context.Context, ran *amf.Radio, msg decode.Handov
 			logger.WithTrace(ctx, sourceUe.Log).Error("Get Cause from Handover Failure Error", zap.Error(err))
 			return
 		}
+	}
+
+	// Clear the N2 Handover procedure since it was cancelled by the source.
+	if amfUe := sourceUe.AmfUe(); amfUe != nil {
+		amfUe.Procedures.End(procedure.N2Handover)
 	}
 
 	targetUe := sourceUe.TargetUe

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
@@ -54,7 +55,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 		logger.WithTrace(ctx, targetUe.Log).Error("N2 Handover between AMF has not been implemented yet")
 	} else {
 		if sourceAmfUe := sourceUe.AmfUe(); sourceAmfUe != nil {
-			sourceAmfUe.SetOnGoing(amf.OnGoingProcedureNothing)
+			sourceAmfUe.Procedures.End(procedure.N2Handover)
 		}
 
 		failureCause := ngapType.Cause{

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
@@ -49,6 +50,7 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	logger.WithTrace(ctx, targetUe.Log).Info("Handle Handover notification Finshed ")
 
+	amfUe.Procedures.End(procedure.N2Handover)
 	amfUe.AttachRanUe(targetUe)
 
 	sourceUe.ReleaseAction = amf.UeContextReleaseHandover

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
@@ -101,7 +102,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		}
 
 		if sourceAmfUe := sourceUe.AmfUe(); sourceAmfUe != nil {
-			sourceAmfUe.SetOnGoing(amf.OnGoingProcedureNothing)
+			sourceAmfUe.Procedures.End(procedure.N2Handover)
 		}
 
 		if sourceUe.Radio == nil {

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/amf/util"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
@@ -66,7 +67,11 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		return
 	}
 
-	amfUe.SetOnGoing(amf.OnGoingProcedureN2Handover)
+	_, beginErr := amfUe.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.N2Handover})
+	if beginErr != nil {
+		logger.WithTrace(ctx, sourceUe.Log).Info("N2Handover rejected by procedure registry", zap.Error(beginErr))
+		return
+	}
 
 	if !amfUe.SecurityContextIsValid() {
 		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [Authentication Failure]")
@@ -78,7 +83,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		sourceUe.AmfUe().SetOnGoing(amf.OnGoingProcedureNothing)
+		sourceUe.AmfUe().Procedures.End(procedure.N2Handover)
 
 		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 		if err != nil {
@@ -132,7 +137,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		sourceUe.AmfUe().SetOnGoing(amf.OnGoingProcedureNothing)
+		sourceUe.AmfUe().Procedures.End(procedure.N2Handover)
 
 		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 		if err != nil {

--- a/internal/amf/procedure/matrix.go
+++ b/internal/amf/procedure/matrix.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package procedure
+
+// Conflict matrix encoding TS 33.501 §6.9.5.1 rules.
+//
+// conflicts(active, incoming) returns (blocked, ruleCode).
+// The matrix is asymmetric: row = active, column = incoming.
+//
+// Legend:
+//   C1  — Rule 1: no N2-new-key while SMC ongoing
+//   C2  — Rule 2: no SMC while N2-new-key ongoing
+//   C4  — Rule 4: UE Context Modification with new KgNB vs. inter-AMF handover
+
+type matrixEntry struct {
+	blocked bool
+	rule    string
+}
+
+// matrixKey is active×incoming.
+type matrixKey struct {
+	active, incoming Type
+}
+
+var matrix = map[matrixKey]matrixEntry{
+	// SecurityMode (active) vs N2Handover (incoming) — Rule 1
+	{SecurityMode, N2Handover}: {blocked: true, rule: "C1"},
+	// N2Handover (active) vs SecurityMode (incoming) — Rule 2
+	{N2Handover, SecurityMode}: {blocked: true, rule: "C2"},
+	// N2Handover (active) vs UEContextMod (incoming) — Rule 4
+	{N2Handover, UEContextMod}: {blocked: true, rule: "C4"},
+	// UEContextMod (active) vs N2Handover (incoming) — Rule 4
+	{UEContextMod, N2Handover}: {blocked: true, rule: "C4"},
+}
+
+func conflicts(active, incoming Type) (blocked bool, rule string) {
+	if e, ok := matrix[matrixKey{active, incoming}]; ok {
+		return e.blocked, e.rule
+	}
+
+	return false, ""
+}
+
+// isReentrant returns true for procedure types that allow multiple
+// concurrent instances (e.g. Paging for different PDU sessions).
+func isReentrant(t Type) bool {
+	return t == Paging
+}

--- a/internal/amf/procedure/procedure.go
+++ b/internal/amf/procedure/procedure.go
@@ -1,0 +1,409 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package procedure
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Type identifies a kind of procedure tracked by the registry.
+type Type string
+
+const (
+	Registration   Type = "Registration"
+	Authentication Type = "Authentication"
+	SecurityMode   Type = "SecurityMode"
+	N2Handover     Type = "N2Handover"
+	UEContextMod   Type = "UEContextModification"
+	Paging         Type = "Paging"
+)
+
+// ID is an opaque handle returned by Begin. It uniquely identifies a
+// procedure instance within the registry and is required for re-entrant
+// types (e.g. Paging) where multiple instances of the same Type coexist.
+type ID uint64
+
+var nextID atomic.Uint64
+
+// Procedure is the unit tracked by the registry.
+type Procedure struct {
+	Type      Type
+	StartedAt time.Time
+	Deadline  time.Time
+	Cancel    func(context.Context) error
+}
+
+// Sentinel errors.
+var (
+	ErrConflict      = errors.New("conflicting procedure active")
+	ErrAlreadyActive = errors.New("procedure already active")
+	ErrNotActive     = errors.New("procedure not active")
+)
+
+// entry is the internal tracked state of an active procedure.
+type entry struct {
+	id        ID
+	proc      Procedure
+	timer     *time.Timer
+	startedAt time.Time
+}
+
+// Registry tracks which procedures are active for a single UE and
+// enforces concurrency rules from TS 33.501 §6.9.5.1 via a conflict
+// matrix.
+type Registry struct {
+	mu      sync.Mutex
+	active  []entry // ordered by insertion (Begin order)
+	log     *zap.Logger
+	stopped bool
+}
+
+// NewRegistry returns an empty registry bound to a logger.
+func NewRegistry(log *zap.Logger) *Registry {
+	return &Registry{log: log}
+}
+
+// Begin atomically starts p. Returns ErrConflict if any currently-active
+// procedure is incompatible with p.Type per the conflict matrix, or
+// ErrAlreadyActive if p.Type is already active and is not re-entrant.
+// On success a deadline timer is armed if p.Deadline is non-zero.
+func (r *Registry) Begin(ctx context.Context, p Procedure) (ID, error) {
+	r.mu.Lock()
+
+	if r.stopped {
+		r.mu.Unlock()
+		return 0, errors.New("registry stopped")
+	}
+
+	// Check conflicts against every active procedure.
+	for _, e := range r.active {
+		if e.proc.Type == p.Type {
+			if isReentrant(p.Type) {
+				continue // re-entrant: allow multiple instances
+			}
+			r.mu.Unlock()
+			r.log.Info("procedure rejected: already active",
+				zap.String("type", string(p.Type)),
+			)
+
+			return 0, ErrAlreadyActive
+		}
+
+		if blocked, rule := conflicts(e.proc.Type, p.Type); blocked {
+			r.mu.Unlock()
+			r.log.Info("procedure rejected: conflict",
+				zap.String("incoming", string(p.Type)),
+				zap.String("active", string(e.proc.Type)),
+				zap.String("rule", rule),
+			)
+
+			return 0, ErrConflict
+		}
+	}
+
+	now := time.Now()
+	if p.StartedAt.IsZero() {
+		p.StartedAt = now
+	}
+
+	id := ID(nextID.Add(1))
+	e := entry{
+		id:        id,
+		proc:      p,
+		startedAt: now,
+	}
+
+	// Arm deadline timer.
+	if !p.Deadline.IsZero() {
+		d := time.Until(p.Deadline)
+		if d <= 0 {
+			d = time.Millisecond
+		}
+
+		e.timer = time.AfterFunc(d, func() {
+			r.expireByID(ctx, id)
+		})
+	}
+
+	r.active = append(r.active, e)
+	r.mu.Unlock()
+
+	r.log.Debug("procedure started",
+		zap.String("type", string(p.Type)),
+		zap.Uint64("id", uint64(id)),
+		zap.Time("deadline", p.Deadline),
+	)
+
+	return id, nil
+}
+
+// End marks t as finished (success path). Does not invoke Cancel.
+// For non-re-entrant types this removes the single active instance.
+// No-op if t is not active.
+func (r *Registry) End(t Type) {
+	r.mu.Lock()
+	idx := -1
+
+	for i, e := range r.active {
+		if e.proc.Type == t {
+			idx = i
+			break
+		}
+	}
+
+	if idx < 0 {
+		r.mu.Unlock()
+		return
+	}
+
+	e := r.active[idx]
+	r.active = append(r.active[:idx], r.active[idx+1:]...)
+	r.mu.Unlock()
+
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+
+	r.log.Debug("procedure ended",
+		zap.String("type", string(t)),
+		zap.Uint64("id", uint64(e.id)),
+	)
+}
+
+// EndByID marks a specific instance as finished. Required for
+// re-entrant types where multiple instances coexist.
+func (r *Registry) EndByID(id ID) {
+	r.mu.Lock()
+
+	idx := r.indexByID(id)
+	if idx < 0 {
+		r.mu.Unlock()
+		return
+	}
+
+	e := r.active[idx]
+	r.active = append(r.active[:idx], r.active[idx+1:]...)
+	r.mu.Unlock()
+
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+
+	r.log.Debug("procedure ended by ID",
+		zap.String("type", string(e.proc.Type)),
+		zap.Uint64("id", uint64(id)),
+	)
+}
+
+// Cancel invokes the Cancel callback of the first instance of t
+// (oldest, FIFO) and removes it. Returns ErrNotActive if t was not active.
+func (r *Registry) Cancel(ctx context.Context, t Type) error {
+	r.mu.Lock()
+	idx := -1
+
+	for i, e := range r.active {
+		if e.proc.Type == t {
+			idx = i
+			break
+		}
+	}
+
+	if idx < 0 {
+		r.mu.Unlock()
+		return ErrNotActive
+	}
+
+	e := r.active[idx]
+	r.active = append(r.active[:idx], r.active[idx+1:]...)
+	r.mu.Unlock()
+
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+
+	r.log.Info("procedure cancelled",
+		zap.String("type", string(t)),
+		zap.Uint64("id", uint64(e.id)),
+		zap.String("reason", "explicit"),
+	)
+
+	r.invokeCancel(ctx, e)
+
+	return nil
+}
+
+// CancelByID cancels a specific instance by ID.
+func (r *Registry) CancelByID(ctx context.Context, id ID) error {
+	r.mu.Lock()
+
+	idx := r.indexByID(id)
+	if idx < 0 {
+		r.mu.Unlock()
+		return ErrNotActive
+	}
+
+	e := r.active[idx]
+	r.active = append(r.active[:idx], r.active[idx+1:]...)
+	r.mu.Unlock()
+
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+
+	r.log.Info("procedure cancelled by ID",
+		zap.String("type", string(e.proc.Type)),
+		zap.Uint64("id", uint64(id)),
+		zap.String("reason", "explicit"),
+	)
+
+	r.invokeCancel(ctx, e)
+
+	return nil
+}
+
+// CancelAll invokes Cancel for every active procedure in reverse-Begin
+// order (most recently started first), then clears the registry.
+func (r *Registry) CancelAll(ctx context.Context) {
+	r.mu.Lock()
+	entries := make([]entry, len(r.active))
+	copy(entries, r.active)
+	r.active = r.active[:0]
+	r.stopped = true
+	r.mu.Unlock()
+
+	// Stop timers first.
+	for _, e := range entries {
+		if e.timer != nil {
+			e.timer.Stop()
+		}
+	}
+
+	// Cancel in reverse-Begin order.
+	for i := len(entries) - 1; i >= 0; i-- {
+		e := entries[i]
+		r.log.Info("procedure cancelled",
+			zap.String("type", string(e.proc.Type)),
+			zap.Uint64("id", uint64(e.id)),
+			zap.String("reason", "teardown"),
+		)
+		r.invokeCancel(ctx, e)
+	}
+}
+
+// Active returns true if t has at least one active instance.
+func (r *Registry) Active(t Type) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, e := range r.active {
+		if e.proc.Type == t {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Snapshot returns a copy of the active set for diagnostics.
+func (r *Registry) Snapshot() []Procedure {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]Procedure, len(r.active))
+	for i, e := range r.active {
+		p := e.proc
+		p.Cancel = nil // don't leak callbacks
+		out[i] = p
+	}
+
+	return out
+}
+
+// ActiveTypes returns the set of active procedure type strings,
+// suitable for diagnostics/export.
+func (r *Registry) ActiveTypes() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.active) == 0 {
+		return nil
+	}
+
+	seen := make(map[Type]bool, len(r.active))
+
+	out := make([]string, 0, len(r.active))
+	for _, e := range r.active {
+		if !seen[e.proc.Type] {
+			seen[e.proc.Type] = true
+			out = append(out, string(e.proc.Type))
+		}
+	}
+
+	return out
+}
+
+// expireByID is called by the deadline timer.
+func (r *Registry) expireByID(ctx context.Context, id ID) {
+	r.mu.Lock()
+
+	idx := r.indexByID(id)
+	if idx < 0 {
+		r.mu.Unlock()
+		return // already ended/cancelled
+	}
+
+	e := r.active[idx]
+	r.active = append(r.active[:idx], r.active[idx+1:]...)
+	r.mu.Unlock()
+
+	// Timer already fired; no need to stop it.
+	r.log.Warn("procedure expired",
+		zap.String("type", string(e.proc.Type)),
+		zap.Uint64("id", uint64(e.id)),
+		zap.String("reason", "timeout"),
+	)
+
+	r.invokeCancel(ctx, e)
+}
+
+// invokeCancel calls the cancel callback outside the lock, recovering panics.
+func (r *Registry) invokeCancel(ctx context.Context, e entry) {
+	if e.proc.Cancel == nil {
+		return
+	}
+
+	func() {
+		defer func() {
+			if rv := recover(); rv != nil {
+				r.log.Error("cancel callback panicked",
+					zap.String("type", string(e.proc.Type)),
+					zap.Any("panic", rv),
+				)
+			}
+		}()
+
+		if err := e.proc.Cancel(ctx); err != nil {
+			r.log.Warn("cancel callback error",
+				zap.String("type", string(e.proc.Type)),
+				zap.Error(err),
+			)
+		}
+	}()
+}
+
+func (r *Registry) indexByID(id ID) int {
+	for i, e := range r.active {
+		if e.id == id {
+			return i
+		}
+	}
+
+	return -1
+}

--- a/internal/amf/procedure/procedure_test.go
+++ b/internal/amf/procedure/procedure_test.go
@@ -1,0 +1,437 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package procedure_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/amf/procedure"
+	"go.uber.org/zap"
+)
+
+func newTestRegistry() *procedure.Registry {
+	return procedure.NewRegistry(zap.NewNop())
+}
+
+func TestBeginEndRoundTrip(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	id, err := r.Begin(ctx, procedure.Procedure{Type: procedure.Registration})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	if id == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+
+	if !r.Active(procedure.Registration) {
+		t.Fatal("expected Registration to be active")
+	}
+
+	r.End(procedure.Registration)
+
+	if r.Active(procedure.Registration) {
+		t.Fatal("expected Registration to be inactive after End")
+	}
+}
+
+func TestSameTypeConflict(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	_, err := r.Begin(ctx, procedure.Procedure{Type: procedure.N2Handover})
+	if err != nil {
+		t.Fatalf("first Begin failed: %v", err)
+	}
+
+	_, err = r.Begin(ctx, procedure.Procedure{Type: procedure.N2Handover})
+	if !errors.Is(err, procedure.ErrAlreadyActive) {
+		t.Fatalf("expected ErrAlreadyActive, got %v", err)
+	}
+}
+
+func TestConflictMatrix(t *testing.T) {
+	tests := []struct {
+		first   procedure.Type
+		second  procedure.Type
+		wantErr error
+		desc    string
+	}{
+		{procedure.SecurityMode, procedure.N2Handover, procedure.ErrConflict, "C1: SMC blocks N2Handover"},
+		{procedure.N2Handover, procedure.SecurityMode, procedure.ErrConflict, "C2: N2Handover blocks SMC"},
+		{procedure.N2Handover, procedure.UEContextMod, procedure.ErrConflict, "C4: N2Handover blocks UEContextMod"},
+		{procedure.UEContextMod, procedure.N2Handover, procedure.ErrConflict, "C4: UEContextMod blocks N2Handover"},
+		{procedure.Registration, procedure.N2Handover, nil, "Registration allows N2Handover"},
+		{procedure.Registration, procedure.Authentication, nil, "Registration allows Authentication"},
+		{procedure.Registration, procedure.SecurityMode, nil, "Registration allows SecurityMode"},
+		{procedure.Authentication, procedure.N2Handover, nil, "Authentication allows N2Handover"},
+		{procedure.Paging, procedure.Registration, nil, "Paging allows Registration"},
+		{procedure.Paging, procedure.N2Handover, nil, "Paging allows N2Handover"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			r := newTestRegistry()
+			ctx := context.Background()
+
+			_, err := r.Begin(ctx, procedure.Procedure{Type: tt.first})
+			if err != nil {
+				t.Fatalf("first Begin(%s) failed: %v", tt.first, err)
+			}
+
+			_, err = r.Begin(ctx, procedure.Procedure{Type: tt.second})
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected %v, got %v", tt.wantErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDeadlineExpiry(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	var cancelled atomic.Bool
+
+	_, err := r.Begin(ctx, procedure.Procedure{
+		Type:     procedure.N2Handover,
+		Deadline: time.Now().Add(50 * time.Millisecond),
+		Cancel: func(context.Context) error {
+			cancelled.Store(true)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	if !cancelled.Load() {
+		t.Fatal("expected cancel callback to be invoked on timeout")
+	}
+
+	if r.Active(procedure.N2Handover) {
+		t.Fatal("expected N2Handover to be removed after timeout")
+	}
+}
+
+func TestCancelCallbackPanicRecovery(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	_, err := r.Begin(ctx, procedure.Procedure{
+		Type: procedure.N2Handover,
+		Cancel: func(context.Context) error {
+			panic("intentional panic")
+		},
+	})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	err = r.Cancel(ctx, procedure.N2Handover)
+	if err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	if r.Active(procedure.N2Handover) {
+		t.Fatal("expected N2Handover removed even after panic")
+	}
+}
+
+func TestCancelCallbackErrorStillRemoves(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	_, err := r.Begin(ctx, procedure.Procedure{
+		Type: procedure.N2Handover,
+		Cancel: func(context.Context) error {
+			return errors.New("cancel failed")
+		},
+	})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	err = r.Cancel(ctx, procedure.N2Handover)
+	if err != nil {
+		t.Fatalf("Cancel should succeed even if callback errors: %v", err)
+	}
+
+	if r.Active(procedure.N2Handover) {
+		t.Fatal("expected N2Handover removed even after callback error")
+	}
+}
+
+func TestConcurrentBeginConflict(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	const n = 50
+
+	var (
+		successes atomic.Int32
+		wg        sync.WaitGroup
+	)
+
+	wg.Add(n)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+
+			_, err := r.Begin(ctx, procedure.Procedure{Type: procedure.N2Handover})
+			if err == nil {
+				successes.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if got := successes.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 success, got %d", got)
+	}
+}
+
+func TestCancelAllReverseOrder(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	var (
+		order []procedure.Type
+		mu    sync.Mutex
+	)
+
+	makeCancel := func(typ procedure.Type) func(context.Context) error {
+		return func(context.Context) error {
+			mu.Lock()
+			defer mu.Unlock()
+
+			order = append(order, typ)
+
+			return nil
+		}
+	}
+
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Registration, Cancel: makeCancel(procedure.Registration)})
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Authentication, Cancel: makeCancel(procedure.Authentication)})
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Paging, Cancel: makeCancel(procedure.Paging)})
+
+	r.CancelAll(ctx)
+
+	expected := []procedure.Type{procedure.Paging, procedure.Authentication, procedure.Registration}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d cancellations, got %d", len(expected), len(order))
+	}
+
+	for i, typ := range expected {
+		if order[i] != typ {
+			t.Fatalf("position %d: expected %s, got %s", i, typ, order[i])
+		}
+	}
+}
+
+func TestPagingReentrant(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	id1, err := r.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+	if err != nil {
+		t.Fatalf("first Paging Begin failed: %v", err)
+	}
+
+	id2, err := r.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+	if err != nil {
+		t.Fatalf("second Paging Begin failed: %v", err)
+	}
+
+	if id1 == id2 {
+		t.Fatal("expected different IDs for re-entrant instances")
+	}
+
+	r.EndByID(id1)
+
+	if !r.Active(procedure.Paging) {
+		t.Fatal("expected Paging still active (second instance)")
+	}
+
+	r.EndByID(id2)
+
+	if r.Active(procedure.Paging) {
+		t.Fatal("expected Paging inactive after both ended")
+	}
+}
+
+func TestCancelNotActive(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	err := r.Cancel(ctx, procedure.N2Handover)
+	if !errors.Is(err, procedure.ErrNotActive) {
+		t.Fatalf("expected ErrNotActive, got %v", err)
+	}
+}
+
+func TestEndIsNoopWhenInactive(t *testing.T) {
+	r := newTestRegistry()
+	r.End(procedure.Registration)
+}
+
+func TestEndDoesNotInvokeCancel(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	var called atomic.Bool
+
+	_, err := r.Begin(ctx, procedure.Procedure{
+		Type: procedure.Registration,
+		Cancel: func(context.Context) error {
+			called.Store(true)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	r.End(procedure.Registration)
+
+	if called.Load() {
+		t.Fatal("End should not invoke Cancel callback")
+	}
+}
+
+func TestSnapshot(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Registration})
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+
+	snap := r.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 entries in snapshot, got %d", len(snap))
+	}
+
+	for _, p := range snap {
+		if p.Cancel != nil {
+			t.Fatal("snapshot leaked Cancel callback")
+		}
+	}
+}
+
+func TestActiveTypes(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Registration})
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+
+	types := r.ActiveTypes()
+	if len(types) != 2 {
+		t.Fatalf("expected 2 unique types, got %d: %v", len(types), types)
+	}
+}
+
+func TestCancelByID(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	var cancelledID atomic.Uint64
+
+	id1, _ := r.Begin(ctx, procedure.Procedure{
+		Type: procedure.Paging,
+		Cancel: func(context.Context) error {
+			cancelledID.Store(1)
+			return nil
+		},
+	})
+
+	id2, _ := r.Begin(ctx, procedure.Procedure{
+		Type: procedure.Paging,
+		Cancel: func(context.Context) error {
+			cancelledID.Store(2)
+			return nil
+		},
+	})
+
+	err := r.CancelByID(ctx, id2)
+	if err != nil {
+		t.Fatalf("CancelByID failed: %v", err)
+	}
+
+	if cancelledID.Load() != 2 {
+		t.Fatalf("expected cancel of instance 2, got %d", cancelledID.Load())
+	}
+
+	if !r.Active(procedure.Paging) {
+		t.Fatal("expected Paging still active (first instance)")
+	}
+
+	r.EndByID(id1)
+
+	if r.Active(procedure.Paging) {
+		t.Fatal("expected Paging inactive")
+	}
+}
+
+func TestCancelFIFOForReentrant(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	var (
+		order []int
+		mu    sync.Mutex
+	)
+
+	_, _ = r.Begin(ctx, procedure.Procedure{
+		Type: procedure.Paging,
+		Cancel: func(context.Context) error {
+			mu.Lock()
+			defer mu.Unlock()
+
+			order = append(order, 1)
+
+			return nil
+		},
+	})
+
+	_, _ = r.Begin(ctx, procedure.Procedure{
+		Type: procedure.Paging,
+		Cancel: func(context.Context) error {
+			mu.Lock()
+			defer mu.Unlock()
+
+			order = append(order, 2)
+
+			return nil
+		},
+	})
+
+	_ = r.Cancel(ctx, procedure.Paging)
+
+	if len(order) != 1 || order[0] != 1 {
+		t.Fatalf("expected FIFO cancel of instance 1, got %v", order)
+	}
+
+	if !r.Active(procedure.Paging) {
+		t.Fatal("expected second Paging instance still active")
+	}
+}

--- a/internal/amf/producer/n1n2message.go
+++ b/internal/amf/producer/n1n2message.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/nas/gmm/message"
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/nas/nasMessage"
@@ -117,13 +118,15 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 		return fmt.Errorf("ue context not found")
 	}
 
-	onGoing := ue.GetOnGoing()
-	switch onGoing {
-	case amf.OnGoingProcedurePaging:
+	if ue.Procedures.Active(procedure.Paging) {
 		return fmt.Errorf("higher priority request ongoing")
-	case amf.OnGoingProcedureRegistration:
+	}
+
+	if ue.Procedures.Active(procedure.Registration) {
 		return fmt.Errorf("temporary reject registration ongoing")
-	case amf.OnGoingProcedureN2Handover:
+	}
+
+	if ue.Procedures.Active(procedure.N2Handover) {
 		return fmt.Errorf("temporary reject handover ongoing")
 	}
 
@@ -186,7 +189,11 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 	var pagingPriority *ngapType.PagingPriority
 
 	ue.N1N2Message = &req
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+
+	_, beginErr := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+	if beginErr != nil {
+		return fmt.Errorf("begin paging procedure: %w", beginErr)
+	}
 
 	pkg, err := send.BuildPaging(
 		ue.Guti,

--- a/internal/amf/producer/n1n2message_test.go
+++ b/internal/amf/producer/n1n2message_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
+	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/amf/producer"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
@@ -337,7 +338,10 @@ func TestN2MessageTransferOrPage_OnGoingPaging(t *testing.T) {
 	amfInstance := amf.New(nil, nil, &fakeSmf{})
 
 	ue := addUE(t, amfInstance, "001010000000006", nil)
-	ue.SetOnGoing(amf.OnGoingProcedurePaging)
+
+	if _, err := ue.Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+		t.Fatal(err)
+	}
 
 	err := producer.N2MessageTransferOrPage(context.Background(), amfInstance, ue.Supi, newReq())
 	if err == nil {
@@ -349,7 +353,10 @@ func TestN2MessageTransferOrPage_OnGoingRegistration(t *testing.T) {
 	amfInstance := amf.New(nil, nil, &fakeSmf{})
 
 	ue := addUE(t, amfInstance, "001010000000007", nil)
-	ue.SetOnGoing(amf.OnGoingProcedureRegistration)
+
+	if _, err := ue.Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.Registration}); err != nil {
+		t.Fatal(err)
+	}
 
 	err := producer.N2MessageTransferOrPage(context.Background(), amfInstance, ue.Supi, newReq())
 	if err == nil {
@@ -361,7 +368,10 @@ func TestN2MessageTransferOrPage_OnGoingN2Handover(t *testing.T) {
 	amfInstance := amf.New(nil, nil, &fakeSmf{})
 
 	ue := addUE(t, amfInstance, "001010000000008", nil)
-	ue.SetOnGoing(amf.OnGoingProcedureN2Handover)
+
+	if _, err := ue.Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.N2Handover}); err != nil {
+		t.Fatal(err)
+	}
 
 	err := producer.N2MessageTransferOrPage(context.Background(), amfInstance, ue.Supi, newReq())
 	if err == nil {


### PR DESCRIPTION
# Description

Description: Remove the single-slot OnGoing/SetOnGoing/GetOnGoing mechanism from AmfUe and replace all call sites with the procedure.Registry directly. The registry tracks multiple concurrent procedures with conflict rules, so Ella Core can now correctly reject or queue conflicting operations (like N2 handover during security mode) instead of silently overwriting the single-slot state.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
