### PR TITLE
chore: replace autoincrement primary key in shared tables with node-defined UUID

### DIFF
--- a/client/logs.go
+++ b/client/logs.go
@@ -9,7 +9,7 @@ import (
 )
 
 type AuditLog struct {
-	ID        int    `json:"id"`
+	ID        string `json:"id"`
 	Timestamp string `json:"timestamp"`
 	Level     string `json:"level"`
 	User      string `json:"user"`

--- a/client/logs_test.go
+++ b/client/logs_test.go
@@ -14,7 +14,7 @@ func TestListAuditLogs_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"items": [{"id": 1, "timestamp": "2023-10-01T12:00:00Z", "level": "info", "user": "admin@ellanetworks.com", "action": "login", "ip": "1.2.3.4", "details": "User logged in"}], "page": 1, "per_page": 10, "total_count": 1}`),
+			Result:     []byte(`{"items": [{"id": "01900000-0000-7000-8000-000000000001", "timestamp": "2023-10-01T12:00:00Z", "level": "info", "user": "admin@ellanetworks.com", "action": "login", "ip": "1.2.3.4", "details": "User logged in"}], "page": 1, "per_page": 10, "total_count": 1}`),
 		},
 		err: nil,
 	}
@@ -38,8 +38,8 @@ func TestListAuditLogs_Success(t *testing.T) {
 		t.Fatalf("expected 1 audit log, got %d", len(resp.Items))
 	}
 
-	if resp.Items[0].ID != 1 {
-		t.Fatalf("expected audit log ID 1, got %d", resp.Items[0].ID)
+	if resp.Items[0].ID != "01900000-0000-7000-8000-000000000001" {
+		t.Fatalf("expected audit log ID, got %q", resp.Items[0].ID)
 	}
 
 	if resp.Items[0].Timestamp != "2023-10-01T12:00:00Z" {
@@ -194,7 +194,7 @@ func TestListAuditLogsByActor_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"items": [{"id": 1, "timestamp": "2023-10-01T12:00:00Z", "level": "info", "user": "admin@example.com", "action": "create_user", "ip": "1.2.3.4", "details": "Created user"}], "page": 1, "per_page": 10, "total_count": 1}`),
+			Result:     []byte(`{"items": [{"id": "01900000-0000-7000-8000-000000000002", "timestamp": "2023-10-01T12:00:00Z", "level": "info", "user": "admin@example.com", "action": "create_user", "ip": "1.2.3.4", "details": "Created user"}], "page": 1, "per_page": 10, "total_count": 1}`),
 		},
 		err: nil,
 	}

--- a/client/operator.go
+++ b/client/operator.go
@@ -17,7 +17,7 @@ type GetOperatorTrackingResponse struct {
 }
 
 type HomeNetworkKeyResponse struct {
-	ID            int    `json:"id"`
+	ID            string `json:"id"` // UUIDv7
 	KeyIdentifier int    `json:"keyIdentifier"`
 	Scheme        string `json:"scheme"`
 	PublicKey     string `json:"publicKey"`

--- a/client/operator_test.go
+++ b/client/operator_test.go
@@ -400,8 +400,8 @@ func TestGetOperator_IncludesHomeNetworkKeys(t *testing.T) {
 			Result: []byte(`{
 				"id": {"mcc": "001", "mnc": "01"},
 				"homeNetworkKeys": [
-					{"id": 1, "keyIdentifier": 0, "scheme": "A", "publicKey": "aabb"},
-					{"id": 2, "keyIdentifier": 0, "scheme": "B", "publicKey": "02cc"}
+					{"id": "018f0000-0000-7000-8000-000000000001", "keyIdentifier": 0, "scheme": "A", "publicKey": "aabb"},
+					{"id": "018f0000-0000-7000-8000-000000000002", "keyIdentifier": 0, "scheme": "B", "publicKey": "02cc"}
 				]
 			}`),
 		},

--- a/client/users.go
+++ b/client/users.go
@@ -45,7 +45,7 @@ type CreateAPITokenResponse struct {
 }
 
 type APIToken struct {
-	ID     int    `json:"id"`
+	ID     string `json:"id"` // public token identifier (token_id), not the DB primary key
 	Name   string `json:"name"`
 	Expiry string `json:"expiry,omitempty"` // ISO 8601 format, optional
 }

--- a/docs/explanation/high_availability.md
+++ b/docs/explanation/high_availability.md
@@ -35,6 +35,12 @@ A UE's user-plane traffic flows through the node that handled its registration �
 
 When BGP is enabled, each node advertises a `/32` route for every UE session it hosts (see [Advertising routes via BGP](bgp.md)). When a UE re-registers on a different node after failover, the lease's owning node is updated in place — the UE keeps its IP — and the new node's speaker begins advertising the same `/32` from its N6. The dead node's BGP session times out after the hold timer (30–180 s, peer-dependent), its routes are withdrawn, and upstream routing converges on the survivor without operator action.
 
+## Replicated identifiers
+
+Every replicated resource — subscribers, profiles, policies, slices, data networks, network rules, IP leases, users, sessions, API tokens, audit logs, retention policies — carries a UUIDv7 primary key generated at the API handler before the request enters the replicated state machine. This is a structural invariant: the primary key of a replicated row is decided before the request is captured, never derived from local mutable state on the leader.
+
+The alternative — server-side `INTEGER PRIMARY KEY AUTOINCREMENT` — is unsafe in this architecture. The leader captures changesets by wrapping the apply in `BEGIN; INSERT; CAPTURE; ROLLBACK; propose-via-Raft`, so the captured INSERT carries an id assigned from `sqlite_sequence`. Two captures back-to-back can pick the same id whenever they see the same `sqlite_sequence` snapshot — most observably when a new leader's first capture races with a previous-term entry that has been replicated but not yet applied to its FSM. The follower then rejects the second INSERT with a CONFLICT and the FSM crashes. Generating UUIDs at the handler eliminates the class: two handlers cannot pick the same UUID, regardless of timing or which node is leader.
+
 ## Failover and timing
 
 Leader re-election completes within a few seconds; surviving nodes continue accepting NGAP and API calls the whole time.

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -557,6 +557,10 @@ func waitForAutopilotReportsUnhealthy(ctx context.Context, leader *client.Client
 // cluster_members from each reachable node. composeDir MUST match the
 // compose project the test brought up — passing the wrong dir silently
 // returns empty logs.
+//
+// (currently skipped) passes haRollingComposeDir.
+//
+//nolint:unparam // composeDir varies by caller; the rolling-upgrade test
 func dumpClusterDiagnostics(t *testing.T, ctx context.Context, dc *DockerClient, composeDir string, services []string, clients []*client.Client) {
 	t.Helper()
 

--- a/integration/ha_rolling_test.go
+++ b/integration/ha_rolling_test.go
@@ -25,6 +25,13 @@ const (
 // previous release image to the current build, one node at a time, and
 // asserts the cluster stays writable and converges on the target schema.
 func TestIntegrationHARollingUpgrade(t *testing.T) {
+	// Skipped until 1.10.2 is released. v11 retypes every replicated
+	// PK from INTEGER to TEXT (UUID); 1.10.1 cannot decode the new
+	// payload format, so 1.10.1 → 1.11 must go through backup/restore
+	// rather than a rolling upgrade. Re-enable with the post-1.10.2
+	// image as baseline.
+	t.Skip("rolling upgrade from 1.10.1 unsupported across the v11 PK migration; re-enable after 1.10.2 ships")
+
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -79,13 +79,13 @@ type TimerValue struct {
 type DBer interface {
 	GetOperator(ctx context.Context) (*db.Operator, error)
 	GetSubscriber(ctx context.Context, imsi string) (*db.Subscriber, error)
-	GetDataNetworkByID(ctx context.Context, id int) (*db.DataNetwork, error)
-	GetNetworkSliceByID(ctx context.Context, id int) (*db.NetworkSlice, error)
-	ListNetworkSlicesByIDs(ctx context.Context, ids []int) ([]db.NetworkSlice, error)
-	GetProfileByID(ctx context.Context, id int) (*db.Profile, error)
-	GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID int) (*db.Policy, error)
+	GetDataNetworkByID(ctx context.Context, id string) (*db.DataNetwork, error)
+	GetNetworkSliceByID(ctx context.Context, id string) (*db.NetworkSlice, error)
+	ListNetworkSlicesByIDs(ctx context.Context, ids []string) ([]db.NetworkSlice, error)
+	GetProfileByID(ctx context.Context, id string) (*db.Profile, error)
+	GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID string) (*db.Policy, error)
 	ListAllNetworkSlices(ctx context.Context) ([]db.NetworkSlice, error)
-	ListPoliciesByProfile(ctx context.Context, profileID int) ([]db.Policy, error)
+	ListPoliciesByProfile(ctx context.Context, profileID string) ([]db.Policy, error)
 	NodeID() int
 }
 

--- a/internal/amf/config.go
+++ b/internal/amf/config.go
@@ -155,21 +155,21 @@ func (amf *AMF) GetSubscriberProfile(ctx context.Context, supi etsi.SUPI) (*Subs
 	// Derive allowed NSSAI from the subscriber's profile policies.
 	policies, err := amf.DBInstance.ListPoliciesByProfile(ctx, subscriber.ProfileID)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't list policies for profile %d: %w", subscriber.ProfileID, err)
+		return nil, fmt.Errorf("couldn't list policies for profile %s: %w", subscriber.ProfileID, err)
 	}
 
 	// Collect unique slice IDs and batch-fetch.
-	sliceIDSet := make(map[int]struct{})
+	sliceIDSet := make(map[string]struct{})
 	for _, p := range policies {
 		sliceIDSet[p.SliceID] = struct{}{}
 	}
 
-	sliceIDs := make([]int, 0, len(sliceIDSet))
+	sliceIDs := make([]string, 0, len(sliceIDSet))
 	for id := range sliceIDSet {
 		sliceIDs = append(sliceIDs, id)
 	}
 
-	sort.Ints(sliceIDs)
+	sort.Strings(sliceIDs)
 
 	slices, err := amf.DBInstance.ListNetworkSlicesByIDs(ctx, sliceIDs)
 	if err != nil {
@@ -193,7 +193,7 @@ func (amf *AMF) GetSubscriberProfile(ctx context.Context, supi etsi.SUPI) (*Subs
 	// Derive bitrate from the subscriber's profile.
 	profile, err := amf.DBInstance.GetProfileByID(ctx, subscriber.ProfileID)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't get profile %d: %v", subscriber.ProfileID, err)
+		return nil, fmt.Errorf("couldn't get profile %s: %v", subscriber.ProfileID, err)
 	}
 
 	return &SubscriberProfile{
@@ -228,28 +228,28 @@ func (amf *AMF) GetSubscriberDnn(ctx context.Context, supi etsi.SUPI, snssai *mo
 
 	policies, err := amf.DBInstance.ListPoliciesByProfile(ctx, subscriber.ProfileID)
 	if err != nil {
-		return "", fmt.Errorf("couldn't list policies for profile %d: %v", subscriber.ProfileID, err)
+		return "", fmt.Errorf("couldn't list policies for profile %s: %v", subscriber.ProfileID, err)
 	}
 
 	// Batch-fetch all referenced network slices.
-	sliceIDSet := make(map[int]struct{})
+	sliceIDSet := make(map[string]struct{})
 	for _, p := range policies {
 		sliceIDSet[p.SliceID] = struct{}{}
 	}
 
-	sliceIDs := make([]int, 0, len(sliceIDSet))
+	sliceIDs := make([]string, 0, len(sliceIDSet))
 	for id := range sliceIDSet {
 		sliceIDs = append(sliceIDs, id)
 	}
 
-	sort.Ints(sliceIDs)
+	sort.Strings(sliceIDs)
 
 	sliceList, err := amf.DBInstance.ListNetworkSlicesByIDs(ctx, sliceIDs)
 	if err != nil {
 		return "", fmt.Errorf("couldn't list slices by IDs: %v", err)
 	}
 
-	sliceMap := make(map[int]db.NetworkSlice, len(sliceList))
+	sliceMap := make(map[string]db.NetworkSlice, len(sliceList))
 	for _, s := range sliceList {
 		sliceMap[s.ID] = s
 	}
@@ -268,14 +268,14 @@ func (amf *AMF) GetSubscriberDnn(ctx context.Context, supi etsi.SUPI, snssai *mo
 		if slice.Sst == snssai.Sst && sliceSd == snssai.Sd {
 			dataNetwork, err := amf.DBInstance.GetDataNetworkByID(ctx, p.DataNetworkID)
 			if err != nil {
-				return "", fmt.Errorf("couldn't get data network %d: %v", p.DataNetworkID, err)
+				return "", fmt.Errorf("couldn't get data network %s: %v", p.DataNetworkID, err)
 			}
 
 			return dataNetwork.Name, nil
 		}
 	}
 
-	return "", fmt.Errorf("no policy matching sst=%d sd=%q for profile %d", snssai.Sst, snssai.Sd, subscriber.ProfileID)
+	return "", fmt.Errorf("no policy matching sst=%d sd=%q for profile %s", snssai.Sst, snssai.Sd, subscriber.ProfileID)
 }
 
 var cipheringNameToAlg = map[string]uint8{

--- a/internal/amf/config_test.go
+++ b/internal/amf/config_test.go
@@ -18,7 +18,7 @@ type configTestDB struct {
 	subErr     error
 	policies   []db.Policy
 	polErr     error
-	slices     map[int]*db.NetworkSlice
+	slices     map[string]*db.NetworkSlice
 	sliceErr   error
 	allSlices  []db.NetworkSlice
 	operator   *db.Operator
@@ -33,20 +33,20 @@ func (d *configTestDB) GetSubscriber(_ context.Context, _ string) (*db.Subscribe
 	return d.subscriber, d.subErr
 }
 
-func (d *configTestDB) GetDataNetworkByID(context.Context, int) (*db.DataNetwork, error) {
+func (d *configTestDB) GetDataNetworkByID(context.Context, string) (*db.DataNetwork, error) {
 	return nil, nil
 }
 
-func (d *configTestDB) GetNetworkSliceByID(_ context.Context, id int) (*db.NetworkSlice, error) {
+func (d *configTestDB) GetNetworkSliceByID(_ context.Context, id string) (*db.NetworkSlice, error) {
 	s, ok := d.slices[id]
 	if !ok {
-		return nil, fmt.Errorf("slice %d not found", id)
+		return nil, fmt.Errorf("slice %s not found", id)
 	}
 
 	return s, nil
 }
 
-func (d *configTestDB) ListNetworkSlicesByIDs(_ context.Context, ids []int) ([]db.NetworkSlice, error) {
+func (d *configTestDB) ListNetworkSlicesByIDs(_ context.Context, ids []string) ([]db.NetworkSlice, error) {
 	var out []db.NetworkSlice
 
 	for _, id := range ids {
@@ -58,11 +58,11 @@ func (d *configTestDB) ListNetworkSlicesByIDs(_ context.Context, ids []int) ([]d
 	return out, d.sliceErr
 }
 
-func (d *configTestDB) GetProfileByID(_ context.Context, id int) (*db.Profile, error) {
+func (d *configTestDB) GetProfileByID(_ context.Context, id string) (*db.Profile, error) {
 	return &db.Profile{ID: id}, nil
 }
 
-func (d *configTestDB) GetPolicyByProfileAndSlice(context.Context, int, int) (*db.Policy, error) {
+func (d *configTestDB) GetPolicyByProfileAndSlice(context.Context, string, string) (*db.Policy, error) {
 	return nil, nil
 }
 
@@ -80,7 +80,7 @@ func (d *configTestDB) ListAllNetworkSlices(context.Context) ([]db.NetworkSlice,
 	return out, d.sliceErr
 }
 
-func (d *configTestDB) ListPoliciesByProfile(_ context.Context, _ int) ([]db.Policy, error) {
+func (d *configTestDB) ListPoliciesByProfile(_ context.Context, _ string) ([]db.Policy, error) {
 	return d.policies, d.polErr
 }
 
@@ -100,9 +100,9 @@ func mustSUPI(t *testing.T) etsi.SUPI {
 func TestGetSubscriberProfile_SinglePolicy(t *testing.T) {
 	sd := "010203"
 	fakeDB := &configTestDB{
-		subscriber: &db.Subscriber{ID: 1, Imsi: "001010000000001", ProfileID: 10},
-		policies:   []db.Policy{{ID: 1, ProfileID: 10, SliceID: 100}},
-		slices:     map[int]*db.NetworkSlice{100: {ID: 100, Name: "slice-a", Sst: 1, Sd: &sd}},
+		subscriber: &db.Subscriber{ID: "sub-1", Imsi: "001010000000001", ProfileID: "profile-10"},
+		policies:   []db.Policy{{ID: "policy-1", ProfileID: "profile-10", SliceID: "slice-100"}},
+		slices:     map[string]*db.NetworkSlice{"slice-100": {ID: "slice-100", Name: "slice-a", Sst: 1, Sd: &sd}},
 	}
 
 	amfInstance := amf.New(fakeDB, nil, nil)
@@ -129,14 +129,14 @@ func TestGetSubscriberProfile_MultiplePoliciesDifferentSlices(t *testing.T) {
 	sd1 := "010203"
 	sd2 := "aabbcc"
 	fakeDB := &configTestDB{
-		subscriber: &db.Subscriber{ID: 1, Imsi: "001010000000001", ProfileID: 10},
+		subscriber: &db.Subscriber{ID: "sub-1", Imsi: "001010000000001", ProfileID: "profile-10"},
 		policies: []db.Policy{
-			{ID: 1, ProfileID: 10, SliceID: 100},
-			{ID: 2, ProfileID: 10, SliceID: 200},
+			{ID: "policy-1", ProfileID: "profile-10", SliceID: "slice-100"},
+			{ID: "policy-2", ProfileID: "profile-10", SliceID: "slice-200"},
 		},
-		slices: map[int]*db.NetworkSlice{
-			100: {ID: 100, Name: "slice-a", Sst: 1, Sd: &sd1},
-			200: {ID: 200, Name: "slice-b", Sst: 2, Sd: &sd2},
+		slices: map[string]*db.NetworkSlice{
+			"slice-100": {ID: "slice-100", Name: "slice-a", Sst: 1, Sd: &sd1},
+			"slice-200": {ID: "slice-200", Name: "slice-b", Sst: 2, Sd: &sd2},
 		},
 	}
 
@@ -165,13 +165,13 @@ func TestGetSubscriberProfile_MultiplePoliciesDifferentSlices(t *testing.T) {
 func TestGetSubscriberProfile_DeduplicatesSameSlice(t *testing.T) {
 	sd := "010203"
 	fakeDB := &configTestDB{
-		subscriber: &db.Subscriber{ID: 1, Imsi: "001010000000001", ProfileID: 10},
+		subscriber: &db.Subscriber{ID: "sub-1", Imsi: "001010000000001", ProfileID: "profile-10"},
 		policies: []db.Policy{
-			{ID: 1, ProfileID: 10, SliceID: 100},
-			{ID: 2, ProfileID: 10, SliceID: 100}, // same slice
+			{ID: "policy-1", ProfileID: "profile-10", SliceID: "slice-100"},
+			{ID: "policy-2", ProfileID: "profile-10", SliceID: "slice-100"}, // same slice
 		},
-		slices: map[int]*db.NetworkSlice{
-			100: {ID: 100, Name: "slice-a", Sst: 1, Sd: &sd},
+		slices: map[string]*db.NetworkSlice{
+			"slice-100": {ID: "slice-100", Name: "slice-a", Sst: 1, Sd: &sd},
 		},
 	}
 
@@ -189,9 +189,9 @@ func TestGetSubscriberProfile_DeduplicatesSameSlice(t *testing.T) {
 
 func TestGetSubscriberProfile_NilSD(t *testing.T) {
 	fakeDB := &configTestDB{
-		subscriber: &db.Subscriber{ID: 1, Imsi: "001010000000001", ProfileID: 10},
-		policies:   []db.Policy{{ID: 1, ProfileID: 10, SliceID: 100}},
-		slices:     map[int]*db.NetworkSlice{100: {ID: 100, Name: "slice-a", Sst: 1, Sd: nil}},
+		subscriber: &db.Subscriber{ID: "sub-1", Imsi: "001010000000001", ProfileID: "profile-10"},
+		policies:   []db.Policy{{ID: "policy-1", ProfileID: "profile-10", SliceID: "slice-100"}},
+		slices:     map[string]*db.NetworkSlice{"slice-100": {ID: "slice-100", Name: "slice-a", Sst: 1, Sd: nil}},
 	}
 
 	amfInstance := amf.New(fakeDB, nil, nil)
@@ -212,9 +212,9 @@ func TestGetSubscriberProfile_NilSD(t *testing.T) {
 
 func TestGetSubscriberProfile_NoPolicies(t *testing.T) {
 	fakeDB := &configTestDB{
-		subscriber: &db.Subscriber{ID: 1, Imsi: "001010000000001", ProfileID: 10},
+		subscriber: &db.Subscriber{ID: "sub-1", Imsi: "001010000000001", ProfileID: "profile-10"},
 		policies:   []db.Policy{},
-		slices:     map[int]*db.NetworkSlice{},
+		slices:     map[string]*db.NetworkSlice{},
 	}
 
 	amfInstance := amf.New(fakeDB, nil, nil)
@@ -244,7 +244,7 @@ func TestGetSubscriberProfile_SubscriberNotFound(t *testing.T) {
 
 func TestGetSubscriberProfile_PolicyListError(t *testing.T) {
 	fakeDB := &configTestDB{
-		subscriber: &db.Subscriber{ID: 1, Imsi: "001010000000001", ProfileID: 10},
+		subscriber: &db.Subscriber{ID: "sub-1", Imsi: "001010000000001", ProfileID: "profile-10"},
 		polErr:     fmt.Errorf("db error"),
 	}
 
@@ -266,8 +266,8 @@ func TestListOperatorSnssai_MultipleSlices(t *testing.T) {
 			SupportedTACs: "[\"000001\"]",
 		},
 		allSlices: []db.NetworkSlice{
-			{ID: 1, Name: "slice-a", Sst: 1, Sd: &sd1},
-			{ID: 2, Name: "slice-b", Sst: 2, Sd: &sd2},
+			{ID: "slice-1", Name: "slice-a", Sst: 1, Sd: &sd1},
+			{ID: "slice-2", Name: "slice-b", Sst: 2, Sd: &sd2},
 		},
 	}
 
@@ -294,7 +294,7 @@ func TestListOperatorSnssai_MultipleSlices(t *testing.T) {
 func TestListOperatorSnssai_SliceWithNilSD(t *testing.T) {
 	fakeDB := &configTestDB{
 		allSlices: []db.NetworkSlice{
-			{ID: 1, Name: "default", Sst: 1, Sd: nil},
+			{ID: "slice-1", Name: "default", Sst: 1, Sd: nil},
 		},
 	}
 

--- a/internal/amf/nas/gmm/handle_test.go
+++ b/internal/amf/nas/gmm/handle_test.go
@@ -29,35 +29,35 @@ func (fdb *FakeDBInstance) GetOperator(ctx context.Context) (*db.Operator, error
 	return fdb.Operator, nil
 }
 
-func (fdb *FakeDBInstance) GetDataNetworkByID(ctx context.Context, id int) (*db.DataNetwork, error) {
+func (fdb *FakeDBInstance) GetDataNetworkByID(ctx context.Context, id string) (*db.DataNetwork, error) {
 	return &db.DataNetwork{
 		ID:   id,
 		Name: "TestDataNetwork",
 	}, nil
 }
 
-func (fdb *FakeDBInstance) GetNetworkSliceByID(_ context.Context, id int) (*db.NetworkSlice, error) {
+func (fdb *FakeDBInstance) GetNetworkSliceByID(_ context.Context, id string) (*db.NetworkSlice, error) {
 	sd1 := "010203"
 	sd2 := "aabbcc"
-	slices := map[int]*db.NetworkSlice{
-		1: {ID: 1, Name: "default", Sst: 1, Sd: &sd1},
-		2: {ID: 2, Name: "secondary", Sst: 1, Sd: &sd2},
+	slices := map[string]*db.NetworkSlice{
+		"slice-1": {ID: "slice-1", Name: "default", Sst: 1, Sd: &sd1},
+		"slice-2": {ID: "slice-2", Name: "secondary", Sst: 1, Sd: &sd2},
 	}
 
 	s, ok := slices[id]
 	if !ok {
-		return nil, fmt.Errorf("slice %d not found", id)
+		return nil, fmt.Errorf("slice %s not found", id)
 	}
 
 	return s, nil
 }
 
-func (fdb *FakeDBInstance) ListNetworkSlicesByIDs(_ context.Context, ids []int) ([]db.NetworkSlice, error) {
+func (fdb *FakeDBInstance) ListNetworkSlicesByIDs(_ context.Context, ids []string) ([]db.NetworkSlice, error) {
 	sd1 := "010203"
 	sd2 := "aabbcc"
-	slices := map[int]db.NetworkSlice{
-		1: {ID: 1, Name: "default", Sst: 1, Sd: &sd1},
-		2: {ID: 2, Name: "secondary", Sst: 1, Sd: &sd2},
+	slices := map[string]db.NetworkSlice{
+		"slice-1": {ID: "slice-1", Name: "default", Sst: 1, Sd: &sd1},
+		"slice-2": {ID: "slice-2", Name: "secondary", Sst: 1, Sd: &sd2},
 	}
 
 	var out []db.NetworkSlice
@@ -77,7 +77,7 @@ func (fdb *FakeDBInstance) GetSubscriber(ctx context.Context, imsi string) (*db.
 	}, nil
 }
 
-func (fdb *FakeDBInstance) GetProfileByID(ctx context.Context, id int) (*db.Profile, error) {
+func (fdb *FakeDBInstance) GetProfileByID(ctx context.Context, id string) (*db.Profile, error) {
 	return &db.Profile{ID: id, Name: "TestProfile"}, nil
 }
 
@@ -86,19 +86,19 @@ func (fdb *FakeDBInstance) ListAllNetworkSlices(ctx context.Context) ([]db.Netwo
 	sd2 := "aabbcc"
 
 	return []db.NetworkSlice{
-		{ID: 1, Name: "default", Sst: 1, Sd: &sd1},
-		{ID: 2, Name: "secondary", Sst: 1, Sd: &sd2},
+		{ID: "slice-1", Name: "default", Sst: 1, Sd: &sd1},
+		{ID: "slice-2", Name: "secondary", Sst: 1, Sd: &sd2},
 	}, nil
 }
 
-func (fdb *FakeDBInstance) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID int) (*db.Policy, error) {
-	return &db.Policy{ID: 1, Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: 1}, nil
+func (fdb *FakeDBInstance) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID string) (*db.Policy, error) {
+	return &db.Policy{ID: "policy-1", Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: "dn-1"}, nil
 }
 
-func (fdb *FakeDBInstance) ListPoliciesByProfile(_ context.Context, _ int) ([]db.Policy, error) {
+func (fdb *FakeDBInstance) ListPoliciesByProfile(_ context.Context, _ string) ([]db.Policy, error) {
 	return []db.Policy{
-		{ID: 1, Name: "TestPolicy", ProfileID: 1, SliceID: 1, DataNetworkID: 1},
-		{ID: 2, Name: "TestPolicy2", ProfileID: 1, SliceID: 2, DataNetworkID: 1},
+		{ID: "policy-1", Name: "TestPolicy", ProfileID: "profile-1", SliceID: "slice-1", DataNetworkID: "dn-1"},
+		{ID: "policy-2", Name: "TestPolicy2", ProfileID: "profile-1", SliceID: "slice-2", DataNetworkID: "dn-1"},
 	}, nil
 }
 

--- a/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating_test.go
@@ -29,15 +29,15 @@ func (fdb *failingSubscriberDB) GetOperator(ctx context.Context) (*db.Operator, 
 	return fdb.Operator, nil
 }
 
-func (fdb *failingSubscriberDB) GetDataNetworkByID(ctx context.Context, id int) (*db.DataNetwork, error) {
+func (fdb *failingSubscriberDB) GetDataNetworkByID(ctx context.Context, id string) (*db.DataNetwork, error) {
 	return &db.DataNetwork{ID: id, Name: "TestDataNetwork"}, nil
 }
 
-func (fdb *failingSubscriberDB) GetNetworkSliceByID(_ context.Context, id int) (*db.NetworkSlice, error) {
+func (fdb *failingSubscriberDB) GetNetworkSliceByID(_ context.Context, id string) (*db.NetworkSlice, error) {
 	return &db.NetworkSlice{ID: id, Name: "TestSlice", Sst: 1}, nil
 }
 
-func (fdb *failingSubscriberDB) ListNetworkSlicesByIDs(_ context.Context, ids []int) ([]db.NetworkSlice, error) {
+func (fdb *failingSubscriberDB) ListNetworkSlicesByIDs(_ context.Context, ids []string) ([]db.NetworkSlice, error) {
 	var out []db.NetworkSlice
 	for _, id := range ids {
 		out = append(out, db.NetworkSlice{ID: id, Name: "TestSlice", Sst: 1})
@@ -50,20 +50,20 @@ func (fdb *failingSubscriberDB) GetSubscriber(ctx context.Context, imsi string) 
 	return nil, fmt.Errorf("subscriber not found")
 }
 
-func (fdb *failingSubscriberDB) GetProfileByID(ctx context.Context, id int) (*db.Profile, error) {
+func (fdb *failingSubscriberDB) GetProfileByID(ctx context.Context, id string) (*db.Profile, error) {
 	return &db.Profile{ID: id, Name: "TestProfile"}, nil
 }
 
 func (fdb *failingSubscriberDB) ListAllNetworkSlices(ctx context.Context) ([]db.NetworkSlice, error) {
-	return []db.NetworkSlice{{ID: 1, Sst: 1, Name: "default"}}, nil
+	return []db.NetworkSlice{{ID: "slice-1", Sst: 1, Name: "default"}}, nil
 }
 
-func (fdb *failingSubscriberDB) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID int) (*db.Policy, error) {
-	return &db.Policy{ID: 1, Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: 1}, nil
+func (fdb *failingSubscriberDB) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID string) (*db.Policy, error) {
+	return &db.Policy{ID: "policy-1", Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: "dn-1"}, nil
 }
 
-func (fdb *failingSubscriberDB) ListPoliciesByProfile(_ context.Context, _ int) ([]db.Policy, error) {
-	return []db.Policy{{ID: 1, Name: "TestPolicy", ProfileID: 1, SliceID: 1, DataNetworkID: 1}}, nil
+func (fdb *failingSubscriberDB) ListPoliciesByProfile(_ context.Context, _ string) ([]db.Policy, error) {
+	return []db.Policy{{ID: "policy-1", Name: "TestPolicy", ProfileID: "profile-1", SliceID: "slice-1", DataNetworkID: "dn-1"}}, nil
 }
 
 func (fdb *failingSubscriberDB) NodeID() int { return 0 }
@@ -856,30 +856,30 @@ func (m *multiSliceDB) GetOperator(ctx context.Context) (*db.Operator, error) {
 	return m.Operator, nil
 }
 
-func (m *multiSliceDB) GetDataNetworkByID(_ context.Context, id int) (*db.DataNetwork, error) {
+func (m *multiSliceDB) GetDataNetworkByID(_ context.Context, id string) (*db.DataNetwork, error) {
 	return &db.DataNetwork{ID: id, Name: "TestDataNetwork"}, nil
 }
 
-func (m *multiSliceDB) GetNetworkSliceByID(_ context.Context, id int) (*db.NetworkSlice, error) {
+func (m *multiSliceDB) GetNetworkSliceByID(_ context.Context, id string) (*db.NetworkSlice, error) {
 	sd1, sd2 := "010203", "aabbcc"
-	slices := map[int]*db.NetworkSlice{
-		1: {ID: 1, Name: "slice-a", Sst: 1, Sd: &sd1},
-		2: {ID: 2, Name: "slice-b", Sst: 2, Sd: &sd2},
+	slices := map[string]*db.NetworkSlice{
+		"slice-1": {ID: "slice-1", Name: "slice-a", Sst: 1, Sd: &sd1},
+		"slice-2": {ID: "slice-2", Name: "slice-b", Sst: 2, Sd: &sd2},
 	}
 
 	s, ok := slices[id]
 	if !ok {
-		return nil, fmt.Errorf("slice %d not found", id)
+		return nil, fmt.Errorf("slice %s not found", id)
 	}
 
 	return s, nil
 }
 
-func (m *multiSliceDB) ListNetworkSlicesByIDs(_ context.Context, ids []int) ([]db.NetworkSlice, error) {
+func (m *multiSliceDB) ListNetworkSlicesByIDs(_ context.Context, ids []string) ([]db.NetworkSlice, error) {
 	sd1, sd2 := "010203", "aabbcc"
-	slices := map[int]db.NetworkSlice{
-		1: {ID: 1, Name: "slice-a", Sst: 1, Sd: &sd1},
-		2: {ID: 2, Name: "slice-b", Sst: 2, Sd: &sd2},
+	slices := map[string]db.NetworkSlice{
+		"slice-1": {ID: "slice-1", Name: "slice-a", Sst: 1, Sd: &sd1},
+		"slice-2": {ID: "slice-2", Name: "slice-b", Sst: 2, Sd: &sd2},
 	}
 
 	var out []db.NetworkSlice
@@ -894,10 +894,10 @@ func (m *multiSliceDB) ListNetworkSlicesByIDs(_ context.Context, ids []int) ([]d
 }
 
 func (m *multiSliceDB) GetSubscriber(_ context.Context, imsi string) (*db.Subscriber, error) {
-	return &db.Subscriber{Imsi: imsi, ProfileID: 1}, nil
+	return &db.Subscriber{Imsi: imsi, ProfileID: "profile-1"}, nil
 }
 
-func (m *multiSliceDB) GetProfileByID(_ context.Context, id int) (*db.Profile, error) {
+func (m *multiSliceDB) GetProfileByID(_ context.Context, id string) (*db.Profile, error) {
 	return &db.Profile{ID: id, Name: "TestProfile"}, nil
 }
 
@@ -905,19 +905,19 @@ func (m *multiSliceDB) ListAllNetworkSlices(_ context.Context) ([]db.NetworkSlic
 	sd1, sd2 := "010203", "aabbcc"
 
 	return []db.NetworkSlice{
-		{ID: 1, Name: "slice-a", Sst: 1, Sd: &sd1},
-		{ID: 2, Name: "slice-b", Sst: 2, Sd: &sd2},
+		{ID: "slice-1", Name: "slice-a", Sst: 1, Sd: &sd1},
+		{ID: "slice-2", Name: "slice-b", Sst: 2, Sd: &sd2},
 	}, nil
 }
 
-func (m *multiSliceDB) GetPolicyByProfileAndSlice(_ context.Context, profileID, sliceID int) (*db.Policy, error) {
-	return &db.Policy{ID: sliceID, Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: 1}, nil
+func (m *multiSliceDB) GetPolicyByProfileAndSlice(_ context.Context, profileID, sliceID string) (*db.Policy, error) {
+	return &db.Policy{ID: sliceID, Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: "dn-1"}, nil
 }
 
-func (m *multiSliceDB) ListPoliciesByProfile(_ context.Context, _ int) ([]db.Policy, error) {
+func (m *multiSliceDB) ListPoliciesByProfile(_ context.Context, _ string) ([]db.Policy, error) {
 	return []db.Policy{
-		{ID: 1, Name: "Policy-A", ProfileID: 1, SliceID: 1, DataNetworkID: 1},
-		{ID: 2, Name: "Policy-B", ProfileID: 1, SliceID: 2, DataNetworkID: 2},
+		{ID: "policy-1", Name: "Policy-A", ProfileID: "profile-1", SliceID: "slice-1", DataNetworkID: "dn-1"},
+		{ID: "policy-2", Name: "Policy-B", ProfileID: "profile-1", SliceID: "slice-2", DataNetworkID: "dn-2"},
 	}, nil
 }
 

--- a/internal/amf/ngap/handle_ng_setup_request_test.go
+++ b/internal/amf/ngap/handle_ng_setup_request_test.go
@@ -506,9 +506,9 @@ func TestHandleNGSetupRequest_ResponseContainsAllConfiguredSlices(t *testing.T) 
 	amfInstance := amf.New(&FakeDBInstance{
 		Operator: op,
 		Slices: []db.NetworkSlice{
-			{ID: 1, Name: "eMBB", Sst: 1, Sd: &sd1},
-			{ID: 2, Name: "URLLC", Sst: 2, Sd: &sd2},
-			{ID: 3, Name: "mMTC", Sst: 3, Sd: nil},
+			{ID: "slice-1", Name: "eMBB", Sst: 1, Sd: &sd1},
+			{ID: "slice-2", Name: "URLLC", Sst: 2, Sd: &sd2},
+			{ID: "slice-3", Name: "mMTC", Sst: 3, Sd: nil},
 		},
 	}, nil, nil)
 	amfInstance.Name = "ella-core"

--- a/internal/amf/ngap/handle_test.go
+++ b/internal/amf/ngap/handle_test.go
@@ -169,18 +169,18 @@ func (fdb *FakeDBInstance) GetOperator(ctx context.Context) (*db.Operator, error
 	return fdb.Operator, nil
 }
 
-func (fdb *FakeDBInstance) GetDataNetworkByID(ctx context.Context, id int) (*db.DataNetwork, error) {
+func (fdb *FakeDBInstance) GetDataNetworkByID(ctx context.Context, id string) (*db.DataNetwork, error) {
 	return &db.DataNetwork{
 		ID:   id,
 		Name: "TestDataNetwork",
 	}, nil
 }
 
-func (fdb *FakeDBInstance) GetNetworkSliceByID(_ context.Context, id int) (*db.NetworkSlice, error) {
+func (fdb *FakeDBInstance) GetNetworkSliceByID(_ context.Context, id string) (*db.NetworkSlice, error) {
 	return &db.NetworkSlice{ID: id, Name: "TestSlice", Sst: 1}, nil
 }
 
-func (fdb *FakeDBInstance) ListNetworkSlicesByIDs(_ context.Context, ids []int) ([]db.NetworkSlice, error) {
+func (fdb *FakeDBInstance) ListNetworkSlicesByIDs(_ context.Context, ids []string) ([]db.NetworkSlice, error) {
 	var out []db.NetworkSlice
 	for _, id := range ids {
 		out = append(out, db.NetworkSlice{ID: id, Name: "TestSlice", Sst: 1})
@@ -195,7 +195,7 @@ func (fdb *FakeDBInstance) GetSubscriber(ctx context.Context, imsi string) (*db.
 	}, nil
 }
 
-func (fdb *FakeDBInstance) GetProfileByID(ctx context.Context, id int) (*db.Profile, error) {
+func (fdb *FakeDBInstance) GetProfileByID(ctx context.Context, id string) (*db.Profile, error) {
 	return &db.Profile{ID: id, Name: "TestProfile"}, nil
 }
 
@@ -204,15 +204,15 @@ func (fdb *FakeDBInstance) ListAllNetworkSlices(ctx context.Context) ([]db.Netwo
 		return fdb.Slices, nil
 	}
 
-	return []db.NetworkSlice{{ID: 1, Name: "default", Sst: 1}}, nil
+	return []db.NetworkSlice{{ID: "slice-1", Name: "default", Sst: 1}}, nil
 }
 
-func (fdb *FakeDBInstance) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID int) (*db.Policy, error) {
-	return &db.Policy{ID: 1, Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: 1}, nil
+func (fdb *FakeDBInstance) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID string) (*db.Policy, error) {
+	return &db.Policy{ID: "policy-1", Name: "TestPolicy", ProfileID: profileID, SliceID: sliceID, DataNetworkID: "dn-1"}, nil
 }
 
-func (fdb *FakeDBInstance) ListPoliciesByProfile(_ context.Context, _ int) ([]db.Policy, error) {
-	return []db.Policy{{ID: 1, Name: "TestPolicy", ProfileID: 1, SliceID: 1, DataNetworkID: 1}}, nil
+func (fdb *FakeDBInstance) ListPoliciesByProfile(_ context.Context, _ string) ([]db.Policy, error) {
+	return []db.Policy{{ID: "policy-1", Name: "TestPolicy", ProfileID: "profile-1", SliceID: "slice-1", DataNetworkID: "dn-1"}}, nil
 }
 
 func (fdb *FakeDBInstance) NodeID() int { return 0 }

--- a/internal/amf/producer/n1n2message_test.go
+++ b/internal/amf/producer/n1n2message_test.go
@@ -127,19 +127,19 @@ func (f *fakeDBInstance) GetSubscriber(context.Context, string) (*db.Subscriber,
 	return nil, nil
 }
 
-func (f *fakeDBInstance) GetDataNetworkByID(context.Context, int) (*db.DataNetwork, error) {
+func (f *fakeDBInstance) GetDataNetworkByID(context.Context, string) (*db.DataNetwork, error) {
 	return nil, nil
 }
 
-func (f *fakeDBInstance) GetNetworkSliceByID(context.Context, int) (*db.NetworkSlice, error) {
+func (f *fakeDBInstance) GetNetworkSliceByID(context.Context, string) (*db.NetworkSlice, error) {
 	return nil, nil
 }
 
-func (f *fakeDBInstance) ListNetworkSlicesByIDs(context.Context, []int) ([]db.NetworkSlice, error) {
+func (f *fakeDBInstance) ListNetworkSlicesByIDs(context.Context, []string) ([]db.NetworkSlice, error) {
 	return nil, nil
 }
 
-func (f *fakeDBInstance) GetProfileByID(context.Context, int) (*db.Profile, error) {
+func (f *fakeDBInstance) GetProfileByID(context.Context, string) (*db.Profile, error) {
 	return nil, nil
 }
 
@@ -147,11 +147,11 @@ func (f *fakeDBInstance) ListAllNetworkSlices(context.Context) ([]db.NetworkSlic
 	return nil, nil
 }
 
-func (f *fakeDBInstance) GetPolicyByProfileAndSlice(context.Context, int, int) (*db.Policy, error) {
+func (f *fakeDBInstance) GetPolicyByProfileAndSlice(context.Context, string, string) (*db.Policy, error) {
 	return nil, nil
 }
 
-func (f *fakeDBInstance) ListPoliciesByProfile(context.Context, int) ([]db.Policy, error) {
+func (f *fakeDBInstance) ListPoliciesByProfile(context.Context, string) ([]db.Policy, error) {
 	return nil, nil
 }
 

--- a/internal/api/server/api_audit_logs.go
+++ b/internal/api/server/api_audit_logs.go
@@ -24,7 +24,7 @@ type UpdateAuditLogsRetentionPolicyParams struct {
 }
 
 type AuditLog struct {
-	ID        int    `json:"id"`
+	ID        string `json:"id"`
 	Timestamp string `json:"timestamp"`
 	Level     string `json:"level"`
 	User      string `json:"user"`

--- a/internal/api/server/api_audit_logs_test.go
+++ b/internal/api/server/api_audit_logs_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type AuditLog struct {
-	ID        int    `json:"id"`
+	ID        string `json:"id"`
 	Timestamp string `json:"timestamp"`
 	Level     string `json:"level"`
 	User      string `json:"user"`

--- a/internal/api/server/api_auth.go
+++ b/internal/api/server/api_auth.go
@@ -52,7 +52,7 @@ const (
 )
 
 // Helper function to generate a JWT
-func generateJWT(id int64, email string, roleID RoleID, jwtSecret []byte) (string, error) {
+func generateJWT(id string, email string, roleID RoleID, jwtSecret []byte) (string, error) {
 	now := time.Now()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims{
 		ID:     id,
@@ -246,7 +246,7 @@ func Login(dbInstance *db.Database, jwtSecret *JWTSecret, secureCookie bool, log
 	})
 }
 
-func createSessionAndSetCookie(ctx context.Context, dbInstance *db.Database, userID int64, secureCookie bool, w http.ResponseWriter) error {
+func createSessionAndSetCookie(ctx context.Context, dbInstance *db.Database, userID string, secureCookie bool, w http.ResponseWriter) error {
 	// Enforce session limit per user to prevent database bloat
 	sessionCount, err := dbInstance.CountSessionsByUser(ctx, userID)
 	if err != nil {

--- a/internal/api/server/api_auth.go
+++ b/internal/api/server/api_auth.go
@@ -283,8 +283,7 @@ func createSessionAndSetCookie(ctx context.Context, dbInstance *db.Database, use
 		ExpiresAt: expiresAt.Unix(),
 	}
 
-	_, err = dbInstance.CreateSession(ctx, session)
-	if err != nil {
+	if err = dbInstance.CreateSession(ctx, session); err != nil {
 		return fmt.Errorf("couldn't create session: %w", err)
 	}
 

--- a/internal/api/server/api_auth_test.go
+++ b/internal/api/server/api_auth_test.go
@@ -1200,8 +1200,14 @@ func TestSessionLimitPerUser(t *testing.T) {
 		}
 	}
 
+	// Resolve the first user's ID (string UUID) for direct DB access.
+	firstUser, err := env.DB.GetUser(context.Background(), FirstUserEmail)
+	if err != nil {
+		t.Fatalf("couldn't get first user: %s", err)
+	}
+
 	// Count sessions - should be MaxSessionsPerUser
-	sessionCount, err := env.DB.CountSessionsByUser(context.Background(), 1) // User ID 1 is the first user
+	sessionCount, err := env.DB.CountSessionsByUser(context.Background(), firstUser.ID)
 	if err != nil {
 		t.Fatalf("couldn't count sessions: %s", err)
 	}
@@ -1224,7 +1230,7 @@ func TestSessionLimitPerUser(t *testing.T) {
 	}
 
 	// Count sessions again - should still be MaxSessionsPerUser
-	sessionCount, err = env.DB.CountSessionsByUser(context.Background(), 1)
+	sessionCount, err = env.DB.CountSessionsByUser(context.Background(), firstUser.ID)
 	if err != nil {
 		t.Fatalf("couldn't count sessions after final login: %s", err)
 	}

--- a/internal/api/server/api_flow_reports_test.go
+++ b/internal/api/server/api_flow_reports_test.go
@@ -375,7 +375,7 @@ func TestUpdateFlowReportsRetentionPolicyInvalidInput(t *testing.T) {
 	}
 }
 
-func createFlowReportTestSubscriber(t *testing.T, dbInstance *db.Database) int {
+func createFlowReportTestSubscriber(t *testing.T, dbInstance *db.Database) string {
 	t.Helper()
 
 	const imsi = "001010100000001"
@@ -395,6 +395,30 @@ func createFlowReportTestSubscriber(t *testing.T, dbInstance *db.Database) int {
 		t.Fatalf("couldn't get data network: %s", err)
 	}
 
+	profile := &db.Profile{
+		Name:           "test-profile-" + imsi,
+		UeAmbrUplink:   "200 Mbps",
+		UeAmbrDownlink: "200 Mbps",
+	}
+	if err := dbInstance.CreateProfile(ctx, profile); err != nil {
+		t.Fatalf("couldn't create profile: %s", err)
+	}
+
+	createdProfile, err := dbInstance.GetProfile(ctx, profile.Name)
+	if err != nil {
+		t.Fatalf("couldn't get profile: %s", err)
+	}
+
+	slice := &db.NetworkSlice{Name: "test-slice-" + imsi, Sst: 1}
+	if err := dbInstance.CreateNetworkSlice(ctx, slice); err != nil {
+		t.Fatalf("couldn't create network slice: %s", err)
+	}
+
+	createdSlice, err := dbInstance.GetNetworkSlice(ctx, slice.Name)
+	if err != nil {
+		t.Fatalf("couldn't get network slice: %s", err)
+	}
+
 	policy := &db.Policy{
 		Name:                "test-policy-" + imsi,
 		SessionAmbrUplink:   "100 Mbps",
@@ -402,8 +426,8 @@ func createFlowReportTestSubscriber(t *testing.T, dbInstance *db.Database) int {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       createdDN.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           createdProfile.ID,
+		SliceID:             createdSlice.ID,
 	}
 	if err := dbInstance.CreatePolicy(ctx, policy); err != nil {
 		t.Fatalf("couldn't create policy: %s", err)

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -272,7 +272,7 @@ func (f *fakeUPFClient) DeleteSession(ctx context.Context, remoteSEID uint64) er
 
 func (f *fakeUPFClient) FlushUsage(ctx context.Context, remoteSEID uint64) {}
 
-func (f *fakeUPFClient) UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
+func (f *fakeUPFClient) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return nil
 }
 

--- a/internal/api/server/api_home_network_keys.go
+++ b/internal/api/server/api_home_network_keys.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/google/uuid"
 )
 
 type CreateHomeNetworkKeyParams struct {
@@ -19,7 +19,7 @@ type CreateHomeNetworkKeyParams struct {
 }
 
 type HomeNetworkKeyResponse struct {
-	ID            int    `json:"id"`
+	ID            string `json:"id"`
 	KeyIdentifier int    `json:"keyIdentifier"`
 	Scheme        string `json:"scheme"`
 	PublicKey     string `json:"publicKey"`
@@ -61,10 +61,8 @@ func GetHomeNetworkKeyPrivateKey(dbInstance *db.Database) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		email := getEmailFromContext(r)
 
-		idStr := r.PathValue("id")
-
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
+		id := r.PathValue("id")
+		if _, err := uuid.Parse(id); err != nil {
 			writeError(r.Context(), w, http.StatusBadRequest, "Invalid key ID", err, logger.APILog)
 			return
 		}
@@ -86,7 +84,7 @@ func GetHomeNetworkKeyPrivateKey(dbInstance *db.Database) http.Handler {
 			ViewHomeNetworkKeyPrivateKeyAction,
 			email,
 			getClientIP(r),
-			fmt.Sprintf("Viewed private key for home network key (id=%d, scheme=%s, keyIdentifier=%d)", id, existingKey.Scheme, existingKey.KeyIdentifier),
+			fmt.Sprintf("Viewed private key for home network key (id=%s, scheme=%s, keyIdentifier=%d)", id, existingKey.Scheme, existingKey.KeyIdentifier),
 		)
 
 		writeResponse(r.Context(), w, HomeNetworkKeyPrivateKeyResponse{
@@ -140,7 +138,14 @@ func CreateHomeNetworkKey(dbInstance *db.Database) http.Handler {
 			return
 		}
 
+		id, err := uuid.NewV7()
+		if err != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to generate key id", err, logger.APILog)
+			return
+		}
+
 		key := &db.HomeNetworkKey{
+			ID:            id.String(),
 			KeyIdentifier: params.KeyIdentifier,
 			Scheme:        params.Scheme,
 			PrivateKey:    params.PrivateKey,
@@ -175,10 +180,8 @@ func DeleteHomeNetworkKey(dbInstance *db.Database) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		email := getEmailFromContext(r)
 
-		idStr := r.PathValue("id")
-
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
+		id := r.PathValue("id")
+		if _, err := uuid.Parse(id); err != nil {
 			writeError(r.Context(), w, http.StatusBadRequest, "Invalid key ID", err, logger.APILog)
 			return
 		}
@@ -207,7 +210,7 @@ func DeleteHomeNetworkKey(dbInstance *db.Database) http.Handler {
 			DeleteHomeNetworkKeyAction,
 			email,
 			getClientIP(r),
-			fmt.Sprintf("Deleted home network key (id=%d, scheme=%s, keyIdentifier=%d)", id, existingKey.Scheme, existingKey.KeyIdentifier),
+			fmt.Sprintf("Deleted home network key (id=%s, scheme=%s, keyIdentifier=%d)", id, existingKey.Scheme, existingKey.KeyIdentifier),
 		)
 	})
 }

--- a/internal/api/server/api_home_network_keys_test.go
+++ b/internal/api/server/api_home_network_keys_test.go
@@ -17,7 +17,7 @@ type CreateHomeNetworkKeyParams struct {
 }
 
 type HomeNetworkKeyResponseItem struct {
-	ID            int    `json:"id"`
+	ID            string `json:"id"`
 	KeyIdentifier int    `json:"keyIdentifier"`
 	Scheme        string `json:"scheme"`
 	PublicKey     string `json:"publicKey"`
@@ -68,8 +68,8 @@ func createHomeNetworkKey(url string, client *http.Client, token string, data *C
 	return res.StatusCode, &resp, nil
 }
 
-func deleteHomeNetworkKey(url string, client *http.Client, token string, id int) (int, *DeleteHomeNetworkKeyResponse, error) { //nolint:unparam
-	req, err := http.NewRequestWithContext(context.Background(), "DELETE", fmt.Sprintf("%s/api/v1/operator/home-network-keys/%d", url, id), nil)
+func deleteHomeNetworkKey(url string, client *http.Client, token string, id string) (int, *DeleteHomeNetworkKeyResponse, error) { //nolint:unparam
+	req, err := http.NewRequestWithContext(context.Background(), "DELETE", fmt.Sprintf("%s/api/v1/operator/home-network-keys/%s", url, id), nil)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -333,7 +333,7 @@ func TestDeleteHomeNetworkKey(t *testing.T) {
 	}
 
 	// Find the key with identifier 1.
-	var keyID int
+	var keyID string
 
 	for _, k := range opResp.Result.HomeNetworkKeys {
 		if k.KeyIdentifier == 1 {
@@ -342,7 +342,7 @@ func TestDeleteHomeNetworkKey(t *testing.T) {
 		}
 	}
 
-	if keyID == 0 {
+	if keyID == "" {
 		t.Fatal("couldn't find key with identifier 1")
 	}
 
@@ -385,7 +385,7 @@ func TestDeleteHomeNetworkKey_NotFound(t *testing.T) {
 		t.Fatalf("couldn't initialize: %s", err)
 	}
 
-	statusCode, _, err := deleteHomeNetworkKey(env.Server.URL, client, token, 9999)
+	statusCode, _, err := deleteHomeNetworkKey(env.Server.URL, client, token, "00000000-0000-7000-8000-000000000000")
 	if err != nil {
 		t.Fatalf("request failed: %s", err)
 	}

--- a/internal/api/server/api_operator.go
+++ b/internal/api/server/api_operator.go
@@ -182,7 +182,7 @@ func GetOperator(dbInstance *db.Database) http.Handler {
 		for _, k := range hnKeys {
 			pubKey, err := k.GetPublicKey()
 			if err != nil {
-				logger.APILog.Warn("Failed to derive public key", zap.Int("id", k.ID), zap.Error(err))
+				logger.APILog.Warn("Failed to derive public key", zap.String("id", k.ID), zap.Error(err))
 				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to derive public key", err, logger.APILog)
 
 				return

--- a/internal/api/server/api_policies.go
+++ b/internal/api/server/api_policies.go
@@ -224,7 +224,7 @@ func validatePolicyRules(rules *PolicyRules) error {
 	return nil
 }
 
-func createNetworkRulesForPolicyTx(ctx context.Context, tx *db.Transaction, policyID int64, rules *PolicyRules) error {
+func createNetworkRulesForPolicyTx(ctx context.Context, tx *db.Transaction, policyID string, rules *PolicyRules) error {
 	if rules == nil {
 		return nil
 	}
@@ -358,7 +358,7 @@ func ListPolicies(dbInstance *db.Database) http.Handler {
 	})
 }
 
-func getPolicyRulesForPolicy(ctx context.Context, dbInstance *db.Database, policyID int64) (*PolicyRules, error) {
+func getPolicyRulesForPolicy(ctx context.Context, dbInstance *db.Database, policyID string) (*PolicyRules, error) {
 	rules, err := dbInstance.ListRulesForPolicy(ctx, policyID)
 	if err != nil {
 		return nil, err
@@ -437,7 +437,7 @@ func GetPolicy(dbInstance *db.Database) http.Handler {
 			return
 		}
 
-		rules, err := getPolicyRulesForPolicy(r.Context(), dbInstance, int64(dbPolicy.ID))
+		rules, err := getPolicyRulesForPolicy(r.Context(), dbInstance, dbPolicy.ID)
 		if err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to retrieve policy rules", err, logger.APILog)
 			return
@@ -679,12 +679,12 @@ func UpdatePolicy(dbInstance *db.Database) http.Handler {
 
 		// Omitting the rules field in the request body is treated as an
 		// explicit deletion of all rules. Re-creating happens below.
-		if err := tx.DeleteNetworkRulesByPolicyID(r.Context(), int64(policy.ID)); err != nil {
+		if err := tx.DeleteNetworkRulesByPolicyID(r.Context(), policy.ID); err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to delete existing policy rules", err, logger.APILog)
 			return
 		}
 
-		if err := createNetworkRulesForPolicyTx(r.Context(), tx, int64(policy.ID), updatePolicyParams.Rules); err != nil {
+		if err := createNetworkRulesForPolicyTx(r.Context(), tx, policy.ID, updatePolicyParams.Rules); err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create policy rules", err, logger.APILog)
 			return
 		}

--- a/internal/api/server/api_routes.go
+++ b/internal/api/server/api_routes.go
@@ -254,7 +254,7 @@ func CreateRoute(dbInstance *db.Database, reconcileRoutes func(context.Context) 
 			}
 		}
 
-		response := CreateSuccessResponse{Message: "Route created successfully", ID: routeID}
+		response := CreateSuccessResponse{Message: "Route created successfully", ID: strconv.FormatInt(routeID, 10)}
 		writeResponse(r.Context(), w, response, http.StatusCreated, logger.APILog)
 		logger.LogAuditEvent(r.Context(), CreateRouteAction, email, getClientIP(r), "User created route: "+fmt.Sprint(routeID))
 	})

--- a/internal/api/server/api_routes_test.go
+++ b/internal/api/server/api_routes_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 type CreateRouteResponseResult struct {
-	ID      int64  `json:"id"`
+	ID      string `json:"id"` // CreateSuccessResponse.id is a string (decimal-formatted route id for local-only routes table)
 	Message string `json:"message"`
 }
 

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -219,7 +219,7 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF) http.Handler
 			return
 		}
 
-		profileByID := make(map[int]*db.Profile, len(allProfiles))
+		profileByID := make(map[string]*db.Profile, len(allProfiles))
 		for i := range allProfiles {
 			profileByID[allProfiles[i].ID] = &allProfiles[i]
 		}
@@ -233,7 +233,7 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF) http.Handler
 
 			profile, ok := profileByID[dbSubscriber.ProfileID]
 			if !ok {
-				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to retrieve profile", fmt.Errorf("no profile for ID %d", dbSubscriber.ProfileID), logger.APILog)
+				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to retrieve profile", fmt.Errorf("no profile for ID %s", dbSubscriber.ProfileID), logger.APILog)
 				return
 			}
 

--- a/internal/api/server/api_users.go
+++ b/internal/api/server/api_users.go
@@ -425,7 +425,7 @@ func UpdateMyUserPassword(dbInstance *db.Database, bcryptCost int) http.Handler 
 
 		userIDAny := r.Context().Value(contextKeyUserID)
 
-		userID, ok := userIDAny.(int64)
+		userID, ok := userIDAny.(string)
 		if !ok {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get user ID", errors.New("user ID missing in context"), logger.APILog)
 			return
@@ -563,7 +563,7 @@ func ListMyAPITokens(dbInstance *db.Database) http.Handler {
 
 		userIDAny := r.Context().Value(contextKeyUserID)
 
-		userID, ok := userIDAny.(int64)
+		userID, ok := userIDAny.(string)
 		if !ok {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get user ID", errors.New("user ID missing in context"), logger.APILog)
 			return
@@ -651,7 +651,7 @@ func CreateMyAPIToken(dbInstance *db.Database, bcryptCost int) http.Handler {
 
 		userIDAny := r.Context().Value(contextKeyUserID)
 
-		userID, ok := userIDAny.(int64)
+		userID, ok := userIDAny.(string)
 		if !ok {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get user ID", errors.New("user ID missing in context"), logger.APILog)
 			return
@@ -763,7 +763,7 @@ func DeleteMyAPIToken(dbInstance *db.Database) http.Handler {
 
 		userIDAny := r.Context().Value(contextKeyUserID)
 
-		userID, ok := userIDAny.(int64)
+		userID, ok := userIDAny.(string)
 		if !ok {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get user ID", errors.New("user ID missing in context"), logger.APILog)
 			return

--- a/internal/api/server/authentication_middleware.go
+++ b/internal/api/server/authentication_middleware.go
@@ -22,7 +22,7 @@ var tracer = otel.Tracer("ella-core/api/authentication_middleware")
 const AuthenticationAction = "user_authentication"
 
 type claims struct {
-	ID     int64  `json:"id"`
+	ID     string `json:"id"`
 	Email  string `json:"email"`
 	RoleID RoleID `json:"role_id"`
 	jwt.RegisteredClaims
@@ -55,7 +55,7 @@ func parseAPIToken(presented string) (tokenID, secret string, ok bool) {
 
 // authenticateRequest validates the Authorization header (JWT or API token),
 // and returns (userID, email, roleID) for authorization.
-func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Database) (int64, string, RoleID, error) {
+func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Database) (string, string, RoleID, error) {
 	var authType string
 
 	var success bool
@@ -78,7 +78,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "missing Authorization header")
 
-		return 0, "", 0, err
+		return "", "", 0, err
 	}
 
 	parts := strings.SplitN(authHeader, " ", 2)
@@ -87,7 +87,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "invalid Authorization scheme")
 
-		return 0, "", 0, err
+		return "", "", 0, err
 	}
 
 	token := strings.TrimSpace(parts[1])
@@ -96,7 +96,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "empty token")
 
-		return 0, "", 0, err
+		return "", "", 0, err
 	}
 
 	// API token path
@@ -109,7 +109,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "invalid API token format")
 
-			return 0, "", 0, err
+			return "", "", 0, err
 		}
 
 		tok, err := store.GetAPITokenByTokenID(ctx, tokenID)
@@ -118,7 +118,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "invalid API token")
 
-			return 0, "", 0, err
+			return "", "", 0, err
 		}
 
 		if tok.ExpiresAt != nil && time.Now().After(*tok.ExpiresAt) {
@@ -126,7 +126,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "API token expired")
 
-			return 0, "", 0, err
+			return "", "", 0, err
 		}
 
 		// CompareHashAndPassword uses constant time comparison, making it safer but slower
@@ -135,7 +135,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "invalid API token")
 
-			return 0, "", 0, err
+			return "", "", 0, err
 		}
 
 		u, err := store.GetUserByID(ctx, tok.UserID)
@@ -144,7 +144,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "user not found")
 
-			return 0, "", 0, err
+			return "", "", 0, err
 		}
 
 		success = true
@@ -157,12 +157,12 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 
 	cl, err := getClaimsFromJWT(token, jwtSecret.Get())
 	if err != nil {
-		return 0, "", 0, err
+		return "", "", 0, err
 	}
 
 	u, err := store.GetUserByID(ctx, cl.ID)
 	if err != nil || u == nil {
-		return 0, "", 0, errors.New("user not found")
+		return "", "", 0, errors.New("user not found")
 	}
 
 	success = true
@@ -171,7 +171,7 @@ func authenticateRequest(r *http.Request, jwtSecret *JWTSecret, store *db.Databa
 }
 
 // putIdentity adds identity to context.
-func putIdentity(ctx context.Context, id int64, email string, role RoleID) context.Context {
+func putIdentity(ctx context.Context, id string, email string, role RoleID) context.Context {
 	ctx = context.WithValue(ctx, contextKeyUserID, id)
 	ctx = context.WithValue(ctx, contextKeyEmail, email)
 	ctx = context.WithValue(ctx, contextKeyRoleID, role)

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3040,8 +3040,9 @@ components:
         message:
           type: string
         id:
-          type: integer
-          format: int64
+          type: string
+          format: uuid
+          description: UUIDv7 of the created resource.
       required: [message, id]
 
     RetentionPolicyParams:
@@ -3937,8 +3938,9 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          description: Internal database ID.
+          type: string
+          format: uuid
+          description: Internal UUIDv7 database ID.
         keyIdentifier:
           type: integer
           minimum: 0

--- a/internal/api/server/response.go
+++ b/internal/api/server/response.go
@@ -17,7 +17,7 @@ type SuccessResponse struct {
 
 type CreateSuccessResponse struct {
 	Message string `json:"message"`
-	ID      int64  `json:"id"`
+	ID      string `json:"id"` // UUIDv7 of created resource
 }
 
 type ErrorResponse struct {

--- a/internal/db/api_tokens.go
+++ b/internal/db/api_tokens.go
@@ -22,7 +22,7 @@ type APIToken struct {
 	TokenID   string     `db:"token_id"`
 	Name      string     `db:"name"`
 	TokenHash string     `db:"token_hash"`
-	UserID    int64      `db:"user_id"`
+	UserID    string     `db:"user_id"` // FK to users.id (UUID)
 	ExpiresAt *time.Time `db:"expires_at"`
 }
 
@@ -35,7 +35,7 @@ const (
 	countAPITokensStmt     = "SELECT COUNT(*) AS &NumItems.count FROM %s WHERE user_id==$APIToken.user_id"                                                                                                                   // #nosec: G101
 )
 
-func (db *Database) ListAPITokensPage(ctx context.Context, userID int64, page int, perPage int) ([]APIToken, int, error) {
+func (db *Database) ListAPITokensPage(ctx context.Context, userID string, page int, perPage int) ([]APIToken, int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (paged)", "SELECT", APITokensTableName),
@@ -174,7 +174,7 @@ func (db *Database) GetAPITokenByTokenID(ctx context.Context, tokenID string) (*
 	return &row, nil
 }
 
-func (db *Database) GetAPITokenByName(ctx context.Context, userID int64, name string) (*APIToken, error) {
+func (db *Database) GetAPITokenByName(ctx context.Context, userID string, name string) (*APIToken, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", APITokensTableName),
@@ -243,7 +243,7 @@ func (db *Database) DeleteAPIToken(ctx context.Context, id string) error {
 	return nil
 }
 
-func (db *Database) CountAPITokens(ctx context.Context, userID int64) (int, error) {
+func (db *Database) CountAPITokens(ctx context.Context, userID string) (int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", APITokensTableName),

--- a/internal/db/api_tokens.go
+++ b/internal/db/api_tokens.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -17,7 +18,7 @@ import (
 const APITokensTableName = "api_tokens"
 
 type APIToken struct {
-	ID        int        `db:"id"`
+	ID        string     `db:"id"` // UUIDv7
 	TokenID   string     `db:"token_id"`
 	Name      string     `db:"name"`
 	TokenHash string     `db:"token_hash"`
@@ -29,9 +30,9 @@ const (
 	listAPITokensPagedStmt = `SELECT &APIToken.*, COUNT(*) OVER() AS &NumItems.count FROM %s WHERE user_id == $APIToken.user_id ORDER BY id DESC LIMIT $ListArgs.limit OFFSET $ListArgs.offset`
 	getByTokenIDStmt       = "SELECT &APIToken.* FROM %s WHERE token_id==$APIToken.token_id"
 	getByNameStmt          = "SELECT &APIToken.* FROM %s WHERE user_id==$APIToken.user_id AND name==$APIToken.name"
-	deleteAPITokenStmt     = "DELETE FROM %s WHERE id==$APIToken.id"                                                                                                                                       // #nosec: G101
-	createAPITokenStmt     = "INSERT INTO %s (token_id, name, token_hash, user_id, expires_at) VALUES ($APIToken.token_id, $APIToken.name, $APIToken.token_hash, $APIToken.user_id, $APIToken.expires_at)" // #nosec: G101
-	countAPITokensStmt     = "SELECT COUNT(*) AS &NumItems.count FROM %s WHERE user_id==$APIToken.user_id"                                                                                                 // #nosec: G101
+	deleteAPITokenStmt     = "DELETE FROM %s WHERE id==$APIToken.id"                                                                                                                                                         // #nosec: G101
+	createAPITokenStmt     = "INSERT INTO %s (id, token_id, name, token_hash, user_id, expires_at) VALUES ($APIToken.id, $APIToken.token_id, $APIToken.name, $APIToken.token_hash, $APIToken.user_id, $APIToken.expires_at)" // #nosec: G101
+	countAPITokensStmt     = "SELECT COUNT(*) AS &NumItems.count FROM %s WHERE user_id==$APIToken.user_id"                                                                                                                   // #nosec: G101
 )
 
 func (db *Database) ListAPITokensPage(ctx context.Context, userID int64, page int, perPage int) ([]APIToken, int, error) {
@@ -112,6 +113,15 @@ func (db *Database) CreateAPIToken(ctx context.Context, apiToken *APIToken) erro
 	defer timer.ObserveDuration()
 
 	DBQueriesTotal.WithLabelValues(APITokensTableName, "insert").Inc()
+
+	if apiToken.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate api token id: %w", err)
+		}
+
+		apiToken.ID = id.String()
+	}
 
 	_, err := opCreateAPIToken.Invoke(db, apiToken)
 	if err != nil {
@@ -202,7 +212,7 @@ func (db *Database) GetAPITokenByName(ctx context.Context, userID int64, name st
 	return &row, nil
 }
 
-func (db *Database) DeleteAPIToken(ctx context.Context, id int) error {
+func (db *Database) DeleteAPIToken(ctx context.Context, id string) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", APITokensTableName),
@@ -220,7 +230,7 @@ func (db *Database) DeleteAPIToken(ctx context.Context, id int) error {
 
 	DBQueriesTotal.WithLabelValues(APITokensTableName, "delete").Inc()
 
-	_, err := opDeleteAPIToken.Invoke(db, &intPayload{Value: id})
+	_, err := opDeleteAPIToken.Invoke(db, &stringPayload{Value: id})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -233,6 +233,7 @@ type (
 		RequiredSchema int    `json:"requiredSchema,omitempty"`
 	}
 	auditLogPayload struct {
+		ID        string `json:"id"`
 		Timestamp string `json:"timestamp"`
 		Level     string `json:"level"`
 		Actor     string `json:"actor"`
@@ -572,6 +573,7 @@ func (db *Database) applyAllocateIPLease(ctx context.Context, p *allocateIPLease
 
 func (db *Database) applyInsertAuditLog(ctx context.Context, p *auditLogPayload) (any, error) {
 	log := &dbwriter.AuditLog{
+		ID:        p.ID,
 		Timestamp: p.Timestamp,
 		Level:     p.Level,
 		Actor:     p.Actor,

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ellanetworks/core/internal/ipam"
 	"github.com/ellanetworks/core/internal/logger"
 	ellaraft "github.com/ellanetworks/core/internal/raft"
+	"github.com/google/uuid"
 	hraft "github.com/hashicorp/raft"
 	"go.uber.org/zap"
 )
@@ -365,6 +366,15 @@ func (db *Database) applyDeleteOldDailyUsage(ctx context.Context, p *int64Payloa
 }
 
 func (db *Database) applyCreateLease(ctx context.Context, lease *IPLease) (any, error) {
+	if lease.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return nil, fmt.Errorf("generate lease id: %w", err)
+		}
+
+		lease.ID = id.String()
+	}
+
 	err := db.runner(ctx).Query(ctx, db.createLeaseStmt, lease).Run()
 	if err != nil {
 		if isUniqueNameError(err) {
@@ -386,7 +396,7 @@ func (db *Database) applyUpdateLeaseSession(ctx context.Context, lease *IPLease)
 	return nil, nil
 }
 
-func (db *Database) applyDeleteDynamicLease(ctx context.Context, p *intPayload) (any, error) {
+func (db *Database) applyDeleteDynamicLease(ctx context.Context, p *stringPayload) (any, error) {
 	err := db.runner(ctx).Query(ctx, db.deleteLeaseStmt, IPLease{ID: p.Value}).Run()
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
@@ -745,7 +755,7 @@ func (db *Database) applyCreateAPIToken(ctx context.Context, t *APIToken) (any, 
 	return nil, nil
 }
 
-func (db *Database) applyDeleteAPIToken(ctx context.Context, p *intPayload) (any, error) {
+func (db *Database) applyDeleteAPIToken(ctx context.Context, p *stringPayload) (any, error) {
 	err := db.runner(ctx).Query(ctx, db.deleteAPITokenStmt, APIToken{ID: p.Value}).Run()
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
@@ -755,19 +765,11 @@ func (db *Database) applyDeleteAPIToken(ctx context.Context, p *intPayload) (any
 }
 
 func (db *Database) applyCreateSession(ctx context.Context, s *Session) (any, error) {
-	var outcome sqlair.Outcome
-
-	err := db.runner(ctx).Query(ctx, db.createSessionStmt, s).Get(&outcome)
-	if err != nil {
+	if err := db.runner(ctx).Query(ctx, db.createSessionStmt, s).Run(); err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
 
-	id, err := outcome.Result().LastInsertId()
-	if err != nil {
-		return nil, fmt.Errorf("last insert id: %w", err)
-	}
-
-	return id, nil
+	return nil, nil
 }
 
 func (db *Database) applyDeleteSessionByTokenHash(ctx context.Context, p *bytesPayload) (any, error) {
@@ -982,10 +984,7 @@ func (db *Database) applyDeletePolicy(ctx context.Context, p *stringPayload) (an
 }
 
 func (db *Database) applyCreateNetworkRule(ctx context.Context, nr *NetworkRule) (any, error) {
-	var outcome sqlair.Outcome
-
-	err := db.runner(ctx).Query(ctx, db.createNetworkRuleStmt, nr).Get(&outcome)
-	if err != nil {
+	if err := db.runner(ctx).Query(ctx, db.createNetworkRuleStmt, nr).Run(); err != nil {
 		if isUniqueNameError(err) {
 			return nil, ErrAlreadyExists
 		}
@@ -993,12 +992,7 @@ func (db *Database) applyCreateNetworkRule(ctx context.Context, nr *NetworkRule)
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
 
-	id, err := outcome.Result().LastInsertId()
-	if err != nil {
-		return nil, fmt.Errorf("last insert id: %w", err)
-	}
-
-	return id, nil
+	return nil, nil
 }
 
 func (db *Database) applyUpdateNetworkRule(ctx context.Context, nr *NetworkRule) (any, error) {
@@ -1021,7 +1015,7 @@ func (db *Database) applyUpdateNetworkRule(ctx context.Context, nr *NetworkRule)
 	return nil, nil
 }
 
-func (db *Database) applyDeleteNetworkRule(ctx context.Context, p *int64Payload) (any, error) {
+func (db *Database) applyDeleteNetworkRule(ctx context.Context, p *stringPayload) (any, error) {
 	var outcome sqlair.Outcome
 
 	err := db.runner(ctx).Query(ctx, db.deleteNetworkRuleStmt, NetworkRule{ID: p.Value}).Get(&outcome)

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -1063,7 +1063,7 @@ func (db *Database) applyCreateHomeNetworkKey(ctx context.Context, k *HomeNetwor
 	return nil, nil
 }
 
-func (db *Database) applyDeleteHomeNetworkKey(ctx context.Context, p *intPayload) (any, error) {
+func (db *Database) applyDeleteHomeNetworkKey(ctx context.Context, p *stringPayload) (any, error) {
 	var outcome sqlair.Outcome
 
 	err := db.runner(ctx).Query(ctx, db.deleteHomeNetworkKeyStmt, HomeNetworkKey{ID: p.Value}).Get(&outcome)

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -437,7 +437,7 @@ func (db *Database) applyUpdateLeaseNode(ctx context.Context, lease *IPLease) (a
 // this op. The leader's apply function picks the address atomically
 // inside leaderCaptureAndPropose's proposeMu.
 type allocateIPLeasePayload struct {
-	PoolID    int    `json:"poolId"`
+	PoolID    string `json:"poolId"`
 	IMSI      string `json:"imsi"`
 	SessionID int    `json:"sessionId"`
 	NodeID    int    `json:"nodeId"`
@@ -478,10 +478,10 @@ func (db *Database) applyAllocateIPLease(ctx context.Context, p *allocateIPLease
 
 	if err := runner.Query(ctx, db.getDataNetworkByIDStmt, dn).Get(&dn); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("data network %d not found", p.PoolID)
+			return nil, fmt.Errorf("data network %s not found", p.PoolID)
 		}
 
-		return nil, fmt.Errorf("get data network %d: %w", p.PoolID, err)
+		return nil, fmt.Errorf("get data network %s: %w", p.PoolID, err)
 	}
 
 	pool, err := ipam.NewPool(dn.ID, dn.IPPool)
@@ -806,7 +806,7 @@ func (db *Database) applyDeleteOldestSessions(ctx context.Context, args *DeleteO
 	return nil, nil
 }
 
-func (db *Database) applyDeleteAllSessionsForUser(ctx context.Context, p *int64Payload) (any, error) {
+func (db *Database) applyDeleteAllSessionsForUser(ctx context.Context, p *stringPayload) (any, error) {
 	err := db.runner(ctx).Query(ctx, db.deleteAllSessionsForUserStmt, UserIDArgs{UserID: p.Value}).Run()
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
@@ -1035,7 +1035,7 @@ func (db *Database) applyDeleteNetworkRule(ctx context.Context, p *stringPayload
 	return nil, nil
 }
 
-func (db *Database) applyDeleteNetworkRulesByPolicy(ctx context.Context, p *int64Payload) (any, error) {
+func (db *Database) applyDeleteNetworkRulesByPolicy(ctx context.Context, p *stringPayload) (any, error) {
 	err := db.runner(ctx).Query(ctx, db.deleteNetworkRulesByPolicyStmt, NetworkRule{PolicyID: p.Value}).Run()
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)

--- a/internal/db/audit_logs.go
+++ b/internal/db/audit_logs.go
@@ -20,11 +20,14 @@ import (
 const AuditLogsTableName = "audit_logs"
 
 const (
-	insertAuditLogStmt     = "INSERT INTO %s (timestamp, level, actor, action, ip, details) VALUES ($AuditLog.timestamp, $AuditLog.level, $AuditLog.actor, $AuditLog.action, $AuditLog.ip, $AuditLog.details)"
+	insertAuditLogStmt     = "INSERT INTO %s (id, timestamp, level, actor, action, ip, details) VALUES ($AuditLog.id, $AuditLog.timestamp, $AuditLog.level, $AuditLog.actor, $AuditLog.action, $AuditLog.ip, $AuditLog.details)"
 	deleteOldAuditLogsStmt = "DELETE FROM %s WHERE timestamp < $cutoffArgs.cutoff"
 	countAuditLogsStmt     = "SELECT COUNT(*) AS &NumItems.count FROM %s"
 )
 
+// id is a UUIDv7, so it's not strictly time-ordered (clock skew between
+// generators); the secondary sort by id keeps the ordering stable when
+// timestamps tie.
 const listAuditLogsFilteredPageStmt = `
   SELECT &AuditLog.*, COUNT(*) OVER() AS &NumItems.count
   FROM %s
@@ -33,7 +36,7 @@ const listAuditLogsFilteredPageStmt = `
     AND ($AuditLogFilters.action IS NULL OR action = $AuditLogFilters.action)
     AND ($AuditLogFilters.timestamp_from IS NULL OR timestamp >= $AuditLogFilters.timestamp_from)
     AND ($AuditLogFilters.timestamp_to IS NULL OR timestamp < $AuditLogFilters.timestamp_to)
-  ORDER BY id DESC
+  ORDER BY timestamp DESC, id DESC
   LIMIT $ListArgs.limit
   OFFSET $ListArgs.offset
 `
@@ -65,7 +68,12 @@ func (db *Database) InsertAuditLog(ctx context.Context, auditLog *dbwriter.Audit
 
 	DBQueriesTotal.WithLabelValues(AuditLogsTableName, "insert").Inc()
 
+	if auditLog.ID == "" {
+		return fmt.Errorf("InsertAuditLog: ID must be set by the caller")
+	}
+
 	payload := &auditLogPayload{
+		ID:        auditLog.ID,
 		Timestamp: auditLog.Timestamp,
 		Level:     auditLog.Level,
 		Actor:     auditLog.Actor,

--- a/internal/db/audit_logs_test.go
+++ b/internal/db/audit_logs_test.go
@@ -11,7 +11,19 @@ import (
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/dbwriter"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/google/uuid"
 )
+
+func newAuditLogID(t *testing.T) string {
+	t.Helper()
+
+	id, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7: %v", err)
+	}
+
+	return id.String()
+}
 
 func TestAuditLogsEndToEnd(t *testing.T) {
 	tempDir := t.TempDir()
@@ -43,6 +55,7 @@ func TestAuditLogsEndToEnd(t *testing.T) {
 	}
 
 	err = database.InsertAuditLog(context.Background(), &dbwriter.AuditLog{
+		ID:        newAuditLogID(t),
 		Timestamp: "2024-10-01T12:00:00Z",
 		Level:     "info",
 		Actor:     "test_actor",
@@ -55,6 +68,7 @@ func TestAuditLogsEndToEnd(t *testing.T) {
 	}
 
 	err = database.InsertAuditLog(context.Background(), &dbwriter.AuditLog{
+		ID:        newAuditLogID(t),
 		Timestamp: "2024-10-01T13:00:00Z",
 		Level:     "info",
 		Actor:     "another_actor",
@@ -124,6 +138,7 @@ func TestAuditLogsRetentionPurgeKeepsNewerAndBoundary(t *testing.T) {
 
 	insert := func(ts time.Time, action string) {
 		if err := database.InsertAuditLog(ctx, &dbwriter.AuditLog{
+			ID:        newAuditLogID(t),
 			Timestamp: ts.UTC().Format(time.RFC3339),
 			Level:     "info",
 			Actor:     "tester",
@@ -218,6 +233,7 @@ func TestListAuditLogsByActorPage(t *testing.T) {
 
 	// Insert logs from different actors
 	err = database.InsertAuditLog(ctx, &dbwriter.AuditLog{
+		ID:        newAuditLogID(t),
 		Timestamp: "2024-10-01T12:00:00Z",
 		Level:     "info",
 		Actor:     "admin@example.com",
@@ -230,6 +246,7 @@ func TestListAuditLogsByActorPage(t *testing.T) {
 	}
 
 	err = database.InsertAuditLog(ctx, &dbwriter.AuditLog{
+		ID:        newAuditLogID(t),
 		Timestamp: "2024-10-01T13:00:00Z",
 		Level:     "info",
 		Actor:     "viewer@example.com",
@@ -242,6 +259,7 @@ func TestListAuditLogsByActorPage(t *testing.T) {
 	}
 
 	err = database.InsertAuditLog(ctx, &dbwriter.AuditLog{
+		ID:        newAuditLogID(t),
 		Timestamp: "2024-10-01T14:00:00Z",
 		Level:     "info",
 		Actor:     "admin@example.com",

--- a/internal/db/changeset_apply_atomic_test.go
+++ b/internal/db/changeset_apply_atomic_test.go
@@ -18,6 +18,7 @@ func captureAuditLogChangeset(t *testing.T, database *Database) []byte {
 	t.Helper()
 
 	payload := &auditLogPayload{
+		ID:        "01900000-0000-7000-8000-00000000aaaa",
 		Timestamp: "2026-05-02T13:00:00Z",
 		Level:     "info",
 		Actor:     "test",

--- a/internal/db/daily_usage_test.go
+++ b/internal/db/daily_usage_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ellanetworks/core/internal/db"
 )
 
-func createDataNetworkPolicyAndSubscriber(database *db.Database, imsi string) (int, error) {
+func createDataNetworkPolicyAndSubscriber(database *db.Database, imsi string) (string, error) {
 	newDataNetwork := &db.DataNetwork{
 		Name:   "not-internet",
 		IPPool: "1.2.3.0/24",
@@ -19,12 +19,12 @@ func createDataNetworkPolicyAndSubscriber(database *db.Database, imsi string) (i
 
 	err := database.CreateDataNetwork(context.Background(), newDataNetwork)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	createdNetwork, err := database.GetDataNetwork(context.Background(), newDataNetwork.Name)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	profile := &db.Profile{
@@ -35,12 +35,12 @@ func createDataNetworkPolicyAndSubscriber(database *db.Database, imsi string) (i
 
 	err = database.CreateProfile(context.Background(), profile)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	createdProfile, err := database.GetProfile(context.Background(), profile.Name)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	slice := &db.NetworkSlice{
@@ -50,12 +50,12 @@ func createDataNetworkPolicyAndSubscriber(database *db.Database, imsi string) (i
 
 	err = database.CreateNetworkSlice(context.Background(), slice)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	createdSlice, err := database.GetNetworkSlice(context.Background(), slice.Name)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	policy := &db.Policy{
@@ -71,7 +71,7 @@ func createDataNetworkPolicyAndSubscriber(database *db.Database, imsi string) (i
 
 	err = database.CreatePolicy(context.Background(), policy)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	subscriber := &db.Subscriber{
@@ -84,7 +84,7 @@ func createDataNetworkPolicyAndSubscriber(database *db.Database, imsi string) (i
 
 	err = database.CreateSubscriber(context.Background(), subscriber)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	return createdProfile.ID, nil

--- a/internal/db/data_networks.go
+++ b/internal/db/data_networks.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,14 +23,14 @@ const (
 	listAllDataNetworksStmt   = "SELECT &DataNetwork.* FROM %s ORDER BY id ASC"
 	getDataNetworkStmt        = "SELECT &DataNetwork.* from %s WHERE name==$DataNetwork.name"
 	getDataNetworkByIDStmt    = "SELECT &DataNetwork.* FROM %s WHERE id==$DataNetwork.id"
-	createDataNetworkStmt     = "INSERT INTO %s (name, ipPool, dns, mtu) VALUES ($DataNetwork.name, $DataNetwork.ipPool, $DataNetwork.dns, $DataNetwork.mtu)"
+	createDataNetworkStmt     = "INSERT INTO %s (id, name, ipPool, dns, mtu) VALUES ($DataNetwork.id, $DataNetwork.name, $DataNetwork.ipPool, $DataNetwork.dns, $DataNetwork.mtu)"
 	editDataNetworkStmt       = "UPDATE %s SET ipPool=$DataNetwork.ipPool, dns=$DataNetwork.dns, mtu=$DataNetwork.mtu WHERE name==$DataNetwork.name"
 	deleteDataNetworkStmt     = "DELETE FROM %s WHERE name==$DataNetwork.name"
 	countDataNetworksStmt     = "SELECT COUNT(*) AS &NumItems.count FROM %s"
 )
 
 type DataNetwork struct {
-	ID     int    `db:"id"`
+	ID     string `db:"id"` // UUIDv7
 	Name   string `db:"name"`
 	IPPool string `db:"ipPool"`
 	DNS    string `db:"dns"`
@@ -173,7 +174,7 @@ func (db *Database) GetDataNetwork(ctx context.Context, name string) (*DataNetwo
 	return &row, nil
 }
 
-func (db *Database) GetDataNetworkByID(ctx context.Context, id int) (*DataNetwork, error) {
+func (db *Database) GetDataNetworkByID(ctx context.Context, id string) (*DataNetwork, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", DataNetworksTableName),
@@ -230,6 +231,15 @@ func (db *Database) CreateDataNetwork(ctx context.Context, dataNetwork *DataNetw
 	defer timer.ObserveDuration()
 
 	DBQueriesTotal.WithLabelValues(DataNetworksTableName, "insert").Inc()
+
+	if dataNetwork.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate data network id: %w", err)
+		}
+
+		dataNetwork.ID = id.String()
+	}
 
 	_, err := opCreateDataNetwork.Invoke(db, dataNetwork)
 	if err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -922,11 +922,15 @@ func newClusterCoordinator(db *Database, parentCtx context.Context) *clusterCoor
 }
 
 func (c *clusterCoordinator) OnBecameLeader() {
-	// Drain previous-term entries before any subsequent observer
-	// callback (notably the leadership-audit callback) captures. Without
-	// this barrier, the new leader's first capture can pick the same
-	// AUTOINCREMENT id as a pending-but-not-yet-applied entry from the
-	// previous leader, causing sqlite3changeset_apply CONFLICT on apply.
+	// Drain previous-term entries before any subsequent observer callback
+	// (notably the leadership-audit callback) captures. The original
+	// motivation was the AUTOINCREMENT race on the leader-takeover
+	// boundary; that class is now closed by spec_uuid.md — replicated
+	// PKs are UUIDs generated at the request handler, never derived from
+	// rollback-able local state. The barrier is kept as defense in depth
+	// for any future ordering invariant that needs the FSM caught up
+	// before leader-only work begins. Cost is one Raft log entry per
+	// leader transition.
 	if err := c.db.raftManager.Barrier(barrierTimeout); err != nil {
 		logger.DBLog.Error("leader-takeover barrier failed", zap.Error(err))
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1596,7 +1596,13 @@ func (db *Database) Initialize(ctx context.Context) error {
 			return fmt.Errorf("failed to generate default home network key: %w", err)
 		}
 
+		defaultKeyID, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("failed to generate default home network key id: %w", err)
+		}
+
 		defaultKey := &HomeNetworkKey{
+			ID:            defaultKeyID.String(),
 			KeyIdentifier: 0,
 			Scheme:        "A",
 			PrivateKey:    initialHNPrivateKey,

--- a/internal/db/helpers.go
+++ b/internal/db/helpers.go
@@ -18,4 +18,4 @@ type cutoffDaysArgs struct {
 }
 
 // SliceIDs is a named slice type used with sqlair's IN ($SliceIDs[:]) syntax.
-type SliceIDs []int
+type SliceIDs []string

--- a/internal/db/home_network_key.go
+++ b/internal/db/home_network_key.go
@@ -28,14 +28,14 @@ const (
 	listHomeNetworkKeysStmtStr                    = "SELECT &HomeNetworkKey.* FROM %s ORDER BY scheme, key_identifier"
 	getHomeNetworkKeyStmtStr                      = "SELECT &HomeNetworkKey.* FROM %s WHERE id==$HomeNetworkKey.id"
 	getHomeNetworkKeyBySchemeAndIdentifierStmtStr = "SELECT &HomeNetworkKey.* FROM %s WHERE scheme==$HomeNetworkKey.scheme AND key_identifier==$HomeNetworkKey.key_identifier"
-	createHomeNetworkKeyStmtStr                   = "INSERT INTO %s (key_identifier, scheme, private_key) VALUES ($HomeNetworkKey.key_identifier, $HomeNetworkKey.scheme, $HomeNetworkKey.private_key)"
+	createHomeNetworkKeyStmtStr                   = "INSERT INTO %s (id, key_identifier, scheme, private_key) VALUES ($HomeNetworkKey.id, $HomeNetworkKey.key_identifier, $HomeNetworkKey.scheme, $HomeNetworkKey.private_key)"
 	deleteHomeNetworkKeyStmtStr                   = "DELETE FROM %s WHERE id==$HomeNetworkKey.id"
 	countHomeNetworkKeysStmtStr                   = "SELECT COUNT(*) AS &NumItems.count FROM %s"
 )
 
 // HomeNetworkKey represents a home network key used for SUCI de-concealment.
 type HomeNetworkKey struct {
-	ID            int    `db:"id"`
+	ID            string `db:"id"` // UUIDv7, generated at the request handler
 	KeyIdentifier int    `db:"key_identifier"`
 	Scheme        string `db:"scheme"` // "A" or "B"
 	PrivateKey    string `db:"private_key"`
@@ -120,8 +120,8 @@ func (db *Database) ListHomeNetworkKeys(ctx context.Context) ([]HomeNetworkKey, 
 	return keys, nil
 }
 
-// GetHomeNetworkKey retrieves a home network key by its database row ID.
-func (db *Database) GetHomeNetworkKey(ctx context.Context, id int) (*HomeNetworkKey, error) {
+// GetHomeNetworkKey retrieves a home network key by its UUID.
+func (db *Database) GetHomeNetworkKey(ctx context.Context, id string) (*HomeNetworkKey, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", HomeNetworkKeysTableName),
@@ -217,6 +217,10 @@ func (db *Database) CreateHomeNetworkKey(ctx context.Context, key *HomeNetworkKe
 
 	DBQueriesTotal.WithLabelValues(HomeNetworkKeysTableName, "insert").Inc()
 
+	if key.ID == "" {
+		return fmt.Errorf("CreateHomeNetworkKey: ID must be set by the caller")
+	}
+
 	_, err := opCreateHomeNetworkKey.Invoke(db, key)
 	if err != nil {
 		span.RecordError(err)
@@ -230,8 +234,8 @@ func (db *Database) CreateHomeNetworkKey(ctx context.Context, key *HomeNetworkKe
 	return nil
 }
 
-// DeleteHomeNetworkKey removes a home network key by its database row ID.
-func (db *Database) DeleteHomeNetworkKey(ctx context.Context, id int) error {
+// DeleteHomeNetworkKey removes a home network key by its UUID.
+func (db *Database) DeleteHomeNetworkKey(ctx context.Context, id string) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", HomeNetworkKeysTableName),
@@ -249,7 +253,7 @@ func (db *Database) DeleteHomeNetworkKey(ctx context.Context, id int) error {
 
 	DBQueriesTotal.WithLabelValues(HomeNetworkKeysTableName, "delete").Inc()
 
-	_, err := opDeleteHomeNetworkKey.Invoke(db, &intPayload{Value: id})
+	_, err := opDeleteHomeNetworkKey.Invoke(db, &stringPayload{Value: id})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/home_network_key_test.go
+++ b/internal/db/home_network_key_test.go
@@ -8,7 +8,17 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/db"
+	"github.com/google/uuid"
 )
+
+func newKeyID(t *testing.T) string {
+	t.Helper()
+	id, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7: %v", err)
+	}
+	return id.String()
+}
 
 func TestHomeNetworkKeysCRUD(t *testing.T) {
 	tempDir := t.TempDir()
@@ -83,6 +93,7 @@ func TestHomeNetworkKeysCRUD(t *testing.T) {
 	// Create a Profile B key.
 	// Use a known valid P-256 private key (from TS 33.501 Annex C.3.4).
 	profileBKey := &db.HomeNetworkKey{
+		ID:            newKeyID(t),
 		KeyIdentifier: 0,
 		Scheme:        "B",
 		PrivateKey:    "f1ab1074477ebcce59b97460c83b4071db578ffab54ee4fbc76aeca38e4b7b01",
@@ -119,6 +130,7 @@ func TestHomeNetworkKeysCRUD(t *testing.T) {
 
 	// Create a second Profile A key (key rotation scenario).
 	rotationKey := &db.HomeNetworkKey{
+		ID:            newKeyID(t),
 		KeyIdentifier: 1,
 		Scheme:        "A",
 		PrivateKey:    keys[0].PrivateKey, // reuse for simplicity
@@ -194,6 +206,7 @@ func TestCreateHomeNetworkKey_Duplicate(t *testing.T) {
 
 	// Default key (A, 0) already exists. Try to create another (A, 0).
 	dupKey := &db.HomeNetworkKey{
+		ID:            newKeyID(t),
 		KeyIdentifier: 0,
 		Scheme:        "A",
 		PrivateKey:    "0000000000000000000000000000000000000000000000000000000000000001",
@@ -225,7 +238,7 @@ func TestGetHomeNetworkKey_NotFound(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err = database.GetHomeNetworkKey(ctx, 9999)
+	_, err = database.GetHomeNetworkKey(ctx, "00000000-0000-7000-8000-000000000000")
 	if err == nil {
 		t.Fatal("Expected error for non-existent key, got nil")
 	}

--- a/internal/db/home_network_key_test.go
+++ b/internal/db/home_network_key_test.go
@@ -13,10 +13,12 @@ import (
 
 func newKeyID(t *testing.T) string {
 	t.Helper()
+
 	id, err := uuid.NewV7()
 	if err != nil {
 		t.Fatalf("uuid.NewV7: %v", err)
 	}
+
 	return id.String()
 }
 

--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -19,7 +19,7 @@ import (
 const IPLeasesTableName = "ip_leases"
 
 const (
-	createLeaseStmt              = "INSERT INTO %s (poolID, addressBin, imsi, sessionID, type, createdAt, nodeID) VALUES ($IPLease.poolID, $IPLease.addressBin, $IPLease.imsi, $IPLease.sessionID, $IPLease.type, $IPLease.createdAt, $IPLease.nodeID)"
+	createLeaseStmt              = "INSERT INTO %s (id, poolID, addressBin, imsi, sessionID, type, createdAt, nodeID) VALUES ($IPLease.id, $IPLease.poolID, $IPLease.addressBin, $IPLease.imsi, $IPLease.sessionID, $IPLease.type, $IPLease.createdAt, $IPLease.nodeID)"
 	getDynamicLeaseStmt          = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND imsi==$IPLease.imsi AND type='dynamic'"
 	getLeaseBySessionStmt        = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND sessionID==$IPLease.sessionID AND imsi==$IPLease.imsi"
 	updateLeaseSessionStmt       = "UPDATE %s SET sessionID=$IPLease.sessionID WHERE id==$IPLease.id"
@@ -40,7 +40,7 @@ const (
 
 // IPLease represents a row in the ip_leases table.
 type IPLease struct {
-	ID         int    `db:"id"`
+	ID         string `db:"id"` // UUIDv7
 	PoolID     int    `db:"poolID"`
 	AddressBin []byte `db:"addressBin"`
 	IMSI       string `db:"imsi"`
@@ -250,7 +250,7 @@ func (db *Database) GetLeaseBySession(ctx context.Context, poolID int, sessionID
 }
 
 // UpdateLeaseSession sets the sessionID on an existing lease.
-func (db *Database) UpdateLeaseSession(ctx context.Context, leaseID int, sessionID int) error {
+func (db *Database) UpdateLeaseSession(ctx context.Context, leaseID string, sessionID int) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (session)", "UPDATE", IPLeasesTableName),
@@ -284,7 +284,7 @@ func (db *Database) UpdateLeaseSession(ctx context.Context, leaseID int, session
 }
 
 // DeleteDynamicLease deletes a dynamic lease by ID.
-func (db *Database) DeleteDynamicLease(ctx context.Context, leaseID int) error {
+func (db *Database) DeleteDynamicLease(ctx context.Context, leaseID string) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", IPLeasesTableName),
@@ -302,7 +302,7 @@ func (db *Database) DeleteDynamicLease(ctx context.Context, leaseID int) error {
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "delete").Inc()
 
-	_, err := opDeleteDynamicLease.Invoke(db, &intPayload{Value: leaseID})
+	_, err := opDeleteDynamicLease.Invoke(db, &stringPayload{Value: leaseID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -385,7 +385,7 @@ func (db *Database) DeleteDynamicLeasesByNode(ctx context.Context, nodeID int) e
 
 // UpdateLeaseNode updates the nodeID and sessionID on an existing lease.
 // Used during failover to transfer lease ownership to the new serving node.
-func (db *Database) UpdateLeaseNode(ctx context.Context, leaseID int, nodeID int, sessionID int) error {
+func (db *Database) UpdateLeaseNode(ctx context.Context, leaseID string, nodeID int, sessionID int) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (node)", "UPDATE", IPLeasesTableName),

--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -40,8 +40,8 @@ const (
 
 // IPLease represents a row in the ip_leases table.
 type IPLease struct {
-	ID         string `db:"id"` // UUIDv7
-	PoolID     int    `db:"poolID"`
+	ID         string `db:"id"`     // UUIDv7
+	PoolID     string `db:"poolID"` // FK to data_networks.id (UUID)
 	AddressBin []byte `db:"addressBin"`
 	IMSI       string `db:"imsi"`
 	SessionID  *int   `db:"sessionID"`
@@ -80,7 +80,7 @@ func (l *IPLease) Address() netip.Addr {
 // CreateLease(IP=X)" path that raced under concurrency: two followers
 // reading a stale local view could both pick the same offset, and the
 // second forwarded INSERT collided at the leader's unique constraint.
-func (db *Database) AllocateIPLease(ctx context.Context, poolID int, imsi string, sessionID int, nodeID int) (netip.Addr, error) {
+func (db *Database) AllocateIPLease(ctx context.Context, poolID string, imsi string, sessionID int, nodeID int) (netip.Addr, error) {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (allocate)", "INSERT", IPLeasesTableName),
@@ -172,7 +172,7 @@ func (db *Database) CreateLease(ctx context.Context, lease *IPLease, address net
 }
 
 // GetDynamicLease returns the dynamic lease for (poolID, imsi), or ErrNotFound.
-func (db *Database) GetDynamicLease(ctx context.Context, poolID int, imsi string) (*IPLease, error) {
+func (db *Database) GetDynamicLease(ctx context.Context, poolID string, imsi string) (*IPLease, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (dynamic)", "SELECT", IPLeasesTableName),
@@ -211,7 +211,7 @@ func (db *Database) GetDynamicLease(ctx context.Context, poolID int, imsi string
 }
 
 // GetLeaseBySession returns the lease matching (poolID, sessionID, imsi), or ErrNotFound.
-func (db *Database) GetLeaseBySession(ctx context.Context, poolID int, sessionID int, imsi string) (*IPLease, error) {
+func (db *Database) GetLeaseBySession(ctx context.Context, poolID string, sessionID int, imsi string) (*IPLease, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by session)", "SELECT", IPLeasesTableName),
@@ -518,7 +518,7 @@ func (db *Database) listAllLeases(ctx context.Context) ([]IPLease, error) {
 }
 
 // ListLeasesByPool returns all leases (dynamic + static) for a given pool.
-func (db *Database) ListLeasesByPool(ctx context.Context, poolID int) ([]IPLease, error) {
+func (db *Database) ListLeasesByPool(ctx context.Context, poolID string) ([]IPLease, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by pool)", "SELECT", IPLeasesTableName),
@@ -558,7 +558,7 @@ func (db *Database) ListLeasesByPool(ctx context.Context, poolID int) ([]IPLease
 
 // ListLeasesByPoolPage returns a page of leases for a pool, ordered by address,
 // along with the total count. The page parameter is 1-based.
-func (db *Database) ListLeasesByPoolPage(ctx context.Context, poolID int, page, perPage int) ([]IPLease, int, error) {
+func (db *Database) ListLeasesByPoolPage(ctx context.Context, poolID string, page, perPage int) ([]IPLease, int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (paged by pool)", "SELECT", IPLeasesTableName),
@@ -618,7 +618,7 @@ func (db *Database) ListLeasesByPoolPage(ctx context.Context, poolID int, page, 
 
 // ListLeaseAddressesByPool returns sorted addresses for all leases in a pool.
 // Used by the allocator to find free offsets via merge-scan.
-func (db *Database) ListLeaseAddressesByPool(ctx context.Context, poolID int) ([]string, error) {
+func (db *Database) ListLeaseAddressesByPool(ctx context.Context, poolID string) ([]string, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (addresses by pool)", "SELECT", IPLeasesTableName),
@@ -663,7 +663,7 @@ func (db *Database) ListLeaseAddressesByPool(ctx context.Context, poolID int) ([
 }
 
 // CountLeasesByPool returns the total number of leases in a pool.
-func (db *Database) CountLeasesByPool(ctx context.Context, poolID int) (int, error) {
+func (db *Database) CountLeasesByPool(ctx context.Context, poolID string) (int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (count by pool)", "SELECT", IPLeasesTableName),

--- a/internal/db/ip_leases_test.go
+++ b/internal/db/ip_leases_test.go
@@ -15,7 +15,12 @@ import (
 // setupLeaseTestDB creates a new database with a data network, policy, and
 // subscriber ready for lease testing. Returns the database, pool (data network)
 // ID, and subscriber IMSI.
-func setupLeaseTestDB(t *testing.T) (*db.Database, int, string) {
+func setupLeaseTestDB(t *testing.T) (database *db.Database, poolID string, imsi string) {
+	database, poolID, imsi, _ = setupLeaseTestDBWithProfile(t)
+	return database, poolID, imsi
+}
+
+func setupLeaseTestDBWithProfile(t *testing.T) (*db.Database, string, string, string) {
 	t.Helper()
 
 	tempDir := t.TempDir()
@@ -47,11 +52,40 @@ func setupLeaseTestDB(t *testing.T) (*db.Database, int, string) {
 		t.Fatalf("GetDataNetwork: %s", err)
 	}
 
+	profile := &db.Profile{
+		Name:           "test-profile",
+		UeAmbrUplink:   "200 Mbps",
+		UeAmbrDownlink: "200 Mbps",
+	}
+
+	if err := database.CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("CreateProfile: %s", err)
+	}
+
+	createdProfile, err := database.GetProfile(context.Background(), profile.Name)
+	if err != nil {
+		t.Fatalf("GetProfile: %s", err)
+	}
+
+	slice := &db.NetworkSlice{
+		Name: "test-slice",
+		Sst:  1,
+	}
+
+	if err := database.CreateNetworkSlice(context.Background(), slice); err != nil {
+		t.Fatalf("CreateNetworkSlice: %s", err)
+	}
+
+	createdSlice, err := database.GetNetworkSlice(context.Background(), slice.Name)
+	if err != nil {
+		t.Fatalf("GetNetworkSlice: %s", err)
+	}
+
 	policy := &db.Policy{
 		Name:          "test-policy",
 		DataNetworkID: createdDNN.ID,
-		ProfileID:     1,
-		SliceID:       1,
+		ProfileID:     createdProfile.ID,
+		SliceID:       createdSlice.ID,
 	}
 
 	if err := database.CreatePolicy(context.Background(), policy); err != nil {
@@ -71,14 +105,14 @@ func setupLeaseTestDB(t *testing.T) (*db.Database, int, string) {
 		SequenceNumber: "000000000001",
 		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
 		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
-		ProfileID:      1,
+		ProfileID:      createdProfile.ID,
 	}
 
 	if err := database.CreateSubscriber(context.Background(), sub); err != nil {
 		t.Fatalf("CreateSubscriber: %s", err)
 	}
 
-	return database, createdDNN.ID, imsi
+	return database, createdDNN.ID, imsi, createdProfile.ID
 }
 
 func addr(s string) netip.Addr { return netip.MustParseAddr(s) }
@@ -124,7 +158,7 @@ func TestCreateAndGetLease(t *testing.T) {
 }
 
 func TestCreateLease_UniqueConstraint(t *testing.T) {
-	database, poolID, imsi := setupLeaseTestDB(t)
+	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
 	ctx := context.Background()
 
 	sessionID := 1
@@ -147,7 +181,7 @@ func TestCreateLease_UniqueConstraint(t *testing.T) {
 		SequenceNumber: "000000000001",
 		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
 		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
-		ProfileID:      1,
+		ProfileID:      profileID,
 	}
 
 	if err := database.CreateSubscriber(ctx, sub2); err != nil {
@@ -273,7 +307,7 @@ func TestDeleteDynamicLease(t *testing.T) {
 }
 
 func TestDeleteAllDynamicLeases(t *testing.T) {
-	database, poolID, imsi := setupLeaseTestDB(t)
+	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
 	ctx := context.Background()
 
 	// Create a second subscriber for a second lease.
@@ -283,7 +317,7 @@ func TestDeleteAllDynamicLeases(t *testing.T) {
 		SequenceNumber: "000000000001",
 		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
 		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
-		ProfileID:      1,
+		ProfileID:      profileID,
 	}
 
 	if err := database.CreateSubscriber(ctx, sub2); err != nil {
@@ -601,7 +635,7 @@ func TestCountLeasesByIMSI(t *testing.T) {
 }
 
 func TestListLeasesByPoolPage(t *testing.T) {
-	database, poolID, imsi := setupLeaseTestDB(t)
+	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
 	ctx := context.Background()
 
 	// Create a second subscriber.
@@ -611,7 +645,7 @@ func TestListLeasesByPoolPage(t *testing.T) {
 		SequenceNumber: "000000000001",
 		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
 		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
-		ProfileID:      1,
+		ProfileID:      profileID,
 	}
 
 	if err := database.CreateSubscriber(ctx, sub2); err != nil {
@@ -688,7 +722,7 @@ func TestListLeasesByPoolPage(t *testing.T) {
 	})
 
 	t.Run("empty pool", func(t *testing.T) {
-		leases, total, err := database.ListLeasesByPoolPage(ctx, 9999, 1, 25)
+		leases, total, err := database.ListLeasesByPoolPage(ctx, "nonexistent-pool", 1, 25)
 		if err != nil {
 			t.Fatalf("ListLeasesByPoolPage: %s", err)
 		}
@@ -704,7 +738,7 @@ func TestListLeasesByPoolPage(t *testing.T) {
 }
 
 func TestListLeaseAddressesByPool_NumericOrder(t *testing.T) {
-	database, poolID, imsi := setupLeaseTestDB(t)
+	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
 	ctx := context.Background()
 
 	// Create additional subscribers for unique (poolID, addressBin, imsi) combos.
@@ -715,7 +749,7 @@ func TestListLeaseAddressesByPool_NumericOrder(t *testing.T) {
 		SequenceNumber: "000000000001",
 		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
 		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
-		ProfileID:      1,
+		ProfileID:      profileID,
 	}
 
 	if err := database.CreateSubscriber(ctx, sub2); err != nil {
@@ -729,7 +763,7 @@ func TestListLeaseAddressesByPool_NumericOrder(t *testing.T) {
 		SequenceNumber: "000000000001",
 		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
 		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
-		ProfileID:      1,
+		ProfileID:      profileID,
 	}
 
 	if err := database.CreateSubscriber(ctx, sub3); err != nil {

--- a/internal/db/metrics_test.go
+++ b/internal/db/metrics_test.go
@@ -54,9 +54,33 @@ func TestDatabaseMetrics(t *testing.T) {
 		t.Fatalf("Couldn't get data network 2: %s", err)
 	}
 
+	profile := &db.Profile{
+		Name:           "test-profile",
+		UeAmbrUplink:   "200 Mbps",
+		UeAmbrDownlink: "200 Mbps",
+	}
+	if err := database.CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("Couldn't create profile: %s", err)
+	}
+
+	createdProfile, err := database.GetProfile(context.Background(), profile.Name)
+	if err != nil {
+		t.Fatalf("Couldn't get profile: %s", err)
+	}
+
+	slice := &db.NetworkSlice{Name: "test-slice", Sst: 1}
+	if err := database.CreateNetworkSlice(context.Background(), slice); err != nil {
+		t.Fatalf("Couldn't create network slice: %s", err)
+	}
+
+	createdSlice, err := database.GetNetworkSlice(context.Background(), slice.Name)
+	if err != nil {
+		t.Fatalf("Couldn't get network slice: %s", err)
+	}
+
 	policies := []db.Policy{
-		{Name: "Policy1", DataNetworkID: createdDN.ID, ProfileID: 1, SliceID: 1},
-		{Name: "Policy2", DataNetworkID: createdDN2.ID, ProfileID: 1, SliceID: 1},
+		{Name: "Policy1", DataNetworkID: createdDN.ID, ProfileID: createdProfile.ID, SliceID: createdSlice.ID},
+		{Name: "Policy2", DataNetworkID: createdDN2.ID, ProfileID: createdProfile.ID, SliceID: createdSlice.ID},
 	}
 	for _, policy := range policies {
 		err := database.CreatePolicy(context.Background(), &policy)
@@ -69,21 +93,21 @@ func TestDatabaseMetrics(t *testing.T) {
 		{
 			Imsi:           "001019379926281",
 			SequenceNumber: "000000000001",
-			ProfileID:      1,
+			ProfileID:      createdProfile.ID,
 			Opc:            "1234567890abcdef1234567890abcdef",
 			PermanentKey:   "1234567890abcdef1234567890abcdef",
 		},
 		{
 			Imsi:           "001019379926282",
 			SequenceNumber: "000000000002",
-			ProfileID:      1,
+			ProfileID:      createdProfile.ID,
 			Opc:            "1234567890abcdef1234567890abcdef",
 			PermanentKey:   "1234567890abcdef1234567890abcdef",
 		},
 		{
 			Imsi:           "001019379926283",
 			SequenceNumber: "000000000003",
-			ProfileID:      1,
+			ProfileID:      createdProfile.ID,
 			Opc:            "1234567890abcdef1234567890abcdef",
 			PermanentKey:   "1234567890abcdef1234567890abcdef",
 		},

--- a/internal/db/migration_gate_internal_test.go
+++ b/internal/db/migration_gate_internal_test.go
@@ -134,8 +134,11 @@ func TestMinVoterSchemaSupport_IgnoresLearners(t *testing.T) {
 		t.Fatalf("minVoterSchemaSupport: %v", err)
 	}
 
-	if floor != 10 {
-		t.Fatalf("floor: want 10 (learner ignored), got %d", floor)
+	// node 1 matches the standalone selfID, so its contribution is the
+	// in-process SchemaVersion(). Tracking the literal would require a
+	// test update on every migration bump.
+	if floor != SchemaVersion() {
+		t.Fatalf("floor: want %d (learner ignored), got %d", SchemaVersion(), floor)
 	}
 
 	if laggard != 1 {

--- a/internal/db/migration_v11.go
+++ b/internal/db/migration_v11.go
@@ -29,6 +29,11 @@ func migrateV11(ctx context.Context, tx *sql.Tx) error {
 	steps := []func(context.Context, *sql.Tx) error{
 		migrateV11AuditLogs,
 		migrateV11HomeNetworkKeys,
+		migrateV11RetentionPolicies,
+		migrateV11NetworkRules,
+		migrateV11Sessions,
+		migrateV11APITokens,
+		migrateV11IPLeases,
 	}
 
 	for _, step := range steps {
@@ -78,6 +83,7 @@ func retypeIDToUUID(ctx context.Context, tx *sql.Tx, table string, namespace uui
 
 	for i := range columns {
 		var v any
+
 		values[i+1] = &v
 		scanArgs[i+1] = &v
 	}
@@ -91,6 +97,7 @@ func retypeIDToUUID(ctx context.Context, tx *sql.Tx, table string, namespace uui
 		newID := uuid.NewSHA1(namespace, []byte(table+":"+strconv.FormatInt(oldID, 10))).String()
 
 		args := make([]any, len(columns)+1)
+
 		args[0] = newID
 		for i := range columns {
 			args[i+1] = *(values[i+1].(*any))
@@ -153,4 +160,115 @@ func migrateV11HomeNetworkKeys(ctx context.Context, tx *sql.Tx) error {
 
 	return retypeIDToUUID(ctx, tx, HomeNetworkKeysTableName, ns, newSchema,
 		[]string{"key_identifier", "scheme", "private_key"})
+}
+
+func migrateV11RetentionPolicies(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id              TEXT PRIMARY KEY,
+			category        TEXT NOT NULL UNIQUE,
+			retention_days  INTEGER NOT NULL CHECK (retention_days >= 1)
+		)`
+
+	ns := uuid.MustParse("d4e6c1f2-9b3a-4c5d-8e7f-0a1b2c3d4e02")
+
+	return retypeIDToUUID(ctx, tx, RetentionPolicyTableName, ns, newSchema,
+		[]string{"category", "retention_days"})
+}
+
+func migrateV11NetworkRules(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id            TEXT PRIMARY KEY,
+			policy_id     INTEGER NOT NULL,
+			description   TEXT NOT NULL,
+			direction     TEXT NOT NULL,
+			remote_prefix TEXT,
+			protocol      INTEGER DEFAULT 255,
+			port_low      INTEGER DEFAULT 0,
+			port_high     INTEGER DEFAULT 0,
+			action        TEXT NOT NULL,
+			precedence    INTEGER NOT NULL,
+			created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (policy_id) REFERENCES policies (id) ON DELETE CASCADE,
+			UNIQUE(policy_id, precedence, direction)
+		)`
+
+	ns := uuid.MustParse("8b2c4d6e-1f3a-4b5c-9d7e-1a2b3c4d5e03")
+
+	return retypeIDToUUID(ctx, tx, NetworkRulesTableName, ns, newSchema,
+		[]string{"policy_id", "description", "direction", "remote_prefix", "protocol", "port_low", "port_high", "action", "precedence", "created_at", "updated_at"})
+}
+
+func migrateV11Sessions(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id          TEXT PRIMARY KEY,
+			user_id     INTEGER NOT NULL,
+			token_hash  BLOB    NOT NULL UNIQUE,
+			created_at  INTEGER NOT NULL DEFAULT (strftime('%%s','now')),
+			expires_at  INTEGER NOT NULL,
+			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+		)`
+
+	ns := uuid.MustParse("f5d8b2a1-7c4e-4f9b-8d6c-2a3b4c5d6e04")
+
+	return retypeIDToUUID(ctx, tx, SessionsTableName, ns, newSchema,
+		[]string{"user_id", "token_hash", "created_at", "expires_at"})
+}
+
+func migrateV11APITokens(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id          TEXT PRIMARY KEY,
+			token_id    TEXT NOT NULL UNIQUE,
+			name        TEXT NOT NULL,
+			token_hash  TEXT NOT NULL,
+			user_id     INTEGER NOT NULL,
+			expires_at  DATETIME,
+			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+			UNIQUE (name, user_id)
+		)`
+
+	ns := uuid.MustParse("c1a3e5f7-9b8d-4e2c-9f1a-3b4c5d6e7f05")
+
+	return retypeIDToUUID(ctx, tx, APITokensTableName, ns, newSchema,
+		[]string{"token_id", "name", "token_hash", "user_id", "expires_at"})
+}
+
+func migrateV11IPLeases(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id          TEXT PRIMARY KEY,
+			poolID      INTEGER NOT NULL REFERENCES data_networks(id) ON DELETE CASCADE,
+			addressBin  BLOB    NOT NULL,
+			imsi        TEXT    NOT NULL REFERENCES subscribers(imsi) ON DELETE CASCADE,
+			sessionID   INTEGER,
+			type        TEXT    NOT NULL DEFAULT 'dynamic',
+			createdAt   INTEGER NOT NULL,
+			nodeID      INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(poolID, addressBin)
+		)`
+
+	ns := uuid.MustParse("9e7c5b3a-1d2f-4a6b-8c5d-4a5b6c7d8e06")
+
+	if err := retypeIDToUUID(ctx, tx, IPLeasesTableName, ns, newSchema,
+		[]string{"poolID", "addressBin", "imsi", "sessionID", "type", "createdAt", "nodeID"}); err != nil {
+		return err
+	}
+
+	// Indexes were dropped with the old table; recreate.
+	for _, stmt := range []string{
+		"CREATE INDEX IF NOT EXISTS idx_leases_pool ON " + IPLeasesTableName + "(poolID)",
+		"CREATE INDEX IF NOT EXISTS idx_leases_imsi ON " + IPLeasesTableName + "(imsi)",
+		"CREATE INDEX IF NOT EXISTS idx_leases_session ON " + IPLeasesTableName + "(sessionID)",
+		"CREATE INDEX IF NOT EXISTS idx_leases_node ON " + IPLeasesTableName + "(nodeID)",
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("recreate ip_leases index %q: %w", stmt, err)
+		}
+	}
+
+	return nil
 }

--- a/internal/db/migration_v11.go
+++ b/internal/db/migration_v11.go
@@ -20,16 +20,27 @@ import (
 // with CONFLICT (see spec_uuid.md).
 //
 // Existing rows get a deterministic UUIDv5 (table-scoped namespace +
-// old integer rowid) so every node materialises the same UUID for the
-// same row when it runs this migration locally.
-//
-// Tables with inbound id-FK dependencies are migrated together so the
-// FK column is retyped in lockstep.
+// old integer id) so every node materialises the same UUID for the
+// same row when it runs this migration locally. Integer FK columns are
+// rewritten in lockstep using the parent table's namespace, so a child
+// row references the same UUID its parent will receive — even on a
+// node that has not yet executed the parent migration step.
 func migrateV11(ctx context.Context, tx *sql.Tx) error {
 	steps := []func(context.Context, *sql.Tx) error{
+		// Standalone tables (no FKs to the replicated set).
 		migrateV11AuditLogs,
 		migrateV11HomeNetworkKeys,
 		migrateV11RetentionPolicies,
+
+		// FK-target parents.
+		migrateV11DataNetworks,
+		migrateV11NetworkSlices,
+		migrateV11Profiles,
+		migrateV11Users,
+
+		// Tables that depend on the parents above.
+		migrateV11Policies,
+		migrateV11Subscribers,
 		migrateV11NetworkRules,
 		migrateV11Sessions,
 		migrateV11APITokens,
@@ -45,12 +56,34 @@ func migrateV11(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
-// retypeIDToUUID rebuilds a table whose PK is INTEGER AUTOINCREMENT id
-// into a table whose PK is TEXT id. Caller supplies the new schema
-// (CREATE TABLE %s_new (...)) and the list of non-id columns to copy.
-// Each old row's new id is uuid.NewSHA1(namespace, "table:oldID"), so
-// every node lands on the same value.
-func retypeIDToUUID(ctx context.Context, tx *sql.Tx, table string, namespace uuid.UUID, newSchema string, columns []string) error {
+// fkRef describes how to rewrite an integer FK column into the parent's
+// TEXT UUID, computed deterministically from the parent's namespace and
+// the original integer FK value.
+type fkRef struct {
+	ParentTable string
+	ParentNS    uuid.UUID
+}
+
+// rebuildTableUUID rebuilds `table` into `<table>_new` with the schema
+// in `newSchema` (a printf-style template that takes the table name).
+// For each old row:
+//   - The new id is uuid.NewSHA1(idNamespace, "<table>:<oldID>") so
+//     every node lands on the same value.
+//   - Each integer FK column listed in `fks` is rewritten with the same
+//     scheme using the parent table's namespace. NULL is preserved.
+//
+// `columns` lists every non-id column in copy order. The new table is
+// renamed back to `table`. Caller is responsible for any indexes the
+// rebuild dropped.
+func rebuildTableUUID(
+	ctx context.Context,
+	tx *sql.Tx,
+	table string,
+	newSchema string,
+	idNamespace uuid.UUID,
+	columns []string,
+	fks map[string]fkRef,
+) error {
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(newSchema, table)); err != nil {
 		return fmt.Errorf("create %s_new: %w", table, err)
 	}
@@ -94,13 +127,23 @@ func retypeIDToUUID(ctx context.Context, tx *sql.Tx, table string, namespace uui
 			return fmt.Errorf("scan %s row: %w", table, err)
 		}
 
-		newID := uuid.NewSHA1(namespace, []byte(table+":"+strconv.FormatInt(oldID, 10))).String()
-
 		args := make([]any, len(columns)+1)
+		args[0] = uuid.NewSHA1(idNamespace, []byte(table+":"+strconv.FormatInt(oldID, 10))).String()
 
-		args[0] = newID
-		for i := range columns {
-			args[i+1] = *(values[i+1].(*any))
+		for i, col := range columns {
+			val := *(values[i+1].(*any))
+
+			if fk, ok := fks[col]; ok {
+				rewritten, err := rewriteFK(fk, val)
+				if err != nil {
+					_ = rows.Close()
+					return fmt.Errorf("rewrite %s.%s (oldID=%d): %w", table, col, oldID, err)
+				}
+
+				args[i+1] = rewritten
+			} else {
+				args[i+1] = val
+			}
 		}
 
 		if _, err := insert.ExecContext(ctx, args...); err != nil {
@@ -128,6 +171,48 @@ func retypeIDToUUID(ctx context.Context, tx *sql.Tx, table string, namespace uui
 	return nil
 }
 
+// rewriteFK turns an integer FK value into the matching TEXT UUID, or
+// preserves NULL.
+func rewriteFK(fk fkRef, val any) (any, error) {
+	if val == nil {
+		return nil, nil
+	}
+
+	var asInt int64
+
+	switch t := val.(type) {
+	case int64:
+		asInt = t
+	case int:
+		asInt = int64(t)
+	default:
+		return nil, fmt.Errorf("unexpected non-integer FK value %T", val)
+	}
+
+	return uuid.NewSHA1(fk.ParentNS, []byte(fk.ParentTable+":"+strconv.FormatInt(asInt, 10))).String(), nil
+}
+
+// Namespaces are stable per-table identifiers that combine with the
+// row's old integer id to produce the deterministic UUIDv5 used during
+// migration. They are also published as the FK reference namespaces
+// for any child table whose FK column targets this parent. NEVER edit
+// once shipped: every node in a cluster must agree on the value.
+var (
+	v11NSAuditLogs       = uuid.MustParse("a8f1e7c0-1d3a-4b9e-9c2f-0a4b7e5d1f01")
+	v11NSHomeNetworkKeys = uuid.MustParse("3c1b2f9a-7e44-4d0e-9a82-5f6c8e1d7a02")
+	v11NSRetentionPolicy = uuid.MustParse("d4e6c1f2-9b3a-4c5d-8e7f-0a1b2c3d4e02")
+	v11NSNetworkRules    = uuid.MustParse("8b2c4d6e-1f3a-4b5c-9d7e-1a2b3c4d5e03")
+	v11NSSessions        = uuid.MustParse("f5d8b2a1-7c4e-4f9b-8d6c-2a3b4c5d6e04")
+	v11NSAPITokens       = uuid.MustParse("c1a3e5f7-9b8d-4e2c-9f1a-3b4c5d6e7f05")
+	v11NSIPLeases        = uuid.MustParse("9e7c5b3a-1d2f-4a6b-8c5d-4a5b6c7d8e06")
+	v11NSDataNetworks    = uuid.MustParse("4f7c1d8a-2b9e-4a1c-8e6d-5b2c3a4d5e07")
+	v11NSNetworkSlices   = uuid.MustParse("a3d2c1b4-5e6f-4a7b-9c8d-1e2f3a4b5c08")
+	v11NSProfiles        = uuid.MustParse("7e6d5c4b-3a2b-4c5d-9e6f-7a8b9c0d1e09")
+	v11NSUsers           = uuid.MustParse("b8a7c6d5-4e3f-4a2b-9c1d-2e3f4a5b6c0a")
+	v11NSPolicies        = uuid.MustParse("c9b8a7d6-5e4f-4a3b-8c2d-3e4f5a6b7c0b")
+	v11NSSubscribers     = uuid.MustParse("d0c9b8a7-6f5e-4a3b-8c2d-4e5f6a7b8c0c")
+)
+
 func migrateV11AuditLogs(ctx context.Context, tx *sql.Tx) error {
 	const newSchema = `
 		CREATE TABLE %s_new (
@@ -140,10 +225,8 @@ func migrateV11AuditLogs(ctx context.Context, tx *sql.Tx) error {
 			details    TEXT NOT NULL DEFAULT ''
 		)`
 
-	ns := uuid.MustParse("a8f1e7c0-1d3a-4b9e-9c2f-0a4b7e5d1f01")
-
-	return retypeIDToUUID(ctx, tx, AuditLogsTableName, ns, newSchema,
-		[]string{"timestamp", "level", "actor", "action", "ip", "details"})
+	return rebuildTableUUID(ctx, tx, AuditLogsTableName, newSchema, v11NSAuditLogs,
+		[]string{"timestamp", "level", "actor", "action", "ip", "details"}, nil)
 }
 
 func migrateV11HomeNetworkKeys(ctx context.Context, tx *sql.Tx) error {
@@ -156,10 +239,8 @@ func migrateV11HomeNetworkKeys(ctx context.Context, tx *sql.Tx) error {
 			UNIQUE(key_identifier, scheme)
 		)`
 
-	ns := uuid.MustParse("3c1b2f9a-7e44-4d0e-9a82-5f6c8e1d7a02")
-
-	return retypeIDToUUID(ctx, tx, HomeNetworkKeysTableName, ns, newSchema,
-		[]string{"key_identifier", "scheme", "private_key"})
+	return rebuildTableUUID(ctx, tx, HomeNetworkKeysTableName, newSchema, v11NSHomeNetworkKeys,
+		[]string{"key_identifier", "scheme", "private_key"}, nil)
 }
 
 func migrateV11RetentionPolicies(ctx context.Context, tx *sql.Tx) error {
@@ -170,17 +251,115 @@ func migrateV11RetentionPolicies(ctx context.Context, tx *sql.Tx) error {
 			retention_days  INTEGER NOT NULL CHECK (retention_days >= 1)
 		)`
 
-	ns := uuid.MustParse("d4e6c1f2-9b3a-4c5d-8e7f-0a1b2c3d4e02")
+	return rebuildTableUUID(ctx, tx, RetentionPolicyTableName, newSchema, v11NSRetentionPolicy,
+		[]string{"category", "retention_days"}, nil)
+}
 
-	return retypeIDToUUID(ctx, tx, RetentionPolicyTableName, ns, newSchema,
-		[]string{"category", "retention_days"})
+func migrateV11DataNetworks(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id     TEXT PRIMARY KEY,
+			name   TEXT NOT NULL UNIQUE,
+			ipPool TEXT NOT NULL,
+			dns    TEXT NOT NULL,
+			mtu    INTEGER NOT NULL
+		)`
+
+	return rebuildTableUUID(ctx, tx, DataNetworksTableName, newSchema, v11NSDataNetworks,
+		[]string{"name", "ipPool", "dns", "mtu"}, nil)
+}
+
+func migrateV11NetworkSlices(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id   TEXT PRIMARY KEY,
+			sst  INTEGER NOT NULL,
+			sd   TEXT,
+			name TEXT NOT NULL UNIQUE,
+			UNIQUE(sst, sd)
+		)`
+
+	return rebuildTableUUID(ctx, tx, NetworkSlicesTableName, newSchema, v11NSNetworkSlices,
+		[]string{"sst", "sd", "name"}, nil)
+}
+
+func migrateV11Profiles(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id             TEXT PRIMARY KEY,
+			name           TEXT NOT NULL UNIQUE,
+			ueAmbrUplink   TEXT NOT NULL,
+			ueAmbrDownlink TEXT NOT NULL
+		)`
+
+	return rebuildTableUUID(ctx, tx, ProfilesTableName, newSchema, v11NSProfiles,
+		[]string{"name", "ueAmbrUplink", "ueAmbrDownlink"}, nil)
+}
+
+func migrateV11Users(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id             TEXT PRIMARY KEY,
+			email          TEXT NOT NULL UNIQUE,
+			roleID         INTEGER NOT NULL,
+			hashedPassword TEXT NOT NULL
+		)`
+
+	return rebuildTableUUID(ctx, tx, UsersTableName, newSchema, v11NSUsers,
+		[]string{"email", "roleID", "hashedPassword"}, nil)
+}
+
+func migrateV11Policies(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id                  TEXT PRIMARY KEY,
+			name                TEXT NOT NULL UNIQUE,
+			profileID           TEXT NOT NULL,
+			sliceID             TEXT NOT NULL,
+			dataNetworkID       TEXT NOT NULL,
+			var5qi              INTEGER NOT NULL,
+			arp                 INTEGER NOT NULL,
+			sessionAmbrUplink   TEXT    NOT NULL,
+			sessionAmbrDownlink TEXT    NOT NULL,
+			FOREIGN KEY (profileID)     REFERENCES profiles (id) ON DELETE RESTRICT,
+			FOREIGN KEY (sliceID)       REFERENCES network_slices (id) ON DELETE RESTRICT,
+			FOREIGN KEY (dataNetworkID) REFERENCES data_networks (id) ON DELETE RESTRICT,
+			UNIQUE(profileID, sliceID, dataNetworkID)
+		)`
+
+	return rebuildTableUUID(ctx, tx, PoliciesTableName, newSchema, v11NSPolicies,
+		[]string{"name", "profileID", "sliceID", "dataNetworkID", "var5qi", "arp", "sessionAmbrUplink", "sessionAmbrDownlink"},
+		map[string]fkRef{
+			"profileID":     {ParentTable: ProfilesTableName, ParentNS: v11NSProfiles},
+			"sliceID":       {ParentTable: NetworkSlicesTableName, ParentNS: v11NSNetworkSlices},
+			"dataNetworkID": {ParentTable: DataNetworksTableName, ParentNS: v11NSDataNetworks},
+		})
+}
+
+func migrateV11Subscribers(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id             TEXT PRIMARY KEY,
+			imsi           TEXT NOT NULL UNIQUE CHECK (length(imsi) BETWEEN 6 AND 15 AND imsi GLOB '[0-9]*'),
+			sequenceNumber TEXT NOT NULL CHECK (length(sequenceNumber) = 12),
+			permanentKey   TEXT NOT NULL CHECK (length(permanentKey) = 32),
+			opc            TEXT NOT NULL CHECK (length(opc) = 32),
+			profileID      TEXT NOT NULL,
+			FOREIGN KEY (profileID) REFERENCES profiles (id) ON DELETE RESTRICT
+		)`
+
+	return rebuildTableUUID(ctx, tx, SubscribersTableName, newSchema, v11NSSubscribers,
+		[]string{"imsi", "sequenceNumber", "permanentKey", "opc", "profileID"},
+		map[string]fkRef{
+			"profileID": {ParentTable: ProfilesTableName, ParentNS: v11NSProfiles},
+		})
 }
 
 func migrateV11NetworkRules(ctx context.Context, tx *sql.Tx) error {
 	const newSchema = `
 		CREATE TABLE %s_new (
 			id            TEXT PRIMARY KEY,
-			policy_id     INTEGER NOT NULL,
+			policy_id     TEXT NOT NULL,
 			description   TEXT NOT NULL,
 			direction     TEXT NOT NULL,
 			remote_prefix TEXT,
@@ -195,27 +374,29 @@ func migrateV11NetworkRules(ctx context.Context, tx *sql.Tx) error {
 			UNIQUE(policy_id, precedence, direction)
 		)`
 
-	ns := uuid.MustParse("8b2c4d6e-1f3a-4b5c-9d7e-1a2b3c4d5e03")
-
-	return retypeIDToUUID(ctx, tx, NetworkRulesTableName, ns, newSchema,
-		[]string{"policy_id", "description", "direction", "remote_prefix", "protocol", "port_low", "port_high", "action", "precedence", "created_at", "updated_at"})
+	return rebuildTableUUID(ctx, tx, NetworkRulesTableName, newSchema, v11NSNetworkRules,
+		[]string{"policy_id", "description", "direction", "remote_prefix", "protocol", "port_low", "port_high", "action", "precedence", "created_at", "updated_at"},
+		map[string]fkRef{
+			"policy_id": {ParentTable: PoliciesTableName, ParentNS: v11NSPolicies},
+		})
 }
 
 func migrateV11Sessions(ctx context.Context, tx *sql.Tx) error {
 	const newSchema = `
 		CREATE TABLE %s_new (
 			id          TEXT PRIMARY KEY,
-			user_id     INTEGER NOT NULL,
+			user_id     TEXT NOT NULL,
 			token_hash  BLOB    NOT NULL UNIQUE,
 			created_at  INTEGER NOT NULL DEFAULT (strftime('%%s','now')),
 			expires_at  INTEGER NOT NULL,
 			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 		)`
 
-	ns := uuid.MustParse("f5d8b2a1-7c4e-4f9b-8d6c-2a3b4c5d6e04")
-
-	return retypeIDToUUID(ctx, tx, SessionsTableName, ns, newSchema,
-		[]string{"user_id", "token_hash", "created_at", "expires_at"})
+	return rebuildTableUUID(ctx, tx, SessionsTableName, newSchema, v11NSSessions,
+		[]string{"user_id", "token_hash", "created_at", "expires_at"},
+		map[string]fkRef{
+			"user_id": {ParentTable: UsersTableName, ParentNS: v11NSUsers},
+		})
 }
 
 func migrateV11APITokens(ctx context.Context, tx *sql.Tx) error {
@@ -225,23 +406,24 @@ func migrateV11APITokens(ctx context.Context, tx *sql.Tx) error {
 			token_id    TEXT NOT NULL UNIQUE,
 			name        TEXT NOT NULL,
 			token_hash  TEXT NOT NULL,
-			user_id     INTEGER NOT NULL,
+			user_id     TEXT NOT NULL,
 			expires_at  DATETIME,
 			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
 			UNIQUE (name, user_id)
 		)`
 
-	ns := uuid.MustParse("c1a3e5f7-9b8d-4e2c-9f1a-3b4c5d6e7f05")
-
-	return retypeIDToUUID(ctx, tx, APITokensTableName, ns, newSchema,
-		[]string{"token_id", "name", "token_hash", "user_id", "expires_at"})
+	return rebuildTableUUID(ctx, tx, APITokensTableName, newSchema, v11NSAPITokens,
+		[]string{"token_id", "name", "token_hash", "user_id", "expires_at"},
+		map[string]fkRef{
+			"user_id": {ParentTable: UsersTableName, ParentNS: v11NSUsers},
+		})
 }
 
 func migrateV11IPLeases(ctx context.Context, tx *sql.Tx) error {
 	const newSchema = `
 		CREATE TABLE %s_new (
 			id          TEXT PRIMARY KEY,
-			poolID      INTEGER NOT NULL REFERENCES data_networks(id) ON DELETE CASCADE,
+			poolID      TEXT NOT NULL REFERENCES data_networks(id) ON DELETE CASCADE,
 			addressBin  BLOB    NOT NULL,
 			imsi        TEXT    NOT NULL REFERENCES subscribers(imsi) ON DELETE CASCADE,
 			sessionID   INTEGER,
@@ -251,14 +433,14 @@ func migrateV11IPLeases(ctx context.Context, tx *sql.Tx) error {
 			UNIQUE(poolID, addressBin)
 		)`
 
-	ns := uuid.MustParse("9e7c5b3a-1d2f-4a6b-8c5d-4a5b6c7d8e06")
-
-	if err := retypeIDToUUID(ctx, tx, IPLeasesTableName, ns, newSchema,
-		[]string{"poolID", "addressBin", "imsi", "sessionID", "type", "createdAt", "nodeID"}); err != nil {
+	if err := rebuildTableUUID(ctx, tx, IPLeasesTableName, newSchema, v11NSIPLeases,
+		[]string{"poolID", "addressBin", "imsi", "sessionID", "type", "createdAt", "nodeID"},
+		map[string]fkRef{
+			"poolID": {ParentTable: DataNetworksTableName, ParentNS: v11NSDataNetworks},
+		}); err != nil {
 		return err
 	}
 
-	// Indexes were dropped with the old table; recreate.
 	for _, stmt := range []string{
 		"CREATE INDEX IF NOT EXISTS idx_leases_pool ON " + IPLeasesTableName + "(poolID)",
 		"CREATE INDEX IF NOT EXISTS idx_leases_imsi ON " + IPLeasesTableName + "(imsi)",

--- a/internal/db/migration_v11.go
+++ b/internal/db/migration_v11.go
@@ -7,28 +7,121 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 )
 
-// auditLogIDNamespace seeds the deterministic UUID assigned to each
-// pre-v11 audit_log row. The choice of namespace is arbitrary; what
-// matters is that every node uses the same value so SHA1-based UUIDs
-// computed from (namespace, old_rowid) match across replicas.
+// V11 retypes every replicated table that previously used
+// `INTEGER PRIMARY KEY AUTOINCREMENT` to `TEXT PRIMARY KEY`. Server-side
+// AUTOINCREMENT in a replicated table is unsafe: the leader's
+// capture/rollback cycle can pick the same id twice across the
+// leader-takeover window, which sqlite3changeset_apply later rejects
+// with CONFLICT (see spec_uuid.md).
 //
-// Treat as a release-stable constant: changing it would break audit-log
-// id stability across the migration.
-var auditLogIDNamespace = uuid.MustParse("a8f1e7c0-1d3a-4b9e-9c2f-0a4b7e5d1f01")
-
-// V11 retypes audit_logs.id from INTEGER AUTOINCREMENT to TEXT (UUID).
-// Server-assigned AUTOINCREMENT in a replicated table races on leader
-// takeover (capture picks an id from sqlite_sequence, which a pending
-// previous-term entry has already claimed). UUIDs generated at the
-// request handler eliminate the class.
+// Existing rows get a deterministic UUIDv5 (table-scoped namespace +
+// old integer rowid) so every node materialises the same UUID for the
+// same row when it runs this migration locally.
 //
-// Existing rows get a deterministic UUIDv5 derived from their old id so
-// every node ends up with identical bytes.
+// Tables with inbound id-FK dependencies are migrated together so the
+// FK column is retyped in lockstep.
 func migrateV11(ctx context.Context, tx *sql.Tx) error {
+	steps := []func(context.Context, *sql.Tx) error{
+		migrateV11AuditLogs,
+		migrateV11HomeNetworkKeys,
+	}
+
+	for _, step := range steps {
+		if err := step(ctx, tx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// retypeIDToUUID rebuilds a table whose PK is INTEGER AUTOINCREMENT id
+// into a table whose PK is TEXT id. Caller supplies the new schema
+// (CREATE TABLE %s_new (...)) and the list of non-id columns to copy.
+// Each old row's new id is uuid.NewSHA1(namespace, "table:oldID"), so
+// every node lands on the same value.
+func retypeIDToUUID(ctx context.Context, tx *sql.Tx, table string, namespace uuid.UUID, newSchema string, columns []string) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(newSchema, table)); err != nil {
+		return fmt.Errorf("create %s_new: %w", table, err)
+	}
+
+	colList := strings.Join(columns, ", ")
+
+	rows, err := tx.QueryContext(ctx,
+		fmt.Sprintf("SELECT id, %s FROM %s ORDER BY id", colList, table))
+	if err != nil {
+		return fmt.Errorf("select %s: %w", table, err)
+	}
+
+	placeholders := strings.Repeat(", ?", len(columns))
+
+	insert, err := tx.PrepareContext(ctx,
+		fmt.Sprintf("INSERT INTO %s_new (id, %s) VALUES (?%s)", table, colList, placeholders))
+	if err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("prepare insert for %s: %w", table, err)
+	}
+
+	defer func() { _ = insert.Close() }()
+
+	scanArgs := make([]any, len(columns)+1)
+	values := make([]any, len(columns)+1)
+
+	var oldID int64
+
+	scanArgs[0] = &oldID
+
+	for i := range columns {
+		var v any
+		values[i+1] = &v
+		scanArgs[i+1] = &v
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(scanArgs...); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan %s row: %w", table, err)
+		}
+
+		newID := uuid.NewSHA1(namespace, []byte(table+":"+strconv.FormatInt(oldID, 10))).String()
+
+		args := make([]any, len(columns)+1)
+		args[0] = newID
+		for i := range columns {
+			args[i+1] = *(values[i+1].(*any))
+		}
+
+		if _, err := insert.ExecContext(ctx, args...); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("insert %s_new row (oldID=%d): %w", table, oldID, err)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate %s: %w", table, err)
+	}
+
+	_ = rows.Close()
+
+	for _, stmt := range []string{
+		fmt.Sprintf("DROP TABLE %s", table),
+		fmt.Sprintf("ALTER TABLE %s_new RENAME TO %s", table, table),
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("execute %q: %w", stmt, err)
+		}
+	}
+
+	return nil
+}
+
+func migrateV11AuditLogs(ctx context.Context, tx *sql.Tx) error {
 	const newSchema = `
 		CREATE TABLE %s_new (
 			id         TEXT PRIMARY KEY,
@@ -40,59 +133,24 @@ func migrateV11(ctx context.Context, tx *sql.Tx) error {
 			details    TEXT NOT NULL DEFAULT ''
 		)`
 
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(newSchema, AuditLogsTableName)); err != nil {
-		return fmt.Errorf("create audit_logs_new: %w", err)
-	}
+	ns := uuid.MustParse("a8f1e7c0-1d3a-4b9e-9c2f-0a4b7e5d1f01")
 
-	rows, err := tx.QueryContext(ctx,
-		fmt.Sprintf("SELECT id, timestamp, level, actor, action, ip, details FROM %s ORDER BY id", AuditLogsTableName))
-	if err != nil {
-		return fmt.Errorf("select audit_logs: %w", err)
-	}
+	return retypeIDToUUID(ctx, tx, AuditLogsTableName, ns, newSchema,
+		[]string{"timestamp", "level", "actor", "action", "ip", "details"})
+}
 
-	insert, err := tx.PrepareContext(ctx,
-		fmt.Sprintf("INSERT INTO %s_new (id, timestamp, level, actor, action, ip, details) VALUES (?, ?, ?, ?, ?, ?, ?)", AuditLogsTableName))
-	if err != nil {
-		_ = rows.Close()
-		return fmt.Errorf("prepare insert: %w", err)
-	}
+func migrateV11HomeNetworkKeys(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id              TEXT PRIMARY KEY,
+			key_identifier  INTEGER NOT NULL CHECK (key_identifier >= 0 AND key_identifier <= 255),
+			scheme          TEXT    NOT NULL CHECK (scheme IN ('A', 'B')),
+			private_key     TEXT    NOT NULL,
+			UNIQUE(key_identifier, scheme)
+		)`
 
-	defer func() { _ = insert.Close() }()
+	ns := uuid.MustParse("3c1b2f9a-7e44-4d0e-9a82-5f6c8e1d7a02")
 
-	for rows.Next() {
-		var (
-			oldID                                        int64
-			timestamp, level, actor, action, ip, details string
-		)
-
-		if err := rows.Scan(&oldID, &timestamp, &level, &actor, &action, &ip, &details); err != nil {
-			_ = rows.Close()
-			return fmt.Errorf("scan audit_logs row: %w", err)
-		}
-
-		newID := uuid.NewSHA1(auditLogIDNamespace, []byte("audit_logs:"+strconv.FormatInt(oldID, 10))).String()
-
-		if _, err := insert.ExecContext(ctx, newID, timestamp, level, actor, action, ip, details); err != nil {
-			_ = rows.Close()
-			return fmt.Errorf("insert audit_logs_new row (oldID=%d): %w", oldID, err)
-		}
-	}
-
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return fmt.Errorf("iterate audit_logs: %w", err)
-	}
-
-	_ = rows.Close()
-
-	for _, stmt := range []string{
-		fmt.Sprintf("DROP TABLE %s", AuditLogsTableName),
-		fmt.Sprintf("ALTER TABLE %s_new RENAME TO %s", AuditLogsTableName, AuditLogsTableName),
-	} {
-		if _, err := tx.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("execute %q: %w", stmt, err)
-		}
-	}
-
-	return nil
+	return retypeIDToUUID(ctx, tx, HomeNetworkKeysTableName, ns, newSchema,
+		[]string{"key_identifier", "scheme", "private_key"})
 }

--- a/internal/db/migration_v11.go
+++ b/internal/db/migration_v11.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Ella Networks
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+// auditLogIDNamespace seeds the deterministic UUID assigned to each
+// pre-v11 audit_log row. The choice of namespace is arbitrary; what
+// matters is that every node uses the same value so SHA1-based UUIDs
+// computed from (namespace, old_rowid) match across replicas.
+//
+// Treat as a release-stable constant: changing it would break audit-log
+// id stability across the migration.
+var auditLogIDNamespace = uuid.MustParse("a8f1e7c0-1d3a-4b9e-9c2f-0a4b7e5d1f01")
+
+// V11 retypes audit_logs.id from INTEGER AUTOINCREMENT to TEXT (UUID).
+// Server-assigned AUTOINCREMENT in a replicated table races on leader
+// takeover (capture picks an id from sqlite_sequence, which a pending
+// previous-term entry has already claimed). UUIDs generated at the
+// request handler eliminate the class.
+//
+// Existing rows get a deterministic UUIDv5 derived from their old id so
+// every node ends up with identical bytes.
+func migrateV11(ctx context.Context, tx *sql.Tx) error {
+	const newSchema = `
+		CREATE TABLE %s_new (
+			id         TEXT PRIMARY KEY,
+			timestamp  TEXT NOT NULL,
+			level      TEXT NOT NULL,
+			actor      TEXT NOT NULL DEFAULT '',
+			action     TEXT NOT NULL,
+			ip         TEXT NOT NULL DEFAULT '',
+			details    TEXT NOT NULL DEFAULT ''
+		)`
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(newSchema, AuditLogsTableName)); err != nil {
+		return fmt.Errorf("create audit_logs_new: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx,
+		fmt.Sprintf("SELECT id, timestamp, level, actor, action, ip, details FROM %s ORDER BY id", AuditLogsTableName))
+	if err != nil {
+		return fmt.Errorf("select audit_logs: %w", err)
+	}
+
+	insert, err := tx.PrepareContext(ctx,
+		fmt.Sprintf("INSERT INTO %s_new (id, timestamp, level, actor, action, ip, details) VALUES (?, ?, ?, ?, ?, ?, ?)", AuditLogsTableName))
+	if err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+
+	defer func() { _ = insert.Close() }()
+
+	for rows.Next() {
+		var (
+			oldID                                        int64
+			timestamp, level, actor, action, ip, details string
+		)
+
+		if err := rows.Scan(&oldID, &timestamp, &level, &actor, &action, &ip, &details); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan audit_logs row: %w", err)
+		}
+
+		newID := uuid.NewSHA1(auditLogIDNamespace, []byte("audit_logs:"+strconv.FormatInt(oldID, 10))).String()
+
+		if _, err := insert.ExecContext(ctx, newID, timestamp, level, actor, action, ip, details); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("insert audit_logs_new row (oldID=%d): %w", oldID, err)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate audit_logs: %w", err)
+	}
+
+	_ = rows.Close()
+
+	for _, stmt := range []string{
+		fmt.Sprintf("DROP TABLE %s", AuditLogsTableName),
+		fmt.Sprintf("ALTER TABLE %s_new RENAME TO %s", AuditLogsTableName, AuditLogsTableName),
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("execute %q: %w", stmt, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/db/migration_v11_test.go
+++ b/internal/db/migration_v11_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Ella Networks
+
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestMigrationV11_PopulatedDB exercises the v11 data migration with
+// representative pre-migration rows for every table that v11 retypes.
+// It verifies:
+//   - the new id is the deterministic UUIDv5 the spec requires;
+//   - integer FK columns are rewritten to the parent's UUID, so
+//     joins still resolve and PRAGMA foreign_key_check is clean;
+//   - all rows survive the rebuild.
+//
+// This is the only end-to-end check that the migration is correct with
+// real data. Without it, an emptied-DB-only test path would let a
+// regression in `rebuildTableUUID` (e.g. wrong column order, dropped FK
+// rewrite) ship undetected.
+func TestMigrationV11_PopulatedDB(t *testing.T) {
+	tmp := t.TempDir()
+
+	conn, err := openSQLiteConnection(context.Background(), filepath.Join(tmp, "db.sqlite3"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	ctx := context.Background()
+
+	// Bring schema to v10.
+	if err := runMigrations(ctx, conn, 10); err != nil {
+		t.Fatalf("migrate to v10: %v", err)
+	}
+
+	// Seed a complete dependency chain at v10:
+	// data_network(id=42) ← policy(id=7, dataNetworkID=42, profileID=3, sliceID=5)
+	//   ← network_rule(policy_id=7)
+	//   ← ip_lease(poolID=42)
+	// profile(id=3) ← subscriber(profileID=3)
+	// network_slice(id=5)
+	// user(id=11) ← session(user_id=11), api_token(user_id=11)
+	stmts := []string{
+		`INSERT INTO data_networks (id, name, ipPool, dns, mtu) VALUES (42, 'dn1', '10.0.0.0/24', '8.8.8.8', 1500)`,
+		`INSERT INTO network_slices (id, sst, sd, name) VALUES (5, 1, '000001', 'slice-a')`,
+		`INSERT INTO profiles (id, name, ueAmbrUplink, ueAmbrDownlink) VALUES (3, 'profile-a', '10 Mbps', '20 Mbps')`,
+		`INSERT INTO policies (id, name, profileID, sliceID, dataNetworkID, var5qi, arp, sessionAmbrUplink, sessionAmbrDownlink)
+		   VALUES (7, 'policy-a', 3, 5, 42, 9, 1, '5 Mbps', '10 Mbps')`,
+		`INSERT INTO subscribers (id, imsi, sequenceNumber, permanentKey, opc, profileID)
+		   VALUES (1, '001010000000001', '000000000001', 'aabbccddeeff00112233445566778899', '0011223344556677889900aabbccddee', 3)`,
+		`INSERT INTO network_rules (id, policy_id, description, direction, protocol, port_low, port_high, action, precedence)
+		   VALUES (100, 7, 'allow-http', 'uplink', 6, 80, 80, 'allow', 1)`,
+		`INSERT INTO ip_leases (id, poolID, addressBin, imsi, sessionID, type, createdAt, nodeID)
+		   VALUES (200, 42, X'00000000000000000000FFFF0A000001', '001010000000001', 1, 'dynamic', 1234567890, 0)`,
+		`INSERT INTO users (id, email, roleID, hashedPassword) VALUES (11, 'admin@test', 1, 'hash')`,
+		`INSERT INTO sessions (id, user_id, token_hash, created_at, expires_at)
+		   VALUES (300, 11, X'01020304', 1234567890, 9999999999)`,
+		`INSERT INTO api_tokens (id, token_id, name, token_hash, user_id, expires_at)
+		   VALUES (400, 'tok1', 'token-a', 'hash', 11, NULL)`,
+		`INSERT INTO audit_logs (timestamp, level, actor, action, ip, details)
+		   VALUES ('2026-01-01T00:00:00Z', 'info', 'admin', 'create', '127.0.0.1', '')`,
+		`INSERT INTO home_network_keys (key_identifier, scheme, private_key) VALUES (1, 'A', 'deadbeef')`,
+		`INSERT INTO retention_policies (category, retention_days) VALUES ('audit', 7)`,
+	}
+
+	for _, s := range stmts {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Fatalf("seed v10 row %q: %v", s, err)
+		}
+	}
+
+	// Run v11.
+	if err := runMigrations(ctx, conn, 11); err != nil {
+		t.Fatalf("migrate to v11: %v", err)
+	}
+
+	// Helper: deterministic UUID for (table, oldID) — must match the
+	// scheme used by rebuildTableUUID.
+	expectUUID := func(ns uuid.UUID, table string, oldID int64) string {
+		return uuid.NewSHA1(ns, []byte(table+":"+strconv.FormatInt(oldID, 10))).String()
+	}
+
+	// Verify each parent's id and that its child's FK column resolves.
+	cases := []struct {
+		query    string
+		wantUUID string
+	}{
+		{`SELECT id FROM data_networks WHERE name='dn1'`, expectUUID(v11NSDataNetworks, DataNetworksTableName, 42)},
+		{`SELECT id FROM network_slices WHERE name='slice-a'`, expectUUID(v11NSNetworkSlices, NetworkSlicesTableName, 5)},
+		{`SELECT id FROM profiles WHERE name='profile-a'`, expectUUID(v11NSProfiles, ProfilesTableName, 3)},
+		{`SELECT id FROM policies WHERE name='policy-a'`, expectUUID(v11NSPolicies, PoliciesTableName, 7)},
+		{`SELECT id FROM users WHERE email='admin@test'`, expectUUID(v11NSUsers, UsersTableName, 11)},
+		{`SELECT id FROM subscribers WHERE imsi='001010000000001'`, expectUUID(v11NSSubscribers, SubscribersTableName, 1)},
+		{`SELECT profileID FROM policies WHERE name='policy-a'`, expectUUID(v11NSProfiles, ProfilesTableName, 3)},
+		{`SELECT sliceID FROM policies WHERE name='policy-a'`, expectUUID(v11NSNetworkSlices, NetworkSlicesTableName, 5)},
+		{`SELECT dataNetworkID FROM policies WHERE name='policy-a'`, expectUUID(v11NSDataNetworks, DataNetworksTableName, 42)},
+		{`SELECT profileID FROM subscribers WHERE imsi='001010000000001'`, expectUUID(v11NSProfiles, ProfilesTableName, 3)},
+		{`SELECT policy_id FROM network_rules WHERE description='allow-http'`, expectUUID(v11NSPolicies, PoliciesTableName, 7)},
+		{`SELECT poolID FROM ip_leases WHERE imsi='001010000000001'`, expectUUID(v11NSDataNetworks, DataNetworksTableName, 42)},
+		{`SELECT user_id FROM sessions WHERE token_hash=X'01020304'`, expectUUID(v11NSUsers, UsersTableName, 11)},
+		{`SELECT user_id FROM api_tokens WHERE token_id='tok1'`, expectUUID(v11NSUsers, UsersTableName, 11)},
+	}
+
+	for _, c := range cases {
+		var got string
+		if err := conn.QueryRowContext(ctx, c.query).Scan(&got); err != nil {
+			t.Errorf("%s: scan: %v", c.query, err)
+			continue
+		}
+
+		if got != c.wantUUID {
+			t.Errorf("%s = %q, want %q", c.query, got, c.wantUUID)
+		}
+	}
+
+	// FK integrity must hold post-migration.
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+		t.Fatalf("enable FK: %v", err)
+	}
+
+	rows, err := conn.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		t.Fatalf("foreign_key_check: %v", err)
+	}
+
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			child  string
+			rowid  int64
+			parent string
+			fkid   int64
+		)
+
+		if err := rows.Scan(&child, &rowid, &parent, &fkid); err != nil {
+			t.Fatalf("scan fk row: %v", err)
+		}
+
+		t.Errorf("FK violation after v11: child=%s row=%d parent=%s fk=%d", child, rowid, parent, fkid)
+	}
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -37,7 +37,17 @@ var migrations = []migration{
 // baselineVersion is the highest migration that runs locally during
 // cluster-mode startup. Post-baseline migrations are proposed through Raft
 // by the leader (§5.5).
-const baselineVersion = 9
+//
+// v11 must be local: the new code path generates UUID strings at every
+// request handler, and the tables it writes to (audit_logs,
+// home_network_keys, …) need v11's TEXT id column in place before the
+// leader's first post-election write fires. Running v11 through Raft
+// instead would leave a window where the schema is still v10 and the
+// handler is already emitting UUIDs — INTEGER PRIMARY KEY rejects
+// those with "datatype mismatch". This is the same reason 1.10.1 →
+// 1.11 cannot be a rolling upgrade; operators take that hop via
+// backup/restore.
+const baselineVersion = 11
 
 // SchemaVersion returns the highest migration version this binary understands.
 // Used during cluster join to reject version-skewed nodes.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -31,7 +31,7 @@ var migrations = []migration{
 	{8, "add action to flow reports", migrateV8},
 	{9, "HA schema additions (amfRegionID, cluster_members, ip_leases.nodeID, bgp_peers.nodeID)", migrateV9},
 	{10, "drop bgp_peers.nodeID and cluster_members.maxSchemaVersion (both dead post-HA-redesign)", migrateV10},
-	{11, "audit_logs.id → TEXT (UUID); decouples PK assignment from rollback-able local state", migrateV11},
+	{11, "replicated AUTOINCREMENT PKs → TEXT (UUID); spec_uuid.md", migrateV11},
 }
 
 // baselineVersion is the highest migration that runs locally during

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -31,6 +31,7 @@ var migrations = []migration{
 	{8, "add action to flow reports", migrateV8},
 	{9, "HA schema additions (amfRegionID, cluster_members, ip_leases.nodeID, bgp_peers.nodeID)", migrateV9},
 	{10, "drop bgp_peers.nodeID and cluster_members.maxSchemaVersion (both dead post-HA-redesign)", migrateV10},
+	{11, "audit_logs.id → TEXT (UUID); decouples PK assignment from rollback-able local state", migrateV11},
 }
 
 // baselineVersion is the highest migration that runs locally during

--- a/internal/db/network_rules.go
+++ b/internal/db/network_rules.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/canonical/sqlair"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,7 +23,7 @@ const NetworkRulesTableName = "network_rules"
 
 const (
 	getNetworkRuleStmt             = "SELECT &NetworkRule.* FROM %s WHERE id==$NetworkRule.id"
-	createNetworkRuleStmt          = "INSERT INTO %s (policy_id, description, direction, remote_prefix, protocol, port_low, port_high, action, precedence, created_at, updated_at) VALUES ($NetworkRule.policy_id, $NetworkRule.description, $NetworkRule.direction, $NetworkRule.remote_prefix, $NetworkRule.protocol, $NetworkRule.port_low, $NetworkRule.port_high, $NetworkRule.action, $NetworkRule.precedence, $NetworkRule.created_at, $NetworkRule.updated_at)"
+	createNetworkRuleStmt          = "INSERT INTO %s (id, policy_id, description, direction, remote_prefix, protocol, port_low, port_high, action, precedence, created_at, updated_at) VALUES ($NetworkRule.id, $NetworkRule.policy_id, $NetworkRule.description, $NetworkRule.direction, $NetworkRule.remote_prefix, $NetworkRule.protocol, $NetworkRule.port_low, $NetworkRule.port_high, $NetworkRule.action, $NetworkRule.precedence, $NetworkRule.created_at, $NetworkRule.updated_at)"
 	updateNetworkRuleStmt          = "UPDATE %s SET description=$NetworkRule.description, direction=$NetworkRule.direction, remote_prefix=$NetworkRule.remote_prefix, protocol=$NetworkRule.protocol, port_low=$NetworkRule.port_low, port_high=$NetworkRule.port_high, action=$NetworkRule.action, precedence=$NetworkRule.precedence, updated_at=$NetworkRule.updated_at WHERE id==$NetworkRule.id"
 	deleteNetworkRuleStmt          = "DELETE FROM %s WHERE id==$NetworkRule.id"
 	deleteNetworkRulesByPolicyStmt = "DELETE FROM %s WHERE policy_id==$NetworkRule.policy_id"
@@ -33,7 +34,7 @@ const (
 const gap = 100
 
 type NetworkRule struct {
-	ID           int64     `db:"id"`
+	ID           string    `db:"id"` // UUIDv7
 	PolicyID     int64     `db:"policy_id"`
 	Description  string    `db:"description"`
 	Direction    string    `db:"direction"`
@@ -48,7 +49,7 @@ type NetworkRule struct {
 }
 
 // CreateNetworkRule creates a new network rule and returns its ID.
-func (db *Database) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (int64, error) {
+func (db *Database) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (string, error) {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "INSERT", NetworkRulesTableName),
@@ -70,21 +71,30 @@ func (db *Database) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (int
 	nr.CreatedAt = now
 	nr.UpdatedAt = now
 
-	result, err := opCreateNetworkRule.Invoke(db, nr)
+	if nr.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return "", fmt.Errorf("generate network rule id: %w", err)
+		}
+
+		nr.ID = id.String()
+	}
+
+	_, err := opCreateNetworkRule.Invoke(db, nr)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
-		return 0, err
+		return "", err
 	}
 
 	span.SetStatus(codes.Ok, "")
 
-	return result.(int64), nil
+	return nr.ID, nil
 }
 
 // GetNetworkRule retrieves a network rule by ID.
-func (db *Database) GetNetworkRule(ctx context.Context, id int64) (*NetworkRule, error) {
+func (db *Database) GetNetworkRule(ctx context.Context, id string) (*NetworkRule, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", NetworkRulesTableName),
@@ -157,7 +167,7 @@ func (db *Database) UpdateNetworkRule(ctx context.Context, nr *NetworkRule) erro
 }
 
 // ReorderRulesForPolicy moves a rule to a new position within its policy and normalizes all precedence values.
-func (db *Database) ReorderRulesForPolicy(ctx context.Context, policyID int64, movedRuleID int64, newIndex int, direction string) error {
+func (db *Database) ReorderRulesForPolicy(ctx context.Context, policyID int64, movedRuleID string, newIndex int, direction string) error {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "UPDATE", NetworkRulesTableName),
@@ -236,18 +246,18 @@ func (db *Database) ReorderRulesForPolicy(ctx context.Context, policyID int64, m
 
 	if err := db.UpdateNetworkRule(ctx, movedRule); err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, fmt.Sprintf("failed to update rule precedence for rule %d", movedRule.ID))
+		span.SetStatus(codes.Error, fmt.Sprintf("failed to update rule precedence for rule %s", movedRule.ID))
 
-		return fmt.Errorf("failed to update rule precedence for rule %d: %w", movedRule.ID, err)
+		return fmt.Errorf("failed to update rule precedence for rule %s: %w", movedRule.ID, err)
 	}
 
 	for i, rule := range reorderedRules {
 		rule.Precedence = int32((i+1)*gap) + offset
 		if err := db.UpdateNetworkRule(ctx, rule); err != nil {
 			span.RecordError(err)
-			span.SetStatus(codes.Error, fmt.Sprintf("failed to update rule precedence for rule %d", rule.ID))
+			span.SetStatus(codes.Error, fmt.Sprintf("failed to update rule precedence for rule %s", rule.ID))
 
-			return fmt.Errorf("failed to update rule precedence for rule %d: %w", rule.ID, err)
+			return fmt.Errorf("failed to update rule precedence for rule %s: %w", rule.ID, err)
 		}
 	}
 
@@ -257,7 +267,7 @@ func (db *Database) ReorderRulesForPolicy(ctx context.Context, policyID int64, m
 }
 
 // DeleteNetworkRule deletes a network rule by ID.
-func (db *Database) DeleteNetworkRule(ctx context.Context, id int64) error {
+func (db *Database) DeleteNetworkRule(ctx context.Context, id string) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", NetworkRulesTableName),
@@ -275,7 +285,7 @@ func (db *Database) DeleteNetworkRule(ctx context.Context, id int64) error {
 
 	DBQueriesTotal.WithLabelValues(NetworkRulesTableName, "delete").Inc()
 
-	_, err := opDeleteNetworkRule.Invoke(db, &int64Payload{Value: id})
+	_, err := opDeleteNetworkRule.Invoke(db, &stringPayload{Value: id})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -364,7 +374,7 @@ func (db *Database) ListRulesForPolicy(ctx context.Context, policyID int64) ([]*
 }
 
 // CreateNetworkRule creates a new network rule in the transaction and returns its ID.
-func (t *Transaction) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (int64, error) {
+func (t *Transaction) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (string, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "INSERT", NetworkRulesTableName),
@@ -386,34 +396,33 @@ func (t *Transaction) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (i
 	nr.CreatedAt = now
 	nr.UpdatedAt = now
 
-	var outcome sqlair.Outcome
+	if nr.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return "", fmt.Errorf("generate network rule id: %w", err)
+		}
 
-	err := t.tx.Query(ctx, t.db.createNetworkRuleStmt, nr).Get(&outcome)
+		nr.ID = id.String()
+	}
+
+	err := t.tx.Query(ctx, t.db.createNetworkRuleStmt, nr).Run()
 	if err != nil {
 		if isUniqueNameError(err) {
 			span.RecordError(ErrAlreadyExists)
 			span.SetStatus(codes.Error, "unique constraint failed")
 
-			return 0, ErrAlreadyExists
+			return "", ErrAlreadyExists
 		}
 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "query failed")
 
-		return 0, fmt.Errorf("query failed: %w", err)
-	}
-
-	id, err := outcome.Result().LastInsertId()
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "retrieving insert ID failed")
-
-		return 0, fmt.Errorf("retrieving insert ID failed: %w", err)
+		return "", fmt.Errorf("query failed: %w", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
 
-	return id, nil
+	return nr.ID, nil
 }
 
 // DeleteNetworkRulesByPolicyID deletes all network rules for a given policy ID within a transaction.

--- a/internal/db/network_rules.go
+++ b/internal/db/network_rules.go
@@ -34,8 +34,8 @@ const (
 const gap = 100
 
 type NetworkRule struct {
-	ID           string    `db:"id"` // UUIDv7
-	PolicyID     int64     `db:"policy_id"`
+	ID           string    `db:"id"`        // UUIDv7
+	PolicyID     string    `db:"policy_id"` // FK to policies.id (UUID)
 	Description  string    `db:"description"`
 	Direction    string    `db:"direction"`
 	RemotePrefix *string   `db:"remote_prefix"`
@@ -167,7 +167,7 @@ func (db *Database) UpdateNetworkRule(ctx context.Context, nr *NetworkRule) erro
 }
 
 // ReorderRulesForPolicy moves a rule to a new position within its policy and normalizes all precedence values.
-func (db *Database) ReorderRulesForPolicy(ctx context.Context, policyID int64, movedRuleID string, newIndex int, direction string) error {
+func (db *Database) ReorderRulesForPolicy(ctx context.Context, policyID string, movedRuleID string, newIndex int, direction string) error {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "UPDATE", NetworkRulesTableName),
@@ -333,7 +333,7 @@ func (db *Database) CountNetworkRules(ctx context.Context) (int, error) {
 }
 
 // ListRulesForPolicy retrieves all network rules associated with a policy.
-func (db *Database) ListRulesForPolicy(ctx context.Context, policyID int64) ([]*NetworkRule, error) {
+func (db *Database) ListRulesForPolicy(ctx context.Context, policyID string) ([]*NetworkRule, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", NetworkRulesTableName),
@@ -426,7 +426,7 @@ func (t *Transaction) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (s
 }
 
 // DeleteNetworkRulesByPolicyID deletes all network rules for a given policy ID within a transaction.
-func (t *Transaction) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID int64) error {
+func (t *Transaction) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID string) error {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", NetworkRulesTableName),
@@ -460,7 +460,7 @@ func (t *Transaction) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID
 }
 
 // DeleteNetworkRulesByPolicyID deletes all network rules for a given policy ID.
-func (db *Database) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID int64) error {
+func (db *Database) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID string) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", NetworkRulesTableName),
@@ -478,7 +478,7 @@ func (db *Database) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID i
 
 	DBQueriesTotal.WithLabelValues(NetworkRulesTableName, "delete").Inc()
 
-	_, err := opDeleteNetworkRulesByPolicy.Invoke(db, &int64Payload{Value: policyID})
+	_, err := opDeleteNetworkRulesByPolicy.Invoke(db, &stringPayload{Value: policyID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/network_rules_test.go
+++ b/internal/db/network_rules_test.go
@@ -72,8 +72,8 @@ func TestNetworkRulesCreateGetUpdate(t *testing.T) {
 		t.Fatalf("Couldn't complete CreateNetworkRule: %s", err)
 	}
 
-	if id == 0 {
-		t.Fatalf("Expected non-zero ID from CreateNetworkRule")
+	if id == "" {
+		t.Fatalf("Expected non-empty ID from CreateNetworkRule")
 	}
 
 	retrieved, err := database.GetNetworkRule(context.Background(), id)
@@ -618,7 +618,7 @@ func TestListRulesForPolicy(t *testing.T) {
 		t.Fatalf("Couldn't get policy 2: %s", err)
 	}
 
-	var ruleIDs []int64
+	var ruleIDs []string
 
 	for i := 1; i <= 3; i++ {
 		rule := &db.NetworkRule{
@@ -742,7 +742,7 @@ func TestListRulesForPolicy_Ordering(t *testing.T) {
 		{"rule-200", 200},
 	}
 
-	ids := make([]int64, len(rules))
+	ids := make([]string, len(rules))
 	for i, tc := range rules {
 		id, err := dbInstance.CreateNetworkRule(ctx, &db.NetworkRule{
 			PolicyID:    int64(policy.ID),
@@ -784,7 +784,7 @@ func TestReorderRulesForPolicy(t *testing.T) {
 
 	policy := createTestPolicy(t, dbInstance)
 
-	var ids [3]int64
+	var ids [3]string
 
 	for i, name := range []string{"rule-a", "rule-b", "rule-c"} {
 		id, err := dbInstance.CreateNetworkRule(ctx, &db.NetworkRule{
@@ -811,10 +811,10 @@ func TestReorderRulesForPolicy(t *testing.T) {
 		t.Fatalf("ListRulesForPolicy after reorder: %v", err)
 	}
 
-	wantIDs := []int64{ids[2], ids[0], ids[1]}
+	wantIDs := []string{ids[2], ids[0], ids[1]}
 	for i, r := range got {
 		if r.ID != wantIDs[i] {
-			t.Errorf("rule[%d]: want id %d, got %d", i, wantIDs[i], r.ID)
+			t.Errorf("rule[%d]: want id %s, got %s", i, wantIDs[i], r.ID)
 		}
 
 		if r.Precedence != int32((i+1)*100)+1 {
@@ -831,10 +831,10 @@ func TestReorderRulesForPolicy(t *testing.T) {
 		t.Fatalf("ListRulesForPolicy after reorder: %v", err)
 	}
 
-	wantIDs = []int64{ids[2], ids[1], ids[0]}
+	wantIDs = []string{ids[2], ids[1], ids[0]}
 	for i, r := range got {
 		if r.ID != wantIDs[i] {
-			t.Errorf("rule[%d]: want id %d, got %d", i, wantIDs[i], r.ID)
+			t.Errorf("rule[%d]: want id %s, got %s", i, wantIDs[i], r.ID)
 		}
 
 		if r.Precedence != int32((i+1)*100) {

--- a/internal/db/network_rules_test.go
+++ b/internal/db/network_rules_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/ellanetworks/core/internal/db"
 )
 
+// createPolicyDeps creates a profile and a network slice and returns their IDs.
+// Used to satisfy the FK constraints on policies.profile_id / slice_id.
+func createPolicyDeps(t *testing.T, database *db.Database, suffix string) (profileID string, sliceID string) {
+	t.Helper()
+
+	profile := &db.Profile{
+		Name:           "test-profile-" + suffix,
+		UeAmbrUplink:   "200 Mbps",
+		UeAmbrDownlink: "200 Mbps",
+	}
+	if err := database.CreateProfile(context.Background(), profile); err != nil {
+		t.Fatalf("CreateProfile: %s", err)
+	}
+
+	createdProfile, err := database.GetProfile(context.Background(), profile.Name)
+	if err != nil {
+		t.Fatalf("GetProfile: %s", err)
+	}
+
+	slice := &db.NetworkSlice{Name: "test-slice-" + suffix, Sst: 1}
+	if err := database.CreateNetworkSlice(context.Background(), slice); err != nil {
+		t.Fatalf("CreateNetworkSlice: %s", err)
+	}
+
+	createdSlice, err := database.GetNetworkSlice(context.Background(), slice.Name)
+	if err != nil {
+		t.Fatalf("GetNetworkSlice: %s", err)
+	}
+
+	return createdProfile.ID, createdSlice.ID
+}
+
 func TestNetworkRulesCreateGetUpdate(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -34,6 +66,8 @@ func TestNetworkRulesCreateGetUpdate(t *testing.T) {
 		t.Fatalf("Couldn't get initial data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, database, "create-get-update")
+
 	newPolicy := &db.Policy{
 		Name:                "test-policy",
 		SessionAmbrUplink:   "100 Mbps",
@@ -41,8 +75,8 @@ func TestNetworkRulesCreateGetUpdate(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), newPolicy)
@@ -56,7 +90,7 @@ func TestNetworkRulesCreateGetUpdate(t *testing.T) {
 	}
 
 	rule := &db.NetworkRule{
-		PolicyID:     int64(createdPolicy.ID),
+		PolicyID:     createdPolicy.ID,
 		Description:  "test-rule-1",
 		Direction:    "uplink",
 		RemotePrefix: nil,
@@ -93,8 +127,8 @@ func TestNetworkRulesCreateGetUpdate(t *testing.T) {
 		t.Fatalf("Retrieved rule action %q doesn't match created rule action %q", retrieved.Action, rule.Action)
 	}
 
-	if retrieved.PolicyID != int64(createdPolicy.ID) {
-		t.Fatalf("Retrieved rule policy_id %d doesn't match expected policy_id %d", retrieved.PolicyID, createdPolicy.ID)
+	if retrieved.PolicyID != createdPolicy.ID {
+		t.Fatalf("Retrieved rule policy_id %s doesn't match expected policy_id %s", retrieved.PolicyID, createdPolicy.ID)
 	}
 
 	retrieved.Direction = "downlink"
@@ -143,6 +177,8 @@ func TestNetworkRulesDelete(t *testing.T) {
 		t.Fatalf("Couldn't get initial data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, database, "delete")
+
 	newPolicy := &db.Policy{
 		Name:                "test-policy-delete",
 		SessionAmbrUplink:   "100 Mbps",
@@ -150,8 +186,8 @@ func TestNetworkRulesDelete(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), newPolicy)
@@ -165,7 +201,7 @@ func TestNetworkRulesDelete(t *testing.T) {
 	}
 
 	rule := &db.NetworkRule{
-		PolicyID:     int64(createdPolicy.ID),
+		PolicyID:     createdPolicy.ID,
 		Description:  "test-rule-delete",
 		Direction:    "uplink",
 		RemotePrefix: nil,
@@ -216,6 +252,8 @@ func TestNetworkRulesDuplicatePrecedencePerPolicy(t *testing.T) {
 		t.Fatalf("Couldn't get initial data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, database, "precedence-unique")
+
 	newPolicy := &db.Policy{
 		Name:                "test-policy-precedence-unique",
 		SessionAmbrUplink:   "100 Mbps",
@@ -223,8 +261,8 @@ func TestNetworkRulesDuplicatePrecedencePerPolicy(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), newPolicy)
@@ -238,7 +276,7 @@ func TestNetworkRulesDuplicatePrecedencePerPolicy(t *testing.T) {
 	}
 
 	_, err = database.CreateNetworkRule(context.Background(), &db.NetworkRule{
-		PolicyID:    int64(createdPolicy.ID),
+		PolicyID:    createdPolicy.ID,
 		Description: "rule-precedence-100",
 		Direction:   "uplink",
 		Protocol:    6,
@@ -252,7 +290,7 @@ func TestNetworkRulesDuplicatePrecedencePerPolicy(t *testing.T) {
 	}
 
 	_, err = database.CreateNetworkRule(context.Background(), &db.NetworkRule{
-		PolicyID:    int64(createdPolicy.ID),
+		PolicyID:    createdPolicy.ID,
 		Description: "rule-precedence-100-duplicate-same-direction",
 		Direction:   "uplink",
 		Protocol:    6,
@@ -290,6 +328,8 @@ func TestNetworkRulesDuplicatePrecedenceDifferentPoliciesAllowed(t *testing.T) {
 		t.Fatalf("Couldn't get initial data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, database, "prec")
+
 	policy1 := &db.Policy{
 		Name:                "test-policy-prec-1",
 		SessionAmbrUplink:   "100 Mbps",
@@ -297,8 +337,8 @@ func TestNetworkRulesDuplicatePrecedenceDifferentPoliciesAllowed(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 	if err := database.CreatePolicy(context.Background(), policy1); err != nil {
 		t.Fatalf("Couldn't create policy 1: %s", err)
@@ -326,8 +366,8 @@ func TestNetworkRulesDuplicatePrecedenceDifferentPoliciesAllowed(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork2.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 	if err := database.CreatePolicy(context.Background(), policy2); err != nil {
 		t.Fatalf("Couldn't create policy 2: %s", err)
@@ -339,7 +379,7 @@ func TestNetworkRulesDuplicatePrecedenceDifferentPoliciesAllowed(t *testing.T) {
 	}
 
 	_, err = database.CreateNetworkRule(context.Background(), &db.NetworkRule{
-		PolicyID:    int64(createdPolicy1.ID),
+		PolicyID:    createdPolicy1.ID,
 		Description: "rule-p1",
 		Direction:   "uplink",
 		Protocol:    6,
@@ -351,7 +391,7 @@ func TestNetworkRulesDuplicatePrecedenceDifferentPoliciesAllowed(t *testing.T) {
 	}
 
 	_, err = database.CreateNetworkRule(context.Background(), &db.NetworkRule{
-		PolicyID:    int64(createdPolicy2.ID),
+		PolicyID:    createdPolicy2.ID,
 		Description: "rule-p2",
 		Direction:   "uplink",
 		Protocol:    6,
@@ -387,6 +427,8 @@ func TestNetworkRulesDuplicateNamePerPolicy(t *testing.T) {
 		t.Fatalf("Couldn't get initial data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, database, "name-unique")
+
 	newPolicy := &db.Policy{
 		Name:                "test-policy-unique",
 		SessionAmbrUplink:   "100 Mbps",
@@ -394,8 +436,8 @@ func TestNetworkRulesDuplicateNamePerPolicy(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), newPolicy)
@@ -409,7 +451,7 @@ func TestNetworkRulesDuplicateNamePerPolicy(t *testing.T) {
 	}
 
 	rule := &db.NetworkRule{
-		PolicyID:     int64(createdPolicy.ID),
+		PolicyID:     createdPolicy.ID,
 		Description:  "duplicate-rule",
 		Direction:    "uplink",
 		RemotePrefix: nil,
@@ -455,6 +497,8 @@ func TestNetworkRulesDifferentPoliciesSameName(t *testing.T) {
 		t.Fatalf("Couldn't get initial data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, database, "diff-pol-same-name")
+
 	policy1 := &db.Policy{
 		Name:                "test-policy-1",
 		SessionAmbrUplink:   "100 Mbps",
@@ -462,8 +506,8 @@ func TestNetworkRulesDifferentPoliciesSameName(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), policy1)
@@ -493,8 +537,8 @@ func TestNetworkRulesDifferentPoliciesSameName(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork2.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), policy2)
@@ -508,7 +552,7 @@ func TestNetworkRulesDifferentPoliciesSameName(t *testing.T) {
 	}
 
 	rule1 := &db.NetworkRule{
-		PolicyID:     int64(createdPolicy1.ID),
+		PolicyID:     createdPolicy1.ID,
 		Description:  "same-rule-name",
 		Direction:    "uplink",
 		RemotePrefix: nil,
@@ -525,7 +569,7 @@ func TestNetworkRulesDifferentPoliciesSameName(t *testing.T) {
 	}
 
 	rule2 := &db.NetworkRule{
-		PolicyID:     int64(createdPolicy2.ID),
+		PolicyID:     createdPolicy2.ID,
 		Description:  "same-rule-name",
 		Direction:    "uplink",
 		RemotePrefix: nil,
@@ -566,6 +610,8 @@ func TestListRulesForPolicy(t *testing.T) {
 		t.Fatalf("Couldn't get initial data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, database, "list-rules")
+
 	policy1 := &db.Policy{
 		Name:                "test-policy-with-rules",
 		SessionAmbrUplink:   "100 Mbps",
@@ -573,8 +619,8 @@ func TestListRulesForPolicy(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), policy1)
@@ -604,8 +650,8 @@ func TestListRulesForPolicy(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork2.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = database.CreatePolicy(context.Background(), policy2)
@@ -622,7 +668,7 @@ func TestListRulesForPolicy(t *testing.T) {
 
 	for i := 1; i <= 3; i++ {
 		rule := &db.NetworkRule{
-			PolicyID:     int64(createdPolicy1.ID),
+			PolicyID:     createdPolicy1.ID,
 			Description:  "rule-for-listing-" + string(rune('0'+i)),
 			Direction:    "uplink",
 			RemotePrefix: nil,
@@ -641,7 +687,7 @@ func TestListRulesForPolicy(t *testing.T) {
 		ruleIDs = append(ruleIDs, ruleID)
 	}
 
-	retrievedRules1, err := database.ListRulesForPolicy(context.Background(), int64(createdPolicy1.ID))
+	retrievedRules1, err := database.ListRulesForPolicy(context.Background(), createdPolicy1.ID)
 	if err != nil {
 		t.Fatalf("Couldn't list rules for policy 1: %s", err)
 	}
@@ -665,7 +711,7 @@ func TestListRulesForPolicy(t *testing.T) {
 		}
 	}
 
-	retrievedRules2, err := database.ListRulesForPolicy(context.Background(), int64(createdPolicy2.ID))
+	retrievedRules2, err := database.ListRulesForPolicy(context.Background(), createdPolicy2.ID)
 	if err != nil {
 		t.Fatalf("Couldn't list rules for policy 2: %s", err)
 	}
@@ -703,6 +749,8 @@ func createTestPolicy(t *testing.T, dbInstance *db.Database) *db.Policy {
 		t.Fatalf("Couldn't get test data network: %s", err)
 	}
 
+	profileID, sliceID := createPolicyDeps(t, dbInstance, t.Name())
+
 	policy := &db.Policy{
 		Name:                "test-policy-" + t.Name(),
 		SessionAmbrUplink:   "100 Mbps",
@@ -710,8 +758,8 @@ func createTestPolicy(t *testing.T, dbInstance *db.Database) *db.Policy {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       dataNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
 	}
 
 	err = dbInstance.CreatePolicy(context.Background(), policy)
@@ -745,7 +793,7 @@ func TestListRulesForPolicy_Ordering(t *testing.T) {
 	ids := make([]string, len(rules))
 	for i, tc := range rules {
 		id, err := dbInstance.CreateNetworkRule(ctx, &db.NetworkRule{
-			PolicyID:    int64(policy.ID),
+			PolicyID:    policy.ID,
 			Description: tc.name,
 			Direction:   "uplink",
 			Protocol:    6,
@@ -761,7 +809,7 @@ func TestListRulesForPolicy_Ordering(t *testing.T) {
 		ids[i] = id
 	}
 
-	got, err := dbInstance.ListRulesForPolicy(ctx, int64(policy.ID))
+	got, err := dbInstance.ListRulesForPolicy(ctx, policy.ID)
 	if err != nil {
 		t.Fatalf("ListRulesForPolicy: %v", err)
 	}
@@ -788,7 +836,7 @@ func TestReorderRulesForPolicy(t *testing.T) {
 
 	for i, name := range []string{"rule-a", "rule-b", "rule-c"} {
 		id, err := dbInstance.CreateNetworkRule(ctx, &db.NetworkRule{
-			PolicyID:    int64(policy.ID),
+			PolicyID:    policy.ID,
 			Description: name,
 			Direction:   "uplink",
 			Protocol:    6,
@@ -802,11 +850,11 @@ func TestReorderRulesForPolicy(t *testing.T) {
 		ids[i] = id
 	}
 
-	if err := dbInstance.ReorderRulesForPolicy(ctx, int64(policy.ID), ids[2], 0, "uplink"); err != nil {
+	if err := dbInstance.ReorderRulesForPolicy(ctx, policy.ID, ids[2], 0, "uplink"); err != nil {
 		t.Fatalf("ReorderRulesForPolicy: %v", err)
 	}
 
-	got, err := dbInstance.ListRulesForPolicy(ctx, int64(policy.ID))
+	got, err := dbInstance.ListRulesForPolicy(ctx, policy.ID)
 	if err != nil {
 		t.Fatalf("ListRulesForPolicy after reorder: %v", err)
 	}
@@ -822,11 +870,11 @@ func TestReorderRulesForPolicy(t *testing.T) {
 		}
 	}
 
-	if err := dbInstance.ReorderRulesForPolicy(ctx, int64(policy.ID), ids[0], 2, "uplink"); err != nil {
+	if err := dbInstance.ReorderRulesForPolicy(ctx, policy.ID, ids[0], 2, "uplink"); err != nil {
 		t.Fatalf("ReorderRulesForPolicy: %v", err)
 	}
 
-	got, err = dbInstance.ListRulesForPolicy(ctx, int64(policy.ID))
+	got, err = dbInstance.ListRulesForPolicy(ctx, policy.ID)
 	if err != nil {
 		t.Fatalf("ListRulesForPolicy after reorder: %v", err)
 	}

--- a/internal/db/network_slices.go
+++ b/internal/db/network_slices.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,7 +23,7 @@ const (
 	listAllNetworkSlicesStmt   = "SELECT &NetworkSlice.* FROM %s ORDER BY id ASC"
 	getNetworkSliceStmt        = "SELECT &NetworkSlice.* FROM %s WHERE name==$NetworkSlice.name"
 	getNetworkSliceByIDStmt    = "SELECT &NetworkSlice.* FROM %s WHERE id==$NetworkSlice.id"
-	createNetworkSliceStmt     = "INSERT INTO %s (sst, sd, name) VALUES ($NetworkSlice.sst, $NetworkSlice.sd, $NetworkSlice.name)"
+	createNetworkSliceStmt     = "INSERT INTO %s (id, sst, sd, name) VALUES ($NetworkSlice.id, $NetworkSlice.sst, $NetworkSlice.sd, $NetworkSlice.name)"
 	editNetworkSliceStmt       = "UPDATE %s SET sst=$NetworkSlice.sst, sd=$NetworkSlice.sd WHERE name==$NetworkSlice.name"
 	deleteNetworkSliceStmt     = "DELETE FROM %s WHERE name==$NetworkSlice.name"
 	countNetworkSlicesStmt     = "SELECT COUNT(*) AS &NumItems.count FROM %s"
@@ -30,7 +31,7 @@ const (
 )
 
 type NetworkSlice struct {
-	ID   int     `db:"id"`
+	ID   string  `db:"id"` // UUIDv7
 	Sst  int32   `db:"sst"`
 	Sd   *string `db:"sd"`
 	Name string  `db:"name"`
@@ -170,7 +171,7 @@ func (db *Database) GetNetworkSlice(ctx context.Context, name string) (*NetworkS
 	return &row, nil
 }
 
-func (db *Database) GetNetworkSliceByID(ctx context.Context, id int) (*NetworkSlice, error) {
+func (db *Database) GetNetworkSliceByID(ctx context.Context, id string) (*NetworkSlice, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", NetworkSlicesTableName),
@@ -225,6 +226,15 @@ func (db *Database) CreateNetworkSlice(ctx context.Context, slice *NetworkSlice)
 	defer timer.ObserveDuration()
 
 	DBQueriesTotal.WithLabelValues(NetworkSlicesTableName, "insert").Inc()
+
+	if slice.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate network slice id: %w", err)
+		}
+
+		slice.ID = id.String()
+	}
 
 	_, err := opCreateNetworkSlice.Invoke(db, slice)
 	if err != nil {
@@ -334,7 +344,7 @@ func (db *Database) CountNetworkSlices(ctx context.Context) (int, error) {
 	return result.Count, nil
 }
 
-func (db *Database) ListNetworkSlicesByIDs(ctx context.Context, ids []int) ([]NetworkSlice, error) {
+func (db *Database) ListNetworkSlicesByIDs(ctx context.Context, ids []string) ([]NetworkSlice, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by IDs)", "SELECT", NetworkSlicesTableName),

--- a/internal/db/network_slices_test.go
+++ b/internal/db/network_slices_test.go
@@ -288,7 +288,7 @@ func TestListNetworkSlicesByIDs(t *testing.T) {
 	}
 
 	// Fetch subset of IDs
-	slices, err := database.ListNetworkSlicesByIDs(context.Background(), []int{defaultSlice.ID, sliceB.ID})
+	slices, err := database.ListNetworkSlicesByIDs(context.Background(), []string{defaultSlice.ID, sliceB.ID})
 	if err != nil {
 		t.Fatalf("Couldn't complete ListNetworkSlicesByIDs: %s", err)
 	}
@@ -297,17 +297,17 @@ func TestListNetworkSlicesByIDs(t *testing.T) {
 		t.Fatalf("Expected 2 slices, got %d", len(slices))
 	}
 
-	foundIDs := map[int]bool{}
+	foundIDs := map[string]bool{}
 	for _, s := range slices {
 		foundIDs[s.ID] = true
 	}
 
 	if !foundIDs[defaultSlice.ID] || !foundIDs[sliceB.ID] {
-		t.Fatalf("Expected IDs %d and %d, got %v", defaultSlice.ID, sliceB.ID, foundIDs)
+		t.Fatalf("Expected IDs %s and %s, got %v", defaultSlice.ID, sliceB.ID, foundIDs)
 	}
 
 	// Fetch all three
-	slices, err = database.ListNetworkSlicesByIDs(context.Background(), []int{defaultSlice.ID, sliceA.ID, sliceB.ID})
+	slices, err = database.ListNetworkSlicesByIDs(context.Background(), []string{defaultSlice.ID, sliceA.ID, sliceB.ID})
 	if err != nil {
 		t.Fatalf("Couldn't complete ListNetworkSlicesByIDs: %s", err)
 	}
@@ -317,7 +317,7 @@ func TestListNetworkSlicesByIDs(t *testing.T) {
 	}
 
 	// Empty IDs returns nil
-	slices, err = database.ListNetworkSlicesByIDs(context.Background(), []int{})
+	slices, err = database.ListNetworkSlicesByIDs(context.Background(), []string{})
 	if err != nil {
 		t.Fatalf("Couldn't complete ListNetworkSlicesByIDs with empty IDs: %s", err)
 	}
@@ -327,7 +327,7 @@ func TestListNetworkSlicesByIDs(t *testing.T) {
 	}
 
 	// Non-existent IDs return empty
-	slices, err = database.ListNetworkSlicesByIDs(context.Background(), []int{9999})
+	slices, err = database.ListNetworkSlicesByIDs(context.Background(), []string{"nonexistent-slice"})
 	if err != nil {
 		t.Fatalf("Couldn't complete ListNetworkSlicesByIDs with non-existent ID: %s", err)
 	}

--- a/internal/db/policies.go
+++ b/internal/db/policies.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/sqlair"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,7 +23,7 @@ const (
 	listPoliciesPagedStmt          = "SELECT &Policy.*, COUNT(*) OVER() AS &NumItems.count FROM %s LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
 	getPolicyStmt                  = "SELECT &Policy.* FROM %s WHERE name==$Policy.name"
 	getPolicyByLookupStmt          = "SELECT &Policy.* FROM %s WHERE profileID==$Policy.profileID AND sliceID==$Policy.sliceID AND dataNetworkID==$Policy.dataNetworkID"
-	createPolicyStmt               = "INSERT INTO %s (name, profileID, sliceID, dataNetworkID, var5qi, arp, sessionAmbrUplink, sessionAmbrDownlink) VALUES ($Policy.name, $Policy.profileID, $Policy.sliceID, $Policy.dataNetworkID, $Policy.var5qi, $Policy.arp, $Policy.sessionAmbrUplink, $Policy.sessionAmbrDownlink)"
+	createPolicyStmt               = "INSERT INTO %s (id, name, profileID, sliceID, dataNetworkID, var5qi, arp, sessionAmbrUplink, sessionAmbrDownlink) VALUES ($Policy.id, $Policy.name, $Policy.profileID, $Policy.sliceID, $Policy.dataNetworkID, $Policy.var5qi, $Policy.arp, $Policy.sessionAmbrUplink, $Policy.sessionAmbrDownlink)"
 	editPolicyStmt                 = "UPDATE %s SET profileID=$Policy.profileID, sliceID=$Policy.sliceID, dataNetworkID=$Policy.dataNetworkID, var5qi=$Policy.var5qi, arp=$Policy.arp, sessionAmbrUplink=$Policy.sessionAmbrUplink, sessionAmbrDownlink=$Policy.sessionAmbrDownlink WHERE name==$Policy.name"
 	deletePolicyStmt               = "DELETE FROM %s WHERE name==$Policy.name"
 	countPoliciesStmt              = "SELECT COUNT(*) AS &NumItems.count FROM %s"
@@ -36,11 +37,11 @@ const (
 )
 
 type Policy struct {
-	ID                  int    `db:"id"`
+	ID                  string `db:"id"` // UUIDv7
 	Name                string `db:"name"`
-	ProfileID           int    `db:"profileID"`
-	SliceID             int    `db:"sliceID"`
-	DataNetworkID       int    `db:"dataNetworkID"`
+	ProfileID           string `db:"profileID"`
+	SliceID             string `db:"sliceID"`
+	DataNetworkID       string `db:"dataNetworkID"`
 	Var5qi              int32  `db:"var5qi"`
 	Arp                 int32  `db:"arp"`
 	SessionAmbrUplink   string `db:"sessionAmbrUplink"`
@@ -105,7 +106,7 @@ func (db *Database) ListPoliciesPage(ctx context.Context, page int, perPage int)
 	return policies, count, nil
 }
 
-func (db *Database) ListPoliciesByProfilePage(ctx context.Context, profileID int, page int, perPage int) ([]Policy, int, error) {
+func (db *Database) ListPoliciesByProfilePage(ctx context.Context, profileID string, page int, perPage int) ([]Policy, int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (paged by profile)", "SELECT", PoliciesTableName),
@@ -114,7 +115,7 @@ func (db *Database) ListPoliciesByProfilePage(ctx context.Context, profileID int
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", PoliciesTableName),
-			attribute.Int("profileID", profileID),
+			attribute.String("profileID", profileID),
 			attribute.Int("page", page),
 			attribute.Int("per_page", perPage),
 		),
@@ -161,7 +162,7 @@ func (db *Database) ListPoliciesByProfilePage(ctx context.Context, profileID int
 	return policies, count, nil
 }
 
-func (db *Database) ListPoliciesByProfile(ctx context.Context, profileID int) ([]Policy, error) {
+func (db *Database) ListPoliciesByProfile(ctx context.Context, profileID string) ([]Policy, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (all by profile)", "SELECT", PoliciesTableName),
@@ -170,7 +171,7 @@ func (db *Database) ListPoliciesByProfile(ctx context.Context, profileID int) ([
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", PoliciesTableName),
-			attribute.Int("profileID", profileID),
+			attribute.String("profileID", profileID),
 		),
 	)
 	defer span.End()
@@ -242,7 +243,7 @@ func (db *Database) GetPolicy(ctx context.Context, name string) (*Policy, error)
 }
 
 // GetPolicyByLookup finds a policy by its profileID, sliceID, and dataNetworkID.
-func (db *Database) GetPolicyByLookup(ctx context.Context, profileID, sliceID, dataNetworkID int) (*Policy, error) {
+func (db *Database) GetPolicyByLookup(ctx context.Context, profileID, sliceID, dataNetworkID string) (*Policy, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (lookup)", "SELECT", PoliciesTableName),
@@ -251,9 +252,9 @@ func (db *Database) GetPolicyByLookup(ctx context.Context, profileID, sliceID, d
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", PoliciesTableName),
-			attribute.Int("profile_id", profileID),
-			attribute.Int("slice_id", sliceID),
-			attribute.Int("data_network_id", dataNetworkID),
+			attribute.String("profile_id", profileID),
+			attribute.String("slice_id", sliceID),
+			attribute.String("data_network_id", dataNetworkID),
 		),
 	)
 	defer span.End()
@@ -286,7 +287,7 @@ func (db *Database) GetPolicyByLookup(ctx context.Context, profileID, sliceID, d
 
 // GetPolicyByProfileAndSlice finds the first policy for a given profile and slice.
 // Used by the AMF to resolve a default DNN when the UE does not specify one.
-func (db *Database) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID int) (*Policy, error) {
+func (db *Database) GetPolicyByProfileAndSlice(ctx context.Context, profileID, sliceID string) (*Policy, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by profile+slice)", "SELECT", PoliciesTableName),
@@ -295,8 +296,8 @@ func (db *Database) GetPolicyByProfileAndSlice(ctx context.Context, profileID, s
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", PoliciesTableName),
-			attribute.Int("profile_id", profileID),
-			attribute.Int("slice_id", sliceID),
+			attribute.String("profile_id", profileID),
+			attribute.String("slice_id", sliceID),
 		),
 	)
 	defer span.End()
@@ -357,16 +358,16 @@ func (db *Database) GetSessionPolicy(ctx context.Context, imsi string, sst int32
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "list policies failed")
 
-		return nil, nil, nil, fmt.Errorf("list policies for profile %d: %w", sub.ProfileID, err)
+		return nil, nil, nil, fmt.Errorf("list policies for profile %s: %w", sub.ProfileID, err)
 	}
 
 	// Batch-fetch all referenced network slices.
-	sliceIDSet := make(map[int]struct{})
+	sliceIDSet := make(map[string]struct{})
 	for _, p := range policies {
 		sliceIDSet[p.SliceID] = struct{}{}
 	}
 
-	sliceIDs := make([]int, 0, len(sliceIDSet))
+	sliceIDs := make([]string, 0, len(sliceIDSet))
 	for id := range sliceIDSet {
 		sliceIDs = append(sliceIDs, id)
 	}
@@ -379,7 +380,7 @@ func (db *Database) GetSessionPolicy(ctx context.Context, imsi string, sst int32
 		return nil, nil, nil, fmt.Errorf("list slices by IDs: %w", err)
 	}
 
-	sliceMap := make(map[int]NetworkSlice, len(sliceList))
+	sliceMap := make(map[string]NetworkSlice, len(sliceList))
 	for _, s := range sliceList {
 		sliceMap[s.ID] = s
 	}
@@ -402,19 +403,19 @@ func (db *Database) GetSessionPolicy(ctx context.Context, imsi string, sst int32
 		dataNetwork, err := db.GetDataNetworkByID(ctx, p.DataNetworkID)
 		if err != nil {
 			span.RecordError(err)
-			return nil, nil, nil, fmt.Errorf("couldn't get data network %d: %w", p.DataNetworkID, err)
+			return nil, nil, nil, fmt.Errorf("couldn't get data network %s: %w", p.DataNetworkID, err)
 		}
 
 		if dataNetwork.Name != dnn {
 			continue
 		}
 
-		rules, err := db.ListRulesForPolicy(ctx, int64(p.ID))
+		rules, err := db.ListRulesForPolicy(ctx, p.ID)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "list rules failed")
 
-			return nil, nil, nil, fmt.Errorf("list rules for policy %d: %w", p.ID, err)
+			return nil, nil, nil, fmt.Errorf("list rules for policy %s: %w", p.ID, err)
 		}
 
 		span.SetStatus(codes.Ok, "")
@@ -424,7 +425,7 @@ func (db *Database) GetSessionPolicy(ctx context.Context, imsi string, sst int32
 
 	span.SetStatus(codes.Error, "no matching policy")
 
-	return nil, nil, nil, fmt.Errorf("no policy matching sst=%d sd=%q dnn=%q for profile %d", sst, sd, dnn, sub.ProfileID)
+	return nil, nil, nil, fmt.Errorf("no policy matching sst=%d sd=%q dnn=%q for profile %s", sst, sd, dnn, sub.ProfileID)
 }
 
 func (db *Database) CreatePolicy(ctx context.Context, policy *Policy) error {
@@ -444,6 +445,15 @@ func (db *Database) CreatePolicy(ctx context.Context, policy *Policy) error {
 	defer timer.ObserveDuration()
 
 	DBQueriesTotal.WithLabelValues(PoliciesTableName, "insert").Inc()
+
+	if policy.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate policy id: %w", err)
+		}
+
+		policy.ID = id.String()
+	}
 
 	_, err := opCreatePolicy.Invoke(db, policy)
 	if err != nil {
@@ -489,7 +499,7 @@ func (db *Database) UpdatePolicy(ctx context.Context, policy *Policy) error {
 	return nil
 }
 
-func (t *Transaction) CreatePolicy(ctx context.Context, policy *Policy) (int64, error) {
+func (t *Transaction) CreatePolicy(ctx context.Context, policy *Policy) (string, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "INSERT", PoliciesTableName),
@@ -507,34 +517,32 @@ func (t *Transaction) CreatePolicy(ctx context.Context, policy *Policy) (int64, 
 
 	DBQueriesTotal.WithLabelValues(PoliciesTableName, "insert").Inc()
 
-	var outcome sqlair.Outcome
+	if policy.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return "", fmt.Errorf("generate policy id: %w", err)
+		}
 
-	err := t.tx.Query(ctx, t.db.createPolicyStmt, policy).Get(&outcome)
-	if err != nil {
+		policy.ID = id.String()
+	}
+
+	if err := t.tx.Query(ctx, t.db.createPolicyStmt, policy).Run(); err != nil {
 		if isUniqueNameError(err) {
 			span.RecordError(ErrAlreadyExists)
 			span.SetStatus(codes.Error, "unique constraint failed")
 
-			return 0, ErrAlreadyExists
+			return "", ErrAlreadyExists
 		}
 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "query failed")
 
-		return 0, fmt.Errorf("query failed: %w", err)
-	}
-
-	id, err := outcome.Result().LastInsertId()
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "retrieving insert ID failed")
-
-		return 0, fmt.Errorf("retrieving insert ID failed: %w", err)
+		return "", fmt.Errorf("query failed: %w", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
 
-	return id, nil
+	return policy.ID, nil
 }
 
 func (t *Transaction) UpdatePolicy(ctx context.Context, policy *Policy) error {
@@ -650,7 +658,7 @@ func (db *Database) CountPolicies(ctx context.Context) (int, error) {
 	return result.Count, nil
 }
 
-func (db *Database) CountPoliciesInProfile(ctx context.Context, profileID int) (int, error) {
+func (db *Database) CountPoliciesInProfile(ctx context.Context, profileID string) (int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by profile)", "SELECT", PoliciesTableName),
@@ -659,7 +667,7 @@ func (db *Database) CountPoliciesInProfile(ctx context.Context, profileID int) (
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", PoliciesTableName),
-			attribute.Int("profile_id", profileID),
+			attribute.String("profile_id", profileID),
 		),
 	)
 	defer span.End()
@@ -686,7 +694,7 @@ func (db *Database) CountPoliciesInProfile(ctx context.Context, profileID int) (
 	return result.Count, nil
 }
 
-func (db *Database) CountPoliciesInSlice(ctx context.Context, sliceID int) (int, error) {
+func (db *Database) CountPoliciesInSlice(ctx context.Context, sliceID string) (int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by slice)", "SELECT", PoliciesTableName),
@@ -695,7 +703,7 @@ func (db *Database) CountPoliciesInSlice(ctx context.Context, sliceID int) (int,
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", PoliciesTableName),
-			attribute.Int("slice_id", sliceID),
+			attribute.String("slice_id", sliceID),
 		),
 	)
 	defer span.End()
@@ -722,7 +730,7 @@ func (db *Database) CountPoliciesInSlice(ctx context.Context, sliceID int) (int,
 	return result.Count, nil
 }
 
-func (db *Database) CountPoliciesInDataNetwork(ctx context.Context, dataNetworkID int) (int, error) {
+func (db *Database) CountPoliciesInDataNetwork(ctx context.Context, dataNetworkID string) (int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by data network)", "SELECT", PoliciesTableName),
@@ -731,7 +739,7 @@ func (db *Database) CountPoliciesInDataNetwork(ctx context.Context, dataNetworkI
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", PoliciesTableName),
-			attribute.Int("data_network_id", dataNetworkID),
+			attribute.String("data_network_id", dataNetworkID),
 		),
 	)
 	defer span.End()

--- a/internal/db/policies_test.go
+++ b/internal/db/policies_test.go
@@ -52,6 +52,16 @@ func TestPoliciesEndToEnd(t *testing.T) {
 		t.Fatalf("Couldn't complete GetDataNetwork: %s", err)
 	}
 
+	defaultProfile, err := database.GetProfile(context.Background(), db.InitialProfileName)
+	if err != nil {
+		t.Fatalf("Couldn't get default profile: %s", err)
+	}
+
+	defaultSlice, err := database.GetNetworkSlice(context.Background(), db.InitialSliceName)
+	if err != nil {
+		t.Fatalf("Couldn't get default slice: %s", err)
+	}
+
 	policy := &db.Policy{
 		Name:                "my-policy",
 		SessionAmbrUplink:   "100 Mbps",
@@ -59,8 +69,8 @@ func TestPoliciesEndToEnd(t *testing.T) {
 		Var5qi:              9,
 		Arp:                 1,
 		DataNetworkID:       createdNetwork.ID,
-		ProfileID:           1,
-		SliceID:             1,
+		ProfileID:           defaultProfile.ID,
+		SliceID:             defaultSlice.ID,
 	}
 
 	err = database.CreatePolicy(context.Background(), policy)
@@ -159,8 +169,22 @@ func TestGetPolicyByLookup(t *testing.T) {
 		}
 	}()
 
-	// The default policy links default profile (1), default slice (1), default data network (1)
-	policy, err := database.GetPolicyByLookup(context.Background(), 1, 1, 1)
+	defaultProfile, err := database.GetProfile(context.Background(), db.InitialProfileName)
+	if err != nil {
+		t.Fatalf("Couldn't get default profile: %s", err)
+	}
+
+	defaultSlice, err := database.GetNetworkSlice(context.Background(), db.InitialSliceName)
+	if err != nil {
+		t.Fatalf("Couldn't get default slice: %s", err)
+	}
+
+	defaultDN, err := database.GetDataNetwork(context.Background(), db.InitialDataNetworkName)
+	if err != nil {
+		t.Fatalf("Couldn't get default data network: %s", err)
+	}
+
+	policy, err := database.GetPolicyByLookup(context.Background(), defaultProfile.ID, defaultSlice.ID, defaultDN.ID)
 	if err != nil {
 		t.Fatalf("Couldn't complete GetPolicyByLookup: %s", err)
 	}
@@ -170,7 +194,7 @@ func TestGetPolicyByLookup(t *testing.T) {
 	}
 
 	// Non-existent lookup
-	_, err = database.GetPolicyByLookup(context.Background(), 999, 999, 999)
+	_, err = database.GetPolicyByLookup(context.Background(), "missing-profile", "missing-slice", "missing-dn")
 	if err != db.ErrNotFound {
 		t.Fatalf("Expected ErrNotFound, got %v", err)
 	}
@@ -190,8 +214,17 @@ func TestGetPolicyByProfileAndSlice(t *testing.T) {
 		}
 	}()
 
-	// Default profile ID = 1, slice ID = 1 has the default policy
-	policy, err := database.GetPolicyByProfileAndSlice(context.Background(), 1, 1)
+	defaultProfile, err := database.GetProfile(context.Background(), db.InitialProfileName)
+	if err != nil {
+		t.Fatalf("Couldn't get default profile: %s", err)
+	}
+
+	defaultSlice, err := database.GetNetworkSlice(context.Background(), db.InitialSliceName)
+	if err != nil {
+		t.Fatalf("Couldn't get default slice: %s", err)
+	}
+
+	policy, err := database.GetPolicyByProfileAndSlice(context.Background(), defaultProfile.ID, defaultSlice.ID)
 	if err != nil {
 		t.Fatalf("Couldn't complete GetPolicyByProfileAndSlice: %s", err)
 	}
@@ -201,7 +234,7 @@ func TestGetPolicyByProfileAndSlice(t *testing.T) {
 	}
 
 	// Non-existent profile + slice combination
-	_, err = database.GetPolicyByProfileAndSlice(context.Background(), 999, 999)
+	_, err = database.GetPolicyByProfileAndSlice(context.Background(), "missing-profile", "missing-slice")
 	if err != db.ErrNotFound {
 		t.Fatalf("Expected ErrNotFound, got %v", err)
 	}
@@ -221,8 +254,22 @@ func TestCountPoliciesInRelations(t *testing.T) {
 		}
 	}()
 
-	// Default policy references profile 1, slice 1, data network 1
-	count, err := database.CountPoliciesInProfile(context.Background(), 1)
+	defaultProfile, err := database.GetProfile(context.Background(), db.InitialProfileName)
+	if err != nil {
+		t.Fatalf("Couldn't get default profile: %s", err)
+	}
+
+	defaultSlice, err := database.GetNetworkSlice(context.Background(), db.InitialSliceName)
+	if err != nil {
+		t.Fatalf("Couldn't get default slice: %s", err)
+	}
+
+	defaultDN, err := database.GetDataNetwork(context.Background(), db.InitialDataNetworkName)
+	if err != nil {
+		t.Fatalf("Couldn't get default data network: %s", err)
+	}
+
+	count, err := database.CountPoliciesInProfile(context.Background(), defaultProfile.ID)
 	if err != nil {
 		t.Fatalf("Couldn't complete CountPoliciesInProfile: %s", err)
 	}
@@ -231,7 +278,7 @@ func TestCountPoliciesInRelations(t *testing.T) {
 		t.Fatalf("Expected 1 policy in default profile, got %d", count)
 	}
 
-	count, err = database.CountPoliciesInSlice(context.Background(), 1)
+	count, err = database.CountPoliciesInSlice(context.Background(), defaultSlice.ID)
 	if err != nil {
 		t.Fatalf("Couldn't complete CountPoliciesInSlice: %s", err)
 	}
@@ -240,7 +287,7 @@ func TestCountPoliciesInRelations(t *testing.T) {
 		t.Fatalf("Expected 1 policy in default slice, got %d", count)
 	}
 
-	count, err = database.CountPoliciesInDataNetwork(context.Background(), 1)
+	count, err = database.CountPoliciesInDataNetwork(context.Background(), defaultDN.ID)
 	if err != nil {
 		t.Fatalf("Couldn't complete CountPoliciesInDataNetwork: %s", err)
 	}
@@ -250,7 +297,7 @@ func TestCountPoliciesInRelations(t *testing.T) {
 	}
 
 	// Non-existent relations
-	count, err = database.CountPoliciesInProfile(context.Background(), 999)
+	count, err = database.CountPoliciesInProfile(context.Background(), "missing-profile")
 	if err != nil {
 		t.Fatalf("Couldn't complete CountPoliciesInProfile: %s", err)
 	}
@@ -327,13 +374,18 @@ func TestGetSessionPolicy(t *testing.T) {
 		}
 	}()
 
+	defaultProfile, err := database.GetProfile(context.Background(), db.InitialProfileName)
+	if err != nil {
+		t.Fatalf("Couldn't get default profile: %s", err)
+	}
+
 	// Create a subscriber on the default profile
 	subscriber := &db.Subscriber{
 		Imsi:           "001010100007487",
 		SequenceNumber: "000000000001",
 		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
 		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
-		ProfileID:      1, // default profile
+		ProfileID:      defaultProfile.ID,
 	}
 
 	err = database.CreateSubscriber(context.Background(), subscriber)

--- a/internal/db/profiles.go
+++ b/internal/db/profiles.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -21,7 +22,7 @@ const (
 	listProfilesPagedStmt         = "SELECT &Profile.*, COUNT(*) OVER() AS &NumItems.count FROM %s LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
 	getProfileStmt                = "SELECT &Profile.* FROM %s WHERE name==$Profile.name"
 	getProfileByIDStmt            = "SELECT &Profile.* FROM %s WHERE id==$Profile.id"
-	createProfileStmt             = "INSERT INTO %s (name, ueAmbrUplink, ueAmbrDownlink) VALUES ($Profile.name, $Profile.ueAmbrUplink, $Profile.ueAmbrDownlink)"
+	createProfileStmt             = "INSERT INTO %s (id, name, ueAmbrUplink, ueAmbrDownlink) VALUES ($Profile.id, $Profile.name, $Profile.ueAmbrUplink, $Profile.ueAmbrDownlink)"
 	editProfileStmt               = "UPDATE %s SET ueAmbrUplink=$Profile.ueAmbrUplink, ueAmbrDownlink=$Profile.ueAmbrDownlink WHERE name==$Profile.name"
 	deleteProfileStmt             = "DELETE FROM %s WHERE name==$Profile.name"
 	countProfilesStmt             = "SELECT COUNT(*) AS &NumItems.count FROM %s"
@@ -29,7 +30,7 @@ const (
 )
 
 type Profile struct {
-	ID             int    `db:"id"`
+	ID             string `db:"id"` // UUIDv7
 	Name           string `db:"name"`
 	UeAmbrUplink   string `db:"ueAmbrUplink"`
 	UeAmbrDownlink string `db:"ueAmbrDownlink"`
@@ -131,7 +132,7 @@ func (db *Database) GetProfile(ctx context.Context, name string) (*Profile, erro
 	return &row, nil
 }
 
-func (db *Database) GetProfileByID(ctx context.Context, id int) (*Profile, error) {
+func (db *Database) GetProfileByID(ctx context.Context, id string) (*Profile, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", ProfilesTableName),
@@ -186,6 +187,15 @@ func (db *Database) CreateProfile(ctx context.Context, profile *Profile) error {
 	defer timer.ObserveDuration()
 
 	DBQueriesTotal.WithLabelValues(ProfilesTableName, "insert").Inc()
+
+	if profile.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate profile id: %w", err)
+		}
+
+		profile.ID = id.String()
+	}
 
 	_, err := opCreateProfile.Invoke(db, profile)
 	if err != nil {
@@ -295,7 +305,7 @@ func (db *Database) CountProfiles(ctx context.Context) (int, error) {
 	return result.Count, nil
 }
 
-func (db *Database) CountSubscribersInProfile(ctx context.Context, profileID int) (int, error) {
+func (db *Database) CountSubscribersInProfile(ctx context.Context, profileID string) (int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (by profile)", "SELECT", SubscribersTableName),
@@ -304,7 +314,7 @@ func (db *Database) CountSubscribersInProfile(ctx context.Context, profileID int
 			semconv.DBSystemNameSQLite,
 			semconv.DBOperationName("SELECT"),
 			attribute.String("db.collection", SubscribersTableName),
-			attribute.Int("profile_id", profileID),
+			attribute.String("profile_id", profileID),
 		),
 	)
 	defer span.End()

--- a/internal/db/replicated_pk_test.go
+++ b/internal/db/replicated_pk_test.go
@@ -28,7 +28,6 @@ var autoIncrementExempt = map[string]struct{}{
 	"ip_leases":          {},
 	"profiles":           {},
 	"subscribers":        {},
-	"home_network_keys":  {},
 	"retention_policies": {},
 }
 

--- a/internal/db/replicated_pk_test.go
+++ b/internal/db/replicated_pk_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Ella Networks
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// autoIncrementExempt lists replicated tables that still use INTEGER
+// PRIMARY KEY AUTOINCREMENT pending migration to UUID PKs. The list
+// must only shrink — adding to it requires a code review nudge that
+// the spec_uuid.md plan is being deferred for that table.
+//
+// Empty target: every replicated table generates its PK at the request
+// handler and stores it as TEXT.
+var autoIncrementExempt = map[string]struct{}{
+	"data_networks":      {},
+	"policies":           {},
+	"users":              {},
+	"sessions":           {},
+	"api_tokens":         {},
+	"network_slices":     {},
+	"network_rules":      {},
+	"ip_leases":          {},
+	"profiles":           {},
+	"subscribers":        {},
+	"home_network_keys":  {},
+	"retention_policies": {},
+}
+
+// TestReplicatedTables_NoUnexpectedAUTOINCREMENT enforces the spec_uuid.md
+// invariant: PKs of replicated tables are decided at the request handler,
+// never derived from rollback-able local state. AUTOINCREMENT on a table
+// that goes through changeset capture lets two captures pick the same id
+// when the new leader's first capture races with a previous-term entry's
+// pending FSM apply (see int_fail8.txt for the observed crash).
+//
+// Failures here mean either: a new replicated table was added with
+// AUTOINCREMENT (don't), or an exempted table was migrated and the
+// exemption stayed in the list (delete it).
+func TestReplicatedTables_NoUnexpectedAUTOINCREMENT(t *testing.T) {
+	tmp := t.TempDir()
+
+	conn, err := openSQLiteConnection(context.Background(), filepath.Join(tmp, "db.sqlite3"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	if err := runMigrations(context.Background(), conn, 0); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	for _, table := range replicatedChangesetTables {
+		if hasAutoIncrement(t, conn, table) {
+			if _, ok := autoIncrementExempt[table]; ok {
+				continue
+			}
+
+			t.Errorf("replicated table %q uses AUTOINCREMENT but is not in autoIncrementExempt; either migrate it to a TEXT UUID PK (spec_uuid.md) or add it to the exempt list", table)
+		} else if _, ok := autoIncrementExempt[table]; ok {
+			t.Errorf("table %q is in autoIncrementExempt but no longer uses AUTOINCREMENT; delete it from the list", table)
+		}
+	}
+}
+
+func hasAutoIncrement(t *testing.T, conn *sql.DB, table string) bool {
+	t.Helper()
+
+	var sqlText string
+
+	err := conn.QueryRowContext(context.Background(),
+		"SELECT sql FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&sqlText)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false
+		}
+
+		t.Fatalf("read schema for %q: %v", table, err)
+	}
+
+	return strings.Contains(strings.ToUpper(sqlText), "AUTOINCREMENT")
+}

--- a/internal/db/replicated_pk_test.go
+++ b/internal/db/replicated_pk_test.go
@@ -18,17 +18,12 @@ import (
 // Empty target: every replicated table generates its PK at the request
 // handler and stores it as TEXT.
 var autoIncrementExempt = map[string]struct{}{
-	"data_networks":      {},
-	"policies":           {},
-	"users":              {},
-	"sessions":           {},
-	"api_tokens":         {},
-	"network_slices":     {},
-	"network_rules":      {},
-	"ip_leases":          {},
-	"profiles":           {},
-	"subscribers":        {},
-	"retention_policies": {},
+	"data_networks":  {},
+	"policies":       {},
+	"users":          {},
+	"network_slices": {},
+	"profiles":       {},
+	"subscribers":    {},
 }
 
 // TestReplicatedTables_NoUnexpectedAUTOINCREMENT enforces the spec_uuid.md

--- a/internal/db/replicated_pk_test.go
+++ b/internal/db/replicated_pk_test.go
@@ -17,14 +17,12 @@ import (
 //
 // Empty target: every replicated table generates its PK at the request
 // handler and stores it as TEXT.
-var autoIncrementExempt = map[string]struct{}{
-	"data_networks":  {},
-	"policies":       {},
-	"users":          {},
-	"network_slices": {},
-	"profiles":       {},
-	"subscribers":    {},
-}
+// All replicated tables have been migrated to TEXT UUID PKs (spec_uuid.md
+// + migration v11). The exempt list is empty: every replicated table now
+// generates its PK at the request handler. Adding a table here in the
+// future requires a code review nudge that the structural fix is being
+// deferred for that table.
+var autoIncrementExempt = map[string]struct{}{}
 
 // TestReplicatedTables_NoUnexpectedAUTOINCREMENT enforces the spec_uuid.md
 // invariant: PKs of replicated tables are decided at the request handler,

--- a/internal/db/retention_policies.go
+++ b/internal/db/retention_policies.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -18,8 +19,8 @@ const RetentionPolicyTableName = "retention_policies"
 const (
 	selectRetentionPolicyStmt = "SELECT &RetentionPolicy.* FROM %s WHERE category = $RetentionPolicy.category"
 	upsertRetentionPolicyStmt = `
-INSERT INTO %s (category, retention_days)
-VALUES ($RetentionPolicy.category, $RetentionPolicy.retention_days)
+INSERT INTO %s (id, category, retention_days)
+VALUES ($RetentionPolicy.id, $RetentionPolicy.category, $RetentionPolicy.retention_days)
 ON CONFLICT(category) DO UPDATE SET retention_days = excluded.retention_days
 `
 )
@@ -34,7 +35,7 @@ const (
 )
 
 type RetentionPolicy struct {
-	ID       int               `db:"id"`
+	ID       string            `db:"id"` // UUIDv7
 	Category RetentionCategory `db:"category"`
 	Days     int               `db:"retention_days"`
 }
@@ -116,6 +117,8 @@ func (db *Database) IsRetentionPolicyInitialized(ctx context.Context, category R
 }
 
 // SetRetentionPolicy upserts the retention policy for a category.
+// If policy.ID is empty (new row, not an update of an existing one),
+// a UUIDv7 is generated. The id is ignored on UPDATE conflict.
 func (db *Database) SetRetentionPolicy(ctx context.Context, policy *RetentionPolicy) error {
 	_, span := tracer.Start(
 		ctx,
@@ -135,6 +138,15 @@ func (db *Database) SetRetentionPolicy(ctx context.Context, policy *RetentionPol
 	defer timer.ObserveDuration()
 
 	DBQueriesTotal.WithLabelValues(RetentionPolicyTableName, "insert").Inc()
+
+	if policy.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate retention policy id: %w", err)
+		}
+
+		policy.ID = id.String()
+	}
 
 	_, err := opSetRetentionPolicy.Invoke(db, policy)
 	if err != nil {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -29,8 +29,8 @@ const (
 )
 
 type Session struct {
-	ID        string `db:"id"` // UUIDv7
-	UserID    int64  `db:"user_id"`
+	ID        string `db:"id"`      // UUIDv7
+	UserID    string `db:"user_id"` // FK to users.id (UUID)
 	TokenHash []byte `db:"token_hash"`
 	CreatedAt int64  `db:"created_at"` // store as Unix timestamp (seconds since epoch)
 	ExpiresAt int64  `db:"expires_at"` // store as Unix timestamp (seconds since epoch)
@@ -41,12 +41,12 @@ type SessionCutoff struct {
 }
 
 type UserIDArgs struct {
-	UserID int64 `db:"user_id"`
+	UserID string `db:"user_id"`
 }
 
 type DeleteOldestArgs struct {
-	UserID int64 `db:"user_id"`
-	Limit  int   `db:"limit"`
+	UserID string `db:"user_id"`
+	Limit  int    `db:"limit"`
 }
 
 func (db *Database) CreateSession(ctx context.Context, session *Session) error {
@@ -191,7 +191,7 @@ func (db *Database) DeleteExpiredSessions(ctx context.Context) (int, error) {
 	return result.(int), nil
 }
 
-func (db *Database) CountSessionsByUser(ctx context.Context, userID int64) (int, error) {
+func (db *Database) CountSessionsByUser(ctx context.Context, userID string) (int, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "COUNT", SessionsTableName),
@@ -226,7 +226,7 @@ func (db *Database) CountSessionsByUser(ctx context.Context, userID int64) (int,
 	return result.Count, nil
 }
 
-func (db *Database) DeleteOldestSessions(ctx context.Context, userID int64, limit int) error {
+func (db *Database) DeleteOldestSessions(ctx context.Context, userID string, limit int) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", SessionsTableName),
@@ -257,7 +257,7 @@ func (db *Database) DeleteOldestSessions(ctx context.Context, userID int64, limi
 	return nil
 }
 
-func (db *Database) DeleteAllSessionsForUser(ctx context.Context, userID int64) error {
+func (db *Database) DeleteAllSessionsForUser(ctx context.Context, userID string) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "DELETE", SessionsTableName),
@@ -275,7 +275,7 @@ func (db *Database) DeleteAllSessionsForUser(ctx context.Context, userID int64) 
 
 	DBQueriesTotal.WithLabelValues(SessionsTableName, "delete").Inc()
 
-	_, err := opDeleteAllSessionsForUser.Invoke(db, &int64Payload{Value: userID})
+	_, err := opDeleteAllSessionsForUser.Invoke(db, &stringPayload{Value: userID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -17,7 +18,7 @@ import (
 const SessionsTableName = "sessions"
 
 const (
-	createSessionStmt            = "INSERT INTO %s (user_id, token_hash, created_at, expires_at) VALUES ($Session.user_id, $Session.token_hash, $Session.created_at, $Session.expires_at)"
+	createSessionStmt            = "INSERT INTO %s (id, user_id, token_hash, created_at, expires_at) VALUES ($Session.id, $Session.user_id, $Session.token_hash, $Session.created_at, $Session.expires_at)"
 	getSessionByTokenHashStmt    = "SELECT &Session.* FROM %s WHERE token_hash==$Session.token_hash"
 	deleteSessionByTokenHashStmt = "DELETE FROM %s WHERE token_hash==$Session.token_hash"       // #nosec: G101
 	deleteExpiredSessionsStmt    = "DELETE FROM %s WHERE expires_at <= $SessionCutoff.now_unix" // #nosec: G101
@@ -28,7 +29,7 @@ const (
 )
 
 type Session struct {
-	ID        int    `db:"id"`
+	ID        string `db:"id"` // UUIDv7
 	UserID    int64  `db:"user_id"`
 	TokenHash []byte `db:"token_hash"`
 	CreatedAt int64  `db:"created_at"` // store as Unix timestamp (seconds since epoch)
@@ -48,7 +49,7 @@ type DeleteOldestArgs struct {
 	Limit  int   `db:"limit"`
 }
 
-func (db *Database) CreateSession(ctx context.Context, session *Session) (int64, error) {
+func (db *Database) CreateSession(ctx context.Context, session *Session) error {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "INSERT", SessionsTableName),
@@ -66,17 +67,26 @@ func (db *Database) CreateSession(ctx context.Context, session *Session) (int64,
 
 	DBQueriesTotal.WithLabelValues(SessionsTableName, "insert").Inc()
 
-	result, err := opCreateSession.Invoke(db, session)
+	if session.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate session id: %w", err)
+		}
+
+		session.ID = id.String()
+	}
+
+	_, err := opCreateSession.Invoke(db, session)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
-		return 0, err
+		return err
 	}
 
 	span.SetStatus(codes.Ok, "")
 
-	return result.(int64), nil
+	return nil
 }
 
 func (db *Database) GetSessionByTokenHash(ctx context.Context, tokenHash []byte) (*Session, error) {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -47,7 +47,7 @@ func TestSessionsEndToEnd(t *testing.T) {
 		ExpiresAt: expiresAt.Unix(),
 	}
 
-	_, err = database.CreateSession(context.Background(), session)
+	err = database.CreateSession(context.Background(), session)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateSession: %s", err)
 	}
@@ -109,7 +109,7 @@ func TestDeleteSessionByTokenHash(t *testing.T) {
 		ExpiresAt: expiresAt.Unix(),
 	}
 
-	_, err = database.CreateSession(context.Background(), session)
+	err = database.CreateSession(context.Background(), session)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateSession: %s", err)
 	}
@@ -179,12 +179,12 @@ func TestDeleteExpiredSessions(t *testing.T) {
 		ExpiresAt: now.Add(1 * time.Hour).Unix(),
 	}
 
-	_, err = database.CreateSession(context.Background(), expiredSession)
+	err = database.CreateSession(context.Background(), expiredSession)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateSession for expired session: %s", err)
 	}
 
-	_, err = database.CreateSession(context.Background(), validSession)
+	err = database.CreateSession(context.Background(), validSession)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateSession for valid session: %s", err)
 	}
@@ -260,7 +260,7 @@ func TestDeleteManyExpiredSessions(t *testing.T) {
 			session.ExpiresAt = now.Add(5 * time.Minute).Unix() // valid
 		}
 
-		_, err = database.CreateSession(context.Background(), session)
+		err = database.CreateSession(context.Background(), session)
 		if err != nil {
 			t.Fatalf("Couldn't complete CreateSession for session %d: %s", i, err)
 		}
@@ -346,7 +346,7 @@ func TestDeleteAllSessionsForUser(t *testing.T) {
 			ExpiresAt: expiresAt,
 		}
 
-		_, err = database.CreateSession(context.Background(), session)
+		err = database.CreateSession(context.Background(), session)
 		if err != nil {
 			t.Fatalf("Couldn't complete CreateSession: %s", err)
 		}
@@ -359,7 +359,7 @@ func TestDeleteAllSessionsForUser(t *testing.T) {
 		ExpiresAt: expiresAt,
 	}
 
-	_, err = database.CreateSession(context.Background(), user2Session)
+	err = database.CreateSession(context.Background(), user2Session)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateSession: %s", err)
 	}
@@ -432,7 +432,7 @@ func TestDeleteAllSessions(t *testing.T) {
 	}
 
 	for _, s := range sessions {
-		_, err = database.CreateSession(context.Background(), s)
+		err = database.CreateSession(context.Background(), s)
 		if err != nil {
 			t.Fatalf("Couldn't complete CreateSession: %s", err)
 		}

--- a/internal/db/subscribers.go
+++ b/internal/db/subscribers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -20,7 +21,7 @@ const SubscribersTableName = "subscribers"
 const (
 	listSubscribersPagedStmt  = "SELECT &Subscriber.*, COUNT(*) OVER() AS &NumItems.count from %s LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
 	getSubscriberStmt         = "SELECT &Subscriber.* from %s WHERE imsi==$Subscriber.imsi"
-	createSubscriberStmt      = "INSERT INTO %s (imsi, sequenceNumber, permanentKey, opc, profileID) VALUES ($Subscriber.imsi, $Subscriber.sequenceNumber, $Subscriber.permanentKey, $Subscriber.opc, $Subscriber.profileID)"
+	createSubscriberStmt      = "INSERT INTO %s (id, imsi, sequenceNumber, permanentKey, opc, profileID) VALUES ($Subscriber.id, $Subscriber.imsi, $Subscriber.sequenceNumber, $Subscriber.permanentKey, $Subscriber.opc, $Subscriber.profileID)"
 	editSubscriberProfileStmt = "UPDATE %s SET profileID=$Subscriber.profileID WHERE imsi==$Subscriber.imsi"
 	editSubscriberSeqNumStmt  = "UPDATE %s SET sequenceNumber=$Subscriber.sequenceNumber WHERE imsi==$Subscriber.imsi"
 	deleteSubscriberStmt      = "DELETE FROM %s WHERE imsi==$Subscriber.imsi"
@@ -28,12 +29,12 @@ const (
 )
 
 type Subscriber struct {
-	ID             int    `db:"id"`
+	ID             string `db:"id"` // UUIDv7
 	Imsi           string `db:"imsi"`
 	SequenceNumber string `db:"sequenceNumber"`
 	PermanentKey   string `db:"permanentKey"`
 	Opc            string `db:"opc"`
-	ProfileID      int    `db:"profileID"`
+	ProfileID      string `db:"profileID"`
 }
 
 func (db *Database) ListSubscribersPage(ctx context.Context, page int, perPage int) ([]Subscriber, int, error) {
@@ -149,6 +150,15 @@ func (db *Database) CreateSubscriber(ctx context.Context, subscriber *Subscriber
 	defer timer.ObserveDuration()
 
 	DBQueriesTotal.WithLabelValues(SubscribersTableName, "insert").Inc()
+
+	if subscriber.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate subscriber id: %w", err)
+		}
+
+		subscriber.ID = id.String()
+	}
 
 	_, err := opCreateSubscriber.Invoke(db, subscriber)
 	if err != nil {

--- a/internal/db/subscribers_test.go
+++ b/internal/db/subscribers_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ellanetworks/core/internal/db"
 )
 
-func createDataNetworkAndPolicy(database *db.Database) (int, error) {
+func createDataNetworkAndPolicy(database *db.Database) (string, error) {
 	newDataNetwork := &db.DataNetwork{
 		Name:   "not-internet",
 		IPPool: "1.2.3.0/24",
@@ -18,12 +18,12 @@ func createDataNetworkAndPolicy(database *db.Database) (int, error) {
 
 	err := database.CreateDataNetwork(context.Background(), newDataNetwork)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	createdNetwork, err := database.GetDataNetwork(context.Background(), newDataNetwork.Name)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	profile := &db.Profile{
@@ -34,12 +34,12 @@ func createDataNetworkAndPolicy(database *db.Database) (int, error) {
 
 	err = database.CreateProfile(context.Background(), profile)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	createdProfile, err := database.GetProfile(context.Background(), profile.Name)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	slice := &db.NetworkSlice{
@@ -49,12 +49,12 @@ func createDataNetworkAndPolicy(database *db.Database) (int, error) {
 
 	err = database.CreateNetworkSlice(context.Background(), slice)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	createdSlice, err := database.GetNetworkSlice(context.Background(), slice.Name)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	policy := &db.Policy{
@@ -70,7 +70,7 @@ func createDataNetworkAndPolicy(database *db.Database) (int, error) {
 
 	err = database.CreatePolicy(context.Background(), policy)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 
 	return createdProfile.ID, nil
@@ -182,7 +182,7 @@ func TestSubscribersDbEndToEnd(t *testing.T) {
 	}
 
 	if retrievedSubscriber.ProfileID != newProfileCreated.ID {
-		t.Fatalf("Profile IDs don't match: %d", retrievedSubscriber.ProfileID)
+		t.Fatalf("Profile IDs don't match: %s", retrievedSubscriber.ProfileID)
 	}
 
 	if err = database.DeleteSubscriber(context.Background(), subscriber.Imsi); err != nil {

--- a/internal/db/supportbundle_test.go
+++ b/internal/db/supportbundle_test.go
@@ -136,7 +136,7 @@ func TestExportSupportData_WithEntries(t *testing.T) {
 		t.Fatalf("unable to list data networks: %v", err)
 	}
 
-	var dnID int
+	var dnID string
 
 	for _, d := range dns {
 		if d.Name == dn.Name {
@@ -145,11 +145,21 @@ func TestExportSupportData_WithEntries(t *testing.T) {
 		}
 	}
 
-	if dnID == 0 {
+	if dnID == "" {
 		t.Fatalf("couldn't find created data network")
 	}
 
-	policy := &db.Policy{Name: "support-policy", SessionAmbrUplink: "100 Mbps", SessionAmbrDownlink: "100 Mbps", Var5qi: 9, Arp: 1, DataNetworkID: dnID, ProfileID: 1, SliceID: 1}
+	defaultProfile, err := database.GetProfile(context.Background(), db.InitialProfileName)
+	if err != nil {
+		t.Fatalf("Couldn't get default profile: %v", err)
+	}
+
+	defaultSlice, err := database.GetNetworkSlice(context.Background(), db.InitialSliceName)
+	if err != nil {
+		t.Fatalf("Couldn't get default slice: %v", err)
+	}
+
+	policy := &db.Policy{Name: "support-policy", SessionAmbrUplink: "100 Mbps", SessionAmbrDownlink: "100 Mbps", Var5qi: 9, Arp: 1, DataNetworkID: dnID, ProfileID: defaultProfile.ID, SliceID: defaultSlice.ID}
 	if err := database.CreatePolicy(context.Background(), policy); err != nil {
 		t.Fatalf("CreatePolicy failed: %v", err)
 	}
@@ -160,7 +170,7 @@ func TestExportSupportData_WithEntries(t *testing.T) {
 		SequenceNumber: "000000000001",
 		PermanentKey:   strings.Repeat("p", 32),
 		Opc:            strings.Repeat("o", 32),
-		ProfileID:      1,
+		ProfileID:      defaultProfile.ID,
 	}
 	if err := database.CreateSubscriber(context.Background(), sub); err != nil {
 		t.Fatalf("CreateSubscriber failed: %v", err)
@@ -239,15 +249,8 @@ func TestExportSupportData_WithEntries(t *testing.T) {
 				idAny = v
 			}
 
-			switch idv := idAny.(type) {
-			case int:
-				if idv == dnID {
-					foundPolicy = true
-				}
-			case float64:
-				if int(idv) == dnID {
-					foundPolicy = true
-				}
+			if idv, ok := idAny.(string); ok && idv == dnID {
+				foundPolicy = true
 			}
 		}
 	}

--- a/internal/db/supportbundle_test.go
+++ b/internal/db/supportbundle_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/dbwriter"
+	"github.com/google/uuid"
 )
 
 func TestExportSupportData_Default(t *testing.T) {
@@ -105,7 +106,13 @@ func TestExportSupportData_WithEntries(t *testing.T) {
 	}()
 
 	// insert an audit log
+	auditID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7: %v", err)
+	}
+
 	al := &dbwriter.AuditLog{
+		ID:        auditID.String(),
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Level:     "INFO",
 		Actor:     "testuser",

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -21,7 +22,7 @@ const (
 	listUsersPageStmt    = "SELECT &User.*, COUNT(*) OVER() AS &NumItems.count from %s ORDER BY id LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
 	getUserStmt          = "SELECT &User.* from %s WHERE email==$User.email"
 	getUserByIDStmt      = "SELECT &User.* from %s WHERE id==$User.id"
-	createUserStmt       = "INSERT INTO %s (email, roleID, hashedPassword) VALUES ($User.email, $User.roleID, $User.hashedPassword)"
+	createUserStmt       = "INSERT INTO %s (id, email, roleID, hashedPassword) VALUES ($User.id, $User.email, $User.roleID, $User.hashedPassword)"
 	editUserStmt         = "UPDATE %s SET roleID=$User.roleID WHERE email==$User.email"
 	editUserPasswordStmt = "UPDATE %s SET hashedPassword=$User.hashedPassword WHERE email==$User.email" // #nosec: G101
 	deleteUserStmt       = "DELETE FROM %s WHERE email==$User.email"
@@ -37,7 +38,7 @@ const (
 )
 
 type User struct {
-	ID             int64  `db:"id"`
+	ID             string `db:"id"` // UUIDv7
 	Email          string `db:"email"`
 	RoleID         RoleID `db:"roleID"`
 	HashedPassword string `db:"hashedPassword"`
@@ -141,7 +142,7 @@ func (db *Database) GetUser(ctx context.Context, email string) (*User, error) {
 }
 
 // GetUserByID fetches a single user by ID with a span named "SELECT users".
-func (db *Database) GetUserByID(ctx context.Context, id int64) (*User, error) {
+func (db *Database) GetUserByID(ctx context.Context, id string) (*User, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "SELECT", UsersTableName),
@@ -179,7 +180,7 @@ func (db *Database) GetUserByID(ctx context.Context, id int64) (*User, error) {
 	return &row, nil
 }
 
-func (db *Database) CreateUser(ctx context.Context, user *User) (int64, error) {
+func (db *Database) CreateUser(ctx context.Context, user *User) (string, error) {
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s", "INSERT", UsersTableName),
@@ -197,17 +198,25 @@ func (db *Database) CreateUser(ctx context.Context, user *User) (int64, error) {
 
 	DBQueriesTotal.WithLabelValues(UsersTableName, "insert").Inc()
 
-	result, err := opCreateUser.Invoke(db, user)
-	if err != nil {
+	if user.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return "", fmt.Errorf("generate user id: %w", err)
+		}
+
+		user.ID = id.String()
+	}
+
+	if _, err := opCreateUser.Invoke(db, user); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
-		return 0, err
+		return "", err
 	}
 
 	span.SetStatus(codes.Ok, "")
 
-	return result.(int64), nil
+	return user.ID, nil
 }
 
 // UpdateUser updates a user's role with a span named "UPDATE users".

--- a/internal/db/users_test.go
+++ b/internal/db/users_test.go
@@ -47,8 +47,8 @@ func TestDBUsersEndToEnd(t *testing.T) {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
 
-	if userID == 0 {
-		t.Fatalf("Expected user ID to be non-zero after creation")
+	if userID == "" {
+		t.Fatalf("Expected user ID to be non-empty after creation")
 	}
 
 	res, total, err = database.ListUsersPage(context.Background(), 1, 10)

--- a/internal/dbwriter/buffered_test.go
+++ b/internal/dbwriter/buffered_test.go
@@ -138,6 +138,7 @@ func TestBufferedDBWriter_AuditLogIsSynchronous(t *testing.T) {
 	buf := dbwriter.NewBufferedDBWriter(fake, 10, zap.NewNop())
 
 	err := buf.InsertAuditLog(context.Background(), &dbwriter.AuditLog{
+		ID:     "01900000-0000-7000-8000-000000000001",
 		Action: "create_subscriber",
 		Actor:  "admin",
 	})

--- a/internal/dbwriter/dbwriter.go
+++ b/internal/dbwriter/dbwriter.go
@@ -16,7 +16,7 @@ type RadioEvent struct {
 }
 
 type AuditLog struct {
-	ID        int    `db:"id"`
+	ID        string `db:"id"`        // UUIDv7, generated at the request handler
 	Timestamp string `db:"timestamp"` // store as RFC3339 string; parse in API layer if needed
 	Level     string `db:"level"`
 	Actor     string `db:"actor"`

--- a/internal/ipam/pool.go
+++ b/internal/ipam/pool.go
@@ -12,15 +12,15 @@ import (
 // offsets and addresses. The offset is relative to the network base address
 // (e.g. for 10.0.0.0/24, offset 1 = 10.0.0.1).
 type Pool struct {
-	// ID is the data_networks.id primary key, used as pool_id in ip_leases.
-	ID int
+	// ID is the data_networks.id primary key (UUID), used as pool_id in ip_leases.
+	ID string
 
 	// Prefix is the parsed CIDR (e.g. "10.45.0.0/22" → 10.45.0.0/22).
 	Prefix netip.Prefix
 }
 
 // NewPool creates a Pool from a data network ID and CIDR string.
-func NewPool(id int, cidr string) (Pool, error) {
+func NewPool(id string, cidr string) (Pool, error) {
 	prefix, err := netip.ParsePrefix(cidr)
 	if err != nil {
 		return Pool{}, fmt.Errorf("invalid CIDR %q: %w", cidr, err)

--- a/internal/ipam/pool_test.go
+++ b/internal/ipam/pool_test.go
@@ -23,7 +23,7 @@ func TestNewPool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pool, err := NewPool(1, tt.cidr)
+			pool, err := NewPool("test-pool", tt.cidr)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -44,7 +44,7 @@ func TestNewPool(t *testing.T) {
 }
 
 func TestPoolFirstUsable(t *testing.T) {
-	pool, _ := NewPool(1, "192.168.1.0/24")
+	pool, _ := NewPool("test-pool", "192.168.1.0/24")
 	if pool.FirstUsable() != 1 {
 		t.Fatalf("expected FirstUsable=1 for IPv4, got %d", pool.FirstUsable())
 	}
@@ -64,7 +64,7 @@ func TestPoolSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.cidr, func(t *testing.T) {
-			pool, err := NewPool(1, tt.cidr)
+			pool, err := NewPool("test-pool", tt.cidr)
 			if err != nil {
 				t.Fatalf("NewPool: %v", err)
 			}
@@ -77,7 +77,7 @@ func TestPoolSize(t *testing.T) {
 }
 
 func TestPoolAddressAtOffset(t *testing.T) {
-	pool, _ := NewPool(1, "192.168.1.0/24")
+	pool, _ := NewPool("test-pool", "192.168.1.0/24")
 
 	tests := []struct {
 		offset int
@@ -99,7 +99,7 @@ func TestPoolAddressAtOffset(t *testing.T) {
 }
 
 func TestPoolAddressAtOffset_Slash22(t *testing.T) {
-	pool, _ := NewPool(1, "10.45.0.0/22")
+	pool, _ := NewPool("test-pool", "10.45.0.0/22")
 
 	// First usable = 10.45.0.1 (offset 1)
 	got := pool.AddressAtOffset(1)
@@ -121,7 +121,7 @@ func TestPoolAddressAtOffset_Slash22(t *testing.T) {
 }
 
 func TestPoolOffsetOf(t *testing.T) {
-	pool, _ := NewPool(1, "192.168.1.0/24")
+	pool, _ := NewPool("test-pool", "192.168.1.0/24")
 
 	tests := []struct {
 		addr       string
@@ -145,7 +145,7 @@ func TestPoolOffsetOf(t *testing.T) {
 }
 
 func TestPoolOffsetOf_Slash22(t *testing.T) {
-	pool, _ := NewPool(1, "10.45.0.0/22")
+	pool, _ := NewPool("test-pool", "10.45.0.0/22")
 
 	addr := netip.MustParseAddr("10.45.3.254")
 
@@ -156,7 +156,7 @@ func TestPoolOffsetOf_Slash22(t *testing.T) {
 }
 
 func TestPoolRoundTrip(t *testing.T) {
-	pool, _ := NewPool(1, "10.45.0.0/22")
+	pool, _ := NewPool("test-pool", "10.45.0.0/22")
 
 	// For every offset in the usable range, AddressAtOffset and OffsetOf
 	// must be inverses of each other.

--- a/internal/ipam/sequential.go
+++ b/internal/ipam/sequential.go
@@ -14,13 +14,13 @@ import (
 // It is satisfied by *db.Database.
 type LeaseStore interface {
 	// GetDynamicLease returns the dynamic lease for (poolID, imsi), or ErrNotFound.
-	GetDynamicLease(ctx context.Context, poolID int, imsi string) (*Lease, error)
+	GetDynamicLease(ctx context.Context, poolID string, imsi string) (*Lease, error)
 
 	// GetLeaseBySession returns the lease for (poolID, sessionID, imsi), or ErrNotFound.
-	GetLeaseBySession(ctx context.Context, poolID int, sessionID int, imsi string) (*Lease, error)
+	GetLeaseBySession(ctx context.Context, poolID string, sessionID int, imsi string) (*Lease, error)
 
 	// ListLeaseAddressesByPool returns sorted address strings for all leases in the pool.
-	ListLeaseAddressesByPool(ctx context.Context, poolID int) ([]string, error)
+	ListLeaseAddressesByPool(ctx context.Context, poolID string) ([]string, error)
 
 	// CreateLease inserts a new lease. Returns ErrAlreadyExists on unique violation.
 	CreateLease(ctx context.Context, lease *Lease) error
@@ -39,7 +39,7 @@ type LeaseStore interface {
 // cycle. The db package satisfies LeaseStore via adapter methods.
 type Lease struct {
 	ID        string
-	PoolID    int
+	PoolID    string
 	Address   string
 	IMSI      string
 	SessionID *int

--- a/internal/ipam/sequential.go
+++ b/internal/ipam/sequential.go
@@ -26,19 +26,19 @@ type LeaseStore interface {
 	CreateLease(ctx context.Context, lease *Lease) error
 
 	// UpdateLeaseSession sets the sessionID on a lease.
-	UpdateLeaseSession(ctx context.Context, leaseID int, sessionID int) error
+	UpdateLeaseSession(ctx context.Context, leaseID string, sessionID int) error
 
 	// UpdateLeaseNode updates the nodeID and sessionID on a lease.
-	UpdateLeaseNode(ctx context.Context, leaseID int, nodeID int, sessionID int) error
+	UpdateLeaseNode(ctx context.Context, leaseID string, nodeID int, sessionID int) error
 
 	// DeleteDynamicLease deletes a dynamic lease by ID.
-	DeleteDynamicLease(ctx context.Context, leaseID int) error
+	DeleteDynamicLease(ctx context.Context, leaseID string) error
 }
 
 // Lease mirrors db.IPLease but lives in the ipam package to avoid an import
 // cycle. The db package satisfies LeaseStore via adapter methods.
 type Lease struct {
-	ID        int
+	ID        string
 	PoolID    int
 	Address   string
 	IMSI      string

--- a/internal/ipam/sequential_test.go
+++ b/internal/ipam/sequential_test.go
@@ -32,7 +32,7 @@ func (s *fakeStore) allocID() string {
 	return fmt.Sprintf("lease-%d", id)
 }
 
-func (s *fakeStore) GetDynamicLease(_ context.Context, poolID int, imsi string) (*Lease, error) {
+func (s *fakeStore) GetDynamicLease(_ context.Context, poolID string, imsi string) (*Lease, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -45,7 +45,7 @@ func (s *fakeStore) GetDynamicLease(_ context.Context, poolID int, imsi string) 
 	return nil, ErrNotFound
 }
 
-func (s *fakeStore) GetLeaseBySession(_ context.Context, poolID int, sessionID int, imsi string) (*Lease, error) {
+func (s *fakeStore) GetLeaseBySession(_ context.Context, poolID string, sessionID int, imsi string) (*Lease, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -59,7 +59,7 @@ func (s *fakeStore) GetLeaseBySession(_ context.Context, poolID int, sessionID i
 	return nil, ErrNotFound
 }
 
-func (s *fakeStore) ListLeaseAddressesByPool(_ context.Context, poolID int) ([]string, error) {
+func (s *fakeStore) ListLeaseAddressesByPool(_ context.Context, poolID string) ([]string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -141,7 +141,7 @@ func (s *fakeStore) DeleteDynamicLease(_ context.Context, leaseID string) error 
 // ---------------------------------------------------------------------------
 
 func mustPool(cidr string) Pool {
-	p, err := NewPool(1, cidr)
+	p, err := NewPool("test-pool", cidr)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/ipam/sequential_test.go
+++ b/internal/ipam/sequential_test.go
@@ -25,6 +25,13 @@ func newFakeStore() *fakeStore {
 	return &fakeStore{nextID: 1}
 }
 
+func (s *fakeStore) allocID() string {
+	id := s.nextID
+	s.nextID++
+
+	return fmt.Sprintf("lease-%d", id)
+}
+
 func (s *fakeStore) GetDynamicLease(_ context.Context, poolID int, imsi string) (*Lease, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -79,14 +86,13 @@ func (s *fakeStore) CreateLease(_ context.Context, lease *Lease) error {
 		}
 	}
 
-	lease.ID = s.nextID
-	s.nextID++
+	lease.ID = s.allocID()
 	s.leases = append(s.leases, *lease)
 
 	return nil
 }
 
-func (s *fakeStore) UpdateLeaseSession(_ context.Context, leaseID int, sessionID int) error {
+func (s *fakeStore) UpdateLeaseSession(_ context.Context, leaseID string, sessionID int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -100,7 +106,7 @@ func (s *fakeStore) UpdateLeaseSession(_ context.Context, leaseID int, sessionID
 	return ErrNotFound
 }
 
-func (s *fakeStore) UpdateLeaseNode(_ context.Context, leaseID int, nodeID int, sessionID int) error {
+func (s *fakeStore) UpdateLeaseNode(_ context.Context, leaseID string, nodeID int, sessionID int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -116,7 +122,7 @@ func (s *fakeStore) UpdateLeaseNode(_ context.Context, leaseID int, nodeID int, 
 	return ErrNotFound
 }
 
-func (s *fakeStore) DeleteDynamicLease(_ context.Context, leaseID int) error {
+func (s *fakeStore) DeleteDynamicLease(_ context.Context, leaseID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/dbwriter"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -179,7 +180,14 @@ func LogAuditEvent(ctx context.Context, action, actor, ip, details string) {
 		return
 	}
 
-	err := dbInstance.InsertAuditLog(ctx, &dbwriter.AuditLog{
+	id, err := uuid.NewV7()
+	if err != nil {
+		AuditLog.Warn("failed to generate audit log id", zap.Error(err))
+		return
+	}
+
+	err = dbInstance.InsertAuditLog(ctx, &dbwriter.AuditLog{
+		ID:        id.String(),
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Level:     "INFO",
 		Actor:     actor,

--- a/internal/models/session.go
+++ b/internal/models/session.go
@@ -13,7 +13,7 @@ import (
 type EstablishRequest struct {
 	LocalSEID uint64
 	IMSI      string
-	PolicyID  int64
+	PolicyID  string
 	PDRs      []PDR
 	FARs      []FAR
 	QERs      []QER
@@ -130,7 +130,7 @@ type URR struct {
 // RuleUpdate→Update, RuleRemove→Remove).
 type ModifyRequest struct {
 	SEID     uint64
-	PolicyID int64
+	PolicyID string
 
 	CreatePDRs   []PDR
 	UpdatePDRs   []PDR

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -335,7 +335,7 @@ func (s *SMF) sendPFCPRules(ctx context.Context, smContext *SMContext) error {
 		return fmt.Errorf("PFCP context not initialized")
 	}
 
-	var policyID int64
+	var policyID string
 	if smContext.PolicyData != nil {
 		policyID = smContext.PolicyData.PolicyID
 	}

--- a/internal/smf/deactivate.go
+++ b/internal/smf/deactivate.go
@@ -60,7 +60,7 @@ func (s *SMF) DeactivateSmContext(ctx context.Context, smContextRef string) erro
 
 	err = s.upf.ModifySession(ctx, BuildModifyRequest(
 		remoteSEID,
-		0,
+		"",
 		nil, farList, nil,
 	))
 	if err != nil {

--- a/internal/smf/pfcp_rules.go
+++ b/internal/smf/pfcp_rules.go
@@ -64,7 +64,7 @@ func (u *URR) ToURR() models.URR {
 func BuildEstablishRequest(
 	localSEID uint64,
 	imsi string,
-	policyID int64,
+	policyID string,
 	pdrs []*PDR,
 	fars []*FAR,
 	qers []*QER,
@@ -116,7 +116,7 @@ func BuildEstablishRequest(
 // states are advanced to RuleCreate.
 func BuildModifyRequest(
 	remoteSEID uint64,
-	policyID int64,
+	policyID string,
 	pdrs []*PDR,
 	fars []*FAR,
 	qers []*QER,

--- a/internal/smf/policy_fetch_test.go
+++ b/internal/smf/policy_fetch_test.go
@@ -89,8 +89,8 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 		t.Fatalf("couldn't create rule 1: %s", err)
 	}
 
-	if id1 == 0 {
-		t.Fatalf("expected non-zero rule ID")
+	if id1 == "" {
+		t.Fatalf("expected non-empty rule ID")
 	}
 
 	prefix2 := "10.0.0.0/8"
@@ -111,8 +111,8 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 		t.Fatalf("couldn't create rule 2: %s", err)
 	}
 
-	if id2 == 0 {
-		t.Fatalf("expected non-zero rule ID")
+	if id2 == "" {
+		t.Fatalf("expected non-empty rule ID")
 	}
 
 	subscriber := &db.Subscriber{

--- a/internal/smf/policy_fetch_test.go
+++ b/internal/smf/policy_fetch_test.go
@@ -50,6 +50,16 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 		t.Fatalf("couldn't get test profile: %s", err)
 	}
 
+	testSlice := &db.NetworkSlice{Name: "test-slice", Sst: 1}
+	if err := database.CreateNetworkSlice(ctx, testSlice); err != nil {
+		t.Fatalf("couldn't create test slice: %s", err)
+	}
+
+	createdSlice, err := database.GetNetworkSlice(ctx, "test-slice")
+	if err != nil {
+		t.Fatalf("couldn't get test slice: %s", err)
+	}
+
 	policy := &db.Policy{
 		Name:                "test-policy",
 		SessionAmbrUplink:   "100 Mbps",
@@ -58,7 +68,7 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 		Arp:                 1,
 		DataNetworkID:       testDataNetwork.ID,
 		ProfileID:           createdProfile.ID,
-		SliceID:             1,
+		SliceID:             createdSlice.ID,
 	}
 
 	err = database.CreatePolicy(ctx, policy)
@@ -73,7 +83,7 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 
 	prefix1 := "192.168.0.0/24"
 	rule1 := &db.NetworkRule{
-		PolicyID:     int64(createdPolicy.ID),
+		PolicyID:     createdPolicy.ID,
 		Description:  "rule-1",
 		Direction:    "uplink",
 		RemotePrefix: &prefix1,
@@ -95,7 +105,7 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 
 	prefix2 := "10.0.0.0/8"
 	rule2 := &db.NetworkRule{
-		PolicyID:     int64(createdPolicy.ID),
+		PolicyID:     createdPolicy.ID,
 		Description:  "rule-2",
 		Direction:    "downlink",
 		RemotePrefix: &prefix2,
@@ -263,6 +273,16 @@ func TestGetSessionPolicy_NoNetworkRules(t *testing.T) {
 		t.Fatalf("couldn't get test profile: %s", err)
 	}
 
+	testSlice := &db.NetworkSlice{Name: "test-slice-2", Sst: 1}
+	if err := database.CreateNetworkSlice(ctx, testSlice); err != nil {
+		t.Fatalf("couldn't create test slice: %s", err)
+	}
+
+	createdSlice, err := database.GetNetworkSlice(ctx, "test-slice-2")
+	if err != nil {
+		t.Fatalf("couldn't get test slice: %s", err)
+	}
+
 	policy := &db.Policy{
 		Name:                "test-policy-no-rules",
 		SessionAmbrUplink:   "50 Mbps",
@@ -271,7 +291,7 @@ func TestGetSessionPolicy_NoNetworkRules(t *testing.T) {
 		Arp:                 1,
 		DataNetworkID:       testDataNetwork.ID,
 		ProfileID:           createdProfile.ID,
-		SliceID:             1,
+		SliceID:             createdSlice.ID,
 	}
 
 	err = database.CreatePolicy(ctx, policy)

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -77,7 +77,7 @@ type UPFClient interface {
 	FlushUsage(ctx context.Context, remoteSEID uint64)
 	DeleteSession(ctx context.Context, remoteSEID uint64) error
 
-	UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error
+	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error
 }
 
 // AMFCallback abstracts the SMF → AMF communication.
@@ -96,7 +96,7 @@ type AMFCallback interface {
 // ResolvedNetworkRule represents a network rule attached to a policy for PDI/SDF filtering.
 type ResolvedNetworkRule struct {
 	Description  string
-	PolicyID     int64
+	PolicyID     string
 	Direction    models.Direction
 	RemotePrefix *string
 	Protocol     int32
@@ -109,7 +109,7 @@ type ResolvedNetworkRule struct {
 // Policy contains the QoS parameters, network rules, and DNN configuration
 // the SMF needs for a session.
 type Policy struct {
-	PolicyID     int64 // DB primary key; populated by GetSessionPolicy
+	PolicyID     string // DB primary key (UUID); populated by GetSessionPolicy
 	Ambr         models.Ambr
 	QosData      models.QosData
 	NetworkRules []*ResolvedNetworkRule

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -138,7 +138,7 @@ func (f *fakeUPF) DeleteSession(_ context.Context, remoteSEID uint64) error {
 
 func (f *fakeUPF) FlushUsage(_ context.Context, _ uint64) {}
 
-func (f *fakeUPF) UpdateFilters(_ context.Context, _ int64, _ models.Direction, _ []models.FilterRule) error {
+func (f *fakeUPF) UpdateFilters(_ context.Context, _ string, _ models.Direction, _ []models.FilterRule) error {
 	return nil
 }
 

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -170,7 +170,7 @@ func (s *SMF) UpdateSmContextN2InfoPduResSetupRsp(ctx context.Context, smContext
 
 	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
 		smContext.PFCPContext.RemoteSEID,
-		0,
+		"",
 		pdrList, farList, nil,
 	)); err != nil {
 		span.RecordError(err)
@@ -562,7 +562,7 @@ func (s *SMF) UpdateSmContextXnHandoverPathSwitchReq(ctx context.Context, smCont
 
 	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
 		smContext.PFCPContext.RemoteSEID,
-		0,
+		"",
 		pdrList, farList, nil,
 	)); err != nil {
 		return nil, fmt.Errorf("failed to send PFCP session modification request: %v", err)

--- a/internal/upf/engine/establish_session.go
+++ b/internal/upf/engine/establish_session.go
@@ -96,7 +96,7 @@ func (conn *SessionEngine) EstablishSession(ctx context.Context, req *models.Est
 			return nil, fmt.Errorf("couldn't extract PDR info: %w", err)
 		}
 
-		if req.PolicyID != 0 {
+		if req.PolicyID != "" {
 			dir := models.DirectionUplink
 			if spdrInfo.UEIP.IsValid() {
 				dir = models.DirectionDownlink
@@ -127,7 +127,7 @@ func (conn *SessionEngine) EstablishSession(ctx context.Context, req *models.Est
 	span.AddEvent("pdrs_processed", trace.WithAttributes(attribute.Int("count", len(createdPDRs))))
 	span.AddEvent("ebpf_maps_updated")
 
-	if req.PolicyID != 0 {
+	if req.PolicyID != "" {
 		sess.SetPolicyID(req.PolicyID)
 	}
 

--- a/internal/upf/engine/modify_session.go
+++ b/internal/upf/engine/modify_session.go
@@ -135,11 +135,11 @@ func (conn *SessionEngine) ModifySession(ctx context.Context, req *models.Modify
 		}
 
 		policyID := req.PolicyID
-		if policyID == 0 {
+		if policyID == "" {
 			policyID = session.PolicyID()
 		}
 
-		if policyID != 0 {
+		if policyID != "" {
 			dir := models.DirectionUplink
 			if spdrInfo.UEIP.IsValid() {
 				dir = models.DirectionDownlink
@@ -199,7 +199,7 @@ func (conn *SessionEngine) ModifySession(ctx context.Context, req *models.Modify
 
 	logger.WithTrace(ctx, logger.UpfLog).Debug("Session modification successful")
 
-	if req.PolicyID != 0 && req.PolicyID != session.PolicyID() {
+	if req.PolicyID != "" && req.PolicyID != session.PolicyID() {
 		oldPolicyID := session.PolicyID()
 		session.SetPolicyID(req.PolicyID)
 

--- a/internal/upf/engine/sdf_handlers.go
+++ b/internal/upf/engine/sdf_handlers.go
@@ -48,12 +48,12 @@ func updateFiltersRule(rule models.FilterRule) ebpf.SdfRule {
 
 // resolveFilterIndex returns the BPF filter map index for a (policyID, direction) pair.
 // Returns ebpf.NoFilterIndex if no filter is allocated.
-func (conn *SessionEngine) resolveFilterIndex(policyID int64, direction models.Direction) uint32 {
-	if policyID == 0 {
+func (conn *SessionEngine) resolveFilterIndex(policyID string, direction models.Direction) uint32 {
+	if policyID == "" {
 		return ebpf.NoFilterIndex
 	}
 
-	key := fmt.Sprintf("%d:%s", policyID, direction.String())
+	key := fmt.Sprintf("%s:%s", policyID, direction.String())
 
 	conn.filterMu.RLock()
 	defer conn.filterMu.RUnlock()
@@ -70,8 +70,8 @@ func (conn *SessionEngine) resolveFilterIndex(policyID int64, direction models.D
 //
 //   - Non-empty rules: allocate or update the BPF slot, propagate to PDRs.
 //   - Empty rules: deallocate the slot and reset PDRs to NoFilterIndex.
-func (conn *SessionEngine) UpdateFilters(_ context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
-	key := fmt.Sprintf("%d:%s", policyID, direction.String())
+func (conn *SessionEngine) UpdateFilters(_ context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
+	key := fmt.Sprintf("%s:%s", policyID, direction.String())
 
 	// Empty rules: deallocate the existing slot (if any) and reset PDRs.
 	if len(rules) == 0 {
@@ -139,7 +139,7 @@ func (conn *SessionEngine) UpdateFilters(_ context.Context, policyID int64, dire
 }
 
 // propagateFilterIndex updates FilterMapIndex on all PDRs matching (policyID, direction).
-func (conn *SessionEngine) propagateFilterIndex(policyID int64, direction models.Direction, idx uint32) error {
+func (conn *SessionEngine) propagateFilterIndex(policyID string, direction models.Direction, idx uint32) error {
 	conn.mu.RLock()
 
 	seids, ok := conn.policyToSEIDs[policyID]

--- a/internal/upf/engine/sdf_handlers_test.go
+++ b/internal/upf/engine/sdf_handlers_test.go
@@ -12,7 +12,7 @@ import (
 func newTestEngine() *SessionEngine {
 	return &SessionEngine{
 		sessions:          make(map[uint64]*Session),
-		policyToSEIDs:     make(map[int64]map[uint64]struct{}),
+		policyToSEIDs:     make(map[string]map[uint64]struct{}),
 		SdfIndexAllocator: NewSdfIndexAllocator(ebpf.MaxSdfFilters),
 		filtersByKey:      make(map[string]uint32),
 	}
@@ -20,7 +20,7 @@ func newTestEngine() *SessionEngine {
 
 // addSessionWithPDRs is a test helper that creates a session with one uplink
 // and one downlink PDR, registers it in the engine, and returns the session.
-func addSessionWithPDRs(t *testing.T, eng *SessionEngine, seid uint64, policyID int64) *Session {
+func addSessionWithPDRs(t *testing.T, eng *SessionEngine, seid uint64, policyID string) *Session {
 	t.Helper()
 
 	sess := NewSession(seid)
@@ -56,10 +56,10 @@ func addSessionWithPDRs(t *testing.T, eng *SessionEngine, seid uint64, policyID 
 
 func TestUpdateFilters_NewRulesPropagatesToPDRs(t *testing.T) {
 	eng := newTestEngine()
-	sess := addSessionWithPDRs(t, eng, 100, 42)
+	sess := addSessionWithPDRs(t, eng, 100, "42")
 
 	// Add uplink rules — should propagate to uplink PDR only.
-	err := eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, []models.FilterRule{
+	err := eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 6, PortLow: 80, PortHigh: 80, Action: models.Allow},
 	})
 	if err != nil {
@@ -77,7 +77,7 @@ func TestUpdateFilters_NewRulesPropagatesToPDRs(t *testing.T) {
 	}
 
 	// Add downlink rules — should propagate to downlink PDR only.
-	err = eng.UpdateFilters(context.Background(), 42, models.DirectionDownlink, []models.FilterRule{
+	err = eng.UpdateFilters(context.Background(), "42", models.DirectionDownlink, []models.FilterRule{
 		{Protocol: 6, PortLow: 443, PortHigh: 443, Action: models.Allow},
 	})
 	if err != nil {
@@ -94,20 +94,20 @@ func TestUpdateFilters_InPlaceUpdateKeepsSameSlot(t *testing.T) {
 	eng := newTestEngine()
 
 	// Allocate a slot.
-	err := eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, []models.FilterRule{
+	err := eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 6, PortLow: 80, PortHigh: 80, Action: models.Allow},
 	})
 	if err != nil {
 		t.Fatalf("initial UpdateFilters: %v", err)
 	}
 
-	idx := eng.resolveFilterIndex(42, models.DirectionUplink)
+	idx := eng.resolveFilterIndex("42", models.DirectionUplink)
 	if idx == ebpf.NoFilterIndex {
 		t.Fatal("filter index not found after initial UpdateFilters")
 	}
 
 	// Create session with the current filter index.
-	sess := addSessionWithPDRs(t, eng, 200, 42)
+	sess := addSessionWithPDRs(t, eng, 200, "42")
 
 	// Manually set the uplink PDR to use the allocated index.
 	spdr := sess.GetPDR(1)
@@ -115,7 +115,7 @@ func TestUpdateFilters_InPlaceUpdateKeepsSameSlot(t *testing.T) {
 	sess.PutPDR(1, spdr)
 
 	// Update the same slot with different rules — should be in-place.
-	err = eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, []models.FilterRule{
+	err = eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 17, PortLow: 53, PortHigh: 53, Action: models.Deny},
 	})
 	if err != nil {
@@ -129,7 +129,7 @@ func TestUpdateFilters_InPlaceUpdateKeepsSameSlot(t *testing.T) {
 	}
 
 	// The resolved index should still be the same.
-	if eng.resolveFilterIndex(42, models.DirectionUplink) != idx {
+	if eng.resolveFilterIndex("42", models.DirectionUplink) != idx {
 		t.Error("resolveFilterIndex returned different index after in-place update")
 	}
 }
@@ -138,10 +138,10 @@ func TestUpdateFilters_MultipleSessionsSamePolicy(t *testing.T) {
 	eng := newTestEngine()
 
 	for _, seid := range []uint64{300, 301} {
-		addSessionWithPDRs(t, eng, seid, 10)
+		addSessionWithPDRs(t, eng, seid, "10")
 	}
 
-	err := eng.UpdateFilters(context.Background(), 10, models.DirectionUplink, []models.FilterRule{
+	err := eng.UpdateFilters(context.Background(), "10", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 6, PortLow: 80, PortHigh: 80, Action: models.Allow},
 	})
 	if err != nil {
@@ -160,10 +160,10 @@ func TestUpdateFilters_MultipleSessionsSamePolicy(t *testing.T) {
 
 func TestUpdateFilters_EmptyRulesClearsFilter(t *testing.T) {
 	eng := newTestEngine()
-	sess := addSessionWithPDRs(t, eng, 500, 42)
+	sess := addSessionWithPDRs(t, eng, 500, "42")
 
 	// Add uplink rules.
-	err := eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, []models.FilterRule{
+	err := eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 6, PortLow: 80, PortHigh: 80, Action: models.Deny},
 	})
 	if err != nil {
@@ -176,7 +176,7 @@ func TestUpdateFilters_EmptyRulesClearsFilter(t *testing.T) {
 	}
 
 	// Now update with empty rules — should clear the filter.
-	err = eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, nil)
+	err = eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, nil)
 	if err != nil {
 		t.Fatalf("UpdateFilters with empty rules: %v", err)
 	}
@@ -186,17 +186,17 @@ func TestUpdateFilters_EmptyRulesClearsFilter(t *testing.T) {
 		t.Errorf("expected FilterMapIndex to be reset to NoFilterIndex, got %d", pdr.PdrInfo.FilterMapIndex)
 	}
 
-	if eng.resolveFilterIndex(42, models.DirectionUplink) != ebpf.NoFilterIndex {
+	if eng.resolveFilterIndex("42", models.DirectionUplink) != ebpf.NoFilterIndex {
 		t.Error("expected resolveFilterIndex to return NoFilterIndex after clearing")
 	}
 }
 
 func TestUpdateFilters_EmptyRulesWhenNoSlotIsNoop(t *testing.T) {
 	eng := newTestEngine()
-	addSessionWithPDRs(t, eng, 600, 42)
+	addSessionWithPDRs(t, eng, 600, "42")
 
 	// Calling UpdateFilters with empty rules when no slot exists should be a no-op.
-	err := eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, nil)
+	err := eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, nil)
 	if err != nil {
 		t.Fatalf("UpdateFilters with empty rules (no existing slot): %v", err)
 	}
@@ -211,33 +211,33 @@ func TestUpdateFilters_EmptyRulesWhenNoSlotIsNoop(t *testing.T) {
 
 func TestUpdateFilters_ClearThenReaddAllocatesNewSlot(t *testing.T) {
 	eng := newTestEngine()
-	sess := addSessionWithPDRs(t, eng, 700, 42)
+	sess := addSessionWithPDRs(t, eng, 700, "42")
 
 	// Add rules.
-	err := eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, []models.FilterRule{
+	err := eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 6, PortLow: 80, PortHigh: 80, Action: models.Allow},
 	})
 	if err != nil {
 		t.Fatalf("initial UpdateFilters: %v", err)
 	}
 
-	firstIdx := eng.resolveFilterIndex(42, models.DirectionUplink)
+	firstIdx := eng.resolveFilterIndex("42", models.DirectionUplink)
 
 	// Clear rules.
-	err = eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, nil)
+	err = eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, nil)
 	if err != nil {
 		t.Fatalf("clear UpdateFilters: %v", err)
 	}
 
 	// Re-add rules — should allocate a new slot and propagate.
-	err = eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, []models.FilterRule{
+	err = eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 17, PortLow: 53, PortHigh: 53, Action: models.Deny},
 	})
 	if err != nil {
 		t.Fatalf("re-add UpdateFilters: %v", err)
 	}
 
-	newIdx := eng.resolveFilterIndex(42, models.DirectionUplink)
+	newIdx := eng.resolveFilterIndex("42", models.DirectionUplink)
 	if newIdx == ebpf.NoFilterIndex {
 		t.Fatal("expected a valid filter index after re-adding rules")
 	}
@@ -254,10 +254,10 @@ func TestUpdateFilters_ClearThenReaddAllocatesNewSlot(t *testing.T) {
 
 func TestUpdateFilters_OnlyAffectsMatchingDirection(t *testing.T) {
 	eng := newTestEngine()
-	sess := addSessionWithPDRs(t, eng, 800, 42)
+	sess := addSessionWithPDRs(t, eng, 800, "42")
 
 	// Add uplink rules.
-	err := eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, []models.FilterRule{
+	err := eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 6, PortLow: 80, PortHigh: 80, Action: models.Deny},
 	})
 	if err != nil {
@@ -265,7 +265,7 @@ func TestUpdateFilters_OnlyAffectsMatchingDirection(t *testing.T) {
 	}
 
 	// Add downlink rules.
-	err = eng.UpdateFilters(context.Background(), 42, models.DirectionDownlink, []models.FilterRule{
+	err = eng.UpdateFilters(context.Background(), "42", models.DirectionDownlink, []models.FilterRule{
 		{Protocol: 6, PortLow: 443, PortHigh: 443, Action: models.Deny},
 	})
 	if err != nil {
@@ -280,7 +280,7 @@ func TestUpdateFilters_OnlyAffectsMatchingDirection(t *testing.T) {
 	}
 
 	// Clear only uplink — downlink should remain.
-	err = eng.UpdateFilters(context.Background(), 42, models.DirectionUplink, nil)
+	err = eng.UpdateFilters(context.Background(), "42", models.DirectionUplink, nil)
 	if err != nil {
 		t.Fatalf("clear uplink: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestUpdateFilters_NoSessionsForPolicy(t *testing.T) {
 	eng := newTestEngine()
 
 	// UpdateFilters with no sessions for the policy should succeed without error.
-	err := eng.UpdateFilters(context.Background(), 99, models.DirectionUplink, []models.FilterRule{
+	err := eng.UpdateFilters(context.Background(), "99", models.DirectionUplink, []models.FilterRule{
 		{Protocol: 6, PortLow: 80, PortHigh: 80, Action: models.Allow},
 	})
 	if err != nil {
@@ -306,7 +306,7 @@ func TestUpdateFilters_NoSessionsForPolicy(t *testing.T) {
 	}
 
 	// The slot should still be allocated (ready for future sessions).
-	if eng.resolveFilterIndex(99, models.DirectionUplink) == ebpf.NoFilterIndex {
+	if eng.resolveFilterIndex("99", models.DirectionUplink) == ebpf.NoFilterIndex {
 		t.Error("expected filter index to be allocated even with no sessions")
 	}
 }
@@ -315,16 +315,16 @@ func TestDeleteSession_DeregistersFromPolicyIndex(t *testing.T) {
 	eng := newTestEngine()
 
 	sess := NewSession(400)
-	sess.SetPolicyID(50)
+	sess.SetPolicyID("50")
 
 	eng.mu.Lock()
 	eng.sessions[400] = sess
-	eng.registerPolicy(50, 400)
+	eng.registerPolicy("50", 400)
 	eng.mu.Unlock()
 
 	// Verify the reverse index has the entry.
 	eng.mu.Lock()
-	seids := eng.policyToSEIDs[50]
+	seids := eng.policyToSEIDs["50"]
 	eng.mu.Unlock()
 
 	if len(seids) != 1 {
@@ -341,7 +341,7 @@ func TestDeleteSession_DeregistersFromPolicyIndex(t *testing.T) {
 
 	eng.mu.Lock()
 
-	_, exists := eng.policyToSEIDs[50]
+	_, exists := eng.policyToSEIDs["50"]
 
 	eng.mu.Unlock()
 

--- a/internal/upf/engine/session.go
+++ b/internal/upf/engine/session.go
@@ -12,7 +12,7 @@ import (
 type Session struct {
 	mu       sync.RWMutex
 	SEID     uint64
-	policyID int64
+	policyID string
 	pdrs     map[uint32]SPDRInfo
 	fars     map[uint32]ebpf.FarInfo
 	qers     map[uint32]ebpf.QerInfo
@@ -35,14 +35,14 @@ type SPDRInfo struct {
 	Allocated bool
 }
 
-func (s *Session) PolicyID() int64 {
+func (s *Session) PolicyID() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	return s.policyID
 }
 
-func (s *Session) SetPolicyID(id int64) {
+func (s *Session) SetPolicyID(id string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/upf/engine/session_engine.go
+++ b/internal/upf/engine/session_engine.go
@@ -20,7 +20,7 @@ type SessionEngine struct {
 	mu sync.RWMutex
 
 	sessions                map[uint64]*Session
-	policyToSEIDs           map[int64]map[uint64]struct{}
+	policyToSEIDs           map[string]map[uint64]struct{}
 	nodeID                  string
 	nodeAddrV4              net.IP
 	n3AddressIPv4           netip.Addr // may be zero if not available
@@ -66,8 +66,8 @@ func (pc *SessionEngine) AddSession(seid uint64, session *Session) {
 
 // registerPolicy links a policyID to a session SEID in the reverse index.
 // Caller must hold pc.mu.
-func (pc *SessionEngine) registerPolicy(policyID int64, seid uint64) {
-	if policyID == 0 {
+func (pc *SessionEngine) registerPolicy(policyID string, seid uint64) {
+	if policyID == "" {
 		return
 	}
 
@@ -82,8 +82,8 @@ func (pc *SessionEngine) registerPolicy(policyID int64, seid uint64) {
 
 // deregisterPolicy removes a session SEID from the reverse index.
 // Caller must hold pc.mu.
-func (pc *SessionEngine) deregisterPolicy(policyID int64, seid uint64) {
-	if policyID == 0 {
+func (pc *SessionEngine) deregisterPolicy(policyID string, seid uint64) {
+	if policyID == "" {
 		return
 	}
 
@@ -122,11 +122,11 @@ func (pc *SessionEngine) InitializeFiltersFromDB(ctx context.Context, dbInstance
 	}
 
 	for _, policy := range policies {
-		rules, err := dbInstance.ListRulesForPolicy(ctx, int64(policy.ID))
+		rules, err := dbInstance.ListRulesForPolicy(ctx, policy.ID)
 		if err != nil {
 			logger.WithTrace(ctx, logger.DBLog).Error(
 				"failed to list rules for policy",
-				zap.Int("policyID", policy.ID),
+				zap.String("policyID", policy.ID),
 				zap.Error(err),
 			)
 
@@ -158,20 +158,20 @@ func (pc *SessionEngine) InitializeFiltersFromDB(ctx context.Context, dbInstance
 		}
 
 		if len(uplinkRules) > 0 {
-			if err := pc.UpdateFilters(ctx, int64(policy.ID), models.DirectionUplink, uplinkRules); err != nil {
+			if err := pc.UpdateFilters(ctx, policy.ID, models.DirectionUplink, uplinkRules); err != nil {
 				logger.WithTrace(ctx, logger.DBLog).Error(
 					"failed to update uplink filters",
-					zap.Int("policyID", policy.ID),
+					zap.String("policyID", policy.ID),
 					zap.Error(err),
 				)
 			}
 		}
 
 		if len(downlinkRules) > 0 {
-			if err := pc.UpdateFilters(ctx, int64(policy.ID), models.DirectionDownlink, downlinkRules); err != nil {
+			if err := pc.UpdateFilters(ctx, policy.ID, models.DirectionDownlink, downlinkRules); err != nil {
 				logger.WithTrace(ctx, logger.DBLog).Error(
 					"failed to update downlink filters",
-					zap.Int("policyID", policy.ID),
+					zap.String("policyID", policy.ID),
 					zap.Error(err),
 				)
 			}
@@ -261,7 +261,7 @@ func NewSessionEngine(addr string, nodeID string, n3IPv4 string, n3IPv6 string, 
 
 	conn := &SessionEngine{
 		sessions:                make(map[uint64]*Session),
-		policyToSEIDs:           make(map[int64]map[uint64]struct{}),
+		policyToSEIDs:           make(map[string]map[uint64]struct{}),
 		nodeID:                  nodeID,
 		nodeAddrV4:              addrV4,
 		n3AddressIPv4:           n3AddrIPv4,

--- a/internal/upf/reconciler.go
+++ b/internal/upf/reconciler.go
@@ -33,7 +33,7 @@ type SettingsStore interface {
 	IsFlowAccountingEnabled(ctx context.Context) (bool, error)
 	GetN3Settings(ctx context.Context) (*db.N3Settings, error)
 	ListPoliciesPage(ctx context.Context, page int, perPage int) ([]db.Policy, int, error)
-	ListRulesForPolicy(ctx context.Context, policyID int64) ([]*db.NetworkRule, error)
+	ListRulesForPolicy(ctx context.Context, policyID string) ([]*db.NetworkRule, error)
 }
 
 // Updater is the narrow view the reconciler needs over the UPF runtime.
@@ -42,7 +42,7 @@ type Updater interface {
 	ReloadNAT(enabled bool) error
 	ReloadFlowAccounting(enabled bool) error
 	UpdateAdvertisedN3Address(addr netip.Addr)
-	UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error
+	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error
 }
 
 // SettingsReconciler drives this node's UPF runtime from replicated DB
@@ -67,7 +67,7 @@ type SettingsReconciler struct {
 	appliedNAT            *bool
 	appliedFlowAccounting *bool
 	appliedN3Address      netip.Addr
-	appliedFilters        map[int64]filterSnapshot
+	appliedFilters        map[string]filterSnapshot
 }
 
 type filterSnapshot struct {
@@ -86,7 +86,7 @@ func NewSettingsReconciler(updater Updater, store SettingsStore, changefeed *db.
 		changefeed:     changefeed,
 		fallbackN3IP:   fallbackN3IP,
 		backstop:       upfReconcileBackstop,
-		appliedFilters: make(map[int64]filterSnapshot),
+		appliedFilters: make(map[string]filterSnapshot),
 	}
 }
 
@@ -298,15 +298,15 @@ func (r *SettingsReconciler) reconcileFilters(ctx context.Context) error {
 		return fmt.Errorf("list policies: %w", err)
 	}
 
-	desired := make(map[int64]filterSnapshot, len(policies))
+	desired := make(map[string]filterSnapshot, len(policies))
 
 	for _, p := range policies {
-		rules, err := r.store.ListRulesForPolicy(ctx, int64(p.ID))
+		rules, err := r.store.ListRulesForPolicy(ctx, p.ID)
 		if err != nil {
-			return fmt.Errorf("list rules for policy %d: %w", p.ID, err)
+			return fmt.Errorf("list rules for policy %s: %w", p.ID, err)
 		}
 
-		desired[int64(p.ID)] = filterSnapshot{
+		desired[p.ID] = filterSnapshot{
 			uplink:   networkRulesToFilterRules(rules, directionUplinkString),
 			downlink: networkRulesToFilterRules(rules, directionDownlinkString),
 		}
@@ -322,7 +322,7 @@ func (r *SettingsReconciler) reconcileFilters(ctx context.Context) error {
 		if !hadApplied || !reflect.DeepEqual(appliedSnap.uplink, desiredSnap.uplink) {
 			if err := r.updater.UpdateFilters(ctx, policyID, models.DirectionUplink, desiredSnap.uplink); err != nil {
 				logger.UpfLog.Warn("failed to update uplink filters",
-					zap.Int64("policyID", policyID), zap.Error(err))
+					zap.String("policyID", policyID), zap.Error(err))
 
 				continue
 			}
@@ -331,7 +331,7 @@ func (r *SettingsReconciler) reconcileFilters(ctx context.Context) error {
 		if !hadApplied || !reflect.DeepEqual(appliedSnap.downlink, desiredSnap.downlink) {
 			if err := r.updater.UpdateFilters(ctx, policyID, models.DirectionDownlink, desiredSnap.downlink); err != nil {
 				logger.UpfLog.Warn("failed to update downlink filters",
-					zap.Int64("policyID", policyID), zap.Error(err))
+					zap.String("policyID", policyID), zap.Error(err))
 
 				continue
 			}
@@ -346,12 +346,12 @@ func (r *SettingsReconciler) reconcileFilters(ctx context.Context) error {
 		// Policy deleted: clear filters so the eBPF slot is freed.
 		if err := r.updater.UpdateFilters(ctx, policyID, models.DirectionUplink, nil); err != nil {
 			logger.UpfLog.Warn("failed to clear uplink filters for deleted policy",
-				zap.Int64("policyID", policyID), zap.Error(err))
+				zap.String("policyID", policyID), zap.Error(err))
 		}
 
 		if err := r.updater.UpdateFilters(ctx, policyID, models.DirectionDownlink, nil); err != nil {
 			logger.UpfLog.Warn("failed to clear downlink filters for deleted policy",
-				zap.Int64("policyID", policyID), zap.Error(err))
+				zap.String("policyID", policyID), zap.Error(err))
 		}
 	}
 

--- a/internal/upf/reconciler_test.go
+++ b/internal/upf/reconciler_test.go
@@ -22,7 +22,7 @@ type fakeStore struct {
 	n3External      string
 	n3GetErr        error
 	policies        []db.Policy
-	rulesByPolicyID map[int64][]*db.NetworkRule
+	rulesByPolicyID map[string][]*db.NetworkRule
 }
 
 func (f *fakeStore) IsNATEnabled(_ context.Context) (bool, error) {
@@ -60,7 +60,7 @@ func (f *fakeStore) ListPoliciesPage(_ context.Context, _ int, _ int) ([]db.Poli
 	return out, len(out), nil
 }
 
-func (f *fakeStore) ListRulesForPolicy(_ context.Context, policyID int64) ([]*db.NetworkRule, error) {
+func (f *fakeStore) ListRulesForPolicy(_ context.Context, policyID string) ([]*db.NetworkRule, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -72,7 +72,7 @@ func (f *fakeStore) ListRulesForPolicy(_ context.Context, policyID int64) ([]*db
 }
 
 type filterCall struct {
-	policyID  int64
+	policyID  string
 	direction models.Direction
 	rules     []models.FilterRule
 }
@@ -121,7 +121,7 @@ func (f *fakeUpdater) UpdateAdvertisedN3Address(addr netip.Addr) {
 	f.n3Calls = append(f.n3Calls, addr)
 }
 
-func (f *fakeUpdater) UpdateFilters(_ context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
+func (f *fakeUpdater) UpdateFilters(_ context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -266,9 +266,9 @@ func TestReconcile_N3HandlesGetN3SettingsNotFound(t *testing.T) {
 
 func TestReconcile_FiltersAddRemoveModify(t *testing.T) {
 	store := &fakeStore{
-		policies: []db.Policy{{ID: 1}},
-		rulesByPolicyID: map[int64][]*db.NetworkRule{
-			1: {
+		policies: []db.Policy{{ID: "policy-1"}},
+		rulesByPolicyID: map[string][]*db.NetworkRule{
+			"policy-1": {
 				{Direction: directionUplinkString, Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
 			},
 		},
@@ -281,7 +281,7 @@ func TestReconcile_FiltersAddRemoveModify(t *testing.T) {
 		t.Fatalf("reconcile 1: %v", err)
 	}
 
-	uplinkCalls, downlinkCalls := splitFilterCalls(updater.filterCalls, 1)
+	uplinkCalls, downlinkCalls := splitFilterCalls(updater.filterCalls, "policy-1")
 
 	if len(uplinkCalls) != 1 || len(uplinkCalls[0].rules) != 1 {
 		t.Fatalf("expected one uplink call with one rule, got %v", uplinkCalls)
@@ -304,7 +304,7 @@ func TestReconcile_FiltersAddRemoveModify(t *testing.T) {
 	}
 
 	store.mu.Lock()
-	store.rulesByPolicyID[1] = []*db.NetworkRule{
+	store.rulesByPolicyID["policy-1"] = []*db.NetworkRule{
 		{Direction: directionUplinkString, Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
 	}
 	store.mu.Unlock()
@@ -317,7 +317,7 @@ func TestReconcile_FiltersAddRemoveModify(t *testing.T) {
 		t.Fatalf("reconcile 3: %v", err)
 	}
 
-	uplinkCalls, _ = splitFilterCalls(updater.filterCalls, 1)
+	uplinkCalls, _ = splitFilterCalls(updater.filterCalls, "policy-1")
 	if len(uplinkCalls) != 1 || uplinkCalls[0].rules[0].Protocol != 17 {
 		t.Fatalf("expected uplink reapplied with new rules, got %v", uplinkCalls)
 	}
@@ -335,7 +335,7 @@ func TestReconcile_FiltersAddRemoveModify(t *testing.T) {
 		t.Fatalf("reconcile 4: %v", err)
 	}
 
-	uplinkCalls, downlinkCalls = splitFilterCalls(updater.filterCalls, 1)
+	uplinkCalls, downlinkCalls = splitFilterCalls(updater.filterCalls, "policy-1")
 
 	if len(uplinkCalls) != 1 || len(uplinkCalls[0].rules) != 0 {
 		t.Fatalf("expected uplink cleared (empty rules) on policy delete, got %v", uplinkCalls)
@@ -426,7 +426,7 @@ func TestReconcile_PropagatesNATError(t *testing.T) {
 	}
 }
 
-func splitFilterCalls(calls []filterCall, policyID int64) (uplink, downlink []filterCall) {
+func splitFilterCalls(calls []filterCall, policyID string) (uplink, downlink []filterCall) {
 	for _, c := range calls {
 		if c.policyID != policyID {
 			continue

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -234,7 +234,7 @@ func (u *UPF) UpdateAdvertisedN3Address(newN3Addr netip.Addr) {
 	}
 }
 
-func (u *UPF) UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
+func (u *UPF) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return u.se.UpdateFilters(ctx, policyID, direction, rules)
 }
 

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -93,7 +93,7 @@ func ipamLeaseToDB(l *ipam.Lease) *db.IPLease {
 	}
 }
 
-func (a *leaseStoreAdapter) GetDynamicLease(ctx context.Context, poolID int, imsi string) (*ipam.Lease, error) {
+func (a *leaseStoreAdapter) GetDynamicLease(ctx context.Context, poolID string, imsi string) (*ipam.Lease, error) {
 	l, err := a.db.GetDynamicLease(ctx, poolID, imsi)
 	if err != nil {
 		return nil, mapDBError(err)
@@ -102,7 +102,7 @@ func (a *leaseStoreAdapter) GetDynamicLease(ctx context.Context, poolID int, ims
 	return dbLeaseToIPAM(l), nil
 }
 
-func (a *leaseStoreAdapter) GetLeaseBySession(ctx context.Context, poolID int, sessionID int, imsi string) (*ipam.Lease, error) {
+func (a *leaseStoreAdapter) GetLeaseBySession(ctx context.Context, poolID string, sessionID int, imsi string) (*ipam.Lease, error) {
 	l, err := a.db.GetLeaseBySession(ctx, poolID, sessionID, imsi)
 	if err != nil {
 		return nil, mapDBError(err)
@@ -111,7 +111,7 @@ func (a *leaseStoreAdapter) GetLeaseBySession(ctx context.Context, poolID int, s
 	return dbLeaseToIPAM(l), nil
 }
 
-func (a *leaseStoreAdapter) ListLeaseAddressesByPool(ctx context.Context, poolID int) ([]string, error) {
+func (a *leaseStoreAdapter) ListLeaseAddressesByPool(ctx context.Context, poolID string) ([]string, error) {
 	return a.db.ListLeaseAddressesByPool(ctx, poolID)
 }
 
@@ -232,7 +232,7 @@ func (a *pcfDBAdapter) GetSessionPolicy(ctx context.Context, imsi string, snssai
 	dns := net.ParseIP(dn.DNS)
 
 	policy := &smf.Policy{
-		PolicyID: int64(pol.ID),
+		PolicyID: pol.ID,
 		Ambr: models.Ambr{
 			Uplink:   pol.SessionAmbrUplink,
 			Downlink: pol.SessionAmbrDownlink,
@@ -334,7 +334,7 @@ func (a *smfUPFAdapter) DeleteSession(ctx context.Context, remoteSEID uint64) er
 	return a.engine.DeleteSession(ctx, &models.DeleteRequest{SEID: remoteSEID})
 }
 
-func (a *smfUPFAdapter) UpdateFilters(ctx context.Context, policyID int64, direction models.Direction, rules []models.FilterRule) error {
+func (a *smfUPFAdapter) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return a.engine.UpdateFilters(ctx, policyID, direction, rules)
 }
 

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -124,15 +124,15 @@ func (a *leaseStoreAdapter) CreateLease(ctx context.Context, lease *ipam.Lease) 
 	return mapDBError(a.db.CreateLease(ctx, ipamLeaseToDB(lease), addr))
 }
 
-func (a *leaseStoreAdapter) UpdateLeaseSession(ctx context.Context, leaseID int, sessionID int) error {
+func (a *leaseStoreAdapter) UpdateLeaseSession(ctx context.Context, leaseID string, sessionID int) error {
 	return mapDBError(a.db.UpdateLeaseSession(ctx, leaseID, sessionID))
 }
 
-func (a *leaseStoreAdapter) UpdateLeaseNode(ctx context.Context, leaseID int, nodeID int, sessionID int) error {
+func (a *leaseStoreAdapter) UpdateLeaseNode(ctx context.Context, leaseID string, nodeID int, sessionID int) error {
 	return mapDBError(a.db.UpdateLeaseNode(ctx, leaseID, nodeID, sessionID))
 }
 
-func (a *leaseStoreAdapter) DeleteDynamicLease(ctx context.Context, leaseID int) error {
+func (a *leaseStoreAdapter) DeleteDynamicLease(ctx context.Context, leaseID string) error {
 	return mapDBError(a.db.DeleteDynamicLease(ctx, leaseID))
 }
 
@@ -252,7 +252,7 @@ func (a *pcfDBAdapter) GetSessionPolicy(ctx context.Context, imsi string, snssai
 	for i, dbRule := range dbRules {
 		dir, err := models.ParseDirection(dbRule.Direction)
 		if err != nil {
-			return nil, fmt.Errorf("invalid direction for rule %d: %w", dbRule.ID, err)
+			return nil, fmt.Errorf("invalid direction for rule %s: %w", dbRule.ID, err)
 		}
 
 		resolvedRules[i] = &smf.ResolvedNetworkRule{

--- a/ui/src/queries/api_tokens.tsx
+++ b/ui/src/queries/api_tokens.tsx
@@ -1,7 +1,7 @@
 import { apiFetch, apiFetchVoid } from "@/queries/utils";
 
 export type APIToken = {
-  id: number;
+  id: string;
   name: string;
   expires_at: string | null;
 };
@@ -38,7 +38,7 @@ export const createAPIToken = async (
 
 export const deleteAPIToken = async (
   authToken: string,
-  id: number,
+  id: string,
 ): Promise<void> => {
   await apiFetchVoid(`/api/v1/users/me/api-tokens/${id}`, {
     method: "DELETE",
@@ -74,7 +74,7 @@ export const createUserAPIToken = async (
 export const deleteUserAPIToken = async (
   authToken: string,
   email: string,
-  id: number,
+  id: string,
 ): Promise<void> => {
   await apiFetchVoid(`/api/v1/users/${email}/api-tokens/${id}`, {
     method: "DELETE",

--- a/ui/src/queries/audit_logs.tsx
+++ b/ui/src/queries/audit_logs.tsx
@@ -5,7 +5,7 @@ export type AuditLogRetentionPolicy = {
 };
 
 export type APIAuditLog = {
-  id: number;
+  id: string; // UUIDv7
   timestamp: string;
   level: string;
   user: string;

--- a/ui/src/queries/network_rules.tsx
+++ b/ui/src/queries/network_rules.tsx
@@ -1,8 +1,8 @@
 import { apiFetch, apiFetchVoid } from "@/queries/utils";
 
 export type NetworkRule = {
-  id: number;
-  policy_id: number;
+  id: string;
+  policy_id: string;
   description: string;
   direction: "uplink" | "downlink";
   remote_prefix?: string;
@@ -35,7 +35,7 @@ export async function listNetworkRules(
 export async function reorderNetworkRule(
   authToken: string,
   policyName: string,
-  ruleId: number,
+  ruleId: string,
   newIndex: number,
 ): Promise<void> {
   await apiFetchVoid(
@@ -61,8 +61,8 @@ export async function createNetworkRule(
   protocol?: number,
   portLow?: number,
   portHigh?: number,
-): Promise<{ id: number }> {
-  return apiFetch<{ id: number }>(
+): Promise<{ id: string }> {
+  return apiFetch<{ id: string }>(
     `/api/v1/policies/${encodeURIComponent(policyName)}/rules`,
     {
       method: "POST",
@@ -84,7 +84,7 @@ export async function createNetworkRule(
 export async function updateNetworkRule(
   authToken: string,
   policyName: string,
-  ruleId: number,
+  ruleId: string,
   description: string,
   direction: "uplink" | "downlink",
   action: "allow" | "deny",
@@ -116,7 +116,7 @@ export async function updateNetworkRule(
 export async function deleteNetworkRule(
   authToken: string,
   policyName: string,
-  ruleId: number,
+  ruleId: string,
 ): Promise<void> {
   await apiFetchVoid(
     `/api/v1/policies/${encodeURIComponent(policyName)}/rules/${ruleId}`,
@@ -130,7 +130,7 @@ export async function deleteNetworkRule(
 export async function getNetworkRule(
   authToken: string,
   policyName: string,
-  ruleId: number,
+  ruleId: string,
 ): Promise<NetworkRule> {
   return apiFetch<NetworkRule>(
     `/api/v1/policies/${encodeURIComponent(policyName)}/rules/${ruleId}`,


### PR DESCRIPTION
# Description

Replicated tables that use `INTEGER PRIMARY KEY AUTOINCREMENT` derive their PK from `sqlite_sequence` at INSERT time. The leader's capture path wraps the apply in `BEGIN IMMEDIATE; INSERT (autoinc); CAPTURE; ROLLBACK`, which means **the captured changeset bytes carry an id that was assigned from rollback-able local state**. The same id can be picked twice in two different captures whenever those captures see the same `sqlite_sequence` value — most observably when a new leader's first capture races with a previous-term entry that has been replicated but not yet applied to the new leader's FSM.

To avoid this class of problems, now each node generates its own UUID when writing to the DB instead of relying on auto increment. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
