### PR TITLE
fix: run drain/resume on the leader

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -182,6 +182,10 @@ func (c *Client) ResumeClusterMember(ctx context.Context, nodeID int) (*ResumeRe
 	return &out, nil
 }
 
+// PromoteClusterMember promotes a non-voter to a voter immediately.
+// Autopilot also promotes stable non-voters automatically after a short
+// stabilization window; use this call when you need promotion without
+// waiting.
 func (c *Client) PromoteClusterMember(ctx context.Context, nodeID int) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/docs/explanation/high_availability.md
+++ b/docs/explanation/high_availability.md
@@ -74,11 +74,19 @@ Draining prepares a node for removal without disrupting traffic on its peers. A 
 
 Drain is a reversible state: a node moves through `active → draining → drained` and back. Resume clears the drain and restarts route advertisement. It does not reclaim Raft leadership, and radios only treat the node as available again on their next reconnection.
 
+A node receiving a shutdown signal (SIGTERM) also marks itself `drained` as part of a clean shutdown, so operators see an explicit state change instead of a brief window of apparent unresponsiveness before the cluster removes the dead member.
+
 Removal requires a drained node; the cluster rejects removing an undrained one.
+
+## Scaling the cluster
+
+New voters join in two steps. The operator registers the node as a non-voter, which lets it catch up on the Raft log without counting toward quorum; once the node has been healthy and up-to-date for a short stabilization window, the cluster automatically promotes it to a voter. Operators who want to promote immediately can call the promote endpoint by hand.
+
+Shrinking is symmetric. Drain the node, then remove it; the remaining voters continue serving writes while the configuration change commits.
 
 ## Rolling upgrades
 
-Upgrades proceed one node at a time: drain, remove, upgrade, rejoin as non-voter, promote. Writes continue throughout; the cluster is briefly mixed-version during each swap.
+Upgrades proceed one node at a time: drain, remove, upgrade, rejoin as non-voter, wait for auto-promotion (or promote manually). Writes continue throughout; the cluster is briefly mixed-version during each swap.
 
 To keep a mixed-version cluster consistent, the leader applies a schema migration only once every voter's binary supports it, and refuses to admit a new voter whose schema trails what the cluster has already applied. Skip-version upgrades (`vN → vN+2`) and downgrades are not supported.
 

--- a/docs/reference/api/cluster.md
+++ b/docs/reference/api/cluster.md
@@ -121,6 +121,8 @@ Removes a node from the Raft cluster and deletes its record. The node must be dr
 
 Promotes a nonvoter node to a full voter in the Raft cluster. Requires admin privileges.
 
+Autopilot also promotes non-voters automatically once they have been healthy and up-to-date for the server stabilization window (10 seconds). This endpoint is intended for operators who need to promote a node immediately without waiting, for example during a rolling upgrade.
+
 | Method | Path                                    |
 | ------ | --------------------------------------- |
 | POST   | `/api/v1/cluster/members/{id}/promote`  |
@@ -228,9 +230,9 @@ Marks the target node as draining and runs the local drain side-effects on it: t
 
 Drain persists a three-state machine on the cluster_members row (`active` → `draining` → `drained`) that every node can read. A node must be `drained` before it can be removed (see Remove Cluster Member), or the caller must pass `?force=true`.
 
-When `deadlineSeconds` is 0 (default), drain is synchronous: the call returns once side-effects complete and `state` is `drained`. When `deadlineSeconds > 0`, the call returns `state: draining` immediately; a background poller on the target flips the state to `drained` once its local active-lease count reaches zero or the deadline elapses.
+When `deadlineSeconds` is 0 (default), drain is synchronous: the call returns once side-effects complete and `state` is `drained`. When `deadlineSeconds > 0`, the call returns `state: draining` immediately; a background watcher on the leader flips the state to `drained` once the target's active-lease count reaches zero or the deadline elapses.
 
-The proxy middleware routes drain/resume directly to the target node (bypassing the leader), so you can issue the request against any node in the cluster.
+In HA mode, drain runs on the leader (followers forward the request automatically). The leader persists drain state through Raft and dispatches the node-local side-effects to the target node over the cluster mTLS port; when the target is the leader itself, the side-effects run inline.
 
 | Method | Path                                            |
 | ------ | ----------------------------------------------- |

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -237,6 +237,15 @@ func (s *Server) Upgrade(ctx context.Context, opts UpgradeConfig) error {
 	s.handler.set(fullHandler)
 	s.ready.Store(true)
 
+	// Install the AMF/BGP references used by the cluster-port drain and
+	// resume side-effect endpoints. The cluster HTTP mux starts before
+	// these services exist (cluster formation needs the port up early),
+	// so the endpoints late-bind dependencies from this atomic pointer.
+	server.SetClusterSideEffectDeps(server.ClusterSideEffectDeps{
+		AMF: opts.AMF,
+		BGP: opts.BGP,
+	})
+
 	reconcile := routeReconciler
 
 	go func() {

--- a/internal/api/server/api_cluster_test.go
+++ b/internal/api/server/api_cluster_test.go
@@ -720,6 +720,300 @@ func postResume(url string, client *http.Client, token string, nodeID int) (int,
 	return res.StatusCode, string(buf[:n]), nil
 }
 
+// TestDrainClusterMember_Idempotent verifies that re-draining a node
+// already in draining or drained state returns the current state and does
+// not re-run side-effects.
+func TestDrainClusterMember_Idempotent(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	c := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, c)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	ctx := context.Background()
+	self := env.DB.NodeID()
+
+	if err := env.DB.UpsertClusterMember(ctx, &db.ClusterMember{
+		NodeID:      self,
+		RaftAddress: env.DB.LeaderAddress(),
+		APIAddress:  "http://127.0.0.1:0",
+		Suffrage:    "voter",
+	}); err != nil {
+		t.Fatalf("upsert self: %s", err)
+	}
+
+	if err := env.DB.SetDrainState(ctx, self, db.DrainStateDrained); err != nil {
+		t.Fatalf("seed drained state: %s", err)
+	}
+
+	status, body, err := postDrain(env.Server.URL, c, token, self, 0)
+	if err != nil {
+		t.Fatalf("drain request failed: %s", err)
+	}
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 on idempotent drain, got %d (body: %s)", status, body)
+	}
+
+	if !strings.Contains(body, `"state":"drained"`) {
+		t.Errorf("expected state=drained in body, got %s", body)
+	}
+
+	if !strings.Contains(body, "drain already in effect") {
+		t.Errorf("expected idempotent message, got %s", body)
+	}
+}
+
+// TestDrainClusterMember_InvalidDeadline covers the bounds check on
+// deadlineSeconds.
+func TestDrainClusterMember_InvalidDeadline(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	c := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, c)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	self := env.DB.NodeID()
+
+	if err := env.DB.UpsertClusterMember(context.Background(), &db.ClusterMember{
+		NodeID:      self,
+		RaftAddress: env.DB.LeaderAddress(),
+		APIAddress:  "http://127.0.0.1:0",
+		Suffrage:    "voter",
+	}); err != nil {
+		t.Fatalf("upsert self: %s", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		deadline int
+	}{
+		{"negative", -1},
+		{"over-max", 3601},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body, err := postDrain(env.Server.URL, c, token, self, tc.deadline)
+			if err != nil {
+				t.Fatalf("drain request failed: %s", err)
+			}
+
+			if status != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d (body: %s)", status, body)
+			}
+		})
+	}
+}
+
+// TestDrainClusterMember_NotFound verifies 404 for an unknown node.
+func TestDrainClusterMember_NotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	c := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, c)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	status, body, err := postDrain(env.Server.URL, c, token, 999, 0)
+	if err != nil {
+		t.Fatalf("drain request failed: %s", err)
+	}
+
+	if status != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body: %s)", status, body)
+	}
+}
+
+// TestResumeClusterMember_AlreadyActive covers the no-op response when the
+// target is already in the active state.
+func TestResumeClusterMember_AlreadyActive(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	c := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, c)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	self := env.DB.NodeID()
+
+	if err := env.DB.UpsertClusterMember(context.Background(), &db.ClusterMember{
+		NodeID:      self,
+		RaftAddress: env.DB.LeaderAddress(),
+		APIAddress:  "http://127.0.0.1:0",
+		Suffrage:    "voter",
+	}); err != nil {
+		t.Fatalf("upsert self: %s", err)
+	}
+
+	status, body, err := postResume(env.Server.URL, c, token, self)
+	if err != nil {
+		t.Fatalf("resume request failed: %s", err)
+	}
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", status, body)
+	}
+
+	if !strings.Contains(body, "already active") {
+		t.Errorf("expected already-active message, got %s", body)
+	}
+}
+
+// TestResumeClusterMember_NotFound verifies 404 for an unknown node.
+func TestResumeClusterMember_NotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	c := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, c)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	status, body, err := postResume(env.Server.URL, c, token, 999)
+	if err != nil {
+		t.Fatalf("resume request failed: %s", err)
+	}
+
+	if status != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body: %s)", status, body)
+	}
+}
+
+// TestPromoteClusterMember_AlreadyVoter verifies the 409 response when the
+// target is already a voter.
+func TestPromoteClusterMember_AlreadyVoter(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	c := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, c)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	const voterID = 6
+
+	if err := env.DB.UpsertClusterMember(context.Background(), &db.ClusterMember{
+		NodeID:      voterID,
+		RaftAddress: "10.0.0.6:7000",
+		APIAddress:  "http://10.0.0.6:5000",
+		Suffrage:    "voter",
+	}); err != nil {
+		t.Fatalf("upsert voter: %s", err)
+	}
+
+	status, body, err := postPromote(env.Server.URL, c, token, voterID)
+	if err != nil {
+		t.Fatalf("promote request failed: %s", err)
+	}
+
+	if status != http.StatusConflict {
+		t.Fatalf("expected 409 on already-voter, got %d (body: %s)", status, body)
+	}
+}
+
+// TestPromoteClusterMember_NotFound verifies 404 for an unknown node.
+func TestPromoteClusterMember_NotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	c := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, c)
+	if err != nil {
+		t.Fatalf("couldn't initialize: %s", err)
+	}
+
+	status, body, err := postPromote(env.Server.URL, c, token, 999)
+	if err != nil {
+		t.Fatalf("promote request failed: %s", err)
+	}
+
+	if status != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body: %s)", status, body)
+	}
+}
+
+func postPromote(url string, client *http.Client, token string, nodeID int) (int, string, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		fmt.Sprintf("%s/api/v1/cluster/members/%d/promote", url, nodeID), nil)
+	if err != nil {
+		return 0, "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+
+	defer func() { _ = res.Body.Close() }()
+
+	buf := make([]byte, 4096)
+	n, _ := res.Body.Read(buf)
+
+	return res.StatusCode, string(buf[:n]), nil
+}
+
 func TestClusterStatusIncluded(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")

--- a/internal/api/server/api_drain.go
+++ b/internal/api/server/api_drain.go
@@ -351,14 +351,14 @@ func postClusterInternal(ctx context.Context, ln *listener.Listener, targetRaftA
 
 	url := fmt.Sprintf("https://%s%s", targetRaftAddr, path)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(nil)) // #nosec G107 -- built from Raft-replicated raft address, not user input
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(nil)) // #nosec G107,G704 -- built from Raft-replicated raft address, not user input
 	if err != nil {
 		return fmt.Errorf("new request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL built from Raft-replicated raft address, not user input
 	if err != nil {
 		return fmt.Errorf("post to %s: %w", targetRaftAddr, err)
 	}

--- a/internal/api/server/api_drain.go
+++ b/internal/api/server/api_drain.go
@@ -365,7 +365,7 @@ func postClusterInternal(ctx context.Context, ln *listener.Listener, targetRaftA
 
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode/100 != 2 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("target returned %s", resp.Status)
 	}
 
@@ -446,6 +446,55 @@ func watchDrainDeadline(ctx context.Context, dbInstance *db.Database, nodeID int
 		logger.APILog.Warn("failed to finalise drain state after sessions reached zero",
 			zap.Int("nodeId", nodeID), zap.Error(err))
 	}
+}
+
+// SignalShutdownDrain marks this node as drained in the replicated
+// cluster_members table so surviving nodes see a clean "active → drained"
+// transition on operator-initiated shutdown, instead of waiting for
+// autopilot to remove a dead voter after LastContactThreshold. On the
+// leader the write is proposed locally; on a follower it is sent to the
+// current leader's cluster mTLS port. Best-effort: errors are logged and
+// do not block the rest of the shutdown sequence.
+func SignalShutdownDrain(ctx context.Context, dbInstance *db.Database, ln *listener.Listener) error {
+	if dbInstance == nil || !dbInstance.ClusterEnabled() {
+		return nil
+	}
+
+	if dbInstance.IsLeader() {
+		return dbInstance.SetDrainState(ctx, dbInstance.NodeID(), db.DrainStateDrained)
+	}
+
+	leaderAddr := dbInstance.LeaderAddress()
+	if leaderAddr == "" {
+		return fmt.Errorf("no leader available")
+	}
+
+	if ln == nil {
+		return fmt.Errorf("cluster listener unavailable")
+	}
+
+	client := newClusterProxyClient(ln)
+	defer client.CloseIdleConnections()
+
+	url := fmt.Sprintf("https://%s/cluster/internal/drain-self", leaderAddr)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(nil)) // #nosec G107,G704 -- URL built from Raft-replicated leader address, not user input
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+
+	resp, err := client.Do(req) // #nosec G704 -- URL built from Raft-replicated leader address, not user input
+	if err != nil {
+		return fmt.Errorf("post to leader: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("leader returned %s", resp.Status)
+	}
+
+	return nil
 }
 
 // notifyRANsUnavailable signals every connected RAN that this AMF's GUAMI is

--- a/internal/api/server/api_drain.go
+++ b/internal/api/server/api_drain.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
 	"github.com/ellanetworks/core/internal/bgp"
+	"github.com/ellanetworks/core/internal/cluster/listener"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
 	"go.uber.org/zap"
@@ -49,28 +52,31 @@ type ResumeResponse struct {
 
 // DrainClusterMember handles POST /api/v1/cluster/members/{id}/drain.
 //
-// The request must execute on the target node itself; LeaderProxyMiddleware
-// routes per-member drain requests to the target's cluster port so this
-// handler always runs on the node being drained. As defense-in-depth, it
-// also verifies {id} matches the local node and refuses otherwise.
+// Runs on the Raft leader (follower requests arrive via the standard leader
+// proxy). The leader persists drain-state transitions through Raft and
+// invokes node-local side-effects (AMF Status Indication, BGP stop) either
+// inline when the target is the leader itself or over the cluster mTLS port
+// when the target is a different node. Leadership transfer runs only when
+// the target is the leader and is the last local step, so subsequent
+// state writes all land on the new leader cleanly.
 //
-// Side-effects (leadership transfer, AMF Status Indication, BGP stop) run
-// synchronously. The drain_state row is set to "draining" before returning;
-// if deadlineSeconds > 0 a background goroutine flips it to "drained" when
-// the local active-lease count reaches zero or the deadline expires. When
-// deadlineSeconds is 0, the row is flipped to "drained" before returning.
-func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpService *bgp.BGPService) http.Handler {
+// When deadlineSeconds is 0 (default) drain is synchronous and the response
+// state is "drained". When deadlineSeconds > 0 the response returns
+// immediately with state "draining"; a background watcher on the leader
+// flips the state to "drained" once the target's active-lease count
+// reaches zero or the deadline expires.
+func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpService *bgp.BGPService, ln *listener.Listener) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nodeID, ok := parseMemberIDPath(r)
-		if !ok {
-			writeError(r.Context(), w, http.StatusBadRequest, "Invalid node ID", nil, logger.APILog)
+		if dbInstance.ClusterEnabled() && !dbInstance.IsLeader() {
+			writeError(r.Context(), w, http.StatusMisdirectedRequest,
+				"not the leader; retry against the current leader", nil, logger.APILog)
+
 			return
 		}
 
-		if nodeID != dbInstance.NodeID() {
-			writeError(r.Context(), w, http.StatusBadGateway,
-				"drain handler reached on a non-target node; check proxy configuration", nil, logger.APILog)
-
+		nodeID, ok := parseMemberIDPath(r)
+		if !ok {
+			writeError(r.Context(), w, http.StatusBadRequest, "Invalid node ID", nil, logger.APILog)
 			return
 		}
 
@@ -103,15 +109,11 @@ func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpServic
 		}
 
 		// Idempotent: re-draining a draining/drained node just returns the
-		// current state and skips side-effects. Callers that want to retry
-		// a failed drain should resume first.
+		// current state and skips side-effects.
 		if member.DrainState == db.DrainStateDraining || member.DrainState == db.DrainStateDrained {
-			remaining := countLocalActiveLeases(r.Context(), dbInstance, nodeID)
-
 			writeResponse(r.Context(), w, DrainResponse{
-				Message:           "drain already in effect",
-				State:             member.DrainState,
-				SessionsRemaining: remaining,
+				Message: "drain already in effect",
+				State:   member.DrainState,
 			}, http.StatusOK, logger.APILog)
 
 			return
@@ -124,39 +126,23 @@ func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpServic
 			return
 		}
 
-		transferred := false
-
-		if dbInstance.IsLeader() && dbInstance.ClusterEnabled() {
-			if err := dbInstance.LeadershipTransfer(); err != nil {
-				// Rollback state so the operator can retry cleanly.
-				if rbErr := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateActive); rbErr != nil {
-					logger.APILog.Warn("failed to roll back drain state after leadership-transfer failure",
-						zap.Error(rbErr))
-				}
-
-				writeError(r.Context(), w, http.StatusInternalServerError,
-					"drain aborted: leadership transfer failed", err, logger.APILog)
-
-				return
+		// Run node-local side-effects on the target: either inline (target
+		// is the leader) or over the cluster mTLS port (target is a
+		// follower).
+		sideEffects, sideErr := runDrainSideEffects(r.Context(), dbInstance, amfInstance, bgpService, ln, member)
+		if sideErr != nil {
+			if rbErr := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateActive); rbErr != nil {
+				logger.APILog.Warn("failed to roll back drain state after side-effects failure",
+					zap.Error(rbErr))
 			}
 
-			transferred = true
-		}
+			writeError(r.Context(), w, http.StatusInternalServerError,
+				"drain side-effects failed", sideErr, logger.APILog)
 
-		ransNotified := notifyRANsUnavailable(r.Context(), amfInstance, defaultDrainStepTimeout)
-
-		bgpStopped := false
-
-		if bgpService != nil {
-			if err := bgpService.Stop(); err != nil {
-				logger.APILog.Warn("BGP stop during drain failed", zap.Error(err))
-			} else {
-				bgpStopped = true
-			}
+			return
 		}
 
 		state := db.DrainStateDraining
-		remaining := countLocalActiveLeases(r.Context(), dbInstance, nodeID)
 
 		if req.DeadlineSeconds == 0 {
 			if err := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateDrained); err != nil {
@@ -169,10 +155,21 @@ func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpServic
 			state = db.DrainStateDrained
 		} else {
 			// #nosec G118 -- the deadline watcher must outlive r.Context(),
-			// which is cancelled as soon as this handler returns; the
-			// goroutine polls for up to deadlineSeconds and then finalises
-			// drain_state, so it deliberately uses a detached context.
+			// which is cancelled as soon as this handler returns.
 			go watchDrainDeadline(context.Background(), dbInstance, nodeID, time.Duration(req.DeadlineSeconds)*time.Second)
+		}
+
+		// Leadership transfer is the last local step: transferring earlier
+		// would strand subsequent proposeChangeset writes on a now-follower.
+		transferred := false
+
+		if nodeID == dbInstance.NodeID() && dbInstance.ClusterEnabled() && dbInstance.IsLeader() {
+			if err := dbInstance.LeadershipTransfer(); err != nil {
+				logger.APILog.Warn("leadership transfer failed during self-drain; drain state is already drained",
+					zap.Error(err))
+			} else {
+				transferred = true
+			}
 		}
 
 		actor := getActorFromContext(r)
@@ -182,39 +179,39 @@ func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpServic
 			DrainAction,
 			actor,
 			getClientIP(r),
-			fmt.Sprintf("Node %d drain started, state=%s, leadership_transferred=%v, rans_notified=%d, bgp_stopped=%v, deadline_s=%d",
-				nodeID, state, transferred, ransNotified, bgpStopped, req.DeadlineSeconds),
+			fmt.Sprintf("Node %d drain, state=%s, leadership_transferred=%v, rans_notified=%d, bgp_stopped=%v, deadline_s=%d",
+				nodeID, state, transferred, sideEffects.RANsNotified, sideEffects.BGPStopped, req.DeadlineSeconds),
 		)
 
 		writeResponse(r.Context(), w, DrainResponse{
 			Message:               "draining",
 			State:                 state,
 			TransferredLeadership: transferred,
-			RANsNotified:          ransNotified,
-			BGPStopped:            bgpStopped,
-			SessionsRemaining:     remaining,
+			RANsNotified:          sideEffects.RANsNotified,
+			BGPStopped:            sideEffects.BGPStopped,
+			SessionsRemaining:     countLocalActiveLeases(r.Context(), dbInstance, nodeID),
 		}, http.StatusOK, logger.APILog)
 	})
 }
 
 // ResumeClusterMember handles POST /api/v1/cluster/members/{id}/resume.
 //
-// Restarts the local BGP speaker (if BGP is globally enabled and was stopped
-// by a prior drain) and clears the drain_state back to "active". Does not
-// reverse AMF Status Indication (no NGAP message does that) and does not
-// reclaim Raft leadership that was transferred during drain.
-func ResumeClusterMember(dbInstance *db.Database, bgpService *bgp.BGPService) http.Handler {
+// Runs on the leader. Restarts the target's local BGP speaker (either inline
+// when target is the leader or over the cluster mTLS port) and then clears
+// the drain state. Does not reverse AMF Status Indication (no NGAP message
+// does that) or reclaim Raft leadership transferred during drain.
+func ResumeClusterMember(dbInstance *db.Database, bgpService *bgp.BGPService, ln *listener.Listener) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nodeID, ok := parseMemberIDPath(r)
-		if !ok {
-			writeError(r.Context(), w, http.StatusBadRequest, "Invalid node ID", nil, logger.APILog)
+		if dbInstance.ClusterEnabled() && !dbInstance.IsLeader() {
+			writeError(r.Context(), w, http.StatusMisdirectedRequest,
+				"not the leader; retry against the current leader", nil, logger.APILog)
+
 			return
 		}
 
-		if nodeID != dbInstance.NodeID() {
-			writeError(r.Context(), w, http.StatusBadGateway,
-				"resume handler reached on a non-target node; check proxy configuration", nil, logger.APILog)
-
+		nodeID, ok := parseMemberIDPath(r)
+		if !ok {
+			writeError(r.Context(), w, http.StatusBadRequest, "Invalid node ID", nil, logger.APILog)
 			return
 		}
 
@@ -239,20 +236,12 @@ func ResumeClusterMember(dbInstance *db.Database, bgpService *bgp.BGPService) ht
 			return
 		}
 
-		bgpStarted := false
+		bgpStarted, sideErr := runResumeSideEffects(r.Context(), dbInstance, bgpService, ln, member)
+		if sideErr != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError,
+				"resume side-effects failed", sideErr, logger.APILog)
 
-		if bgpService != nil && !bgpService.IsRunning() {
-			bgpEnabled, err := dbInstance.IsBGPEnabled(r.Context())
-			if err != nil {
-				logger.APILog.Warn("resume: failed to read BGP enabled flag; skipping BGP restart",
-					zap.Error(err))
-			} else if bgpEnabled {
-				if err := bgpService.Restart(r.Context()); err != nil {
-					logger.APILog.Warn("resume: failed to restart BGP speaker", zap.Error(err))
-				} else {
-					bgpStarted = true
-				}
-			}
+			return
 		}
 
 		if err := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateActive); err != nil {
@@ -280,6 +269,126 @@ func ResumeClusterMember(dbInstance *db.Database, bgpService *bgp.BGPService) ht
 	})
 }
 
+// runDrainSideEffects notifies RANs and stops the BGP speaker on the target.
+// When the target is the local (leader) node the steps run inline; otherwise
+// they are dispatched to the target over the cluster mTLS port.
+func runDrainSideEffects(ctx context.Context, dbInstance *db.Database, amfInstance *amf.AMF, bgpService *bgp.BGPService, ln *listener.Listener, member *db.ClusterMember) (DrainSideEffectsResponse, error) {
+	if member.NodeID == dbInstance.NodeID() {
+		ransNotified := notifyRANsUnavailable(ctx, amfInstance, defaultDrainStepTimeout)
+
+		bgpStopped := false
+
+		if bgpService != nil {
+			if err := bgpService.Stop(); err != nil {
+				logger.APILog.Warn("BGP stop during drain failed", zap.Error(err))
+			} else {
+				bgpStopped = true
+			}
+		}
+
+		return DrainSideEffectsResponse{RANsNotified: ransNotified, BGPStopped: bgpStopped}, nil
+	}
+
+	var out DrainSideEffectsResponse
+
+	if err := postClusterInternal(ctx, ln, member.RaftAddress, "/cluster/internal/drain-side-effects", &out); err != nil {
+		return DrainSideEffectsResponse{}, err
+	}
+
+	return out, nil
+}
+
+func runResumeSideEffects(ctx context.Context, dbInstance *db.Database, bgpService *bgp.BGPService, ln *listener.Listener, member *db.ClusterMember) (bool, error) {
+	if member.NodeID == dbInstance.NodeID() {
+		if bgpService == nil || bgpService.IsRunning() {
+			return false, nil
+		}
+
+		bgpEnabled, err := dbInstance.IsBGPEnabled(ctx)
+		if err != nil {
+			logger.APILog.Warn("resume: failed to read BGP enabled flag; skipping BGP restart",
+				zap.Error(err))
+
+			return false, nil
+		}
+
+		if !bgpEnabled {
+			return false, nil
+		}
+
+		if err := bgpService.Restart(ctx); err != nil {
+			logger.APILog.Warn("resume: failed to restart BGP speaker", zap.Error(err))
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	var out ResumeSideEffectsResponse
+
+	if err := postClusterInternal(ctx, ln, member.RaftAddress, "/cluster/internal/resume-side-effects", &out); err != nil {
+		return false, err
+	}
+
+	return out.BGPStarted, nil
+}
+
+// postClusterInternal issues a JSON-body-less POST to the target node's
+// cluster mTLS port and decodes the 2xx response JSON into out. The caller
+// supplies the target's Raft address and the path (including leading
+// slash). Used for the drain/resume side-effect RPCs.
+func postClusterInternal(ctx context.Context, ln *listener.Listener, targetRaftAddr, path string, out any) error {
+	if ln == nil {
+		return fmt.Errorf("cluster listener unavailable")
+	}
+
+	if targetRaftAddr == "" {
+		return fmt.Errorf("target node has no raft address")
+	}
+
+	client := newClusterProxyClient(ln)
+	defer client.CloseIdleConnections()
+
+	url := fmt.Sprintf("https://%s%s", targetRaftAddr, path)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(nil)) // #nosec G107 -- built from Raft-replicated raft address, not user input
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post to %s: %w", targetRaftAddr, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("target returned %s", resp.Status)
+	}
+
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	if len(envelope.Result) == 0 {
+		return nil
+	}
+
+	return json.Unmarshal(envelope.Result, out)
+}
+
 func parseMemberIDPath(r *http.Request) (int, bool) {
 	idStr := r.PathValue("id")
 	if idStr == "" {
@@ -304,10 +413,12 @@ func countLocalActiveLeases(ctx context.Context, dbInstance *db.Database, nodeID
 	return len(leases)
 }
 
-// watchDrainDeadline polls the local active-lease count every second and
+// watchDrainDeadline polls the target's active-lease count every second and
 // flips drain_state to "drained" once the count reaches zero or the deadline
-// elapses. Runs in its own goroutine with a background context so it
-// survives the originating HTTP request ending.
+// elapses. Runs on the leader that handled the drain request. If leadership
+// changes during the wait, the final SetDrainState proposal fails with
+// ErrNotLeader and the state stays "draining"; the operator must re-drain.
+// This matches the spec's non-goal of deadline persistence across failures.
 func watchDrainDeadline(ctx context.Context, dbInstance *db.Database, nodeID int, deadline time.Duration) {
 	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()

--- a/internal/api/server/cluster_http_mux.go
+++ b/internal/api/server/cluster_http_mux.go
@@ -66,6 +66,7 @@ func newClusterMux(dbInstance *db.Database, operatorHandler http.Handler) *http.
 	mux.Handle("POST /cluster/members/self", selfRegistrationGuard(SelfAnnounceClusterMember(dbInstance)))
 	mux.Handle("POST /cluster/internal/drain-side-effects", removedNodeFence(dbInstance, DrainLocalSideEffects()))
 	mux.Handle("POST /cluster/internal/resume-side-effects", removedNodeFence(dbInstance, ResumeLocalSideEffects()))
+	mux.Handle("POST /cluster/internal/drain-self", removedNodeFence(dbInstance, DrainSelfOnLeader(dbInstance)))
 
 	if operatorHandler != nil {
 		mux.Handle("/cluster/proxy/", removedNodeFence(dbInstance, http.StripPrefix("/cluster/proxy", operatorHandler)))
@@ -146,6 +147,43 @@ func ResumeLocalSideEffects() http.Handler {
 		}
 
 		writeResponse(r.Context(), w, ResumeSideEffectsResponse{BGPStarted: bgpStarted}, http.StatusOK, logger.APILog)
+	})
+}
+
+// DrainSelfOnLeader accepts a shutdown-drain request from a peer. Runs only
+// on the leader; the calling peer's nodeID is derived from its mTLS client
+// certificate, so the caller can only mark itself drained. Used by the
+// shutdown path: a node about to exit tells the leader to flip its
+// drain_state to "drained" so operators see a clean "active → drained"
+// transition instead of the 10s "active → removed-by-autopilot" gap.
+func DrainSelfOnLeader(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !dbInstance.IsLeader() {
+			writeError(r.Context(), w, http.StatusMisdirectedRequest,
+				"not the leader; retry against the current leader", nil, logger.APILog)
+
+			return
+		}
+
+		peerID, ok := peerNodeIDFromContext(r.Context())
+		if !ok {
+			writeError(r.Context(), w, http.StatusForbidden, "peer identity unavailable", nil, logger.APILog)
+			return
+		}
+
+		if err := dbInstance.SetDrainState(r.Context(), peerID, db.DrainStateDrained); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				writeError(r.Context(), w, http.StatusNotFound, "cluster member not found", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError,
+				"failed to set drain state", err, logger.APILog)
+
+			return
+		}
+
+		writeResponse(r.Context(), w, SuccessResponse{Message: "drained"}, http.StatusOK, logger.APILog)
 	})
 }
 

--- a/internal/api/server/cluster_http_mux.go
+++ b/internal/api/server/cluster_http_mux.go
@@ -9,11 +9,42 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync/atomic"
 
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/bgp"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
 	"go.uber.org/zap"
 )
+
+// ClusterSideEffectDeps carries the AMF and BGP services the drain/resume
+// side-effect endpoints need. The cluster HTTP mux starts before these
+// services exist (discovery needs the cluster port up while Raft forms), so
+// the deps are populated by `SetClusterSideEffectDeps` after the public API
+// `Upgrade` call. Until then, side-effect endpoints return 503.
+type ClusterSideEffectDeps struct {
+	AMF *amf.AMF
+	BGP *bgp.BGPService
+}
+
+var clusterSideEffectDeps atomic.Pointer[ClusterSideEffectDeps]
+
+// SetClusterSideEffectDeps installs the AMF and BGP references used by the
+// /cluster/internal/*-side-effects endpoints. Intended to be called once,
+// from the same place that wires the full operator API (api.Server.Upgrade).
+func SetClusterSideEffectDeps(deps ClusterSideEffectDeps) {
+	clusterSideEffectDeps.Store(&deps)
+}
+
+func loadClusterSideEffectDeps() (*amf.AMF, *bgp.BGPService, bool) {
+	deps := clusterSideEffectDeps.Load()
+	if deps == nil {
+		return nil, nil, false
+	}
+
+	return deps.AMF, deps.BGP, true
+}
 
 // maxClusterJoinBodyBytes caps the self-registration POST body. The real
 // payload (AddClusterMemberRequest) is a handful of short fields; 4 KiB
@@ -33,12 +64,89 @@ func newClusterMux(dbInstance *db.Database, operatorHandler http.Handler) *http.
 	mux.HandleFunc("GET /cluster/status", ClusterStatus(dbInstance).ServeHTTP)
 	mux.Handle("POST /cluster/members", selfRegistrationGuard(AddClusterMember(dbInstance)))
 	mux.Handle("POST /cluster/members/self", selfRegistrationGuard(SelfAnnounceClusterMember(dbInstance)))
+	mux.Handle("POST /cluster/internal/drain-side-effects", removedNodeFence(dbInstance, DrainLocalSideEffects()))
+	mux.Handle("POST /cluster/internal/resume-side-effects", removedNodeFence(dbInstance, ResumeLocalSideEffects()))
 
 	if operatorHandler != nil {
 		mux.Handle("/cluster/proxy/", removedNodeFence(dbInstance, http.StripPrefix("/cluster/proxy", operatorHandler)))
 	}
 
 	return mux
+}
+
+// DrainSideEffectsResponse reports which node-local drain side-effects ran.
+type DrainSideEffectsResponse struct {
+	RANsNotified int  `json:"ransNotified"`
+	BGPStopped   bool `json:"bgpStopped"`
+}
+
+// DrainLocalSideEffects runs the node-local drain side-effects on the
+// receiving node (AMF Status Indication + BGP stop). The leader calls this
+// endpoint over mTLS when the drain target is a different node; when the
+// target is the leader itself, the leader runs these steps inline without
+// the RPC. Returns 503 if dependencies are not yet installed, which happens
+// only during the brief window between cluster HTTP startup and the public
+// API `Upgrade` call.
+func DrainLocalSideEffects() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		amfInstance, bgpService, ok := loadClusterSideEffectDeps()
+		if !ok {
+			writeError(r.Context(), w, http.StatusServiceUnavailable,
+				"cluster side-effect dependencies not yet installed", nil, logger.APILog)
+
+			return
+		}
+
+		ransNotified := notifyRANsUnavailable(r.Context(), amfInstance, defaultDrainStepTimeout)
+
+		bgpStopped := false
+
+		if bgpService != nil {
+			if err := bgpService.Stop(); err != nil {
+				logger.APILog.Warn("BGP stop during drain failed", zap.Error(err))
+			} else {
+				bgpStopped = true
+			}
+		}
+
+		writeResponse(r.Context(), w, DrainSideEffectsResponse{
+			RANsNotified: ransNotified,
+			BGPStopped:   bgpStopped,
+		}, http.StatusOK, logger.APILog)
+	})
+}
+
+// ResumeSideEffectsResponse reports which node-local resume side-effects ran.
+type ResumeSideEffectsResponse struct {
+	BGPStarted bool `json:"bgpStarted"`
+}
+
+// ResumeLocalSideEffects restarts the local BGP speaker on the receiving
+// node. The leader calls this endpoint over mTLS when the resume target is a
+// different node; when the target is the leader itself, the leader runs this
+// step inline.
+func ResumeLocalSideEffects() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, bgpService, ok := loadClusterSideEffectDeps()
+		if !ok {
+			writeError(r.Context(), w, http.StatusServiceUnavailable,
+				"cluster side-effect dependencies not yet installed", nil, logger.APILog)
+
+			return
+		}
+
+		bgpStarted := false
+
+		if bgpService != nil && !bgpService.IsRunning() {
+			if err := bgpService.Restart(r.Context()); err != nil {
+				logger.APILog.Warn("resume: failed to restart BGP speaker", zap.Error(err))
+			} else {
+				bgpStarted = true
+			}
+		}
+
+		writeResponse(r.Context(), w, ResumeSideEffectsResponse{BGPStarted: bgpStarted}, http.StatusOK, logger.APILog)
+	})
 }
 
 // removedNodeFence rejects proxied writes from peers whose nodeID is no

--- a/internal/api/server/cluster_http_mux_test.go
+++ b/internal/api/server/cluster_http_mux_test.go
@@ -4,10 +4,13 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ellanetworks/core/internal/db"
 	ellaraft "github.com/ellanetworks/core/internal/raft"
@@ -98,6 +101,169 @@ func TestRemovedNodeFence_AllowsCurrentMember(t *testing.T) {
 
 	if !nextCalled {
 		t.Fatal("expected next handler to be called for current member")
+	}
+}
+
+// newLeaderTestDB creates a real SQLite-backed DB and waits up to 3s for
+// the embedded single-node Raft cluster to elect itself leader, so the
+// returned DB is guaranteed to accept proposeChangeset calls.
+func newLeaderTestDB(t *testing.T) *db.Database {
+	t.Helper()
+
+	testDB := newTestDB(t)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for !testDB.IsLeader() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !testDB.IsLeader() {
+		t.Fatal("single-node DB did not become leader")
+	}
+
+	return testDB
+}
+
+func TestDrainSelfOnLeader_HappyPath(t *testing.T) {
+	testDB := newLeaderTestDB(t)
+
+	const peerID = 42
+	if err := testDB.UpsertClusterMember(context.Background(), &db.ClusterMember{
+		NodeID:      peerID,
+		RaftAddress: "10.0.0.42:7000",
+		APIAddress:  "http://10.0.0.42:5000",
+		Suffrage:    "voter",
+	}); err != nil {
+		t.Fatalf("upsert peer: %v", err)
+	}
+
+	handler := DrainSelfOnLeader(testDB)
+
+	req := httptest.NewRequestWithContext(
+		ctxWithPeerNodeID(context.Background(), peerID),
+		http.MethodPost, "/cluster/internal/drain-self", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	member, err := testDB.GetClusterMember(context.Background(), peerID)
+	if err != nil {
+		t.Fatalf("get peer: %v", err)
+	}
+
+	if member.DrainState != db.DrainStateDrained {
+		t.Errorf("expected drainState=drained, got %s", member.DrainState)
+	}
+}
+
+func TestDrainSelfOnLeader_MissingPeerIdentity(t *testing.T) {
+	testDB := newLeaderTestDB(t)
+
+	handler := DrainSelfOnLeader(testDB)
+
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/cluster/internal/drain-self", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 when peer identity missing, got %d", w.Code)
+	}
+}
+
+func TestDrainSelfOnLeader_UnknownPeer(t *testing.T) {
+	testDB := newLeaderTestDB(t)
+
+	handler := DrainSelfOnLeader(testDB)
+
+	req := httptest.NewRequestWithContext(
+		ctxWithPeerNodeID(context.Background(), 999),
+		http.MethodPost, "/cluster/internal/drain-self", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown peer, got %d", w.Code)
+	}
+}
+
+func TestDrainLocalSideEffects_NoDeps(t *testing.T) {
+	// Clear any previously-set deps so this test sees the pre-Upgrade state.
+	clusterSideEffectDeps.Store(nil)
+
+	handler := DrainLocalSideEffects()
+
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/cluster/internal/drain-side-effects", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when deps not installed, got %d", w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), "dependencies not yet installed") {
+		t.Errorf("expected deps-missing message, got %s", w.Body.String())
+	}
+}
+
+func TestResumeLocalSideEffects_NoDeps(t *testing.T) {
+	clusterSideEffectDeps.Store(nil)
+
+	handler := ResumeLocalSideEffects()
+
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/cluster/internal/resume-side-effects", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when deps not installed, got %d", w.Code)
+	}
+}
+
+func TestDrainLocalSideEffects_HappyPath(t *testing.T) {
+	// AMF nil is acceptable (notifyRANsUnavailable treats nil as a no-op);
+	// BGP nil is also acceptable. With both nil, the handler still succeeds
+	// and reports zero notifications / bgpStopped=false.
+	SetClusterSideEffectDeps(ClusterSideEffectDeps{AMF: nil, BGP: nil})
+
+	t.Cleanup(func() { clusterSideEffectDeps.Store(nil) })
+
+	handler := DrainLocalSideEffects()
+
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/cluster/internal/drain-side-effects", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	var env struct {
+		Result DrainSideEffectsResponse `json:"result"`
+	}
+
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if env.Result.RANsNotified != 0 {
+		t.Errorf("expected 0 RANs notified with nil AMF, got %d", env.Result.RANsNotified)
+	}
+
+	if env.Result.BGPStopped {
+		t.Errorf("expected bgpStopped=false with nil BGP, got true")
 	}
 }
 

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -2762,7 +2762,10 @@ paths:
       summary: Promote a nonvoter to voter
       description: >-
         Promotes a nonvoter cluster member to a full voter in the Raft cluster.
-        Requires admin privileges.
+        Autopilot also promotes stable non-voters automatically after the
+        server stabilization window (10 seconds); this endpoint lets
+        operators promote immediately without waiting. Requires admin
+        privileges.
       parameters:
         - name: id
           in: path
@@ -2825,14 +2828,17 @@ paths:
         When `deadlineSeconds` is 0 (the default), the response returns only
         after the drain completes and `state` is `"drained"`. When
         `deadlineSeconds > 0` the call returns immediately with
-        `state: "draining"`; a background poll flips the state to `"drained"`
-        once the target's local active-lease count reaches zero or the
-        deadline elapses. Idempotent: re-draining a draining or drained node
-        returns the current state without re-running side-effects.
+        `state: "draining"`; a background watcher on the leader flips the
+        state to `"drained"` once the target's active-lease count reaches
+        zero or the deadline elapses. Idempotent: re-draining a draining or
+        drained node returns the current state without re-running
+        side-effects.
 
-        Unlike most cluster mutations, this request is **not** proxied to the
-        leader — the proxy middleware forwards it directly to the target
-        node. Requires admin privileges.
+        In HA mode, drain runs on the leader (followers forward the request
+        automatically). The leader persists drain state through Raft and
+        dispatches the node-local side-effects to the target node over the
+        cluster mTLS port; when the target is the leader itself, the
+        side-effects run inline. Requires admin privileges.
       parameters:
         - name: id
           in: path

--- a/internal/api/server/proxy_middleware.go
+++ b/internal/api/server/proxy_middleware.go
@@ -64,41 +64,6 @@ func isLeaderOnlyRead(r *http.Request) bool {
 	return ok
 }
 
-// targetedEndpointNodeID returns the node-id when r targets a per-member
-// endpoint that must execute on the target node itself (not the leader).
-// Currently this covers drain and resume. The proxy forwards such requests
-// directly to the target's cluster port, bypassing the leader, because the
-// side-effects are local runtime state (BGP speaker, connected RANs).
-func targetedEndpointNodeID(r *http.Request) (int, bool) {
-	if !isWriteMethod(r.Method) {
-		return 0, false
-	}
-
-	const prefix = "/api/v1/cluster/members/"
-	if !strings.HasPrefix(r.URL.Path, prefix) {
-		return 0, false
-	}
-
-	rest := r.URL.Path[len(prefix):]
-
-	slash := strings.IndexByte(rest, '/')
-	if slash <= 0 {
-		return 0, false
-	}
-
-	idStr, tail := rest[:slash], rest[slash+1:]
-	if tail != "drain" && tail != "resume" {
-		return 0, false
-	}
-
-	id, err := strconv.Atoi(idStr)
-	if err != nil || id <= 0 {
-		return 0, false
-	}
-
-	return id, true
-}
-
 // isSelfRemoval reports whether r is a `DELETE /api/v1/cluster/members/{n}`
 // where n matches the node id evaluating the request. Used to reject
 // the request before proxying so an operator cannot delete the cluster
@@ -148,36 +113,6 @@ func LeaderProxyMiddleware(dbInstance *db.Database, ln *listener.Listener, next 
 			writeError(r.Context(), w, http.StatusConflict,
 				"Cannot remove the node you are currently connected to; issue the request against another node",
 				nil, logger.APILog)
-
-			return
-		}
-
-		// Per-member drain/resume must execute on the target node itself;
-		// forward directly to that node's cluster port (bypassing the
-		// leader). If we are already the target, serve locally. An
-		// already-forwarded request on the wrong node is a routing bug
-		// rather than something to silently loop on.
-		if targetID, ok := targetedEndpointNodeID(r); ok {
-			if targetID == dbInstance.NodeID() {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			if r.Header.Get(headerForwarded) != "" {
-				writeError(r.Context(), w, http.StatusBadGateway,
-					"per-member request forwarded to wrong node", nil, logger.APILog)
-
-				return
-			}
-
-			if clusterClient == nil {
-				writeError(r.Context(), w, http.StatusServiceUnavailable,
-					"cluster client unavailable", nil, logger.APILog)
-
-				return
-			}
-
-			proxyToMemberCluster(w, r, clusterClient, dbInstance, targetID)
 
 			return
 		}
@@ -288,57 +223,6 @@ func proxyToLeaderCluster(w http.ResponseWriter, r *http.Request, client *http.C
 
 		return
 	}
-
-	copyProxyResponse(w, resp, dbInstance)
-}
-
-// proxyToMemberCluster forwards r to a specific cluster member's HTTP cluster
-// port over mTLS. Used for per-member endpoints (drain, resume) whose
-// side-effects must execute on the target node itself.
-func proxyToMemberCluster(w http.ResponseWriter, r *http.Request, client *http.Client, dbInstance *db.Database, targetNodeID int) {
-	target, err := dbInstance.GetClusterMember(r.Context(), targetNodeID)
-	if err != nil {
-		writeError(r.Context(), w, http.StatusNotFound, "target cluster member not found", err, logger.APILog)
-		return
-	}
-
-	if target.RaftAddress == "" {
-		writeError(r.Context(), w, http.StatusServiceUnavailable,
-			"target cluster member has no raft address", nil, logger.APILog)
-
-		return
-	}
-
-	targetURL := fmt.Sprintf("https://%s/cluster/proxy%s", target.RaftAddress, r.RequestURI)
-
-	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body) // #nosec G704 -- built from cluster_members row (Raft-replicated)
-	if err != nil {
-		writeError(r.Context(), w, http.StatusBadGateway, "failed to create proxy request", err, logger.APILog)
-		return
-	}
-
-	for key, values := range r.Header {
-		if isHopByHopHeader(key) {
-			continue
-		}
-
-		for _, v := range values {
-			proxyReq.Header.Add(key, v)
-		}
-	}
-
-	proxyReq.Header.Set(headerForwarded, "true")
-
-	resp, err := client.Do(proxyReq) // #nosec G704 -- built from cluster_members row (Raft-replicated)
-	if err != nil {
-		logger.APILog.Warn("Member cluster proxy failed",
-			zap.Int("targetNodeId", targetNodeID), zap.Error(err))
-		writeError(r.Context(), w, http.StatusBadGateway, "target node unreachable", err, logger.APILog)
-
-		return
-	}
-
-	defer func() { _ = resp.Body.Close() }()
 
 	copyProxyResponse(w, resp, dbInstance)
 }

--- a/internal/api/server/proxy_middleware_test.go
+++ b/internal/api/server/proxy_middleware_test.go
@@ -221,41 +221,6 @@ func TestIsSelfRemoval(t *testing.T) {
 	}
 }
 
-func TestTargetedEndpointNodeID(t *testing.T) {
-	tests := []struct {
-		name      string
-		method    string
-		path      string
-		wantID    int
-		wantMatch bool
-	}{
-		{"drain POST", http.MethodPost, "/api/v1/cluster/members/3/drain", 3, true},
-		{"resume POST", http.MethodPost, "/api/v1/cluster/members/7/resume", 7, true},
-		{"drain GET is not a write", http.MethodGet, "/api/v1/cluster/members/3/drain", 0, false},
-		{"promote is not targeted", http.MethodPost, "/api/v1/cluster/members/3/promote", 0, false},
-		{"delete member is not targeted", http.MethodDelete, "/api/v1/cluster/members/3", 0, false},
-		{"unrelated write", http.MethodPost, "/api/v1/subscribers", 0, false},
-		{"non-numeric id", http.MethodPost, "/api/v1/cluster/members/abc/drain", 0, false},
-		{"negative id", http.MethodPost, "/api/v1/cluster/members/-1/drain", 0, false},
-		{"missing verb", http.MethodPost, "/api/v1/cluster/members/3", 0, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequestWithContext(context.Background(), tt.method, tt.path, nil)
-			id, ok := targetedEndpointNodeID(req)
-
-			if ok != tt.wantMatch {
-				t.Errorf("targetedEndpointNodeID(%s %s).ok = %v, want %v", tt.method, tt.path, ok, tt.wantMatch)
-			}
-
-			if id != tt.wantID {
-				t.Errorf("targetedEndpointNodeID(%s %s).id = %d, want %d", tt.method, tt.path, id, tt.wantID)
-			}
-		})
-	}
-}
-
 func TestLeaderProxyMiddleware_NilDB(t *testing.T) {
 	called := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -224,8 +224,8 @@ func NewHandler(cfg HandlerConfig) http.Handler {
 	mux.HandleFunc("GET /api/v1/cluster/members/{id}", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, GetClusterMember(dbInstance))).ServeHTTP)
 	mux.HandleFunc("DELETE /api/v1/cluster/members/{id}", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, RemoveClusterMember(dbInstance))).ServeHTTP)
 	mux.HandleFunc("POST /api/v1/cluster/members/{id}/promote", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, PromoteClusterMember(dbInstance))).ServeHTTP)
-	mux.HandleFunc("POST /api/v1/cluster/members/{id}/drain", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, DrainClusterMember(dbInstance, amfInstance, bgpService))).ServeHTTP)
-	mux.HandleFunc("POST /api/v1/cluster/members/{id}/resume", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, ResumeClusterMember(dbInstance, bgpService))).ServeHTTP)
+	mux.HandleFunc("POST /api/v1/cluster/members/{id}/drain", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, DrainClusterMember(dbInstance, amfInstance, bgpService, cfg.ClusterListener))).ServeHTTP)
+	mux.HandleFunc("POST /api/v1/cluster/members/{id}/resume", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, ResumeClusterMember(dbInstance, bgpService, cfg.ClusterListener))).ServeHTTP)
 
 	mux.HandleFunc("GET /api/v1/cluster/autopilot", Authenticate(jwtSecret, dbInstance, Authorize(PermManageCluster, GetAutopilotState(dbInstance))).ServeHTTP)
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -443,8 +443,23 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		// does not starve subsequent ones.
 		stepTimeout := 5 * time.Second
 
-		// 0. Transfer leadership (HA only) so the cluster can continue
-		//    serving writes while this node tears down.
+		// 0a. Signal the replicated cluster_members row that this node
+		//     is draining out. Must happen before the leadership transfer
+		//     so the write lands while we are still leader (if we are);
+		//     a follower sends the write to the current leader over the
+		//     cluster mTLS port.
+		if dbInstance.ClusterEnabled() {
+			sdCtx, sdCancel := context.WithTimeout(context.Background(), stepTimeout)
+
+			if err := server.SignalShutdownDrain(sdCtx, dbInstance, clusterLn); err != nil {
+				logger.EllaLog.Warn("Shutdown-drain state write failed", zap.Error(err))
+			}
+
+			sdCancel()
+		}
+
+		// 0b. Transfer leadership (HA only) so the cluster can continue
+		//     serving writes while this node tears down.
 		if dbInstance.ClusterEnabled() && dbInstance.IsLeader() {
 			logger.EllaLog.Info("Transferring Raft leadership before shutdown")
 


### PR DESCRIPTION
# Description

Drain/resume used to land on the target node and fail SetDrainState with  ErrNotLeader on followers. Rework to run on the leader (matching Nomad's Node.UpdateDrain) with node-local side effects dispatched via two new  mTLS cluster-port RPCs when `target != leader`; fixes  TestIntegrationHAScaleUpDown.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
