### PR TITLE
chore: advertise max schema version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/spf13/viper v1.20.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/stretchr/testify v1.11.1
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tim-ywliu/nested-logrus-formatter v1.3.2 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect

--- a/integration/ha_test.go
+++ b/integration/ha_test.go
@@ -975,3 +975,207 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 
 	t.Log("data survived quorum-loss recovery, test passed")
 }
+
+// TestIntegrationHARestoreWhileLeader verifies that a backup taken on the
+// leader can be restored on the leader of a live 3-node cluster, followers
+// converge on the restored replicated state via InstallSnapshot, subscribers
+// committed after the backup are gone, and writes resume afterwards.
+func TestIntegrationHARestoreWhileLeader(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	ctx := context.Background()
+
+	dockerClient, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dockerClient.Close(); err != nil {
+			t.Logf("failed to close docker client: %v", err)
+		}
+	}()
+
+	dockerClient.ComposeDown(ctx, haComposeDir)
+
+	err = dockerClient.ComposeUp(ctx, haComposeDir)
+	if err != nil {
+		t.Fatalf("failed to bring up HA compose: %v", err)
+	}
+
+	t.Cleanup(func() {
+		dockerClient.ComposeDown(ctx, haComposeDir)
+	})
+
+	clients, err := newHANodeClients()
+	if err != nil {
+		t.Fatalf("failed to create HA node clients: %v", err)
+	}
+
+	t.Cleanup(func() {
+		dumpClusterDiagnostics(ctx, dockerClient, clients, t.Logf)
+	})
+
+	if err := waitForClusterReady(ctx, clients); err != nil {
+		t.Fatalf("cluster not ready: %v", err)
+	}
+
+	_, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("failed to find leader: %v", err)
+	}
+
+	if err := initializeCluster(ctx, leader, clients); err != nil {
+		t.Fatalf("failed to initialize cluster: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("not all nodes became ready: %v", err)
+	}
+
+	const (
+		imsiPreBackup   = "001019756139960"
+		imsiPostBackup  = "001019756139961"
+		imsiPostRestore = "001019756139962"
+	)
+
+	createSub := func(c *client.Client, imsi string) error {
+		return c.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+			Imsi:           imsi,
+			Key:            "0eefb0893e6f1c2855a3a244c6db1277",
+			OPc:            "98da19bbc55e2a5b53857d10557b1d26",
+			SequenceNumber: "000000000022",
+			ProfileName:    "default",
+		})
+	}
+
+	t.Log("creating subscriber that must survive the restore")
+
+	if err := createSub(leader, imsiPreBackup); err != nil {
+		t.Fatalf("failed to create pre-backup subscriber: %v", err)
+	}
+
+	idx, err := leaderAppliedIndex(ctx, leader)
+	if err != nil {
+		t.Fatalf("failed to get leader applied index: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, clients, idx); err != nil {
+		t.Fatalf("followers did not converge before backup: %v", err)
+	}
+
+	backupPath := filepath.Join(t.TempDir(), "backup.tar.gz")
+	t.Logf("creating backup on leader at %s", backupPath)
+
+	if err := leader.CreateBackup(ctx, &client.CreateBackupParams{Path: backupPath}); err != nil {
+		t.Fatalf("failed to create backup: %v", err)
+	}
+
+	t.Log("creating subscriber that must NOT exist after restore")
+
+	if err := createSub(leader, imsiPostBackup); err != nil {
+		t.Fatalf("failed to create post-backup subscriber: %v", err)
+	}
+
+	idx, err = leaderAppliedIndex(ctx, leader)
+	if err != nil {
+		t.Fatalf("failed to get leader applied index: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, clients, idx); err != nil {
+		t.Fatalf("followers did not converge after post-backup write: %v", err)
+	}
+
+	// Sanity: post-backup subscriber visible on every node before restore.
+	for i, c := range clients {
+		sub, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsiPostBackup})
+		if err != nil {
+			t.Fatalf("pre-restore: failed to read post-backup subscriber from node %d: %v", i+1, err)
+		}
+
+		if sub.Imsi != imsiPostBackup {
+			t.Fatalf("pre-restore: node %d returned IMSI %q, expected %q", i+1, sub.Imsi, imsiPostBackup)
+		}
+	}
+
+	t.Log("triggering restore on leader")
+
+	if err := leader.RestoreBackup(ctx, &client.RestoreBackupParams{Path: backupPath}); err != nil {
+		t.Fatalf("restore on leader: %v", err)
+	}
+
+	// The leader briefly stops serving the status endpoint while it reopens
+	// its DB connection and replaces the on-disk file. Wait for the cluster
+	// to stabilize before reading leader state.
+	if err := waitForClusterReady(ctx, clients); err != nil {
+		t.Fatalf("cluster not ready after restore: %v", err)
+	}
+
+	// Raft.Restore advances the leader's applied index past the old commit
+	// index and triggers InstallSnapshot for followers. Use the post-restore
+	// leader applied index as the convergence target.
+	_, postRestoreLeader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("post-restore: failed to find leader: %v", err)
+	}
+
+	idx, err = leaderAppliedIndex(ctx, postRestoreLeader)
+	if err != nil {
+		t.Fatalf("failed to get leader applied index after restore: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, clients, idx); err != nil {
+		t.Fatalf("followers did not converge after restore: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("not all nodes ready after restore: %v", err)
+	}
+
+	t.Log("verifying replicated state rolled back to backup snapshot on every node")
+
+	for i, c := range clients {
+		sub, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsiPreBackup})
+		if err != nil {
+			t.Fatalf("post-restore: pre-backup subscriber missing from node %d: %v", i+1, err)
+		}
+
+		if sub.Imsi != imsiPreBackup {
+			t.Fatalf("post-restore: node %d returned IMSI %q, expected %q", i+1, sub.Imsi, imsiPreBackup)
+		}
+
+		if _, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsiPostBackup}); err == nil {
+			t.Fatalf("post-restore: node %d still has post-backup subscriber; restore did not roll back state", i+1)
+		}
+	}
+
+	t.Log("verifying writes resume after restore")
+
+	if err := createSub(postRestoreLeader, imsiPostRestore); err != nil {
+		t.Fatalf("post-restore write failed: %v", err)
+	}
+
+	idx, err = leaderAppliedIndex(ctx, postRestoreLeader)
+	if err != nil {
+		t.Fatalf("failed to get leader applied index after post-restore write: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, clients, idx); err != nil {
+		t.Fatalf("followers did not converge after post-restore write: %v", err)
+	}
+
+	for i, c := range clients {
+		sub, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsiPostRestore})
+		if err != nil {
+			t.Fatalf("post-restore write: failed to read on node %d: %v", i+1, err)
+		}
+
+		if sub.Imsi != imsiPostRestore {
+			t.Fatalf("post-restore write: node %d returned IMSI %q, expected %q", i+1, sub.Imsi, imsiPostRestore)
+		}
+	}
+
+	t.Log("restore-while-leader test passed")
+}

--- a/internal/api/server/api_cluster.go
+++ b/internal/api/server/api_cluster.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	ClusterMemberAddAction    = "cluster_member_add"
-	ClusterMemberRemoveAction = "cluster_member_remove"
+	ClusterMemberAddAction          = "cluster_member_add"
+	ClusterMemberRemoveAction       = "cluster_member_remove"
+	ClusterMemberSelfAnnounceAction = "cluster_member_self_announce"
 )
 
 type ClusterMemberResponse struct {
@@ -149,12 +150,12 @@ func AddClusterMember(dbInstance *db.Database) http.Handler {
 			return
 		}
 
-		email := getEmailFromContext(r)
+		actor := getActorFromContext(r)
 
 		logger.LogAuditEvent(
 			r.Context(),
 			ClusterMemberAddAction,
-			email,
+			actor,
 			getClientIP(r),
 			fmt.Sprintf("Added cluster member node %d at %s (suffrage: %s)", req.NodeID, req.RaftAddress, suffrage),
 		)

--- a/internal/api/server/api_cluster.go
+++ b/internal/api/server/api_cluster.go
@@ -16,20 +16,22 @@ const (
 )
 
 type ClusterMemberResponse struct {
-	NodeID        int    `json:"nodeId"`
-	RaftAddress   string `json:"raftAddress"`
-	APIAddress    string `json:"apiAddress"`
-	BinaryVersion string `json:"binaryVersion"`
-	Suffrage      string `json:"suffrage"`
+	NodeID           int    `json:"nodeId"`
+	RaftAddress      string `json:"raftAddress"`
+	APIAddress       string `json:"apiAddress"`
+	BinaryVersion    string `json:"binaryVersion"`
+	Suffrage         string `json:"suffrage"`
+	MaxSchemaVersion int    `json:"maxSchemaVersion"`
 }
 
 type AddClusterMemberRequest struct {
-	NodeID        int    `json:"nodeId"`
-	RaftAddress   string `json:"raftAddress"`
-	APIAddress    string `json:"apiAddress"`
-	ClusterID     string `json:"clusterId,omitempty"`
-	SchemaVersion int    `json:"schemaVersion,omitempty"`
-	Suffrage      string `json:"suffrage,omitempty"`
+	NodeID           int    `json:"nodeId"`
+	RaftAddress      string `json:"raftAddress"`
+	APIAddress       string `json:"apiAddress"`
+	ClusterID        string `json:"clusterId,omitempty"`
+	SchemaVersion    int    `json:"schemaVersion,omitempty"`
+	MaxSchemaVersion int    `json:"maxSchemaVersion,omitempty"`
+	Suffrage         string `json:"suffrage,omitempty"`
 }
 
 func ListClusterMembers(dbInstance *db.Database) http.Handler {
@@ -43,11 +45,12 @@ func ListClusterMembers(dbInstance *db.Database) http.Handler {
 		result := make([]ClusterMemberResponse, 0, len(members))
 		for _, m := range members {
 			result = append(result, ClusterMemberResponse{
-				NodeID:        m.NodeID,
-				RaftAddress:   m.RaftAddress,
-				APIAddress:    m.APIAddress,
-				BinaryVersion: m.BinaryVersion,
-				Suffrage:      m.Suffrage,
+				NodeID:           m.NodeID,
+				RaftAddress:      m.RaftAddress,
+				APIAddress:       m.APIAddress,
+				BinaryVersion:    m.BinaryVersion,
+				Suffrage:         m.Suffrage,
+				MaxSchemaVersion: m.MaxSchemaVersion,
 			})
 		}
 
@@ -133,11 +136,12 @@ func AddClusterMember(dbInstance *db.Database) http.Handler {
 		}
 
 		member := &db.ClusterMember{
-			NodeID:        req.NodeID,
-			RaftAddress:   req.RaftAddress,
-			APIAddress:    req.APIAddress,
-			BinaryVersion: "", // populated by the joining node during startup registration
-			Suffrage:      suffrage,
+			NodeID:           req.NodeID,
+			RaftAddress:      req.RaftAddress,
+			APIAddress:       req.APIAddress,
+			BinaryVersion:    "", // populated by the joining node's self-announce
+			Suffrage:         suffrage,
+			MaxSchemaVersion: req.MaxSchemaVersion,
 		}
 
 		if err := dbInstance.UpsertClusterMember(r.Context(), member); err != nil {

--- a/internal/api/server/cluster_http.go
+++ b/internal/api/server/cluster_http.go
@@ -3,6 +3,8 @@
 package server
 
 import (
+	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"sync"
@@ -84,6 +86,7 @@ func StartClusterHTTP(dbInstance *db.Database, ln *listener.Listener, operatorHa
 	srv := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
+		ConnContext:       peerNodeIDConnContext,
 	}
 
 	go func() {
@@ -96,4 +99,41 @@ func StartClusterHTTP(dbInstance *db.Database, ln *listener.Listener, operatorHa
 		_ = cl.Close()
 		_ = srv.Close()
 	}
+}
+
+// peerNodeIDCtxKey is the context key used to carry the peer certificate's
+// CN-derived node-id through cluster-port requests. It is set by
+// peerNodeIDConnContext at TLS handshake time and consumed by handlers
+// that need peer identity (e.g. self-registration on POST /cluster/members).
+type peerNodeIDCtxKey struct{}
+
+// peerNodeIDConnContext extracts the peer node-id from the cluster TLS
+// connection and stashes it in the request context. Returns the context
+// unchanged when the connection is not a cluster TLS connection (should
+// not happen in production — guarded defensively).
+func peerNodeIDConnContext(ctx context.Context, c net.Conn) context.Context {
+	oc, ok := c.(*opaqueConn)
+	if !ok {
+		return ctx
+	}
+
+	tc, ok := oc.Conn.(*tls.Conn)
+	if !ok {
+		return ctx
+	}
+
+	id, err := listener.PeerNodeID(tc)
+	if err != nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, peerNodeIDCtxKey{}, id)
+}
+
+// peerNodeIDFromContext returns the peer node-id set by
+// peerNodeIDConnContext. The boolean is false when the request did not
+// originate on the cluster port.
+func peerNodeIDFromContext(ctx context.Context) (int, bool) {
+	v, ok := ctx.Value(peerNodeIDCtxKey{}).(int)
+	return v, ok
 }

--- a/internal/api/server/cluster_http_mux.go
+++ b/internal/api/server/cluster_http_mux.go
@@ -5,12 +5,14 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
+	"go.uber.org/zap"
 )
 
 // maxClusterJoinBodyBytes caps the self-registration POST body. The real
@@ -33,10 +35,47 @@ func newClusterMux(dbInstance *db.Database, operatorHandler http.Handler) *http.
 	mux.Handle("POST /cluster/members/self", selfRegistrationGuard(SelfAnnounceClusterMember(dbInstance)))
 
 	if operatorHandler != nil {
-		mux.Handle("/cluster/proxy/", http.StripPrefix("/cluster/proxy", operatorHandler))
+		mux.Handle("/cluster/proxy/", removedNodeFence(dbInstance, http.StripPrefix("/cluster/proxy", operatorHandler)))
 	}
 
 	return mux
+}
+
+// removedNodeFence rejects proxied writes from peers whose nodeID is no
+// longer present in cluster_members. Membership is the authoritative ACL:
+// a node removed via RemoveClusterMember must not continue pushing writes
+// through the proxy path, even if its mTLS cert is still valid (cert
+// revocation lag is a real operational window). Returns 410 Gone so the
+// client can surface the condition distinctly from 401/403/503.
+func removedNodeFence(dbInstance *db.Database, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerID, ok := peerNodeIDFromContext(r.Context())
+		if !ok {
+			writeError(r.Context(), w, http.StatusForbidden, "peer identity unavailable", nil, logger.APILog)
+			return
+		}
+
+		_, err := dbInstance.GetClusterMember(r.Context(), peerID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				logger.APILog.Warn("proxy: rejected write from removed cluster member",
+					zap.Int("peerNodeId", peerID),
+					zap.String("method", r.Method),
+					zap.String("path", r.URL.Path))
+				writeError(r.Context(), w, http.StatusGone,
+					fmt.Sprintf("node-id %d is not a current cluster member", peerID), nil, logger.APILog)
+
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError,
+				"failed to verify cluster membership", err, logger.APILog)
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // selfRegistrationGuard restricts POST /cluster/members on the cluster

--- a/internal/api/server/cluster_http_mux.go
+++ b/internal/api/server/cluster_http_mux.go
@@ -230,6 +230,14 @@ func SelfAnnounceClusterMember(dbInstance *db.Database) http.Handler {
 			return
 		}
 
+		logger.LogAuditEvent(
+			r.Context(),
+			ClusterMemberSelfAnnounceAction,
+			getActorFromContext(r),
+			getClientIP(r),
+			fmt.Sprintf("Self-announced cluster member node %d at %s", req.NodeID, req.RaftAddress),
+		)
+
 		writeResponse(r.Context(), w, SuccessResponse{Message: "self-announce accepted"}, http.StatusOK, logger.APILog)
 	})
 }

--- a/internal/api/server/cluster_http_mux.go
+++ b/internal/api/server/cluster_http_mux.go
@@ -3,23 +3,34 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
 )
 
+// maxClusterJoinBodyBytes caps the self-registration POST body. The real
+// payload (AddClusterMemberRequest) is a handful of short fields; 4 KiB
+// leaves generous headroom without enabling abuse through slow readers.
+const maxClusterJoinBodyBytes = 4096
+
 // newClusterMux builds the HTTP mux served on the cluster port.
-// Routes here are protected by mTLS (no JWT auth). The operatorHandler,
-// when non-nil, is mounted behind /cluster/proxy/ so followers can
-// forward authenticated writes to the leader over the cluster port.
+// Routes here are protected by mTLS (no JWT auth). The cluster port
+// exposes only what peers actually need: status probes, self-registration
+// at join time, and the /cluster/proxy/ mount that followers use to
+// forward authenticated writes to the leader. Destructive cluster-
+// membership operations (remove, promote) live on the public API under
+// /api/v1/cluster/members/*, gated by JWT + PermManageCluster.
 func newClusterMux(dbInstance *db.Database, operatorHandler http.Handler) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /cluster/status", ClusterStatus(dbInstance).ServeHTTP)
-	mux.HandleFunc("POST /cluster/members", AddClusterMember(dbInstance).ServeHTTP)
-	mux.HandleFunc("DELETE /cluster/members/{id}", RemoveClusterMember(dbInstance).ServeHTTP)
-	mux.HandleFunc("POST /cluster/members/{id}/promote", PromoteClusterMember(dbInstance).ServeHTTP)
+	mux.Handle("POST /cluster/members", selfRegistrationGuard(AddClusterMember(dbInstance)))
+	mux.Handle("POST /cluster/members/self", selfRegistrationGuard(SelfAnnounceClusterMember(dbInstance)))
 
 	if operatorHandler != nil {
 		mux.Handle("/cluster/proxy/", http.StripPrefix("/cluster/proxy", operatorHandler))
@@ -28,11 +39,58 @@ func newClusterMux(dbInstance *db.Database, operatorHandler http.Handler) *http.
 	return mux
 }
 
+// selfRegistrationGuard restricts POST /cluster/members on the cluster
+// port to self-registration: the body's nodeId must match the node-id
+// encoded in the peer certificate's CN. This blocks a compromised peer
+// cert from being used to register a node-id it was not issued for.
+// Operator-initiated adds use the public API, which does not pass
+// through this guard.
+func selfRegistrationGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerID, ok := peerNodeIDFromContext(r.Context())
+		if !ok {
+			writeError(r.Context(), w, http.StatusForbidden, "peer identity unavailable", nil, logger.APILog)
+			return
+		}
+
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxClusterJoinBodyBytes))
+		_ = r.Body.Close()
+
+		if err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "failed to read request body", err, logger.APILog)
+			return
+		}
+
+		var probe struct {
+			NodeID int `json:"nodeId"`
+		}
+
+		if err := json.Unmarshal(body, &probe); err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "invalid request body", err, logger.APILog)
+			return
+		}
+
+		if probe.NodeID != peerID {
+			writeError(r.Context(), w, http.StatusForbidden,
+				fmt.Sprintf("nodeId %d does not match peer certificate CN (node-id %d)", probe.NodeID, peerID),
+				nil, logger.APILog)
+
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		next.ServeHTTP(w, r)
+	})
+}
+
 type clusterNodeStatus struct {
 	Role          string `json:"role"`
 	NodeID        int    `json:"nodeId"`
 	ClusterID     string `json:"clusterId,omitempty"`
 	SchemaVersion int    `json:"schemaVersion"`
+	AppliedSchema int    `json:"appliedSchema,omitempty"`
+	PendingSchema int    `json:"pendingSchema,omitempty"`
 }
 
 type clusterStatusResponse struct {
@@ -54,6 +112,85 @@ func ClusterStatus(dbInstance *db.Database) http.Handler {
 			status.ClusterID = op.ClusterID
 		}
 
+		if applied, err := dbInstance.CurrentSchemaVersion(r.Context()); err == nil {
+			status.AppliedSchema = applied
+			if db.SchemaVersion() > applied {
+				status.PendingSchema = db.SchemaVersion()
+			}
+		}
+
 		writeResponse(r.Context(), w, clusterStatusResponse{Cluster: status}, http.StatusOK, logger.APILog)
+	})
+}
+
+// SelfAnnounceRequest is the body a node sends to POST /cluster/members/self
+// on the leader's cluster port. Every field is self-reported capability data.
+type SelfAnnounceRequest struct {
+	NodeID           int    `json:"nodeId"`
+	RaftAddress      string `json:"raftAddress"`
+	APIAddress       string `json:"apiAddress"`
+	BinaryVersion    string `json:"binaryVersion"`
+	MaxSchemaVersion int    `json:"maxSchemaVersion"`
+	Suffrage         string `json:"suffrage,omitempty"`
+}
+
+// SelfAnnounceClusterMember handles a node refreshing its own
+// cluster_members row. Only the leader can service the request; the
+// selfRegistrationGuard wrapper has already validated that the body's
+// nodeId matches the peer certificate CN, so the request is authentic.
+// Followers return 421 Misdirected Request so the caller can retry
+// against the current leader.
+func SelfAnnounceClusterMember(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !dbInstance.IsLeader() {
+			writeError(r.Context(), w, http.StatusMisdirectedRequest,
+				"not the leader; retry against the current leader", nil, logger.APILog)
+
+			return
+		}
+
+		var req SelfAnnounceRequest
+		if err := json.NewDecoder(io.LimitReader(r.Body, maxClusterJoinBodyBytes)).Decode(&req); err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "invalid request body", err, logger.APILog)
+			return
+		}
+
+		if req.NodeID <= 0 || req.RaftAddress == "" || req.APIAddress == "" {
+			writeError(r.Context(), w, http.StatusBadRequest, "nodeId, raftAddress, apiAddress are required", nil, logger.APILog)
+			return
+		}
+
+		suffrage := req.Suffrage
+		if suffrage == "" {
+			suffrage = "voter"
+		}
+
+		if suffrage != "voter" && suffrage != "nonvoter" {
+			writeError(r.Context(), w, http.StatusBadRequest, `suffrage must be "voter" or "nonvoter"`, nil, logger.APILog)
+			return
+		}
+
+		// Preserve the suffrage already recorded by the leader: a node
+		// self-announcing a conflicting suffrage must not be able to
+		// promote itself.
+		if existing, err := dbInstance.GetClusterMember(r.Context(), req.NodeID); err == nil && existing != nil && existing.Suffrage != "" {
+			suffrage = existing.Suffrage
+		}
+
+		member := &db.ClusterMember{
+			NodeID:           req.NodeID,
+			RaftAddress:      req.RaftAddress,
+			APIAddress:       req.APIAddress,
+			BinaryVersion:    req.BinaryVersion,
+			Suffrage:         suffrage,
+			MaxSchemaVersion: req.MaxSchemaVersion,
+		}
+
+		if err := dbInstance.UpsertClusterMember(r.Context(), member); err != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, "failed to record cluster member", err, logger.APILog)
+			return
+		}
+
+		writeResponse(r.Context(), w, SuccessResponse{Message: "self-announce accepted"}, http.StatusOK, logger.APILog)
 	})
 }

--- a/internal/api/server/cluster_http_mux_test.go
+++ b/internal/api/server/cluster_http_mux_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Ella Networks
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/db"
+	ellaraft "github.com/ellanetworks/core/internal/raft"
+)
+
+// newTestDB creates a real SQLite-backed *db.Database for in-package tests.
+func newTestDB(t *testing.T) *db.Database {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+
+	t.Cleanup(func() { _ = testDB.Close() })
+
+	return testDB
+}
+
+// ctxWithPeerNodeID injects a peer node-id into the request context using
+// the same key that peerNodeIDConnContext uses in production. Exists so
+// in-package tests do not need to stand up a TLS connection.
+func ctxWithPeerNodeID(ctx context.Context, nodeID int) context.Context {
+	return context.WithValue(ctx, peerNodeIDCtxKey{}, nodeID)
+}
+
+func TestRemovedNodeFence_RejectsUnknownPeer(t *testing.T) {
+	testDB := newTestDB(t)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := removedNodeFence(testDB, next)
+
+	req := httptest.NewRequestWithContext(
+		ctxWithPeerNodeID(context.Background(), 42),
+		http.MethodPost, "/api/v1/subscribers", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410, got %d", w.Code)
+	}
+
+	if nextCalled {
+		t.Fatal("next handler must not be called when peer is fenced")
+	}
+}
+
+func TestRemovedNodeFence_AllowsCurrentMember(t *testing.T) {
+	testDB := newTestDB(t)
+
+	if err := testDB.UpsertClusterMember(context.Background(), &db.ClusterMember{
+		NodeID:      7,
+		RaftAddress: "127.0.0.1:9000",
+		APIAddress:  "127.0.0.1:9001",
+		Suffrage:    "voter",
+	}); err != nil {
+		t.Fatalf("seed cluster member: %v", err)
+	}
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := removedNodeFence(testDB, next)
+
+	req := httptest.NewRequestWithContext(
+		ctxWithPeerNodeID(context.Background(), 7),
+		http.MethodPost, "/api/v1/subscribers", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	if !nextCalled {
+		t.Fatal("expected next handler to be called for current member")
+	}
+}
+
+func TestRemovedNodeFence_MissingPeerIdentity(t *testing.T) {
+	testDB := newTestDB(t)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := removedNodeFence(testDB, next)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/subscribers", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 when peer identity missing, got %d", w.Code)
+	}
+
+	if nextCalled {
+		t.Fatal("next handler must not be called without peer identity")
+	}
+}

--- a/internal/api/server/cluster_http_test.go
+++ b/internal/api/server/cluster_http_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,4 +126,99 @@ func TestClusterHTTP_Status(t *testing.T) {
 	}
 
 	serverLn.Stop()
+}
+
+// clusterTestServer spins up a cluster HTTP server under a listener and
+// returns the server's advertise address and a per-peer-node-id client
+// factory. Callers close the returned cleanup func.
+func clusterTestServer(t *testing.T, pki *testutil.PKI, serverNodeID int, peerNodeIDs []int) (serverAddr string, clients map[int]*http.Client, cleanup func()) {
+	t.Helper()
+
+	port := clusterFreePort(t)
+	serverAddr = fmt.Sprintf("127.0.0.1:%d", port)
+
+	serverLn := listener.New(listener.Config{
+		BindAddress:      serverAddr,
+		AdvertiseAddress: serverAddr,
+		NodeID:           serverNodeID,
+		CAPool:           pki.CAPool,
+		LeafCert:         pki.Nodes[serverNodeID].TLSCert,
+	})
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+
+	stopCluster := server.StartClusterHTTP(testDB, serverLn, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := serverLn.Start(ctx); err != nil {
+		cancel()
+		stopCluster()
+		t.Fatalf("start listener: %v", err)
+	}
+
+	clients = make(map[int]*http.Client, len(peerNodeIDs))
+
+	for _, id := range peerNodeIDs {
+		clientLn := listener.New(listener.Config{
+			BindAddress:      "127.0.0.1:0",
+			AdvertiseAddress: "127.0.0.1:0",
+			NodeID:           id,
+			CAPool:           pki.CAPool,
+			LeafCert:         pki.Nodes[id].TLSCert,
+		})
+
+		clients[id] = &http.Client{
+			Transport: &http.Transport{
+				DialTLSContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+					return clientLn.Dial(ctx, addr, listener.ALPNHTTP, 5*time.Second)
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+	}
+
+	cleanup = func() {
+		cancel()
+		stopCluster()
+		serverLn.Stop()
+	}
+
+	return serverAddr, clients, cleanup
+}
+
+// TestClusterHTTP_SelfRegistrationMismatch verifies that a peer whose
+// cert CN encodes node-id 5 cannot register as node-id 3 via
+// POST /cluster/members on the cluster port.
+func TestClusterHTTP_SelfRegistrationMismatch(t *testing.T) {
+	pki := testutil.GenTestPKI(t, []int{1, 5})
+
+	serverAddr, clients, cleanup := clusterTestServer(t, pki, 1, []int{5})
+	defer cleanup()
+
+	body := `{"nodeId":3,"raftAddress":"127.0.0.1:9000","apiAddress":"127.0.0.1:9001"}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		fmt.Sprintf("https://%s/cluster/members", serverAddr), strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := clients[5].Do(req)
+	if err != nil {
+		t.Fatalf("POST /cluster/members: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for nodeId mismatch, got %d", resp.StatusCode)
+	}
 }

--- a/internal/api/server/cluster_http_test.go
+++ b/internal/api/server/cluster_http_test.go
@@ -222,3 +222,67 @@ func TestClusterHTTP_SelfRegistrationMismatch(t *testing.T) {
 		t.Fatalf("expected 403 for nodeId mismatch, got %d", resp.StatusCode)
 	}
 }
+
+// TestClusterHTTP_SelfAnnounceAccepted verifies the happy path: a peer with
+// matching CN successfully refreshes its row via POST /cluster/members/self
+// against a standalone DB (db.IsLeader returns true when no raft manager is
+// attached).
+func TestClusterHTTP_SelfAnnounceAccepted(t *testing.T) {
+	pki := testutil.GenTestPKI(t, []int{1, 5})
+
+	serverAddr, clients, cleanup := clusterTestServer(t, pki, 1, []int{5})
+	defer cleanup()
+
+	body := `{"nodeId":5,"raftAddress":"127.0.0.1:9000","apiAddress":"127.0.0.1:9001","binaryVersion":"abc","maxSchemaVersion":9}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		fmt.Sprintf("https://%s/cluster/members/self", serverAddr), strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := clients[5].Do(req)
+	if err != nil {
+		t.Fatalf("POST /cluster/members/self: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for valid self-announce, got %d", resp.StatusCode)
+	}
+}
+
+// TestClusterHTTP_SelfAnnounceCNMismatch verifies that the selfRegistrationGuard
+// wrapping POST /cluster/members/self rejects a peer announcing a nodeId that
+// doesn't match its cert CN, even though the underlying handler (which would
+// otherwise upsert on the leader) never runs.
+func TestClusterHTTP_SelfAnnounceCNMismatch(t *testing.T) {
+	pki := testutil.GenTestPKI(t, []int{1, 5})
+
+	serverAddr, clients, cleanup := clusterTestServer(t, pki, 1, []int{5})
+	defer cleanup()
+
+	body := `{"nodeId":3,"raftAddress":"127.0.0.1:9000","apiAddress":"127.0.0.1:9001","binaryVersion":"abc","maxSchemaVersion":10}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		fmt.Sprintf("https://%s/cluster/members/self", serverAddr), strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := clients[5].Do(req)
+	if err != nil {
+		t.Fatalf("POST /cluster/members/self: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for CN mismatch, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/server/helpers.go
+++ b/internal/api/server/helpers.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -12,6 +13,18 @@ func getEmailFromContext(r *http.Request) string {
 	}
 
 	return ""
+}
+
+// getActorFromContext resolves the audit-log actor for a request. Requests
+// arriving on the cluster mTLS port carry a peer node-id (set by
+// peerNodeIDConnContext) and have no JWT email; attribute them to
+// ella-node-<n>. Requests on the public API port fall back to the JWT email.
+func getActorFromContext(r *http.Request) string {
+	if nodeID, ok := peerNodeIDFromContext(r.Context()); ok {
+		return fmt.Sprintf("ella-node-%d", nodeID)
+	}
+
+	return getEmailFromContext(r)
 }
 
 // getClientIP extracts the client IP address from the direct connection.

--- a/internal/api/server/helpers_test.go
+++ b/internal/api/server/helpers_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Ella Networks
+
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetActorFromContext_ClusterPortUsesNodeID(t *testing.T) {
+	ctx := context.WithValue(context.Background(), peerNodeIDCtxKey{}, 5)
+	ctx = context.WithValue(ctx, contextKeyEmail, "alice@example.com")
+
+	req := httptest.NewRequestWithContext(ctx, "POST", "/cluster/members", nil)
+
+	got := getActorFromContext(req)
+	if want := "ella-node-5"; got != want {
+		t.Fatalf("cluster-port actor: got %q, want %q (node-id must take precedence over email)", got, want)
+	}
+}
+
+func TestGetActorFromContext_APIPortFallsBackToEmail(t *testing.T) {
+	ctx := context.WithValue(context.Background(), contextKeyEmail, "alice@example.com")
+
+	req := httptest.NewRequestWithContext(ctx, "POST", "/api/v1/cluster/members", nil)
+
+	got := getActorFromContext(req)
+	if want := "alice@example.com"; got != want {
+		t.Fatalf("API-port actor: got %q, want %q", got, want)
+	}
+}
+
+func TestGetActorFromContext_NoIdentityReturnsEmpty(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/", nil)
+
+	if got := getActorFromContext(req); got != "" {
+		t.Fatalf("no-identity actor: got %q, want empty", got)
+	}
+}

--- a/internal/api/server/proxy_middleware.go
+++ b/internal/api/server/proxy_middleware.go
@@ -174,7 +174,17 @@ func copyProxyResponse(w http.ResponseWriter, resp *http.Response, dbInstance *d
 	if idxStr := resp.Header.Get(headerAppliedIndex); idxStr != "" {
 		targetIdx, parseErr := strconv.ParseUint(idxStr, 10, 64)
 		if parseErr == nil {
-			waitForLocalIndex(dbInstance, targetIdx)
+			start := time.Now()
+
+			localIdx, caughtUp := waitForLocalIndex(dbInstance, targetIdx)
+			if !caughtUp {
+				logger.APILog.Warn(
+					"proxy: follower did not catch up to leader applied index before response; read-your-writes may be violated for an immediate subsequent read on this node",
+					zap.Uint64("targetIdx", targetIdx),
+					zap.Uint64("localIdx", localIdx),
+					zap.Duration("waited", time.Since(start)),
+				)
+			}
 		}
 	}
 
@@ -185,21 +195,31 @@ func copyProxyResponse(w http.ResponseWriter, resp *http.Response, dbInstance *d
 	}
 }
 
-// waitForLocalIndex blocks briefly until the local Raft applied index catches
-// up, implementing read-your-writes consistency for proxied requests.
-func waitForLocalIndex(dbInstance *db.Database, targetIdx uint64) {
-	const (
-		pollInterval = 5 * time.Millisecond
-		maxWait      = 2 * time.Second
-	)
+const (
+	proxyReadYourWritesMaxWait      = 2 * time.Second
+	proxyReadYourWritesPollInterval = 5 * time.Millisecond
+)
 
+// waitForLocalIndex blocks until the local Raft applied index reaches
+// targetIdx or the deadline elapses. Returns the last-observed local index
+// and whether it caught up.
+func waitForLocalIndex(dbInstance *db.Database, targetIdx uint64) (uint64, bool) {
+	return waitForIndex(targetIdx, dbInstance.RaftAppliedIndex, proxyReadYourWritesMaxWait, proxyReadYourWritesPollInterval)
+}
+
+func waitForIndex(targetIdx uint64, get func() uint64, maxWait, poll time.Duration) (uint64, bool) {
 	deadline := time.Now().Add(maxWait)
 
-	for time.Now().Before(deadline) {
-		if dbInstance.RaftAppliedIndex() >= targetIdx {
-			return
+	for {
+		local := get()
+		if local >= targetIdx {
+			return local, true
 		}
 
-		time.Sleep(pollInterval)
+		if !time.Now().Before(deadline) {
+			return local, false
+		}
+
+		time.Sleep(poll)
 	}
 }

--- a/internal/api/server/proxy_middleware.go
+++ b/internal/api/server/proxy_middleware.go
@@ -154,6 +154,19 @@ func proxyToLeaderCluster(w http.ResponseWriter, r *http.Request, client *http.C
 
 	defer func() { _ = resp.Body.Close() }()
 
+	// 410 Gone from the leader means this node has been removed from
+	// cluster_members (removedNodeFence). The end-user caller did not
+	// remove anything, so surface 502 Bad Gateway rather than forwarding
+	// the 410 verbatim.
+	if resp.StatusCode == http.StatusGone {
+		logger.APILog.Error("proxy: this node has been removed from the cluster; operator must shut it down",
+			zap.Int("nodeId", dbInstance.NodeID()))
+		writeError(r.Context(), w, http.StatusBadGateway,
+			"this node is no longer a cluster member", nil, logger.APILog)
+
+		return
+	}
+
 	copyProxyResponse(w, resp, dbInstance)
 }
 

--- a/internal/api/server/proxy_middleware_test.go
+++ b/internal/api/server/proxy_middleware_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestIsWriteMethod(t *testing.T) {
@@ -27,6 +29,62 @@ func TestIsWriteMethod(t *testing.T) {
 				t.Errorf("isWriteMethod(%q) = %v, want %v", tt.method, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWaitForIndex_CatchesUpBeforeDeadline(t *testing.T) {
+	var local atomic.Uint64
+
+	local.Store(5)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		local.Store(10)
+	}()
+
+	got, caughtUp := waitForIndex(10, local.Load, 500*time.Millisecond, 2*time.Millisecond)
+	if !caughtUp {
+		t.Fatalf("expected catch-up before deadline, got timeout (localIdx=%d)", got)
+	}
+
+	if got < 10 {
+		t.Fatalf("expected localIdx >= 10, got %d", got)
+	}
+}
+
+func TestWaitForIndex_TimesOutReportsLastIndex(t *testing.T) {
+	var local atomic.Uint64
+
+	local.Store(7)
+
+	got, caughtUp := waitForIndex(10, local.Load, 20*time.Millisecond, 2*time.Millisecond)
+	if caughtUp {
+		t.Fatalf("expected timeout, got catch-up (localIdx=%d)", got)
+	}
+
+	if got != 7 {
+		t.Fatalf("expected last-observed localIdx=7, got %d", got)
+	}
+}
+
+func TestWaitForIndex_AlreadyCaughtUpReturnsImmediately(t *testing.T) {
+	var local atomic.Uint64
+
+	local.Store(42)
+
+	start := time.Now()
+
+	got, caughtUp := waitForIndex(10, local.Load, 500*time.Millisecond, 50*time.Millisecond)
+	if !caughtUp {
+		t.Fatalf("expected immediate catch-up, got timeout")
+	}
+
+	if got != 42 {
+		t.Fatalf("expected localIdx=42, got %d", got)
+	}
+
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("expected near-instant return, took %v", elapsed)
 	}
 }
 

--- a/internal/api/server/proxy_middleware_test.go
+++ b/internal/api/server/proxy_middleware_test.go
@@ -1,12 +1,20 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/ellanetworks/core/internal/db"
+	ellaraft "github.com/ellanetworks/core/internal/raft"
 )
 
 func TestIsWriteMethod(t *testing.T) {
@@ -85,6 +93,103 @@ func TestWaitForIndex_AlreadyCaughtUpReturnsImmediately(t *testing.T) {
 
 	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
 		t.Fatalf("expected near-instant return, took %v", elapsed)
+	}
+}
+
+// stubRoundTripper returns a canned response regardless of the request URL.
+// Lets the proxy-client tests exercise branch logic without dialing a real
+// listener.
+type stubRoundTripper struct {
+	statusCode int
+	body       string
+}
+
+func (s *stubRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: s.statusCode,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestProxyToLeaderCluster_410TranslatesTo502(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+
+	t.Cleanup(func() { _ = testDB.Close() })
+
+	// Single-server raft bootstraps self as leader; LeaderAddress is the
+	// local transport addr — non-empty, which is all proxyToLeaderCluster
+	// needs since the stub RoundTripper never dials.
+	deadline := time.Now().Add(3 * time.Second)
+	for testDB.LeaderAddress() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if testDB.LeaderAddress() == "" {
+		t.Fatal("single-server DB did not elect a leader")
+	}
+
+	client := &http.Client{Transport: &stubRoundTripper{
+		statusCode: http.StatusGone,
+		body:       `{"error":"node-id 5 is not a current cluster member"}`,
+	}}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/subscribers", bytes.NewReader(nil))
+	w := httptest.NewRecorder()
+
+	proxyToLeaderCluster(w, req, client, testDB)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 410 from leader to translate to 502, got %d", w.Code)
+	}
+
+	var body struct {
+		Error string `json:"error"`
+	}
+
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if !strings.Contains(body.Error, "no longer a cluster member") {
+		t.Fatalf("expected evicted-node error message, got %q", body.Error)
+	}
+}
+
+func TestProxyToLeaderCluster_PassesNon410Through(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+
+	t.Cleanup(func() { _ = testDB.Close() })
+
+	deadline := time.Now().Add(3 * time.Second)
+	for testDB.LeaderAddress() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	client := &http.Client{Transport: &stubRoundTripper{
+		statusCode: http.StatusCreated,
+		body:       `{"result":{"message":"ok"}}`,
+	}}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/subscribers", bytes.NewReader(nil))
+	w := httptest.NewRecorder()
+
+	proxyToLeaderCluster(w, req, client, testDB)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected non-410 response to pass through, got %d", w.Code)
 	}
 }
 

--- a/internal/api/server/response.go
+++ b/internal/api/server/response.go
@@ -61,6 +61,13 @@ func writeError(ctx context.Context, w http.ResponseWriter, status int, message 
 		message = "raft commit timeout"
 	}
 
+	if errors.Is(err, db.ErrMigrationPending) {
+		status = http.StatusServiceUnavailable
+		message = "cluster is upgrading; feature unavailable until schema migration completes"
+
+		w.Header().Set("Retry-After", "10")
+	}
+
 	log := logger.WithTrace(ctx, l)
 	if status >= 500 {
 		log.Error(message, zap.Error(err))

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -31,7 +31,12 @@ func (db *Database) ApplyCommand(ctx context.Context, cmd *ellaraft.Command) (an
 			return nil, err
 		}
 
-		return db.applyChangeset(ctx, payload)
+		result, applyErr := db.applyChangeset(ctx, payload)
+		if applyErr == nil && payload.Operation == "UpsertClusterMember" {
+			db.signalMigrationCheck()
+		}
+
+		return result, applyErr
 
 	case ellaraft.CmdDeleteOldAuditLogs:
 		payload, err := unmarshalPayload[stringPayload](cmd.Payload)
@@ -66,7 +71,12 @@ func (db *Database) ApplyCommand(ctx context.Context, cmd *ellaraft.Command) (an
 			return nil, err
 		}
 
-		return db.applyMigrateShared(ctx, payload)
+		result, applyErr := db.applyMigrateShared(ctx, payload)
+		if applyErr == nil {
+			db.signalMigrationCheck()
+		}
+
+		return result, applyErr
 
 	default:
 		return nil, fmt.Errorf("unknown command type: %s", cmd.Type)
@@ -1187,7 +1197,14 @@ func (db *Database) applyDeleteClusterMember(ctx context.Context, p *intPayload)
 func (db *Database) applyMigrateShared(ctx context.Context, p *migrateSharedPayload) (any, error) {
 	idx := p.TargetVersion - 1
 	if idx < 0 || idx >= len(migrations) {
-		return nil, fmt.Errorf("unknown shared migration version %d", p.TargetVersion)
+		// The leader's proposal gate (CheckPendingMigrations) normally
+		// prevents this path. Reaching it means a laggard voter is being
+		// asked to apply a migration beyond its binary — the fail-stop
+		// FSM will panic. Keep the message informative: it's likely to
+		// be the last thing the operator sees before a node restart.
+		return nil, fmt.Errorf(
+			"refusing to apply migration v%d: this binary supports up to v%d (rolling upgrade skew)",
+			p.TargetVersion, SchemaVersion())
 	}
 
 	m := migrations[idx]

--- a/internal/db/cluster_members.go
+++ b/internal/db/cluster_members.go
@@ -18,17 +18,18 @@ const ClusterMembersTableName = "cluster_members"
 const (
 	listClusterMembersStmtStr  = "SELECT &ClusterMember.* FROM %s ORDER BY nodeID ASC"
 	getClusterMemberStmtStr    = "SELECT &ClusterMember.* FROM %s WHERE nodeID==$ClusterMember.nodeID"
-	upsertClusterMemberStmtStr = "INSERT INTO %s (nodeID, raftAddress, apiAddress, binaryVersion, suffrage) VALUES ($ClusterMember.nodeID, $ClusterMember.raftAddress, $ClusterMember.apiAddress, $ClusterMember.binaryVersion, $ClusterMember.suffrage) ON CONFLICT(nodeID) DO UPDATE SET raftAddress=$ClusterMember.raftAddress, apiAddress=$ClusterMember.apiAddress, binaryVersion=$ClusterMember.binaryVersion, suffrage=$ClusterMember.suffrage"
+	upsertClusterMemberStmtStr = "INSERT INTO %s (nodeID, raftAddress, apiAddress, binaryVersion, suffrage, maxSchemaVersion) VALUES ($ClusterMember.nodeID, $ClusterMember.raftAddress, $ClusterMember.apiAddress, $ClusterMember.binaryVersion, $ClusterMember.suffrage, $ClusterMember.maxSchemaVersion) ON CONFLICT(nodeID) DO UPDATE SET raftAddress=$ClusterMember.raftAddress, apiAddress=$ClusterMember.apiAddress, binaryVersion=$ClusterMember.binaryVersion, suffrage=$ClusterMember.suffrage, maxSchemaVersion=$ClusterMember.maxSchemaVersion"
 	deleteClusterMemberStmtStr = "DELETE FROM %s WHERE nodeID==$ClusterMember.nodeID"
 	countClusterMembersStmtStr = "SELECT COUNT(*) AS &NumItems.count FROM %s"
 )
 
 type ClusterMember struct {
-	NodeID        int    `db:"nodeID"`
-	RaftAddress   string `db:"raftAddress"`
-	APIAddress    string `db:"apiAddress"`
-	BinaryVersion string `db:"binaryVersion"`
-	Suffrage      string `db:"suffrage"`
+	NodeID           int    `db:"nodeID"`
+	RaftAddress      string `db:"raftAddress"`
+	APIAddress       string `db:"apiAddress"`
+	BinaryVersion    string `db:"binaryVersion"`
+	Suffrage         string `db:"suffrage"`
+	MaxSchemaVersion int    `db:"maxSchemaVersion"`
 }
 
 func (db *Database) ListClusterMembers(ctx context.Context) ([]ClusterMember, error) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -509,64 +509,15 @@ func (db *Database) ClusterEnabled() bool {
 	return db.raftManager.ClusterEnabled()
 }
 
-// LeadershipTransfer triggers a leadership transfer to another node. During a
-// rolling upgrade the target preference is the highest advertise API address
-// lexicographically, excluding self, with a fallback to raft's default choice.
+// LeadershipTransfer triggers a leadership transfer to another voter. The raft
+// library picks the most up-to-date follower (highest replicated nextIndex)
+// excluding self.
 func (db *Database) LeadershipTransfer() error {
 	if db.raftManager == nil {
 		return fmt.Errorf("clustering not enabled")
 	}
 
-	target := db.pickLeadershipTransferTarget()
-	if target == nil {
-		return db.raftManager.LeadershipTransfer()
-	}
-
-	return db.raftManager.LeadershipTransferToServer(target.NodeID, target.RaftAddress)
-}
-
-// pickLeadershipTransferTarget returns the preferred voter to transfer
-// leadership to, or nil if no suitable target is found (fall back to the
-// library's default choice). Excludes self.
-func (db *Database) pickLeadershipTransferTarget() *ClusterMember {
-	if db.raftManager == nil {
-		return nil
-	}
-
-	voterIDs := db.raftManager.VoterIDs()
-	if len(voterIDs) == 0 {
-		return nil
-	}
-
-	selfID := db.raftManager.NodeID()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	var best *ClusterMember
-
-	for _, id := range voterIDs {
-		if id == selfID {
-			continue
-		}
-
-		member, err := db.GetClusterMember(ctx, id)
-		if err != nil {
-			continue
-		}
-
-		if best == nil {
-			best = member
-			continue
-		}
-
-		if member.APIAddress > best.APIAddress ||
-			(member.APIAddress == best.APIAddress && member.NodeID < best.NodeID) {
-			best = member
-		}
-	}
-
-	return best
+	return db.raftManager.LeadershipTransfer()
 }
 
 // AddVoter adds a node to the Raft cluster. Only callable on the leader.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -43,8 +43,8 @@ type Database struct {
 	// (after UpsertClusterMember or CmdMigrateShared commits) so the
 	// leader re-runs CheckPendingMigrations without waiting for the
 	// next leadership change. Debounced by the worker.
-	migrationCheckCh   chan struct{}
-	migrationCheckStop chan struct{}
+	migrationCheckCh     chan struct{}
+	migrationCheckCancel context.CancelFunc
 
 	// Subscriber statements
 	listSubscribersStmt         *sqlair.Statement
@@ -366,12 +366,8 @@ func openSQLiteConnection(ctx context.Context, databasePath string) (*sql.DB, er
 func (db *Database) Close() error {
 	var raftErr, connErr error
 
-	if db.migrationCheckStop != nil {
-		select {
-		case <-db.migrationCheckStop:
-		default:
-			close(db.migrationCheckStop)
-		}
+	if db.migrationCheckCancel != nil {
+		db.migrationCheckCancel()
 	}
 
 	if db.raftManager != nil {
@@ -403,12 +399,12 @@ func (db *Database) signalMigrationCheck() {
 // to coalesce bursts, and calls CheckPendingMigrations. The check itself
 // no-ops on followers; running it on every node is harmless because
 // leader-state is checked inside.
-func (db *Database) runMigrationCheckWorker() {
+func (db *Database) runMigrationCheckWorker(ctx context.Context) {
 	const debounce = 100 * time.Millisecond
 
 	for {
 		select {
-		case <-db.migrationCheckStop:
+		case <-ctx.Done():
 			return
 		case <-db.migrationCheckCh:
 		}
@@ -421,16 +417,16 @@ func (db *Database) runMigrationCheckWorker() {
 			case <-db.migrationCheckCh:
 			case <-timer.C:
 				break drain
-			case <-db.migrationCheckStop:
+			case <-ctx.Done():
 				timer.Stop()
 				return
 			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 
-		if err := db.CheckPendingMigrations(ctx); err != nil {
-			logger.WithTrace(ctx, logger.DBLog).Warn("pending migration check (re-trigger) failed",
+		if err := db.CheckPendingMigrations(checkCtx); err != nil {
+			logger.WithTrace(checkCtx, logger.DBLog).Warn("pending migration check (re-trigger) failed",
 				zap.Error(err))
 		}
 
@@ -921,9 +917,10 @@ func NewDatabase(ctx context.Context, dbPath string, raftCfg ellaraft.ClusterCon
 	db.proposeTimeout = raftMgr.ProposeTimeout()
 
 	db.migrationCheckCh = make(chan struct{}, 1)
-	db.migrationCheckStop = make(chan struct{})
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	db.migrationCheckCancel = workerCancel
 
-	go db.runMigrationCheckWorker()
+	go db.runMigrationCheckWorker(workerCtx)
 
 	if observer := raftMgr.LeaderObserver(); observer != nil {
 		observer.Register(newClusterCoordinator(db))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -39,6 +39,13 @@ type Database struct {
 	raftManager    *ellaraft.Manager
 	proposeTimeout time.Duration
 
+	// migrationCheckCh fan-ins re-trigger signals from the FSM applier
+	// (after UpsertClusterMember or CmdMigrateShared commits) so the
+	// leader re-runs CheckPendingMigrations without waiting for the
+	// next leadership change. Debounced by the worker.
+	migrationCheckCh   chan struct{}
+	migrationCheckStop chan struct{}
+
 	// Subscriber statements
 	listSubscribersStmt         *sqlair.Statement
 	countSubscribersStmt        *sqlair.Statement
@@ -359,6 +366,14 @@ func openSQLiteConnection(ctx context.Context, databasePath string) (*sql.DB, er
 func (db *Database) Close() error {
 	var raftErr, connErr error
 
+	if db.migrationCheckStop != nil {
+		select {
+		case <-db.migrationCheckStop:
+		default:
+			close(db.migrationCheckStop)
+		}
+	}
+
 	if db.raftManager != nil {
 		raftErr = db.raftManager.Shutdown()
 	}
@@ -368,6 +383,59 @@ func (db *Database) Close() error {
 	}
 
 	return errors.Join(raftErr, connErr)
+}
+
+// signalMigrationCheck requests a non-blocking re-run of
+// CheckPendingMigrations. Debounced by runMigrationCheckWorker. Safe to
+// call from applier goroutines.
+func (db *Database) signalMigrationCheck() {
+	if db.migrationCheckCh == nil {
+		return
+	}
+
+	select {
+	case db.migrationCheckCh <- struct{}{}:
+	default:
+	}
+}
+
+// runMigrationCheckWorker consumes migrationCheckCh signals, waits 100ms
+// to coalesce bursts, and calls CheckPendingMigrations. The check itself
+// no-ops on followers; running it on every node is harmless because
+// leader-state is checked inside.
+func (db *Database) runMigrationCheckWorker() {
+	const debounce = 100 * time.Millisecond
+
+	for {
+		select {
+		case <-db.migrationCheckStop:
+			return
+		case <-db.migrationCheckCh:
+		}
+
+		timer := time.NewTimer(debounce)
+
+	drain:
+		for {
+			select {
+			case <-db.migrationCheckCh:
+			case <-timer.C:
+				break drain
+			case <-db.migrationCheckStop:
+				timer.Stop()
+				return
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+		if err := db.CheckPendingMigrations(ctx); err != nil {
+			logger.WithTrace(ctx, logger.DBLog).Warn("pending migration check (re-trigger) failed",
+				zap.Error(err))
+		}
+
+		cancel()
+	}
 }
 
 // Dir returns the directory containing the database file.
@@ -536,9 +604,36 @@ func (db *Database) CurrentSchemaVersion(ctx context.Context) (int, error) {
 	return v, nil
 }
 
+// RequireSchema returns ErrMigrationPending when the applied schema
+// version is below minVersion. Handlers that depend on a migration not
+// yet rolled out to every voter call this up-front; the 503 translation
+// in writeError maps the sentinel to a retryable status for clients.
+func (db *Database) RequireSchema(ctx context.Context, minVersion int) error {
+	current, err := db.CurrentSchemaVersion(ctx)
+	if err != nil {
+		return err
+	}
+
+	if current < minVersion {
+		return ErrMigrationPending
+	}
+
+	return nil
+}
+
 // CheckPendingMigrations proposes CmdMigrateShared entries for each
-// migration beyond the current applied version. Called on leadership
-// transitions. Only the leader proposes; followers no-op.
+// migration beyond the current applied version, bounded by what every
+// voter can apply. Called on leadership transitions and when voter
+// capabilities change. Only the leader proposes.
+//
+// The proposal gate upholds the rolling-upgrade invariant:
+//
+//	dbSchema ≤ binarySchema(v) for every voter v.
+//
+// If any voter has not yet self-announced its maxSchemaVersion
+// (column default 0), the gate defers entirely: "unknown" is treated
+// as "cannot apply." Learners are ignored — they can crash on an
+// unsupported migration without breaking quorum.
 func (db *Database) CheckPendingMigrations(ctx context.Context) error {
 	if db.raftManager == nil || !db.raftManager.ClusterEnabled() {
 		return nil
@@ -553,8 +648,29 @@ func (db *Database) CheckPendingMigrations(ctx context.Context) error {
 		return err
 	}
 
-	target := SchemaVersion()
+	binaryMax := SchemaVersion()
+	if current >= binaryMax {
+		return nil
+	}
+
+	floor, laggard, err := db.minVoterSchemaSupport(ctx)
+	if err != nil {
+		return err
+	}
+
+	target := binaryMax
+	if floor < target {
+		target = floor
+	}
+
 	if current >= target {
+		logger.WithTrace(ctx, logger.DBLog).Info("Migration deferred: waiting on voter upgrades",
+			zap.Int("current", current),
+			zap.Int("binaryMax", binaryMax),
+			zap.Int("voterFloor", floor),
+			zap.Int("laggardNodeID", laggard),
+		)
+
 		return nil
 	}
 
@@ -568,6 +684,40 @@ func (db *Database) CheckPendingMigrations(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// minVoterSchemaSupport returns the minimum maxSchemaVersion across
+// voter rows in cluster_members and the nodeID of the laggard. Any
+// voter whose maxSchemaVersion is 0 (not yet self-announced) returns
+// a floor of 0 — the gate blocks until every voter reports support.
+// When there are no voter rows yet (e.g. fresh bootstrap before any
+// self-announce) the floor is the leader's own binary max, so the
+// leader is not blocked from applying its own migrations.
+func (db *Database) minVoterSchemaSupport(ctx context.Context) (int, int, error) {
+	members, err := db.ListClusterMembers(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("list cluster members: %w", err)
+	}
+
+	floor := -1
+	laggard := 0
+
+	for _, m := range members {
+		if m.Suffrage != "voter" {
+			continue
+		}
+
+		if floor < 0 || m.MaxSchemaVersion < floor {
+			floor = m.MaxSchemaVersion
+			laggard = m.NodeID
+		}
+	}
+
+	if floor < 0 {
+		return SchemaVersion(), db.raftManager.NodeID(), nil
+	}
+
+	return floor, laggard, nil
 }
 
 // clusterCoordinator implements ellaraft.LeaderCallback to propose deferred
@@ -649,8 +799,7 @@ func (db *Database) PostInitClusterSetup(ctx context.Context, binaryVersion stri
 
 // selfUpsertClusterMember proposes this leader's own cluster_members row with
 // the running binary version. Idempotent via ON CONFLICT(nodeID). Called after
-// discovery on the leader. Followers self-register indirectly via the join
-// handshake.
+// discovery on the leader. Followers self-announce via SelfAnnounce.
 //
 // Addresses are pulled from the raft manager (authoritative for raftAddress
 // post-bind and for the configured apiAddress) rather than from any existing
@@ -669,14 +818,54 @@ func (db *Database) selfUpsertClusterMember(ctx context.Context, binaryVersion s
 	}
 
 	member := &ClusterMember{
-		NodeID:        db.raftManager.NodeID(),
-		RaftAddress:   db.raftManager.RaftAddress(),
-		APIAddress:    db.raftManager.APIAddress(),
-		BinaryVersion: binaryVersion,
-		Suffrage:      suffrage,
+		NodeID:           db.raftManager.NodeID(),
+		RaftAddress:      db.raftManager.RaftAddress(),
+		APIAddress:       db.raftManager.APIAddress(),
+		BinaryVersion:    binaryVersion,
+		Suffrage:         suffrage,
+		MaxSchemaVersion: SchemaVersion(),
 	}
 
 	return db.UpsertClusterMember(ctx, member)
+}
+
+// SelfAnnounce refreshes this node's cluster_members row so voter
+// capability (binaryVersion + maxSchemaVersion) stays current. On the
+// leader it proposes the upsert directly; on a follower it POSTs to the
+// current leader's cluster port. Called on every startup after Raft is
+// up so rolling-restart upgrades rendezvous on the migration gate.
+func (db *Database) SelfAnnounce(ctx context.Context, binaryVersion string) error {
+	if db.raftManager == nil || !db.raftManager.ClusterEnabled() {
+		return nil
+	}
+
+	if db.raftManager.IsLeader() {
+		return db.selfUpsertClusterMember(ctx, binaryVersion)
+	}
+
+	suffrage := "voter"
+
+	if existing, err := db.GetClusterMember(ctx, db.raftManager.NodeID()); err == nil && existing != nil && existing.Suffrage != "" {
+		suffrage = existing.Suffrage
+	}
+
+	payload := struct {
+		NodeID           int    `json:"nodeId"`
+		RaftAddress      string `json:"raftAddress"`
+		APIAddress       string `json:"apiAddress"`
+		BinaryVersion    string `json:"binaryVersion"`
+		MaxSchemaVersion int    `json:"maxSchemaVersion"`
+		Suffrage         string `json:"suffrage,omitempty"`
+	}{
+		NodeID:           db.raftManager.NodeID(),
+		RaftAddress:      db.raftManager.RaftAddress(),
+		APIAddress:       db.raftManager.APIAddress(),
+		BinaryVersion:    binaryVersion,
+		MaxSchemaVersion: SchemaVersion(),
+		Suffrage:         suffrage,
+	}
+
+	return db.raftManager.SelfAnnounce(ctx, payload)
 }
 
 // NewDatabase opens (or creates) the SQLite database file at dbPath. The
@@ -730,6 +919,11 @@ func NewDatabase(ctx context.Context, dbPath string, raftCfg ellaraft.ClusterCon
 
 	db.raftManager = raftMgr
 	db.proposeTimeout = raftMgr.ProposeTimeout()
+
+	db.migrationCheckCh = make(chan struct{}, 1)
+	db.migrationCheckStop = make(chan struct{})
+
+	go db.runMigrationCheckWorker()
 
 	if observer := raftMgr.LeaderObserver(); observer != nil {
 		observer.Register(newClusterCoordinator(db))

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -16,6 +16,11 @@ var (
 	// (queue full, leader lost mid-commit, or Raft shutting down). Callers
 	// should treat it as a transient 503 condition.
 	ErrProposeTimeout = errors.New("raft commit timeout")
+	// ErrMigrationPending is returned when a handler depends on a schema
+	// version the cluster has not yet rolled forward to. Surfaces as 503
+	// with Retry-After so clients back off until the slowest voter
+	// catches up and the leader proposes the migration.
+	ErrMigrationPending = errors.New("schema migration pending")
 )
 
 func isUniqueNameError(err error) bool {

--- a/internal/db/migration_gate_internal_test.go
+++ b/internal/db/migration_gate_internal_test.go
@@ -111,3 +111,47 @@ func TestMinVoterSchemaSupport_IgnoresLearners(t *testing.T) {
 		t.Fatalf("laggard: want 1, got %d", laggard)
 	}
 }
+
+func TestRequireSchema(t *testing.T) {
+	database := newStandaloneDB(t)
+	ctx := context.Background()
+
+	applied, err := database.CurrentSchemaVersion(ctx)
+	if err != nil {
+		t.Fatalf("CurrentSchemaVersion: %v", err)
+	}
+
+	if err := database.RequireSchema(ctx, applied); err != nil {
+		t.Fatalf("RequireSchema(current) unexpected error: %v", err)
+	}
+
+	if err := database.RequireSchema(ctx, applied+1); err != ErrMigrationPending {
+		t.Fatalf("RequireSchema(current+1): want ErrMigrationPending, got %v", err)
+	}
+}
+
+func TestClusterMember_MaxSchemaVersionRoundtrip(t *testing.T) {
+	database := newStandaloneDB(t)
+	ctx := context.Background()
+
+	m := &ClusterMember{
+		NodeID:           7,
+		RaftAddress:      "10.0.0.7:8300",
+		APIAddress:       "10.0.0.7:8443",
+		Suffrage:         "voter",
+		MaxSchemaVersion: 42,
+	}
+
+	if err := database.UpsertClusterMember(ctx, m); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := database.GetClusterMember(ctx, 7)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.MaxSchemaVersion != 42 {
+		t.Fatalf("MaxSchemaVersion: want 42, got %d", got.MaxSchemaVersion)
+	}
+}

--- a/internal/db/migration_gate_internal_test.go
+++ b/internal/db/migration_gate_internal_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Ella Networks
+
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	ellaraft "github.com/ellanetworks/core/internal/raft"
+)
+
+// Whitebox tests for the schema-migration proposal gate. minVoterSchemaSupport
+// is unexported and the full CheckPendingMigrations path requires a leader;
+// here we seed cluster_members directly via the public upsert API on a
+// standalone DB and exercise the gate logic.
+
+func newStandaloneDB(t *testing.T) *Database {
+	t.Helper()
+
+	tmp := t.TempDir()
+
+	database, err := NewDatabase(context.Background(), filepath.Join(tmp, "db.sqlite3"), ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	t.Cleanup(func() { _ = database.Close() })
+
+	return database
+}
+
+func TestMinVoterSchemaSupport_FloorIsLaggard(t *testing.T) {
+	database := newStandaloneDB(t)
+	ctx := context.Background()
+
+	for _, m := range []*ClusterMember{
+		{NodeID: 1, RaftAddress: "a:1", APIAddress: "a:2", Suffrage: "voter", MaxSchemaVersion: 10},
+		{NodeID: 2, RaftAddress: "b:1", APIAddress: "b:2", Suffrage: "voter", MaxSchemaVersion: 9},
+		{NodeID: 3, RaftAddress: "c:1", APIAddress: "c:2", Suffrage: "voter", MaxSchemaVersion: 11},
+	} {
+		if err := database.UpsertClusterMember(ctx, m); err != nil {
+			t.Fatalf("seed member %d: %v", m.NodeID, err)
+		}
+	}
+
+	floor, laggard, err := database.minVoterSchemaSupport(ctx)
+	if err != nil {
+		t.Fatalf("minVoterSchemaSupport: %v", err)
+	}
+
+	if floor != 9 {
+		t.Fatalf("floor: want 9, got %d", floor)
+	}
+
+	if laggard != 2 {
+		t.Fatalf("laggard: want 2, got %d", laggard)
+	}
+}
+
+func TestMinVoterSchemaSupport_UnknownBlocks(t *testing.T) {
+	database := newStandaloneDB(t)
+	ctx := context.Background()
+
+	for _, m := range []*ClusterMember{
+		{NodeID: 1, RaftAddress: "a:1", APIAddress: "a:2", Suffrage: "voter", MaxSchemaVersion: 10},
+		{NodeID: 2, RaftAddress: "b:1", APIAddress: "b:2", Suffrage: "voter", MaxSchemaVersion: 0},
+	} {
+		if err := database.UpsertClusterMember(ctx, m); err != nil {
+			t.Fatalf("seed member %d: %v", m.NodeID, err)
+		}
+	}
+
+	floor, laggard, err := database.minVoterSchemaSupport(ctx)
+	if err != nil {
+		t.Fatalf("minVoterSchemaSupport: %v", err)
+	}
+
+	if floor != 0 {
+		t.Fatalf("floor: want 0 (unknown blocks), got %d", floor)
+	}
+
+	if laggard != 2 {
+		t.Fatalf("laggard: want 2, got %d", laggard)
+	}
+}
+
+func TestMinVoterSchemaSupport_IgnoresLearners(t *testing.T) {
+	database := newStandaloneDB(t)
+	ctx := context.Background()
+
+	for _, m := range []*ClusterMember{
+		{NodeID: 1, RaftAddress: "a:1", APIAddress: "a:2", Suffrage: "voter", MaxSchemaVersion: 10},
+		{NodeID: 2, RaftAddress: "b:1", APIAddress: "b:2", Suffrage: "nonvoter", MaxSchemaVersion: 5},
+	} {
+		if err := database.UpsertClusterMember(ctx, m); err != nil {
+			t.Fatalf("seed member %d: %v", m.NodeID, err)
+		}
+	}
+
+	floor, laggard, err := database.minVoterSchemaSupport(ctx)
+	if err != nil {
+		t.Fatalf("minVoterSchemaSupport: %v", err)
+	}
+
+	if floor != 10 {
+		t.Fatalf("floor: want 10 (learner ignored), got %d", floor)
+	}
+
+	if laggard != 1 {
+		t.Fatalf("laggard: want 1, got %d", laggard)
+	}
+}

--- a/internal/db/migration_v9.go
+++ b/internal/db/migration_v9.go
@@ -20,11 +20,12 @@ import (
 
 const v9CreateClusterMembers = `
 	CREATE TABLE IF NOT EXISTS %s (
-		nodeID          INTEGER PRIMARY KEY,
-		raftAddress     TEXT NOT NULL,
-		apiAddress      TEXT NOT NULL,
-		binaryVersion   TEXT NOT NULL DEFAULT '',
-		suffrage        TEXT NOT NULL DEFAULT 'voter'
+		nodeID            INTEGER PRIMARY KEY,
+		raftAddress       TEXT NOT NULL,
+		apiAddress        TEXT NOT NULL,
+		binaryVersion     TEXT NOT NULL DEFAULT '',
+		suffrage          TEXT NOT NULL DEFAULT 'voter',
+		maxSchemaVersion  INTEGER NOT NULL DEFAULT 0
 )`
 
 func migrateV9(ctx context.Context, tx *sql.Tx) error {

--- a/internal/raft/discovery.go
+++ b/internal/raft/discovery.go
@@ -123,6 +123,20 @@ func (m *Manager) discoveryTick(ctx context.Context) (bool, error) {
 
 		state, nodeID, clusterID, peerSchema := m.probePeer(ctx, peerAddr)
 
+		if state == peerUnreachable {
+			continue
+		}
+
+		// Duplicate node-id is a hard misconfiguration: two nodes can't share
+		// an ID without risking split-brain during bootstrap (both would see
+		// themselves as the lowest reachable node-id) or clobbering an
+		// existing cluster member at join time. Fail loud so the operator
+		// fixes cluster.node-id rather than letting the cluster form
+		// silently wrong.
+		if nodeID > 0 && nodeID == m.nodeID {
+			return false, fmt.Errorf("peer %s advertises the same node-id (%d) as this node; check cluster.node-id configuration", peerAddr, nodeID)
+		}
+
 		switch state {
 		case peerFormed:
 			// Schema handshake (follower side): allow joining a peer whose
@@ -154,13 +168,6 @@ func (m *Manager) discoveryTick(ctx context.Context) (bool, error) {
 
 		case peerForming:
 			reachableCount++
-
-			if nodeID == m.nodeID {
-				logger.RaftLog.Warn("Peer reports duplicate node-id during discovery",
-					zap.String("peer", peerAddr),
-					zap.Int("node_id", nodeID),
-				)
-			}
 
 			if nodeID > 0 && nodeID < lowestReachableNodeID {
 				lowestReachableNodeID = nodeID
@@ -272,22 +279,56 @@ func (m *Manager) probePeer(ctx context.Context, peerAddr string) (peerState, in
 	return peerForming, nodeID, clusterID, schemaVersion
 }
 
+// SelfAnnounce POSTs this node's capability record (node-id, addresses,
+// binary version, max schema version, suffrage) to the current leader's
+// cluster port. Callers invoke this on startup after Raft is up so
+// follower rows in `cluster_members` reflect the running binary. When
+// this node is the leader, callers should write directly via
+// db.UpsertClusterMember rather than calling this method.
+func (m *Manager) SelfAnnounce(ctx context.Context, payload any) error {
+	leader := m.LeaderAddress()
+	if leader == "" {
+		return fmt.Errorf("no known leader")
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal self-announce: %w", err)
+	}
+
+	resp, err := m.clusterHTTPDo(ctx, http.MethodPost, leader, "/cluster/members/self", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("dial leader %s: %w", leader, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("leader returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
 // joinCluster POSTs our membership to a peer's cluster port.
 func (m *Manager) joinCluster(ctx context.Context, peerAddr string, clusterID string) error {
 	payload := struct {
-		NodeID        int    `json:"nodeId"`
-		RaftAddress   string `json:"raftAddress"`
-		APIAddress    string `json:"apiAddress"`
-		ClusterID     string `json:"clusterId"`
-		SchemaVersion int    `json:"schemaVersion"`
-		Suffrage      string `json:"suffrage,omitempty"`
+		NodeID           int    `json:"nodeId"`
+		RaftAddress      string `json:"raftAddress"`
+		APIAddress       string `json:"apiAddress"`
+		ClusterID        string `json:"clusterId"`
+		SchemaVersion    int    `json:"schemaVersion"`
+		MaxSchemaVersion int    `json:"maxSchemaVersion"`
+		Suffrage         string `json:"suffrage,omitempty"`
 	}{
-		NodeID:        m.nodeID,
-		RaftAddress:   string(m.transport.LocalAddr()),
-		APIAddress:    m.config.APIAddress,
-		ClusterID:     clusterID,
-		SchemaVersion: m.config.SchemaVersion,
-		Suffrage:      m.config.InitialSuffrage,
+		NodeID:           m.nodeID,
+		RaftAddress:      string(m.transport.LocalAddr()),
+		APIAddress:       m.config.APIAddress,
+		ClusterID:        clusterID,
+		SchemaVersion:    m.config.SchemaVersion,
+		MaxSchemaVersion: m.config.SchemaVersion,
+		Suffrage:         m.config.InitialSuffrage,
 	}
 
 	body, err := json.Marshal(payload)

--- a/internal/raft/discovery_test.go
+++ b/internal/raft/discovery_test.go
@@ -288,6 +288,91 @@ func TestProbePeer_FormingNode(t *testing.T) {
 	}
 }
 
+// TestDiscoveryTick_DuplicateNodeIDFails verifies that discoveryTick fails
+// hard when a reachable peer advertises the same node-id as this node.
+// Warning and continuing would risk silent split-brain at bootstrap or a
+// join request that clobbers an existing cluster member.
+func TestDiscoveryTick_DuplicateNodeIDFails(t *testing.T) {
+	cases := []struct {
+		name string
+		role string // "" means forming (no clusterId), "Leader"/"Follower" means formed
+	}{
+		{name: "forming_peer", role: ""},
+		{name: "formed_peer", role: "Leader"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pki := testutil.GenTestPKI(t, []int{1, 2})
+
+			serverPort := discoveryFreePort(t)
+			serverAddr := fmt.Sprintf("127.0.0.1:%d", serverPort)
+
+			serverLn := listener.New(listener.Config{
+				BindAddress:      serverAddr,
+				AdvertiseAddress: serverAddr,
+				NodeID:           1,
+				CAPool:           pki.CAPool,
+				LeafCert:         pki.Nodes[1].TLSCert,
+			})
+
+			cluster := &statusClusterBlock{
+				Role:          tc.role,
+				NodeID:        2, // same as probing node
+				SchemaVersion: 9,
+			}
+
+			if tc.role != "" {
+				cluster.ClusterID = "cluster-1"
+			}
+
+			startTestClusterHTTP(t, serverLn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(statusResponse{
+					Result: statusResult{Cluster: cluster},
+				})
+			}))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if err := serverLn.Start(ctx); err != nil {
+				t.Fatalf("start listener: %v", err)
+			}
+
+			defer serverLn.Stop()
+
+			clientLn := listener.New(listener.Config{
+				BindAddress:      "127.0.0.1:0",
+				AdvertiseAddress: "127.0.0.1:0",
+				NodeID:           2,
+				CAPool:           pki.CAPool,
+				LeafCert:         pki.Nodes[2].TLSCert,
+			})
+
+			m := &Manager{
+				nodeID:          2,
+				clusterListener: clientLn,
+				config: ClusterConfig{
+					Peers:            []string{serverAddr},
+					AdvertiseAddress: "127.0.0.1:9999",
+					BootstrapExpect:  2,
+					SchemaVersion:    9,
+				},
+			}
+
+			joined, err := m.discoveryTick(ctx)
+			if err == nil {
+				t.Fatalf("expected error on duplicate node-id, got nil (joined=%v)", joined)
+			}
+
+			if joined {
+				t.Fatalf("joined should be false when duplicate node-id is detected")
+			}
+		})
+	}
+}
+
 func TestProbePeer_503IsUnreachable(t *testing.T) {
 	pki := testutil.GenTestPKI(t, []int{1, 2})
 

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -558,21 +558,6 @@ func (m *Manager) LeadershipTransfer() error {
 	return m.raft.LeadershipTransfer().Error()
 }
 
-// LeadershipTransferToServer triggers a leadership transfer to a specific
-// target node. Returns an error if the target is not a voter or the transfer
-// fails.
-func (m *Manager) LeadershipTransferToServer(nodeID int, raftAddress string) error {
-	serverID := raft.ServerID(fmt.Sprintf("%d", nodeID))
-	serverAddr := raft.ServerAddress(raftAddress)
-
-	future := m.raft.LeadershipTransferToServer(serverID, serverAddr)
-	if err := future.Error(); err != nil {
-		return fmt.Errorf("leadership transfer to %d: %w", nodeID, err)
-	}
-
-	return nil
-}
-
 // VoterIDs returns the server IDs of all voting members in the current Raft
 // configuration. Returns nil on error (e.g. no quorum).
 func (m *Manager) VoterIDs() []int {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -195,6 +195,14 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 
 			logger.EllaLog.Info("Leader initialization replicated successfully")
 		}
+
+		// Every node (leader and follower) refreshes its cluster_members
+		// row so the migration gate sees an accurate maxSchemaVersion.
+		// Best effort: a transient leader miss just defers the gate until
+		// the next leadership change or peer self-announce.
+		if err := dbInstance.SelfAnnounce(ctx, ver.Version); err != nil {
+			logger.EllaLog.Warn("self-announce to leader failed", zap.Error(err))
+		}
 	} else {
 		if err := dbInstance.DeleteAllDynamicLeases(ctx); err != nil {
 			return fmt.Errorf("couldn't release all dynamic leases: %w", err)


### PR DESCRIPTION
# Description

Harden rolling upgrades in HA mode by having nodes advertising their max supported DB schema version.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
