### PR TITLE
fix: evict node duplicate Global RAN node ID

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
 	"github.com/ellanetworks/core/internal/amf/sctp"
+	"github.com/ellanetworks/core/internal/amf/util"
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
@@ -25,6 +26,7 @@ import (
 	"github.com/ellanetworks/core/internal/smf"
 	"github.com/ellanetworks/core/internal/util/idgenerator"
 	"github.com/free5gc/nas/nasConvert"
+	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
 )
 
@@ -300,6 +302,67 @@ func (amf *AMF) FindRadioByRanID(ranNodeID models.GlobalRanNodeID) (*Radio, bool
 	}
 
 	return nil, false
+}
+
+// ClaimRanID assigns ranNodeID to radio, evicting any other radio holding the
+// same Global RAN Node ID. Returns the evicted radio, or nil.
+func (amf *AMF) ClaimRanID(radio *Radio, ranNodeID *ngapType.GlobalRANNodeID) *Radio {
+	newID := util.RanIDToModels(*ranNodeID)
+	present := ranNodeID.Present
+
+	amf.mu.Lock()
+
+	var evicted *Radio
+
+	for _, other := range amf.Radios {
+		if other == radio {
+			continue
+		}
+
+		if !ranIDMatches(other.RanPresent, other.RanID, present, &newID) {
+			continue
+		}
+
+		evicted = other
+		delete(amf.Radios, other.Conn)
+
+		break
+	}
+
+	radio.RanPresent = present
+	radio.RanID = &newID
+	amf.mu.Unlock()
+
+	if evicted != nil {
+		evicted.RemoveAllUeInRan()
+
+		if evicted.Conn != nil {
+			evicted.Conn.Close()
+		}
+	}
+
+	return evicted
+}
+
+func ranIDMatches(aPresent int, a *models.GlobalRanNodeID, bPresent int, b *models.GlobalRanNodeID) bool {
+	if a == nil || b == nil || aPresent != bPresent {
+		return false
+	}
+
+	switch aPresent {
+	case RanPresentGNbID:
+		if a.GNbID == nil || b.GNbID == nil {
+			return false
+		}
+
+		return a.GNbID.GNBValue == b.GNbID.GNBValue
+	case RanPresentNgeNbID:
+		return a.NgeNbID == b.NgeNbID
+	case RanPresentN3IwfID:
+		return a.N3IwfID == b.N3IwfID
+	}
+
+	return false
 }
 
 func (amf *AMF) ListRadios() []*Radio {

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -337,7 +337,7 @@ func (amf *AMF) ClaimRanID(radio *Radio, ranNodeID *ngapType.GlobalRANNodeID) *R
 		evicted.RemoveAllUeInRan()
 
 		if evicted.Conn != nil {
-			evicted.Conn.Close()
+			_ = evicted.Conn.Close()
 		}
 	}
 

--- a/internal/amf/amf_ran.go
+++ b/internal/amf/amf_ran.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
 	"github.com/ellanetworks/core/internal/amf/sctp"
-	"github.com/ellanetworks/core/internal/amf/util"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/aper"
@@ -119,12 +118,6 @@ func (r *Radio) FindUEByAmfUeNgapID(amfUeNgapID int64) *RanUe {
 	}
 
 	return nil
-}
-
-func (r *Radio) SetRanID(ranNodeID *ngapType.GlobalRANNodeID) {
-	ranID := util.RanIDToModels(*ranNodeID)
-	r.RanPresent = ranNodeID.Present
-	r.RanID = &ranID
 }
 
 func (r *Radio) TouchLastSeen() {

--- a/internal/amf/claim_ran_id_test.go
+++ b/internal/amf/claim_ran_id_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Ella Networks
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package amf_test
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/sctp"
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapConvert"
+	"github.com/free5gc/ngap/ngapType"
+	"go.uber.org/zap"
+)
+
+func gnbGlobalRANNodeID(t *testing.T, hexID string) *ngapType.GlobalRANNodeID {
+	t.Helper()
+
+	id := &ngapType.GlobalRANNodeID{}
+	id.Present = ngapType.GlobalRANNodeIDPresentGlobalGNBID
+	id.GlobalGNBID = &ngapType.GlobalGNBID{}
+	id.GlobalGNBID.GNBID.Present = ngapType.GNBIDPresentGNBID
+	id.GlobalGNBID.GNBID.GNBID = new(aper.BitString)
+	*id.GlobalGNBID.GNBID.GNBID = ngapConvert.HexToBitString(hexID, 24)
+
+	return id
+}
+
+func newRadioForTest(conn *sctp.SCTPConn, name string) *amf.Radio {
+	return &amf.Radio{
+		Name:   name,
+		Conn:   conn,
+		RanUEs: make(map[int64]*amf.RanUe),
+		Log:    zap.NewNop(),
+	}
+}
+
+func TestClaimRanID_NoExistingRadio(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+
+	conn := &sctp.SCTPConn{}
+
+	radio := newRadioForTest(conn, "gNB-A")
+	amfInstance.Radios[conn] = radio
+
+	evicted := amfInstance.ClaimRanID(radio, gnbGlobalRANNodeID(t, "ABCDE1"))
+	if evicted != nil {
+		t.Fatalf("expected no eviction, got radio %q", evicted.Name)
+	}
+
+	if radio.RanID == nil || radio.RanID.GNbID == nil {
+		t.Fatal("expected radio.RanID and RanID.GNbID to be populated")
+	}
+
+	if radio.RanPresent != amf.RanPresentGNbID {
+		t.Errorf("expected RanPresent=%d, got %d", amf.RanPresentGNbID, radio.RanPresent)
+	}
+
+	if len(amfInstance.Radios) != 1 {
+		t.Errorf("expected 1 radio in pool, got %d", len(amfInstance.Radios))
+	}
+}
+
+func TestClaimRanID_EvictsDuplicateGNB(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+
+	existingConn := &sctp.SCTPConn{}
+	existing := newRadioForTest(existingConn, "gNB-old")
+	amfInstance.Radios[existingConn] = existing
+
+	if evicted := amfInstance.ClaimRanID(existing, gnbGlobalRANNodeID(t, "ABCDE1")); evicted != nil {
+		t.Fatalf("setup: unexpected eviction of %q", evicted.Name)
+	}
+
+	newConn := &sctp.SCTPConn{}
+	newRadio := newRadioForTest(newConn, "gNB-new")
+	amfInstance.Radios[newConn] = newRadio
+
+	evicted := amfInstance.ClaimRanID(newRadio, gnbGlobalRANNodeID(t, "ABCDE1"))
+	if evicted == nil {
+		t.Fatal("expected existing radio to be evicted")
+	}
+
+	if evicted != existing {
+		t.Errorf("expected evicted radio to be the existing one (%q), got %q", existing.Name, evicted.Name)
+	}
+
+	if _, still := amfInstance.Radios[existingConn]; still {
+		t.Error("evicted radio should have been removed from Radios map")
+	}
+
+	if got, ok := amfInstance.Radios[newConn]; !ok || got != newRadio {
+		t.Error("new radio should remain in Radios map")
+	}
+
+	if newRadio.RanID == nil || newRadio.RanID.GNbID == nil || newRadio.RanID.GNbID.GNBValue == "" {
+		t.Error("new radio should have RanID set to the claimed value")
+	}
+}
+
+func TestClaimRanID_DifferentIDDoesNotEvict(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+
+	existingConn := &sctp.SCTPConn{}
+	existing := newRadioForTest(existingConn, "gNB-old")
+	amfInstance.Radios[existingConn] = existing
+
+	if evicted := amfInstance.ClaimRanID(existing, gnbGlobalRANNodeID(t, "ABCDE1")); evicted != nil {
+		t.Fatalf("setup: unexpected eviction of %q", evicted.Name)
+	}
+
+	newConn := &sctp.SCTPConn{}
+	newRadio := newRadioForTest(newConn, "gNB-new")
+	amfInstance.Radios[newConn] = newRadio
+
+	evicted := amfInstance.ClaimRanID(newRadio, gnbGlobalRANNodeID(t, "FEDCBA"))
+	if evicted != nil {
+		t.Fatalf("expected no eviction for a different Global RAN Node ID, got %q", evicted.Name)
+	}
+
+	if len(amfInstance.Radios) != 2 {
+		t.Errorf("expected both radios to remain in pool, got %d", len(amfInstance.Radios))
+	}
+}
+
+func TestClaimRanID_SelfClaimIsNoOp(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+
+	conn := &sctp.SCTPConn{}
+	radio := newRadioForTest(conn, "gNB-A")
+	amfInstance.Radios[conn] = radio
+
+	if evicted := amfInstance.ClaimRanID(radio, gnbGlobalRANNodeID(t, "ABCDE1")); evicted != nil {
+		t.Fatalf("first claim should not evict, got %q", evicted.Name)
+	}
+
+	evicted := amfInstance.ClaimRanID(radio, gnbGlobalRANNodeID(t, "ABCDE1"))
+	if evicted != nil {
+		t.Fatalf("self-claim should be a no-op, got eviction of %q", evicted.Name)
+	}
+
+	if _, still := amfInstance.Radios[conn]; !still {
+		t.Error("radio should remain in Radios map after self-claim")
+	}
+}

--- a/internal/amf/ngap/handle_ng_setup_request.go
+++ b/internal/amf/ngap/handle_ng_setup_request.go
@@ -104,10 +104,20 @@ func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	// Set RanID only after all validation passes — this gates the
-	// dispatcher guard (ran.RanID != nil) that protects all other
-	// NGAP handlers (TS 38.413 §10.4).
-	ran.SetRanID(msg.GlobalRANNodeID.Raw())
+	// Claim RanID only after validation passes; the dispatcher's
+	// ran.RanID != nil guard gates all other NGAP handlers.
+	evicted := amfInstance.ClaimRanID(ran, msg.GlobalRANNodeID.Raw())
+	if evicted != nil {
+		evictedRemote := ""
+		if evicted.Conn != nil && evicted.Conn.RemoteAddr() != nil {
+			evictedRemote = evicted.Conn.RemoteAddr().String()
+		}
+
+		logger.WithTrace(ctx, ran.Log).Warn("Evicted existing NG-C association with duplicate Global RAN Node ID",
+			zap.String("evicted_remote", evictedRemote),
+			zap.String("evicted_name", evicted.Name),
+		)
+	}
 
 	err = ran.NGAPSender.SendNGSetupResponse(ctx, operatorInfo.Guami, snssaiList, amfInstance.Name, amfInstance.RelativeCapacity)
 	if err != nil {


### PR DESCRIPTION
# Description

Ella Core behaved un-deterministically if 2 nodes claimed to have the same node ID. Now we only permit 1 node with a given ID. If a second node appears, the first is evicted.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
