### PR TITLE
fix: Make policies and network rules properly use raft

### DIFF
--- a/internal/api/server/api_policies.go
+++ b/internal/api/server/api_policies.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
-	"go.uber.org/zap"
 )
 
 const (
@@ -34,6 +33,33 @@ type PolicyRule struct {
 type PolicyRules struct {
 	Uplink   []PolicyRule `json:"uplink,omitempty"`
 	Downlink []PolicyRule `json:"downlink,omitempty"`
+}
+
+func toDBPolicyRules(rules *PolicyRules) *db.PolicyRulesInput {
+	if rules == nil {
+		return nil
+	}
+
+	convert := func(in []PolicyRule) []db.PolicyRuleInput {
+		out := make([]db.PolicyRuleInput, 0, len(in))
+		for _, rule := range in {
+			out = append(out, db.PolicyRuleInput{
+				Description:  rule.Description,
+				RemotePrefix: rule.RemotePrefix,
+				Protocol:     rule.Protocol,
+				PortLow:      rule.PortLow,
+				PortHigh:     rule.PortHigh,
+				Action:       rule.Action,
+			})
+		}
+
+		return out
+	}
+
+	return &db.PolicyRulesInput{
+		Uplink:   convert(rules.Uplink),
+		Downlink: convert(rules.Downlink),
+	}
 }
 
 type CreatePolicyParams struct {
@@ -218,54 +244,6 @@ func validatePolicyRules(rules *PolicyRules) error {
 	for i, rule := range rules.Downlink {
 		if err := validatePolicyRule(rule); err != nil {
 			return fmt.Errorf("downlink rule %d: %w", i, err)
-		}
-	}
-
-	return nil
-}
-
-func createNetworkRulesForPolicyTx(ctx context.Context, tx *db.Transaction, policyID string, rules *PolicyRules) error {
-	if rules == nil {
-		return nil
-	}
-
-	// Create uplink rules with precedence
-	for i, rule := range rules.Uplink {
-		dbRule := &db.NetworkRule{
-			PolicyID:     policyID,
-			Description:  rule.Description,
-			Direction:    DirectionUplink,
-			RemotePrefix: rule.RemotePrefix,
-			Protocol:     rule.Protocol,
-			PortLow:      rule.PortLow,
-			PortHigh:     rule.PortHigh,
-			Action:       rule.Action,
-			Precedence:   int32(i + 1), // 1-indexed
-		}
-
-		_, err := tx.CreateNetworkRule(ctx, dbRule)
-		if err != nil {
-			return fmt.Errorf("failed to create uplink rule %d: %w", i, err)
-		}
-	}
-
-	// Create downlink rules with precedence
-	for i, rule := range rules.Downlink {
-		dbRule := &db.NetworkRule{
-			PolicyID:     policyID,
-			Description:  rule.Description,
-			Direction:    DirectionDownlink,
-			RemotePrefix: rule.RemotePrefix,
-			Protocol:     rule.Protocol,
-			PortLow:      rule.PortLow,
-			PortHigh:     rule.PortHigh,
-			Action:       rule.Action,
-			Precedence:   int32(i + 1), // 1-indexed
-		}
-
-		_, err := tx.CreateNetworkRule(ctx, dbRule)
-		if err != nil {
-			return fmt.Errorf("failed to create downlink rule %d: %w", i, err)
 		}
 	}
 
@@ -548,48 +526,29 @@ func CreatePolicy(dbInstance *db.Database) http.Handler {
 			SliceID:             slice.ID,
 		}
 
-		tx, err := dbInstance.BeginTransaction(r.Context())
-		if err != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, "Internal error starting transaction", err, logger.APILog)
-			return
-		}
-
-		committed := false
-
-		defer func() {
-			if !committed {
-				if rbErr := tx.Rollback(); rbErr != nil {
-					logger.APILog.Error("Failed to rollback transaction", zap.Error(rbErr))
-				}
-			}
-		}()
-
-		policyID, err := tx.CreatePolicy(r.Context(), dbPolicy)
-		if err != nil {
-			if errors.Is(err, db.ErrAlreadyExists) {
-				writeError(r.Context(), w, http.StatusConflict, "Policy already exists", nil, logger.APILog)
-				return
-			}
-
-			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create policy", err, logger.APILog)
-
-			return
-		}
-
-		// Create network rules inside the same transaction if provided
 		if createPolicyParams.Rules != nil {
-			if err := createNetworkRulesForPolicyTx(r.Context(), tx, policyID, createPolicyParams.Rules); err != nil {
-				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create policy rules", err, logger.APILog)
+			if err := dbInstance.CreatePolicyWithRules(r.Context(), dbPolicy, toDBPolicyRules(createPolicyParams.Rules)); err != nil {
+				if errors.Is(err, db.ErrAlreadyExists) {
+					writeError(r.Context(), w, http.StatusConflict, "Policy already exists", nil, logger.APILog)
+					return
+				}
+
+				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create policy", err, logger.APILog)
+
+				return
+			}
+		} else {
+			if err := dbInstance.CreatePolicy(r.Context(), dbPolicy); err != nil {
+				if errors.Is(err, db.ErrAlreadyExists) {
+					writeError(r.Context(), w, http.StatusConflict, "Policy already exists", nil, logger.APILog)
+					return
+				}
+
+				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create policy", err, logger.APILog)
+
 				return
 			}
 		}
-
-		if err := tx.Commit(); err != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to commit transaction", err, logger.APILog)
-			return
-		}
-
-		committed = true
 
 		writeResponse(r.Context(), w, SuccessResponse{Message: "Policy created successfully"}, http.StatusCreated, logger.APILog)
 
@@ -656,45 +615,10 @@ func UpdatePolicy(dbInstance *db.Database) http.Handler {
 		policy.SliceID = slice.ID
 		policy.DataNetworkID = dataNetwork.ID
 
-		tx, err := dbInstance.BeginTransaction(r.Context())
-		if err != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, "Internal error starting transaction", err, logger.APILog)
-			return
-		}
-
-		committed := false
-
-		defer func() {
-			if !committed {
-				if rbErr := tx.Rollback(); rbErr != nil {
-					logger.APILog.Error("Failed to rollback transaction", zap.Error(rbErr))
-				}
-			}
-		}()
-
-		if err := tx.UpdatePolicy(r.Context(), policy); err != nil {
+		if err := dbInstance.UpdatePolicyWithRules(r.Context(), policy, toDBPolicyRules(updatePolicyParams.Rules)); err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to update policy", err, logger.APILog)
 			return
 		}
-
-		// Omitting the rules field in the request body is treated as an
-		// explicit deletion of all rules. Re-creating happens below.
-		if err := tx.DeleteNetworkRulesByPolicyID(r.Context(), policy.ID); err != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to delete existing policy rules", err, logger.APILog)
-			return
-		}
-
-		if err := createNetworkRulesForPolicyTx(r.Context(), tx, policy.ID, updatePolicyParams.Rules); err != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create policy rules", err, logger.APILog)
-			return
-		}
-
-		if err := tx.Commit(); err != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to commit transaction", err, logger.APILog)
-			return
-		}
-
-		committed = true
 
 		writeResponse(r.Context(), w, SuccessResponse{Message: "Policy updated successfully"}, http.StatusOK, logger.APILog)
 		logger.LogAuditEvent(r.Context(), UpdatePolicyAction, email, getClientIP(r), "User updated policy: "+policyName)

--- a/internal/api/server/api_policies_test.go
+++ b/internal/api/server/api_policies_test.go
@@ -1288,3 +1288,255 @@ func TestUpdatePolicyPersistsRules(t *testing.T) {
 		t.Fatalf("expected downlink rule action 'deny', got %q", getResp.Result.Rules.Downlink[0].Action)
 	}
 }
+
+func TestUpdatePolicyRulesSurviveRestart(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServerWithRaft(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize and login: %s", err)
+	}
+
+	_, _, err = createDataNetwork(env.Server.URL, client, token, &CreateDataNetworkParams{
+		Name: DataNetworkName, MTU: MTU, IPv4Pool: IPv4Pool, DNS: DNS,
+	})
+	if err != nil {
+		t.Fatalf("couldn't create data network: %s", err)
+	}
+
+	_, _, err = createProfile(env.Server.URL, client, token, &CreateProfileParams{
+		Name: "restart-rules-profile", UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "100 Mbps",
+	})
+	if err != nil {
+		t.Fatalf("couldn't create profile: %s", err)
+	}
+
+	_, _, err = createPolicy(env.Server.URL, client, token, &CreatePolicyParams{
+		Name:                "restart-rules-policy",
+		ProfileName:         "restart-rules-profile",
+		SliceName:           DefaultSliceName,
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkName:     DataNetworkName,
+	})
+	if err != nil {
+		t.Fatalf("couldn't create policy: %s", err)
+	}
+
+	cidr := "2001:db8::/64"
+
+	statusCode, updateResp, err := editPolicy(env.Server.URL, client, "restart-rules-policy", token, &UpdatePolicyParams{
+		ProfileName:         "restart-rules-profile",
+		SliceName:           DefaultSliceName,
+		SessionAmbrUplink:   "200 Mbps",
+		SessionAmbrDownlink: "200 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkName:     DataNetworkName,
+		Rules: &PolicyRules{
+			Uplink: []PolicyRule{{
+				Description:  "Allow IPv6",
+				RemotePrefix: &cidr,
+				Protocol:     6,
+				PortLow:      443,
+				PortHigh:     443,
+				Action:       "allow",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("couldn't update policy: %s", err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got %d (error: %s)", http.StatusOK, statusCode, updateResp.Error)
+	}
+
+	env.Server.Close()
+
+	if err := env.DB.Close(); err != nil {
+		t.Fatalf("couldn't close database: %s", err)
+	}
+
+	env2, err := setupServerWithRaft(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't restart server: %s", err)
+	}
+	defer env2.Server.Close()
+	defer func() { _ = env2.DB.Close() }()
+
+	client2 := newTestClient(env2.Server)
+
+	loginResp2Code, loginResp2, err := login(env2.Server.URL, client2, &LoginParams{
+		Email:    FirstUserEmail,
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("couldn't login after restart: %s", err)
+	}
+
+	if loginResp2Code != http.StatusOK {
+		t.Fatalf("expected login status %d, got %d", http.StatusOK, loginResp2Code)
+	}
+
+	token2 := loginResp2.Result.Token
+
+	_, getResp, err := getPolicy(env2.Server.URL, client2, token2, "restart-rules-policy")
+	if err != nil {
+		t.Fatalf("couldn't get policy after restart: %s", err)
+	}
+
+	if getResp.Result.Rules == nil || len(getResp.Result.Rules.Uplink) != 1 {
+		t.Fatalf("expected rules to persist after restart, got %+v", getResp.Result.Rules)
+	}
+}
+
+// TestUpdatePolicyAllZeroRulePersists verifies that an "allow all" rule with
+// all-zero numeric fields (protocol=0, port_low=0, port_high=0, no
+// remote_prefix) is correctly persisted by UpdatePolicy and returned by
+// GetPolicy. This is the specific rule shape that was reported as being
+// silently dropped when added as the 5th rule after 4 non-zero rules.
+func TestUpdatePolicyAllZeroRulePersists(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServerWithRaft(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+	defer func() { _ = env.DB.Close() }()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't initialize and login: %s", err)
+	}
+
+	_, _, err = createDataNetwork(env.Server.URL, client, token, &CreateDataNetworkParams{
+		Name: DataNetworkName, MTU: MTU, IPv4Pool: IPv4Pool, DNS: DNS,
+	})
+	if err != nil {
+		t.Fatalf("couldn't create data network: %s", err)
+	}
+
+	_, _, err = createProfile(env.Server.URL, client, token, &CreateProfileParams{
+		Name: "allzero-profile", UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "100 Mbps",
+	})
+	if err != nil {
+		t.Fatalf("couldn't create profile: %s", err)
+	}
+
+	_, _, err = createPolicy(env.Server.URL, client, token, &CreatePolicyParams{
+		Name:                "allzero-policy",
+		ProfileName:         "allzero-profile",
+		SliceName:           DefaultSliceName,
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkName:     DataNetworkName,
+	})
+	if err != nil {
+		t.Fatalf("couldn't create policy: %s", err)
+	}
+
+	// First update: set 4 non-zero rules.
+	statusCode, updateResp, err := editPolicy(env.Server.URL, client, "allzero-policy", token, &UpdatePolicyParams{
+		ProfileName:         "allzero-profile",
+		SliceName:           DefaultSliceName,
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkName:     DataNetworkName,
+		Rules: &PolicyRules{
+			Uplink: []PolicyRule{
+				{Description: "rule-1", Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+				{Description: "rule-2", Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+				{Description: "rule-3", Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
+				{Description: "rule-4", Protocol: 1, PortLow: 0, PortHigh: 0, Action: "deny"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("couldn't update policy with initial 4 rules: %s", err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status %d for initial update, got %d (error: %s)", http.StatusOK, statusCode, updateResp.Error)
+	}
+
+	_, getResp, err := getPolicy(env.Server.URL, client, token, "allzero-policy")
+	if err != nil {
+		t.Fatalf("couldn't get policy after initial update: %s", err)
+	}
+
+	if getResp.Result.Rules == nil || len(getResp.Result.Rules.Uplink) != 4 {
+		t.Fatalf("expected 4 uplink rules after initial update, got %+v", getResp.Result.Rules)
+	}
+
+	// Second update: add the "allow all" rule (all-zero fields) as the 5th rule.
+	statusCode, updateResp, err = editPolicy(env.Server.URL, client, "allzero-policy", token, &UpdatePolicyParams{
+		ProfileName:         "allzero-profile",
+		SliceName:           DefaultSliceName,
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkName:     DataNetworkName,
+		Rules: &PolicyRules{
+			Uplink: []PolicyRule{
+				{Description: "rule-1", Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+				{Description: "rule-2", Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+				{Description: "rule-3", Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
+				{Description: "rule-4", Protocol: 1, PortLow: 0, PortHigh: 0, Action: "deny"},
+				{Description: "allow all", Protocol: 0, PortLow: 0, PortHigh: 0, Action: "allow"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("couldn't update policy with allow-all rule: %s", err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status %d for allow-all update, got %d (error: %s)", http.StatusOK, statusCode, updateResp.Error)
+	}
+
+	_, getResp, err = getPolicy(env.Server.URL, client, token, "allzero-policy")
+	if err != nil {
+		t.Fatalf("couldn't get policy after allow-all update: %s", err)
+	}
+
+	if getResp.Result.Rules == nil {
+		t.Fatal("expected rules to exist after allow-all update, got nil")
+	}
+
+	if len(getResp.Result.Rules.Uplink) != 5 {
+		t.Fatalf("expected 5 uplink rules after allow-all update, got %d (allow-all rule may have been dropped)", len(getResp.Result.Rules.Uplink))
+	}
+
+	found := false
+
+	for _, r := range getResp.Result.Rules.Uplink {
+		if r.Description == "allow all" && r.Protocol == 0 && r.PortLow == 0 && r.PortHigh == 0 {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("allow-all rule (protocol=0, port_low=0, port_high=0) not found in GET response after PUT: %+v", getResp.Result.Rules.Uplink)
+	}
+}

--- a/internal/db/changeset_replication.go
+++ b/internal/db/changeset_replication.go
@@ -79,7 +79,6 @@ var replicatedChangesetTables = []string{
 var localOnlyTables = []string{
 	RadioEventsTableName,
 	FlowReportsTableName,
-	FsmStateTableName,
 	RoutesTableName,
 	BGPSettingsTableName,
 	BGPPeersTableName,
@@ -87,6 +86,24 @@ var localOnlyTables = []string{
 	N3SettingsTableName,
 	NATSettingsTableName,
 	FlowAccountingSettingsTableName,
+}
+
+// fsmInternalTables are managed directly by the FSM layer, not through
+// changeset replication or local-only backup/restore. The fsm_state table
+// tracks the Raft index of the last applied log entry. Its value must
+// always match the database content:
+//
+//   - In a snapshot, fsm_state.lastApplied reflects the last log entry
+//     applied before the snapshot was taken.
+//   - During FSM.Restore, fsm_state must NOT be overwritten from the
+//     pre-restore database (as localOnlyTables are). Preserving a stale
+//     lastApplied causes the FSM to skip replaying log entries that
+//     follow the snapshot, silently losing committed mutations.
+//
+// The table is created/seeded by ensureFsmStateTable on every startup and
+// after every Reopen.
+var fsmInternalTables = []string{
+	FsmStateTableName,
 }
 
 func (db *Database) assertTableReplicationClassification(ctx context.Context) error {
@@ -98,12 +115,16 @@ func (db *Database) assertTableReplicationClassification(ctx context.Context) er
 
 	defer func() { _ = rows.Close() }()
 
-	class := make(map[string]struct{}, len(replicatedChangesetTables)+len(localOnlyTables))
+	class := make(map[string]struct{}, len(replicatedChangesetTables)+len(localOnlyTables)+len(fsmInternalTables))
 	for _, t := range replicatedChangesetTables {
 		class[t] = struct{}{}
 	}
 
 	for _, t := range localOnlyTables {
+		class[t] = struct{}{}
+	}
+
+	for _, t := range fsmInternalTables {
 		class[t] = struct{}{}
 	}
 
@@ -117,7 +138,7 @@ func (db *Database) assertTableReplicationClassification(ctx context.Context) er
 			continue
 		}
 
-		return fmt.Errorf("table %q is not classified as replicated or local-only", table)
+		return fmt.Errorf("table %q is not classified as replicated, local-only, or fsm-internal", table)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -615,6 +616,16 @@ func (db *Database) AddNonvoter(nodeID int, raftAddress string) error {
 	return db.raftManager.AddNonvoter(nodeID, raftAddress)
 }
 
+// ForceSnapshot triggers a Raft snapshot and blocks until it completes.
+// Used in tests to exercise the snapshot-restore path.
+func (db *Database) ForceSnapshot() error {
+	if db.raftManager == nil {
+		return fmt.Errorf("clustering not enabled")
+	}
+
+	return db.raftManager.Snapshot()
+}
+
 // CurrentSchemaVersion reads the schema_version singleton.
 // Returns 0 on error.
 func (db *Database) CurrentSchemaVersion(ctx context.Context) (int, error) {
@@ -1092,6 +1103,16 @@ func NewDatabase(ctx context.Context, dbPath string, raftCfg ellaraft.ClusterCon
 	db.raftManager = raftMgr
 	db.proposeTimeout = raftMgr.ProposeTimeout()
 	db.probeVoterSchema = raftMgr.ProbePeerSchemaVersion
+
+	// Ensure the FSM migration marker exists so future FSM.Restore
+	// calls know the new code is active and use the snapshot's
+	// lastApplied instead of preserving a potentially stale value.
+	migrationMarker := filepath.Join(dataDir, ".fsm_migrated")
+	if _, statErr := os.Stat(migrationMarker); os.IsNotExist(statErr) {
+		if wErr := os.WriteFile(migrationMarker, []byte("1"), 0o600); wErr != nil {
+			logger.DBLog.Warn("failed to create fsm migration marker", zap.Error(wErr))
+		}
+	}
 
 	db.migrationCheckCh = make(chan struct{}, 1)
 	workerCtx, workerCancel := context.WithCancel(context.Background())

--- a/internal/db/network_rules.go
+++ b/internal/db/network_rules.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/canonical/sqlair"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
@@ -336,96 +335,6 @@ func (db *Database) ListRulesForPolicy(ctx context.Context, policyID string) ([]
 	span.SetStatus(codes.Ok, "")
 
 	return rules, nil
-}
-
-// CreateNetworkRule creates a new network rule in the transaction and returns its ID.
-func (t *Transaction) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (string, error) {
-	ctx, span := tracer.Start(
-		ctx,
-		fmt.Sprintf("%s %s", "INSERT", NetworkRulesTableName),
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			semconv.DBSystemNameSQLite,
-			semconv.DBOperationName("INSERT"),
-			attribute.String("db.collection", NetworkRulesTableName),
-		),
-	)
-	defer span.End()
-
-	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(NetworkRulesTableName, "insert"))
-	defer timer.ObserveDuration()
-
-	DBQueriesTotal.WithLabelValues(NetworkRulesTableName, "insert").Inc()
-
-	now := time.Now().UTC()
-	nr.CreatedAt = now
-	nr.UpdatedAt = now
-
-	if nr.ID == "" {
-		id, err := uuid.NewV7()
-		if err != nil {
-			return "", fmt.Errorf("generate network rule id: %w", err)
-		}
-
-		nr.ID = id.String()
-	}
-
-	err := t.tx.Query(ctx, t.db.createNetworkRuleStmt, nr).Run()
-	if err != nil {
-		if isUniqueNameError(err) {
-			span.RecordError(ErrAlreadyExists)
-			span.SetStatus(codes.Error, "unique constraint failed")
-
-			return "", ErrAlreadyExists
-		}
-
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "query failed")
-
-		return "", fmt.Errorf("query failed: %w", err)
-	}
-
-	span.SetStatus(codes.Ok, "")
-
-	t.db.publishOpTopics([]Topic{TopicNetworkRules}, 0)
-
-	return nr.ID, nil
-}
-
-// DeleteNetworkRulesByPolicyID deletes all network rules for a given policy ID within a transaction.
-func (t *Transaction) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID string) error {
-	ctx, span := tracer.Start(
-		ctx,
-		fmt.Sprintf("%s %s", "DELETE", NetworkRulesTableName),
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			semconv.DBSystemNameSQLite,
-			semconv.DBOperationName("DELETE"),
-			attribute.String("db.collection", NetworkRulesTableName),
-		),
-	)
-	defer span.End()
-
-	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(NetworkRulesTableName, "delete"))
-	defer timer.ObserveDuration()
-
-	DBQueriesTotal.WithLabelValues(NetworkRulesTableName, "delete").Inc()
-
-	var outcome sqlair.Outcome
-
-	err := t.tx.Query(ctx, t.db.deleteNetworkRulesByPolicyStmt, NetworkRule{PolicyID: policyID}).Get(&outcome)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "query failed")
-
-		return fmt.Errorf("query failed: %w", err)
-	}
-
-	span.SetStatus(codes.Ok, "")
-
-	t.db.publishOpTopics([]Topic{TopicNetworkRules}, 0)
-
-	return nil
 }
 
 // DeleteNetworkRulesByPolicyID deletes all network rules for a given policy ID.

--- a/internal/db/network_rules_test.go
+++ b/internal/db/network_rules_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/db"
+	ellaraft "github.com/ellanetworks/core/internal/raft"
 )
 
 // createPolicyDeps creates a profile and a network slice and returns their IDs.
@@ -888,5 +889,426 @@ func TestReorderRulesForPolicy(t *testing.T) {
 		if r.Precedence != int32((i+1)*100) {
 			t.Errorf("rule[%d]: want precedence %d, got %d", i, (i+1)*100, r.Precedence)
 		}
+	}
+}
+
+// TestUpdatePolicyWithRules_AllZeroRule tests that a rule with all-zero
+// numeric fields (protocol=0, port_low=0, port_high=0) is correctly stored
+// and retrieved by UpdatePolicyWithRules. This exercises the specific
+// "allow all" rule shape that was reported as being silently dropped.
+func TestUpdatePolicyWithRules_AllZeroRule_NoRaft(t *testing.T) {
+	dbInstance := setupTestDB(t)
+	ctx := context.Background()
+
+	policy := createTestPolicy(t, dbInstance)
+
+	// Start with 4 non-zero rules.
+	initial := &db.PolicyRulesInput{
+		Uplink: []db.PolicyRuleInput{
+			{Description: "rule-1", Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+			{Description: "rule-2", Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+			{Description: "rule-3", Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
+			{Description: "rule-4", Protocol: 1, PortLow: 0, PortHigh: 0, Action: "deny"},
+		},
+	}
+
+	if err := dbInstance.UpdatePolicyWithRules(ctx, policy, initial); err != nil {
+		t.Fatalf("UpdatePolicyWithRules (initial): %v", err)
+	}
+
+	rules, err := dbInstance.ListRulesForPolicy(ctx, policy.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy after initial update: %v", err)
+	}
+
+	if len(rules) != 4 {
+		t.Fatalf("expected 4 rules after initial update, got %d", len(rules))
+	}
+
+	// Now update with 5 rules where the 5th is an "allow all"
+	// (protocol=0, port_low=0, port_high=0, no remote_prefix).
+	updated := &db.PolicyRulesInput{
+		Uplink: []db.PolicyRuleInput{
+			{Description: "rule-1", Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+			{Description: "rule-2", Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+			{Description: "rule-3", Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
+			{Description: "rule-4", Protocol: 1, PortLow: 0, PortHigh: 0, Action: "deny"},
+			{Description: "allow all", Protocol: 0, PortLow: 0, PortHigh: 0, Action: "allow"},
+		},
+	}
+
+	if err := dbInstance.UpdatePolicyWithRules(ctx, policy, updated); err != nil {
+		t.Fatalf("UpdatePolicyWithRules (with allow-all): %v", err)
+	}
+
+	rules, err = dbInstance.ListRulesForPolicy(ctx, policy.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy after update with allow-all: %v", err)
+	}
+
+	if len(rules) != 5 {
+		t.Fatalf("expected 5 rules after update, got %d (allow-all rule may have been dropped)", len(rules))
+	}
+
+	found := false
+
+	for _, r := range rules {
+		if r.Description == "allow all" && r.Protocol == 0 && r.PortLow == 0 && r.PortHigh == 0 {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("allow-all rule (protocol=0, port_low=0, port_high=0) not found in stored rules")
+	}
+}
+
+// TestUpdatePolicyWithRules_AllZeroRule_Raft is the Raft-path analogue of
+// TestUpdatePolicyWithRules_AllZeroRule_NoRaft. It verifies the changeset
+// capture and Raft proposal succeed for the all-zero rule shape.
+func TestUpdatePolicyWithRules_AllZeroRule_Raft(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "data")
+
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	defer func() {
+		if err := database.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	testDN := &db.DataNetwork{Name: "allzero-dn", IPv4Pool: "10.77.0.0/24"}
+	if err := database.CreateDataNetwork(ctx, testDN); err != nil {
+		t.Fatalf("CreateDataNetwork: %v", err)
+	}
+
+	dn, err := database.GetDataNetwork(ctx, testDN.Name)
+	if err != nil {
+		t.Fatalf("GetDataNetwork: %v", err)
+	}
+
+	profileID, sliceID := createPolicyDeps(t, database, "allzero-raft")
+
+	policy := &db.Policy{
+		Name:                "allzero-raft-policy",
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkID:       dn.ID,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
+	}
+
+	if err := database.CreatePolicy(ctx, policy); err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	created, err := database.GetPolicy(ctx, policy.Name)
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	// Populate 4 initial rules.
+	initial := &db.PolicyRulesInput{
+		Uplink: []db.PolicyRuleInput{
+			{Description: "rule-1", Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+			{Description: "rule-2", Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+			{Description: "rule-3", Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
+			{Description: "rule-4", Protocol: 1, PortLow: 0, PortHigh: 0, Action: "deny"},
+		},
+	}
+
+	if err := database.UpdatePolicyWithRules(ctx, created, initial); err != nil {
+		t.Fatalf("UpdatePolicyWithRules (initial): %v", err)
+	}
+
+	rules, err := database.ListRulesForPolicy(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy after initial: %v", err)
+	}
+
+	if len(rules) != 4 {
+		t.Fatalf("expected 4 rules after initial update, got %d", len(rules))
+	}
+
+	// Now update with the all-zero "allow all" rule added as the 5th.
+	withAllZero := &db.PolicyRulesInput{
+		Uplink: []db.PolicyRuleInput{
+			{Description: "rule-1", Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+			{Description: "rule-2", Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+			{Description: "rule-3", Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
+			{Description: "rule-4", Protocol: 1, PortLow: 0, PortHigh: 0, Action: "deny"},
+			{Description: "allow all", Protocol: 0, PortLow: 0, PortHigh: 0, Action: "allow"},
+		},
+	}
+
+	if err := database.UpdatePolicyWithRules(ctx, created, withAllZero); err != nil {
+		t.Fatalf("UpdatePolicyWithRules (with allow-all): %v", err)
+	}
+
+	rules, err = database.ListRulesForPolicy(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy after allow-all update: %v", err)
+	}
+
+	if len(rules) != 5 {
+		t.Fatalf("expected 5 rules after update, got %d (allow-all rule may have been dropped by changeset path)", len(rules))
+	}
+
+	found := false
+
+	for _, r := range rules {
+		if r.Description == "allow all" && r.Protocol == 0 && r.PortLow == 0 && r.PortHigh == 0 {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("allow-all rule (protocol=0, port_low=0, port_high=0) not found after Raft update")
+	}
+}
+
+// TestUpdatePolicyWithRules_Raft_SurviveRestart verifies that rules written
+// through the Raft changeset path persist across a full database close/reopen.
+// This is the production code path (single-node Raft). The earlier API-level
+// restart test uses NewDatabaseWithoutRaft, which bypasses changeset capture.
+func TestUpdatePolicyWithRules_Raft_SurviveRestart(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "data")
+
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	// Create prerequisite entities.
+	testDN := &db.DataNetwork{Name: "raft-dn", IPv4Pool: "10.99.0.0/24"}
+	if err := database.CreateDataNetwork(ctx, testDN); err != nil {
+		t.Fatalf("CreateDataNetwork: %v", err)
+	}
+
+	dn, err := database.GetDataNetwork(ctx, testDN.Name)
+	if err != nil {
+		t.Fatalf("GetDataNetwork: %v", err)
+	}
+
+	profileID, sliceID := createPolicyDeps(t, database, "raft-restart")
+
+	policy := &db.Policy{
+		Name:                "raft-restart-policy",
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkID:       dn.ID,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
+	}
+
+	if err := database.CreatePolicy(ctx, policy); err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	created, err := database.GetPolicy(ctx, policy.Name)
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	cidr := "2001:db8::/64"
+	rules := &db.PolicyRulesInput{
+		Uplink: []db.PolicyRuleInput{{
+			Description:  "allow-ipv6",
+			RemotePrefix: &cidr,
+			Protocol:     6,
+			PortLow:      443,
+			PortHigh:     443,
+			Action:       "allow",
+		}},
+	}
+
+	if err := database.UpdatePolicyWithRules(ctx, created, rules); err != nil {
+		t.Fatalf("UpdatePolicyWithRules: %v", err)
+	}
+
+	// Verify rules are visible before restart.
+	beforeRules, err := database.ListRulesForPolicy(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy (before restart): %v", err)
+	}
+
+	if len(beforeRules) != 1 {
+		t.Fatalf("expected 1 rule before restart, got %d", len(beforeRules))
+	}
+
+	// Close and reopen with Raft.
+	if err := database.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	database2, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("NewDatabase (reopen): %v", err)
+	}
+
+	defer func() {
+		if err := database2.Close(); err != nil {
+			t.Fatalf("Close (reopen): %v", err)
+		}
+	}()
+
+	afterPolicy, err := database2.GetPolicy(ctx, "raft-restart-policy")
+	if err != nil {
+		t.Fatalf("GetPolicy after restart: %v", err)
+	}
+
+	afterRules, err := database2.ListRulesForPolicy(ctx, afterPolicy.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy (after restart): %v", err)
+	}
+
+	if len(afterRules) != 1 {
+		t.Fatalf("expected 1 rule after restart, got %d", len(afterRules))
+	}
+
+	if afterRules[0].Description != "allow-ipv6" {
+		t.Fatalf("rule description mismatch: got %q", afterRules[0].Description)
+	}
+}
+
+// TestUpdatePolicyWithRules_SnapshotRestore_SurviveRestart exercises the
+// snapshot-restore path that triggered the original persistence bug.
+//
+// Scenario:
+//  1. Create a policy (no rules) and force a Raft snapshot — the snapshot
+//     captures fsm_state.lastApplied at the current log index.
+//  2. Update the policy with rules — this changeset goes into the Raft log
+//     AFTER the snapshot.
+//  3. Close and reopen the database — Raft restores from the snapshot, then
+//     replays post-snapshot log entries (including the rules changeset).
+//
+// Before the fix, fsm_state was in localOnlyTables. During restore, the
+// pre-restore database's lastApplied (higher than the snapshot's) was
+// preserved. The FSM then skipped replaying the post-snapshot changeset
+// because l.Index <= lastApplied, silently losing the rules.
+func TestUpdatePolicyWithRules_SnapshotRestore_SurviveRestart(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "data")
+
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	// Create prerequisite entities.
+	testDN := &db.DataNetwork{Name: "snap-dn", IPv4Pool: "10.88.0.0/24"}
+	if err := database.CreateDataNetwork(ctx, testDN); err != nil {
+		t.Fatalf("CreateDataNetwork: %v", err)
+	}
+
+	dn, err := database.GetDataNetwork(ctx, testDN.Name)
+	if err != nil {
+		t.Fatalf("GetDataNetwork: %v", err)
+	}
+
+	profileID, sliceID := createPolicyDeps(t, database, "snap-restore")
+
+	policy := &db.Policy{
+		Name:                "snap-restore-policy",
+		SessionAmbrUplink:   "100 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 1,
+		DataNetworkID:       dn.ID,
+		ProfileID:           profileID,
+		SliceID:             sliceID,
+	}
+
+	if err := database.CreatePolicy(ctx, policy); err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	created, err := database.GetPolicy(ctx, policy.Name)
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	// Force a snapshot BEFORE adding rules. The snapshot captures the
+	// current DB state (policy exists, no rules) and the corresponding
+	// fsm_state.lastApplied.
+	if err := database.ForceSnapshot(); err != nil {
+		t.Fatalf("ForceSnapshot: %v", err)
+	}
+
+	// Now add rules — this changeset goes into the Raft log AFTER the
+	// snapshot. On restart, Raft must replay it.
+	cidr := "2001:db8:abcd::/48"
+	rules := &db.PolicyRulesInput{
+		Uplink: []db.PolicyRuleInput{{
+			Description:  "post-snapshot-rule",
+			RemotePrefix: &cidr,
+			Protocol:     6,
+			PortLow:      443,
+			PortHigh:     443,
+			Action:       "allow",
+		}},
+	}
+
+	if err := database.UpdatePolicyWithRules(ctx, created, rules); err != nil {
+		t.Fatalf("UpdatePolicyWithRules: %v", err)
+	}
+
+	// Verify rules exist before restart.
+	beforeRules, err := database.ListRulesForPolicy(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy (before restart): %v", err)
+	}
+
+	if len(beforeRules) != 1 {
+		t.Fatalf("expected 1 rule before restart, got %d", len(beforeRules))
+	}
+
+	// Close and reopen. On reopen, Raft restores from the snapshot (no
+	// rules) and must replay the post-snapshot changeset (with rules).
+	if err := database.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	database2, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	if err != nil {
+		t.Fatalf("NewDatabase (reopen): %v", err)
+	}
+
+	defer func() {
+		if err := database2.Close(); err != nil {
+			t.Fatalf("Close (reopen): %v", err)
+		}
+	}()
+
+	afterPolicy, err := database2.GetPolicy(ctx, "snap-restore-policy")
+	if err != nil {
+		t.Fatalf("GetPolicy after restart: %v", err)
+	}
+
+	afterRules, err := database2.ListRulesForPolicy(ctx, afterPolicy.ID)
+	if err != nil {
+		t.Fatalf("ListRulesForPolicy (after restart): %v", err)
+	}
+
+	if len(afterRules) != 1 {
+		t.Fatalf("expected 1 rule after snapshot-restore restart, got %d", len(afterRules))
+	}
+
+	if afterRules[0].Description != "post-snapshot-rule" {
+		t.Fatalf("rule description mismatch: got %q, want %q", afterRules[0].Description, "post-snapshot-rule")
 	}
 }

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -88,9 +88,11 @@ var (
 
 // Policies
 var (
-	opCreatePolicy = registerChangesetOp("CreatePolicy", (*Database).applyCreatePolicy, AffectsTopic(TopicPolicies))
-	opUpdatePolicy = registerChangesetOp("UpdatePolicy", (*Database).applyUpdatePolicy, AffectsTopic(TopicPolicies))
-	opDeletePolicy = registerChangesetOp("DeletePolicy", (*Database).applyDeletePolicy, AffectsTopic(TopicPolicies))
+	opCreatePolicy          = registerChangesetOp("CreatePolicy", (*Database).applyCreatePolicy, AffectsTopic(TopicPolicies))
+	opUpdatePolicy          = registerChangesetOp("UpdatePolicy", (*Database).applyUpdatePolicy, AffectsTopic(TopicPolicies))
+	opDeletePolicy          = registerChangesetOp("DeletePolicy", (*Database).applyDeletePolicy, AffectsTopic(TopicPolicies))
+	opCreatePolicyWithRules = registerChangesetOp("CreatePolicyWithRules", (*Database).applyCreatePolicyWithRules, AffectsTopic(TopicPolicies), AffectsTopic(TopicNetworkRules))
+	opUpdatePolicyWithRules = registerChangesetOp("UpdatePolicyWithRules", (*Database).applyUpdatePolicyWithRules, AffectsTopic(TopicPolicies), AffectsTopic(TopicNetworkRules))
 )
 
 // Network rules

--- a/internal/db/policies.go
+++ b/internal/db/policies.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/canonical/sqlair"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
@@ -495,104 +494,6 @@ func (db *Database) UpdatePolicy(ctx context.Context, policy *Policy) error {
 	}
 
 	span.SetStatus(codes.Ok, "")
-
-	return nil
-}
-
-func (t *Transaction) CreatePolicy(ctx context.Context, policy *Policy) (string, error) {
-	ctx, span := tracer.Start(
-		ctx,
-		fmt.Sprintf("%s %s", "INSERT", PoliciesTableName),
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			semconv.DBSystemNameSQLite,
-			semconv.DBOperationName("INSERT"),
-			attribute.String("db.collection", PoliciesTableName),
-		),
-	)
-	defer span.End()
-
-	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(PoliciesTableName, "insert"))
-	defer timer.ObserveDuration()
-
-	DBQueriesTotal.WithLabelValues(PoliciesTableName, "insert").Inc()
-
-	if policy.ID == "" {
-		id, err := uuid.NewV7()
-		if err != nil {
-			return "", fmt.Errorf("generate policy id: %w", err)
-		}
-
-		policy.ID = id.String()
-	}
-
-	if err := t.tx.Query(ctx, t.db.createPolicyStmt, policy).Run(); err != nil {
-		if isUniqueNameError(err) {
-			span.RecordError(ErrAlreadyExists)
-			span.SetStatus(codes.Error, "unique constraint failed")
-
-			return "", ErrAlreadyExists
-		}
-
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "query failed")
-
-		return "", fmt.Errorf("query failed: %w", err)
-	}
-
-	span.SetStatus(codes.Ok, "")
-
-	t.db.publishOpTopics([]Topic{TopicPolicies}, 0)
-
-	return policy.ID, nil
-}
-
-func (t *Transaction) UpdatePolicy(ctx context.Context, policy *Policy) error {
-	ctx, span := tracer.Start(
-		ctx,
-		fmt.Sprintf("%s %s", "UPDATE", PoliciesTableName),
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			semconv.DBSystemNameSQLite,
-			semconv.DBOperationName("UPDATE"),
-			attribute.String("db.collection", PoliciesTableName),
-		),
-	)
-	defer span.End()
-
-	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(PoliciesTableName, "update"))
-	defer timer.ObserveDuration()
-
-	DBQueriesTotal.WithLabelValues(PoliciesTableName, "update").Inc()
-
-	var outcome sqlair.Outcome
-
-	err := t.tx.Query(ctx, t.db.editPolicyStmt, policy).Get(&outcome)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "query failed")
-
-		return fmt.Errorf("query failed: %w", err)
-	}
-
-	rowsAffected, err := outcome.Result().RowsAffected()
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "retrieving rows affected failed")
-
-		return fmt.Errorf("retrieving rows affected failed: %w", err)
-	}
-
-	if rowsAffected == 0 {
-		span.RecordError(ErrNotFound)
-		span.SetStatus(codes.Error, "not found")
-
-		return ErrNotFound
-	}
-
-	span.SetStatus(codes.Ok, "")
-
-	t.db.publishOpTopics([]Topic{TopicPolicies}, 0)
 
 	return nil
 }

--- a/internal/db/policy_rules_ops.go
+++ b/internal/db/policy_rules_ops.go
@@ -1,0 +1,145 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type PolicyRuleInput struct {
+	Description  string  `json:"description" db:"description"`
+	RemotePrefix *string `json:"remote_prefix" db:"remote_prefix"`
+	Protocol     int32   `json:"protocol" db:"protocol"`
+	PortLow      int32   `json:"port_low" db:"port_low"`
+	PortHigh     int32   `json:"port_high" db:"port_high"`
+	Action       string  `json:"action" db:"action"`
+}
+
+type PolicyRulesInput struct {
+	Uplink   []PolicyRuleInput `json:"uplink,omitempty"`
+	Downlink []PolicyRuleInput `json:"downlink,omitempty"`
+}
+
+type policyWithRulesPayload struct {
+	Policy Policy            `json:"policy"`
+	Rules  *PolicyRulesInput `json:"rules,omitempty"`
+}
+
+func (db *Database) CreatePolicyWithRules(ctx context.Context, policy *Policy, rules *PolicyRulesInput) error {
+	if policy.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("generate policy id: %w", err)
+		}
+
+		policy.ID = id.String()
+	}
+
+	_, err := opCreatePolicyWithRules.Invoke(db, &policyWithRulesPayload{Policy: *policy, Rules: rules})
+
+	return err
+}
+
+func (db *Database) UpdatePolicyWithRules(ctx context.Context, policy *Policy, rules *PolicyRulesInput) error {
+	_, err := opUpdatePolicyWithRules.Invoke(db, &policyWithRulesPayload{Policy: *policy, Rules: rules})
+
+	return err
+}
+
+func (db *Database) applyCreatePolicyWithRules(ctx context.Context, payload *policyWithRulesPayload) (any, error) {
+	policy := payload.Policy
+	if policy.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return nil, fmt.Errorf("generate policy id: %w", err)
+		}
+
+		policy.ID = id.String()
+	}
+
+	if err := db.runner(ctx).Query(ctx, db.createPolicyStmt, &policy).Run(); err != nil {
+		if isUniqueNameError(err) {
+			return nil, ErrAlreadyExists
+		}
+
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	if err := db.applyPolicyRulesPayload(ctx, policy.ID, payload.Rules); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (db *Database) applyUpdatePolicyWithRules(ctx context.Context, payload *policyWithRulesPayload) (any, error) {
+	if _, err := db.applyUpdatePolicy(ctx, &payload.Policy); err != nil {
+		return nil, err
+	}
+
+	if err := db.applyPolicyRulesPayload(ctx, payload.Policy.ID, payload.Rules); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (db *Database) applyPolicyRulesPayload(ctx context.Context, policyID string, rules *PolicyRulesInput) error {
+	if err := db.runner(ctx).Query(ctx, db.deleteNetworkRulesByPolicyStmt, NetworkRule{PolicyID: policyID}).Run(); err != nil {
+		return fmt.Errorf("query failed: %w", err)
+	}
+
+	if rules == nil {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	if err := db.insertPolicyRules(ctx, policyID, "uplink", rules.Uplink, now); err != nil {
+		return err
+	}
+
+	if err := db.insertPolicyRules(ctx, policyID, "downlink", rules.Downlink, now); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (db *Database) insertPolicyRules(ctx context.Context, policyID, direction string, rules []PolicyRuleInput, now time.Time) error {
+	for i, rule := range rules {
+		nr := &NetworkRule{
+			PolicyID:     policyID,
+			Description:  rule.Description,
+			Direction:    direction,
+			RemotePrefix: rule.RemotePrefix,
+			Protocol:     rule.Protocol,
+			PortLow:      rule.PortLow,
+			PortHigh:     rule.PortHigh,
+			Action:       rule.Action,
+			Precedence:   int32(i + 1),
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}
+
+		if nr.ID == "" {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return fmt.Errorf("generate network rule id: %w", err)
+			}
+
+			nr.ID = id.String()
+		}
+
+		if err := db.runner(ctx).Query(ctx, db.createNetworkRuleStmt, nr).Run(); err != nil {
+			if isUniqueNameError(err) {
+				return ErrAlreadyExists
+			}
+
+			return fmt.Errorf("query failed: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/raft/fsm.go
+++ b/internal/raft/fsm.go
@@ -51,12 +51,16 @@ type Applier interface {
 	Reopen(ctx context.Context) error
 
 	// BackupLocalTables copies local-only tables (radio_events,
-	// flow_reports, fsm_state) from srcPath into destPath so they survive
-	// a full database file swap during restore.
+	// flow_reports, etc.) from srcPath into destPath so they survive
+	// a full database file swap during restore. fsm_state is NOT
+	// included: its value must come from the snapshot so post-snapshot
+	// log entries are replayed correctly.
 	BackupLocalTables(ctx context.Context, srcPath, destPath string) error
 
 	// RestoreLocalTables copies previously backed-up local-only tables
 	// from backupPath back into destPath after a database file swap.
+	// fsm_state is NOT restored: the snapshot already contains the
+	// correct lastApplied for its point-in-time state.
 	RestoreLocalTables(ctx context.Context, backupPath, destPath string) error
 }
 
@@ -445,9 +449,16 @@ func (f *FSM) Restore(rc io.ReadCloser) error {
 
 	_ = tmpFile.Close()
 
-	// Preserve local-only tables (radio_events, flow_reports, fsm_state)
+	// Read lastApplied from the old database before it is replaced.
+	// Used below for a one-time migration check.
+	oldLastApplied, _ := f.readLastApplied()
+
+	// Preserve local-only tables (radio_events, flow_reports, etc.)
 	// across the file swap. These are per-node and not part of the
-	// replicated snapshot.
+	// replicated snapshot. fsm_state is intentionally NOT preserved:
+	// the snapshot contains the correct lastApplied for its data, and
+	// overwriting it with a stale value would cause the FSM to skip
+	// replaying post-snapshot log entries.
 	dbPath := f.applier.Path()
 	localOnlyPath := filepath.Join(f.dataDir, "restore_snapshot_local.db")
 
@@ -485,6 +496,38 @@ func (f *FSM) Restore(rc io.ReadCloser) error {
 
 	if err := f.applier.Reopen(ctx); err != nil {
 		return fmt.Errorf("reopen database after restore: %w", err)
+	}
+
+	// One-time migration: older code kept fsm_state in localOnlyTables,
+	// which preserved lastApplied across snapshot restores. If a previous
+	// restart cycle skipped entries (because the preserved lastApplied was
+	// higher than the snapshot's), later entries in the Raft log were
+	// captured against the divergent post-skip state. Replaying ALL entries
+	// now would hit changeset conflicts (NOTFOUND) because entries from
+	// before the skip and after the skip are incompatible.
+	//
+	// Detect the upgrade by checking for a marker file that the new code
+	// creates after every successful startup. If absent, this is the first
+	// restore with the new code; preserve the old lastApplied so entries
+	// from the buggy cycle remain skipped (they were captured against a
+	// divergent state anyway). Future restores (after a new snapshot is
+	// taken by the fixed code) use the snapshot's lastApplied normally.
+	migrationMarker := filepath.Join(f.dataDir, ".fsm_migrated")
+	if _, statErr := os.Stat(migrationMarker); os.IsNotExist(statErr) {
+		snapshotLastApplied, _ := f.readLastApplied()
+		if oldLastApplied > snapshotLastApplied {
+			if wErr := f.writeLastApplied(oldLastApplied); wErr != nil {
+				return fmt.Errorf("migration: preserve old lastApplied: %w", wErr)
+			}
+
+			logger.RaftLog.Warn("FSM: preserved lastApplied from pre-upgrade database (one-time migration)",
+				zap.Uint64("snapshot_lastApplied", snapshotLastApplied),
+				zap.Uint64("preserved_lastApplied", oldLastApplied))
+		}
+
+		if wErr := os.WriteFile(migrationMarker, []byte("1"), 0o600); wErr != nil {
+			logger.RaftLog.Warn("FSM: failed to write migration marker", zap.Error(wErr))
+		}
 	}
 
 	logger.RaftLog.Info("FSM: restored database from Raft snapshot")


### PR DESCRIPTION
# Description

There were issues with changes to policies and network rules that I experienced while testing IPv6 network rules. This PR addresses this by making policies and network rules use raft and fix restarts losing data by fixing the snapshot storing the wrong last applied in certain cases.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
