### PR TITLE
fix: nil-pointer during update when no  tunnel

### DIFF
--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -985,6 +985,34 @@ func TestUpdateSmContextN2InfoPduResSetupRsp_NilPFCPContext(t *testing.T) {
 	}
 }
 
+func TestUpdateSmContextN2InfoPduResSetupRsp_TunnelReleased(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+	smCtx.Tunnel = nil
+	smCtx.PFCPContext = nil
+
+	gnbIP := net.ParseIP("10.0.0.200").To4()
+
+	n2Data, err := buildPDUSessionResourceSetupResponseTransfer(7000, gnbIP)
+	if err != nil {
+		t.Fatalf("build N2 payload: %v", err)
+	}
+
+	if err := s.UpdateSmContextN2InfoPduResSetupRsp(ctx, ref, n2Data); err == nil {
+		t.Fatal("expected error when tunnel was released, got nil")
+	}
+
+	upf.mu.Lock()
+	defer upf.mu.Unlock()
+
+	if len(upf.modifyCalls) != 0 {
+		t.Fatalf("expected no PFCP modify calls after tunnel release, got %d", len(upf.modifyCalls))
+	}
+}
+
 // ===========================
 // HandleDownlinkDataReport tests
 // ===========================

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -146,6 +146,13 @@ func (s *SMF) UpdateSmContextN2InfoPduResSetupRsp(ctx context.Context, smContext
 	smContext.Mutex.Lock()
 	defer smContext.Mutex.Unlock()
 
+	if smContext.Tunnel == nil || smContext.Tunnel.DataPath == nil {
+		span.RecordError(fmt.Errorf("session already released"))
+		span.SetStatus(codes.Error, "session already released")
+
+		return fmt.Errorf("session already released")
+	}
+
 	pdrList, farList, err := handleUpdateN2MsgPDUResourceSetupResp(n2Data, smContext)
 	if err != nil {
 		span.RecordError(err)


### PR DESCRIPTION
# Description


There was a bug where Ella Core would panic when sending a PFCP update for a tunnel that does not exist.

```
Apr 28 14:03:39 protectli main[6407]: {"level":"info","ts":"2026-04-28T14:03:39.338Z","caller":"runtime/runtime.go:521","msg":"removed radio on connection close","component":"AMF","fd":40}
Apr 28 14:03:39 protectli main[6407]: panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
Apr 28 14:03:39 protectli main[6407]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xfed045]
Apr 28 14:03:39 protectli main[6407]: goroutine 1150 [running]:
Apr 28 14:03:39 protectli main[6407]: go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.43.0/trace/span.go:478 +0x1b
Apr 28 14:03:39 protectli main[6407]: go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x292ca871f4a0, {0x0, 0x0, 0x292ca81a7680?})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.43.0/trace/span.go:528 +0xc7b
Apr 28 14:03:39 protectli main[6407]: panic({0x15d29a0?, 0x28a7880?})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/src/runtime/panic.go:860 +0x13a
Apr 28 14:03:39 protectli main[6407]: go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.43.0/trace/span.go:478 +0x1b
Apr 28 14:03:39 protectli main[6407]: go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x292ca871f680, {0x0, 0x0, 0x292ca81a7680?})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.43.0/trace/span.go:528 +0xc7b
Apr 28 14:03:39 protectli main[6407]: panic({0x15d29a0?, 0x28a7880?})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/src/runtime/panic.go:860 +0x13a
Apr 28 14:03:39 protectli main[6407]: github.com/ellanetworks/core/internal/smf.handleUpdateN2MsgPDUResourceSetupResp({0x292ca8f82020, 0xd, 0x10}, 0x292ca7ef7800)
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/internal/smf/update.go:187 +0x245
Apr 28 14:03:39 protectli main[6407]: github.com/ellanetworks/core/internal/smf.(*SMF).UpdateSmContextN2InfoPduResSetupRsp(0x292ca7d31e60, {0x1b31ec8, 0x292ca80ed2f0}, {0x292ca8ab34b8, 0x16}, {0x292ca8f82020, 0xd, 0x10})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/internal/smf/update.go:149 +0x499
Apr 28 14:03:39 protectli main[6407]: github.com/ellanetworks/core/internal/amf/ngap.HandlePDUSessionResourceSetupResponse({0x1b31ec8, 0x292ca80ed2f0}, 0x292ca8322160, 0x10?, {0x292ca8f82090, 0x292ca8f82098, {0x292ca80ed650, 0x1, 0x1}, {0x0, ...}})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/internal/amf/ngap/handle_pdu_session_resource_setup_response.go:44 +0x223
Apr 28 14:03:39 protectli main[6407]: github.com/ellanetworks/core/internal/amf/ngap.dispatchNgapMsg({0x1b31ec8, 0x292ca80ed2f0}, 0x292ca8322160, 0x292ca839e500, 0x292ca86029c6?)
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/internal/amf/ngap/dispatcher.go:310 +0x150d
Apr 28 14:03:39 protectli main[6407]: github.com/ellanetworks/core/internal/amf/ngap.Dispatch({0x1b32050, 0x292ca7d21280}, 0x292ca8322160, 0x292ca8149440, {0x292ca827c120, 0x29, 0x29})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/internal/amf/ngap/dispatcher.go:140 +0x134d
Apr 28 14:03:39 protectli main[6407]: github.com/ellanetworks/core/pkg/runtime.Start.func11({0x1b32050?, 0x292ca7d21280?}, 0x20000?, {0x292ca827c120?, 0x1?, 0x1?})
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/pkg/runtime/runtime.go:513 +0x35
Apr 28 14:03:39 protectli main[6407]: github.com/ellanetworks/core/internal/amf/ngap/service.(*Server).serveConn(0x292ca7fb2af0, {0x1b32050, 0x292ca7d21280}, 0x292ca8149440)
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/internal/amf/ngap/service/service.go:224 +0x6e6
Apr 28 14:03:39 protectli main[6407]: created by github.com/ellanetworks/core/internal/amf/ngap/service.(*Server).acceptLoop in goroutine 336
Apr 28 14:03:39 protectli main[6407]:         /home/protectli/core/internal/amf/ngap/service/service.go:159 +0x2e5
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
