### PR TITLE
feat: add leader address to HA cluster status API

### DIFF
--- a/client/status.go
+++ b/client/status.go
@@ -3,10 +3,11 @@ package client
 import "context"
 
 type ClusterStatus struct {
-	Enabled      bool   `json:"enabled"`
-	Role         string `json:"role"`
-	NodeID       int    `json:"nodeId"`
-	AppliedIndex uint64 `json:"appliedIndex"`
+	Enabled       bool   `json:"enabled"`
+	Role          string `json:"role"`
+	NodeID        int    `json:"nodeId"`
+	AppliedIndex  uint64 `json:"appliedIndex"`
+	LeaderAddress string `json:"leaderAddress,omitempty"`
 }
 
 type Status struct {

--- a/docs/reference/api/cluster.md
+++ b/docs/reference/api/cluster.md
@@ -22,12 +22,16 @@ Returns all registered cluster members.
         {
             "nodeId": 1,
             "raftAddress": "10.0.0.1:7000",
-            "apiAddress": "10.0.0.1:5000"
+            "apiAddress": "https://10.0.0.1:5000",
+            "binaryVersion": "v1.9.1",
+            "suffrage": "voter"
         },
         {
             "nodeId": 2,
             "raftAddress": "10.0.0.2:7000",
-            "apiAddress": "10.0.0.2:5000"
+            "apiAddress": "https://10.0.0.2:5000",
+            "binaryVersion": "v1.9.1",
+            "suffrage": "voter"
         }
     ]
 }
@@ -35,7 +39,7 @@ Returns all registered cluster members.
 
 ## Add a Cluster Member
 
-Adds a new node to the Raft cluster and registers it in the cluster members table. Requires admin privileges.
+Adds a new node to the Raft cluster and registers it in the cluster members table. This endpoint accepts either admin credentials or the cluster join token for authentication.
 
 | Method | Path                       |
 | ------ | -------------------------- |
@@ -43,9 +47,12 @@ Adds a new node to the Raft cluster and registers it in the cluster members tabl
 
 ### Parameters
 
-- `nodeId` (integer): Raft node ID for the new member. Must be a positive integer.
-- `raftAddress` (string): The `host:port` used for Raft consensus communication.
-- `apiAddress` (string): The `host:port` used for the REST API.
+- `nodeId` (integer, required): Raft node ID for the new member. Must be a positive integer.
+- `raftAddress` (string, required): The `host:port` used for Raft consensus communication.
+- `apiAddress` (string, required): The URL used for the REST API.
+- `suffrage` (string, optional): Either `"voter"` or `"nonvoter"`. Defaults to `"voter"`.
+- `clusterId` (string, optional): Cluster ID to validate against the operator configuration.
+- `schemaVersion` (integer, optional): Schema version of the joining node. Rejected if lower than the leader's schema.
 
 ### Sample Response
 
@@ -75,6 +82,53 @@ Removes a node from the Raft cluster and deletes its record. Requires admin priv
 {
     "result": {
         "message": "Cluster member removed"
+    }
+}
+```
+
+## Promote a Cluster Member
+
+Promotes a nonvoter node to a full voter in the Raft cluster. Requires admin privileges.
+
+| Method | Path                                    |
+| ------ | --------------------------------------- |
+| POST   | `/api/v1/cluster/members/{id}/promote`  |
+
+### Parameters
+
+- `id` (integer, path): Node ID of the cluster member to promote.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "message": "Cluster member promoted to voter"
+    }
+}
+```
+
+## Drain Node
+
+Gracefully prepares this node for removal. Signals RANs to redirect new UE registrations elsewhere, withdraws BGP advertisements so upstream routers reroute user‑plane traffic, and transfers Raft leadership if this node is the leader. The node continues serving existing flows until it is shut down. Requires admin privileges.
+
+| Method | Path                     |
+| ------ | ------------------------ |
+| POST   | `/api/v1/cluster/drain`  |
+
+### Parameters
+
+- `timeoutSeconds` (integer, optional): Maximum time in seconds for each drain step. Defaults to 5.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "message": "draining",
+        "transferredLeadership": true,
+        "ransNotified": 2,
+        "bgpStopped": true
     }
 }
 ```

--- a/docs/reference/api/status.md
+++ b/docs/reference/api/status.md
@@ -6,8 +6,7 @@ description: RESTful API reference for getting the system status.
 
 ## Get the status
 
-This path returns the status of Ella core
-
+This path returns the status of Ella core.
 
 | Method | Path             |
 | ------ | ---------------- |
@@ -17,6 +16,10 @@ This path returns the status of Ella core
 
 None
 
+### Response Headers
+
+When clustering is enabled, the response includes an `X-Ella-Role` header with the Raft role of the responding node (`Leader`, `Follower`, or `Candidate`). Load balancers can use this header to direct write traffic to the leader.
+
 ### Sample Response
 
 ```json
@@ -24,7 +27,8 @@ None
     "result": {
         "version": "v1.9.1",
         "revision": "388ce92244a0b304e9f6c15e3f896acee6fe7b1a",
-        "initialized": true
+        "initialized": true,
+        "ready": true
     }
 }
 ```
@@ -37,11 +41,15 @@ When clustering is enabled, the response includes a `cluster` object:
         "version": "v1.9.1",
         "revision": "388ce92244a0b304e9f6c15e3f896acee6fe7b1a",
         "initialized": true,
+        "ready": true,
         "cluster": {
             "enabled": true,
             "role": "Leader",
             "nodeId": 1,
-            "appliedIndex": 42
+            "appliedIndex": 42,
+            "clusterId": "my-cluster",
+            "schemaVersion": 9,
+            "leaderAddress": "https://10.0.0.1:5002"
         }
     }
 }

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -48,6 +48,7 @@ func waitForClusterReady(ctx context.Context, clients []*client.Client) error {
 	for time.Now().Before(deadline) {
 		reachable := 0
 		leaders := 0
+		withLeaderAddr := 0
 
 		for _, c := range clients {
 			status, err := c.GetStatus(ctx)
@@ -64,9 +65,13 @@ func waitForClusterReady(ctx context.Context, clients []*client.Client) error {
 			if status.Cluster.Role == "Leader" {
 				leaders++
 			}
+
+			if status.Cluster.LeaderAddress != "" {
+				withLeaderAddr++
+			}
 		}
 
-		if reachable == expected && leaders == 1 {
+		if reachable == expected && leaders == 1 && withLeaderAddr == expected {
 			return nil
 		}
 

--- a/integration/ha_test.go
+++ b/integration/ha_test.go
@@ -58,6 +58,8 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 	leaderCount := 0
 	followerCount := 0
 
+	var leaderAddress string
+
 	for i, c := range clients {
 		status, err := c.GetStatus(ctx)
 		if err != nil {
@@ -66,6 +68,17 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 
 		if status.Cluster == nil {
 			t.Fatalf("node %d has no cluster status", i+1)
+		}
+
+		if status.Cluster.LeaderAddress == "" {
+			t.Fatalf("node %d reports empty leader address", i+1)
+		}
+
+		if leaderAddress == "" {
+			leaderAddress = status.Cluster.LeaderAddress
+		} else if status.Cluster.LeaderAddress != leaderAddress {
+			t.Fatalf("node %d reports leader address %q, expected %q",
+				i+1, status.Cluster.LeaderAddress, leaderAddress)
 		}
 
 		switch status.Cluster.Role {

--- a/internal/api/server/api_status.go
+++ b/internal/api/server/api_status.go
@@ -16,6 +16,7 @@ type ClusterStatusResponse struct {
 	AppliedIndex  uint64 `json:"appliedIndex"`
 	ClusterID     string `json:"clusterId,omitempty"`
 	SchemaVersion int    `json:"schemaVersion"`
+	LeaderAddress string `json:"leaderAddress,omitempty"`
 }
 
 type StatusResponse struct {
@@ -48,9 +49,10 @@ func GetStatus(dbInstance *db.Database, ready *atomic.Bool) http.Handler {
 		}
 
 		if dbInstance.ClusterEnabled() {
+			role := dbInstance.RaftState()
 			clusterStatus := &ClusterStatusResponse{
 				Enabled:       true,
-				Role:          dbInstance.RaftState(),
+				Role:          role,
 				NodeID:        dbInstance.NodeID(),
 				AppliedIndex:  dbInstance.RaftAppliedIndex(),
 				SchemaVersion: db.SchemaVersion(),
@@ -62,6 +64,9 @@ func GetStatus(dbInstance *db.Database, ready *atomic.Bool) http.Handler {
 			}
 
 			statusResponse.Cluster = clusterStatus
+			clusterStatus.LeaderAddress = resolveLeaderAPI(dbInstance)
+
+			w.Header().Set("X-Ella-Role", role)
 		}
 
 		writeResponse(r.Context(), w, statusResponse, http.StatusOK, logger.APILog)

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -105,7 +105,17 @@ paths:
       security: []
       responses:
         "200":
-          description: System status.
+          description: |
+            System status. When clustering is enabled, the response includes an
+            `X-Ella-Role` header (`Leader`, `Follower`, or `Candidate`) that
+            load balancers can use to direct write traffic to the leader node.
+          headers:
+            X-Ella-Role:
+              description: Raft role of the responding node. Only present when clustering is enabled.
+              required: false
+              schema:
+                type: string
+                enum: [Leader, Follower, Candidate]
           content:
             application/json:
               schema:
@@ -2706,6 +2716,62 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/cluster/members/{id}/promote:
+    post:
+      operationId: promoteClusterMember
+      tags: [Cluster]
+      summary: Promote a nonvoter to voter
+      description: >-
+        Promotes a nonvoter cluster member to a full voter in the Raft cluster.
+        Requires admin privileges.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Node ID of the cluster member to promote.
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /api/v1/cluster/drain:
+    post:
+      operationId: drainNode
+      tags: [Cluster]
+      summary: Drain this node
+      description: >-
+        Gracefully prepares this node for removal. Signals RANs to redirect new
+        UE registrations elsewhere, withdraws BGP advertisements so upstream
+        routers reroute user-plane traffic, and transfers Raft leadership if this
+        node is the leader. The node continues serving existing flows until it is
+        shut down. Requires admin privileges.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DrainParams"
+      responses:
+        "200":
+          description: Drain result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DrainResponseEnvelope"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
 components:
   securitySchemes:
     BearerAuth:
@@ -4793,6 +4859,9 @@ components:
           type: integer
           format: uint64
           description: Last applied Raft log index.
+        leaderAddress:
+          type: string
+          description: API address of the current Raft leader. Empty when the leader is unknown.
       required: [enabled, role, nodeId, appliedIndex]
 
     ClusterMember:
@@ -4831,3 +4900,33 @@ components:
         apiAddress:
           type: string
           description: "API address of the new member (host:port)."
+
+    DrainParams:
+      type: object
+      properties:
+        timeoutSeconds:
+          type: integer
+          minimum: 1
+          description: Maximum time in seconds for each drain step. Defaults to 5.
+
+    DrainResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        transferredLeadership:
+          type: boolean
+          description: Whether Raft leadership was transferred to another node.
+        ransNotified:
+          type: integer
+          description: Number of RANs notified to redirect UE registrations.
+        bgpStopped:
+          type: boolean
+          description: Whether BGP advertisements were withdrawn.
+      required: [message, transferredLeadership, ransNotified, bgpStopped]
+
+    DrainResponseEnvelope:
+      type: object
+      properties:
+        result:
+          $ref: "#/components/schemas/DrainResponse"

--- a/internal/raft/discovery_test.go
+++ b/internal/raft/discovery_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Ella Networks
+
+package raft
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newProbePeerServer(t *testing.T, statusCode int, body statusResponse) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/status" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}))
+
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func TestProbePeer_LeaderReturns200(t *testing.T) {
+	ts := newProbePeerServer(t, http.StatusOK, statusResponse{
+		Result: statusResult{
+			Cluster: &statusClusterBlock{
+				Role:          "Leader",
+				NodeID:        1,
+				ClusterID:     "cluster-1",
+				SchemaVersion: 9,
+			},
+		},
+	})
+
+	m := &Manager{}
+	state, nodeID, clusterID, schema := m.probePeer(context.Background(), ts.Client(), ts.URL)
+
+	if state != peerFormed {
+		t.Fatalf("expected peerFormed, got %d", state)
+	}
+
+	if nodeID != 1 {
+		t.Fatalf("expected nodeID=1, got %d", nodeID)
+	}
+
+	if clusterID != "cluster-1" {
+		t.Fatalf("expected clusterID=cluster-1, got %s", clusterID)
+	}
+
+	if schema != 9 {
+		t.Fatalf("expected schema=9, got %d", schema)
+	}
+}
+
+func TestProbePeer_FollowerReturns200(t *testing.T) {
+	ts := newProbePeerServer(t, http.StatusOK, statusResponse{
+		Result: statusResult{
+			Cluster: &statusClusterBlock{
+				Role:          "Follower",
+				NodeID:        2,
+				ClusterID:     "cluster-1",
+				SchemaVersion: 9,
+			},
+		},
+	})
+
+	m := &Manager{}
+	state, nodeID, clusterID, schema := m.probePeer(context.Background(), ts.Client(), ts.URL)
+
+	if state != peerFormed {
+		t.Fatalf("expected peerFormed, got %d", state)
+	}
+
+	if nodeID != 2 {
+		t.Fatalf("expected nodeID=2, got %d", nodeID)
+	}
+
+	if clusterID != "cluster-1" {
+		t.Fatalf("expected clusterID=cluster-1, got %s", clusterID)
+	}
+
+	if schema != 9 {
+		t.Fatalf("expected schema=9, got %d", schema)
+	}
+}
+
+func TestProbePeer_FormingNode(t *testing.T) {
+	ts := newProbePeerServer(t, http.StatusOK, statusResponse{
+		Result: statusResult{
+			Cluster: &statusClusterBlock{
+				Role:   "Follower",
+				NodeID: 3,
+			},
+		},
+	})
+
+	m := &Manager{}
+	state, nodeID, _, _ := m.probePeer(context.Background(), ts.Client(), ts.URL)
+
+	if state != peerForming {
+		t.Fatalf("expected peerForming, got %d", state)
+	}
+
+	if nodeID != 3 {
+		t.Fatalf("expected nodeID=3, got %d", nodeID)
+	}
+}
+
+func TestProbePeer_503IsUnreachable(t *testing.T) {
+	ts := newProbePeerServer(t, http.StatusServiceUnavailable, statusResponse{})
+
+	m := &Manager{}
+	state, nodeID, clusterID, schema := m.probePeer(context.Background(), ts.Client(), ts.URL)
+
+	if state != peerUnreachable {
+		t.Fatalf("expected peerUnreachable, got %d", state)
+	}
+
+	if nodeID != 0 {
+		t.Fatalf("expected nodeID=0, got %d", nodeID)
+	}
+
+	if clusterID != "" {
+		t.Fatalf("expected empty clusterID, got %s", clusterID)
+	}
+
+	if schema != 0 {
+		t.Fatalf("expected schema=0, got %d", schema)
+	}
+}


### PR DESCRIPTION
# Description

Enhance the HA cluster status endpoint with the leader address.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
