### PR TITLE
fix: preserve typed results across follower-forward boundary

### DIFF
--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -96,7 +96,7 @@ func (db *Database) AllocateIPLease(ctx context.Context, poolID string, poolType
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "allocate").Inc()
 
-	raw, err := opAllocateIPLease.Invoke(db, &allocateIPLeasePayload{
+	addrStr, err := opAllocateIPLease.Invoke(db, &allocateIPLeasePayload{
 		PoolID:    poolID,
 		PoolType:  poolType,
 		IMSI:      imsi,
@@ -104,15 +104,6 @@ func (db *Database) AllocateIPLease(ctx context.Context, poolID string, poolType
 		NodeID:    nodeID,
 	})
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-
-		return netip.Addr{}, err
-	}
-
-	addrStr, ok := raw.(string)
-	if !ok {
-		err := fmt.Errorf("allocate IP lease: unexpected apply result type %T", raw)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -156,7 +147,7 @@ func (db *Database) AllocateIPv6Lease(ctx context.Context, poolID string, poolTy
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "allocate_ipv6").Inc()
 
-	raw, err := opAllocateIPv6Lease.Invoke(db, &allocateIPLeasePayload{
+	addrStr, err := opAllocateIPv6Lease.Invoke(db, &allocateIPLeasePayload{
 		PoolID:    poolID,
 		PoolType:  poolType,
 		IMSI:      imsi,
@@ -164,15 +155,6 @@ func (db *Database) AllocateIPv6Lease(ctx context.Context, poolID string, poolTy
 		NodeID:    nodeID,
 	})
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-
-		return netip.Addr{}, err
-	}
-
-	addrStr, ok := raw.(string)
-	if !ok {
-		err := fmt.Errorf("allocate IPv6 lease: unexpected apply result type %T", raw)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -39,6 +39,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -101,9 +102,10 @@ var (
 	intentOps    = map[string]intentOpHandler{}
 )
 
-// ChangesetOp binds an operation name to a typed apply function.
-// Call-site handle returned by registerChangesetOp.
-type ChangesetOp[P any] struct {
+// ChangesetOp binds an operation name to a typed apply function. R is the
+// declared result type the dispatcher narrows the apply's `any` to, including
+// the typed JSON decode on the follower-forward path.
+type ChangesetOp[P any, R any] struct {
 	name      string
 	minSchema int
 	apply     func(db *Database, ctx context.Context, p *P) (any, error)
@@ -113,7 +115,15 @@ func registerChangesetOp[P any](
 	name string,
 	apply func(db *Database, ctx context.Context, p *P) (any, error),
 	opts ...OpOption,
-) *ChangesetOp[P] {
+) *ChangesetOp[P, struct{}] {
+	return registerChangesetOpReturning[P, struct{}](name, apply, opts...)
+}
+
+func registerChangesetOpReturning[P any, R any](
+	name string,
+	apply func(db *Database, ctx context.Context, p *P) (any, error),
+	opts ...OpOption,
+) *ChangesetOp[P, R] {
 	if _, exists := changesetOps[name]; exists {
 		panic(fmt.Sprintf("duplicate changeset op registration: %s", name))
 	}
@@ -126,8 +136,6 @@ func registerChangesetOp[P any](
 	for _, opt := range opts {
 		opt(&meta)
 	}
-
-	op := &ChangesetOp[P]{name: name, minSchema: meta.minSchema, apply: apply}
 
 	changesetOps[name] = changesetOpHandler{
 		minSchema: meta.minSchema,
@@ -142,14 +150,14 @@ func registerChangesetOp[P any](
 		},
 	}
 
-	return op
+	return &ChangesetOp[P, R]{name: name, minSchema: meta.minSchema, apply: apply}
 }
 
-// opts retained for symmetry with registerChangesetOp; no shipped
-// intent op currently needs a non-default RequireSchema.
-//
-//nolint:unparam
-func registerIntentOp(name string, cmdType ellaraft.CommandType, opts ...OpOption) intentOp {
+func registerIntentOp(name string, cmdType ellaraft.CommandType, opts ...OpOption) intentOp[struct{}] {
+	return registerIntentOpReturning[struct{}](name, cmdType, opts...)
+}
+
+func registerIntentOpReturning[R any](name string, cmdType ellaraft.CommandType, opts ...OpOption) intentOp[R] {
 	if _, exists := intentOps[name]; exists {
 		panic(fmt.Sprintf("duplicate intent op registration: %s", name))
 	}
@@ -165,7 +173,7 @@ func registerIntentOp(name string, cmdType ellaraft.CommandType, opts ...OpOptio
 
 	intentOps[name] = intentOpHandler{minSchema: meta.minSchema, topics: meta.topics, cmdType: cmdType}
 
-	return intentOp{name: name, minSchema: meta.minSchema, cmdType: cmdType}
+	return intentOp[R]{name: name, minSchema: meta.minSchema, cmdType: cmdType}
 }
 
 // topicsForChangesetOp returns the topics declared by a registered
@@ -191,7 +199,7 @@ func topicsForIntentCmd(t ellaraft.CommandType) []Topic {
 	return nil
 }
 
-type intentOp struct {
+type intentOp[R any] struct {
 	name      string
 	minSchema int
 	cmdType   ellaraft.CommandType
@@ -210,20 +218,57 @@ func intentMinSchemaForCmd(t ellaraft.CommandType) int {
 	return 1
 }
 
-// Invoke runs the op locally on leader / standalone, or forwards
-// (operation, payload JSON) to the leader on a follower.
-func (op *ChangesetOp[P]) Invoke(db *Database, payload *P) (any, error) {
+// narrowResult converts the dispatcher's `any` into the op's declared R.
+// Three shapes reach here: a typed any (standalone / leader local FSM),
+// a json.RawMessage (follower forward, raw bytes preserved by forward.go),
+// and nil (FSM replay-skip or void op). R = struct{} short-circuits — void
+// ops discard whatever the applier returned, typically a last-insert-id.
+// Mismatches are reported as errors rather than panicking so wire-format
+// drift surfaces normally.
+func narrowResult[R any](opName string, raw any) (R, error) {
+	var zero R
+
+	if _, void := any(zero).(struct{}); void {
+		return zero, nil
+	}
+
+	switch v := raw.(type) {
+	case nil:
+		return zero, nil
+	case json.RawMessage:
+		if len(v) == 0 || bytes.Equal(v, []byte("null")) {
+			return zero, nil
+		}
+
+		var r R
+		if err := json.Unmarshal(v, &r); err != nil {
+			return zero, fmt.Errorf("decode %s result: %w", opName, err)
+		}
+
+		return r, nil
+	case R:
+		return v, nil
+	default:
+		return zero, fmt.Errorf("op %s: unexpected result type %T (want %T)", opName, raw, zero)
+	}
+}
+
+func (op *ChangesetOp[P, R]) Invoke(db *Database, payload *P) (R, error) {
+	var zero R
+
 	if err := db.checkOpSchema(op.minSchema); err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	if db.raftManager == nil {
 		result, err := op.apply(db, context.Background(), payload)
-		if err == nil {
-			db.publishOpTopics(topicsForChangesetOp(op.name), 0)
+		if err != nil {
+			return zero, err
 		}
 
-		return result, err
+		db.publishOpTopics(topicsForChangesetOp(op.name), 0)
+
+		return narrowResult[R](op.name, result)
 	}
 
 	if db.IsLeader() {
@@ -231,11 +276,11 @@ func (op *ChangesetOp[P]) Invoke(db *Database, payload *P) (any, error) {
 			return op.apply(db, ctx, payload)
 		})
 		if err == nil {
-			return result, nil
+			return narrowResult[R](op.name, result)
 		}
 
 		if !errors.Is(err, hraft.ErrNotLeader) && !errors.Is(err, hraft.ErrLeadershipLost) {
-			return nil, err
+			return zero, err
 		}
 
 		// Leadership lost between IsLeader() and Propose(); fall through
@@ -246,68 +291,75 @@ func (op *ChangesetOp[P]) Invoke(db *Database, payload *P) (any, error) {
 	return op.invokeFollower(db, payload)
 }
 
-func (op *ChangesetOp[P]) invokeFollower(db *Database, payload *P) (any, error) {
+func (op *ChangesetOp[P, R]) invokeFollower(db *Database, payload *P) (R, error) {
+	var zero R
+
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshal %s payload: %w", op.name, err)
+		return zero, fmt.Errorf("marshal %s payload: %w", op.name, err)
 	}
 
 	result, err := db.forwardOperation(op.name, payloadJSON)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
-	return result.Value, nil
+	return narrowResult[R](op.name, result.Value)
 }
 
-// Invoke runs an intent op via raft.Apply on the leader, or forwards
-// to the leader on a follower.
-func (op intentOp) Invoke(db *Database, payload any) (any, error) {
+func (op intentOp[R]) Invoke(db *Database, payload any) (R, error) {
+	var zero R
+
 	if err := db.checkOpSchema(op.minSchema); err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	cmd, err := ellaraft.NewCommand(op.cmdType, payload)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	if db.raftManager == nil {
-		return db.ApplyCommand(context.Background(), cmd, 0)
+		result, err := db.ApplyCommand(context.Background(), cmd, 0)
+		if err != nil {
+			return zero, err
+		}
+
+		return narrowResult[R](op.name, result)
 	}
 
 	if db.IsLeader() {
 		data, err := cmd.MarshalBinary()
 		if err != nil {
-			return nil, fmt.Errorf("marshal intent command: %w", err)
+			return zero, fmt.Errorf("marshal intent command: %w", err)
 		}
 
 		result, applyErr := db.raftManager.ApplyBytes(data, db.proposeTimeout)
 		if applyErr == nil {
-			return result.Value, nil
+			return narrowResult[R](op.name, result.Value)
 		}
 
 		if !errors.Is(applyErr, hraft.ErrNotLeader) && !errors.Is(applyErr, hraft.ErrLeadershipLost) {
 			if isTransientRaftErr(applyErr) {
-				return nil, fmt.Errorf("%w: %v", ErrProposeTimeout, applyErr)
+				return zero, fmt.Errorf("%w: %v", ErrProposeTimeout, applyErr)
 			}
 
-			return nil, applyErr
+			return zero, applyErr
 		}
 		// Lost leadership mid-apply — fall through to forward path.
 	}
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshal %s payload: %w", op.name, err)
+		return zero, fmt.Errorf("marshal %s payload: %w", op.name, err)
 	}
 
 	result, err := db.forwardOperation(op.name, payloadJSON)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
-	return result.Value, nil
+	return narrowResult[R](op.name, result.Value)
 }
 
 // leaderCaptureAndPropose runs the capture→propose cycle on the leader.

--- a/internal/db/operations_internal_test.go
+++ b/internal/db/operations_internal_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Ella Networks
+
+package db
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNarrowResult_TypedAny(t *testing.T) {
+	got, err := narrowResult[int]("op", 5)
+	if err != nil {
+		t.Fatalf("typed any: %v", err)
+	}
+
+	if got != 5 {
+		t.Fatalf("typed any: got %d want 5", got)
+	}
+}
+
+func TestNarrowResult_RawMessageDecodesToTyped(t *testing.T) {
+	got, err := narrowResult[int]("op", json.RawMessage("5"))
+	if err != nil {
+		t.Fatalf("raw message: %v", err)
+	}
+
+	if got != 5 {
+		t.Fatalf("raw message: got %d want 5", got)
+	}
+}
+
+func TestNarrowResult_RawMessageDecodesToStruct(t *testing.T) {
+	type result struct {
+		Addr string `json:"addr"`
+	}
+
+	got, err := narrowResult[result]("op", json.RawMessage(`{"addr":"10.0.0.5"}`))
+	if err != nil {
+		t.Fatalf("raw struct: %v", err)
+	}
+
+	if got.Addr != "10.0.0.5" {
+		t.Fatalf("raw struct: got %q want 10.0.0.5", got.Addr)
+	}
+}
+
+func TestNarrowResult_NilReturnsZero(t *testing.T) {
+	got, err := narrowResult[int]("op", nil)
+	if err != nil {
+		t.Fatalf("nil: %v", err)
+	}
+
+	if got != 0 {
+		t.Fatalf("nil: got %d want 0", got)
+	}
+}
+
+func TestNarrowResult_RawNullReturnsZero(t *testing.T) {
+	got, err := narrowResult[int]("op", json.RawMessage("null"))
+	if err != nil {
+		t.Fatalf("raw null: %v", err)
+	}
+
+	if got != 0 {
+		t.Fatalf("raw null: got %d want 0", got)
+	}
+}
+
+func TestNarrowResult_VoidShortCircuits(t *testing.T) {
+	// R = struct{}: any apply-side residue (last-insert-id, etc.) is dropped.
+	// Without the short-circuit, an int64 last-insert-id would error.
+	if _, err := narrowResult[struct{}]("op", int64(42)); err != nil {
+		t.Fatalf("void / int64 residue: %v", err)
+	}
+
+	if _, err := narrowResult[struct{}]("op", json.RawMessage(`{"any":"shape"}`)); err != nil {
+		t.Fatalf("void / raw residue: %v", err)
+	}
+
+	if _, err := narrowResult[struct{}]("op", nil); err != nil {
+		t.Fatalf("void / nil: %v", err)
+	}
+}
+
+func TestNarrowResult_TypeMismatchErrors(t *testing.T) {
+	// A buggy applier returning the wrong type must surface as an error,
+	// not a panic. Guards the call site against undeclared shape changes.
+	_, err := narrowResult[int]("op", "not-an-int")
+	if err == nil {
+		t.Fatal("expected error on type mismatch")
+	}
+
+	if !strings.Contains(err.Error(), "unexpected result type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNarrowResult_RawMessageDecodeError(t *testing.T) {
+	_, err := narrowResult[int]("op", json.RawMessage("not json"))
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("expected json.SyntaxError, got %v", err)
+	}
+}

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -32,9 +32,9 @@ var (
 	opUpdateLeaseNode           = registerChangesetOp("UpdateLeaseNode", (*Database).applyUpdateLeaseNode, RequireSchema(9), AffectsTopic(TopicIPLeases))
 	// AllocateIPLease forwards intent only; leader resolves the IP
 	// atomically under proposeMu (see applyAllocateIPLease).
-	opAllocateIPLease = registerChangesetOp("AllocateIPLease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
+	opAllocateIPLease = registerChangesetOpReturning[allocateIPLeasePayload, string]("AllocateIPLease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
 	// AllocateIPv6Lease is the same for IPv6 /64 prefix delegation.
-	opAllocateIPv6Lease = registerChangesetOp("AllocateIPv6Lease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
+	opAllocateIPv6Lease = registerChangesetOpReturning[allocateIPLeasePayload, string]("AllocateIPv6Lease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
 )
 
 // Audit logs
@@ -158,6 +158,6 @@ var (
 	opDeleteOldAuditLogs     = registerIntentOp("DeleteOldAuditLogs", ellaraft.CmdDeleteOldAuditLogs)
 	opDeleteOldDailyUsage    = registerIntentOp("DeleteOldDailyUsage", ellaraft.CmdDeleteOldDailyUsage)
 	opDeleteAllDynamicLeases = registerIntentOp("DeleteAllDynamicLeases", ellaraft.CmdDeleteAllDynamicLeases, AffectsTopic(TopicIPLeases))
-	opDeleteExpiredSessions  = registerIntentOp("DeleteExpiredSessions", ellaraft.CmdDeleteExpiredSessions)
+	opDeleteExpiredSessions  = registerIntentOpReturning[int]("DeleteExpiredSessions", ellaraft.CmdDeleteExpiredSessions)
 	opMigrateShared          = registerIntentOp("MigrateShared", ellaraft.CmdMigrateShared)
 )

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -178,7 +178,7 @@ func (db *Database) DeleteExpiredSessions(ctx context.Context) (int, error) {
 
 	nowUnix := time.Now().Unix()
 
-	result, err := opDeleteExpiredSessions.Invoke(db, &int64Payload{Value: nowUnix})
+	count, err := opDeleteExpiredSessions.Invoke(db, &int64Payload{Value: nowUnix})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -188,7 +188,7 @@ func (db *Database) DeleteExpiredSessions(ctx context.Context) (int, error) {
 
 	span.SetStatus(codes.Ok, "")
 
-	return result.(int), nil
+	return count, nil
 }
 
 func (db *Database) CountSessionsByUser(ctx context.Context, userID string) (int, error) {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -3,13 +3,17 @@
 package db_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ellanetworks/core/internal/db"
+	ellaraft "github.com/ellanetworks/core/internal/raft"
 )
 
 func TestSessionsEndToEnd(t *testing.T) {
@@ -449,5 +453,36 @@ func TestDeleteAllSessions(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expected error when retrieving deleted session with hash %v", s.TokenHash)
 		}
+	}
+}
+
+// TestDeleteExpiredSessions_TypedResultSurvivesForwardWire is the regression
+// test for issue #1331. The leader's int result is JSON-encoded into the
+// propose-forward envelope and then decoded on the follower; the dispatcher
+// must surface int(N), not panic on a JSON-roundtripped float64.
+func TestDeleteExpiredSessions_TypedResultSurvivesForwardWire(t *testing.T) {
+	const fsmCount = 3
+
+	rec := httptest.NewRecorder()
+	if err := ellaraft.WriteProposeForwardResponse(rec, &ellaraft.ProposeResult{Index: 7, Value: fsmCount}); err != nil {
+		t.Fatalf("WriteProposeForwardResponse: %v", err)
+	}
+
+	var env ellaraft.ProposeForwardResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(env.Value) == 0 || bytes.Equal(env.Value, []byte("null")) {
+		t.Fatalf("envelope value missing: %s", rec.Body.String())
+	}
+
+	var got int
+	if err := json.Unmarshal(env.Value, &got); err != nil {
+		t.Fatalf("decode result into int: %v", err)
+	}
+
+	if got != fsmCount {
+		t.Fatalf("typed decode mismatch: got %d, want %d", got, fsmCount)
 	}
 }

--- a/internal/raft/forward.go
+++ b/internal/raft/forward.go
@@ -241,12 +241,9 @@ func (m *Manager) doForwardRequest(ctx context.Context, leaderAddr string, leade
 	result := &ProposeResult{Index: env.Index}
 
 	if len(env.Value) > 0 && !bytes.Equal(env.Value, []byte("null")) {
-		var v any
-		if err := json.Unmarshal(env.Value, &v); err != nil {
-			return nil, 0, fmt.Errorf("decode result value: %w", err)
-		}
-
-		result.Value = v
+		// Preserve raw bytes; the typed-op dispatcher decodes into the
+		// op's declared result type to avoid `any → float64` erasure.
+		result.Value = env.Value
 	}
 
 	return result, http.StatusOK, nil


### PR DESCRIPTION
# Description

Fix a panic in  `DeleteExpiredSessions` (#1331) and the latent same-class  bug in every replicated op.

Superseedes #1331

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
