### PR TITLE
chore: integration test with FQDN in peers

### DIFF
--- a/docs/explanation/bgp.md
+++ b/docs/explanation/bgp.md
@@ -27,4 +27,4 @@ Ella Core receives routes from BGP peers and installs them into the kernel routi
 
 ### In an HA cluster
 
-Each node runs its own BGP speaker and advertises `/32` subnets for the sessions it currently hosts.See [High Availability](high_availability.md) for the broader cluster model.
+Each node runs its own BGP speaker and advertises `/32` subnets for the sessions it currently hosts. See [High Availability](high_availability.md) for the broader cluster model.

--- a/docs/explanation/high_availability.md
+++ b/docs/explanation/high_availability.md
@@ -21,11 +21,13 @@ Two things HA does not handle automatically. If more than half the voters fail a
 
 ## What replicates, and what does not
 
-All persistent resources are replicated across the cluster, so if a node dies, the others have the same subscribers, policies, and operator configuration. The cluster automatically elects a new leader and keeps accepting operator changes with no manual intervention.
+Network-wide resources — subscribers, profiles, policies, slices, data networks, network rules, IP leases, users, API tokens, audit logs, the operator configuration — replicate across the cluster. If a node dies, the survivors hold the same state, automatically elect a new leader, and keep accepting writes.
 
-Runtime state tied to a specific connection or session does not replicate. This includes SCTP associations with gNBs, UE contexts, active PDU sessions and their User Plane state, GTP-U tunnels, and active BGP adjacencies.
+Per-node configuration does not replicate. This covers the local data-plane and routing settings each node owns: static routes, BGP settings, BGP peers and import prefixes, NAT, the N3 external address, and flow accounting. To configure these on an HA cluster, hit each node's API directly — a change made on one node does not propagate to its peers. This lets nodes in different racks or AZs run with different upstream gateways and BGP topologies.
 
-Observability is also per-node: each instance exposes its own Prometheus endpoint and radio events and flow reports, so operators scrape every node for a cluster-wide view.
+Runtime state tied to a specific connection or session also does not replicate: SCTP associations with gNBs, UE contexts, active PDU sessions and their User Plane state, GTP-U tunnels, and active BGP adjacencies.
+
+Observability is per-node: each instance exposes its own Prometheus endpoint, radio events, and flow reports, so operators scrape every node for a cluster-wide view.
 
 ## User plane and routing
 
@@ -54,7 +56,7 @@ When a Core dies, gNBs reselect within the Set automatically; affected UEs re-re
 
 ### Radios Pinned to Specific Nodes
 
-Useful for site- or tenant-partitioned deployments. The cluster still replicates operator state across all nodes, so changes made anywhere are visible everywhere — but if a Core dies, its paired gNBs lose N2 and must be reconfigured to reach a surviving node. UE failover is manual, not automatic.
+Useful for site- or tenant-partitioned deployments. Network-wide state still replicates, so subscribers and policies stay consistent across nodes — but if a Core dies, its paired gNBs lose N2 and must be reconfigured to reach a surviving node. UE failover is manual, not automatic.
 
 <figure markdown="span">
   ![Radios Pinned to Specific Nodes](../images/ha_scenario_2.svg){ width="700" }

--- a/integration/ha_3gpp_test.go
+++ b/integration/ha_3gpp_test.go
@@ -70,7 +70,12 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 
 	t.Cleanup(func() { _ = dc.Close() })
 
-	adminToken, nodeClients, err := bringUpHA3GPPCluster(t, ctx, dc, composeDir, composeFile, "ella-core-tester", "router")
+	adminToken, nodeClients, err := bringUpHA3GPPCluster(t, ctx, dc, composeDir, composeFile, bringUpHA3GPPClusterOpts{
+		// Exercise the hostname-resolved peer path; TestIntegration3GPPMultiGNB
+		// covers the IP-literal path.
+		UseFQDN:       true,
+		ExtraServices: []string{"ella-core-tester", "router"},
+	})
 	if err != nil {
 		t.Fatalf("bring up cluster: %v", err)
 	}
@@ -257,15 +262,44 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 // any extraServices listed (typically the tester sidecar and the N6
 // router). Compose topologies that need a different sidecar shape
 // (e.g., one tester per gNB) pass their own service names instead.
-func bringUpHA3GPPCluster(t *testing.T, ctx context.Context, dc *DockerClient, composeDir, composeFile string, extraServices ...string) (string, []*client.Client, error) {
+// bringUpHA3GPPClusterOpts captures the optional flags accepted by
+// bringUpHA3GPPCluster. Anything that varies per-test goes here so the
+// helper signature stays stable.
+type bringUpHA3GPPClusterOpts struct {
+	// UseFQDN selects compose-service-name FQDNs (ella-core-1 / ella-core-2
+	// / ella-core-3) for the cluster peer list and bind-address instead of
+	// raw IP literals. Docker's embedded DNS on the user-defined `cluster`
+	// network resolves those names to the per-node IP. Used to verify that
+	// the cluster control-plane works against hostname peers — the way
+	// real deployments name their members. Default false: peers stay on
+	// IP literals so most tests still cover the IP-based path.
+	UseFQDN bool
+
+	// ExtraServices are compose services started after the cluster is
+	// converged (testers, routers). Cluster formation does not depend on
+	// them.
+	ExtraServices []string
+}
+
+func bringUpHA3GPPCluster(t *testing.T, ctx context.Context, dc *DockerClient, composeDir, composeFile string, opts bringUpHA3GPPClusterOpts) (string, []*client.Client, error) {
 	t.Helper()
 
 	nodeServices := []string{"ella-core-1", "ella-core-2", "ella-core-3"}
 
-	peers := []string{
-		"10.100.0.11:7000",
-		"10.100.0.12:7000",
-		"10.100.0.13:7000",
+	var peers []string
+
+	if opts.UseFQDN {
+		peers = []string{
+			"ella-core-1:7000",
+			"ella-core-2:7000",
+			"ella-core-3:7000",
+		}
+	} else {
+		peers = []string{
+			"10.100.0.11:7000",
+			"10.100.0.12:7000",
+			"10.100.0.13:7000",
+		}
 	}
 
 	dc.ComposeCleanup(ctx)
@@ -275,7 +309,7 @@ func bringUpHA3GPPCluster(t *testing.T, ctx context.Context, dc *DockerClient, c
 		return "", nil, err
 	}
 
-	if err := writeHA3GPPNodeConfig(composeDir, 1, peers, ""); err != nil {
+	if err := writeHA3GPPNodeConfig(composeDir, 1, peers, "", opts.UseFQDN); err != nil {
 		return fail(err)
 	}
 
@@ -312,7 +346,7 @@ func bringUpHA3GPPCluster(t *testing.T, ctx context.Context, dc *DockerClient, c
 			return fail(fmt.Errorf("mint join token for node %d: %w", nodeID, err))
 		}
 
-		if err := writeHA3GPPNodeConfig(composeDir, nodeID, peers, tok.Token); err != nil {
+		if err := writeHA3GPPNodeConfig(composeDir, nodeID, peers, tok.Token, opts.UseFQDN); err != nil {
 			return fail(err)
 		}
 
@@ -348,9 +382,9 @@ func bringUpHA3GPPCluster(t *testing.T, ctx context.Context, dc *DockerClient, c
 
 	// Start any caller-supplied sidecars (testers, router) last; they
 	// don't affect cluster formation.
-	if len(extraServices) > 0 {
-		if err := dc.ComposeUpServicesWithFile(ctx, composeDir, composeFile, extraServices...); err != nil {
-			return fail(fmt.Errorf("start extra services %v: %w", extraServices, err))
+	if len(opts.ExtraServices) > 0 {
+		if err := dc.ComposeUpServicesWithFile(ctx, composeDir, composeFile, opts.ExtraServices...); err != nil {
+			return fail(fmt.Errorf("start extra services %v: %w", opts.ExtraServices, err))
 		}
 	}
 
@@ -400,7 +434,13 @@ func composeKill(ctx context.Context, composeDir, composeFile, service string) e
 // Mirrors the pattern of writeNodeConfig in ha_helpers_test.go but with
 // per-node n3 addresses instead of the single-bridge shape used by the
 // non-5G HA tests.
-func writeHA3GPPNodeConfig(composeDir string, nodeID int, peers []string, joinToken string) error {
+//
+// When useFQDN is true, the cluster.bind-address uses the compose service
+// name (ella-core-N) rather than the per-node IP, exercising the
+// hostname-resolved peer path. n2/n3/api addresses stay on IP literals
+// because they are data-plane endpoints reached by simulators that bind
+// directly to fixed IPs.
+func writeHA3GPPNodeConfig(composeDir string, nodeID int, peers []string, joinToken string, useFQDN bool) error {
 	cfgDir, err := filepath.Abs(filepath.Join(composeDir, "cfg", fmt.Sprintf("node%d", nodeID)))
 	if err != nil {
 		return fmt.Errorf("abs path %s: %w", composeDir, err)
@@ -416,6 +456,11 @@ func writeHA3GPPNodeConfig(composeDir string, nodeID int, peers []string, joinTo
 
 	clusterAddr := fmt.Sprintf("10.100.0.%d", 10+nodeID)
 	n3Addr := fmt.Sprintf("10.3.0.%d", 10+nodeID)
+
+	clusterBindHost := clusterAddr
+	if useFQDN {
+		clusterBindHost = fmt.Sprintf("ella-core-%d", nodeID)
+	}
 
 	var peersYAML strings.Builder
 
@@ -454,7 +499,7 @@ cluster:
   node-id: %d
   bind-address: "%s:7000"
   peers:
-%s%s`, clusterAddr, n3Addr, clusterAddr, nodeID, clusterAddr, peersYAML.String(), joinTokenLine)
+%s%s`, clusterAddr, n3Addr, clusterAddr, nodeID, clusterBindHost, peersYAML.String(), joinTokenLine)
 
 	return os.WriteFile(filepath.Join(cfgDir, "core.yaml"), []byte(body), 0o644)
 }

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -113,11 +113,11 @@ func bringUpHAClusterAt(t *testing.T, ctx context.Context, dc *DockerClient, com
 
 	composeFile := ComposeFile()
 
-	if err := dc.ComposeStartWithFile(ctx, composeDir, services[0], composeFile); err != nil {
-		// Service may not exist yet — create and start.
-		if err2 := dc.ComposeUpServicesWithFile(ctx, composeDir, composeFile, services[0]); err2 != nil {
-			return fail(fmt.Errorf("start node 1: %w (create: %v)", err, err2))
-		}
+	// ComposeCleanup above wiped all containers, so node 1 needs to be
+	// (re-)created — `up -d` is the only path that does both create and
+	// start. A plain `start` would always fail with "no such container".
+	if err := dc.ComposeUpServicesWithFile(ctx, composeDir, composeFile, services[0]); err != nil {
+		return fail(fmt.Errorf("start node 1: %w", err))
 	}
 
 	node1, err := newInsecureClient(getHANodeURLs()[0])

--- a/integration/ha_multi_gnb_test.go
+++ b/integration/ha_multi_gnb_test.go
@@ -88,7 +88,11 @@ func TestIntegration3GPPMultiGNB(t *testing.T) {
 
 	testerServices = append(testerServices, "router")
 
-	adminToken, nodeClients, err := bringUpHA3GPPCluster(t, ctx, dc, composeDir, composeFile, testerServices...)
+	adminToken, nodeClients, err := bringUpHA3GPPCluster(t, ctx, dc, composeDir, composeFile, bringUpHA3GPPClusterOpts{
+		// Stay on IP-literal peers — TestIntegration3GPPHAFailover covers
+		// the FQDN path.
+		ExtraServices: testerServices,
+	})
 	if err != nil {
 		t.Fatalf("bring up cluster: %v", err)
 	}

--- a/internal/db/bgp_settings.go
+++ b/internal/db/bgp_settings.go
@@ -34,8 +34,6 @@ func defaultBGPSettings() *BGPSettings {
 
 const BGPSettingsTableName = "bgp_settings"
 
-const insertDefaultBGPSettingsStmt = `INSERT OR IGNORE INTO %s (singleton, enabled, localAS, routerID, listenAddress) VALUES (TRUE, $BGPSettings.enabled, $BGPSettings.localAS, $BGPSettings.routerID, $BGPSettings.listenAddress);`
-
 const upsertBGPSettingsStmt = `
 INSERT INTO %s (singleton, enabled, localAS, routerID, listenAddress) VALUES (TRUE, $BGPSettings.enabled, $BGPSettings.localAS, $BGPSettings.routerID, $BGPSettings.listenAddress)
 ON CONFLICT(singleton) DO UPDATE SET enabled=$BGPSettings.enabled, localAS=$BGPSettings.localAS, routerID=$BGPSettings.routerID, listenAddress=$BGPSettings.listenAddress;

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -113,19 +113,16 @@ type Database struct {
 	countDataNetworksStmt   *sqlair.Statement
 
 	// N3 Settings statements
-	insertDefaultN3SettingsStmt *sqlair.Statement
-	updateN3SettingsStmt        *sqlair.Statement
-	getN3SettingsStmt           *sqlair.Statement
+	updateN3SettingsStmt *sqlair.Statement
+	getN3SettingsStmt    *sqlair.Statement
 
 	// NAT Settings statements
-	insertDefaultNATSettingsStmt *sqlair.Statement
-	getNATSettingsStmt           *sqlair.Statement
-	upsertNATSettingsStmt        *sqlair.Statement
+	getNATSettingsStmt    *sqlair.Statement
+	upsertNATSettingsStmt *sqlair.Statement
 
 	// BGP Settings statements
-	insertDefaultBGPSettingsStmt *sqlair.Statement
-	getBGPSettingsStmt           *sqlair.Statement
-	upsertBGPSettingsStmt        *sqlair.Statement
+	getBGPSettingsStmt    *sqlair.Statement
+	upsertBGPSettingsStmt *sqlair.Statement
 
 	// BGP Peers statements
 	listBGPPeersStmt    *sqlair.Statement
@@ -142,9 +139,8 @@ type Database struct {
 	deleteImportPrefixesByPeerStmt *sqlair.Statement
 
 	// Flow Accounting Settings statements
-	insertDefaultFlowAccountingSettingsStmt *sqlair.Statement
-	getFlowAccountingSettingsStmt           *sqlair.Statement
-	upsertFlowAccountingSettingsStmt        *sqlair.Statement
+	getFlowAccountingSettingsStmt    *sqlair.Statement
+	upsertFlowAccountingSettingsStmt *sqlair.Statement
 
 	// Operator statements
 	getOperatorStmt                      *sqlair.Statement
@@ -1277,17 +1273,14 @@ func (db *Database) PrepareStatements() error {
 		{&db.countDataNetworksStmt, fmt.Sprintf(countDataNetworksStmt, DataNetworksTableName), []any{NumItems{}}},
 
 		// N3 Settings
-		{&db.insertDefaultN3SettingsStmt, fmt.Sprintf(insertDefaultN3SettingsStmt, N3SettingsTableName), []any{N3Settings{}}},
 		{&db.updateN3SettingsStmt, fmt.Sprintf(upsertN3SettingsStmt, N3SettingsTableName), []any{N3Settings{}}},
 		{&db.getN3SettingsStmt, fmt.Sprintf(getN3SettingsStmt, N3SettingsTableName), []any{N3Settings{}}},
 
 		// NAT Settings
-		{&db.insertDefaultNATSettingsStmt, fmt.Sprintf(insertDefaultNATSettingsStmt, NATSettingsTableName), []any{NATSettings{}}},
 		{&db.getNATSettingsStmt, fmt.Sprintf(getNATSettingsStmt, NATSettingsTableName), []any{NATSettings{}}},
 		{&db.upsertNATSettingsStmt, fmt.Sprintf(upsertNATSettingsStmt, NATSettingsTableName), []any{NATSettings{}}},
 
 		// BGP Settings
-		{&db.insertDefaultBGPSettingsStmt, fmt.Sprintf(insertDefaultBGPSettingsStmt, BGPSettingsTableName), []any{BGPSettings{}}},
 		{&db.getBGPSettingsStmt, fmt.Sprintf(getBGPSettingsStmt, BGPSettingsTableName), []any{BGPSettings{}}},
 		{&db.upsertBGPSettingsStmt, fmt.Sprintf(upsertBGPSettingsStmt, BGPSettingsTableName), []any{BGPSettings{}}},
 
@@ -1306,7 +1299,6 @@ func (db *Database) PrepareStatements() error {
 		{&db.deleteImportPrefixesByPeerStmt, fmt.Sprintf(deleteImportPrefixesByPeerStmt, BGPImportPrefixesTableName), []any{BGPImportPrefix{}}},
 
 		// Flow Accounting Settings
-		{&db.insertDefaultFlowAccountingSettingsStmt, fmt.Sprintf(insertDefaultFlowAccountingSettingsStmt, FlowAccountingSettingsTableName), []any{FlowAccountingSettings{}}},
 		{&db.getFlowAccountingSettingsStmt, fmt.Sprintf(getFlowAccountingSettingsStmt, FlowAccountingSettingsTableName), []any{FlowAccountingSettings{}}},
 		{&db.upsertFlowAccountingSettingsStmt, fmt.Sprintf(upsertFlowAccountingSettingsStmt, FlowAccountingSettingsTableName), []any{FlowAccountingSettings{}}},
 

--- a/internal/db/flow_accounting_settings.go
+++ b/internal/db/flow_accounting_settings.go
@@ -19,8 +19,6 @@ const (
 
 const FlowAccountingSettingsTableName = "flow_accounting_settings"
 
-const insertDefaultFlowAccountingSettingsStmt = `INSERT OR IGNORE INTO %s (singleton, enabled) VALUES (TRUE, $FlowAccountingSettings.enabled);`
-
 const upsertFlowAccountingSettingsStmt = `
 INSERT INTO %s (singleton, enabled) VALUES (TRUE, $FlowAccountingSettings.enabled)
 ON CONFLICT(singleton) DO UPDATE SET enabled=$FlowAccountingSettings.enabled;

--- a/internal/db/n3_settings.go
+++ b/internal/db/n3_settings.go
@@ -19,11 +19,6 @@ const (
 
 const N3SettingsTableName = "n3_settings"
 
-const insertDefaultN3SettingsStmt = `
-INSERT OR IGNORE INTO %s (singleton, external_address)
-VALUES (TRUE, $N3Settings.external_address);
-`
-
 const upsertN3SettingsStmt = `
 INSERT INTO %s (singleton, external_address) VALUES (TRUE, $N3Settings.external_address)
 ON CONFLICT(singleton) DO UPDATE SET external_address=$N3Settings.external_address;

--- a/internal/db/nat_settings.go
+++ b/internal/db/nat_settings.go
@@ -19,8 +19,6 @@ const (
 
 const NATSettingsTableName = "nat_settings"
 
-const insertDefaultNATSettingsStmt = `INSERT OR IGNORE INTO %s (singleton, enabled) VALUES (TRUE, $NATSettings.enabled);`
-
 const upsertNATSettingsStmt = `
 INSERT INTO %s (singleton, enabled) VALUES (TRUE, $NATSettings.enabled)
 ON CONFLICT(singleton) DO UPDATE SET enabled=$NATSettings.enabled;


### PR DESCRIPTION
# Description

FQDN's can be used instead of IPs to identify peers in a HA cluster. Here we validate that end-to-end in the integration tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
