### PR TITLE
fix: SCTP listening on all IPs and N3 interface not displayed properly in UI

### DIFF
--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -22,7 +22,7 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
     - `path` (string): The path to the directory holding the database file (`ella.db`).
 - `interfaces` (object): The network interfaces configuration.
     - `n2` (object): The configuration for the n2 interface. This interface should be connected to the radios.
-        - `name` (string): The name of the network interface to listen on (optional: either name or address must be provided). When set, the server listens on all addresses (`0.0.0.0`) but uses `SO_BINDTODEVICE` to restrict incoming traffic to this interface. Use this when you want to bind to a device without pinning to a specific IP address.
+        - `name` (string): The name of the network interface to listen on (optional: either name or address must be provided). When set, the server binds to all IP addresses configured on this interface. Link-local addresses (IPv6 link-local and IPv4 link-local) are automatically excluded.
         - `address` (string): The IP address to listen on. Supports both IPv4 and IPv6 addresses (optional: either name or address must be provided). When set, the server binds to this specific address.
         - `port` (int): The port to listen on.
     - `n3` (object): The configuration for the n3 interface. This interface should be connected to the radios.

--- a/internal/amf/ngap/dispatcher.go
+++ b/internal/amf/ngap/dispatcher.go
@@ -374,7 +374,7 @@ func HandleSCTPNotification(amfInstance *amf.AMF, conn *sctp.SCTPConn, notificat
 		event := notification.(*sctp.SCTPAssocChangeEvent)
 		if event.Info() != nil {
 			ran.Log.Info("SCTP assoc change info",
-				zap.Any("info", event.Info()),
+				zap.Binary("info", event.Info()),
 				zap.Uint16("error", event.Error()))
 		}
 

--- a/internal/amf/ngap/dispatcher.go
+++ b/internal/amf/ngap/dispatcher.go
@@ -372,6 +372,12 @@ func HandleSCTPNotification(amfInstance *amf.AMF, conn *sctp.SCTPConn, notificat
 		ran.Log.Info("SCTPAssocChange notification")
 
 		event := notification.(*sctp.SCTPAssocChangeEvent)
+		if event.Info() != nil {
+			ran.Log.Info("SCTP assoc change info",
+				zap.Any("info", event.Info()),
+				zap.Uint16("error", event.Error()))
+		}
+
 		switch event.State() {
 		case sctp.SCTPCommLost:
 			amfInstance.RemoveRadio(ran)

--- a/internal/amf/ngap/service/service.go
+++ b/internal/amf/ngap/service/service.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"net"
 	"sync"
-	"syscall"
 
 	"github.com/ellanetworks/core/internal/amf/sctp"
 	"github.com/ellanetworks/core/internal/logger"
@@ -62,10 +61,45 @@ func (s *Server) ListenAndServe(ctx context.Context, address string, port int, i
 	)
 
 	if interfaceName != "" {
-		laddr = &sctp.SCTPAddr{
-			Port: port,
+		iface, err := net.InterfaceByName(interfaceName)
+		if err != nil {
+			return fmt.Errorf("failed to get interface %s: %w", interfaceName, err)
 		}
-		addrStr = fmt.Sprintf(":%d", port)
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return fmt.Errorf("failed to get interface addresses: %w", err)
+		}
+
+		var ipAddrs []net.IPAddr
+
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			ip := ipNet.IP
+			if ip.IsLoopback() {
+				continue
+			}
+
+			if ip.IsLinkLocalUnicast() {
+				continue
+			}
+
+			ipAddrs = append(ipAddrs, net.IPAddr{IP: ip})
+		}
+
+		if len(ipAddrs) == 0 {
+			return fmt.Errorf("no IP addresses found on interface %s", interfaceName)
+		}
+
+		laddr = &sctp.SCTPAddr{
+			IPAddrs: ipAddrs,
+			Port:    port,
+		}
+		addrStr = laddr.String()
 	} else {
 		netAddr, err := net.ResolveIPAddr("ip", address)
 		if err != nil {
@@ -78,23 +112,6 @@ func (s *Server) ListenAndServe(ctx context.Context, address string, port int, i
 		}
 		addrStr = laddr.String()
 	}
-
-	var control func(network, address string, c syscall.RawConn) error
-	if interfaceName != "" {
-		control = func(network, address string, c syscall.RawConn) error {
-			var setSockOptErr error
-
-			if err := c.Control(func(fd uintptr) {
-				setSockOptErr = syscall.SetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, interfaceName)
-			}); err != nil {
-				return err
-			}
-
-			return setSockOptErr
-		}
-	}
-
-	sctpConfig.Control = control
 
 	listener, err := sctpConfig.Listen("sctp", laddr)
 	if err != nil {

--- a/internal/amf/sctp/sctp.go
+++ b/internal/amf/sctp/sctp.go
@@ -589,7 +589,7 @@ func resolveFromRawAddr(ptr unsafe.Pointer, n int) (*SCTPAddr, error) {
 			addr.IPAddrs[i] = net.IPAddr{IP: a.Addr[:]}
 		}
 	case syscall.AF_INET6:
-		addr.Port = int(ntohs((*(*syscall.RawSockaddrInet4)(ptr)).Port))
+		addr.Port = int(ntohs((*(*syscall.RawSockaddrInet6)(ptr)).Port))
 
 		size := unsafe.Sizeof(syscall.RawSockaddrInet6{})
 		for i := 0; i < n; i++ {

--- a/internal/amf/sctp/sctp_notification.go
+++ b/internal/amf/sctp/sctp_notification.go
@@ -55,6 +55,10 @@ func (s *SCTPAssocChangeEvent) AssocID() SCTPAssocID {
 	return s.sacAssocID
 }
 
+func (s *SCTPAssocChangeEvent) Error() uint16 {
+	return s.sacError
+}
+
 func (s *SCTPAssocChangeEvent) Info() []uint8 {
 	return s.sacInfo
 }

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -137,7 +137,6 @@ func setupServer(filepath string) (testEnv, error) {
 				Port:    2152,
 			},
 			N3: config.N3Interface{
-				Name:    "eth0",
 				Address: "13.13.13.13",
 			},
 			N6: config.N6Interface{
@@ -198,7 +197,6 @@ func setupServerWithUPF(filepath string, upf server.UPFUpdater) (testEnv, error)
 				Port:    2152,
 			},
 			N3: config.N3Interface{
-				Name:    "eth0",
 				Address: "13.13.13.13",
 			},
 			N6: config.N6Interface{

--- a/internal/api/server/api_interfaces.go
+++ b/internal/api/server/api_interfaces.go
@@ -18,10 +18,10 @@ type N2Interface struct {
 }
 
 type N3Interface struct {
-	Name            string `json:"name"`
-	Address         string `json:"address"`
-	ExternalAddress string `json:"external_address"`
-	Vlan            *Vlan  `json:"vlan,omitempty"`
+	Name            string   `json:"name"`
+	Addresses       []string `json:"addresses"`
+	ExternalAddress string   `json:"external_address"`
+	Vlan            *Vlan    `json:"vlan,omitempty"`
 }
 
 type Vlan struct {
@@ -90,6 +90,20 @@ func ListNetworkInterfaces(dbInstance *db.Database, cfg config.Config) http.Hand
 			n2Addresses = []string{cfg.Interfaces.N2.Address}
 		}
 
+		var n3Addresses []string
+
+		if cfg.Interfaces.N3.Name != "" {
+			ips, err := config.GetInterfaceIPs(cfg.Interfaces.N3.Name)
+			if err != nil {
+				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get N3 interface IPs", err, logger.APILog)
+				return
+			}
+
+			n3Addresses = ips
+		} else if cfg.Interfaces.N3.Address != "" {
+			n3Addresses = []string{cfg.Interfaces.N3.Address}
+		}
+
 		resp := &NetworkInterfaces{
 			N2: N2Interface{
 				Addresses: n2Addresses,
@@ -98,7 +112,7 @@ func ListNetworkInterfaces(dbInstance *db.Database, cfg config.Config) http.Hand
 			},
 			N3: N3Interface{
 				Name:            cfg.Interfaces.N3.Name,
-				Address:         cfg.Interfaces.N3.Address,
+				Addresses:       n3Addresses,
 				ExternalAddress: n3Settings.ExternalAddress,
 			},
 			N6: N6Interface{

--- a/internal/api/server/api_interfaces_test.go
+++ b/internal/api/server/api_interfaces_test.go
@@ -16,9 +16,9 @@ type N2Interface struct {
 }
 
 type N3Interface struct {
-	Name            string `json:"name"`
-	Address         string `json:"address"`
-	ExternalAddress string `json:"external_address"`
+	Name            string   `json:"name"`
+	Addresses       []string `json:"addresses"`
+	ExternalAddress string   `json:"external_address"`
 }
 
 type N6Interface struct {
@@ -161,12 +161,12 @@ func TestNetworkInteraces_EndToEnd(t *testing.T) {
 			t.Fatalf("unexpected N2 interface port: %d", resp.Result.N2.Port)
 		}
 
-		if resp.Result.N3.Name != "eth0" {
+		if resp.Result.N3.Name != "" {
 			t.Fatalf("unexpected N3 interface name: %s", resp.Result.N3.Name)
 		}
 
-		if resp.Result.N3.Address != "13.13.13.13" {
-			t.Fatalf("unexpected N3 interface address: %s", resp.Result.N3.Address)
+		if resp.Result.N3.Addresses[0] != "13.13.13.13" {
+			t.Fatalf("unexpected N3 interface address: %v", resp.Result.N3.Addresses)
 		}
 
 		if resp.Result.N3.ExternalAddress != "" {

--- a/ui/src/pages/networking/InterfacesTab.tsx
+++ b/ui/src/pages/networking/InterfacesTab.tsx
@@ -157,10 +157,10 @@ export default function InterfacesTab() {
                 Interface name:{" "}
                 <strong>{interfacesInfo.n3?.name ?? "—"}</strong>
               </Typography>
-              {interfacesInfo.n2?.addresses &&
-              interfacesInfo.n2.addresses.length > 0 ? (
-                interfacesInfo.n2.addresses.map((addr) => (
-                  <Typography key={addr} variant="body2" color="textSecondary">
+              {interfacesInfo.n3?.addresses &&
+              interfacesInfo.n3.addresses.length > 0 ? (
+                interfacesInfo.n3.addresses.map((addr) => (
+                  <Typography key={addr} variant="body2" color="text.secondary">
                     Address: <strong>{addr}</strong>
                   </Typography>
                 ))
@@ -169,10 +169,7 @@ export default function InterfacesTab() {
                   Address: <strong>—</strong>
                 </Typography>
               )}
-              <Typography variant="body2" color="textSecondary">
-                Port: <strong>{interfacesInfo.n2?.port ?? "—"}</strong>
-              </Typography>
-              <Typography variant="body2" color="textSecondary">
+              <Typography variant="body2" color="text.secondary">
                 External address:{" "}
                 <strong>{interfacesInfo.n3?.external_address || "—"}</strong>
               </Typography>

--- a/ui/src/queries/interfaces.tsx
+++ b/ui/src/queries/interfaces.tsx
@@ -9,7 +9,7 @@ export type InterfacesInfo = {
   n2?: { addresses?: string[]; port?: number; interface?: string };
   n3?: {
     name?: string;
-    address?: string;
+    addresses?: string[];
     external_address?: string;
     vlan?: VlanInfo;
   };


### PR DESCRIPTION
# Description

While testing `GTP-U` over `IPv6`, I noticed a couple of bugs with previous `IPv6` work:

1. The `N3` interface was displaying the information from `N2` in the UI. It did not impact functionality, but it was confusing for the user.
2. The `SCTP` socket was listening on all unicast routable IPs, with no regard to the interface. The `SO_BINDTODEVICE` does not seem to work properly on an `SCTP` socket.

The second bug caused a significant issue, because `SCTP` supports multi-homing. It advertised all addresses of the same family in the `INIT` message, and it caused the `gNodeB` to send heartbeat to those interfaces, that were then failing and causing the `SCTP` connection to drop. The `PDU` session stayed up, but with the control plane connection down.

With this PR, we explicitly listen on the unicast, non-loopback and non-link-local, IP addresses on the specified interface. This fixes the issue on both address families.

This does not properly address support for multi-homing however, and is something we should consider supporting in the future. That would require supporting configuring multiple interfaces or multiple addresses in the configuration file to setup the socket properly.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
