### PR TITLE
feat: add autopilot HA API

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -8,11 +8,13 @@ import (
 )
 
 type ClusterMember struct {
-	NodeID        int    `json:"nodeId"`
-	RaftAddress   string `json:"raftAddress"`
-	APIAddress    string `json:"apiAddress"`
-	BinaryVersion string `json:"binaryVersion"`
-	Suffrage      string `json:"suffrage"`
+	NodeID           int    `json:"nodeId"`
+	RaftAddress      string `json:"raftAddress"`
+	APIAddress       string `json:"apiAddress"`
+	BinaryVersion    string `json:"binaryVersion"`
+	Suffrage         string `json:"suffrage"`
+	MaxSchemaVersion int    `json:"maxSchemaVersion"`
+	IsLeader         bool   `json:"isLeader"`
 }
 
 type DrainOptions struct {
@@ -24,6 +26,30 @@ type DrainResponse struct {
 	TransferredLeadership bool   `json:"transferredLeadership"`
 	RANsNotified          int    `json:"ransNotified"`
 	BGPStopped            bool   `json:"bgpStopped"`
+}
+
+// AutopilotServer is the live per-peer health reported by raft-autopilot.
+type AutopilotServer struct {
+	NodeID          int    `json:"nodeId"`
+	RaftAddress     string `json:"raftAddress"`
+	NodeStatus      string `json:"nodeStatus"`
+	Healthy         bool   `json:"healthy"`
+	IsLeader        bool   `json:"isLeader"`
+	HasVotingRights bool   `json:"hasVotingRights"`
+	LastContactMs   int64  `json:"lastContactMs"`
+	LastTerm        uint64 `json:"lastTerm"`
+	LastIndex       uint64 `json:"lastIndex"`
+	StableSince     string `json:"stableSince,omitempty"`
+}
+
+// AutopilotState is the cluster-wide live health snapshot. Autopilot
+// runs leader-only; followers proxy the request transparently.
+type AutopilotState struct {
+	Healthy          bool              `json:"healthy"`
+	FailureTolerance int               `json:"failureTolerance"`
+	LeaderNodeID     int               `json:"leaderNodeId"`
+	Voters           []int             `json:"voters"`
+	Servers          []AutopilotServer `json:"servers"`
 }
 
 func (c *Client) ListClusterMembers(ctx context.Context) ([]ClusterMember, error) {
@@ -44,6 +70,48 @@ func (c *Client) ListClusterMembers(ctx context.Context) ([]ClusterMember, error
 	}
 
 	return members, nil
+}
+
+func (c *Client) GetClusterMember(ctx context.Context, nodeID int) (*ClusterMember, error) {
+	resp, err := c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   fmt.Sprintf("api/v1/cluster/members/%d", nodeID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var member ClusterMember
+
+	err = resp.DecodeResult(&member)
+	if err != nil {
+		return nil, err
+	}
+
+	return &member, nil
+}
+
+// GetAutopilotState returns the live autopilot view. Safe to call from
+// any node — the server proxies to the leader when needed.
+func (c *Client) GetAutopilotState(ctx context.Context) (*AutopilotState, error) {
+	resp, err := c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "api/v1/cluster/autopilot",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var state AutopilotState
+
+	err = resp.DecodeResult(&state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &state, nil
 }
 
 func (c *Client) DrainNode(ctx context.Context, opts *DrainOptions) (*DrainResponse, error) {

--- a/client/status.go
+++ b/client/status.go
@@ -3,18 +3,23 @@ package client
 import "context"
 
 type ClusterStatus struct {
-	Enabled       bool   `json:"enabled"`
-	Role          string `json:"role"`
-	NodeID        int    `json:"nodeId"`
-	AppliedIndex  uint64 `json:"appliedIndex"`
-	LeaderAddress string `json:"leaderAddress,omitempty"`
+	Enabled          bool   `json:"enabled"`
+	Role             string `json:"role"`
+	NodeID           int    `json:"nodeId"`
+	IsLeader         bool   `json:"isLeader"`
+	LeaderNodeID     int    `json:"leaderNodeId"`
+	AppliedIndex     uint64 `json:"appliedIndex"`
+	ClusterID        string `json:"clusterId,omitempty"`
+	LeaderAPIAddress string `json:"leaderAPIAddress,omitempty"`
 }
 
 type Status struct {
-	Version     string         `json:"version"`
-	Initialized bool           `json:"initialized"`
-	Ready       bool           `json:"ready"`
-	Cluster     *ClusterStatus `json:"cluster,omitempty"`
+	Version       string         `json:"version"`
+	Revision      string         `json:"revision,omitempty"`
+	Initialized   bool           `json:"initialized"`
+	Ready         bool           `json:"ready"`
+	SchemaVersion int            `json:"schemaVersion"`
+	Cluster       *ClusterStatus `json:"cluster,omitempty"`
 }
 
 // GetStatus retrieves the current status of the system.

--- a/docs/reference/api/cluster.md
+++ b/docs/reference/api/cluster.md
@@ -39,6 +39,34 @@ Returns all registered cluster members. This is the static configuration view â€
 }
 ```
 
+## Get a Cluster Member
+
+Returns a single cluster member by node ID.
+
+| Method | Path                            |
+| ------ | ------------------------------- |
+| GET    | `/api/v1/cluster/members/{id}`  |
+
+### Parameters
+
+- `id` (integer, path): Node ID of the cluster member.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "nodeId": 1,
+        "raftAddress": "10.0.0.1:7000",
+        "apiAddress": "https://10.0.0.1:5000",
+        "binaryVersion": "v1.9.1",
+        "suffrage": "voter",
+        "maxSchemaVersion": 9,
+        "isLeader": true
+    }
+}
+```
+
 ## Add a Cluster Member
 
 Adds a new node to the Raft cluster and registers it in the cluster members table. In HA mode, follower nodes automatically forward this request to the current leader.

--- a/docs/reference/api/cluster.md
+++ b/docs/reference/api/cluster.md
@@ -8,7 +8,7 @@ These endpoints are only available when clustering is enabled in the configurati
 
 ## List Cluster Members
 
-Returns all registered cluster members.
+Returns all registered cluster members. This is the static configuration view — who the cluster is configured to be. For the live operational view (who is healthy, how much replication lag, how many failures the cluster can absorb) use [Get Autopilot State](#get-autopilot-state) instead.
 
 | Method | Path                       |
 | ------ | -------------------------- |
@@ -24,14 +24,16 @@ Returns all registered cluster members.
             "raftAddress": "10.0.0.1:7000",
             "apiAddress": "https://10.0.0.1:5000",
             "binaryVersion": "v1.9.1",
-            "suffrage": "voter"
+            "suffrage": "voter",
+            "isLeader": true
         },
         {
             "nodeId": 2,
             "raftAddress": "10.0.0.2:7000",
             "apiAddress": "https://10.0.0.2:5000",
             "binaryVersion": "v1.9.1",
-            "suffrage": "voter"
+            "suffrage": "voter",
+            "isLeader": false
         }
     ]
 }
@@ -108,9 +110,96 @@ Promotes a nonvoter node to a full voter in the Raft cluster. Requires admin pri
 }
 ```
 
+## Get Autopilot State
+
+Returns the live autopilot view of the cluster: per‑peer health and replication lag, voter/nonvoter roster, and cluster‑wide `failureTolerance`. Requires admin privileges.
+
+`cluster/members` answers *what the cluster is configured to be*. `cluster/autopilot` answers *how the cluster is actually doing right now*. The two complement each other — the UI polls both.
+
+| Method | Path                         |
+| ------ | ---------------------------- |
+| GET    | `/api/v1/cluster/autopilot`  |
+
+### Leader‑only; automatic proxy
+
+Autopilot runs only on the leader, so only the leader can produce state. Followers proxy this GET to the leader over the cluster port; the response is returned to the original caller verbatim. Immediately after a leadership change the new leader may return an empty state for a short window (typically under one second) until its first autopilot tick publishes a state.
+
+### Fields
+
+- `healthy` (boolean): True when every voter is healthy according to autopilot's current config.
+- `failureTolerance` (integer): How many voter failures the cluster can currently absorb without losing quorum. Zero means any additional failure will stall writes.
+- `leaderNodeId` (integer): Raft node ID of the current leader; zero when unknown. Matches the field of the same name on `GET /api/v1/status`.
+- `voters` (array of integers): Node IDs of voting members, ascending.
+- `servers` (array): Per‑peer state, sorted by `nodeId`.
+    - `nodeId` (integer): Raft node ID.
+    - `raftAddress` (string): Raft transport address (`host:port`). Matches the field of the same name on `/api/v1/cluster/members`.
+    - `nodeStatus` (string): Autopilot lifecycle state — `alive`, `left`, `failed`.
+    - `healthy` (boolean): Autopilot's verdict combining last‑contact, last‑term, and log‑lag checks.
+    - `isLeader` (boolean): True when this peer is the current Raft leader.
+    - `hasVotingRights` (boolean): True for voters and the leader; false for nonvoters.
+    - `lastContactMs` (integer): Milliseconds since this peer last heartbeated with the leader. Zero for the leader's own row.
+    - `lastTerm` (integer): Highest Raft term this peer has a record of.
+    - `lastIndex` (integer): Last Raft log index this peer has acknowledged. Compare against the leader's row to read replication lag.
+    - `stableSince` (string, RFC 3339, optional): Last time this peer's `healthy` value changed. Omitted when unknown.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "healthy": true,
+        "failureTolerance": 1,
+        "leaderNodeId": 1,
+        "voters": [1, 2, 3],
+        "servers": [
+            {
+                "nodeId": 1,
+                "raftAddress": "10.0.0.1:7000",
+                "nodeStatus": "alive",
+                "healthy": true,
+                "isLeader": true,
+                "hasVotingRights": true,
+                "lastContactMs": 0,
+                "lastTerm": 7,
+                "lastIndex": 18234,
+                "stableSince": "2026-04-20T08:15:02Z"
+            },
+            {
+                "nodeId": 2,
+                "raftAddress": "10.0.0.2:7000",
+                "nodeStatus": "alive",
+                "healthy": true,
+                "isLeader": false,
+                "hasVotingRights": true,
+                "lastContactMs": 12,
+                "lastTerm": 7,
+                "lastIndex": 18233,
+                "stableSince": "2026-04-20T08:15:02Z"
+            },
+            {
+                "nodeId": 3,
+                "raftAddress": "10.0.0.3:7000",
+                "nodeStatus": "left",
+                "healthy": false,
+                "isLeader": false,
+                "hasVotingRights": true,
+                "lastContactMs": 30000,
+                "lastTerm": 7,
+                "lastIndex": 17500,
+                "stableSince": "2026-04-20T08:15:02Z"
+            }
+        ]
+    }
+}
+```
+
 ## Drain Node
 
-Gracefully prepares this node for removal. Signals RANs to redirect new UE registrations elsewhere, withdraws BGP advertisements so upstream routers reroute user‑plane traffic, and transfers Raft leadership if this node is the leader. The node continues serving existing flows until it is shut down. Requires admin privileges.
+Gracefully prepares this node for removal. Signals RANs to redirect new UE registrations elsewhere, withdraws BGP advertisements so upstream routers reroute user‑plane traffic, and — in HA mode only — transfers Raft leadership when this node is the leader. The node continues serving existing flows until it is shut down. Requires admin privileges.
+
+In **single‑node mode** the Raft step is a no‑op (no peer to receive leadership); the RAN and BGP steps still run, which makes drain useful as a pre‑shutdown hook.
+
+Unlike other mutating cluster endpoints, this request is **not** proxied to the leader — it acts on per‑node runtime state (local BGP, local RANs, local Raft participation). You must send it to the specific node you want to drain.
 
 | Method | Path                     |
 | ------ | ------------------------ |

--- a/docs/reference/api/status.md
+++ b/docs/reference/api/status.md
@@ -20,6 +20,27 @@ None
 
 When clustering is enabled, the response includes an `X-Ella-Role` header with the Raft role of the responding node (`Leader`, `Follower`, or `Candidate`). Load balancers can use this header to direct write traffic to the leader.
 
+### Fields
+
+Top‑level (always present):
+
+- `version` (string): Software version.
+- `revision` (string): Git commit hash.
+- `initialized` (boolean): True once the system has at least one user.
+- `ready` (boolean): True once the node has completed full startup.
+- `schemaVersion` (integer): Shared‑database schema version this binary expects. Reported in both standalone and HA modes.
+
+The nested `cluster` object is present only when HA is enabled:
+
+- `enabled` (boolean): Always `true` inside this object.
+- `role` (string): Raft role of this node — `Leader`, `Follower`, or `Candidate`.
+- `nodeId` (integer): Raft node ID of this instance.
+- `isLeader` (boolean): Convenience — `role == "Leader"`.
+- `leaderNodeId` (integer): Raft node ID of the current leader; zero when unknown.
+- `leaderAPIAddress` (string): HTTP API URL of the current leader. Omitted when the leader is unknown.
+- `appliedIndex` (integer): Last Raft log index applied by this node.
+- `clusterId` (string): Cluster ID from the operator configuration. Omitted when not set.
+
 ### Sample Response
 
 ```json
@@ -28,7 +49,8 @@ When clustering is enabled, the response includes an `X-Ella-Role` header with t
         "version": "v1.9.1",
         "revision": "388ce92244a0b304e9f6c15e3f896acee6fe7b1a",
         "initialized": true,
-        "ready": true
+        "ready": true,
+        "schemaVersion": 9
     }
 }
 ```
@@ -42,14 +64,16 @@ When clustering is enabled, the response includes a `cluster` object:
         "revision": "388ce92244a0b304e9f6c15e3f896acee6fe7b1a",
         "initialized": true,
         "ready": true,
+        "schemaVersion": 9,
         "cluster": {
             "enabled": true,
             "role": "Leader",
             "nodeId": 1,
+            "isLeader": true,
+            "leaderNodeId": 1,
             "appliedIndex": 42,
             "clusterId": "my-cluster",
-            "schemaVersion": 9,
-            "leaderAddress": "https://10.0.0.1:5002"
+            "leaderAPIAddress": "https://10.0.0.1:5002"
         }
     }
 }

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -66,7 +66,7 @@ func waitForClusterReady(ctx context.Context, clients []*client.Client) error {
 				leaders++
 			}
 
-			if status.Cluster.LeaderAddress != "" {
+			if status.Cluster.LeaderAPIAddress != "" {
 				withLeaderAddr++
 			}
 		}
@@ -268,6 +268,71 @@ func waitForMemberSuffrage(ctx context.Context, c *client.Client, nodeID int, wa
 	}
 
 	return fmt.Errorf("node %d did not reach suffrage %q within %v", nodeID, wantSuffrage, timeout)
+}
+
+// waitForAutopilotHealthy polls GetAutopilotState on the given client until
+// the cluster reports healthy with the expected failure tolerance, and every
+// listed peer is individually healthy. Used to confirm raft-autopilot has
+// caught up after formation or leadership changes.
+func waitForAutopilotHealthy(ctx context.Context, c *client.Client, wantFailureTolerance, wantServers int) (*client.AutopilotState, error) {
+	timeout := 30 * time.Second
+	deadline := time.Now().Add(timeout)
+
+	var last *client.AutopilotState
+
+	for time.Now().Before(deadline) {
+		state, err := c.GetAutopilotState(ctx)
+		if err == nil {
+			last = state
+			if state.Healthy && state.FailureTolerance == wantFailureTolerance && len(state.Servers) == wantServers {
+				allHealthy := true
+
+				for _, s := range state.Servers {
+					if !s.Healthy {
+						allHealthy = false
+						break
+					}
+				}
+
+				if allHealthy {
+					return state, nil
+				}
+			}
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return last, fmt.Errorf("autopilot did not report healthy (failureTolerance=%d, servers=%d) within %v; last=%+v",
+		wantFailureTolerance, wantServers, timeout, last)
+}
+
+// waitForAutopilotReportsUnhealthy polls autopilot on leader until the given
+// node is reported unhealthy. Autopilot flips a peer unhealthy once
+// LastContactThreshold (10s) elapses without heartbeats.
+func waitForAutopilotReportsUnhealthy(ctx context.Context, leader *client.Client, nodeID int) (*client.AutopilotState, error) {
+	timeout := 30 * time.Second
+	deadline := time.Now().Add(timeout)
+
+	var last *client.AutopilotState
+
+	for time.Now().Before(deadline) {
+		state, err := leader.GetAutopilotState(ctx)
+		if err == nil {
+			last = state
+
+			for _, s := range state.Servers {
+				if s.NodeID == nodeID && !s.Healthy {
+					return state, nil
+				}
+			}
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return last, fmt.Errorf("autopilot did not flag node %d unhealthy within %v; last=%+v",
+		nodeID, timeout, last)
 }
 
 // dumpClusterDiagnostics logs node status and cluster members from each

--- a/integration/ha_test.go
+++ b/integration/ha_test.go
@@ -72,15 +72,15 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 			t.Fatalf("node %d has no cluster status", i+1)
 		}
 
-		if status.Cluster.LeaderAddress == "" {
+		if status.Cluster.LeaderAPIAddress == "" {
 			t.Fatalf("node %d reports empty leader address", i+1)
 		}
 
 		if leaderAddress == "" {
-			leaderAddress = status.Cluster.LeaderAddress
-		} else if status.Cluster.LeaderAddress != leaderAddress {
+			leaderAddress = status.Cluster.LeaderAPIAddress
+		} else if status.Cluster.LeaderAPIAddress != leaderAddress {
 			t.Fatalf("node %d reports leader address %q, expected %q",
-				i+1, status.Cluster.LeaderAddress, leaderAddress)
+				i+1, status.Cluster.LeaderAPIAddress, leaderAddress)
 		}
 
 		switch status.Cluster.Role {
@@ -120,7 +120,21 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 		t.Fatalf("not all nodes became ready: %v", err)
 	}
 
-	t.Log("all nodes ready, creating subscriber on leader")
+	t.Log("all nodes ready, verifying autopilot reports cluster healthy")
+
+	apState, err := waitForAutopilotHealthy(ctx, leader, 1, 3)
+	if err != nil {
+		t.Fatalf("autopilot did not report healthy: %v", err)
+	}
+
+	if apState.LeaderNodeID == 0 {
+		t.Fatalf("autopilot reports unknown leader: %+v", apState)
+	}
+
+	t.Logf("autopilot healthy: leaderNodeId=%d failureTolerance=%d voters=%v",
+		apState.LeaderNodeID, apState.FailureTolerance, apState.Voters)
+
+	t.Log("creating subscriber on leader")
 
 	err = leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139935",
@@ -366,6 +380,15 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 		t.Fatalf("not all nodes became ready: %v", err)
 	}
 
+	// Record the leader's node ID before stopping it, so we can match it in
+	// the autopilot report afterward.
+	leaderStatus, err := leader.GetStatus(ctx)
+	if err != nil || leaderStatus.Cluster == nil {
+		t.Fatalf("failed to read leader status pre-stop: %v", err)
+	}
+
+	stoppedNodeID := leaderStatus.Cluster.NodeID
+
 	// Build the survivor list (all nodes except the current leader).
 	survivors := make([]*client.Client, 0, 2)
 
@@ -376,7 +399,7 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 	}
 
 	leaderService := haNodeServices[leaderIdx]
-	t.Logf("stopping leader %s (node %d)", leaderService, leaderIdx+1)
+	t.Logf("stopping leader %s (node %d)", leaderService, stoppedNodeID)
 
 	err = dockerClient.ComposeStop(ctx, haComposeDir, leaderService)
 	if err != nil {
@@ -390,7 +413,19 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 		t.Fatalf("re-election failed: %v", err)
 	}
 
-	t.Log("new leader elected, writing subscriber via new leader")
+	t.Log("new leader elected, verifying autopilot reports stopped node unhealthy")
+
+	apAfterKill, err := waitForAutopilotReportsUnhealthy(ctx, newLeader, stoppedNodeID)
+	if err != nil {
+		t.Fatalf("autopilot did not flag stopped node unhealthy: %v", err)
+	}
+
+	if apAfterKill.FailureTolerance != 0 {
+		t.Fatalf("expected failureTolerance=0 after losing one voter, got %d (state=%+v)",
+			apAfterKill.FailureTolerance, apAfterKill)
+	}
+
+	t.Log("autopilot reflects the outage; writing subscriber via new leader")
 
 	err = newLeader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139937",
@@ -464,7 +499,15 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 		t.Fatalf("restarted node returned IMSI %q, expected %q", sub.Imsi, "001019756139937")
 	}
 
-	t.Log("restarted node returned subscriber correctly, leader failure test passed")
+	t.Log("restarted node returned subscriber correctly; verifying autopilot recovered")
+
+	apRecovered, err := waitForAutopilotHealthy(ctx, newLeader, 1, 3)
+	if err != nil {
+		t.Fatalf("autopilot did not recover after node restart: %v", err)
+	}
+
+	t.Logf("autopilot recovered: failureTolerance=%d voters=%v",
+		apRecovered.FailureTolerance, apRecovered.Voters)
 }
 
 func TestIntegrationHADrainLeadership(t *testing.T) {

--- a/internal/api/server/api_autopilot.go
+++ b/internal/api/server/api_autopilot.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/hashicorp/raft"
+	autopilot "github.com/hashicorp/raft-autopilot"
+)
+
+// AutopilotServerResponse is the per-peer live state on the wire. It is
+// mapped from autopilot.ServerState so the library struct never leaks
+// into the public API.
+type AutopilotServerResponse struct {
+	NodeID          int    `json:"nodeId"`
+	RaftAddress     string `json:"raftAddress"`
+	NodeStatus      string `json:"nodeStatus"`
+	Healthy         bool   `json:"healthy"`
+	IsLeader        bool   `json:"isLeader"`
+	HasVotingRights bool   `json:"hasVotingRights"`
+	LastContactMs   int64  `json:"lastContactMs"`
+	LastTerm        uint64 `json:"lastTerm"`
+	LastIndex       uint64 `json:"lastIndex"`
+	StableSince     string `json:"stableSince,omitempty"`
+}
+
+// AutopilotStateResponse is the cluster-wide live state on the wire.
+type AutopilotStateResponse struct {
+	Healthy          bool                      `json:"healthy"`
+	FailureTolerance int                       `json:"failureTolerance"`
+	LeaderNodeID     int                       `json:"leaderNodeId"`
+	Voters           []int                     `json:"voters"`
+	Servers          []AutopilotServerResponse `json:"servers"`
+}
+
+// GetAutopilotState serves the live autopilot state. Autopilot only runs
+// on the leader, so followers proxy the request via LeaderProxyMiddleware.
+// On the leader, an empty response is served during the cold-start window
+// immediately after leadership acquisition, before the first autopilot
+// tick has published a state.
+func GetAutopilotState(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		state := dbInstance.AutopilotState()
+		resp := mapAutopilotState(state)
+		writeResponse(r.Context(), w, resp, http.StatusOK, logger.APILog)
+	})
+}
+
+func mapAutopilotState(state *autopilot.State) AutopilotStateResponse {
+	if state == nil {
+		return AutopilotStateResponse{
+			Voters:  []int{},
+			Servers: []AutopilotServerResponse{},
+		}
+	}
+
+	voters := make([]int, 0, len(state.Voters))
+
+	for _, id := range state.Voters {
+		if n, err := parseRaftServerID(id); err == nil {
+			voters = append(voters, n)
+		}
+	}
+
+	sort.Ints(voters)
+
+	leaderID, _ := parseRaftServerID(state.Leader)
+
+	servers := make([]AutopilotServerResponse, 0, len(state.Servers))
+	for id, srv := range state.Servers {
+		nodeID, err := parseRaftServerID(id)
+		if err != nil {
+			continue
+		}
+
+		item := AutopilotServerResponse{
+			NodeID:          nodeID,
+			RaftAddress:     string(srv.Server.Address),
+			NodeStatus:      string(srv.Server.NodeStatus),
+			Healthy:         srv.Health.Healthy,
+			IsLeader:        srv.Server.IsLeader,
+			HasVotingRights: srv.HasVotingRights(),
+			LastContactMs:   srv.Stats.LastContact.Milliseconds(),
+			LastTerm:        srv.Stats.LastTerm,
+			LastIndex:       srv.Stats.LastIndex,
+		}
+
+		if !srv.Health.StableSince.IsZero() {
+			item.StableSince = srv.Health.StableSince.UTC().Format(time.RFC3339)
+		}
+
+		servers = append(servers, item)
+	}
+
+	sort.Slice(servers, func(i, j int) bool {
+		return servers[i].NodeID < servers[j].NodeID
+	})
+
+	return AutopilotStateResponse{
+		Healthy:          state.Healthy,
+		FailureTolerance: state.FailureTolerance,
+		LeaderNodeID:     leaderID,
+		Voters:           voters,
+		Servers:          servers,
+	}
+}
+
+func parseRaftServerID(id raft.ServerID) (int, error) {
+	return strconv.Atoi(string(id))
+}

--- a/internal/api/server/api_autopilot_http_test.go
+++ b/internal/api/server/api_autopilot_http_test.go
@@ -1,0 +1,136 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+)
+
+type autopilotServerItem struct {
+	NodeID          int    `json:"nodeId"`
+	RaftAddress     string `json:"raftAddress"`
+	NodeStatus      string `json:"nodeStatus"`
+	Healthy         bool   `json:"healthy"`
+	IsLeader        bool   `json:"isLeader"`
+	HasVotingRights bool   `json:"hasVotingRights"`
+	LastContactMs   int64  `json:"lastContactMs"`
+	LastTerm        uint64 `json:"lastTerm"`
+	LastIndex       uint64 `json:"lastIndex"`
+	StableSince     string `json:"stableSince,omitempty"`
+}
+
+type autopilotStateResult struct {
+	Healthy          bool                  `json:"healthy"`
+	FailureTolerance int                   `json:"failureTolerance"`
+	LeaderNodeID     int                   `json:"leaderNodeId"`
+	Voters           []int                 `json:"voters"`
+	Servers          []autopilotServerItem `json:"servers"`
+}
+
+type autopilotStateResponse struct {
+	Error  string               `json:"error,omitempty"`
+	Result autopilotStateResult `json:"result"`
+}
+
+func getAutopilotState(url string, client *http.Client, token string) (int, *autopilotStateResponse, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url+"/api/v1/cluster/autopilot", nil)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	defer func() { _ = res.Body.Close() }()
+
+	var body autopilotStateResponse
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return 0, nil, err
+	}
+
+	return res.StatusCode, &body, nil
+}
+
+// TestGetAutopilotState_NoCluster verifies that on a node where HA is not
+// enabled (the test harness default), the endpoint still responds 200 with
+// an empty envelope. Autopilot only runs on the leader of a real cluster;
+// returning an empty state here keeps the UI contract consistent.
+func TestGetAutopilotState_NoCluster(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	status, body, err := getAutopilotState(env.Server.URL, client, token)
+	if err != nil {
+		t.Fatalf("couldn't get autopilot state: %s", err)
+	}
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %+v", status, body)
+	}
+
+	if body.Result.Healthy {
+		t.Errorf("expected healthy=false without a running cluster")
+	}
+
+	if body.Result.FailureTolerance != 0 {
+		t.Errorf("expected failureTolerance=0, got %d", body.Result.FailureTolerance)
+	}
+
+	if body.Result.LeaderNodeID != 0 {
+		t.Errorf("expected leaderNodeId=0, got %d", body.Result.LeaderNodeID)
+	}
+
+	// Slices must be present (not nil) so the UI can iterate without guards.
+	if body.Result.Voters == nil {
+		t.Errorf("expected non-nil voters array")
+	}
+
+	if body.Result.Servers == nil {
+		t.Errorf("expected non-nil servers array")
+	}
+}
+
+func TestGetAutopilotState_Unauthorized(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	if _, err := initializeAndRefresh(env.Server.URL, client); err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	status, _, err := getAutopilotState(env.Server.URL, client, "")
+	if err != nil {
+		t.Fatalf("request failed: %s", err)
+	}
+
+	if status != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", status)
+	}
+}

--- a/internal/api/server/api_autopilot_test.go
+++ b/internal/api/server/api_autopilot_test.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	autopilot "github.com/hashicorp/raft-autopilot"
+)
+
+// NOTE: End-to-end HTTP tests of the /api/v1/cluster/autopilot route
+// live in api_autopilot_http_test.go (black-box server_test package)
+// where the test harness is available.
+
+func TestMapAutopilotState_Nil(t *testing.T) {
+	resp := mapAutopilotState(nil)
+
+	if resp.Healthy {
+		t.Errorf("expected Healthy=false for nil state, got true")
+	}
+
+	if resp.FailureTolerance != 0 {
+		t.Errorf("expected FailureTolerance=0, got %d", resp.FailureTolerance)
+	}
+
+	if resp.LeaderNodeID != 0 {
+		t.Errorf("expected LeaderNodeID=0, got %d", resp.LeaderNodeID)
+	}
+
+	if resp.Voters == nil {
+		t.Errorf("expected non-nil empty Voters slice for stable JSON marshaling")
+	}
+
+	if resp.Servers == nil {
+		t.Errorf("expected non-nil empty Servers slice for stable JSON marshaling")
+	}
+
+	// JSON must encode empty slices as [], not null — the UI relies on this.
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := string(b)
+
+	for _, substr := range []string{`"voters":[]`, `"servers":[]`} {
+		if !contains(got, substr) {
+			t.Errorf("expected JSON to contain %s, got %s", substr, got)
+		}
+	}
+}
+
+func TestMapAutopilotState_Populated(t *testing.T) {
+	stable := time.Date(2026, 4, 20, 8, 15, 2, 0, time.UTC)
+
+	state := &autopilot.State{
+		Healthy:          true,
+		FailureTolerance: 1,
+		Leader:           raft.ServerID("1"),
+		Voters:           []raft.ServerID{"3", "1", "2"},
+		Servers: map[raft.ServerID]*autopilot.ServerState{
+			"2": {
+				Server: autopilot.Server{
+					ID:         raft.ServerID("2"),
+					Address:    raft.ServerAddress("10.0.0.2:7000"),
+					NodeStatus: autopilot.NodeAlive,
+					IsLeader:   false,
+				},
+				State:  autopilot.RaftVoter,
+				Stats:  autopilot.ServerStats{LastContact: 12 * time.Millisecond, LastTerm: 7, LastIndex: 18233},
+				Health: autopilot.ServerHealth{Healthy: true, StableSince: stable},
+			},
+			"1": {
+				Server: autopilot.Server{
+					ID:         raft.ServerID("1"),
+					Address:    raft.ServerAddress("10.0.0.1:7000"),
+					NodeStatus: autopilot.NodeAlive,
+					IsLeader:   true,
+				},
+				State:  autopilot.RaftLeader,
+				Stats:  autopilot.ServerStats{LastContact: 0, LastTerm: 7, LastIndex: 18234},
+				Health: autopilot.ServerHealth{Healthy: true, StableSince: stable},
+			},
+			"3": {
+				Server: autopilot.Server{
+					ID:         raft.ServerID("3"),
+					Address:    raft.ServerAddress("10.0.0.3:7000"),
+					NodeStatus: autopilot.NodeLeft,
+					IsLeader:   false,
+				},
+				State:  autopilot.RaftVoter,
+				Stats:  autopilot.ServerStats{LastContact: 30 * time.Second, LastTerm: 7, LastIndex: 17500},
+				Health: autopilot.ServerHealth{Healthy: false, StableSince: stable},
+			},
+		},
+	}
+
+	resp := mapAutopilotState(state)
+
+	if !resp.Healthy {
+		t.Errorf("expected Healthy=true")
+	}
+
+	if resp.FailureTolerance != 1 {
+		t.Errorf("expected FailureTolerance=1, got %d", resp.FailureTolerance)
+	}
+
+	if resp.LeaderNodeID != 1 {
+		t.Errorf("expected LeaderNodeID=1, got %d", resp.LeaderNodeID)
+	}
+
+	// Voters must be sorted and integer-decoded.
+	if got := resp.Voters; !intSliceEqual(got, []int{1, 2, 3}) {
+		t.Errorf("expected Voters=[1 2 3], got %v", got)
+	}
+
+	// Servers must be sorted by nodeId.
+	if len(resp.Servers) != 3 {
+		t.Fatalf("expected 3 servers, got %d", len(resp.Servers))
+	}
+
+	for i, want := range []int{1, 2, 3} {
+		if resp.Servers[i].NodeID != want {
+			t.Errorf("server[%d]: expected NodeID=%d, got %d", i, want, resp.Servers[i].NodeID)
+		}
+	}
+
+	leader := resp.Servers[0]
+	if !leader.IsLeader || !leader.Healthy || !leader.HasVotingRights {
+		t.Errorf("leader row should be leader+healthy+voting, got %+v", leader)
+	}
+
+	if leader.LastContactMs != 0 {
+		t.Errorf("expected leader LastContactMs=0, got %d", leader.LastContactMs)
+	}
+
+	departed := resp.Servers[2]
+	if departed.Healthy {
+		t.Errorf("expected node 3 unhealthy")
+	}
+
+	if departed.NodeStatus != string(autopilot.NodeLeft) {
+		t.Errorf("expected node 3 nodeStatus=%q, got %q", autopilot.NodeLeft, departed.NodeStatus)
+	}
+
+	if departed.LastContactMs != 30_000 {
+		t.Errorf("expected node 3 LastContactMs=30000, got %d", departed.LastContactMs)
+	}
+
+	if leader.StableSince != "2026-04-20T08:15:02Z" {
+		t.Errorf("expected stableSince RFC3339 UTC, got %q", leader.StableSince)
+	}
+}
+
+func TestMapAutopilotState_SkipsMalformedIDs(t *testing.T) {
+	state := &autopilot.State{
+		Leader: raft.ServerID("not-a-number"),
+		Voters: []raft.ServerID{"1", "not-a-number", "2"},
+		Servers: map[raft.ServerID]*autopilot.ServerState{
+			"not-a-number": {
+				Server: autopilot.Server{ID: raft.ServerID("not-a-number")},
+			},
+			"1": {
+				Server: autopilot.Server{ID: raft.ServerID("1"), IsLeader: true},
+			},
+		},
+	}
+
+	resp := mapAutopilotState(state)
+
+	if resp.LeaderNodeID != 0 {
+		t.Errorf("expected LeaderNodeID=0 for malformed id, got %d", resp.LeaderNodeID)
+	}
+
+	if !intSliceEqual(resp.Voters, []int{1, 2}) {
+		t.Errorf("expected malformed voter dropped, got %v", resp.Voters)
+	}
+
+	if len(resp.Servers) != 1 || resp.Servers[0].NodeID != 1 {
+		t.Errorf("expected single server row for node 1, got %+v", resp.Servers)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+
+	return false
+}
+
+func intSliceEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/api/server/api_cluster.go
+++ b/internal/api/server/api_cluster.go
@@ -37,6 +37,44 @@ type AddClusterMemberRequest struct {
 	Suffrage         string `json:"suffrage,omitempty"`
 }
 
+func GetClusterMember(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nodeIDStr := r.PathValue("id")
+
+		nodeID, err := strconv.Atoi(nodeIDStr)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "Invalid node ID", err, logger.APILog)
+			return
+		}
+
+		member, err := dbInstance.GetClusterMember(r.Context(), nodeID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				writeError(r.Context(), w, http.StatusNotFound, "Cluster member not found", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to look up cluster member", err, logger.APILog)
+
+			return
+		}
+
+		leaderAddr := dbInstance.LeaderAddress()
+
+		resp := ClusterMemberResponse{
+			NodeID:           member.NodeID,
+			RaftAddress:      member.RaftAddress,
+			APIAddress:       member.APIAddress,
+			BinaryVersion:    member.BinaryVersion,
+			Suffrage:         member.Suffrage,
+			MaxSchemaVersion: member.MaxSchemaVersion,
+			IsLeader:         leaderAddr != "" && member.RaftAddress == leaderAddr,
+		}
+
+		writeResponse(r.Context(), w, resp, http.StatusOK, logger.APILog)
+	})
+}
+
 func ListClusterMembers(dbInstance *db.Database) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		members, err := dbInstance.ListClusterMembers(r.Context())
@@ -84,6 +122,18 @@ func AddClusterMember(dbInstance *db.Database) http.Handler {
 
 		if req.APIAddress == "" {
 			writeError(r.Context(), w, http.StatusBadRequest, "apiAddress is required", nil, logger.APILog)
+			return
+		}
+
+		// Zero means "not provided" by convention; negative is always a
+		// client bug and must not pass through silently.
+		if req.SchemaVersion < 0 {
+			writeError(r.Context(), w, http.StatusBadRequest, "schemaVersion must be non-negative", nil, logger.APILog)
+			return
+		}
+
+		if req.MaxSchemaVersion < 0 {
+			writeError(r.Context(), w, http.StatusBadRequest, "maxSchemaVersion must be non-negative", nil, logger.APILog)
 			return
 		}
 

--- a/internal/api/server/api_cluster.go
+++ b/internal/api/server/api_cluster.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -23,6 +24,7 @@ type ClusterMemberResponse struct {
 	BinaryVersion    string `json:"binaryVersion"`
 	Suffrage         string `json:"suffrage"`
 	MaxSchemaVersion int    `json:"maxSchemaVersion"`
+	IsLeader         bool   `json:"isLeader"`
 }
 
 type AddClusterMemberRequest struct {
@@ -43,6 +45,8 @@ func ListClusterMembers(dbInstance *db.Database) http.Handler {
 			return
 		}
 
+		leaderAddr := dbInstance.LeaderAddress()
+
 		result := make([]ClusterMemberResponse, 0, len(members))
 		for _, m := range members {
 			result = append(result, ClusterMemberResponse{
@@ -52,6 +56,7 @@ func ListClusterMembers(dbInstance *db.Database) http.Handler {
 				BinaryVersion:    m.BinaryVersion,
 				Suffrage:         m.Suffrage,
 				MaxSchemaVersion: m.MaxSchemaVersion,
+				IsLeader:         leaderAddr != "" && m.RaftAddress == leaderAddr,
 			})
 		}
 
@@ -174,6 +179,29 @@ func RemoveClusterMember(dbInstance *db.Database) http.Handler {
 			return
 		}
 
+		member, err := dbInstance.GetClusterMember(r.Context(), nodeID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				writeError(r.Context(), w, http.StatusNotFound, "Cluster member not found", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to look up cluster member", err, logger.APILog)
+
+			return
+		}
+
+		// Refuse to remove the current leader. The operator must drain and
+		// transfer leadership first; otherwise we disrupt writes and risk
+		// proxied callers losing the session mid-remove.
+		if leaderAddr := dbInstance.LeaderAddress(); leaderAddr != "" && member.RaftAddress == leaderAddr {
+			writeError(r.Context(), w, http.StatusConflict,
+				"Cannot remove the current leader; drain this node first so leadership transfers, then retry",
+				nil, logger.APILog)
+
+			return
+		}
+
 		if err := dbInstance.RemoveServer(nodeID); err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to remove server from Raft cluster", err, logger.APILog)
 			return
@@ -184,12 +212,12 @@ func RemoveClusterMember(dbInstance *db.Database) http.Handler {
 			return
 		}
 
-		email := getEmailFromContext(r)
+		actor := getActorFromContext(r)
 
 		logger.LogAuditEvent(
 			r.Context(),
 			ClusterMemberRemoveAction,
-			email,
+			actor,
 			getClientIP(r),
 			fmt.Sprintf("Removed cluster member node %d", nodeID),
 		)
@@ -233,12 +261,12 @@ func PromoteClusterMember(dbInstance *db.Database) http.Handler {
 			return
 		}
 
-		email := getEmailFromContext(r)
+		actor := getActorFromContext(r)
 
 		logger.LogAuditEvent(
 			r.Context(),
 			ClusterMemberPromoteAction,
-			email,
+			actor,
 			getClientIP(r),
 			fmt.Sprintf("Promoted cluster member node %d to voter", nodeID),
 		)

--- a/internal/api/server/api_cluster_test.go
+++ b/internal/api/server/api_cluster_test.go
@@ -3,16 +3,45 @@ package server_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ellanetworks/core/internal/db"
 )
+
+func removeClusterMember(url string, client *http.Client, token string, nodeID int) (int, string, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "DELETE",
+		fmt.Sprintf("%s/api/v1/cluster/members/%d", url, nodeID), nil)
+	if err != nil {
+		return 0, "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+
+	defer func() { _ = res.Body.Close() }()
+
+	var body struct {
+		Error string `json:"error,omitempty"`
+	}
+
+	_ = json.NewDecoder(res.Body).Decode(&body)
+
+	return res.StatusCode, body.Error, nil
+}
 
 type ClusterMemberResponseItem struct {
 	NodeID      int    `json:"nodeId"`
 	RaftAddress string `json:"raftAddress"`
 	APIAddress  string `json:"apiAddress"`
+	IsLeader    bool   `json:"isLeader"`
 }
 
 type ListClusterMembersResponse struct {
@@ -104,6 +133,144 @@ func TestClusterMembersEndToEnd(t *testing.T) {
 			t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
 		}
 	})
+}
+
+func TestListClusterMembers_IncludesHAFields(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	member := &db.ClusterMember{
+		NodeID:           7,
+		RaftAddress:      "10.0.0.7:7000",
+		APIAddress:       "10.0.0.7:8443",
+		BinaryVersion:    "v1.2.3",
+		Suffrage:         "voter",
+		MaxSchemaVersion: 1,
+	}
+
+	if err := env.DB.UpsertClusterMember(context.Background(), member); err != nil {
+		t.Fatalf("couldn't upsert cluster member: %s", err)
+	}
+
+	statusCode, response, err := listClusterMembers(env.Server.URL, client, token)
+	if err != nil {
+		t.Fatalf("couldn't list cluster members: %s", err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, statusCode)
+	}
+
+	if len(response.Result) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(response.Result))
+	}
+
+	m := response.Result[0]
+	if m.NodeID != 7 {
+		t.Fatalf("expected nodeId 7, got %d", m.NodeID)
+	}
+
+	// Test server runs without a Raft cluster, so no leader is known.
+	if m.IsLeader {
+		t.Fatalf("expected isLeader=false with no cluster, got true")
+	}
+}
+
+func TestRemoveClusterMember_NotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	status, msg, err := removeClusterMember(env.Server.URL, client, token, 99)
+	if err != nil {
+		t.Fatalf("request failed: %s", err)
+	}
+
+	if status != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown nodeId, got %d (body: %s)", status, msg)
+	}
+
+	if !strings.Contains(strings.ToLower(msg), "not found") {
+		t.Errorf("expected body to mention not found, got %q", msg)
+	}
+}
+
+// TestRemoveClusterMember_RefusesLeader verifies the server rejects a
+// remove call targeting the current leader with 409. In standalone mode
+// (the test harness default) the single node is itself the leader, so
+// this double-checks the guard against the most common footgun: an
+// operator calling remove against node 1 before draining.
+func TestRemoveClusterMember_RefusesLeader(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	leaderAddr := env.DB.LeaderAddress()
+	if leaderAddr == "" {
+		t.Fatal("test harness did not elect a leader")
+	}
+
+	member := &db.ClusterMember{
+		NodeID:        env.DB.NodeID(),
+		RaftAddress:   leaderAddr,
+		APIAddress:    "http://127.0.0.1:0",
+		BinaryVersion: "test",
+		Suffrage:      "voter",
+	}
+
+	if err := env.DB.UpsertClusterMember(context.Background(), member); err != nil {
+		t.Fatalf("upsert cluster member: %s", err)
+	}
+
+	status, msg, err := removeClusterMember(env.Server.URL, client, token, member.NodeID)
+	if err != nil {
+		t.Fatalf("request failed: %s", err)
+	}
+
+	if status != http.StatusConflict {
+		t.Fatalf("expected 409 when removing leader, got %d (body: %s)", status, msg)
+	}
+
+	if !strings.Contains(strings.ToLower(msg), "leader") {
+		t.Errorf("expected body to mention leader, got %q", msg)
+	}
 }
 
 func TestClusterStatusIncluded(t *testing.T) {

--- a/internal/api/server/api_cluster_test.go
+++ b/internal/api/server/api_cluster_test.go
@@ -133,6 +133,32 @@ func TestClusterMembersEndToEnd(t *testing.T) {
 			t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
 		}
 	})
+
+	t.Run("3. Negative schemaVersion is rejected", func(t *testing.T) {
+		body := `{"nodeId": 5, "raftAddress": "10.0.0.5:7000", "apiAddress": "https://10.0.0.5:5000", "schemaVersion": -1}`
+
+		statusCode, err := addClusterMember(env.Server.URL, client, token, body)
+		if err != nil {
+			t.Fatalf("request failed: %s", err)
+		}
+
+		if statusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 for negative schemaVersion, got %d", statusCode)
+		}
+	})
+
+	t.Run("4. Negative maxSchemaVersion is rejected", func(t *testing.T) {
+		body := `{"nodeId": 5, "raftAddress": "10.0.0.5:7000", "apiAddress": "https://10.0.0.5:5000", "maxSchemaVersion": -1}`
+
+		statusCode, err := addClusterMember(env.Server.URL, client, token, body)
+		if err != nil {
+			t.Fatalf("request failed: %s", err)
+		}
+
+		if statusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 for negative maxSchemaVersion, got %d", statusCode)
+		}
+	})
 }
 
 func TestListClusterMembers_IncludesHAFields(t *testing.T) {
@@ -187,6 +213,111 @@ func TestListClusterMembers_IncludesHAFields(t *testing.T) {
 	if m.IsLeader {
 		t.Fatalf("expected isLeader=false with no cluster, got true")
 	}
+}
+
+func getClusterMember(url string, client *http.Client, token string, nodeID int) (int, *ClusterMemberResponseItem, string, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "GET",
+		fmt.Sprintf("%s/api/v1/cluster/members/%d", url, nodeID), nil)
+	if err != nil {
+		return 0, nil, "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, "", err
+	}
+
+	defer func() { _ = res.Body.Close() }()
+
+	var body struct {
+		Error  string                     `json:"error,omitempty"`
+		Result *ClusterMemberResponseItem `json:"result,omitempty"`
+	}
+
+	_ = json.NewDecoder(res.Body).Decode(&body)
+
+	return res.StatusCode, body.Result, body.Error, nil
+}
+
+func TestGetClusterMember(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		status, _, msg, err := getClusterMember(env.Server.URL, client, token, 99)
+		if err != nil {
+			t.Fatalf("request failed: %s", err)
+		}
+
+		if status != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d (body: %s)", status, msg)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		req, _ := http.NewRequestWithContext(context.Background(), "GET",
+			env.Server.URL+"/api/v1/cluster/members/not-a-number", nil)
+
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		res, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %s", err)
+		}
+
+		defer func() { _ = res.Body.Close() }()
+
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", res.StatusCode)
+		}
+	})
+
+	t.Run("returns member", func(t *testing.T) {
+		member := &db.ClusterMember{
+			NodeID:           7,
+			RaftAddress:      "10.0.0.7:7000",
+			APIAddress:       "https://10.0.0.7:5000",
+			BinaryVersion:    "v1.2.3",
+			Suffrage:         "nonvoter",
+			MaxSchemaVersion: 9,
+		}
+
+		if err := env.DB.UpsertClusterMember(context.Background(), member); err != nil {
+			t.Fatalf("upsert: %s", err)
+		}
+
+		status, result, msg, err := getClusterMember(env.Server.URL, client, token, 7)
+		if err != nil {
+			t.Fatalf("request failed: %s", err)
+		}
+
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d (body: %s)", status, msg)
+		}
+
+		if result == nil || result.NodeID != 7 || result.RaftAddress != "10.0.0.7:7000" {
+			t.Fatalf("unexpected result: %+v", result)
+		}
+
+		if result.IsLeader {
+			t.Errorf("expected isLeader=false for member 7 (leader is node 1)")
+		}
+	})
 }
 
 func TestRemoveClusterMember_NotFound(t *testing.T) {

--- a/internal/api/server/api_drain.go
+++ b/internal/api/server/api_drain.go
@@ -33,8 +33,16 @@ type DrainResponse struct {
 // DrainNode gracefully prepares this node for removal: it signals RANs to
 // redirect new UE registrations elsewhere via AMF Status Indication,
 // withdraws BGP advertisements so upstream routers reroute user plane
-// traffic, and transfers Raft leadership if this node is the leader.
-// The node continues serving existing flows until it is shut down.
+// traffic, and — in HA mode only — transfers Raft leadership when this
+// node is the leader. In single-node mode there is nothing to transfer
+// leadership to, so the Raft step is a no-op; the RAN and BGP steps
+// still run because drain is also useful as a pre-shutdown hook in
+// standalone.
+//
+// Drain acts on per-node runtime state (local BGP, local RANs, local Raft
+// participation), so the request must be served by the target node and
+// must NOT be forwarded to the leader. LeaderProxyMiddleware's
+// localOnlyWritePaths list enforces this.
 func DrainNode(dbInstance *db.Database, amfInstance *amf.AMF, bgpService *bgp.BGPService) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req DrainRequest
@@ -54,13 +62,8 @@ func DrainNode(dbInstance *db.Database, amfInstance *amf.AMF, bgpService *bgp.BG
 
 		if dbInstance.IsLeader() && dbInstance.ClusterEnabled() {
 			if err := dbInstance.LeadershipTransfer(); err != nil {
-				logger.APILog.Warn("Leadership transfer failed during drain", zap.Error(err))
-				writeResponse(r.Context(), w, DrainResponse{
-					Message:               "drain aborted: leadership transfer failed",
-					TransferredLeadership: false,
-					RANsNotified:          0,
-					BGPStopped:            false,
-				}, http.StatusInternalServerError, logger.APILog)
+				writeError(r.Context(), w, http.StatusInternalServerError,
+					"drain aborted: leadership transfer failed", err, logger.APILog)
 
 				return
 			}
@@ -80,12 +83,12 @@ func DrainNode(dbInstance *db.Database, amfInstance *amf.AMF, bgpService *bgp.BG
 			}
 		}
 
-		email := getEmailFromContext(r)
+		actor := getActorFromContext(r)
 
 		logger.LogAuditEvent(
 			r.Context(),
 			DrainAction,
-			email,
+			actor,
 			getClientIP(r),
 			fmt.Sprintf("Node %d draining, leadership_transferred=%v, rans_notified=%d, bgp_stopped=%v",
 				dbInstance.NodeID(), transferred, ransNotified, bgpStopped),

--- a/internal/api/server/api_status.go
+++ b/internal/api/server/api_status.go
@@ -10,21 +10,23 @@ import (
 )
 
 type ClusterStatusResponse struct {
-	Enabled       bool   `json:"enabled"`
-	Role          string `json:"role"`
-	NodeID        int    `json:"nodeId"`
-	AppliedIndex  uint64 `json:"appliedIndex"`
-	ClusterID     string `json:"clusterId,omitempty"`
-	SchemaVersion int    `json:"schemaVersion"`
-	LeaderAddress string `json:"leaderAddress,omitempty"`
+	Enabled          bool   `json:"enabled"`
+	Role             string `json:"role"`
+	NodeID           int    `json:"nodeId"`
+	IsLeader         bool   `json:"isLeader"`
+	LeaderNodeID     int    `json:"leaderNodeId"`
+	AppliedIndex     uint64 `json:"appliedIndex"`
+	ClusterID        string `json:"clusterId,omitempty"`
+	LeaderAPIAddress string `json:"leaderAPIAddress,omitempty"`
 }
 
 type StatusResponse struct {
-	Version     string                 `json:"version"`
-	Revision    string                 `json:"revision"`
-	Initialized bool                   `json:"initialized"`
-	Ready       bool                   `json:"ready"`
-	Cluster     *ClusterStatusResponse `json:"cluster,omitempty"`
+	Version       string                 `json:"version"`
+	Revision      string                 `json:"revision"`
+	Initialized   bool                   `json:"initialized"`
+	Ready         bool                   `json:"ready"`
+	SchemaVersion int                    `json:"schemaVersion"`
+	Cluster       *ClusterStatusResponse `json:"cluster,omitempty"`
 }
 
 func GetStatus(dbInstance *db.Database, ready *atomic.Bool) http.Handler {
@@ -42,20 +44,21 @@ func GetStatus(dbInstance *db.Database, ready *atomic.Bool) http.Handler {
 		ver := version.GetVersion()
 
 		statusResponse := StatusResponse{
-			Version:     ver.Version,
-			Revision:    ver.Revision,
-			Initialized: initialized,
-			Ready:       ready.Load(),
+			Version:       ver.Version,
+			Revision:      ver.Revision,
+			Initialized:   initialized,
+			Ready:         ready.Load(),
+			SchemaVersion: db.SchemaVersion(),
 		}
 
 		if dbInstance.ClusterEnabled() {
 			role := dbInstance.RaftState()
 			clusterStatus := &ClusterStatusResponse{
-				Enabled:       true,
-				Role:          role,
-				NodeID:        dbInstance.NodeID(),
-				AppliedIndex:  dbInstance.RaftAppliedIndex(),
-				SchemaVersion: db.SchemaVersion(),
+				Enabled:      true,
+				Role:         role,
+				NodeID:       dbInstance.NodeID(),
+				IsLeader:     dbInstance.IsLeader(),
+				AppliedIndex: dbInstance.RaftAppliedIndex(),
 			}
 
 			op, err := dbInstance.GetOperator(ctx)
@@ -63,8 +66,8 @@ func GetStatus(dbInstance *db.Database, ready *atomic.Bool) http.Handler {
 				clusterStatus.ClusterID = op.ClusterID
 			}
 
+			clusterStatus.LeaderAPIAddress, clusterStatus.LeaderNodeID = resolveLeader(dbInstance)
 			statusResponse.Cluster = clusterStatus
-			clusterStatus.LeaderAddress = resolveLeaderAPI(dbInstance)
 
 			w.Header().Set("X-Ella-Role", role)
 		}

--- a/internal/api/server/api_status_test.go
+++ b/internal/api/server/api_status_test.go
@@ -8,8 +8,19 @@ import (
 	"testing"
 )
 
+type ClusterStatusBody struct {
+	Enabled          bool   `json:"enabled"`
+	Role             string `json:"role"`
+	NodeID           int    `json:"nodeId"`
+	IsLeader         bool   `json:"isLeader"`
+	LeaderNodeID     int    `json:"leaderNodeId"`
+	LeaderAPIAddress string `json:"leaderAPIAddress,omitempty"`
+}
+
 type GetStatusResponseResult struct {
-	Version string `json:"version"`
+	Version       string             `json:"version"`
+	SchemaVersion int                `json:"schemaVersion"`
+	Cluster       *ClusterStatusBody `json:"cluster,omitempty"`
 }
 
 type GetStatusResponse struct {
@@ -69,6 +80,17 @@ func TestStatusEndToEnd(t *testing.T) {
 
 		if response.Result.Version == "" {
 			t.Fatalf("expected version to be non-empty")
+		}
+
+		// schemaVersion is per-binary and must be reported at the top
+		// level regardless of whether HA is enabled.
+		if response.Result.SchemaVersion <= 0 {
+			t.Fatalf("expected positive schemaVersion, got %d", response.Result.SchemaVersion)
+		}
+
+		// Test server runs without Raft, so the cluster sub-object is omitted.
+		if response.Result.Cluster != nil {
+			t.Fatalf("expected cluster to be nil with clustering disabled, got %+v", response.Result.Cluster)
 		}
 	})
 }

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -2743,6 +2743,34 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
 
+  /api/v1/cluster/autopilot:
+    get:
+      operationId: getAutopilotState
+      tags: [Cluster]
+      summary: Get the current autopilot state
+      description: >-
+        Returns the live autopilot view of the cluster: per-peer health and
+        replication lag, voter/nonvoter roster, and cluster-wide
+        `failureTolerance`. Autopilot runs only on the leader, so requests
+        on a follower are proxied to the leader over the cluster port.
+        Immediately after a leadership change, the leader may return an
+        empty state for a short window (typically under one second) until
+        its first autopilot tick publishes a state. Requires admin
+        privileges.
+      responses:
+        "200":
+          description: Autopilot state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutopilotStateResponseEnvelope"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "502":
+          description: Proxy to leader failed; try again.
+        "503":
+          description: No leader is currently available; try again.
+
   /api/v1/cluster/drain:
     post:
       operationId: drainNode
@@ -2751,9 +2779,17 @@ paths:
       description: >-
         Gracefully prepares this node for removal. Signals RANs to redirect new
         UE registrations elsewhere, withdraws BGP advertisements so upstream
-        routers reroute user-plane traffic, and transfers Raft leadership if this
-        node is the leader. The node continues serving existing flows until it is
+        routers reroute user-plane traffic, and — in HA mode only — transfers
+        Raft leadership when this node is the leader. In single-node mode the
+        Raft step is a no-op (no peer to receive leadership); the RAN and BGP
+        steps still run, which makes drain useful as a pre-shutdown hook even
+        in standalone. The node continues serving existing flows until it is
         shut down. Requires admin privileges.
+
+        Unlike other mutating cluster endpoints, this request is **not**
+        proxied to the leader — it acts on per-node runtime state (local
+        BGP, local RANs, local Raft participation). The caller must send
+        the request to the specific node they wish to drain.
       requestBody:
         required: false
         content:
@@ -2961,9 +2997,14 @@ components:
         ready:
           type: boolean
           description: True if the node has completed full startup and can serve the complete API.
+        schemaVersion:
+          type: integer
+          description: >-
+            Shared-database schema version this node's binary expects.
+            Reported in both standalone and HA modes.
         cluster:
           $ref: "#/components/schemas/ClusterStatus"
-      required: [version, revision, initialized, ready]
+      required: [version, revision, initialized, ready, schemaVersion]
 
     StatusResponseEnvelope:
       type: object
@@ -4855,6 +4896,12 @@ components:
         nodeId:
           type: integer
           description: Raft node ID of this instance.
+        isLeader:
+          type: boolean
+          description: True when this node is the current Raft leader.
+        leaderNodeId:
+          type: integer
+          description: Raft node ID of the current leader. Zero when the leader is unknown or its cluster_members row is not yet present.
         appliedIndex:
           type: integer
           format: uint64
@@ -4862,13 +4909,14 @@ components:
         clusterId:
           type: string
           description: Cluster ID from the operator configuration. Omitted when not set.
-        schemaVersion:
-          type: integer
-          description: Database schema version of this node.
-        leaderAddress:
+        leaderAPIAddress:
           type: string
-          description: API address of the current Raft leader. Empty when the leader is unknown.
-      required: [enabled, role, nodeId, appliedIndex, schemaVersion]
+          description: >-
+            HTTP API URL of the current Raft leader (e.g.
+            `https://10.0.0.1:5000`). Empty when the leader is unknown.
+            The Raft transport address is available on
+            `/api/v1/cluster/members` as `raftAddress`.
+      required: [enabled, role, nodeId, isLeader, leaderNodeId, appliedIndex]
 
     ClusterMember:
       type: object
@@ -4889,7 +4937,16 @@ components:
           type: string
           enum: [voter, nonvoter]
           description: Whether this member participates in leader election.
-      required: [nodeId, raftAddress, apiAddress, binaryVersion, suffrage]
+        maxSchemaVersion:
+          type: integer
+          description: >-
+            Highest shared-DB schema version this member's binary can
+            apply. Compared against the cluster's applied schema during
+            rolling upgrades to gate migrations behind quorum support.
+        isLeader:
+          type: boolean
+          description: True when this member is the current Raft leader.
+      required: [nodeId, raftAddress, apiAddress, binaryVersion, suffrage, maxSchemaVersion, isLeader]
 
     ListClusterMembersResponseEnvelope:
       type: object
@@ -4898,6 +4955,97 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ClusterMember"
+
+    AutopilotServer:
+      type: object
+      description: Live autopilot view of a single cluster peer.
+      properties:
+        nodeId:
+          type: integer
+          description: Raft node ID.
+        raftAddress:
+          type: string
+          description: "Raft transport address of this peer (host:port)."
+        nodeStatus:
+          type: string
+          description: >-
+            Autopilot lifecycle state for this peer (e.g. `alive`, `left`,
+            `failed`). A node goes `left` once it has missed heartbeats for
+            longer than the configured LastContactThreshold.
+        healthy:
+          type: boolean
+          description: >-
+            Autopilot's health verdict for this peer, combining
+            last-contact, last-term, and log-lag checks against the
+            autopilot configuration.
+        isLeader:
+          type: boolean
+          description: True when this peer is the current Raft leader.
+        hasVotingRights:
+          type: boolean
+          description: True when this peer is a voter or leader (not a nonvoter).
+        lastContactMs:
+          type: integer
+          format: int64
+          description: >-
+            Milliseconds since this peer last heartbeated with the leader.
+            Zero for the leader's own row.
+        lastTerm:
+          type: integer
+          format: uint64
+          description: Highest Raft term this peer has a record of.
+        lastIndex:
+          type: integer
+          format: uint64
+          description: >-
+            Last log index this peer has acknowledged. Compare to the
+            leader's row to read replication lag.
+        stableSince:
+          type: string
+          format: date-time
+          description: >-
+            UTC timestamp of the last time this peer's `healthy` value
+            changed. Used by autopilot's promotion logic and surfaced as a
+            signal of churn. Omitted when unknown.
+      required: [nodeId, raftAddress, nodeStatus, healthy, isLeader, hasVotingRights, lastContactMs, lastTerm, lastIndex]
+
+    AutopilotState:
+      type: object
+      description: >-
+        Live cluster health produced by raft-autopilot on the leader.
+        Complements `/api/v1/cluster/members` (static configuration) by
+        answering operational questions like "is the cluster actually
+        healthy" and "how many more failures can it survive."
+      properties:
+        healthy:
+          type: boolean
+          description: True when every voter is healthy.
+        failureTolerance:
+          type: integer
+          description: >-
+            Number of voter failures the cluster can currently absorb
+            without losing quorum. Zero means any additional failure
+            stalls writes.
+        leaderNodeId:
+          type: integer
+          description: Raft node ID of the current leader; zero when unknown.
+        voters:
+          type: array
+          items:
+            type: integer
+          description: Node IDs of voting members, ascending.
+        servers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AutopilotServer"
+          description: Per-peer state, sorted by nodeId.
+      required: [healthy, failureTolerance, leaderNodeId, voters, servers]
+
+    AutopilotStateResponseEnvelope:
+      type: object
+      properties:
+        result:
+          $ref: "#/components/schemas/AutopilotState"
 
     AddClusterMemberParams:
       type: object
@@ -4923,6 +5071,12 @@ components:
         schemaVersion:
           type: integer
           description: Schema version of the joining node. Rejected if lower than the leader's schema.
+        maxSchemaVersion:
+          type: integer
+          description: >-
+            Highest shared-DB schema version the joining node's binary can
+            apply. Recorded on the cluster member row so the cluster can
+            gate migrations on quorum support during rolling upgrades.
 
     DrainParams:
       type: object

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -2659,7 +2659,9 @@ paths:
       operationId: listClusterMembers
       tags: [Cluster]
       summary: List cluster members
-      description: Returns all registered cluster members. Only available when clustering is enabled.
+      description: >-
+        Returns all registered cluster members. Returns an empty array
+        when clustering is disabled. Requires admin privileges.
       responses:
         "200":
           description: List of cluster members.
@@ -2692,6 +2694,31 @@ paths:
           $ref: "#/components/responses/Unauthorized"
 
   /api/v1/cluster/members/{id}:
+    get:
+      operationId: getClusterMember
+      tags: [Cluster]
+      summary: Get a cluster member
+      description: Returns a single cluster member by node ID. Requires admin privileges.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Node ID of the cluster member.
+      responses:
+        "200":
+          description: Cluster member.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetClusterMemberResponseEnvelope"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     delete:
       operationId: removeClusterMember
       tags: [Cluster]
@@ -4955,6 +4982,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ClusterMember"
+
+    GetClusterMemberResponseEnvelope:
+      type: object
+      properties:
+        result:
+          $ref: "#/components/schemas/ClusterMember"
 
     AutopilotServer:
       type: object

--- a/internal/api/server/proxy_middleware.go
+++ b/internal/api/server/proxy_middleware.go
@@ -46,6 +46,44 @@ func isWriteMethod(method string) bool {
 	return false
 }
 
+// leaderOnlyReadPaths enumerates the GET paths that must be served by the
+// leader even though they do not mutate state. Autopilot state only
+// exists on the leader; a follower has nothing useful to return, so the
+// middleware proxies these requests the same way it proxies writes.
+var leaderOnlyReadPaths = map[string]struct{}{
+	"/api/v1/cluster/autopilot": {},
+}
+
+func isLeaderOnlyRead(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+
+	_, ok := leaderOnlyReadPaths[r.URL.Path]
+
+	return ok
+}
+
+// localOnlyWritePaths enumerates write endpoints that MUST run on the node
+// that received the request, not on the leader. Drain mutates per-node
+// runtime state (BGP daemon, connected RANs, local Raft participation) and
+// has no meaning if silently redirected — a drain issued against node N
+// must drain node N. Proxying to the leader would drain the wrong node
+// and corrupt operator intent.
+var localOnlyWritePaths = map[string]struct{}{
+	"/api/v1/cluster/drain": {},
+}
+
+func isLocalOnlyWrite(r *http.Request) bool {
+	if !isWriteMethod(r.Method) {
+		return false
+	}
+
+	_, ok := localOnlyWritePaths[r.URL.Path]
+
+	return ok
+}
+
 // LeaderProxyMiddleware forwards write requests to the Raft leader when this
 // node is a follower. Read requests are served locally. The middleware runs
 // before authentication so the leader handles auth for proxied writes.
@@ -64,7 +102,13 @@ func LeaderProxyMiddleware(dbInstance *db.Database, ln *listener.Listener, next 
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if dbInstance.IsLeader() || !isWriteMethod(r.Method) {
+		if isLocalOnlyWrite(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		mustProxy := isWriteMethod(r.Method) || isLeaderOnlyRead(r)
+		if dbInstance.IsLeader() || !mustProxy {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -83,24 +127,27 @@ func LeaderProxyMiddleware(dbInstance *db.Database, ln *listener.Listener, next 
 	})
 }
 
-func resolveLeaderAPI(dbInstance *db.Database) string {
+// resolveLeader looks up the current leader in the cluster_members table
+// and returns the leader's API address and node-id. Either field is zero
+// when no leader is known or the leader's row is not yet present.
+func resolveLeader(dbInstance *db.Database) (apiAddress string, nodeID int) {
 	raftAddr := dbInstance.LeaderAddress()
 	if raftAddr == "" {
-		return ""
+		return "", 0
 	}
 
 	members, err := dbInstance.ListClusterMembers(context.Background())
 	if err != nil {
-		return ""
+		return "", 0
 	}
 
 	for _, m := range members {
 		if m.RaftAddress == raftAddr {
-			return m.APIAddress
+			return m.APIAddress, m.NodeID
 		}
 	}
 
-	return ""
+	return "", 0
 }
 
 // isHopByHopHeader returns true for headers that must not be forwarded by

--- a/internal/api/server/proxy_middleware_test.go
+++ b/internal/api/server/proxy_middleware_test.go
@@ -193,6 +193,66 @@ func TestProxyToLeaderCluster_PassesNon410Through(t *testing.T) {
 	}
 }
 
+func TestIsLocalOnlyWrite(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		{"drain POST", http.MethodPost, "/api/v1/cluster/drain", true},
+		{"drain GET is not a write", http.MethodGet, "/api/v1/cluster/drain", false},
+		{"drain DELETE matches path even though route is POST-only", http.MethodDelete, "/api/v1/cluster/drain", true},
+		{"subscriber write is not local-only", http.MethodPost, "/api/v1/subscribers", false},
+		{"cluster member write is not local-only", http.MethodDelete, "/api/v1/cluster/members/3", false},
+		{"drain with trailing slash is not matched", http.MethodPost, "/api/v1/cluster/drain/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), tt.method, tt.path, nil)
+			if got := isLocalOnlyWrite(req); got != tt.want {
+				t.Errorf("isLocalOnlyWrite(%s %s) = %v, want %v", tt.method, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLeaderProxyMiddleware_DrainNotProxied verifies that drain is served
+// locally even when this node is a follower. Regression test for the bug
+// where `POST /api/v1/cluster/drain` on a follower was being forwarded to
+// the leader, which then drained *itself* instead of the follower the
+// operator targeted.
+func TestLeaderProxyMiddleware_DrainNotProxied(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+
+	t.Cleanup(func() { _ = testDB.Close() })
+
+	// The single-server DB auto-elects as leader; isLeader() == true would
+	// short-circuit the middleware to `next` regardless, bypassing the
+	// check we care about. Instead, test the decision function directly:
+	// isLocalOnlyWrite must return true for drain, which is what the
+	// middleware uses to skip proxy on a follower.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/cluster/drain", nil)
+
+	if !isLocalOnlyWrite(req) {
+		t.Fatal("drain must be flagged as local-only so the proxy middleware never forwards it")
+	}
+
+	// Also sanity-check that drain does NOT match the leader-only read
+	// path (it's a POST, not a GET) — otherwise we'd also be proxying it
+	// through that branch.
+	if isLeaderOnlyRead(req) {
+		t.Fatal("drain is a POST and must not be matched by isLeaderOnlyRead")
+	}
+}
+
 func TestLeaderProxyMiddleware_NilDB(t *testing.T) {
 	called := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -221,6 +221,7 @@ func NewHandler(cfg HandlerConfig) http.Handler {
 	// Cluster (Authenticated, admin only)
 	mux.HandleFunc("GET /api/v1/cluster/members", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, ListClusterMembers(dbInstance))).ServeHTTP)
 	mux.HandleFunc("POST /api/v1/cluster/members", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, AddClusterMember(dbInstance))).ServeHTTP)
+	mux.HandleFunc("GET /api/v1/cluster/members/{id}", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, GetClusterMember(dbInstance))).ServeHTTP)
 	mux.HandleFunc("DELETE /api/v1/cluster/members/{id}", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, RemoveClusterMember(dbInstance))).ServeHTTP)
 	mux.HandleFunc("POST /api/v1/cluster/members/{id}/promote", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, PromoteClusterMember(dbInstance))).ServeHTTP)
 

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -226,6 +226,8 @@ func NewHandler(cfg HandlerConfig) http.Handler {
 
 	mux.HandleFunc("POST /api/v1/cluster/drain", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, DrainNode(dbInstance, amfInstance, bgpService))).ServeHTTP)
 
+	mux.HandleFunc("GET /api/v1/cluster/autopilot", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, GetAutopilotState(dbInstance))).ServeHTTP)
+
 	// Fallback to UI
 	frontendHandler, err := newFrontendFileServer(embedFS)
 	if err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 	ellaraft "github.com/ellanetworks/core/internal/raft"
 	"github.com/google/uuid"
+	autopilot "github.com/hashicorp/raft-autopilot"
 	_ "github.com/mattn/go-sqlite3"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -498,6 +499,18 @@ func (db *Database) RaftState() string {
 	}
 
 	return db.raftManager.State().String()
+}
+
+// AutopilotState returns the current autopilot state snapshot, or nil
+// when this node is not the leader (autopilot runs leader-only) or when
+// autopilot has not yet produced a first tick. Never returns non-nil on
+// a follower or in single-server mode.
+func (db *Database) AutopilotState() *autopilot.State {
+	if db.raftManager == nil {
+		return nil
+	}
+
+	return db.raftManager.AutopilotState()
 }
 
 // ClusterEnabled returns whether clustering is active.

--- a/internal/raft/autopilot.go
+++ b/internal/raft/autopilot.go
@@ -211,3 +211,16 @@ func (a *autopilotRunner) OnBecameLeader() {
 func (a *autopilotRunner) OnLostLeadership() {
 	a.ap.Stop()
 }
+
+// State returns the current autopilot state snapshot. The state is only
+// continuously updated while this node is leader; callers should check
+// Manager.IsLeader() to decide whether to trust it. Returns nil when
+// autopilot has not yet produced a first state (cold start window
+// immediately after becoming leader).
+func (a *autopilotRunner) State() *autopilot.State {
+	if a == nil {
+		return nil
+	}
+
+	return a.ap.GetState()
+}

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ellanetworks/core/internal/cluster/listener"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/hashicorp/raft"
+	autopilot "github.com/hashicorp/raft-autopilot"
 	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
 	"go.uber.org/zap"
 )
@@ -413,6 +414,20 @@ func (m *Manager) Propose(cmd *Command, timeout time.Duration) (*ProposeResult, 
 // IsLeader returns true if this node is the current Raft leader.
 func (m *Manager) IsLeader() bool {
 	return m.raft.State() == raft.Leader
+}
+
+// AutopilotState returns the current autopilot state snapshot.
+//
+// Autopilot only runs on the leader, so this returns nil on followers and
+// in single-server mode. On the leader, it may still return nil during
+// the cold-start window immediately after leadership acquisition, before
+// the first autopilot tick has completed.
+func (m *Manager) AutopilotState() *autopilot.State {
+	if m.autopilot == nil {
+		return nil
+	}
+
+	return m.autopilot.State()
 }
 
 // LeaderAddress returns the Raft transport address of the current leader.


### PR DESCRIPTION
# Description

Add HTTP API endpoint for admins to get the autopilot state of the Ella Core cluster. This endpoint is only available on the leader node and contains  per-peer live state.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
