### PR TITLE
fix: Show N6 addresses in Interfaces tab

### DIFF
--- a/internal/api/server/api_interfaces.go
+++ b/internal/api/server/api_interfaces.go
@@ -30,8 +30,9 @@ type Vlan struct {
 }
 
 type N6Interface struct {
-	Name string `json:"name"`
-	Vlan *Vlan  `json:"vlan,omitempty"`
+	Name      string   `json:"name"`
+	Addresses []string `json:"addresses"`
+	Vlan      *Vlan    `json:"vlan,omitempty"`
 }
 
 type APIInterface struct {
@@ -104,6 +105,18 @@ func ListNetworkInterfaces(dbInstance *db.Database, cfg config.Config) http.Hand
 			n3Addresses = []string{cfg.Interfaces.N3.Address}
 		}
 
+		var n6Addresses []string
+
+		if cfg.Interfaces.N6.Name != "" {
+			ips, err := config.GetInterfaceIPs(cfg.Interfaces.N6.Name)
+			if err != nil {
+				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get N6 interface IPs", err, logger.APILog)
+				return
+			}
+
+			n6Addresses = ips
+		}
+
 		resp := &NetworkInterfaces{
 			N2: N2Interface{
 				Addresses: n2Addresses,
@@ -116,7 +129,8 @@ func ListNetworkInterfaces(dbInstance *db.Database, cfg config.Config) http.Hand
 				ExternalAddress: n3Settings.ExternalAddress,
 			},
 			N6: N6Interface{
-				Name: cfg.Interfaces.N6.Name,
+				Name:      cfg.Interfaces.N6.Name,
+				Addresses: n6Addresses,
 			},
 			API: APIInterface{
 				Addresses: apiAddresses,

--- a/internal/api/server/api_interfaces_test.go
+++ b/internal/api/server/api_interfaces_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"path/filepath"
 	"testing"
+
+	"github.com/ellanetworks/core/internal/config"
 )
 
 type N2Interface struct {
@@ -22,7 +24,8 @@ type N3Interface struct {
 }
 
 type N6Interface struct {
-	Name string `json:"name"`
+	Name      string   `json:"name"`
+	Addresses []string `json:"addresses"`
 }
 
 type APIInterface struct {
@@ -122,6 +125,20 @@ func updateN3Info(url string, client *http.Client, token string, externalAddress
 }
 
 func TestNetworkInteraces_EndToEnd(t *testing.T) {
+	originalGetInterfaceIPsFunc := config.GetInterfaceIPsFunc
+	config.GetInterfaceIPsFunc = func(name string) ([]string, error) {
+		switch name {
+		case "eth1":
+			return []string{"14.14.14.14"}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	t.Cleanup(func() {
+		config.GetInterfaceIPsFunc = originalGetInterfaceIPsFunc
+	})
+
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
 
@@ -175,6 +192,10 @@ func TestNetworkInteraces_EndToEnd(t *testing.T) {
 
 		if resp.Result.N6.Name != "eth1" {
 			t.Fatalf("unexpected N6 interface name: %s", resp.Result.N6.Name)
+		}
+
+		if len(resp.Result.N6.Addresses) != 1 || resp.Result.N6.Addresses[0] != "14.14.14.14" {
+			t.Fatalf("unexpected N6 interface addresses: %v", resp.Result.N6.Addresses)
 		}
 
 		if len(resp.Result.API.Addresses) != 0 {

--- a/ui/src/pages/networking/InterfacesTab.tsx
+++ b/ui/src/pages/networking/InterfacesTab.tsx
@@ -211,6 +211,18 @@ export default function InterfacesTab() {
                 Interface name:{" "}
                 <strong>{interfacesInfo.n6?.name ?? "—"}</strong>
               </Typography>
+              {interfacesInfo.n6?.addresses &&
+              interfacesInfo.n6.addresses.length > 0 ? (
+                interfacesInfo.n6.addresses.map((addr) => (
+                  <Typography key={addr} variant="body2" color="textSecondary">
+                    Address: <strong>{addr}</strong>
+                  </Typography>
+                ))
+              ) : (
+                <Typography variant="body2" color="textSecondary">
+                  Address: <strong>—</strong>
+                </Typography>
+              )}
               {interfacesInfo.n6?.vlan && (
                 <Typography variant="body2" color="textSecondary">
                   VLAN:{" "}

--- a/ui/src/queries/interfaces.tsx
+++ b/ui/src/queries/interfaces.tsx
@@ -13,7 +13,7 @@ export type InterfacesInfo = {
     external_address?: string;
     vlan?: VlanInfo;
   };
-  n6?: { name?: string; vlan?: VlanInfo };
+  n6?: { name?: string; addresses?: string[]; vlan?: VlanInfo };
   api?: { addresses?: string[]; port?: number };
 };
 


### PR DESCRIPTION
# Description

Now that we support IPv6 for PDU sessions, it makes sense to show the N6 addresses including IPv6, like with the other interfaces:

<img width="2063" height="911" alt="2026-05-07-080938_2063x911_scrot" src="https://github.com/user-attachments/assets/3a25cd3d-4653-460f-a546-f84e69892d70" />


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
