### PR TITLE
chore: add rolling upgrade integration test against latest tagged release

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -6,6 +6,9 @@ permissions:
 
 on:
   workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * 1"
 
 jobs:
   scan:

--- a/docs/how_to/rolling_upgrade.md
+++ b/docs/how_to/rolling_upgrade.md
@@ -31,13 +31,11 @@ Repeat these steps for each node, **upgrading the leader last**.
 
 ## Verify the upgrade
 
-After every node has been refreshed, confirm on `GET /api/v1/status` from each node:
+After every node has been refreshed, open the **Cluster** page and confirm:
 
-- `version` and `revision` match the target release.
-- `cluster.appliedSchemaVersion` equals the top-level `schemaVersion`.
-- `cluster.pendingMigration` is absent.
-
-If `cluster.pendingMigration` is still present, the `laggardNodeId` field identifies the node that must be upgraded next.
+- Every node's **Version** column shows the target release.
+- The mixed-version warning banner is gone.
+- Every node is **Healthy** and its **Drain State** is `active`.
 
 !!! note
     All steps in this guide can also be performed via the REST API. See the [Cluster API reference](../reference/api/cluster.md) for details.

--- a/integration/compose/ha-rolling/build-images.sh
+++ b/integration/compose/ha-rolling/build-images.sh
@@ -15,7 +15,7 @@ set -eu
 
 # Pinned to the previous release tag. Bump this in the same PR that cuts
 # a new release.
-ROLLING_BASELINE_VERSION="${ROLLING_BASELINE_VERSION:-v1.10.0}"
+ROLLING_BASELINE_VERSION="${ROLLING_BASELINE_VERSION:-v1.10.1}"
 ROLLING_BASELINE_IMAGE="ghcr.io/ellanetworks/ella-core:${ROLLING_BASELINE_VERSION}"
 
 if ! docker image inspect ella-core:latest >/dev/null 2>&1; then

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -557,11 +557,6 @@ func waitForAutopilotReportsUnhealthy(ctx context.Context, leader *client.Client
 // cluster_members from each reachable node. composeDir MUST match the
 // compose project the test brought up — passing the wrong dir silently
 // returns empty logs.
-//
-// passes a different value is t.Skip'd until v1.10.1); keeping the parameter
-// preserves the bug fix for when that test re-enables.
-//
-//nolint:unparam // composeDir is constant today (the rolling-upgrade test that
 func dumpClusterDiagnostics(t *testing.T, ctx context.Context, dc *DockerClient, composeDir string, services []string, clients []*client.Client) {
 	t.Helper()
 

--- a/integration/ha_rolling_test.go
+++ b/integration/ha_rolling_test.go
@@ -441,6 +441,13 @@ func startSubscriberWriter(t *testing.T, parent context.Context, clients []*clie
 				SequenceNumber: "000000000022",
 				ProfileName:    "default",
 			})
+
+			// stop() cancels ctx; any in-flight request then fails with
+			// "context canceled". That is shutdown, not a real error.
+			if ctx.Err() != nil {
+				return
+			}
+
 			switch {
 			case err == nil:
 				w.success.Add(1)

--- a/integration/ha_rolling_test.go
+++ b/integration/ha_rolling_test.go
@@ -25,15 +25,6 @@ const (
 // previous release image to the current build, one node at a time, and
 // asserts the cluster stays writable and converges on the target schema.
 func TestIntegrationHARollingUpgrade(t *testing.T) {
-	// v1.10.0's FSM apply path was non-atomic with fsm_state.lastApplied,
-	// so a SIGKILL of the v1.10.0 binary mid-batch leaves SQLite ahead of
-	// the recorded lastApplied. The new binary inherits the discrepancy
-	// and crash-loops on replay (CONFLICT on duplicate auto-increment
-	// INSERT). Re-enable this test with ROLLING_BASELINE_VERSION=v1.10.1
-	// in integration/compose/ha-rolling/build-images.sh once v1.10.1 is
-	// tagged.
-	t.Skip("disabled until rolling baseline is bumped to v1.10.1 (carries the atomic-apply fix)")
-
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -912,13 +912,25 @@ type clusterCoordinator struct {
 	cancelTick context.CancelFunc
 }
 
-const migrationGateTickInterval = 5 * time.Second
+const (
+	migrationGateTickInterval = 5 * time.Second
+	barrierTimeout            = 30 * time.Second
+)
 
 func newClusterCoordinator(db *Database, parentCtx context.Context) *clusterCoordinator {
 	return &clusterCoordinator{db: db, parentCtx: parentCtx}
 }
 
 func (c *clusterCoordinator) OnBecameLeader() {
+	// Drain previous-term entries before any subsequent observer
+	// callback (notably the leadership-audit callback) captures. Without
+	// this barrier, the new leader's first capture can pick the same
+	// AUTOINCREMENT id as a pending-but-not-yet-applied entry from the
+	// previous leader, causing sqlite3changeset_apply CONFLICT on apply.
+	if err := c.db.raftManager.Barrier(barrierTimeout); err != nil {
+		logger.DBLog.Error("leader-takeover barrier failed", zap.Error(err))
+	}
+
 	c.db.signalMigrationCheck()
 
 	c.mu.Lock()


### PR DESCRIPTION
# Description

Re-add rolling upgrade integration tests against the latest tagged release.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
