### PR TITLE
fix: decode NGAP initial context setup failure

### DIFF
--- a/internal/decoder/ngap/initial_context_setup_failure.go
+++ b/internal/decoder/ngap/initial_context_setup_failure.go
@@ -1,0 +1,87 @@
+package ngap
+
+import (
+	"fmt"
+
+	"github.com/free5gc/ngap/ngapType"
+)
+
+type PDUSessionResourceFailedToSetupCxtFail struct {
+	PDUSessionID                                int64                                               `json:"pdu_session_id"`
+	PDUSessionResourceSetupUnsuccessfulTransfer *PDUSessionResourceSetupUnsuccessfulTransferDecoded `json:"pdu_session_resource_setup_unsuccessful_transfer,omitempty"`
+
+	Error string `json:"error,omitempty"`
+}
+
+func buildInitialContextSetupFailure(initialContextSetupFailure ngapType.InitialContextSetupFailure) NGAPMessageValue {
+	ies := make([]IE, 0)
+
+	for i := 0; i < len(initialContextSetupFailure.ProtocolIEs.List); i++ {
+		ie := initialContextSetupFailure.ProtocolIEs.List[i]
+
+		switch ie.Id.Value {
+		case ngapType.ProtocolIEIDAMFUENGAPID:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       ie.Value.AMFUENGAPID.Value,
+			})
+		case ngapType.ProtocolIEIDRANUENGAPID:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       ie.Value.RANUENGAPID.Value,
+			})
+		case ngapType.ProtocolIEIDCause:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       causeToEnum(*ie.Value.Cause),
+			})
+		case ngapType.ProtocolIEIDPDUSessionResourceFailedToSetupListCxtFail:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       buildPDUSessionResourceFailedToSetupListCxtFailIE(*ie.Value.PDUSessionResourceFailedToSetupListCxtFail),
+			})
+		case ngapType.ProtocolIEIDCriticalityDiagnostics:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       buildCriticalityDiagnosticsIE(ie.Value.CriticalityDiagnostics),
+			})
+		default:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Error:       fmt.Sprintf("unsupported ie type %d", ie.Id.Value),
+			})
+		}
+	}
+
+	return NGAPMessageValue{
+		IEs: ies,
+	}
+}
+
+func buildPDUSessionResourceFailedToSetupListCxtFailIE(pduList ngapType.PDUSessionResourceFailedToSetupListCxtFail) []PDUSessionResourceFailedToSetupCxtFail {
+	pduSessionList := make([]PDUSessionResourceFailedToSetupCxtFail, 0)
+
+	for i := 0; i < len(pduList.List); i++ {
+		item := pduList.List[i]
+		entry := PDUSessionResourceFailedToSetupCxtFail{
+			PDUSessionID: item.PDUSessionID.Value,
+		}
+
+		transfer, err := decodeSetupUnsuccessfulTransfer(item.PDUSessionResourceSetupUnsuccessfulTransfer)
+		if err != nil {
+			entry.Error = fmt.Sprintf("failed to decode unsuccessful transfer: %v", err)
+		} else {
+			entry.PDUSessionResourceSetupUnsuccessfulTransfer = transfer
+		}
+
+		pduSessionList = append(pduSessionList, entry)
+	}
+
+	return pduSessionList
+}

--- a/internal/decoder/ngap/initial_context_setup_failure_test.go
+++ b/internal/decoder/ngap/initial_context_setup_failure_test.go
@@ -1,0 +1,89 @@
+package ngap_test
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/decoder/ngap"
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/free5gc/ngap/ngapType"
+)
+
+// Captured InitialContextSetupFailure PDU with cause radioNetwork=SliceNotSupported (39).
+// Hex dump:
+//
+//	40 0e 00 15 00 00 03 00 0a 40 02 00 09 00 55 40
+//	02 00 09 00 0f 40 02 09 c0
+func TestDecodeNGAPMessage_InitialContextSetupFailure(t *testing.T) {
+	const message = "QA4AFQAAAwAKQAIACQBVQAIACQAPQAIJwA=="
+
+	raw, err := decodeB64(message)
+	if err != nil {
+		t.Fatalf("base64 decode failed: %v", err)
+	}
+
+	ngapMsg := ngap.DecodeNGAPMessage(raw)
+
+	if ngapMsg.PDUType != "UnsuccessfulOutcome" {
+		t.Errorf("expected PDUType=UnsuccessfulOutcome, got %v", ngapMsg.PDUType)
+	}
+
+	if ngapMsg.ProcedureCode.Label != "InitialContextSetup" {
+		t.Errorf("expected ProcedureCode=InitialContextSetup, got %v", ngapMsg.ProcedureCode)
+	}
+
+	if ngapMsg.ProcedureCode.Value != ngapType.ProcedureCodeInitialContextSetup {
+		t.Errorf("expected ProcedureCode value=%d, got %d", ngapType.ProcedureCodeInitialContextSetup, ngapMsg.ProcedureCode.Value)
+	}
+
+	if ngapMsg.Criticality.Label != "Reject" {
+		t.Errorf("expected Criticality=Reject, got %v", ngapMsg.Criticality)
+	}
+
+	if ngapMsg.Criticality.Value != 0 {
+		t.Errorf("expected Criticality value=0, got %d", ngapMsg.Criticality.Value)
+	}
+
+	if ngapMsg.Value.Error != "" {
+		t.Fatalf("expected no decode error, got %q", ngapMsg.Value.Error)
+	}
+
+	if len(ngapMsg.Value.IEs) != 3 {
+		t.Fatalf("expected 3 ProtocolIEs, got %d", len(ngapMsg.Value.IEs))
+	}
+
+	amfUEID := ngapMsg.Value.IEs[0]
+	if amfUEID.ID.Value != ngapType.ProtocolIEIDAMFUENGAPID {
+		t.Errorf("expected first IE=AMF-UE-NGAP-ID (%d), got %d", ngapType.ProtocolIEIDAMFUENGAPID, amfUEID.ID.Value)
+	}
+
+	if v, ok := amfUEID.Value.(int64); !ok || v != 9 {
+		t.Errorf("expected AMF-UE-NGAP-ID=9, got %T %v", amfUEID.Value, amfUEID.Value)
+	}
+
+	ranUEID := ngapMsg.Value.IEs[1]
+	if ranUEID.ID.Value != ngapType.ProtocolIEIDRANUENGAPID {
+		t.Errorf("expected second IE=RAN-UE-NGAP-ID (%d), got %d", ngapType.ProtocolIEIDRANUENGAPID, ranUEID.ID.Value)
+	}
+
+	if v, ok := ranUEID.Value.(int64); !ok || v != 9 {
+		t.Errorf("expected RAN-UE-NGAP-ID=9, got %T %v", ranUEID.Value, ranUEID.Value)
+	}
+
+	causeIE := ngapMsg.Value.IEs[2]
+	if causeIE.ID.Label != "Cause" {
+		t.Errorf("expected third IE=Cause, got %v", causeIE.ID)
+	}
+
+	cause, ok := causeIE.Value.(utils.EnumField[uint64])
+	if !ok {
+		t.Fatalf("expected Cause enum, got %T", causeIE.Value)
+	}
+
+	if cause.Label != "SliceNotSupported" {
+		t.Errorf("expected Cause=SliceNotSupported, got %v", cause.Label)
+	}
+
+	if cause.Value != uint64(ngapType.CauseRadioNetworkPresentSliceNotSupported) {
+		t.Errorf("expected Cause value=%d, got %d", ngapType.CauseRadioNetworkPresentSliceNotSupported, cause.Value)
+	}
+}

--- a/internal/decoder/ngap/ngap.go
+++ b/internal/decoder/ngap/ngap.go
@@ -176,6 +176,8 @@ func buildUnsuccessfulOutcome(unsucMsg ngapType.UnsuccessfulOutcome) NGAPMessage
 	switch unsucMsg.Value.Present {
 	case ngapType.UnsuccessfulOutcomePresentNGSetupFailure:
 		return buildNGSetupFailure(*unsucMsg.Value.NGSetupFailure)
+	case ngapType.UnsuccessfulOutcomePresentInitialContextSetupFailure:
+		return buildInitialContextSetupFailure(*unsucMsg.Value.InitialContextSetupFailure)
 	default:
 		return NGAPMessageValue{
 			Error: fmt.Sprintf("Unsupported message %d", unsucMsg.Value.Present),


### PR DESCRIPTION
# Description

Whenever radios respond with NGAP Initial Context Setup Failure, we wouldn't see the cause in the UI Radio events page.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
