### PR TITLE
fix: validate UE Radio ownership in NGAP handlers

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -438,7 +438,7 @@ func (a *AMF) NewRanUe(radio *Radio, ranUeNgapID int64) (*RanUe, error) {
 	ranUe := &RanUe{
 		AmfUeNgapID: amfUeNgapID,
 		RanUeNgapID: ranUeNgapID,
-		Radio:       radio,
+		radio:       radio,
 		Log:         radio.Log.With(logger.AmfUeNgapID(amfUeNgapID)),
 		freeNgapID:  a.ngapIDs.FreeID,
 	}

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -236,8 +236,8 @@ func (ue *AmfUe) AttachRanUe(ranUe *RanUe) {
 	}
 
 	ue.LastSeenAt = time.Now()
-	if ranUe.Radio != nil {
-		ue.LastSeenRadio = ranUe.Radio.Name
+	if ranUe.radio != nil {
+		ue.LastSeenRadio = ranUe.radio.Name
 	}
 
 	ue.Log = logger.AmfLog.With(logger.AmfUeNgapID(ranUe.AmfUeNgapID))

--- a/internal/amf/decode_nas_message_test.go
+++ b/internal/amf/decode_nas_message_test.go
@@ -30,7 +30,7 @@ func newDecoderTestUE(t *testing.T) *AmfUe {
 		Log:    zap.NewNop(),
 	}
 	ranUe := &RanUe{
-		Radio:       radio,
+		radio:       radio,
 		RanUeNgapID: 1,
 		AmfUeNgapID: 1,
 		Log:         zap.NewNop(),

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -378,8 +378,8 @@ func (amf *AMF) exportAmfUe(ue *AmfUe) AmfUeExport {
 			AmfUeNgapID: ue.ranUe.AmfUeNgapID,
 			RanTai:      ue.ranUe.Tai,
 		}
-		if ue.ranUe.Radio != nil {
-			rc.RadioName = ue.ranUe.Radio.Name
+		if ue.ranUe.radio != nil {
+			rc.RadioName = ue.ranUe.radio.Name
 		}
 
 		export.RANConnection = rc

--- a/internal/amf/export_test.go
+++ b/internal/amf/export_test.go
@@ -218,13 +218,8 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 			Snssai: &models.Snssai{Sst: 1, Sd: "000001"},
 		}
 		radio := &amf.Radio{Name: "gNB-001", RanUEs: make(map[int64]*amf.RanUe), Log: zap.NewNop()}
-		ranUe := &amf.RanUe{
-			RanUeNgapID: 42,
-			AmfUeNgapID: 100,
-			Tai:         models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
-			Radio:       radio,
-			Log:         zap.NewNop(),
-		}
+		ranUe := amf.NewRanUeForTest(radio, 42, 100, zap.NewNop())
+		ranUe.Tai = models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}
 		ue.AttachRanUe(ranUe)
 		ue.T3513 = amf.NewTimer(1*time.Hour, 3, func(_ int32) {}, func() {})
 		ue.T3512Value = 3600 * time.Second

--- a/internal/amf/nas/gmm/message/send.go
+++ b/internal/amf/nas/gmm/message/send.go
@@ -490,7 +490,7 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *amf.AMF, a
 				return
 			}
 
-			if retryRanUe.Radio == nil {
+			if retryRanUe.Radio() == nil {
 				amfUe.Log.Warn("Radio is nil, abort retransmission of Configuration Update Command")
 				return
 			}

--- a/internal/amf/ngap/handle_handover_cancel_test.go
+++ b/internal/amf/ngap/handle_handover_cancel_test.go
@@ -53,23 +53,11 @@ func TestHandleHandoverCancel_HappyPath(t *testing.T) {
 	targetRan := newTestRadio()
 	targetSender := targetRan.NGAPSender.(*FakeNGAPSender)
 
-	sourceUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
-
-	targetUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 20,
-		Radio:       targetRan,
-		Log:         logger.AmfLog,
-	}
+	sourceUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
+	targetUe := amf.NewRanUeForTest(targetRan, 2, 20, logger.AmfLog)
 
 	sourceUe.TargetUe = targetUe
 	targetUe.SourceUe = sourceUe
-	sourceRan.RanUEs[1] = sourceUe
 
 	msg := decode.HandoverCancel{
 		AMFUENGAPID: 10,

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -27,27 +27,13 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 		}
 	}
 
-	targetUe := amfInstance.FindRanUeByAmfUeNgapID(msg.AMFUENGAPID)
+	targetUe := ran.FindUEByAmfUeNgapID(msg.AMFUENGAPID)
 	if targetUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("AmfUeNgapID", msg.AMFUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-			return
-		}
-
+		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Int64("AmfUeNgapID", msg.AMFUENGAPID))
+		sendUnknownLocalUEError(ctx, ran)
 		return
 	}
 
-	targetUe.Radio = ran
 	targetUe.TouchLastSeen()
 
 	sourceUe := targetUe.SourceUe
@@ -68,10 +54,10 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 			failureCause = *msg.Cause
 		}
 
-		if sourceUe.Radio == nil {
+		if sourceUe.Radio() == nil {
 			logger.WithTrace(ctx, targetUe.Log).Error("source UE radio is nil, cannot send handover preparation failure")
 		} else {
-			err := sourceUe.Radio.NGAPSender.SendHandoverPreparationFailure(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, failureCause, msg.CriticalityDiagnostics)
+			err := sourceUe.Radio().NGAPSender.SendHandoverPreparationFailure(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, failureCause, msg.CriticalityDiagnostics)
 			if err != nil {
 				logger.WithTrace(ctx, targetUe.Log).Error("error sending handover preparation failure", zap.Error(err))
 				return
@@ -81,7 +67,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 
 	targetUe.ReleaseAction = amf.UeContextReleaseHandover
 
-	err = targetUe.Radio.NGAPSender.SendUEContextReleaseCommand(ctx, targetUe.AmfUeNgapID, targetUe.RanUeNgapID, causePresent, causeValue)
+	err = targetUe.Radio().NGAPSender.SendUEContextReleaseCommand(ctx, targetUe.AmfUeNgapID, targetUe.RanUeNgapID, causePresent, causeValue)
 	if err != nil {
 		logger.WithTrace(ctx, targetUe.Log).Error("error sending UE Context Release Command to target UE", zap.Error(err))
 		return

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -31,6 +31,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 	if targetUe == nil {
 		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Int64("AmfUeNgapID", msg.AMFUENGAPID))
 		sendUnknownLocalUEError(ctx, ran)
+
 		return
 	}
 

--- a/internal/amf/ngap/handle_handover_failure_test.go
+++ b/internal/amf/ngap/handle_handover_failure_test.go
@@ -40,21 +40,10 @@ func TestHandleHandoverFailure_SourceAmfUeDetached(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	sourceUe := &amf.RanUe{
-		RanUeNgapID: 10,
-		AmfUeNgapID: 100,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	sourceUe := amf.NewRanUeForTest(sourceRan, 10, 100, logger.AmfLog)
 	amfUe.AttachRanUe(sourceUe)
-	sourceRan.RanUEs[10] = sourceUe
 
-	targetUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 200,
-		Radio:       targetRan,
-		Log:         logger.AmfLog,
-	}
+	targetUe := amf.NewRanUeForTest(targetRan, 2, 200, logger.AmfLog)
 
 	err := amf.AttachSourceUeTargetUe(sourceUe, targetUe)
 	if err != nil {

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -55,7 +55,7 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	sourceUe.ReleaseAction = amf.UeContextReleaseHandover
 
-	err := sourceUe.Radio.NGAPSender.SendUEContextReleaseCommand(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
+	err := sourceUe.Radio().NGAPSender.SendUEContextReleaseCommand(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 	if err != nil {
 		logger.WithTrace(ctx, targetUe.Log).Error("error sending ue context release command", zap.Error(err))
 		return

--- a/internal/amf/ngap/handle_handover_notify_test.go
+++ b/internal/amf/ngap/handle_handover_notify_test.go
@@ -58,13 +58,7 @@ func TestHandoverNotify_NilAmfUe(t *testing.T) {
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
 
-	targetUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 1,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[2] = targetUe
+	amf.NewRanUeForTest(ran, 2, 1, logger.AmfLog)
 
 	amfInstance := amf.New(nil, nil, nil)
 
@@ -89,15 +83,9 @@ func TestHandoverNotify_NoSourceUe(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	targetUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 1,
-		SourceUe:    nil,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	targetUe := amf.NewRanUeForTest(ran, 2, 1, logger.AmfLog)
+	targetUe.SourceUe = nil
 	amfUe.AttachRanUe(targetUe)
-	ran.RanUEs[2] = targetUe
 
 	amfInstance := amf.New(nil, nil, nil)
 
@@ -122,14 +110,8 @@ func TestHandoverNotify_HappyPath(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	sourceUe := &amf.RanUe{
-		RanUeNgapID: 10,
-		AmfUeNgapID: 100,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	sourceUe := amf.NewRanUeForTest(sourceRan, 10, 100, logger.AmfLog)
 	amfUe.AttachRanUe(sourceUe)
-	sourceRan.RanUEs[10] = sourceUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -139,19 +121,12 @@ func TestHandoverNotify_HappyPath(t *testing.T) {
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
 
-	targetUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 1,
-		Radio:       targetRan,
-		Log:         logger.AmfLog,
-	}
+	targetUe := amf.NewRanUeForTest(targetRan, 2, 1, logger.AmfLog)
 
 	err := amf.AttachSourceUeTargetUe(sourceUe, targetUe)
 	if err != nil {
 		t.Fatalf("failed to attach source/target: %v", err)
 	}
-
-	targetRan.RanUEs[2] = targetUe
 
 	amfInstance := amf.New(nil, nil, nil)
 

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -17,9 +17,10 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	targetUe := amfInstance.FindRanUeByAmfUeNgapID(*msg.AMFUENGAPID)
+	targetUe := ran.FindUEByAmfUeNgapID(*msg.AMFUENGAPID)
 	if targetUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
+		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
+		sendUnknownLocalUEError(ctx, ran)
 		return
 	}
 
@@ -27,7 +28,6 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		targetUe.RanUeNgapID = *msg.RANUENGAPID
 	}
 
-	targetUe.Radio = ran
 	targetUe.TouchLastSeen()
 	logger.WithTrace(ctx, targetUe.Log).Debug("Handle Handover Request Acknowledge", zap.Any("RanUeNgapID", targetUe.RanUeNgapID), zap.Any("AmfUeNgapID", targetUe.AmfUeNgapID))
 
@@ -105,12 +105,12 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 			sourceAmfUe.Procedures.End(procedure.N2Handover)
 		}
 
-		if sourceUe.Radio == nil {
+		if sourceUe.Radio() == nil {
 			logger.WithTrace(ctx, targetUe.Log).Error("source UE radio is nil, cannot send handover preparation failure")
 			return
 		}
 
-		err := sourceUe.Radio.NGAPSender.SendHandoverPreparationFailure(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, *cause, nil)
+		err := sourceUe.Radio().NGAPSender.SendHandoverPreparationFailure(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, *cause, nil)
 		if err != nil {
 			logger.WithTrace(ctx, targetUe.Log).Error("error sending handover preparation failure", zap.Error(err))
 		}
@@ -118,7 +118,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	err := sourceUe.Radio.NGAPSender.SendHandoverCommand(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, sourceUe.HandOverType, pduSessionResourceHandoverList, pduSessionResourceToReleaseList, msg.TargetToSourceTransparentContainer)
+	err := sourceUe.Radio().NGAPSender.SendHandoverCommand(ctx, sourceUe.AmfUeNgapID, sourceUe.RanUeNgapID, sourceUe.HandOverType, pduSessionResourceHandoverList, pduSessionResourceToReleaseList, msg.TargetToSourceTransparentContainer)
 	if err != nil {
 		logger.WithTrace(ctx, targetUe.Log).Error("error sending handover command to source UE", zap.Error(err))
 	}

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -21,6 +21,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 	if targetUe == nil {
 		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
 		sendUnknownLocalUEError(ctx, ran)
+
 		return
 	}
 

--- a/internal/amf/ngap/handle_handover_request_acknowledge_test.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge_test.go
@@ -68,14 +68,8 @@ func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *FakeNGAPSender, *am
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
 
-	sourceUe := &amf.RanUe{
-		RanUeNgapID: 10,
-		AmfUeNgapID: 100,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	sourceUe := amf.NewRanUeForTest(sourceRan, 10, 100, logger.AmfLog)
 	amfUe.AttachRanUe(sourceUe)
-	sourceRan.RanUEs[10] = sourceUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -85,19 +79,12 @@ func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *FakeNGAPSender, *am
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
 
-	targetUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 1,
-		Radio:       targetRan,
-		Log:         logger.AmfLog,
-	}
+	targetUe := amf.NewRanUeForTest(targetRan, 2, 1, logger.AmfLog)
 
 	err := amf.AttachSourceUeTargetUe(sourceUe, targetUe)
 	if err != nil {
 		t.Fatalf("failed to attach source/target: %v", err)
 	}
-
-	targetRan.RanUEs[2] = targetUe
 
 	amfInstance := amf.New(nil, nil, &FakeSmfSbi{SMF: smfInstance})
 	amfInstance.Radios[new(sctp.SCTPConn)] = sourceRan
@@ -134,8 +121,8 @@ func TestHandoverRequestAcknowledge_UeNotFound(t *testing.T) {
 		t.Fatalf("expected no HandoverCommand, got %d", len(fakeNGAPSender.SentHandoverCommands))
 	}
 
-	if len(fakeNGAPSender.SentErrorIndications) != 0 {
-		t.Fatalf("expected no ErrorIndication, got %d", len(fakeNGAPSender.SentErrorIndications))
+	if len(fakeNGAPSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication (TS 38.413 §10.6), got %d", len(fakeNGAPSender.SentErrorIndications))
 	}
 }
 
@@ -151,15 +138,9 @@ func TestHandoverRequestAcknowledge_NoSourceUe(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	targetUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 1,
-		SourceUe:    nil,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	targetUe := amf.NewRanUeForTest(ran, 2, 1, logger.AmfLog)
+	targetUe.SourceUe = nil
 	amfUe.AttachRanUe(targetUe)
-	ran.RanUEs[2] = targetUe
 
 	amfInstance := newTestAMF()
 	amfInstance.Radios[new(sctp.SCTPConn)] = ran
@@ -226,9 +207,9 @@ func TestHandoverRequestAcknowledge_NoPDUSessionsAdmitted_SendsPreparationFailur
 func TestHandoverRequestAcknowledge_NoPDUSessionsAdmitted_SourceAmfUeDetached(t *testing.T) {
 	targetRan, sourceNGAPSender, amfInstance := setupHandoverAckTestContext(t)
 
-	targetUe := amfInstance.FindRanUeByAmfUeNgapID(1)
+	targetUe := targetRan.FindUEByAmfUeNgapID(1)
 	if targetUe == nil {
-		t.Fatal("target UE not found")
+		t.Fatal("target UE not found on target radio")
 	}
 
 	sourceAmfUe := targetUe.SourceUe.AmfUe()

--- a/internal/amf/ngap/handle_handover_required_test.go
+++ b/internal/amf/ngap/handle_handover_required_test.go
@@ -254,14 +254,8 @@ func TestHandoverRequired(t *testing.T) {
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
 
-	sourceUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 1,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	sourceUe := amf.NewRanUeForTest(sourceRan, 1, 1, logger.AmfLog)
 	amfUe.AttachRanUe(sourceUe)
-	sourceRan.RanUEs[1] = sourceUe
 
 	// Set up target RAN with matching GNB ID
 	targetNGAPSender := &FakeNGAPSender{}
@@ -439,14 +433,8 @@ func TestHandoverRequired_InvalidSecurityContext(t *testing.T) {
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
 
-	sourceUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 1,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	sourceUe := amf.NewRanUeForTest(sourceRan, 1, 1, logger.AmfLog)
 	amfUe.AttachRanUe(sourceUe)
-	sourceRan.RanUEs[1] = sourceUe
 
 	amfInstance := amf.New(nil, nil, nil)
 

--- a/internal/amf/ngap/handle_initial_context_setup_failure_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure_test.go
@@ -51,13 +51,7 @@ func TestHandleInitialContextSetupFailure_NilAmfUe(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	msg := decode.InitialContextSetupFailure{
 		AMFUENGAPID: 10,
@@ -81,14 +75,8 @@ func TestHandleInitialContextSetupFailure_T3550Running(t *testing.T) {
 	amfUe.ForceState(amf.ContextSetup)
 	amfUe.T3550 = amf.NewTimer(time.Hour, 4, func(int32) {}, func() {})
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	msg := decode.InitialContextSetupFailure{
 		AMFUENGAPID: 10,
@@ -122,14 +110,8 @@ func TestHandleInitialContextSetupFailure_PDUSessionFailureForwardedToSmf(t *tes
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	transfer := []byte{0xEE, 0xFF}
 

--- a/internal/amf/ngap/handle_initial_context_setup_response_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_response_test.go
@@ -27,13 +27,7 @@ func TestInitialContextSetupResponse_UnknownRanUeNgapID(t *testing.T) {
 
 func TestInitialContextSetupResponse_NilAmfUe(t *testing.T) {
 	ran := newTestRadio()
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	amfInstance := newTestAMFWithSmf(&FakeSmfSbi{})
 
@@ -64,14 +58,8 @@ func TestInitialContextSetupResponse_SetupItemsForwardedToSmf(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	transfer := []byte{0xAA, 0xBB}
 
@@ -111,14 +99,8 @@ func TestInitialContextSetupResponse_FailedItemsForwardedToSmf(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	transfer := []byte{0xCC, 0xDD}
 
@@ -150,14 +132,8 @@ func TestInitialContextSetupResponse_SetupItemSmContextNotFound(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleInitialContextSetupResponse(context.Background(), amfInstance, ran, decode.InitialContextSetupResponse{
 		RANUENGAPID: 1,
@@ -187,14 +163,8 @@ func TestInitialContextSetupResponse_InvalidPDUSessionID(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleInitialContextSetupResponse(context.Background(), amfInstance, ran, decode.InitialContextSetupResponse{
 		RANUENGAPID: 1,
@@ -228,14 +198,8 @@ func TestInitialContextSetupResponse_MixedSetupAndFailedItems(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleInitialContextSetupResponse(context.Background(), amfInstance, ran, decode.InitialContextSetupResponse{
 		RANUENGAPID: 1,

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -62,13 +62,7 @@ func TestHandleInitialUEMessage_ReusedRanUeNgapID_EvictsStale(t *testing.T) {
 	ran := newTestRadio()
 	ran.RanID = &models.GlobalRanNodeID{GNbID: &models.GNbID{GNBValue: "001"}}
 
-	oldRanUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 99,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = oldRanUe
+	amf.NewRanUeForTest(ran, 1, 99, logger.AmfLog)
 
 	ngap.HandleInitialUEMessage(context.Background(), amfInstance, ran, decode.InitialUEMessage{
 		RANUENGAPID: 1,

--- a/internal/amf/ngap/handle_location_report.go
+++ b/internal/amf/ngap/handle_location_report.go
@@ -59,7 +59,7 @@ func HandleLocationReport(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		}
 
 	case ngapType.EventTypePresentStopChangeOfServeCell:
-		err := ranUe.Radio.NGAPSender.SendLocationReportingControl(ctx, ranUe.AmfUeNgapID, ranUe.RanUeNgapID, msg.LocationReportingRequestType.EventType)
+		err := ranUe.Radio().NGAPSender.SendLocationReportingControl(ctx, ranUe.AmfUeNgapID, ranUe.RanUeNgapID, msg.LocationReportingRequestType.EventType)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error("error sending location reporting control", zap.Error(err))
 		}

--- a/internal/amf/ngap/handle_location_report_test.go
+++ b/internal/amf/ngap/handle_location_report_test.go
@@ -16,6 +16,7 @@ import (
 func TestHandleLocationReport_MissingLocationReportingRequestType(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
+
 	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{
@@ -38,6 +39,7 @@ func TestHandleLocationReport_MissingLocationReportingRequestType(t *testing.T) 
 func TestHandleLocationReport_UePresenceInAreaOfInterest_NilList(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
+
 	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{
@@ -68,6 +70,7 @@ func TestHandleLocationReport_UePresenceInAreaOfInterest_NilList(t *testing.T) {
 func TestHandleLocationReport_StopUePresence_NilReferenceIDToBeCancelled(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
+
 	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{
@@ -98,6 +101,7 @@ func TestHandleLocationReport_StopUePresence_NilReferenceIDToBeCancelled(t *test
 func TestHandleLocationReport_UePresence_NilAreaOfInterestList(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
+
 	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{

--- a/internal/amf/ngap/handle_location_report_test.go
+++ b/internal/amf/ngap/handle_location_report_test.go
@@ -16,13 +16,7 @@ import (
 func TestHandleLocationReport_MissingLocationReportingRequestType(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 1,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{
 		AMFUENGAPID: 1,
@@ -44,13 +38,7 @@ func TestHandleLocationReport_MissingLocationReportingRequestType(t *testing.T) 
 func TestHandleLocationReport_UePresenceInAreaOfInterest_NilList(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 1,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{
 		AMFUENGAPID: 1,
@@ -80,13 +68,7 @@ func TestHandleLocationReport_UePresenceInAreaOfInterest_NilList(t *testing.T) {
 func TestHandleLocationReport_StopUePresence_NilReferenceIDToBeCancelled(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 1,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{
 		AMFUENGAPID: 1,
@@ -116,13 +98,7 @@ func TestHandleLocationReport_StopUePresence_NilReferenceIDToBeCancelled(t *test
 func TestHandleLocationReport_UePresence_NilAreaOfInterestList(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 1,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.LocationReport{
 		AMFUENGAPID: 1,

--- a/internal/amf/ngap/handle_nas_non_delivery_indication_test.go
+++ b/internal/amf/ngap/handle_nas_non_delivery_indication_test.go
@@ -29,14 +29,8 @@ func TestNasNonDeliveryIndication_UEFoundDispatchesNAS(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	amfInstance := newTestAMF()
 
@@ -61,14 +55,8 @@ func TestNasNonDeliveryIndication_VerifyNASCalledWithPDU(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	nasPDU := []byte{0xDE, 0xAD}
 
@@ -103,14 +91,8 @@ func TestNasNonDeliveryIndication_NilPDU_PropagatesCorrectly(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleNasNonDeliveryIndication(context.Background(), amfInstance, ran, decode.NASNonDeliveryIndication{
 		RANUENGAPID: 1,

--- a/internal/amf/ngap/handle_ng_reset_test.go
+++ b/internal/amf/ngap/handle_ng_reset_test.go
@@ -26,17 +26,13 @@ func TestHandleNGReset_ResetNGInterface(t *testing.T) {
 	fakeNGAPSender := &FakeNGAPSender{}
 
 	ran := &amf.Radio{
-		Log:        logger.AmfLog,
-		NGAPSender: fakeNGAPSender,
-		RanUEs: map[int64]*amf.RanUe{
-			0: {RanUeNgapID: 0, AmfUeNgapID: 0, Radio: &amf.Radio{}},
-			1: {RanUeNgapID: 1, AmfUeNgapID: 1, Radio: &amf.Radio{}},
-		},
+		Log:           logger.AmfLog,
+		NGAPSender:    fakeNGAPSender,
+		RanUEs:        make(map[int64]*amf.RanUe),
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
-
-	ran.RanUEs[0].Radio = ran
-	ran.RanUEs[1].Radio = ran
+	amf.NewRanUeForTest(ran, 0, 0, logger.AmfLog)
+	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	msg := decode.NGReset{
 		Cause: miscCause(),
@@ -65,17 +61,13 @@ func TestHandleNGReset_PartOfNGInterface(t *testing.T) {
 	fakeNGAPSender := &FakeNGAPSender{}
 
 	ran := &amf.Radio{
-		Log:        logger.AmfLog,
-		NGAPSender: fakeNGAPSender,
-		RanUEs: map[int64]*amf.RanUe{
-			0: {RanUeNgapID: 0, AmfUeNgapID: 0, Radio: &amf.Radio{}},
-			1: {RanUeNgapID: 1, AmfUeNgapID: 1, Radio: &amf.Radio{}},
-		},
+		Log:           logger.AmfLog,
+		NGAPSender:    fakeNGAPSender,
+		RanUEs:        make(map[int64]*amf.RanUe),
 		SupportedTAIs: make([]amf.SupportedTAI, 0),
 	}
-
-	ran.RanUEs[0].Radio = ran
-	ran.RanUEs[1].Radio = ran
+	amf.NewRanUeForTest(ran, 0, 0, logger.AmfLog)
+	amf.NewRanUeForTest(ran, 1, 1, logger.AmfLog)
 
 	partOfNG := &ngapType.UEAssociatedLogicalNGConnectionList{
 		List: []ngapType.UEAssociatedLogicalNGConnectionItem{

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -26,7 +26,6 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 		return
 	}
 
-	ranUe.Radio = ran
 	ranUe.TouchLastSeen()
 	logger.WithTrace(ctx, ranUe.Log).Debug("Handle Path Switch Request", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID), zap.Int64("RanUeNgapID", ranUe.RanUeNgapID))
 
@@ -137,7 +136,7 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 			return
 		}
 
-		err = ranUe.Radio.NGAPSender.SendPathSwitchRequestAcknowledge(
+		err = ranUe.Radio().NGAPSender.SendPathSwitchRequestAcknowledge(
 			ctx,
 			ranUe.AmfUeNgapID,
 			ranUe.RanUeNgapID,

--- a/internal/amf/ngap/handle_path_switch_request_test.go
+++ b/internal/amf/ngap/handle_path_switch_request_test.go
@@ -203,13 +203,7 @@ func TestPathSwitchRequest_NilAmfUe(t *testing.T) {
 	}
 
 	// RanUe exists but AmfUe is nil
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
-	sourceRan.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -262,14 +256,8 @@ func TestPathSwitchRequest_InvalidSecurityContext(t *testing.T) {
 	amfUe.NgKsi.Ksi = nasMessage.NasKeySetIdentifierNoKeyIsAvailable
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -320,14 +308,8 @@ func TestPathSwitchRequest_SmContextNotFound(t *testing.T) {
 	amfUe := newValidAmfUe()
 	// SmContextList is empty — no PDU session ID 1
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -386,14 +368,8 @@ func TestPathSwitchRequest_SmfReturnsError(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -472,14 +448,8 @@ func TestPathSwitchRequest_HappyPath(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	sourceUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: sourceAmfUeNgapID,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	sourceUe := amf.NewRanUeForTest(sourceRan, 1, sourceAmfUeNgapID, logger.AmfLog)
 	amfUe.AttachRanUe(sourceUe)
-	sourceRan.RanUEs[1] = sourceUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -556,7 +526,7 @@ func TestPathSwitchRequest_HappyPath(t *testing.T) {
 	}
 
 	// Verify the RAN UE was switched to the new RAN
-	if sourceUe.Radio != targetRan {
+	if sourceUe.Radio() != targetRan {
 		t.Error("expected RanUe to be switched to targetRan")
 	}
 
@@ -586,14 +556,8 @@ func TestPathSwitchRequest_MultiplePDUSessions_PartialSuccess(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -679,14 +643,8 @@ func TestPathSwitchRequest_FailedPDUSessionsReportedToSmf(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -791,14 +749,8 @@ func TestPathSwitchRequest_UESecurityCapabilitiesNotOverwritten(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -918,14 +870,8 @@ func TestPathSwitchRequest_UESecurityCapabilitiesMatching(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{
@@ -1029,14 +975,8 @@ func TestPathSwitchRequest_EmptySecurityCapabilityBytes(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       sourceRan,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	sourceRan.RanUEs[1] = ranUe
 
 	targetNGAPSender := &FakeNGAPSender{}
 	targetRan := &amf.Radio{

--- a/internal/amf/ngap/handle_pdu_session_resource_modify.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify.go
@@ -16,7 +16,6 @@ func HandlePDUSessionResourceNotify(ctx context.Context, amfInstance *amf.AMF, r
 		return
 	}
 
-	ranUe.Radio = ran
 	ranUe.TouchLastSeen()
 	logger.WithTrace(ctx, ranUe.Log).Debug("Handle PDUSessionResourceNotify", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID))
 

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication_test.go
@@ -39,13 +39,7 @@ func TestPDUSessionResourceModifyIndication_SendsModifyConfirm(t *testing.T) {
 	ran := newTestRadio()
 	sender := ran.NGAPSender.(*FakeNGAPSender)
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	ngap.HandlePDUSessionResourceModifyIndication(context.Background(), ran, decode.PDUSessionResourceModifyIndication{
 		RANUENGAPID: 1,

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_response.go
@@ -10,28 +10,11 @@ import (
 )
 
 func HandlePDUSessionResourceModifyResponse(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.PDUSessionResourceModifyResponse) {
-	var ranUe *amf.RanUe
-
-	if msg.RANUENGAPID != nil {
-		ranUe = ran.FindUEByRanUeNgapID(*msg.RANUENGAPID)
-		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("No UE Context", zap.Int64("RanUeNgapID", *msg.RANUENGAPID))
-		}
-	}
-
-	if msg.AMFUENGAPID != nil {
-		ranUe = amfInstance.FindRanUeByAmfUeNgapID(*msg.AMFUENGAPID)
-		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("No UE Context", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
-			return
-		}
-	}
-
-	if ranUe == nil {
+	ranUe, ok := resolveUE(ctx, ran, msg.RANUENGAPID, msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 
-	ranUe.Radio = ran
 	ranUe.TouchLastSeen()
 	logger.WithTrace(ctx, ranUe.Log).Debug("Handle PDUSessionResourceModifyResponse", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID))
 

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_response_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_response_test.go
@@ -31,28 +31,23 @@ func TestPDUSessionResourceModifyResponse_RanUeNgapIDNotFound(t *testing.T) {
 	})
 }
 
-func TestPDUSessionResourceModifyResponse_AmfUeNgapIDLookup(t *testing.T) {
+func TestPDUSessionResourceModifyResponse_CrossRadioRejected(t *testing.T) {
 	ran := newTestRadio()
-
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	amfInstance := newTestAMFWithSmf(&FakeSmfSbi{})
 	amfInstance.Radios[new(sctp.SCTPConn)] = ran
 
-	targetRan := newTestRadio()
+	// A different radio claims the same AMF-UE-NGAP-ID — must be rejected.
+	attackerRan := newTestRadio()
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
 	amfID := int64(10)
 
-	ngap.HandlePDUSessionResourceModifyResponse(context.Background(), amfInstance, targetRan, decode.PDUSessionResourceModifyResponse{
+	ngap.HandlePDUSessionResourceModifyResponse(context.Background(), amfInstance, attackerRan, decode.PDUSessionResourceModifyResponse{
 		AMFUENGAPID: &amfID,
 	})
 
-	if ranUe.Radio != targetRan {
-		t.Error("expected ranUe.Radio to be updated to targetRan")
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication for cross-radio AMF-UE-NGAP-ID, got %d", len(attackerSender.SentErrorIndications))
 	}
 }

--- a/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
@@ -25,13 +25,7 @@ func TestPDUSessionResourceNotify_UnknownRanUeNgapID(t *testing.T) {
 
 func TestPDUSessionResourceNotify_NilAmfUe(t *testing.T) {
 	ran := newTestRadio()
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	amfInstance := newTestAMF()
 
@@ -52,14 +46,8 @@ func TestPDUSessionResourceNotify_ReleasedSessionDeactivated(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 1,
@@ -97,14 +85,8 @@ func TestPDUSessionResourceNotify_ReleasedSessionSmContextNotFound(t *testing.T)
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 1,
@@ -129,14 +111,8 @@ func TestPDUSessionResourceNotify_InvalidPDUSessionID(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 1,
@@ -161,14 +137,8 @@ func TestPDUSessionResourceNotify_NotifyListLogsWarning(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID:   1,

--- a/internal/amf/ngap/handle_pdu_session_resource_release_response_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_release_response_test.go
@@ -40,14 +40,8 @@ func TestHandlePDUSessionResourceReleaseResponse_UEFoundWithReleasedSessions(t *
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	amfUeNgapID := int64(10)
 	ranUeNgapID := int64(1)

--- a/internal/amf/ngap/handle_pdu_session_resource_setup_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_setup_response.go
@@ -10,28 +10,11 @@ import (
 )
 
 func HandlePDUSessionResourceSetupResponse(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.PDUSessionResourceSetupResponse) {
-	var ranUe *amf.RanUe
-
-	if msg.RANUENGAPID != nil {
-		ranUe = ran.FindUEByRanUeNgapID(*msg.RANUENGAPID)
-		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("No UE Context", zap.Int64("RanUeNgapID", *msg.RANUENGAPID))
-		}
-	}
-
-	if msg.AMFUENGAPID != nil {
-		ranUe = amfInstance.FindRanUeByAmfUeNgapID(*msg.AMFUENGAPID)
-		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("UE Context not found", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
-			return
-		}
-	}
-
-	if ranUe == nil {
+	ranUe, ok := resolveUE(ctx, ran, msg.RANUENGAPID, msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 
-	ranUe.Radio = ran
 	ranUe.TouchLastSeen()
 
 	amfUe := ranUe.AmfUe()

--- a/internal/amf/ngap/handle_pdu_session_resource_setup_response_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_setup_response_test.go
@@ -43,8 +43,8 @@ func TestHandlePDUSessionResourceSetupResponse_UnknownAMFUENGAPID(t *testing.T) 
 	ngap.HandlePDUSessionResourceSetupResponse(context.Background(), amfInstance, ran, msg)
 
 	sender := ran.NGAPSender.(*FakeNGAPSender)
-	if len(sender.SentErrorIndications) != 0 {
-		t.Fatalf("expected no ErrorIndication, got %d", len(sender.SentErrorIndications))
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication (TS 38.413 §10.6), got %d", len(sender.SentErrorIndications))
 	}
 }
 
@@ -60,8 +60,8 @@ func TestHandlePDUSessionResourceSetupResponse_OnlyUnknownRANUENGAPID(t *testing
 	ngap.HandlePDUSessionResourceSetupResponse(context.Background(), amfInstance, ran, msg)
 
 	sender := ran.NGAPSender.(*FakeNGAPSender)
-	if len(sender.SentErrorIndications) != 0 {
-		t.Fatalf("expected no ErrorIndication, got %d", len(sender.SentErrorIndications))
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication (TS 38.413 §10.6), got %d", len(sender.SentErrorIndications))
 	}
 }
 
@@ -78,14 +78,8 @@ func TestHandlePDUSessionResourceSetupResponse_HappyPath(t *testing.T) {
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	transfer := []byte{0xAA, 0xBB}
 	amfUeNgapID := int64(10)
@@ -126,14 +120,8 @@ func TestHandlePDUSessionResourceSetupResponse_FailedItemForwardedToSmf(t *testi
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	transfer := []byte{0xCC, 0xDD}
 	amfUeNgapID := int64(10)

--- a/internal/amf/ngap/handle_ue_context_modification_failure.go
+++ b/internal/amf/ngap/handle_ue_context_modification_failure.go
@@ -10,28 +10,8 @@ import (
 )
 
 func HandleUEContextModificationFailure(ctx gocontext.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.UEContextModificationFailure) {
-	var ranUe *amf.RanUe
-
-	if msg.RANUENGAPID != nil {
-		ranUe = ran.FindUEByRanUeNgapID(*msg.RANUENGAPID)
-		if ranUe == nil {
-			if msg.AMFUENGAPID != nil {
-				logger.WithTrace(ctx, ran.Log).Warn("No UE Context", zap.Int64("RanUeNgapID", *msg.RANUENGAPID), zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
-			} else {
-				logger.WithTrace(ctx, ran.Log).Warn("No UE Context", zap.Int64("RanUeNgapID", *msg.RANUENGAPID))
-			}
-		}
-	}
-
-	if msg.AMFUENGAPID != nil {
-		ranUe = amfInstance.FindRanUeByAmfUeNgapID(*msg.AMFUENGAPID)
-		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("UE Context not found", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
-		}
-	}
-
-	if ranUe != nil {
-		ranUe.Radio = ran
+	ranUe, ok := resolveUE(ctx, ran, msg.RANUENGAPID, msg.AMFUENGAPID)
+	if ok {
 		ranUe.TouchLastSeen()
 		logger.WithTrace(ctx, ranUe.Log).Debug("Handle UE Context Modification Failure", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID), zap.Int64("RanUeNgapID", ranUe.RanUeNgapID))
 	}

--- a/internal/amf/ngap/handle_ue_context_modification_failure_test.go
+++ b/internal/amf/ngap/handle_ue_context_modification_failure_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/free5gc/ngap/ngapType"
 )
 
-func TestHandleUEContextModificationFailure_MissingAMFUENGAPID(t *testing.T) {
+func TestHandleUEContextModificationFailure_UnknownRanUeNgapID(t *testing.T) {
 	ran := newTestRadio()
 	sender := ran.NGAPSender.(*FakeNGAPSender)
 	amfInstance := newTestAMF()
@@ -25,8 +25,8 @@ func TestHandleUEContextModificationFailure_MissingAMFUENGAPID(t *testing.T) {
 
 	ngap.HandleUEContextModificationFailure(context.Background(), amfInstance, ran, msg)
 
-	if len(sender.SentErrorIndications) != 0 {
-		t.Fatalf("expected no ErrorIndication, got %d", len(sender.SentErrorIndications))
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication (TS 38.413 §10.6), got %d", len(sender.SentErrorIndications))
 	}
 }
 
@@ -35,13 +35,7 @@ func TestHandleUEContextModificationFailure_UEFound(t *testing.T) {
 	amfInstance := newTestAMF()
 	amfInstance.Radios[new(sctp.SCTPConn)] = ran
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	amfUeNgapID := int64(10)
 	msg := decode.UEContextModificationFailure{
@@ -54,7 +48,8 @@ func TestHandleUEContextModificationFailure_UEFound(t *testing.T) {
 
 	ngap.HandleUEContextModificationFailure(context.Background(), amfInstance, ran, msg)
 
-	if ranUe.Radio != ran {
-		t.Error("expected ranUe.Radio to be set to ran")
+	// ranUe was already created on 'ran', so Radio() should still be 'ran'.
+	if ranUe.Radio() != ran {
+		t.Error("expected ranUe.Radio to still be ran")
 	}
 }

--- a/internal/amf/ngap/handle_ue_context_modification_response.go
+++ b/internal/amf/ngap/handle_ue_context_modification_response.go
@@ -11,43 +11,24 @@ import (
 )
 
 func HandleUEContextModificationResponse(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.UEContextModificationResponse) {
-	var ranUe *amf.RanUe
+	ranUe, ok := resolveUE(ctx, ran, msg.RANUENGAPID, msg.AMFUENGAPID)
+	if !ok {
+		return
+	}
 
-	if msg.RANUENGAPID != nil {
-		ranUe = ran.FindUEByRanUeNgapID(*msg.RANUENGAPID)
-		if ranUe == nil {
-			if msg.AMFUENGAPID != nil {
-				logger.WithTrace(ctx, ran.Log).Warn("No UE Context", zap.Int64("RanUeNgapID", *msg.RANUENGAPID), zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
-			} else {
-				logger.WithTrace(ctx, ran.Log).Warn("No UE Context", zap.Int64("RanUeNgapID", *msg.RANUENGAPID))
-			}
+	ranUe.TouchLastSeen()
+	logger.WithTrace(ctx, ranUe.Log).Debug("Handle UE Context Modification Response", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID), zap.Int64("RanUeNgapID", ranUe.RanUeNgapID))
+
+	if msg.RRCState != nil {
+		switch msg.RRCState.Value {
+		case ngapType.RRCStatePresentInactive:
+			logger.WithTrace(ctx, ranUe.Log).Debug("UE RRC State: Inactive")
+		case ngapType.RRCStatePresentConnected:
+			logger.WithTrace(ctx, ranUe.Log).Debug("UE RRC State: Connected")
 		}
 	}
 
-	if msg.AMFUENGAPID != nil {
-		ranUe = amfInstance.FindRanUeByAmfUeNgapID(*msg.AMFUENGAPID)
-		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("UE Context not found", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
-			return
-		}
-	}
-
-	if ranUe != nil {
-		ranUe.Radio = ran
-		ranUe.TouchLastSeen()
-		logger.WithTrace(ctx, ranUe.Log).Debug("Handle UE Context Modification Response", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID), zap.Int64("RanUeNgapID", ranUe.RanUeNgapID))
-
-		if msg.RRCState != nil {
-			switch msg.RRCState.Value {
-			case ngapType.RRCStatePresentInactive:
-				logger.WithTrace(ctx, ranUe.Log).Debug("UE RRC State: Inactive")
-			case ngapType.RRCStatePresentConnected:
-				logger.WithTrace(ctx, ranUe.Log).Debug("UE RRC State: Connected")
-			}
-		}
-
-		if msg.UserLocationInformation != nil {
-			ranUe.UpdateLocation(ctx, amfInstance, msg.UserLocationInformation)
-		}
+	if msg.UserLocationInformation != nil {
+		ranUe.UpdateLocation(ctx, amfInstance, msg.UserLocationInformation)
 	}
 }

--- a/internal/amf/ngap/handle_ue_context_modification_response_test.go
+++ b/internal/amf/ngap/handle_ue_context_modification_response_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 )
 
-func TestHandleUEContextModificationResponse_MissingAMFUENGAPID(t *testing.T) {
+func TestHandleUEContextModificationResponse_UnknownRanUeNgapID(t *testing.T) {
 	ran := newTestRadio()
 	sender := ran.NGAPSender.(*FakeNGAPSender)
 	amfInstance := newTestAMF()
@@ -25,8 +25,8 @@ func TestHandleUEContextModificationResponse_MissingAMFUENGAPID(t *testing.T) {
 
 	ngap.HandleUEContextModificationResponse(context.Background(), amfInstance, ran, msg)
 
-	if len(sender.SentErrorIndications) != 0 {
-		t.Fatalf("expected no ErrorIndication, got %d", len(sender.SentErrorIndications))
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication (TS 38.413 §10.6), got %d", len(sender.SentErrorIndications))
 	}
 }
 
@@ -35,13 +35,7 @@ func TestHandleUEContextModificationResponse_UEFound(t *testing.T) {
 	amfInstance := newTestAMF()
 	amfInstance.Radios[new(sctp.SCTPConn)] = ran
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	amfUeNgapID := int64(10)
 	msg := decode.UEContextModificationResponse{
@@ -50,7 +44,8 @@ func TestHandleUEContextModificationResponse_UEFound(t *testing.T) {
 
 	ngap.HandleUEContextModificationResponse(context.Background(), amfInstance, ran, msg)
 
-	if ranUe.Radio != ran {
-		t.Error("expected ranUe.Radio to be set to ran")
+	// ranUe was already created on 'ran', so Radio() should still be 'ran'.
+	if ranUe.Radio() != ran {
+		t.Error("expected ranUe.Radio to still be ran")
 	}
 }

--- a/internal/amf/ngap/handle_ue_context_release_complete.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/logger"
-	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
 )
 
@@ -21,23 +20,8 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 		return
 	}
 
-	ranUe := amfInstance.FindRanUeByAmfUeNgapID(*msg.AMFUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No RanUe Context", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID), zap.Int64("RanUeNgapID", *msg.RANUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-			return
-		}
-
+	ranUe, ok := resolveUE(ctx, ran, msg.RANUENGAPID, msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 
@@ -45,7 +29,6 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 		ranUe.UpdateLocation(ctx, amfInstance, msg.UserLocationInformation)
 	}
 
-	ranUe.Radio = ran
 	ranUe.TouchLastSeen()
 
 	amfUe := ranUe.AmfUe()
@@ -148,15 +131,9 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 		if ranUe.TargetUe != nil {
 			// Success path: ranUe is the SOURCE being released after a
 			// completed handover (HandoverNotify). Transfer the AMF UE
-			// association to the target.
-			targetRanUe := amfInstance.FindRanUeByAmfUeNgapID(ranUe.TargetUe.AmfUeNgapID)
-			if targetRanUe == nil {
-				logger.WithTrace(ctx, ranUe.Log).Error("target RAN UE not found during handover release",
-					zap.Int64("targetAmfUeNgapID", ranUe.TargetUe.AmfUeNgapID))
-			} else {
-				targetRanUe.Radio = ran
-				amfUe.AttachRanUe(targetRanUe)
-			}
+			// association to the target. The target UE is already on
+			// the correct radio (set during HandoverRequired/SwitchToRan).
+			amfUe.AttachRanUe(ranUe.TargetUe)
 		} else {
 			// Failure/cancel path: ranUe is the TARGET being released
 			// after a failed or cancelled handover. The source UE

--- a/internal/amf/ngap/handle_ue_context_release_complete_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete_test.go
@@ -25,22 +25,10 @@ func TestHandleUEContextReleaseComplete_HandoverTargetNilTargetUe(t *testing.T) 
 	amfUe.ForceState(amf.Registered)
 	amfUe.Log = logger.AmfLog
 
-	sourceRanUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 100,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	sourceRanUe := amf.NewRanUeForTest(ran, 1, 100, logger.AmfLog)
 	amfUe.AttachRanUe(sourceRanUe)
-	ran.RanUEs[sourceRanUe.RanUeNgapID] = sourceRanUe
 
-	targetRanUe := &amf.RanUe{
-		RanUeNgapID: 2,
-		AmfUeNgapID: 200,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[targetRanUe.RanUeNgapID] = targetRanUe
+	targetRanUe := amf.NewRanUeForTest(ran, 2, 200, logger.AmfLog)
 
 	err := amf.AttachSourceUeTargetUe(sourceRanUe, targetRanUe)
 	if err != nil {
@@ -76,14 +64,8 @@ func TestHandleUEContextReleaseComplete_SmContextNotFound(t *testing.T) {
 	amfUe.ForceState(amf.Registered)
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 100,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 100, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	amfInstance.Radios = map[*sctp.SCTPConn]*amf.Radio{new(sctp.SCTPConn): ran}
 

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -11,31 +11,11 @@ import (
 )
 
 func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.UEContextReleaseRequest) {
-	ranUe := amfInstance.FindRanUeByAmfUeNgapID(msg.AMFUENGAPID)
-	if ranUe == nil {
-		ranUe = ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	}
-
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No RanUe Context", zap.Int64("AmfUeNgapID", msg.AMFUENGAPID), zap.Int64("RanUeNgapID", msg.RANUENGAPID))
-
-		cause := &ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-			return
-		}
-
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 
-	ranUe.Radio = ran
 	ranUe.TouchLastSeen()
 	logger.WithTrace(ctx, ranUe.Log).Debug("Handle UE Context Release Request", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID), zap.Int64("RanUeNgapID", ranUe.RanUeNgapID))
 

--- a/internal/amf/ngap/handle_ue_context_release_request_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_request_test.go
@@ -56,14 +56,8 @@ func TestHandleUEContextReleaseRequest_UEFoundRegistered(t *testing.T) {
 	amfUe.Log = logger.AmfLog
 	amfUe.ForceState(amf.Registered)
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	msg := decode.UEContextReleaseRequest{
 		AMFUENGAPID: 10,

--- a/internal/amf/ngap/handle_ue_radio_capability_info_indication_test.go
+++ b/internal/amf/ngap/handle_ue_radio_capability_info_indication_test.go
@@ -23,13 +23,7 @@ func TestUERadioCapabilityInfoIndication_UnknownRanUeNgapID(t *testing.T) {
 
 func TestUERadioCapabilityInfoIndication_NilAmfUe(t *testing.T) {
 	ran := newTestRadio()
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID: 1,
@@ -41,14 +35,8 @@ func TestUERadioCapabilityInfoIndication_SetsRadioCapability(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID:       1,
@@ -65,14 +53,8 @@ func TestUERadioCapabilityInfoIndication_SetsRadioCapabilityForPaging(t *testing
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID: 1,
@@ -104,14 +86,8 @@ func TestUERadioCapabilityInfoIndication_NilCapabilityFieldsNoOp(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID: 1,

--- a/internal/amf/ngap/handle_uplink_nas_transport.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport.go
@@ -16,7 +16,6 @@ func HandleUplinkNasTransport(ctx context.Context, amfInstance *amf.AMF, ran *am
 		return
 	}
 
-	ranUe.Radio = ran
 	ranUe.TouchLastSeen()
 
 	amfUe := ranUe.AmfUe()

--- a/internal/amf/ngap/handle_uplink_nas_transport_test.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport_test.go
@@ -33,13 +33,7 @@ func TestHandleUplinkNasTransport_NilAmfUe_RemovesRanUe(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
-	ran.RanUEs[1] = ranUe
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 
 	ngap.HandleUplinkNasTransport(context.Background(), amfInstance, ran, decode.UplinkNASTransport{
 		AMFUENGAPID: 10,
@@ -61,14 +55,8 @@ func TestHandleUplinkNasTransport_HappyPath_NASDispatched(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	nasPDU := []byte{0xAA, 0xBB}
 
@@ -86,7 +74,7 @@ func TestHandleUplinkNasTransport_HappyPath_NASDispatched(t *testing.T) {
 		t.Errorf("NAS PDU = %x, want %x", fakeNAS.Calls[0].NASPDU, nasPDU)
 	}
 
-	if ranUe.Radio != ran {
+	if ranUe.Radio() != ran {
 		t.Error("ranUe.Radio not set to ran")
 	}
 }
@@ -100,14 +88,8 @@ func TestHandleUplinkNasTransport_LocationUpdatedBeforeNAS(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 
-	ranUe := &amf.RanUe{
-		RanUeNgapID: 1,
-		AmfUeNgapID: 10,
-		Radio:       ran,
-		Log:         logger.AmfLog,
-	}
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
-	ran.RanUEs[1] = ranUe
 
 	ngap.HandleUplinkNasTransport(context.Background(), amfInstance, ran, decode.UplinkNASTransport{
 		AMFUENGAPID:             10,

--- a/internal/amf/ngap/resolve_ue.go
+++ b/internal/amf/ngap/resolve_ue.go
@@ -1,0 +1,87 @@
+package ngap
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/ngap/ngapType"
+	"go.uber.org/zap"
+)
+
+// resolveUE looks up a UE context scoped to the sending radio, following
+// TS 38.413 clause 10.6 (Handling of AP ID).
+//
+// When both IDs are present it looks up by RAN-UE-NGAP-ID (scoped to the
+// sender) and cross-checks AMF-UE-NGAP-ID. When only AMF-UE-NGAP-ID is
+// present it looks up by that ID, still scoped to the sender.
+//
+// On any mismatch an Error Indication is sent to the sender and the
+// function returns (nil, false).
+func resolveUE(ctx context.Context, ran *amf.Radio, ranID *int64, amfID *int64) (*amf.RanUe, bool) {
+	if ranID != nil {
+		ranUe := ran.FindUEByRanUeNgapID(*ranID)
+		if ranUe == nil {
+			logger.WithTrace(ctx, ran.Log).Warn("No UE context for RAN-UE-NGAP-ID on this radio",
+				zap.Int64("RanUeNgapID", *ranID))
+			sendUnknownLocalUEError(ctx, ran)
+
+			return nil, false
+		}
+
+		if amfID != nil && ranUe.AmfUeNgapID != *amfID {
+			logger.WithTrace(ctx, ran.Log).Warn("Inconsistent AMF-UE-NGAP-ID",
+				zap.Int64("RanUeNgapID", *ranID),
+				zap.Int64("storedAmfUeNgapID", ranUe.AmfUeNgapID),
+				zap.Int64("receivedAmfUeNgapID", *amfID))
+			sendInconsistentRemoteUEError(ctx, ran)
+
+			return nil, false
+		}
+
+		return ranUe, true
+	}
+
+	if amfID != nil {
+		ranUe := ran.FindUEByAmfUeNgapID(*amfID)
+		if ranUe == nil {
+			logger.WithTrace(ctx, ran.Log).Warn("No UE context for AMF-UE-NGAP-ID on this radio",
+				zap.Int64("AmfUeNgapID", *amfID))
+			sendUnknownLocalUEError(ctx, ran)
+
+			return nil, false
+		}
+
+		return ranUe, true
+	}
+
+	return nil, false
+}
+
+func sendUnknownLocalUEError(ctx context.Context, ran *amf.Radio) {
+	cause := ngapType.Cause{
+		Present: ngapType.CausePresentRadioNetwork,
+		RadioNetwork: &ngapType.CauseRadioNetwork{
+			Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
+		},
+	}
+
+	err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
+	if err != nil {
+		logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
+	}
+}
+
+func sendInconsistentRemoteUEError(ctx context.Context, ran *amf.Radio) {
+	cause := ngapType.Cause{
+		Present: ngapType.CausePresentRadioNetwork,
+		RadioNetwork: &ngapType.CauseRadioNetwork{
+			Value: ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID,
+		},
+	}
+
+	err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
+	if err != nil {
+		logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
+	}
+}

--- a/internal/amf/ngap/resolve_ue_test.go
+++ b/internal/amf/ngap/resolve_ue_test.go
@@ -44,7 +44,7 @@ func setupCrossRadioScenario(t *testing.T) (legitimateRan, attackerRan *amf.Radi
 // cannot claim a UE by sending a PDUSessionResourceSetupResponse with a valid
 // AMF-UE-NGAP-ID that belongs to a UE on a different radio.
 func TestCrossRadio_PDUSessionResourceSetupResponse(t *testing.T) {
-	_, attackerRan, ranUe, amfInstance := setupCrossRadioScenario(t)
+	legitimateRan, attackerRan, ranUe, amfInstance := setupCrossRadioScenario(t)
 	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
 
 	amfID := int64(10)
@@ -62,7 +62,7 @@ func TestCrossRadio_PDUSessionResourceSetupResponse(t *testing.T) {
 		t.Errorf("expected UnknownLocalUENGAPID cause, got %d", attackerSender.SentErrorIndications[0].Cause.RadioNetwork.Value)
 	}
 
-	if ranUe.Radio() != ranUe.Radio() {
+	if ranUe.Radio() != legitimateRan {
 		t.Error("UE radio association must not change")
 	}
 }

--- a/internal/amf/ngap/resolve_ue_test.go
+++ b/internal/amf/ngap/resolve_ue_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Ella Networks
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ngap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/ngap"
+	"github.com/ellanetworks/core/internal/amf/ngap/decode"
+	"github.com/ellanetworks/core/internal/amf/sctp"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/ngap/ngapType"
+)
+
+// setupCrossRadioScenario creates:
+//   - legitimateRan: the radio the UE is actually registered on
+//   - attackerRan: a different radio that will try to claim the UE
+//   - ranUe: the UE context living on legitimateRan
+//   - amfInstance: the AMF with both radios registered
+func setupCrossRadioScenario(t *testing.T) (legitimateRan, attackerRan *amf.Radio, ranUe *amf.RanUe, amfInstance *amf.AMF) {
+	t.Helper()
+
+	legitimateRan = newTestRadio()
+	attackerRan = newTestRadio()
+
+	amfInstance = newTestAMF()
+	amfInstance.Radios[new(sctp.SCTPConn)] = legitimateRan
+	amfInstance.Radios[new(sctp.SCTPConn)] = attackerRan
+
+	ranUe = amf.NewRanUeForTest(legitimateRan, 1, 10, logger.AmfLog)
+
+	amfUe := amf.NewAmfUe()
+	amfUe.Log = logger.AmfLog
+	amfUe.AttachRanUe(ranUe)
+
+	return legitimateRan, attackerRan, ranUe, amfInstance
+}
+
+// TestCrossRadio_PDUSessionResourceSetupResponse verifies that a rogue radio
+// cannot claim a UE by sending a PDUSessionResourceSetupResponse with a valid
+// AMF-UE-NGAP-ID that belongs to a UE on a different radio.
+func TestCrossRadio_PDUSessionResourceSetupResponse(t *testing.T) {
+	_, attackerRan, ranUe, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	amfID := int64(10)
+	ranID := int64(1)
+	ngap.HandlePDUSessionResourceSetupResponse(context.Background(), amfInstance, attackerRan, decode.PDUSessionResourceSetupResponse{
+		AMFUENGAPID: &amfID,
+		RANUENGAPID: &ranID,
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication on attacker radio, got %d", len(attackerSender.SentErrorIndications))
+	}
+
+	if attackerSender.SentErrorIndications[0].Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID {
+		t.Errorf("expected UnknownLocalUENGAPID cause, got %d", attackerSender.SentErrorIndications[0].Cause.RadioNetwork.Value)
+	}
+
+	if ranUe.Radio() != ranUe.Radio() {
+		t.Error("UE radio association must not change")
+	}
+}
+
+// TestCrossRadio_PDUSessionResourceModifyResponse verifies cross-radio
+// rejection for PDUSessionResourceModifyResponse.
+func TestCrossRadio_PDUSessionResourceModifyResponse(t *testing.T) {
+	_, attackerRan, _, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	amfID := int64(10)
+	ngap.HandlePDUSessionResourceModifyResponse(context.Background(), amfInstance, attackerRan, decode.PDUSessionResourceModifyResponse{
+		AMFUENGAPID: &amfID,
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(attackerSender.SentErrorIndications))
+	}
+}
+
+// TestCrossRadio_UEContextModificationResponse verifies cross-radio
+// rejection for UEContextModificationResponse.
+func TestCrossRadio_UEContextModificationResponse(t *testing.T) {
+	_, attackerRan, _, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	amfID := int64(10)
+	ngap.HandleUEContextModificationResponse(context.Background(), amfInstance, attackerRan, decode.UEContextModificationResponse{
+		AMFUENGAPID: &amfID,
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(attackerSender.SentErrorIndications))
+	}
+}
+
+// TestCrossRadio_UEContextModificationFailure verifies cross-radio
+// rejection for UEContextModificationFailure.
+func TestCrossRadio_UEContextModificationFailure(t *testing.T) {
+	_, attackerRan, _, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	amfID := int64(10)
+	ngap.HandleUEContextModificationFailure(context.Background(), amfInstance, attackerRan, decode.UEContextModificationFailure{
+		AMFUENGAPID: &amfID,
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(attackerSender.SentErrorIndications))
+	}
+}
+
+// TestCrossRadio_UEContextReleaseRequest verifies cross-radio
+// rejection for UEContextReleaseRequest.
+func TestCrossRadio_UEContextReleaseRequest(t *testing.T) {
+	_, attackerRan, _, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	ngap.HandleUEContextReleaseRequest(context.Background(), amfInstance, attackerRan, decode.UEContextReleaseRequest{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 1,
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(attackerSender.SentErrorIndications))
+	}
+
+	if len(attackerSender.SentUEContextReleaseCommands) != 0 {
+		t.Error("attacker radio must not receive UEContextReleaseCommand for victim UE")
+	}
+}
+
+// TestCrossRadio_UEContextReleaseComplete verifies cross-radio
+// rejection for UEContextReleaseComplete.
+func TestCrossRadio_UEContextReleaseComplete(t *testing.T) {
+	_, attackerRan, _, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	amfID := int64(10)
+	ranID := int64(1)
+	ngap.HandleUEContextReleaseComplete(context.Background(), amfInstance, attackerRan, decode.UEContextReleaseComplete{
+		AMFUENGAPID: &amfID,
+		RANUENGAPID: &ranID,
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(attackerSender.SentErrorIndications))
+	}
+}
+
+// TestCrossRadio_HandoverRequestAcknowledge verifies cross-radio
+// rejection for HandoverRequestAcknowledge.
+func TestCrossRadio_HandoverRequestAcknowledge(t *testing.T) {
+	_, attackerRan, _, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	amfID := int64(10)
+	ranID := int64(1)
+	ngap.HandleHandoverRequestAcknowledge(context.Background(), amfInstance, attackerRan, decode.HandoverRequestAcknowledge{
+		AMFUENGAPID: &amfID,
+		RANUENGAPID: &ranID,
+		TargetToSourceTransparentContainer: ngapType.TargetToSourceTransparentContainer{
+			Value: []byte{0x01},
+		},
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(attackerSender.SentErrorIndications))
+	}
+
+	if len(attackerSender.SentHandoverCommands) != 0 {
+		t.Error("attacker radio must not receive HandoverCommand")
+	}
+}
+
+// TestCrossRadio_HandoverFailure verifies cross-radio
+// rejection for HandoverFailure.
+func TestCrossRadio_HandoverFailure(t *testing.T) {
+	_, attackerRan, _, amfInstance := setupCrossRadioScenario(t)
+	attackerSender := attackerRan.NGAPSender.(*FakeNGAPSender)
+
+	ngap.HandleHandoverFailure(context.Background(), amfInstance, attackerRan, decode.HandoverFailure{
+		AMFUENGAPID: 10,
+	})
+
+	if len(attackerSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(attackerSender.SentErrorIndications))
+	}
+}
+
+// TestCrossRadio_InconsistentAmfUeNgapID verifies that when the RAN-UE-NGAP-ID
+// matches but the AMF-UE-NGAP-ID does not, an InconsistentRemoteUENGAPID error
+// is sent back.
+func TestCrossRadio_InconsistentAmfUeNgapID(t *testing.T) {
+	legitimateRan, _, _, amfInstance := setupCrossRadioScenario(t)
+	sender := legitimateRan.NGAPSender.(*FakeNGAPSender)
+
+	// RAN-UE-NGAP-ID=1 exists on legitimateRan with AMF-UE-NGAP-ID=10,
+	// but we claim AMF-UE-NGAP-ID=999.
+	ranID := int64(1)
+	wrongAmfID := int64(999)
+	ngap.HandlePDUSessionResourceSetupResponse(context.Background(), amfInstance, legitimateRan, decode.PDUSessionResourceSetupResponse{
+		RANUENGAPID: &ranID,
+		AMFUENGAPID: &wrongAmfID,
+	})
+
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(sender.SentErrorIndications))
+	}
+
+	if sender.SentErrorIndications[0].Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
+		t.Errorf("expected InconsistentRemoteUENGAPID, got %d", sender.SentErrorIndications[0].Cause.RadioNetwork.Value)
+	}
+}

--- a/internal/amf/producer/n1n2message_test.go
+++ b/internal/amf/producer/n1n2message_test.go
@@ -268,13 +268,9 @@ func TestTransferN1N2Message_InitialContextAlreadySent(t *testing.T) {
 		u.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
 	})
 
-	ranUe := &amf.RanUe{
-		AmfUeNgapID:                    1,
-		RanUeNgapID:                    1,
-		SentInitialContextSetupRequest: true,
-		Radio:                          &amf.Radio{NGAPSender: sender},
-		Log:                            zap.NewNop(),
-	}
+	radio := &amf.Radio{NGAPSender: sender, RanUEs: make(map[int64]*amf.RanUe)}
+	ranUe := amf.NewRanUeForTest(radio, 1, 1, zap.NewNop())
+	ranUe.SentInitialContextSetupRequest = true
 	ue.AttachRanUe(ranUe)
 
 	err := producer.TransferN1N2Message(context.Background(), amfInstance, ue.Supi, newReq())
@@ -301,13 +297,9 @@ func TestTransferN1N2Message_InitialContextNotYetSent(t *testing.T) {
 		u.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
 	})
 
-	ranUe := &amf.RanUe{
-		AmfUeNgapID:                    1,
-		RanUeNgapID:                    1,
-		SentInitialContextSetupRequest: false,
-		Radio:                          &amf.Radio{NGAPSender: sender},
-		Log:                            zap.NewNop(),
-	}
+	radio := &amf.Radio{NGAPSender: sender, RanUEs: make(map[int64]*amf.RanUe)}
+	ranUe := amf.NewRanUeForTest(radio, 1, 1, zap.NewNop())
+	ranUe.SentInitialContextSetupRequest = false
 	ue.AttachRanUe(ranUe)
 
 	err := producer.TransferN1N2Message(context.Background(), amfInstance, ue.Supi, newReq())
@@ -389,13 +381,9 @@ func TestN2MessageTransferOrPage_ConnectedUE_InitialCtxSent(t *testing.T) {
 		u.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
 	})
 
-	ranUe := &amf.RanUe{
-		AmfUeNgapID:                    1,
-		RanUeNgapID:                    1,
-		SentInitialContextSetupRequest: true,
-		Radio:                          &amf.Radio{NGAPSender: sender},
-		Log:                            zap.NewNop(),
-	}
+	radio := &amf.Radio{NGAPSender: sender, RanUEs: make(map[int64]*amf.RanUe)}
+	ranUe := amf.NewRanUeForTest(radio, 1, 1, zap.NewNop())
+	ranUe.SentInitialContextSetupRequest = true
 	ue.AttachRanUe(ranUe)
 
 	err := producer.N2MessageTransferOrPage(context.Background(), amfInstance, ue.Supi, newReq())
@@ -448,12 +436,8 @@ func TestTransferN1Msg_Success(t *testing.T) {
 
 	ue := addUE(t, amfInstance, "001010000000013", nil)
 
-	ranUe := &amf.RanUe{
-		AmfUeNgapID: 1,
-		RanUeNgapID: 1,
-		Radio:       &amf.Radio{NGAPSender: sender},
-		Log:         zap.NewNop(),
-	}
+	radio := &amf.Radio{NGAPSender: sender, RanUEs: make(map[int64]*amf.RanUe)}
+	ranUe := amf.NewRanUeForTest(radio, 1, 1, zap.NewNop())
 	ue.AttachRanUe(ranUe)
 
 	err := producer.TransferN1Msg(context.Background(), amfInstance, ue.Supi, []byte{0x01}, 1)

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -49,13 +49,22 @@ type RanUe struct {
 	Tai                              models.Tai
 	Location                         models.UserLocation
 	amfUe                            *AmfUe
-	Radio                            *Radio
+	radio                            *Radio
 	ReleaseAction                    RelAction
 	UeContextRequest                 bool
 	SentInitialContextSetupRequest   bool
 	RecvdInitialContextSetupResponse bool /*Received Initial context setup response or not */
 	Log                              *zap.Logger
 	freeNgapID                       func(int64) // set by AMF.NewRanUe to release the NGAP ID
+}
+
+// Radio returns the Radio this RanUe is associated with, or nil.
+func (ranUe *RanUe) Radio() *Radio {
+	if ranUe == nil {
+		return nil
+	}
+
+	return ranUe.radio
 }
 
 // AmfUe returns the currently attached AmfUe, or nil.
@@ -75,8 +84,8 @@ func (ranUe *RanUe) TouchLastSeen() {
 	}
 
 	radioName := ""
-	if ranUe.Radio != nil {
-		radioName = ranUe.Radio.Name
+	if ranUe.radio != nil {
+		radioName = ranUe.radio.Name
 	}
 
 	ranUe.amfUe.TouchLastSeen(radioName)
@@ -87,15 +96,15 @@ func (ranUe *RanUe) ngapSender() (NGAPSender, error) {
 		return nil, fmt.Errorf("ran ue is nil")
 	}
 
-	if ranUe.Radio == nil {
+	if ranUe.radio == nil {
 		return nil, fmt.Errorf("radio is nil")
 	}
 
-	if ranUe.Radio.NGAPSender == nil {
+	if ranUe.radio.NGAPSender == nil {
 		return nil, fmt.Errorf("ngap sender is nil")
 	}
 
-	return ranUe.Radio.NGAPSender, nil
+	return ranUe.radio.NGAPSender, nil
 }
 
 func (ranUe *RanUe) SendDownlinkNasTransport(ctx context.Context, nasPdu []byte, mobilityRestrictionList *ngapType.MobilityRestrictionList) error {
@@ -253,7 +262,7 @@ func (ranUe *RanUe) Remove() error {
 		ranUe.amfUe.DetachRanUe(ranUe)
 	}
 
-	ran := ranUe.Radio
+	ran := ranUe.radio
 	if ran == nil {
 		return fmt.Errorf("ran not found in ranUe")
 	}
@@ -283,7 +292,7 @@ func (ranUe *RanUe) SwitchToRan(newRan *Radio, ranUeNgapID int64) error {
 		return fmt.Errorf("new ran is nil")
 	}
 
-	oldRan := ranUe.Radio
+	oldRan := ranUe.radio
 
 	// remove ranUe from oldRan
 	oldRan.mu.Lock()
@@ -296,7 +305,7 @@ func (ranUe *RanUe) SwitchToRan(newRan *Radio, ranUeNgapID int64) error {
 	newRan.mu.Unlock()
 
 	// switch to newRan
-	ranUe.Radio = newRan
+	ranUe.radio = newRan
 	ranUe.RanUeNgapID = ranUeNgapID
 	ranUe.Log = newRan.Log.With(logger.AmfUeNgapID(ranUe.AmfUeNgapID))
 
@@ -432,4 +441,21 @@ func (ranUe *RanUe) UpdateLocation(ctx context.Context, amf *AMF, userLocationIn
 		}
 	case ngapType.UserLocationInformationPresentNothing:
 	}
+}
+
+// NewRanUeForTest creates a RanUe and registers it in radio.RanUEs.
+// It is intended for use in external test packages only.
+func NewRanUeForTest(radio *Radio, ranUeNgapID, amfUeNgapID int64, log *zap.Logger) *RanUe {
+	ranUe := &RanUe{
+		RanUeNgapID: ranUeNgapID,
+		AmfUeNgapID: amfUeNgapID,
+		radio:       radio,
+		Log:         log,
+	}
+
+	radio.mu.Lock()
+	radio.RanUEs[ranUeNgapID] = ranUe
+	radio.mu.Unlock()
+
+	return ranUe
 }

--- a/internal/amf/status.go
+++ b/internal/amf/status.go
@@ -32,11 +32,11 @@ func (amf *AMF) RadioNameForSubscriber(supi etsi.SUPI) string {
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	if ue.state != Registered || ue.ranUe == nil || ue.ranUe.Radio == nil {
+	if ue.state != Registered || ue.ranUe == nil || ue.ranUe.radio == nil {
 		return ""
 	}
 
-	return ue.ranUe.Radio.Name
+	return ue.ranUe.radio.Name
 }
 
 // LastSeenAtForSubscriber returns the last-seen timestamp for a registered
@@ -73,7 +73,7 @@ func (amf *AMF) RegisteredSubscribersForRadio(radioName string) []string {
 
 	for _, ue := range amf.UEs {
 		ue.Mutex.Lock()
-		match := ue.state == Registered && ue.ranUe != nil && ue.ranUe.Radio != nil && ue.ranUe.Radio.Name == radioName
+		match := ue.state == Registered && ue.ranUe != nil && ue.ranUe.radio != nil && ue.ranUe.radio.Name == radioName
 		ue.Mutex.Unlock()
 
 		if match && ue.Supi.IsValid() && ue.Supi.IsIMSI() {


### PR DESCRIPTION
# Description

Some UE specific NGAP handlers accepted the AMF UE NGAP ID provided provided in the message without validation. Now they always validate ownership.

## Reference
- [3GPP TS 38.413](https://www.etsi.org/deliver/etsi_ts/138400_138499/138413/18.05.00_60/ts_138413v180500p.pdf)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
