### PR TITLE
chore: add complete CRUD API integration tests

### DIFF
--- a/.github/workflows/integration-tests-api-matrix.yaml
+++ b/.github/workflows/integration-tests-api-matrix.yaml
@@ -1,0 +1,48 @@
+name: Integration tests - API matrix
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+
+jobs:
+  api-matrix-test:
+    # The API matrix exercises the REST surface only — no NGAP/NAS/UPF data
+    # plane — so a single architecture and the IPv4 compose are sufficient.
+    # Running cross-arch / cross-family would duplicate identical REST
+    # coverage for no added signal.
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Docker registry
+        run: |
+          docker run -d -p 5000:5000 --name registry registry:2
+
+      - name: Download Ella Core image from GitHub Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ellacore-image-amd64
+
+      - name: Download Ella Core Tester image from GitHub Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ellacore-tester-image-amd64
+
+      - name: Load images into Docker
+        run: |
+          docker load -i ellacore_latest-amd64.tar
+          docker tag ella-core:latest localhost:5000/ella-core:latest
+          docker push localhost:5000/ella-core:latest
+          docker load -i ellacore_tester_latest-amd64.tar
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run API matrix integration test
+        run: |
+          INTEGRATION=1 IP_VERSION=ipv4 go test ./integration -run TestAPIMatrix -timeout 10m -v

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         env:
           HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -skip 'TestIntegrationHA|TestIntegration3GPPHAFailover' -v
+          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -skip 'TestIntegrationHA|TestIntegration3GPPHAFailover|TestAPIMatrix' -v
 
       - name: Upload cluster logs
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
   integration-tests:
     needs: [image-build, image-build-tester]
     uses: ./.github/workflows/integration-tests.yaml
+  integration-tests-api-matrix:
+    needs: [image-build, image-build-tester]
+    uses: ./.github/workflows/integration-tests-api-matrix.yaml
   integration-tests-ha:
     needs: [image-build]
     uses: ./.github/workflows/integration-tests-ha.yaml

--- a/client/operator.go
+++ b/client/operator.go
@@ -55,6 +55,13 @@ type UpdateOperatorIDOptions struct {
 	Mnc string
 }
 
+// UpdateOperatorCodeOptions sets the operator code (OPC root used by
+// MILENAGE). The server requires a 32-character hex string and rejects
+// the update when any subscribers exist.
+type UpdateOperatorCodeOptions struct {
+	OperatorCode string
+}
+
 type UpdateOperatorTrackingOptions struct {
 	SupportedTacs []string
 }
@@ -111,6 +118,36 @@ func (c *Client) UpdateOperatorID(ctx context.Context, opts *UpdateOperatorIDOpt
 		Type:   SyncRequest,
 		Method: "PUT",
 		Path:   "api/v1/operator/id",
+		Body:   &body,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateOperatorCode updates the operator's secret code (OPC root).
+// Must be a 32-character hex string. The server rejects the update with
+// 400 when any subscribers exist (api_operator.go:396-399).
+func (c *Client) UpdateOperatorCode(ctx context.Context, opts *UpdateOperatorCodeOptions) error {
+	payload := struct {
+		OperatorCode string `json:"operatorCode,omitempty"`
+	}{
+		OperatorCode: opts.OperatorCode,
+	}
+
+	var body bytes.Buffer
+
+	err := json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "PUT",
+		Path:   "api/v1/operator/code",
 		Body:   &body,
 	})
 	if err != nil {

--- a/client/operator.go
+++ b/client/operator.go
@@ -56,8 +56,8 @@ type UpdateOperatorIDOptions struct {
 }
 
 // UpdateOperatorCodeOptions sets the operator code (OPC root used by
-// MILENAGE). The server requires a 32-character hex string and rejects
-// the update when any subscribers exist.
+// MILENAGE). Must be a 32-character hex string. The server rejects the
+// update when any subscribers exist.
 type UpdateOperatorCodeOptions struct {
 	OperatorCode string
 }
@@ -76,7 +76,6 @@ type UpdateOperatorSPNOptions struct {
 	ShortName string
 }
 
-// GetOperator retrieves the current operator configuration.
 func (c *Client) GetOperator(ctx context.Context) (*Operator, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -97,7 +96,6 @@ func (c *Client) GetOperator(ctx context.Context) (*Operator, error) {
 	return &operatorResponse, nil
 }
 
-// UpdateOperatorID updates the operator's Mobile Country Code (MCC) and Mobile Network Code (MNC).
 func (c *Client) UpdateOperatorID(ctx context.Context, opts *UpdateOperatorIDOptions) error {
 	payload := struct {
 		Mcc string `json:"mcc"`
@@ -127,9 +125,6 @@ func (c *Client) UpdateOperatorID(ctx context.Context, opts *UpdateOperatorIDOpt
 	return nil
 }
 
-// UpdateOperatorCode updates the operator's secret code (OPC root).
-// Must be a 32-character hex string. The server rejects the update with
-// 400 when any subscribers exist (api_operator.go:396-399).
 func (c *Client) UpdateOperatorCode(ctx context.Context, opts *UpdateOperatorCodeOptions) error {
 	payload := struct {
 		OperatorCode string `json:"operatorCode,omitempty"`
@@ -157,7 +152,6 @@ func (c *Client) UpdateOperatorCode(ctx context.Context, opts *UpdateOperatorCod
 	return nil
 }
 
-// UpdateOperatorTracking updates the operator's tracking information (supported TACs).
 func (c *Client) UpdateOperatorTracking(ctx context.Context, opts *UpdateOperatorTrackingOptions) error {
 	payload := struct {
 		SupportedTacs []string `json:"supportedTacs"`
@@ -185,7 +179,6 @@ func (c *Client) UpdateOperatorTracking(ctx context.Context, opts *UpdateOperato
 	return nil
 }
 
-// CreateHomeNetworkKey creates a new home network key.
 func (c *Client) CreateHomeNetworkKey(ctx context.Context, opts *CreateHomeNetworkKeyOptions) error {
 	payload := struct {
 		KeyIdentifier int    `json:"keyIdentifier"`
@@ -217,9 +210,8 @@ func (c *Client) CreateHomeNetworkKey(ctx context.Context, opts *CreateHomeNetwo
 	return nil
 }
 
-// DeleteHomeNetworkKey deletes a home network key by ID. The ID is a
-// UUIDv7 string assigned by the server at create time and is returned
-// in the operator's HomeNetworkKeys list.
+// DeleteHomeNetworkKey deletes a home network key by ID. The ID is the
+// UUIDv7 string returned in Operator.HomeNetworkKeys.
 func (c *Client) DeleteHomeNetworkKey(ctx context.Context, id string) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -233,9 +225,8 @@ func (c *Client) DeleteHomeNetworkKey(ctx context.Context, id string) error {
 	return nil
 }
 
-// GetHomeNetworkKeyPrivateKey retrieves the private key for a home network
-// key by ID. The ID is a UUIDv7 string assigned by the server at create
-// time and is returned in the operator's HomeNetworkKeys list.
+// GetHomeNetworkKeyPrivateKey returns the private key for a home network
+// key. The ID is the UUIDv7 string returned in Operator.HomeNetworkKeys.
 func (c *Client) GetHomeNetworkKeyPrivateKey(ctx context.Context, id string) (*HomeNetworkKeyPrivateKeyResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -256,7 +247,6 @@ func (c *Client) GetHomeNetworkKeyPrivateKey(ctx context.Context, id string) (*H
 	return &keyResponse, nil
 }
 
-// UpdateOperatorNASSecurity updates the operator's NAS security algorithm preference order.
 func (c *Client) UpdateOperatorNASSecurity(ctx context.Context, opts *UpdateOperatorNASSecurityOptions) error {
 	payload := struct {
 		Ciphering []string `json:"ciphering"`
@@ -286,7 +276,6 @@ func (c *Client) UpdateOperatorNASSecurity(ctx context.Context, opts *UpdateOper
 	return nil
 }
 
-// UpdateOperatorSPN updates the operator's Service Provider Name (full and short).
 func (c *Client) UpdateOperatorSPN(ctx context.Context, opts *UpdateOperatorSPNOptions) error {
 	payload := struct {
 		FullName  string `json:"fullName"`

--- a/client/operator.go
+++ b/client/operator.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 )
 
 type GetOperatorIDResponse struct {
@@ -181,12 +180,14 @@ func (c *Client) CreateHomeNetworkKey(ctx context.Context, opts *CreateHomeNetwo
 	return nil
 }
 
-// DeleteHomeNetworkKey deletes a home network key by ID.
-func (c *Client) DeleteHomeNetworkKey(ctx context.Context, id int) error {
+// DeleteHomeNetworkKey deletes a home network key by ID. The ID is a
+// UUIDv7 string assigned by the server at create time and is returned
+// in the operator's HomeNetworkKeys list.
+func (c *Client) DeleteHomeNetworkKey(ctx context.Context, id string) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "DELETE",
-		Path:   fmt.Sprintf("api/v1/operator/home-network-keys/%d", id),
+		Path:   "api/v1/operator/home-network-keys/" + id,
 	})
 	if err != nil {
 		return err
@@ -195,12 +196,14 @@ func (c *Client) DeleteHomeNetworkKey(ctx context.Context, id int) error {
 	return nil
 }
 
-// GetHomeNetworkKeyPrivateKey retrieves the private key for a home network key by ID.
-func (c *Client) GetHomeNetworkKeyPrivateKey(ctx context.Context, id int) (*HomeNetworkKeyPrivateKeyResponse, error) {
+// GetHomeNetworkKeyPrivateKey retrieves the private key for a home network
+// key by ID. The ID is a UUIDv7 string assigned by the server at create
+// time and is returned in the operator's HomeNetworkKeys list.
+func (c *Client) GetHomeNetworkKeyPrivateKey(ctx context.Context, id string) (*HomeNetworkKeyPrivateKeyResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "GET",
-		Path:   fmt.Sprintf("api/v1/operator/home-network-keys/%d/private-key", id),
+		Path:   "api/v1/operator/home-network-keys/" + id + "/private-key",
 	})
 	if err != nil {
 		return nil, err

--- a/client/operator.go
+++ b/client/operator.go
@@ -38,8 +38,8 @@ type CreateHomeNetworkKeyOptions struct {
 }
 
 type GetOperatorSPNResponse struct {
-	SpnFull  string `json:"spnFull"`
-	SpnShort string `json:"spnShort"`
+	FullName  string `json:"fullName"`
+	ShortName string `json:"shortName"`
 }
 
 type Operator struct {

--- a/client/operator_test.go
+++ b/client/operator_test.go
@@ -502,7 +502,7 @@ func TestGetOperator_IncludesSPN(t *testing.T) {
 			Headers:    http.Header{},
 			Result: []byte(`{
 				"id": {"mcc": "001", "mnc": "01"},
-				"spn": {"spnFull": "My Network", "spnShort": "MyNet"}
+				"spn": {"fullName": "My Network", "shortName": "MyNet"}
 			}`),
 		},
 		err: nil,
@@ -518,11 +518,11 @@ func TestGetOperator_IncludesSPN(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if operator.SPN.SpnFull != "My Network" {
-		t.Fatalf("expected spnFull 'My Network', got '%s'", operator.SPN.SpnFull)
+	if operator.SPN.FullName != "My Network" {
+		t.Fatalf("expected fullName 'My Network', got '%s'", operator.SPN.FullName)
 	}
 
-	if operator.SPN.SpnShort != "MyNet" {
-		t.Fatalf("expected spnShort 'MyNet', got '%s'", operator.SPN.SpnShort)
+	if operator.SPN.ShortName != "MyNet" {
+		t.Fatalf("expected shortName 'MyNet', got '%s'", operator.SPN.ShortName)
 	}
 }

--- a/client/operator_test.go
+++ b/client/operator_test.go
@@ -303,7 +303,7 @@ func TestDeleteHomeNetworkKey_Success(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := clientObj.DeleteHomeNetworkKey(ctx, 42)
+	err := clientObj.DeleteHomeNetworkKey(ctx, "0190b3d2-7c12-7c00-8000-000000000001")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -312,8 +312,8 @@ func TestDeleteHomeNetworkKey_Success(t *testing.T) {
 		t.Fatalf("expected method DELETE, got %s", fake.lastOpts.Method)
 	}
 
-	if fake.lastOpts.Path != "api/v1/operator/home-network-keys/42" {
-		t.Fatalf("expected path api/v1/operator/home-network-keys/42, got %s", fake.lastOpts.Path)
+	if fake.lastOpts.Path != "api/v1/operator/home-network-keys/0190b3d2-7c12-7c00-8000-000000000001" {
+		t.Fatalf("expected path api/v1/operator/home-network-keys/0190b3d2-7c12-7c00-8000-000000000001, got %s", fake.lastOpts.Path)
 	}
 }
 
@@ -332,7 +332,7 @@ func TestDeleteHomeNetworkKey_Failure(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := clientObj.DeleteHomeNetworkKey(ctx, 999)
+	err := clientObj.DeleteHomeNetworkKey(ctx, "0190b3d2-7c12-7c00-8000-000000000999")
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}
@@ -353,7 +353,7 @@ func TestGetHomeNetworkKeyPrivateKey_Success(t *testing.T) {
 
 	ctx := context.Background()
 
-	resp, err := clientObj.GetHomeNetworkKeyPrivateKey(ctx, 7)
+	resp, err := clientObj.GetHomeNetworkKeyPrivateKey(ctx, "0190b3d2-7c12-7c00-8000-000000000007")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -366,8 +366,8 @@ func TestGetHomeNetworkKeyPrivateKey_Success(t *testing.T) {
 		t.Fatalf("expected method GET, got %s", fake.lastOpts.Method)
 	}
 
-	if fake.lastOpts.Path != "api/v1/operator/home-network-keys/7/private-key" {
-		t.Fatalf("expected path api/v1/operator/home-network-keys/7/private-key, got %s", fake.lastOpts.Path)
+	if fake.lastOpts.Path != "api/v1/operator/home-network-keys/0190b3d2-7c12-7c00-8000-000000000007/private-key" {
+		t.Fatalf("expected path api/v1/operator/home-network-keys/0190b3d2-7c12-7c00-8000-000000000007/private-key, got %s", fake.lastOpts.Path)
 	}
 }
 
@@ -386,7 +386,7 @@ func TestGetHomeNetworkKeyPrivateKey_Failure(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := clientObj.GetHomeNetworkKeyPrivateKey(ctx, 999)
+	_, err := clientObj.GetHomeNetworkKeyPrivateKey(ctx, "0190b3d2-7c12-7c00-8000-000000000999")
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}

--- a/client/operator_test.go
+++ b/client/operator_test.go
@@ -495,6 +495,60 @@ func TestUpdateOperatorSPN_Failure(t *testing.T) {
 	}
 }
 
+func TestUpdateOperatorCode_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 201,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Operator Code updated successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.UpdateOperatorCode(ctx, &client.UpdateOperatorCodeOptions{
+		OperatorCode: "0123456789abcdef0123456789abcdef",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if fake.lastOpts.Method != "PUT" {
+		t.Fatalf("expected PUT method, got: %s", fake.lastOpts.Method)
+	}
+
+	if fake.lastOpts.Path != "api/v1/operator/code" {
+		t.Fatalf("expected path api/v1/operator/code, got: %s", fake.lastOpts.Path)
+	}
+}
+
+func TestUpdateOperatorCode_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 400,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Invalid operator code format"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.UpdateOperatorCode(ctx, &client.UpdateOperatorCodeOptions{
+		OperatorCode: "not-hex",
+	})
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
 func TestGetOperator_IncludesSPN(t *testing.T) {
 	fake := &fakeRequester{
 		response: &client.RequestResponse{

--- a/client/policies.go
+++ b/client/policies.go
@@ -22,23 +22,21 @@ type PolicyRules struct {
 	Downlink []PolicyRule `json:"downlink,omitempty"`
 }
 
-// CreatePolicyOptions contains the parameters for creating a new policy.
 type CreatePolicyOptions struct {
 	Name            string `json:"name"`
 	ProfileName     string `json:"profile_name"`
 	SliceName       string `json:"slice_name"`
 	DataNetworkName string `json:"data_network_name"`
-	// SessionAmbrUplink is the maximum uplink bitrate for a single PDU session.
-	// Enforced by Ella Core. Example: "100 Mbps".
+	// SessionAmbrUplink caps the uplink bitrate of a single PDU session,
+	// e.g. "100 Mbps".
 	SessionAmbrUplink string `json:"session_ambr_uplink"`
-	// SessionAmbrDownlink is the maximum downlink bitrate for a single PDU session.
-	// Enforced by Ella Core. Example: "200 Mbps".
+	// SessionAmbrDownlink caps the downlink bitrate of a single PDU session,
+	// e.g. "200 Mbps".
 	SessionAmbrDownlink string `json:"session_ambr_downlink"`
-	// Var5qi is the 5G QoS Identifier, signaled to the radio for scheduling.
-	// Non-GBR values only: 5, 6, 7, 8, 9, 69, 70, 79, 80.
+	// Var5qi is the 5G QoS Identifier. Non-GBR values only: 5, 6, 7, 8, 9,
+	// 69, 70, 79, 80.
 	Var5qi int32 `json:"var5qi"`
-	// Arp is the Allocation and Retention Priority (1–15). Used at session setup
-	// for admission control and pre-emption; 1 = highest priority.
+	// Arp is the Allocation and Retention Priority (1–15, 1 = highest).
 	Arp   int32        `json:"arp"`
 	Rules *PolicyRules `json:"rules,omitempty"`
 }
@@ -49,11 +47,10 @@ type UpdatePolicyOptions struct {
 	DataNetworkName     string `json:"data_network_name,omitempty"`
 	SessionAmbrUplink   string `json:"session_ambr_uplink,omitempty"`
 	SessionAmbrDownlink string `json:"session_ambr_downlink,omitempty"`
-	// Var5qi is the 5G QoS Identifier, signaled to the radio for scheduling.
-	// Non-GBR values only: 5, 6, 7, 8, 9, 69, 70, 79, 80.
+	// Var5qi is the 5G QoS Identifier. Non-GBR values only: 5, 6, 7, 8, 9,
+	// 69, 70, 79, 80.
 	Var5qi int32 `json:"var5qi,omitempty"`
-	// Arp is the Allocation and Retention Priority (1–15). Used at session setup
-	// for admission control and pre-emption; 1 = highest priority.
+	// Arp is the Allocation and Retention Priority (1–15, 1 = highest).
 	Arp   int32        `json:"arp,omitempty"`
 	Rules *PolicyRules `json:"rules,omitempty"`
 }
@@ -66,8 +63,8 @@ type DeletePolicyOptions struct {
 	Name string `json:"name"`
 }
 
-// Policy represents a QoS policy for a specific (profile, slice, data network) combination.
-// Session AMBR caps the bitrate of a single PDU session and is enforced by Ella Core.
+// Policy is a QoS policy bound to a specific (profile, slice, data network)
+// combination. Session AMBR caps the bitrate of a single PDU session.
 type Policy struct {
 	Name                string `json:"name"`
 	ProfileName         string `json:"profile_name"`
@@ -75,11 +72,10 @@ type Policy struct {
 	DataNetworkName     string `json:"data_network_name"`
 	SessionAmbrUplink   string `json:"session_ambr_uplink"`
 	SessionAmbrDownlink string `json:"session_ambr_downlink"`
-	// Var5qi is the 5G QoS Identifier, signaled to the radio for scheduling.
-	// Non-GBR values only: 5, 6, 7, 8, 9, 69, 70, 79, 80.
+	// Var5qi is the 5G QoS Identifier. Non-GBR values only: 5, 6, 7, 8, 9,
+	// 69, 70, 79, 80.
 	Var5qi int32 `json:"var5qi"`
-	// Arp is the Allocation and Retention Priority (1–15). Used at session setup
-	// for admission control and pre-emption; 1 = highest priority.
+	// Arp is the Allocation and Retention Priority (1–15, 1 = highest).
 	Arp   int32        `json:"arp"`
 	Rules *PolicyRules `json:"rules,omitempty"`
 }
@@ -91,9 +87,8 @@ type ListPoliciesResponse struct {
 	TotalCount int      `json:"total_count"`
 }
 
-// CreatePolicy creates a new policy with the provided options.
-// Optionally includes network rules organized by direction (uplink/downlink).
-// Rules are created in the order they are provided.
+// CreatePolicy creates a policy, optionally with network rules. Rules are
+// applied in the order they appear in opts.Rules.
 func (c *Client) CreatePolicy(ctx context.Context, opts *CreatePolicyOptions) error {
 	payload := struct {
 		Name                string       `json:"name"`
@@ -137,7 +132,8 @@ func (c *Client) CreatePolicy(ctx context.Context, opts *CreatePolicyOptions) er
 	return nil
 }
 
-// GetPolicy retrieves a policy by name, including any associated network rules.
+// GetPolicy retrieves a policy by name. The response includes the
+// associated network rules; ListPolicies omits them.
 func (c *Client) GetPolicy(ctx context.Context, opts *GetPolicyOptions) (*Policy, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -158,11 +154,9 @@ func (c *Client) GetPolicy(ctx context.Context, opts *GetPolicyOptions) (*Policy
 	return &policyResponse, nil
 }
 
-// UpdatePolicy updates an existing policy by name.
-// Existing network rules are always replaced on every update.
-// If Rules is nil (omitted), all existing rules are deleted.
-// To keep existing rules, re-supply them in opts.Rules.
-// To set specific rules, provide them in opts.Rules; existing rules are deleted and replaced.
+// UpdatePolicy replaces an existing policy by name. Network rules are
+// destructively replaced on every update: if opts.Rules is nil, all
+// existing rules are deleted. To keep them, re-supply the current list.
 func (c *Client) UpdatePolicy(ctx context.Context, name string, opts *UpdatePolicyOptions) error {
 	payload := struct {
 		ProfileName         string       `json:"profile_name,omitempty"`
@@ -204,7 +198,6 @@ func (c *Client) UpdatePolicy(ctx context.Context, name string, opts *UpdatePoli
 	return nil
 }
 
-// DeletePolicy deletes a policy by name.
 func (c *Client) DeletePolicy(ctx context.Context, opts *DeletePolicyOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -218,7 +211,6 @@ func (c *Client) DeletePolicy(ctx context.Context, opts *DeletePolicyOptions) er
 	return nil
 }
 
-// ListPolicies lists policies with pagination.
 func (c *Client) ListPolicies(ctx context.Context, p *ListParams) (*ListPoliciesResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/radios.go
+++ b/client/radios.go
@@ -207,7 +207,7 @@ func (c *Client) ClearRadioEvents(ctx context.Context) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "DELETE",
-		Path:   "api/v1/logs/network",
+		Path:   "api/v1/ran/events",
 	})
 	if err != nil {
 		return err
@@ -221,7 +221,7 @@ func (c *Client) GetRadioEventRetentionPolicy(ctx context.Context) (*GetRadioEve
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "GET",
-		Path:   "api/v1/logs/network/retention",
+		Path:   "api/v1/ran/events/retention",
 	})
 	if err != nil {
 		return nil, err
@@ -255,7 +255,7 @@ func (c *Client) UpdateRadioEventRetentionPolicy(ctx context.Context, opts *Upda
 	_, err = c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "PUT",
-		Path:   "api/v1/logs/network/retention",
+		Path:   "api/v1/ran/events/retention",
 		Body:   &body,
 	})
 	if err != nil {
@@ -270,7 +270,7 @@ func (c *Client) GetRadioEvent(ctx context.Context, id int) (*RadioEventContent,
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "GET",
-		Path:   fmt.Sprintf("api/v1/logs/network/%d", id),
+		Path:   fmt.Sprintf("api/v1/ran/events/%d", id),
 	})
 	if err != nil {
 		return nil, err

--- a/client/radios.go
+++ b/client/radios.go
@@ -101,7 +101,6 @@ type RadioEventContent struct {
 	Raw     string `json:"raw"`
 }
 
-// GetRadio retrieves a radio by name.
 func (c *Client) GetRadio(ctx context.Context, opts *GetRadioOptions) (*RadioDetail, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -122,7 +121,6 @@ func (c *Client) GetRadio(ctx context.Context, opts *GetRadioOptions) (*RadioDet
 	return &radioResponse, nil
 }
 
-// ListRadios lists radios with pagination.
 func (c *Client) ListRadios(ctx context.Context, p *ListParams) (*ListRadiosResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -147,7 +145,6 @@ func (c *Client) ListRadios(ctx context.Context, p *ListParams) (*ListRadiosResp
 	return &radios, nil
 }
 
-// ListRadioEvents lists radio events with filtering and pagination.
 func (c *Client) ListRadioEvents(ctx context.Context, p *ListRadioEventsParams) (*ListRadioEventsResponse, error) {
 	query := url.Values{}
 	if p.Page != 0 {
@@ -202,7 +199,7 @@ func (c *Client) ListRadioEvents(ctx context.Context, p *ListRadioEventsParams) 
 	return &radioEvents, nil
 }
 
-// ClearRadioEvents clears all radio events. Events will be permanently deleted.
+// ClearRadioEvents permanently deletes every stored radio event.
 func (c *Client) ClearRadioEvents(ctx context.Context) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -216,7 +213,6 @@ func (c *Client) ClearRadioEvents(ctx context.Context) error {
 	return nil
 }
 
-// GetRadioEventRetentionPolicy retrieves the current radio event retention policy.
 func (c *Client) GetRadioEventRetentionPolicy(ctx context.Context) (*GetRadioEventsRetentionPolicy, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -237,7 +233,6 @@ func (c *Client) GetRadioEventRetentionPolicy(ctx context.Context) (*GetRadioEve
 	return &policy, nil
 }
 
-// UpdateRadioEventRetentionPolicy updates the radio event retention policy.
 func (c *Client) UpdateRadioEventRetentionPolicy(ctx context.Context, opts *UpdateRadioEventsRetentionPolicyOptions) error {
 	payload := struct {
 		Days int `json:"days"`
@@ -265,7 +260,6 @@ func (c *Client) UpdateRadioEventRetentionPolicy(ctx context.Context, opts *Upda
 	return nil
 }
 
-// GetRadioEvent retrieves a radio event by ID.
 func (c *Client) GetRadioEvent(ctx context.Context, id int) (*RadioEventContent, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/radios_test.go
+++ b/client/radios_test.go
@@ -203,6 +203,38 @@ func TestListRadioEvents_Success(t *testing.T) {
 	if resp.Items[0].Raw != expectedRaw {
 		t.Fatalf("expected raw '%s', got '%s'", expectedRaw, resp.Items[0].Raw)
 	}
+
+	if fake.lastOpts.Path != "api/v1/ran/events" {
+		t.Fatalf("expected path api/v1/ran/events, got %s", fake.lastOpts.Path)
+	}
+}
+
+func TestClearRadioEvents_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Radio events cleared"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	ctx := context.Background()
+
+	if err := clientObj.ClearRadioEvents(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if fake.lastOpts.Method != "DELETE" {
+		t.Fatalf("expected DELETE method, got: %s", fake.lastOpts.Method)
+	}
+
+	if fake.lastOpts.Path != "api/v1/ran/events" {
+		t.Fatalf("expected path api/v1/ran/events, got %s", fake.lastOpts.Path)
+	}
 }
 
 func TestListRadioEvents_Failure(t *testing.T) {
@@ -254,6 +286,10 @@ func TestGetRadioEventsRetentionPolicy_Success(t *testing.T) {
 	if policy.Days != 15 {
 		t.Fatalf("expected retention days 15, got %d", policy.Days)
 	}
+
+	if fake.lastOpts.Path != "api/v1/ran/events/retention" {
+		t.Fatalf("expected path api/v1/ran/events/retention, got %s", fake.lastOpts.Path)
+	}
 }
 
 func TestGetRadioEventsRetentionPolicy_Failure(t *testing.T) {
@@ -299,6 +335,14 @@ func TestUpdateRadioEventsRetentionPolicy_Success(t *testing.T) {
 	err := clientObj.UpdateRadioEventRetentionPolicy(ctx, updateOpts)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if fake.lastOpts.Method != "PUT" {
+		t.Fatalf("expected PUT method, got: %s", fake.lastOpts.Method)
+	}
+
+	if fake.lastOpts.Path != "api/v1/ran/events/retention" {
+		t.Fatalf("expected path api/v1/ran/events/retention, got %s", fake.lastOpts.Path)
 	}
 }
 
@@ -361,6 +405,10 @@ func TestGetRadioEvent_Success(t *testing.T) {
 
 	if decodedMap["pduSessionID"] != json.Number("1") { // JSON numbers are float64
 		t.Fatalf("expected decoded pduSessionID to be 1, got %v", decodedMap["pduSessionID"])
+	}
+
+	if fake.lastOpts.Path != "api/v1/ran/events/1" {
+		t.Fatalf("expected path api/v1/ran/events/1, got %s", fake.lastOpts.Path)
 	}
 }
 

--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -28,14 +28,14 @@ type DeleteSubscriberOptions struct {
 	ID string `json:"id"`
 }
 
-// SubscriberStatus is the lightweight status returned by the list endpoint.
+// SubscriberStatus is the lightweight status carried in list responses.
 type SubscriberStatus struct {
 	Registered     bool   `json:"registered"`
 	NumPDUSessions int    `json:"num_pdu_sessions"`
 	LastSeenAt     string `json:"lastSeenAt,omitempty"`
 }
 
-// Subscriber is the summary representation returned by the list endpoint.
+// Subscriber is the summary form returned by ListSubscribers.
 type Subscriber struct {
 	Imsi        string           `json:"imsi"`
 	ProfileName string           `json:"profile_name"`
@@ -43,7 +43,6 @@ type Subscriber struct {
 	Status      SubscriberStatus `json:"status"`
 }
 
-// ListSubscribersParams holds the parameters for ListSubscribers.
 type ListSubscribersParams struct {
 	Page    int    `json:"page"`
 	PerPage int    `json:"per_page"`
@@ -57,7 +56,7 @@ type ListSubscribersResponse struct {
 	TotalCount int          `json:"total_count"`
 }
 
-// SubscriberDetailStatus is the rich status returned by the get-single endpoint.
+// SubscriberDetailStatus is the rich status carried in GetSubscriber responses.
 type SubscriberDetailStatus struct {
 	Registered         bool   `json:"registered"`
 	Imei               string `json:"imei"`
@@ -67,7 +66,7 @@ type SubscriberDetailStatus struct {
 	LastSeenRadio      string `json:"lastSeenRadio,omitempty"`
 }
 
-// SubscriberDetail is the full representation returned by the get-single endpoint.
+// SubscriberDetail is the full form returned by GetSubscriber.
 type SubscriberDetail struct {
 	Imsi        string                 `json:"imsi"`
 	ProfileName string                 `json:"profile_name"`
@@ -75,7 +74,6 @@ type SubscriberDetail struct {
 	PDUSessions []SessionInfo          `json:"pdu_sessions"`
 }
 
-// SessionInfo is a representation of a PDU session.
 type SessionInfo struct {
 	PDUSessionID    uint8  `json:"pdu_session_id"`
 	Status          string `json:"status"`
@@ -88,19 +86,16 @@ type SessionInfo struct {
 	SessionAmbrDown string `json:"session_ambr_downlink,omitempty"`
 }
 
-// SubscriberCredentials contains the authentication credentials for a subscriber.
 type SubscriberCredentials struct {
 	Key            string `json:"key"`
 	Opc            string `json:"opc"`
 	SequenceNumber string `json:"sequenceNumber"`
 }
 
-// GetSubscriberCredentialsOptions holds the parameters for GetSubscriberCredentials.
 type GetSubscriberCredentialsOptions struct {
 	ID string `json:"id"`
 }
 
-// CreateSubscriber creates a new subscriber with the provided options.
 func (c *Client) CreateSubscriber(ctx context.Context, opts *CreateSubscriberOptions) error {
 	payload := struct {
 		Imsi           string `json:"imsi"`
@@ -136,7 +131,6 @@ func (c *Client) CreateSubscriber(ctx context.Context, opts *CreateSubscriberOpt
 	return nil
 }
 
-// GetSubscriber retrieves a subscriber by ID.
 func (c *Client) GetSubscriber(ctx context.Context, opts *GetSubscriberOptions) (*SubscriberDetail, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -157,8 +151,8 @@ func (c *Client) GetSubscriber(ctx context.Context, opts *GetSubscriberOptions) 
 	return &subscriberResponse, nil
 }
 
-// UpdateSubscriber updates an existing subscriber by IMSI. Only profile_name
-// is settable.
+// UpdateSubscriber moves a subscriber to a different profile.
+// profile_name is the only settable field.
 func (c *Client) UpdateSubscriber(ctx context.Context, imsi string, opts *UpdateSubscriberOptions) error {
 	payload := struct {
 		ProfileName string `json:"profile_name"`
@@ -186,7 +180,6 @@ func (c *Client) UpdateSubscriber(ctx context.Context, imsi string, opts *Update
 	return nil
 }
 
-// DeleteSubscriber deletes a subscriber by ID.
 func (c *Client) DeleteSubscriber(ctx context.Context, opts *DeleteSubscriberOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -200,7 +193,6 @@ func (c *Client) DeleteSubscriber(ctx context.Context, opts *DeleteSubscriberOpt
 	return nil
 }
 
-// ListSubscribers lists subscribers with pagination and optional filters.
 func (c *Client) ListSubscribers(ctx context.Context, p *ListSubscribersParams) (*ListSubscribersResponse, error) {
 	query := url.Values{
 		"page":     {fmt.Sprintf("%d", p.Page)},
@@ -231,8 +223,8 @@ func (c *Client) ListSubscribers(ctx context.Context, p *ListSubscribersParams) 
 	return &subscribers, nil
 }
 
-// GetSubscriberCredentials retrieves the authentication credentials for a subscriber.
-// requires Admin or Network Manager role.
+// GetSubscriberCredentials returns the authentication credentials.
+// Admin or Network Manager role required.
 func (c *Client) GetSubscriberCredentials(ctx context.Context, opts *GetSubscriberCredentialsOptions) (*SubscriberCredentials, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -16,6 +16,10 @@ type CreateSubscriberOptions struct {
 	OPc            string `json:"opc,omitempty"`
 }
 
+type UpdateSubscriberOptions struct {
+	ProfileName string `json:"profile_name"`
+}
+
 type GetSubscriberOptions struct {
 	ID string `json:"id"`
 }
@@ -151,6 +155,35 @@ func (c *Client) GetSubscriber(ctx context.Context, opts *GetSubscriberOptions) 
 	}
 
 	return &subscriberResponse, nil
+}
+
+// UpdateSubscriber updates an existing subscriber by IMSI. Only profile_name
+// is settable.
+func (c *Client) UpdateSubscriber(ctx context.Context, imsi string, opts *UpdateSubscriberOptions) error {
+	payload := struct {
+		ProfileName string `json:"profile_name"`
+	}{
+		ProfileName: opts.ProfileName,
+	}
+
+	var body bytes.Buffer
+
+	err := json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "PUT",
+		Path:   "api/v1/subscribers/" + imsi,
+		Body:   &body,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // DeleteSubscriber deletes a subscriber by ID.

--- a/client/subscribers_test.go
+++ b/client/subscribers_test.go
@@ -167,6 +167,64 @@ func TestGetSubscriber_Failure(t *testing.T) {
 	}
 }
 
+func TestUpdateSubscriber_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Subscriber updated successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	opts := &client.UpdateSubscriberOptions{
+		ProfileName: "enterprise",
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.UpdateSubscriber(ctx, "001010100000022", opts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if fake.lastOpts.Method != "PUT" {
+		t.Fatalf("expected PUT method, got: %s", fake.lastOpts.Method)
+	}
+
+	if fake.lastOpts.Path != "api/v1/subscribers/001010100000022" {
+		t.Fatalf("expected path api/v1/subscribers/001010100000022, got: %s", fake.lastOpts.Path)
+	}
+}
+
+func TestUpdateSubscriber_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 404,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Subscriber not found"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	opts := &client.UpdateSubscriberOptions{
+		ProfileName: "enterprise",
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.UpdateSubscriber(ctx, "non_existent_imsi", opts)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
 func TestDeleteSubscriber_Success(t *testing.T) {
 	fake := &fakeRequester{
 		response: &client.RequestResponse{

--- a/client/users.go
+++ b/client/users.go
@@ -79,7 +79,6 @@ type ListAPITokensResponse struct {
 	TotalCount int        `json:"total_count"`
 }
 
-// ListUsers lists users with pagination.
 func (c *Client) ListUsers(ctx context.Context, p *ListParams) (*ListUsersResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -104,7 +103,6 @@ func (c *Client) ListUsers(ctx context.Context, p *ListParams) (*ListUsersRespon
 	return &users, nil
 }
 
-// CreateUser creates a new user with the provided options.
 func (c *Client) CreateUser(ctx context.Context, opts *CreateUserOptions) error {
 	payload := struct {
 		Email    string `json:"email"`
@@ -136,7 +134,6 @@ func (c *Client) CreateUser(ctx context.Context, opts *CreateUserOptions) error 
 	return nil
 }
 
-// GetUser retrieves a user by email.
 func (c *Client) GetUser(ctx context.Context, opts *GetUserOptions) (*User, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -157,8 +154,8 @@ func (c *Client) GetUser(ctx context.Context, opts *GetUserOptions) (*User, erro
 	return &user, nil
 }
 
-// UpdateUser updates an existing user's role by email. Only role_id is
-// settable; password changes go through UpdateUserPassword.
+// UpdateUser changes a user's role. Password changes go through
+// UpdateUserPassword.
 func (c *Client) UpdateUser(ctx context.Context, email string, opts *UpdateUserOptions) error {
 	payload := struct {
 		RoleID RoleID `json:"role_id"`
@@ -186,7 +183,6 @@ func (c *Client) UpdateUser(ctx context.Context, email string, opts *UpdateUserO
 	return nil
 }
 
-// DeleteUser deletes a user by email.
 func (c *Client) DeleteUser(ctx context.Context, opts *DeleteUserOptions) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -200,7 +196,7 @@ func (c *Client) DeleteUser(ctx context.Context, opts *DeleteUserOptions) error 
 	return nil
 }
 
-// CreateMyAPIToken creates a new API token for the authenticated user.
+// CreateMyAPIToken creates an API token for the authenticated user.
 func (c *Client) CreateMyAPIToken(ctx context.Context, opts *CreateAPITokenOptions) (*CreateAPITokenResponse, error) {
 	payload := struct {
 		Name      string `json:"name"`
@@ -237,7 +233,7 @@ func (c *Client) CreateMyAPIToken(ctx context.Context, opts *CreateAPITokenOptio
 	return &tokenResponse, nil
 }
 
-// ListMyAPITokens lists API tokens for the authenticated user with pagination.
+// ListMyAPITokens lists API tokens for the authenticated user.
 func (c *Client) ListMyAPITokens(ctx context.Context, p *ListParams) (*ListAPITokensResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -262,7 +258,7 @@ func (c *Client) ListMyAPITokens(ctx context.Context, p *ListParams) (*ListAPITo
 	return &tokens, nil
 }
 
-// DeleteMyAPIToken deletes an API token for the authenticated user by token ID.
+// DeleteMyAPIToken deletes an API token owned by the authenticated user.
 func (c *Client) DeleteMyAPIToken(ctx context.Context, tokenID string) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -276,7 +272,7 @@ func (c *Client) DeleteMyAPIToken(ctx context.Context, tokenID string) error {
 	return nil
 }
 
-// ListUserAPITokens lists API tokens for a specific user with pagination. Requires admin privileges.
+// ListUserAPITokens lists API tokens for the given user. Admin-only.
 func (c *Client) ListUserAPITokens(ctx context.Context, email string, p *ListParams) (*ListAPITokensResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
@@ -301,7 +297,7 @@ func (c *Client) ListUserAPITokens(ctx context.Context, email string, p *ListPar
 	return &tokens, nil
 }
 
-// CreateUserAPIToken creates a new API token for the specified user. Requires admin privileges.
+// CreateUserAPIToken creates an API token for the given user. Admin-only.
 func (c *Client) CreateUserAPIToken(ctx context.Context, email string, opts *CreateAPITokenOptions) (*CreateAPITokenResponse, error) {
 	payload := struct {
 		Name      string `json:"name"`
@@ -338,7 +334,7 @@ func (c *Client) CreateUserAPIToken(ctx context.Context, email string, opts *Cre
 	return &tokenResponse, nil
 }
 
-// DeleteUserAPIToken deletes an API token for the specified user by token ID. Requires admin privileges.
+// DeleteUserAPIToken deletes an API token from the given user. Admin-only.
 func (c *Client) DeleteUserAPIToken(ctx context.Context, email string, tokenID string) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/users.go
+++ b/client/users.go
@@ -44,8 +44,9 @@ type DeleteUserOptions struct {
 }
 
 type CreateAPITokenOptions struct {
-	Name   string `json:"name"`
-	Expiry string `json:"expiry,omitempty"` // ISO 8601 format, optional
+	Name string `json:"name"`
+	// ExpiresAt is an optional RFC 3339 timestamp. Empty means "no expiry".
+	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 type CreateAPITokenResponse struct {
@@ -53,9 +54,10 @@ type CreateAPITokenResponse struct {
 }
 
 type APIToken struct {
-	ID     string `json:"id"` // public token identifier (token_id), not the DB primary key
-	Name   string `json:"name"`
-	Expiry string `json:"expiry,omitempty"` // ISO 8601 format, optional
+	ID   string `json:"id"` // public token identifier (token_id), not the DB primary key
+	Name string `json:"name"`
+	// ExpiresAt is an RFC 3339 timestamp; empty when the token has no expiry.
+	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 type User struct {
@@ -201,11 +203,11 @@ func (c *Client) DeleteUser(ctx context.Context, opts *DeleteUserOptions) error 
 // CreateMyAPIToken creates a new API token for the authenticated user.
 func (c *Client) CreateMyAPIToken(ctx context.Context, opts *CreateAPITokenOptions) (*CreateAPITokenResponse, error) {
 	payload := struct {
-		Name   string `json:"name"`
-		Expiry string `json:"expiry,omitempty"` // ISO 8601 format, optional
+		Name      string `json:"name"`
+		ExpiresAt string `json:"expires_at,omitempty"`
 	}{
-		Name:   opts.Name,
-		Expiry: opts.Expiry,
+		Name:      opts.Name,
+		ExpiresAt: opts.ExpiresAt,
 	}
 
 	var body bytes.Buffer
@@ -302,11 +304,11 @@ func (c *Client) ListUserAPITokens(ctx context.Context, email string, p *ListPar
 // CreateUserAPIToken creates a new API token for the specified user. Requires admin privileges.
 func (c *Client) CreateUserAPIToken(ctx context.Context, email string, opts *CreateAPITokenOptions) (*CreateAPITokenResponse, error) {
 	payload := struct {
-		Name   string `json:"name"`
-		Expiry string `json:"expiry,omitempty"`
+		Name      string `json:"name"`
+		ExpiresAt string `json:"expires_at,omitempty"`
 	}{
-		Name:   opts.Name,
-		Expiry: opts.Expiry,
+		Name:      opts.Name,
+		ExpiresAt: opts.ExpiresAt,
 	}
 
 	var body bytes.Buffer

--- a/client/users.go
+++ b/client/users.go
@@ -31,6 +31,14 @@ type CreateUserOptions struct {
 	Password string `json:"password"`
 }
 
+type UpdateUserOptions struct {
+	RoleID RoleID `json:"role_id"`
+}
+
+type GetUserOptions struct {
+	Email string `json:"email"`
+}
+
 type DeleteUserOptions struct {
 	Email string `json:"email"`
 }
@@ -117,6 +125,56 @@ func (c *Client) CreateUser(ctx context.Context, opts *CreateUserOptions) error 
 		Type:   SyncRequest,
 		Method: "POST",
 		Path:   "api/v1/users",
+		Body:   &body,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetUser retrieves a user by email.
+func (c *Client) GetUser(ctx context.Context, opts *GetUserOptions) (*User, error) {
+	resp, err := c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "api/v1/users/" + opts.Email,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var user User
+
+	err = resp.DecodeResult(&user)
+	if err != nil {
+		return nil, err
+	}
+
+	return &user, nil
+}
+
+// UpdateUser updates an existing user's role by email. Only role_id is
+// settable; password changes go through UpdateUserPassword.
+func (c *Client) UpdateUser(ctx context.Context, email string, opts *UpdateUserOptions) error {
+	payload := struct {
+		RoleID RoleID `json:"role_id"`
+	}{
+		RoleID: opts.RoleID,
+	}
+
+	var body bytes.Buffer
+
+	err := json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "PUT",
+		Path:   "api/v1/users/" + email,
 		Body:   &body,
 	})
 	if err != nil {

--- a/client/users_test.go
+++ b/client/users_test.go
@@ -167,6 +167,114 @@ func TestDeleteUser_Failure(t *testing.T) {
 	}
 }
 
+func TestGetUser_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"email": "alice@example.com", "role_id": 3}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	ctx := context.Background()
+
+	user, err := clientObj.GetUser(ctx, &client.GetUserOptions{Email: "alice@example.com"})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if user.Email != "alice@example.com" {
+		t.Fatalf("expected email alice@example.com, got %s", user.Email)
+	}
+
+	if user.RoleID != client.RoleNetworkManager {
+		t.Fatalf("expected role %d, got %d", client.RoleNetworkManager, user.RoleID)
+	}
+
+	if fake.lastOpts.Method != "GET" {
+		t.Fatalf("expected GET method, got: %s", fake.lastOpts.Method)
+	}
+
+	if fake.lastOpts.Path != "api/v1/users/alice@example.com" {
+		t.Fatalf("expected path api/v1/users/alice@example.com, got %s", fake.lastOpts.Path)
+	}
+}
+
+func TestGetUser_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 404,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "User not found"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	ctx := context.Background()
+
+	_, err := clientObj.GetUser(ctx, &client.GetUserOptions{Email: "missing@example.com"})
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestUpdateUser_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "User updated successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.UpdateUser(ctx, "alice@example.com", &client.UpdateUserOptions{RoleID: client.RoleAdmin})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if fake.lastOpts.Method != "PUT" {
+		t.Fatalf("expected PUT method, got: %s", fake.lastOpts.Method)
+	}
+
+	if fake.lastOpts.Path != "api/v1/users/alice@example.com" {
+		t.Fatalf("expected path api/v1/users/alice@example.com, got %s", fake.lastOpts.Path)
+	}
+}
+
+func TestUpdateUser_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 404,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "User not found"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{
+		Requester: fake,
+	}
+
+	ctx := context.Background()
+
+	err := clientObj.UpdateUser(ctx, "missing@example.com", &client.UpdateUserOptions{RoleID: client.RoleAdmin})
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
 func TestCreateMyAPIToken_Success(t *testing.T) {
 	fake := &fakeRequester{
 		response: &client.RequestResponse{

--- a/client/users_test.go
+++ b/client/users_test.go
@@ -289,8 +289,8 @@ func TestCreateMyAPIToken_Success(t *testing.T) {
 	}
 
 	createAPITokenOpts := &client.CreateAPITokenOptions{
-		Name:   "whatevername",
-		Expiry: "",
+		Name:      "whatevername",
+		ExpiresAt: "",
 	}
 
 	ctx := context.Background()
@@ -319,8 +319,8 @@ func TestCreateMyAPIToken_Failure(t *testing.T) {
 	}
 
 	createAPITokenOpts := &client.CreateAPITokenOptions{
-		Name:   "",
-		Expiry: "",
+		Name:      "",
+		ExpiresAt: "",
 	}
 
 	ctx := context.Background()

--- a/integration/api_matrix_api_tokens_test.go
+++ b/integration/api_matrix_api_tokens_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ellanetworks/core/client"
 )
@@ -13,13 +14,15 @@ import (
 //
 //	List → Create → List(contains) → Delete → List(absent)
 //
-// The bootstrap creates an admin API token used by the test client
-// itself (tester_env_test.go:131); we must not delete it. To isolate
-// completely we create a side user and operate on tokens belonging to
-// that user via the admin-scoped /users/{email}/api-tokens endpoints.
+// Two sub-cases are run on the same backing user — one with no expiry,
+// one with an explicit RFC 3339 ExpiresAt — to round-trip the optional
+// field. The bootstrap creates an admin API token used by the test
+// client itself (tester_env_test.go:131); we must not delete it. To
+// isolate completely we create a side user and operate on tokens
+// belonging to that user via the admin-scoped /users/{email}/api-tokens
+// endpoints.
 func runAPITokensMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	email := "apimat-token-user@example.com"
-	tokenName := "apimat-token"
 
 	if err := c.CreateUser(ctx, &client.CreateUserOptions{
 		Email:    email,
@@ -54,49 +57,94 @@ func runAPITokensMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		return nil
 	}
 
-	baseline := listAll()
+	// Server expects RFC 3339 (api_users.go:663 calls time.Parse(time.RFC3339, ...)).
+	expiry := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second).Format(time.RFC3339)
 
-	if _, err := c.CreateUserAPIToken(ctx, email, &client.CreateAPITokenOptions{
-		Name: tokenName,
-	}); err != nil {
-		t.Fatalf("create api token: %v", err)
+	cases := []struct {
+		name       string
+		tokenName  string
+		opts       *client.CreateAPITokenOptions
+		wantExpiry string // empty means "must be empty on the list response"
+	}{
+		{
+			name:       "no_expiry",
+			tokenName:  "apimat-token-noexp",
+			opts:       &client.CreateAPITokenOptions{Name: "apimat-token-noexp"},
+			wantExpiry: "",
+		},
+		{
+			name:       "with_expiry",
+			tokenName:  "apimat-token-exp",
+			opts:       &client.CreateAPITokenOptions{Name: "apimat-token-exp", ExpiresAt: expiry},
+			wantExpiry: expiry,
+		},
 	}
 
-	afterCreate := listAll()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			baseline := listAll()
 
-	created := findByName(afterCreate.Items, tokenName)
-	if created == nil {
-		t.Fatalf("list after create missing token name %q", tokenName)
-	}
+			if _, err := c.CreateUserAPIToken(ctx, email, tc.opts); err != nil {
+				t.Fatalf("create api token: %v", err)
+			}
 
-	deleted := false
+			afterCreate := listAll()
 
-	t.Cleanup(func() {
-		if deleted {
-			return
-		}
+			created := findByName(afterCreate.Items, tc.tokenName)
+			if created == nil {
+				t.Fatalf("list after create missing token name %q", tc.tokenName)
+			}
 
-		if err := c.DeleteUserAPIToken(ctx, email, created.ID); err != nil {
-			t.Logf("cleanup: delete api token %q: %v", created.ID, err)
-		}
-	})
+			deleted := false
 
-	if afterCreate.TotalCount != baseline.TotalCount+1 {
-		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
-	}
+			t.Cleanup(func() {
+				if deleted {
+					return
+				}
 
-	if err := c.DeleteUserAPIToken(ctx, email, created.ID); err != nil {
-		t.Fatalf("delete api token %q: %v", created.ID, err)
-	}
+				if err := c.DeleteUserAPIToken(ctx, email, created.ID); err != nil {
+					t.Logf("cleanup: delete api token %q: %v", created.ID, err)
+				}
+			})
 
-	deleted = true
+			if afterCreate.TotalCount != baseline.TotalCount+1 {
+				t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+			}
 
-	afterDelete := listAll()
-	if afterDelete.TotalCount != baseline.TotalCount {
-		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
-	}
+			// Round-trip the ExpiresAt field. Compare as time.Time to be
+			// tolerant of timezone formatting normalization on the server
+			// side (e.g. "Z" vs "+00:00") while still pinning the moment.
+			if tc.wantExpiry == "" {
+				if created.ExpiresAt != "" {
+					t.Fatalf("ExpiresAt: got %q, want empty", created.ExpiresAt)
+				}
+			} else {
+				got, err := time.Parse(time.RFC3339, created.ExpiresAt)
+				if err != nil {
+					t.Fatalf("ExpiresAt: not RFC 3339: %q (%v)", created.ExpiresAt, err)
+				}
 
-	if findByName(afterDelete.Items, tokenName) != nil {
-		t.Fatalf("list after delete still contains token name %q", tokenName)
+				want, _ := time.Parse(time.RFC3339, tc.wantExpiry)
+				if !got.Equal(want) {
+					t.Fatalf("ExpiresAt: got %q, want %q", created.ExpiresAt, tc.wantExpiry)
+				}
+			}
+
+			if err := c.DeleteUserAPIToken(ctx, email, created.ID); err != nil {
+				t.Fatalf("delete api token %q: %v", created.ID, err)
+			}
+
+			deleted = true
+
+			afterDelete := listAll()
+			if afterDelete.TotalCount != baseline.TotalCount {
+				t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+			}
+
+			if findByName(afterDelete.Items, tc.tokenName) != nil {
+				t.Fatalf("list after delete still contains token name %q", tc.tokenName)
+			}
+		})
 	}
 }

--- a/integration/api_matrix_api_tokens_test.go
+++ b/integration/api_matrix_api_tokens_test.go
@@ -1,0 +1,102 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runAPITokensMatrix exercises Create/List/Delete for user API tokens.
+// API tokens have no Get or Update verb (server.go:93-95), so this is a
+// 3-step matrix:
+//
+//	List → Create → List(contains) → Delete → List(absent)
+//
+// The bootstrap creates an admin API token used by the test client
+// itself (tester_env_test.go:131); we must not delete it. To isolate
+// completely we create a side user and operate on tokens belonging to
+// that user via the admin-scoped /users/{email}/api-tokens endpoints.
+func runAPITokensMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	email := "apimat-token-user@example.com"
+	tokenName := "apimat-token"
+
+	if err := c.CreateUser(ctx, &client.CreateUserOptions{
+		Email:    email,
+		RoleID:   client.RoleReadOnly,
+		Password: "ApiMatrixPassw0rd!",
+	}); err != nil {
+		t.Fatalf("create dep user %q: %v", email, err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteUser(ctx, &client.DeleteUserOptions{Email: email}); err != nil {
+			t.Logf("cleanup: delete dep user %q: %v", email, err)
+		}
+	})
+
+	listAll := func() *client.ListAPITokensResponse {
+		resp, err := c.ListUserAPITokens(ctx, email, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list api tokens for %q: %v", email, err)
+		}
+
+		return resp
+	}
+
+	findByName := func(items []client.APIToken, name string) *client.APIToken {
+		for i := range items {
+			if items[i].Name == name {
+				return &items[i]
+			}
+		}
+
+		return nil
+	}
+
+	baseline := listAll()
+
+	if _, err := c.CreateUserAPIToken(ctx, email, &client.CreateAPITokenOptions{
+		Name: tokenName,
+	}); err != nil {
+		t.Fatalf("create api token: %v", err)
+	}
+
+	afterCreate := listAll()
+
+	created := findByName(afterCreate.Items, tokenName)
+	if created == nil {
+		t.Fatalf("list after create missing token name %q", tokenName)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteUserAPIToken(ctx, email, created.ID); err != nil {
+			t.Logf("cleanup: delete api token %q: %v", created.ID, err)
+		}
+	})
+
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if err := c.DeleteUserAPIToken(ctx, email, created.ID); err != nil {
+		t.Fatalf("delete api token %q: %v", created.ID, err)
+	}
+
+	deleted = true
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if findByName(afterDelete.Items, tokenName) != nil {
+		t.Fatalf("list after delete still contains token name %q", tokenName)
+	}
+}

--- a/integration/api_matrix_api_tokens_test.go
+++ b/integration/api_matrix_api_tokens_test.go
@@ -8,19 +8,8 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runAPITokensMatrix exercises Create/List/Delete for user API tokens.
-// API tokens have no Get or Update verb (server.go:93-95), so this is a
-// 3-step matrix:
-//
-//	List → Create → List(contains) → Delete → List(absent)
-//
-// Two sub-cases are run on the same backing user — one with no expiry,
-// one with an explicit RFC 3339 ExpiresAt — to round-trip the optional
-// field. The bootstrap creates an admin API token used by the test
-// client itself (tester_env_test.go:131); we must not delete it. To
-// isolate completely we create a side user and operate on tokens
-// belonging to that user via the admin-scoped /users/{email}/api-tokens
-// endpoints.
+// runAPITokensMatrix operates on a side user so the bootstrap admin
+// token (in use by the test client itself) is never at risk.
 func runAPITokensMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	email := "apimat-token-user@example.com"
 
@@ -57,7 +46,7 @@ func runAPITokensMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		return nil
 	}
 
-	// Server expects RFC 3339 (api_users.go:663 calls time.Parse(time.RFC3339, ...)).
+	// Server expects RFC 3339.
 	expiry := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second).Format(time.RFC3339)
 
 	cases := []struct {
@@ -112,9 +101,8 @@ func runAPITokensMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 				t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
 			}
 
-			// Round-trip the ExpiresAt field. Compare as time.Time to be
-			// tolerant of timezone formatting normalization on the server
-			// side (e.g. "Z" vs "+00:00") while still pinning the moment.
+			// Compare as time.Time to tolerate timezone formatting
+			// differences ("Z" vs "+00:00") while pinning the moment.
 			if tc.wantExpiry == "" {
 				if created.ExpiresAt != "" {
 					t.Fatalf("ExpiresAt: got %q, want empty", created.ExpiresAt)

--- a/integration/api_matrix_bgp_peers_test.go
+++ b/integration/api_matrix_bgp_peers_test.go
@@ -7,14 +7,9 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runBGPPeersMatrix exercises CRUD for BGP peers. The handler at
-// internal/api/server/api_bgp.go:435 does not require BGP to be enabled
-// for create — peers are stored in the DB regardless — so we can run
-// this matrix without first toggling BGP settings.
-//
-// Peers are identified by integer ID assigned at create time; since the
-// Create response does not echo the ID back, we List immediately after
-// Create and look up our peer by Address.
+// runBGPPeersMatrix runs without enabling the BGP speaker; peers are
+// stored regardless of the speaker state. The Create response does not
+// echo the assigned ID, so we recover it by listing and matching Address.
 func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	listAll := func() *client.ListBGPPeersResponse {
 		resp, err := c.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
@@ -37,8 +32,7 @@ func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	baseline := listAll()
 
-	// 192.0.2.0/24 is TEST-NET-1 (RFC 5737); not routable, so the BGP
-	// session never establishes — but the DB record exists.
+	// TEST-NET-1 (RFC 5737); not routable, so no BGP session ever forms.
 	createOpts := &client.CreateBGPPeerOptions{
 		Address:     "192.0.2.10",
 		RemoteAS:    65000,
@@ -152,10 +146,9 @@ func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 			},
 		},
 		{
-			// Password is *string on Update with two semantics: nil = leave
-			// unchanged, &"<value>" = set, &"" = clear. The server doesn't
-			// echo the password back, so we observe the change via the
-			// HasPassword boolean on the Get response.
+			// Password is *string with three semantics: nil leaves it
+			// unchanged, &"value" sets it, &"" clears it. The server never
+			// echoes the password back, so HasPassword is the witness.
 			field: "Password_set",
 			mutate: func(o *client.UpdateBGPPeerOptions) {
 				secret := "topsecret"
@@ -224,10 +217,8 @@ func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	}
 }
 
-// updateOptsFromBGPPeer mirrors current Get state into an
-// UpdateBGPPeerOptions so per-field sub-cases mutate exactly one field
-// without overwriting others. Password is intentionally left nil (the
-// "leave unchanged" pointer-nil semantics) since the server doesn't
+// updateOptsFromBGPPeer mirrors current Get state into Update options.
+// Password is left nil ("leave unchanged") since the server doesn't
 // expose the current password.
 func updateOptsFromBGPPeer(p *client.BGPPeer) client.UpdateBGPPeerOptions {
 	return client.UpdateBGPPeerOptions{

--- a/integration/api_matrix_bgp_peers_test.go
+++ b/integration/api_matrix_bgp_peers_test.go
@@ -1,0 +1,196 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runBGPPeersMatrix exercises CRUD for BGP peers. The handler at
+// internal/api/server/api_bgp.go:435 does not require BGP to be enabled
+// for create — peers are stored in the DB regardless — so we can run
+// this matrix without first toggling BGP settings.
+//
+// Peers are identified by integer ID assigned at create time; since the
+// Create response does not echo the ID back, we List immediately after
+// Create and look up our peer by Address.
+func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	listAll := func() *client.ListBGPPeersResponse {
+		resp, err := c.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list bgp peers: %v", err)
+		}
+
+		return resp
+	}
+
+	findByAddress := func(items []client.BGPPeer, addr string) *client.BGPPeer {
+		for i := range items {
+			if items[i].Address == addr {
+				return &items[i]
+			}
+		}
+
+		return nil
+	}
+
+	baseline := listAll()
+
+	// 192.0.2.0/24 is TEST-NET-1 (RFC 5737); not routable, so the BGP
+	// session never establishes — but the DB record exists.
+	createOpts := &client.CreateBGPPeerOptions{
+		Address:     "192.0.2.10",
+		RemoteAS:    65000,
+		HoldTime:    90,
+		Description: "apimatrix peer",
+		ImportPrefixes: []client.BGPImportPrefix{
+			{Prefix: "10.0.0.0/8", MaxLength: 24},
+		},
+	}
+
+	if err := c.CreateBGPPeer(ctx, createOpts); err != nil {
+		t.Fatalf("create bgp peer: %v", err)
+	}
+
+	afterCreate := listAll()
+
+	created := findByAddress(afterCreate.Items, createOpts.Address)
+	if created == nil {
+		t.Fatalf("list after create missing address %q", createOpts.Address)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteBGPPeer(ctx, &client.DeleteBGPPeerOptions{ID: created.ID}); err != nil {
+			t.Logf("cleanup: delete bgp peer %d: %v", created.ID, err)
+		}
+	})
+
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if created.RemoteAS != createOpts.RemoteAS ||
+		created.HoldTime != createOpts.HoldTime ||
+		created.Description != createOpts.Description ||
+		len(created.ImportPrefixes) != 1 ||
+		created.ImportPrefixes[0].Prefix != "10.0.0.0/8" ||
+		created.ImportPrefixes[0].MaxLength != 24 {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want %+v", created, createOpts)
+	}
+
+	got, err := c.GetBGPPeer(ctx, &client.GetBGPPeerOptions{ID: created.ID})
+	if err != nil {
+		t.Fatalf("get bgp peer %d: %v", created.ID, err)
+	}
+
+	if got.ID != created.ID || got.Address != createOpts.Address {
+		t.Fatalf("get bgp peer mismatch: got %+v, want id=%d address=%q", got, created.ID, createOpts.Address)
+	}
+
+	updateCases := []struct {
+		field  string
+		mutate func(o *client.UpdateBGPPeerOptions)
+		assert func(t *testing.T, p *client.BGPPeer)
+	}{
+		{
+			field: "RemoteAS",
+			mutate: func(o *client.UpdateBGPPeerOptions) {
+				o.RemoteAS = 65001
+			},
+			assert: func(t *testing.T, p *client.BGPPeer) {
+				if p.RemoteAS != 65001 {
+					t.Fatalf("RemoteAS: got %d, want 65001", p.RemoteAS)
+				}
+			},
+		},
+		{
+			field: "HoldTime",
+			mutate: func(o *client.UpdateBGPPeerOptions) {
+				o.HoldTime = 120
+			},
+			assert: func(t *testing.T, p *client.BGPPeer) {
+				if p.HoldTime != 120 {
+					t.Fatalf("HoldTime: got %d, want 120", p.HoldTime)
+				}
+			},
+		},
+		{
+			field: "Description",
+			mutate: func(o *client.UpdateBGPPeerOptions) {
+				o.Description = "apimatrix peer updated"
+			},
+			assert: func(t *testing.T, p *client.BGPPeer) {
+				if p.Description != "apimatrix peer updated" {
+					t.Fatalf("Description: got %q, want %q", p.Description, "apimatrix peer updated")
+				}
+			},
+		},
+		{
+			field: "ImportPrefixes",
+			mutate: func(o *client.UpdateBGPPeerOptions) {
+				o.ImportPrefixes = []client.BGPImportPrefix{
+					{Prefix: "172.16.0.0/12", MaxLength: 20},
+				}
+			},
+			assert: func(t *testing.T, p *client.BGPPeer) {
+				if len(p.ImportPrefixes) != 1 ||
+					p.ImportPrefixes[0].Prefix != "172.16.0.0/12" ||
+					p.ImportPrefixes[0].MaxLength != 20 {
+					t.Fatalf("ImportPrefixes: got %+v, want [172.16.0.0/12 maxLength=20]", p.ImportPrefixes)
+				}
+			},
+		},
+	}
+
+	for _, tc := range updateCases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			opts := client.UpdateBGPPeerOptions{
+				ID:             created.ID,
+				Address:        createOpts.Address,
+				RemoteAS:       createOpts.RemoteAS,
+				HoldTime:       createOpts.HoldTime,
+				Description:    createOpts.Description,
+				ImportPrefixes: createOpts.ImportPrefixes,
+			}
+
+			tc.mutate(&opts)
+
+			if err := c.UpdateBGPPeer(ctx, &opts); err != nil {
+				t.Fatalf("update bgp peer %d (%s): %v", created.ID, tc.field, err)
+			}
+
+			updated, err := c.GetBGPPeer(ctx, &client.GetBGPPeerOptions{ID: created.ID})
+			if err != nil {
+				t.Fatalf("get bgp peer after update: %v", err)
+			}
+
+			tc.assert(t, updated)
+		})
+	}
+
+	if err := c.DeleteBGPPeer(ctx, &client.DeleteBGPPeerOptions{ID: created.ID}); err != nil {
+		t.Fatalf("delete bgp peer %d: %v", created.ID, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetBGPPeer(ctx, &client.GetBGPPeerOptions{ID: created.ID})
+	assertNotFound(t, err, "bgp peer after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if findByAddress(afterDelete.Items, createOpts.Address) != nil {
+		t.Fatalf("list after delete still contains address %q", createOpts.Address)
+	}
+}

--- a/integration/api_matrix_bgp_peers_test.go
+++ b/integration/api_matrix_bgp_peers_test.go
@@ -85,6 +85,10 @@ func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("post-create round-trip mismatch: got %+v, want %+v", created, createOpts)
 	}
 
+	if created.HasPassword {
+		t.Fatalf("HasPassword: got true, want false (peer was created without a password)")
+	}
+
 	got, err := c.GetBGPPeer(ctx, &client.GetBGPPeerOptions{ID: created.ID})
 	if err != nil {
 		t.Fatalf("get bgp peer %d: %v", created.ID, err)
@@ -147,20 +151,45 @@ func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 				}
 			},
 		},
+		{
+			// Password is *string on Update with two semantics: nil = leave
+			// unchanged, &"<value>" = set, &"" = clear. The server doesn't
+			// echo the password back, so we observe the change via the
+			// HasPassword boolean on the Get response.
+			field: "Password_set",
+			mutate: func(o *client.UpdateBGPPeerOptions) {
+				secret := "topsecret"
+				o.Password = &secret
+			},
+			assert: func(t *testing.T, p *client.BGPPeer) {
+				if !p.HasPassword {
+					t.Fatalf("HasPassword after set: got false, want true")
+				}
+			},
+		},
+		{
+			field: "Password_clear",
+			mutate: func(o *client.UpdateBGPPeerOptions) {
+				empty := ""
+				o.Password = &empty
+			},
+			assert: func(t *testing.T, p *client.BGPPeer) {
+				if p.HasPassword {
+					t.Fatalf("HasPassword after clear: got true, want false")
+				}
+			},
+		},
 	}
 
 	for _, tc := range updateCases {
 		tc := tc
 		t.Run("update_"+tc.field, func(t *testing.T) {
-			opts := client.UpdateBGPPeerOptions{
-				ID:             created.ID,
-				Address:        createOpts.Address,
-				RemoteAS:       createOpts.RemoteAS,
-				HoldTime:       createOpts.HoldTime,
-				Description:    createOpts.Description,
-				ImportPrefixes: createOpts.ImportPrefixes,
+			current, err := c.GetBGPPeer(ctx, &client.GetBGPPeerOptions{ID: created.ID})
+			if err != nil {
+				t.Fatalf("get bgp peer %d before update: %v", created.ID, err)
 			}
 
+			opts := updateOptsFromBGPPeer(current)
 			tc.mutate(&opts)
 
 			if err := c.UpdateBGPPeer(ctx, &opts); err != nil {
@@ -192,5 +221,21 @@ func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	if findByAddress(afterDelete.Items, createOpts.Address) != nil {
 		t.Fatalf("list after delete still contains address %q", createOpts.Address)
+	}
+}
+
+// updateOptsFromBGPPeer mirrors current Get state into an
+// UpdateBGPPeerOptions so per-field sub-cases mutate exactly one field
+// without overwriting others. Password is intentionally left nil (the
+// "leave unchanged" pointer-nil semantics) since the server doesn't
+// expose the current password.
+func updateOptsFromBGPPeer(p *client.BGPPeer) client.UpdateBGPPeerOptions {
+	return client.UpdateBGPPeerOptions{
+		ID:             p.ID,
+		Address:        p.Address,
+		RemoteAS:       p.RemoteAS,
+		HoldTime:       p.HoldTime,
+		Description:    p.Description,
+		ImportPrefixes: p.ImportPrefixes,
 	}
 }

--- a/integration/api_matrix_bgp_settings_test.go
+++ b/integration/api_matrix_bgp_settings_test.go
@@ -1,0 +1,114 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runBGPSettingsMatrix exercises GET/PUT /api/v1/networking/bgp.
+// Handler validators (api_bgp.go:138-196): LocalAS in [1, 4294967295];
+// RouterID is a valid IPv4 or empty (defaults to effective); ListenAddress
+// is "host:port" or ":port", default ":179".
+func runBGPSettingsMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	orig, err := c.GetBGPSettings(ctx)
+	if err != nil {
+		t.Fatalf("get bgp settings (baseline): %v", err)
+	}
+
+	restore := &client.UpdateBGPSettingsOptions{
+		Enabled:       orig.Enabled,
+		LocalAS:       orig.LocalAS,
+		RouterID:      orig.RouterID,
+		ListenAddress: orig.ListenAddress,
+	}
+
+	if restore.LocalAS == 0 {
+		restore.LocalAS = 65000
+	}
+
+	if restore.ListenAddress == "" {
+		restore.ListenAddress = ":179"
+	}
+
+	if err := c.UpdateBGPSettings(ctx, restore); err != nil {
+		t.Fatalf("set bgp settings baseline: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateBGPSettings(ctx, restore); err != nil {
+			t.Logf("cleanup: restore bgp settings: %v", err)
+		}
+	})
+
+	cases := []struct {
+		field  string
+		mutate func(o *client.UpdateBGPSettingsOptions)
+		assert func(t *testing.T, s *client.GetBGPSettingsResponse)
+	}{
+		{
+			field: "Enabled",
+			mutate: func(o *client.UpdateBGPSettingsOptions) {
+				o.Enabled = !restore.Enabled
+			},
+			assert: func(t *testing.T, s *client.GetBGPSettingsResponse) {
+				if s.Enabled != !restore.Enabled {
+					t.Fatalf("Enabled: got %t, want %t", s.Enabled, !restore.Enabled)
+				}
+			},
+		},
+		{
+			field: "LocalAS",
+			mutate: func(o *client.UpdateBGPSettingsOptions) {
+				o.LocalAS = 65042
+			},
+			assert: func(t *testing.T, s *client.GetBGPSettingsResponse) {
+				if s.LocalAS != 65042 {
+					t.Fatalf("LocalAS: got %d, want 65042", s.LocalAS)
+				}
+			},
+		},
+		{
+			field: "RouterID",
+			mutate: func(o *client.UpdateBGPSettingsOptions) {
+				o.RouterID = "10.99.99.99"
+			},
+			assert: func(t *testing.T, s *client.GetBGPSettingsResponse) {
+				if s.RouterID != "10.99.99.99" {
+					t.Fatalf("RouterID: got %q, want %q", s.RouterID, "10.99.99.99")
+				}
+			},
+		},
+		{
+			field: "ListenAddress",
+			mutate: func(o *client.UpdateBGPSettingsOptions) {
+				o.ListenAddress = ":1790"
+			},
+			assert: func(t *testing.T, s *client.GetBGPSettingsResponse) {
+				if s.ListenAddress != ":1790" {
+					t.Fatalf("ListenAddress: got %q, want %q", s.ListenAddress, ":1790")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			opts := *restore
+			tc.mutate(&opts)
+
+			if err := c.UpdateBGPSettings(ctx, &opts); err != nil {
+				t.Fatalf("update bgp settings (%s): %v", tc.field, err)
+			}
+
+			got, err := c.GetBGPSettings(ctx)
+			if err != nil {
+				t.Fatalf("get bgp settings after update: %v", err)
+			}
+
+			tc.assert(t, got)
+		})
+	}
+}

--- a/integration/api_matrix_bgp_settings_test.go
+++ b/integration/api_matrix_bgp_settings_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runBGPSettingsMatrix exercises GET/PUT /api/v1/networking/bgp.
-// Handler validators (api_bgp.go:138-196): LocalAS in [1, 4294967295];
-// RouterID is a valid IPv4 or empty (defaults to effective); ListenAddress
-// is "host:port" or ":port", default ":179".
+// runBGPSettingsMatrix round-trips the BGP speaker configuration.
+// Validation constraints enforced by the server: LocalAS in [1, 4294967295];
+// RouterID is a valid IPv4 address or empty (server picks the effective
+// one); ListenAddress is "host:port" or ":port", defaulting to ":179".
 func runBGPSettingsMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	orig, err := c.GetBGPSettings(ctx)
 	if err != nil {

--- a/integration/api_matrix_data_networks_test.go
+++ b/integration/api_matrix_data_networks_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runDataNetworksMatrix exercises CRUD for data networks. See
-// api_matrix_profiles_test.go for the matrix shape.
-//
-// IPv4Pool, IPv6Pool, DNS, and Mtu are all round-tripped via Update.
 func runDataNetworksMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	name := apiMatrixName("dn")
 
@@ -81,8 +77,6 @@ func runDataNetworksMatrix(ctx context.Context, t *testing.T, c *client.Client) 
 		t.Fatalf("list after create missing %q", name)
 	}
 
-	// Updates round-trip every settable field independently. The base spec
-	// is the post-create state; each case mutates exactly one field.
 	base := *createOpts
 
 	updateCases := []struct {

--- a/integration/api_matrix_data_networks_test.go
+++ b/integration/api_matrix_data_networks_test.go
@@ -1,0 +1,182 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runDataNetworksMatrix exercises CRUD for data networks. See
+// api_matrix_profiles_test.go for the matrix shape.
+//
+// IPv4Pool, IPv6Pool, DNS, and Mtu are all round-tripped via Update.
+func runDataNetworksMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	name := apiMatrixName("dn")
+
+	listAll := func() *client.ListDataNetworksResponse {
+		resp, err := c.ListDataNetworks(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list data networks: %v", err)
+		}
+
+		return resp
+	}
+
+	contains := func(items []client.DataNetwork, name string) bool {
+		for _, dn := range items {
+			if dn.Name == name {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	baseline := listAll()
+
+	createOpts := &client.CreateDataNetworkOptions{
+		Name:     name,
+		IPv4Pool: "10.250.0.0/16",
+		IPv6Pool: "fd99::/48",
+		DNS:      "8.8.8.8",
+		Mtu:      1500,
+	}
+
+	if err := c.CreateDataNetwork(ctx, createOpts); err != nil {
+		t.Fatalf("create data network %q: %v", name, err)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: name}); err != nil {
+			t.Logf("cleanup: delete data network %q: %v", name, err)
+		}
+	})
+
+	got, err := c.GetDataNetwork(ctx, &client.GetDataNetworkOptions{Name: name})
+	if err != nil {
+		t.Fatalf("get data network %q after create: %v", name, err)
+	}
+
+	if got.Name != createOpts.Name ||
+		got.IPv4Pool != createOpts.IPv4Pool ||
+		got.IPv6Pool != createOpts.IPv6Pool ||
+		got.DNS != createOpts.DNS ||
+		got.Mtu != createOpts.Mtu {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want %+v", got, createOpts)
+	}
+
+	afterCreate := listAll()
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if !contains(afterCreate.Items, name) {
+		t.Fatalf("list after create missing %q", name)
+	}
+
+	// Updates round-trip every settable field independently. The base spec
+	// is the post-create state; each case mutates exactly one field.
+	base := *createOpts
+
+	updateCases := []struct {
+		field  string
+		mutate func(o *client.UpdateDataNetworkOptions)
+		assert func(t *testing.T, dn *client.DataNetwork)
+	}{
+		{
+			field: "IPv4Pool",
+			mutate: func(o *client.UpdateDataNetworkOptions) {
+				o.IPv4Pool = "10.251.0.0/16"
+			},
+			assert: func(t *testing.T, dn *client.DataNetwork) {
+				if dn.IPv4Pool != "10.251.0.0/16" {
+					t.Fatalf("IPv4Pool: got %q, want %q", dn.IPv4Pool, "10.251.0.0/16")
+				}
+			},
+		},
+		{
+			field: "IPv6Pool",
+			mutate: func(o *client.UpdateDataNetworkOptions) {
+				o.IPv6Pool = "fd9a::/48"
+			},
+			assert: func(t *testing.T, dn *client.DataNetwork) {
+				if dn.IPv6Pool != "fd9a::/48" {
+					t.Fatalf("IPv6Pool: got %q, want %q", dn.IPv6Pool, "fd9a::/48")
+				}
+			},
+		},
+		{
+			field: "DNS",
+			mutate: func(o *client.UpdateDataNetworkOptions) {
+				o.DNS = "1.1.1.1"
+			},
+			assert: func(t *testing.T, dn *client.DataNetwork) {
+				if dn.DNS != "1.1.1.1" {
+					t.Fatalf("DNS: got %q, want %q", dn.DNS, "1.1.1.1")
+				}
+			},
+		},
+		{
+			field: "Mtu",
+			mutate: func(o *client.UpdateDataNetworkOptions) {
+				o.Mtu = 1400
+			},
+			assert: func(t *testing.T, dn *client.DataNetwork) {
+				if dn.Mtu != 1400 {
+					t.Fatalf("Mtu: got %d, want %d", dn.Mtu, 1400)
+				}
+			},
+		},
+	}
+
+	for _, tc := range updateCases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			opts := client.UpdateDataNetworkOptions{
+				Name:     name,
+				IPv4Pool: base.IPv4Pool,
+				IPv6Pool: base.IPv6Pool,
+				DNS:      base.DNS,
+				Mtu:      base.Mtu,
+			}
+
+			tc.mutate(&opts)
+
+			if err := c.UpdateDataNetwork(ctx, &opts); err != nil {
+				t.Fatalf("update data network %q (%s): %v", name, tc.field, err)
+			}
+
+			updated, err := c.GetDataNetwork(ctx, &client.GetDataNetworkOptions{Name: name})
+			if err != nil {
+				t.Fatalf("get data network %q after update: %v", name, err)
+			}
+
+			tc.assert(t, updated)
+		})
+	}
+
+	if err := c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: name}); err != nil {
+		t.Fatalf("delete data network %q: %v", name, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetDataNetwork(ctx, &client.GetDataNetworkOptions{Name: name})
+	assertNotFound(t, err, "data network after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if contains(afterDelete.Items, name) {
+		t.Fatalf("list after delete still contains %q", name)
+	}
+}

--- a/integration/api_matrix_flow_accounting_test.go
+++ b/integration/api_matrix_flow_accounting_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runFlowAccountingMatrix exercises Get + Update for the flow accounting
-// singleton. See api_matrix_nat_test.go for the shape.
 func runFlowAccountingMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	orig, err := c.GetFlowAccountingInfo(ctx)
 	if err != nil {

--- a/integration/api_matrix_flow_accounting_test.go
+++ b/integration/api_matrix_flow_accounting_test.go
@@ -1,0 +1,38 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runFlowAccountingMatrix exercises Get + Update for the flow accounting
+// singleton. See api_matrix_nat_test.go for the shape.
+func runFlowAccountingMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	orig, err := c.GetFlowAccountingInfo(ctx)
+	if err != nil {
+		t.Fatalf("get flow accounting (baseline): %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateFlowAccountingInfo(ctx, &client.UpdateFlowAccountingInfoOptions{Enabled: orig.Enabled}); err != nil {
+			t.Logf("cleanup: restore flow accounting: %v", err)
+		}
+	})
+
+	target := !orig.Enabled
+
+	if err := c.UpdateFlowAccountingInfo(ctx, &client.UpdateFlowAccountingInfoOptions{Enabled: target}); err != nil {
+		t.Fatalf("update flow accounting: %v", err)
+	}
+
+	got, err := c.GetFlowAccountingInfo(ctx)
+	if err != nil {
+		t.Fatalf("get flow accounting after update: %v", err)
+	}
+
+	if got.Enabled != target {
+		t.Fatalf("Enabled: got %t, want %t", got.Enabled, target)
+	}
+}

--- a/integration/api_matrix_helpers_test.go
+++ b/integration/api_matrix_helpers_test.go
@@ -5,18 +5,12 @@ import (
 	"testing"
 )
 
-// apiMatrixName returns a deterministic resource name scoped to the matrix
-// suite. Strict-create semantics (matching integration/fixture/apply.go) mean
-// a collision from a prior crashed run surfaces as a test failure rather than
-// silent mutation.
+// apiMatrixName prefixes resource names so they're identifiable as matrix
+// state and so a collision from a leaked prior run surfaces immediately.
 func apiMatrixName(resource string) string {
 	return "apimat-" + resource
 }
 
-// assertNotFound fails the test if err is nil, or if err does not look like
-// the server's not-found response. The Go SDK surfaces server errors as
-// `server error <code>: <message>` (client/client.go:243-249), so we match
-// on both the 404 status and the "not found" text.
 func assertNotFound(t *testing.T, err error, what string) {
 	t.Helper()
 

--- a/integration/api_matrix_helpers_test.go
+++ b/integration/api_matrix_helpers_test.go
@@ -1,0 +1,31 @@
+package integration_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// apiMatrixName returns a deterministic resource name scoped to the matrix
+// suite. Strict-create semantics (matching integration/fixture/apply.go) mean
+// a collision from a prior crashed run surfaces as a test failure rather than
+// silent mutation.
+func apiMatrixName(resource string) string {
+	return "apimat-" + resource
+}
+
+// assertNotFound fails the test if err is nil, or if err does not look like
+// the server's not-found response. The Go SDK surfaces server errors as
+// `server error <code>: <message>` (client/client.go:243-249), so we match
+// on both the 404 status and the "not found" text.
+func assertNotFound(t *testing.T, err error, what string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected %s lookup to fail with not-found, got nil", what)
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "404") && !strings.Contains(strings.ToLower(msg), "not found") {
+		t.Fatalf("expected %s lookup to fail with not-found, got: %v", what, err)
+	}
+}

--- a/integration/api_matrix_home_network_keys_test.go
+++ b/integration/api_matrix_home_network_keys_test.go
@@ -1,0 +1,120 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runHomeNetworkKeysMatrix exercises CRD for home network keys (no
+// Update verb in the API — server.go:137-138). The key has no list
+// endpoint of its own; keys are exposed as Operator.HomeNetworkKeys.
+//
+// Shape:
+//
+//	GetOperator → snapshot HomeNetworkKeys
+//	Create
+//	GetOperator → find created key, capture UUID
+//	GetHomeNetworkKeyPrivateKey(uuid) → round-trip private key
+//	Delete(uuid)
+//	GetOperator → assert key gone
+//
+// The bootstrap does not provision a home network key, so any existing
+// keys belong to a leaked prior run; strict-create surfaces collisions
+// on KeyIdentifier+Scheme.
+func runHomeNetworkKeysMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	const (
+		keyIdentifier = 42
+		scheme        = "A"
+		// X25519 private key (scheme A). Borrowed from
+		// internal/tester/scenarios/ue/registration_success_profile_a.go:41.
+		privateKey = "c53c22208b61860b06c62e5406a7b330c2b577aab3cd7cd2d3fa33ef6b3df3f6"
+	)
+
+	findKey := func(items []client.HomeNetworkKeyResponse, keyID int, sch string) *client.HomeNetworkKeyResponse {
+		for i := range items {
+			if items[i].KeyIdentifier == keyID && items[i].Scheme == sch {
+				return &items[i]
+			}
+		}
+
+		return nil
+	}
+
+	op, err := c.GetOperator(ctx)
+	if err != nil {
+		t.Fatalf("get operator (baseline): %v", err)
+	}
+
+	baselineCount := len(op.HomeNetworkKeys)
+
+	if err := c.CreateHomeNetworkKey(ctx, &client.CreateHomeNetworkKeyOptions{
+		KeyIdentifier: keyIdentifier,
+		Scheme:        scheme,
+		PrivateKey:    privateKey,
+	}); err != nil {
+		t.Fatalf("create home network key: %v", err)
+	}
+
+	op, err = c.GetOperator(ctx)
+	if err != nil {
+		t.Fatalf("get operator after create: %v", err)
+	}
+
+	created := findKey(op.HomeNetworkKeys, keyIdentifier, scheme)
+	if created == nil {
+		t.Fatalf("home network keys after create missing keyIdentifier=%d scheme=%s", keyIdentifier, scheme)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteHomeNetworkKey(ctx, created.ID); err != nil {
+			t.Logf("cleanup: delete home network key %q: %v", created.ID, err)
+		}
+	})
+
+	if len(op.HomeNetworkKeys) != baselineCount+1 {
+		t.Fatalf("home network keys count after create: got %d, want %d", len(op.HomeNetworkKeys), baselineCount+1)
+	}
+
+	if created.ID == "" {
+		t.Fatalf("home network key returned without an ID")
+	}
+
+	pk, err := c.GetHomeNetworkKeyPrivateKey(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get home network key private key: %v", err)
+	}
+
+	if pk.PrivateKey != privateKey {
+		t.Fatalf("private key round-trip mismatch: got %q, want %q", pk.PrivateKey, privateKey)
+	}
+
+	if err := c.DeleteHomeNetworkKey(ctx, created.ID); err != nil {
+		t.Fatalf("delete home network key %q: %v", created.ID, err)
+	}
+
+	deleted = true
+
+	op, err = c.GetOperator(ctx)
+	if err != nil {
+		t.Fatalf("get operator after delete: %v", err)
+	}
+
+	if len(op.HomeNetworkKeys) != baselineCount {
+		t.Fatalf("home network keys count after delete: got %d, want %d", len(op.HomeNetworkKeys), baselineCount)
+	}
+
+	if findKey(op.HomeNetworkKeys, keyIdentifier, scheme) != nil {
+		t.Fatalf("home network keys after delete still contains keyIdentifier=%d scheme=%s", keyIdentifier, scheme)
+	}
+
+	_, err = c.GetHomeNetworkKeyPrivateKey(ctx, created.ID)
+	assertNotFound(t, err, "home network key after delete")
+}

--- a/integration/api_matrix_home_network_keys_test.go
+++ b/integration/api_matrix_home_network_keys_test.go
@@ -7,34 +7,47 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runHomeNetworkKeysMatrix exercises CRD for home network keys (no
-// Update verb in the API — server.go:137-138). The key has no list
-// endpoint of its own; keys are exposed as Operator.HomeNetworkKeys.
+// runHomeNetworkKeysMatrix exercises CRD for home network keys. Both
+// supported schemes are covered:
 //
-// Shape:
+//   - "A" (X25519, 32-byte private key)
+//   - "B" (P-256, 32-byte private key)
 //
-//	GetOperator → snapshot HomeNetworkKeys
-//	Create
-//	GetOperator → find created key, capture UUID
-//	GetHomeNetworkKeyPrivateKey(uuid) → round-trip private key
-//	Delete(uuid)
-//	GetOperator → assert key gone
+// For each scheme: create → re-read operator → assert key visible and
+// the server-derived PublicKey is populated → fetch the private key by
+// UUID → delete → assert gone.
 //
-// The bootstrap does not provision a home network key, so any existing
-// keys belong to a leaked prior run; strict-create surfaces collisions
-// on KeyIdentifier+Scheme.
+// Home network keys have no own list endpoint (exposed via
+// Operator.HomeNetworkKeys) and no Update verb (server.go:137-138).
 func runHomeNetworkKeysMatrix(ctx context.Context, t *testing.T, c *client.Client) {
-	const (
-		keyIdentifier = 42
-		scheme        = "A"
-		// X25519 private key (scheme A). Borrowed from
-		// internal/tester/scenarios/ue/registration_success_profile_a.go:41.
-		privateKey = "c53c22208b61860b06c62e5406a7b330c2b577aab3cd7cd2d3fa33ef6b3df3f6"
-	)
+	// Cases use distinct KeyIdentifier values so they don't collide with
+	// each other or with leaked prior-run state (strict-create surfaces
+	// collisions per api_home_network_keys.go:155-159).
+	cases := []struct {
+		name          string
+		keyIdentifier int
+		scheme        string
+		privateKey    string // 32 bytes hex
+	}{
+		{
+			name:          "scheme_A_x25519",
+			keyIdentifier: 42,
+			scheme:        "A",
+			// From internal/tester/scenarios/ue/registration_success_profile_a.go:41.
+			privateKey: "c53c22208b61860b06c62e5406a7b330c2b577aab3cd7cd2d3fa33ef6b3df3f6",
+		},
+		{
+			name:          "scheme_B_p256",
+			keyIdentifier: 43,
+			scheme:        "B",
+			// From internal/api/server/api_home_network_keys_test.go:161.
+			privateKey: "f1ab1074477ebcce59b97460c83b4071db578ffab54ee4fbc76aeca38e4b7b01",
+		},
+	}
 
-	findKey := func(items []client.HomeNetworkKeyResponse, keyID int, sch string) *client.HomeNetworkKeyResponse {
+	findKey := func(items []client.HomeNetworkKeyResponse, keyID int, scheme string) *client.HomeNetworkKeyResponse {
 		for i := range items {
-			if items[i].KeyIdentifier == keyID && items[i].Scheme == sch {
+			if items[i].KeyIdentifier == keyID && items[i].Scheme == scheme {
 				return &items[i]
 			}
 		}
@@ -42,79 +55,127 @@ func runHomeNetworkKeysMatrix(ctx context.Context, t *testing.T, c *client.Clien
 		return nil
 	}
 
-	op, err := c.GetOperator(ctx)
-	if err != nil {
-		t.Fatalf("get operator (baseline): %v", err)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			op, err := c.GetOperator(ctx)
+			if err != nil {
+				t.Fatalf("get operator (baseline): %v", err)
+			}
+
+			baselineCount := len(op.HomeNetworkKeys)
+
+			if err := c.CreateHomeNetworkKey(ctx, &client.CreateHomeNetworkKeyOptions{
+				KeyIdentifier: tc.keyIdentifier,
+				Scheme:        tc.scheme,
+				PrivateKey:    tc.privateKey,
+			}); err != nil {
+				t.Fatalf("create home network key: %v", err)
+			}
+
+			op, err = c.GetOperator(ctx)
+			if err != nil {
+				t.Fatalf("get operator after create: %v", err)
+			}
+
+			created := findKey(op.HomeNetworkKeys, tc.keyIdentifier, tc.scheme)
+			if created == nil {
+				t.Fatalf("home network keys after create missing keyIdentifier=%d scheme=%s", tc.keyIdentifier, tc.scheme)
+			}
+
+			deleted := false
+
+			t.Cleanup(func() {
+				if deleted {
+					return
+				}
+
+				if err := c.DeleteHomeNetworkKey(ctx, created.ID); err != nil {
+					t.Logf("cleanup: delete home network key %q: %v", created.ID, err)
+				}
+			})
+
+			if len(op.HomeNetworkKeys) != baselineCount+1 {
+				t.Fatalf("home network keys count after create: got %d, want %d", len(op.HomeNetworkKeys), baselineCount+1)
+			}
+
+			if created.ID == "" {
+				t.Fatalf("home network key returned without an ID")
+			}
+
+			// The server derives PublicKey from PrivateKey. Both schemes
+			// produce non-empty hex-encoded public keys; locking in
+			// "non-empty + correct decoded length" guards against a
+			// derivation regression without coupling the test to the
+			// crypto implementation.
+			if created.PublicKey == "" {
+				t.Fatalf("PublicKey: got empty, want non-empty")
+			}
+
+			if err := assertPublicKeyForScheme(tc.scheme, created.PublicKey); err != nil {
+				t.Fatalf("PublicKey: %v", err)
+			}
+
+			pk, err := c.GetHomeNetworkKeyPrivateKey(ctx, created.ID)
+			if err != nil {
+				t.Fatalf("get home network key private key: %v", err)
+			}
+
+			if pk.PrivateKey != tc.privateKey {
+				t.Fatalf("private key round-trip mismatch: got %q, want %q", pk.PrivateKey, tc.privateKey)
+			}
+
+			if err := c.DeleteHomeNetworkKey(ctx, created.ID); err != nil {
+				t.Fatalf("delete home network key %q: %v", created.ID, err)
+			}
+
+			deleted = true
+
+			op, err = c.GetOperator(ctx)
+			if err != nil {
+				t.Fatalf("get operator after delete: %v", err)
+			}
+
+			if len(op.HomeNetworkKeys) != baselineCount {
+				t.Fatalf("home network keys count after delete: got %d, want %d", len(op.HomeNetworkKeys), baselineCount)
+			}
+
+			if findKey(op.HomeNetworkKeys, tc.keyIdentifier, tc.scheme) != nil {
+				t.Fatalf("home network keys after delete still contains keyIdentifier=%d scheme=%s", tc.keyIdentifier, tc.scheme)
+			}
+
+			_, err = c.GetHomeNetworkKeyPrivateKey(ctx, created.ID)
+			assertNotFound(t, err, "home network key after delete")
+		})
 	}
+}
 
-	baselineCount := len(op.HomeNetworkKeys)
-
-	if err := c.CreateHomeNetworkKey(ctx, &client.CreateHomeNetworkKeyOptions{
-		KeyIdentifier: keyIdentifier,
-		Scheme:        scheme,
-		PrivateKey:    privateKey,
-	}); err != nil {
-		t.Fatalf("create home network key: %v", err)
-	}
-
-	op, err = c.GetOperator(ctx)
-	if err != nil {
-		t.Fatalf("get operator after create: %v", err)
-	}
-
-	created := findKey(op.HomeNetworkKeys, keyIdentifier, scheme)
-	if created == nil {
-		t.Fatalf("home network keys after create missing keyIdentifier=%d scheme=%s", keyIdentifier, scheme)
-	}
-
-	deleted := false
-
-	t.Cleanup(func() {
-		if deleted {
-			return
+// assertPublicKeyForScheme verifies the server-returned hex-encoded
+// public key has the expected length for the scheme. X25519 public keys
+// are 32 bytes (64 hex chars); compressed P-256 public keys are 33 bytes
+// (66 hex chars) and uncompressed are 65 bytes (130 hex chars). The
+// server uses Go's ecdh package which emits the uncompressed form for
+// P-256.
+func assertPublicKeyForScheme(scheme, pub string) error {
+	switch scheme {
+	case "A":
+		if len(pub) != 64 {
+			return errInvalidPublicKeyLen{scheme: scheme, want: 64, got: len(pub)}
 		}
-
-		if err := c.DeleteHomeNetworkKey(ctx, created.ID); err != nil {
-			t.Logf("cleanup: delete home network key %q: %v", created.ID, err)
+	case "B":
+		if len(pub) != 130 && len(pub) != 66 {
+			return errInvalidPublicKeyLen{scheme: scheme, want: 130, got: len(pub)}
 		}
-	})
-
-	if len(op.HomeNetworkKeys) != baselineCount+1 {
-		t.Fatalf("home network keys count after create: got %d, want %d", len(op.HomeNetworkKeys), baselineCount+1)
 	}
 
-	if created.ID == "" {
-		t.Fatalf("home network key returned without an ID")
-	}
+	return nil
+}
 
-	pk, err := c.GetHomeNetworkKeyPrivateKey(ctx, created.ID)
-	if err != nil {
-		t.Fatalf("get home network key private key: %v", err)
-	}
+type errInvalidPublicKeyLen struct {
+	scheme    string
+	want, got int
+}
 
-	if pk.PrivateKey != privateKey {
-		t.Fatalf("private key round-trip mismatch: got %q, want %q", pk.PrivateKey, privateKey)
-	}
-
-	if err := c.DeleteHomeNetworkKey(ctx, created.ID); err != nil {
-		t.Fatalf("delete home network key %q: %v", created.ID, err)
-	}
-
-	deleted = true
-
-	op, err = c.GetOperator(ctx)
-	if err != nil {
-		t.Fatalf("get operator after delete: %v", err)
-	}
-
-	if len(op.HomeNetworkKeys) != baselineCount {
-		t.Fatalf("home network keys count after delete: got %d, want %d", len(op.HomeNetworkKeys), baselineCount)
-	}
-
-	if findKey(op.HomeNetworkKeys, keyIdentifier, scheme) != nil {
-		t.Fatalf("home network keys after delete still contains keyIdentifier=%d scheme=%s", keyIdentifier, scheme)
-	}
-
-	_, err = c.GetHomeNetworkKeyPrivateKey(ctx, created.ID)
-	assertNotFound(t, err, "home network key after delete")
+func (e errInvalidPublicKeyLen) Error() string {
+	return "scheme " + e.scheme + ": unexpected public key hex length"
 }

--- a/integration/api_matrix_home_network_keys_test.go
+++ b/integration/api_matrix_home_network_keys_test.go
@@ -7,25 +7,13 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runHomeNetworkKeysMatrix exercises CRD for home network keys. Both
-// supported schemes are covered:
-//
-//   - "A" (X25519, 32-byte private key)
-//   - "B" (P-256, 32-byte private key)
-//
-// For each scheme: create → re-read operator → assert key visible and
-// the server-derived PublicKey is populated → fetch the private key by
-// UUID → delete → assert gone.
-//
-// Home network keys have no own list endpoint (exposed via
-// Operator.HomeNetworkKeys) and no Update verb (server.go:137-138).
+// runHomeNetworkKeysMatrix covers both supported SUCI schemes: A
+// (X25519) and B (P-256). Keys are listed via Operator.HomeNetworkKeys
+// rather than a dedicated endpoint, and have no Update verb.
 func runHomeNetworkKeysMatrix(ctx context.Context, t *testing.T, c *client.Client) {
-	// Cases use distinct KeyIdentifier values so they don't collide with
-	// each other or with leaked prior-run state (strict-create surfaces
-	// collisions per api_home_network_keys.go:155-159).
 	cases := []struct {
 		name          string
-		keyIdentifier int
+		keyIdentifier int // distinct per case to avoid strict-create collisions
 		scheme        string
 		privateKey    string // 32 bytes hex
 	}{
@@ -33,15 +21,13 @@ func runHomeNetworkKeysMatrix(ctx context.Context, t *testing.T, c *client.Clien
 			name:          "scheme_A_x25519",
 			keyIdentifier: 42,
 			scheme:        "A",
-			// From internal/tester/scenarios/ue/registration_success_profile_a.go:41.
-			privateKey: "c53c22208b61860b06c62e5406a7b330c2b577aab3cd7cd2d3fa33ef6b3df3f6",
+			privateKey:    "c53c22208b61860b06c62e5406a7b330c2b577aab3cd7cd2d3fa33ef6b3df3f6",
 		},
 		{
 			name:          "scheme_B_p256",
 			keyIdentifier: 43,
 			scheme:        "B",
-			// From internal/api/server/api_home_network_keys_test.go:161.
-			privateKey: "f1ab1074477ebcce59b97460c83b4071db578ffab54ee4fbc76aeca38e4b7b01",
+			privateKey:    "f1ab1074477ebcce59b97460c83b4071db578ffab54ee4fbc76aeca38e4b7b01",
 		},
 	}
 
@@ -103,11 +89,7 @@ func runHomeNetworkKeysMatrix(ctx context.Context, t *testing.T, c *client.Clien
 				t.Fatalf("home network key returned without an ID")
 			}
 
-			// The server derives PublicKey from PrivateKey. Both schemes
-			// produce non-empty hex-encoded public keys; locking in
-			// "non-empty + correct decoded length" guards against a
-			// derivation regression without coupling the test to the
-			// crypto implementation.
+			// PublicKey is derived from PrivateKey by the server.
 			if created.PublicKey == "" {
 				t.Fatalf("PublicKey: got empty, want non-empty")
 			}
@@ -150,12 +132,9 @@ func runHomeNetworkKeysMatrix(ctx context.Context, t *testing.T, c *client.Clien
 	}
 }
 
-// assertPublicKeyForScheme verifies the server-returned hex-encoded
-// public key has the expected length for the scheme. X25519 public keys
-// are 32 bytes (64 hex chars); compressed P-256 public keys are 33 bytes
-// (66 hex chars) and uncompressed are 65 bytes (130 hex chars). The
-// server uses Go's ecdh package which emits the uncompressed form for
-// P-256.
+// assertPublicKeyForScheme checks the hex length of the server-returned
+// public key. X25519 is 32 bytes (64 hex chars); P-256 is 33 bytes
+// compressed (66 hex) or 65 bytes uncompressed (130 hex).
 func assertPublicKeyForScheme(scheme, pub string) error {
 	switch scheme {
 	case "A":

--- a/integration/api_matrix_n3_interface_test.go
+++ b/integration/api_matrix_n3_interface_test.go
@@ -1,0 +1,45 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runN3InterfaceMatrix exercises GET /api/v1/networking/interfaces and
+// PUT /api/v1/networking/interfaces/n3. The only settable field is
+// external_address; an empty string means "use the local interface IP"
+// (client/interfaces.go:71-93).
+func runN3InterfaceMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	orig, err := c.ListNetworkInterfaces(ctx)
+	if err != nil {
+		t.Fatalf("list interfaces (baseline): %v", err)
+	}
+
+	origExternal := orig.N3.ExternalAddress
+
+	t.Cleanup(func() {
+		if err := c.UpdateN3Interface(ctx, &client.UpdateN3InterfaceOptions{ExternalAddress: origExternal}); err != nil {
+			t.Logf("cleanup: restore n3 external_address: %v", err)
+		}
+	})
+
+	target := "10.99.99.99"
+	if origExternal == target {
+		target = "10.99.99.100"
+	}
+
+	if err := c.UpdateN3Interface(ctx, &client.UpdateN3InterfaceOptions{ExternalAddress: target}); err != nil {
+		t.Fatalf("update n3 external_address: %v", err)
+	}
+
+	got, err := c.ListNetworkInterfaces(ctx)
+	if err != nil {
+		t.Fatalf("list interfaces after update: %v", err)
+	}
+
+	if got.N3.ExternalAddress != target {
+		t.Fatalf("N3.ExternalAddress: got %q, want %q", got.N3.ExternalAddress, target)
+	}
+}

--- a/integration/api_matrix_n3_interface_test.go
+++ b/integration/api_matrix_n3_interface_test.go
@@ -7,10 +7,8 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runN3InterfaceMatrix exercises GET /api/v1/networking/interfaces and
-// PUT /api/v1/networking/interfaces/n3. The only settable field is
-// external_address; an empty string means "use the local interface IP"
-// (client/interfaces.go:71-93).
+// runN3InterfaceMatrix round-trips the only mutable N3 field,
+// external_address.
 func runN3InterfaceMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	orig, err := c.ListNetworkInterfaces(ctx)
 	if err != nil {

--- a/integration/api_matrix_nat_test.go
+++ b/integration/api_matrix_nat_test.go
@@ -1,0 +1,41 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runNATMatrix exercises Get + Update for the NAT singleton. The
+// singleton shape captures the original value, mutates, asserts the
+// round-trip, and restores via t.Cleanup so subsequent tests see the
+// system in its original state. The bootstrap sets Enabled=true
+// (tester_env_test.go:140), so the original is typically true.
+func runNATMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	orig, err := c.GetNATInfo(ctx)
+	if err != nil {
+		t.Fatalf("get nat (baseline): %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateNATInfo(ctx, &client.UpdateNATInfoOptions{Enabled: orig.Enabled}); err != nil {
+			t.Logf("cleanup: restore nat: %v", err)
+		}
+	})
+
+	target := !orig.Enabled
+
+	if err := c.UpdateNATInfo(ctx, &client.UpdateNATInfoOptions{Enabled: target}); err != nil {
+		t.Fatalf("update nat: %v", err)
+	}
+
+	got, err := c.GetNATInfo(ctx)
+	if err != nil {
+		t.Fatalf("get nat after update: %v", err)
+	}
+
+	if got.Enabled != target {
+		t.Fatalf("Enabled: got %t, want %t", got.Enabled, target)
+	}
+}

--- a/integration/api_matrix_nat_test.go
+++ b/integration/api_matrix_nat_test.go
@@ -7,11 +7,6 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runNATMatrix exercises Get + Update for the NAT singleton. The
-// singleton shape captures the original value, mutates, asserts the
-// round-trip, and restores via t.Cleanup so subsequent tests see the
-// system in its original state. The bootstrap sets Enabled=true
-// (tester_env_test.go:140), so the original is typically true.
 func runNATMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	orig, err := c.GetNATInfo(ctx)
 	if err != nil {

--- a/integration/api_matrix_operator_code_test.go
+++ b/integration/api_matrix_operator_code_test.go
@@ -1,0 +1,95 @@
+package integration_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runOperatorCodeMatrix exercises PUT /api/v1/operator/code. The
+// endpoint is PUT-only — there is no GET counterpart — so this is a
+// set-only matrix that verifies successful updates and the documented
+// validation errors (api_operator.go:364-415):
+//
+//   - 32-character hex string required
+//   - rejected when any subscribers exist
+//
+// The runner restores a known-good code on cleanup so the operator is
+// in a consistent state for any subsequent test or run. Since the
+// operator code can't be updated while subscribers exist, this runner
+// is sensitive to leaked subscriber state from prior runs; the matrix
+// driver runs subtests sequentially so as long as no other subtest
+// leaks, the constraint is satisfied here.
+func runOperatorCodeMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	const (
+		// Two valid 32-char hex codes — well-known test vectors, no
+		// security significance.
+		codeA = "0123456789abcdef0123456789abcdef"
+		codeB = "fedcba9876543210fedcba9876543210"
+	)
+
+	if err := c.UpdateOperatorCode(ctx, &client.UpdateOperatorCodeOptions{OperatorCode: codeA}); err != nil {
+		t.Fatalf("set operator code baseline: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateOperatorCode(ctx, &client.UpdateOperatorCodeOptions{OperatorCode: codeA}); err != nil {
+			t.Logf("cleanup: restore operator code: %v", err)
+		}
+	})
+
+	t.Run("update_to_alternate_code", func(t *testing.T) {
+		if err := c.UpdateOperatorCode(ctx, &client.UpdateOperatorCodeOptions{OperatorCode: codeB}); err != nil {
+			t.Fatalf("update operator code to alternate: %v", err)
+		}
+	})
+
+	// Validation negatives — each must fail with a 4xx server error.
+	negatives := []struct {
+		name string
+		code string
+		want string
+	}{
+		{
+			name: "empty",
+			code: "",
+			want: "operator code is missing",
+		},
+		{
+			name: "wrong_length_31",
+			code: "0123456789abcdef0123456789abcde",
+			want: "32-character hexadecimal string",
+		},
+		{
+			name: "wrong_length_33",
+			code: "0123456789abcdef0123456789abcdef0",
+			want: "32-character hexadecimal string",
+		},
+		{
+			name: "not_hex",
+			code: "0123456789abcdef0123456789abcdez",
+			want: "32-character hexadecimal string",
+		},
+	}
+
+	for _, n := range negatives {
+		n := n
+		t.Run("negative_"+n.name, func(t *testing.T) {
+			err := c.UpdateOperatorCode(ctx, &client.UpdateOperatorCodeOptions{OperatorCode: n.code})
+			if err == nil {
+				t.Fatalf("expected error, got none")
+			}
+
+			msg := err.Error()
+			if !strings.Contains(msg, n.want) {
+				t.Fatalf("error message: got %q, want substring %q", msg, n.want)
+			}
+
+			if !strings.Contains(msg, "400") {
+				t.Fatalf("expected 400 status, got %q", msg)
+			}
+		})
+	}
+}

--- a/integration/api_matrix_operator_code_test.go
+++ b/integration/api_matrix_operator_code_test.go
@@ -8,24 +8,11 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runOperatorCodeMatrix exercises PUT /api/v1/operator/code. The
-// endpoint is PUT-only — there is no GET counterpart — so this is a
-// set-only matrix that verifies successful updates and the documented
-// validation errors (api_operator.go:364-415):
-//
-//   - 32-character hex string required
-//   - rejected when any subscribers exist
-//
-// The runner restores a known-good code on cleanup so the operator is
-// in a consistent state for any subsequent test or run. Since the
-// operator code can't be updated while subscribers exist, this runner
-// is sensitive to leaked subscriber state from prior runs; the matrix
-// driver runs subtests sequentially so as long as no other subtest
-// leaks, the constraint is satisfied here.
+// runOperatorCodeMatrix sets the operator code via the set-only PUT
+// endpoint. The server rejects the update when any subscribers exist,
+// so this runner must not run concurrently with the subscribers matrix.
 func runOperatorCodeMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	const (
-		// Two valid 32-char hex codes — well-known test vectors, no
-		// security significance.
 		codeA = "0123456789abcdef0123456789abcdef"
 		codeB = "fedcba9876543210fedcba9876543210"
 	)
@@ -46,7 +33,6 @@ func runOperatorCodeMatrix(ctx context.Context, t *testing.T, c *client.Client) 
 		}
 	})
 
-	// Validation negatives — each must fail with a 4xx server error.
 	negatives := []struct {
 		name string
 		code string

--- a/integration/api_matrix_operator_id_test.go
+++ b/integration/api_matrix_operator_id_test.go
@@ -7,15 +7,9 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runOperatorIDMatrix exercises GET /api/v1/operator (for the ID
-// section) and PUT /api/v1/operator/id, round-tripping MCC and MNC.
-// Handler-side validators (api_operator.go:78-106) require MCC = 3
-// digits and MNC = 2 or 3 digits.
-//
-// The matrix test sets a known baseline (001/01) before mutating so
-// it works against both a fresh post-init operator (empty MCC/MNC) and
-// a previously-configured one. The post-Cleanup state is the same known
-// baseline regardless of pre-test state.
+// runOperatorIDMatrix sets a known baseline before mutating so the
+// matrix works whether the operator was previously configured or freshly
+// initialised with empty MCC/MNC. Cleanup restores the same baseline.
 func runOperatorIDMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	const (
 		baselineMCC = "001"

--- a/integration/api_matrix_operator_id_test.go
+++ b/integration/api_matrix_operator_id_test.go
@@ -1,0 +1,66 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runOperatorIDMatrix exercises GET /api/v1/operator (for the ID
+// section) and PUT /api/v1/operator/id, round-tripping MCC and MNC.
+// Handler-side validators (api_operator.go:78-106) require MCC = 3
+// digits and MNC = 2 or 3 digits.
+//
+// The matrix test sets a known baseline (001/01) before mutating so
+// it works against both a fresh post-init operator (empty MCC/MNC) and
+// a previously-configured one. The post-Cleanup state is the same known
+// baseline regardless of pre-test state.
+func runOperatorIDMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	const (
+		baselineMCC = "001"
+		baselineMNC = "01"
+	)
+
+	if err := c.UpdateOperatorID(ctx, &client.UpdateOperatorIDOptions{Mcc: baselineMCC, Mnc: baselineMNC}); err != nil {
+		t.Fatalf("set operator id baseline: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateOperatorID(ctx, &client.UpdateOperatorIDOptions{Mcc: baselineMCC, Mnc: baselineMNC}); err != nil {
+			t.Logf("cleanup: restore operator id: %v", err)
+		}
+	})
+
+	cases := []struct {
+		field string
+		mcc   string
+		mnc   string
+	}{
+		{field: "Mcc", mcc: "208", mnc: baselineMNC},
+		{field: "Mnc", mcc: "208", mnc: "10"},
+		{field: "Mnc_3digit", mcc: "208", mnc: "100"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			if err := c.UpdateOperatorID(ctx, &client.UpdateOperatorIDOptions{Mcc: tc.mcc, Mnc: tc.mnc}); err != nil {
+				t.Fatalf("update operator id: %v", err)
+			}
+
+			op, err := c.GetOperator(ctx)
+			if err != nil {
+				t.Fatalf("get operator after update: %v", err)
+			}
+
+			if op.ID.Mcc != tc.mcc {
+				t.Fatalf("Mcc: got %q, want %q", op.ID.Mcc, tc.mcc)
+			}
+
+			if op.ID.Mnc != tc.mnc {
+				t.Fatalf("Mnc: got %q, want %q", op.ID.Mnc, tc.mnc)
+			}
+		})
+	}
+}

--- a/integration/api_matrix_operator_nas_security_test.go
+++ b/integration/api_matrix_operator_nas_security_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runOperatorNASSecurityMatrix exercises GET /api/v1/operator (for the
-// NASSecurity section) and PUT /api/v1/operator/nas-security,
-// round-tripping ciphering and integrity algorithm preference orders.
-// Valid algorithms per api_operator.go:474-491: NEA0/1/2 for ciphering,
-// NIA0/1/2 for integrity. Maximum 3 each, no duplicates.
+// runOperatorNASSecurityMatrix round-trips the ciphering and integrity
+// algorithm preference orders. Valid values: NEA0/1/2 for ciphering,
+// NIA0/1/2 for integrity. Max 3 each, no duplicates.
 func runOperatorNASSecurityMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	baseline := &client.UpdateOperatorNASSecurityOptions{
 		Ciphering: []string{"NEA0", "NEA1", "NEA2"},

--- a/integration/api_matrix_operator_nas_security_test.go
+++ b/integration/api_matrix_operator_nas_security_test.go
@@ -1,0 +1,79 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runOperatorNASSecurityMatrix exercises GET /api/v1/operator (for the
+// NASSecurity section) and PUT /api/v1/operator/nas-security,
+// round-tripping ciphering and integrity algorithm preference orders.
+// Valid algorithms per api_operator.go:474-491: NEA0/1/2 for ciphering,
+// NIA0/1/2 for integrity. Maximum 3 each, no duplicates.
+func runOperatorNASSecurityMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	baseline := &client.UpdateOperatorNASSecurityOptions{
+		Ciphering: []string{"NEA0", "NEA1", "NEA2"},
+		Integrity: []string{"NIA1", "NIA2"},
+	}
+
+	if err := c.UpdateOperatorNASSecurity(ctx, baseline); err != nil {
+		t.Fatalf("set nas security baseline: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateOperatorNASSecurity(ctx, baseline); err != nil {
+			t.Logf("cleanup: restore nas security: %v", err)
+		}
+	})
+
+	cases := []struct {
+		field string
+		opts  *client.UpdateOperatorNASSecurityOptions
+	}{
+		{
+			field: "ciphering_order",
+			opts: &client.UpdateOperatorNASSecurityOptions{
+				Ciphering: []string{"NEA2", "NEA1", "NEA0"},
+				Integrity: baseline.Integrity,
+			},
+		},
+		{
+			field: "integrity_order",
+			opts: &client.UpdateOperatorNASSecurityOptions{
+				Ciphering: baseline.Ciphering,
+				Integrity: []string{"NIA2", "NIA1", "NIA0"},
+			},
+		},
+		{
+			field: "single_algorithm",
+			opts: &client.UpdateOperatorNASSecurityOptions{
+				Ciphering: []string{"NEA0"},
+				Integrity: []string{"NIA0"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			if err := c.UpdateOperatorNASSecurity(ctx, tc.opts); err != nil {
+				t.Fatalf("update nas security: %v", err)
+			}
+
+			op, err := c.GetOperator(ctx)
+			if err != nil {
+				t.Fatalf("get operator after update: %v", err)
+			}
+
+			if !equalStringSlices(op.NASSecurity.Ciphering, tc.opts.Ciphering) {
+				t.Fatalf("Ciphering: got %v, want %v", op.NASSecurity.Ciphering, tc.opts.Ciphering)
+			}
+
+			if !equalStringSlices(op.NASSecurity.Integrity, tc.opts.Integrity) {
+				t.Fatalf("Integrity: got %v, want %v", op.NASSecurity.Integrity, tc.opts.Integrity)
+			}
+		})
+	}
+}

--- a/integration/api_matrix_operator_spn_test.go
+++ b/integration/api_matrix_operator_spn_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runOperatorSPNMatrix exercises GET /api/v1/operator (for the SPN
-// section) and PUT /api/v1/operator/spn. The handler
-// (api_operator.go:518) caps each name at maxSPNLength=50.
+// runOperatorSPNMatrix round-trips the operator's full and short Service
+// Provider Names. Each name is capped at 50 characters by the server.
 func runOperatorSPNMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	baseline := &client.UpdateOperatorSPNOptions{
 		FullName:  "Ella Networks",

--- a/integration/api_matrix_operator_spn_test.go
+++ b/integration/api_matrix_operator_spn_test.go
@@ -1,0 +1,70 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runOperatorSPNMatrix exercises GET /api/v1/operator (for the SPN
+// section) and PUT /api/v1/operator/spn. The handler
+// (api_operator.go:518) caps each name at maxSPNLength=50.
+func runOperatorSPNMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	baseline := &client.UpdateOperatorSPNOptions{
+		FullName:  "Ella Networks",
+		ShortName: "Ella",
+	}
+
+	if err := c.UpdateOperatorSPN(ctx, baseline); err != nil {
+		t.Fatalf("set spn baseline: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateOperatorSPN(ctx, baseline); err != nil {
+			t.Logf("cleanup: restore spn: %v", err)
+		}
+	})
+
+	cases := []struct {
+		field string
+		opts  *client.UpdateOperatorSPNOptions
+	}{
+		{
+			field: "FullName",
+			opts: &client.UpdateOperatorSPNOptions{
+				FullName:  "Ella Networks 5G Private",
+				ShortName: baseline.ShortName,
+			},
+		},
+		{
+			field: "ShortName",
+			opts: &client.UpdateOperatorSPNOptions{
+				FullName:  baseline.FullName,
+				ShortName: "ELLA5G",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			if err := c.UpdateOperatorSPN(ctx, tc.opts); err != nil {
+				t.Fatalf("update spn: %v", err)
+			}
+
+			op, err := c.GetOperator(ctx)
+			if err != nil {
+				t.Fatalf("get operator after update: %v", err)
+			}
+
+			if op.SPN.SpnFull != tc.opts.FullName {
+				t.Fatalf("SpnFull: got %q, want %q", op.SPN.SpnFull, tc.opts.FullName)
+			}
+
+			if op.SPN.SpnShort != tc.opts.ShortName {
+				t.Fatalf("SpnShort: got %q, want %q", op.SPN.SpnShort, tc.opts.ShortName)
+			}
+		})
+	}
+}

--- a/integration/api_matrix_operator_spn_test.go
+++ b/integration/api_matrix_operator_spn_test.go
@@ -58,12 +58,12 @@ func runOperatorSPNMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 				t.Fatalf("get operator after update: %v", err)
 			}
 
-			if op.SPN.SpnFull != tc.opts.FullName {
-				t.Fatalf("SpnFull: got %q, want %q", op.SPN.SpnFull, tc.opts.FullName)
+			if op.SPN.FullName != tc.opts.FullName {
+				t.Fatalf("FullName: got %q, want %q", op.SPN.FullName, tc.opts.FullName)
 			}
 
-			if op.SPN.SpnShort != tc.opts.ShortName {
-				t.Fatalf("SpnShort: got %q, want %q", op.SPN.SpnShort, tc.opts.ShortName)
+			if op.SPN.ShortName != tc.opts.ShortName {
+				t.Fatalf("ShortName: got %q, want %q", op.SPN.ShortName, tc.opts.ShortName)
 			}
 		})
 	}

--- a/integration/api_matrix_operator_tracking_test.go
+++ b/integration/api_matrix_operator_tracking_test.go
@@ -1,0 +1,69 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runOperatorTrackingMatrix exercises GET /api/v1/operator (for the
+// Tracking section) and PUT /api/v1/operator/tracking, round-tripping
+// SupportedTacs. The handler (api_operator.go:246-296) requires a
+// non-empty list of 6-character hex TACs.
+//
+// The matrix sets a known baseline before mutating; see
+// api_matrix_operator_id_test.go for the rationale.
+func runOperatorTrackingMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	baseline := []string{"000001"}
+
+	if err := c.UpdateOperatorTracking(ctx, &client.UpdateOperatorTrackingOptions{SupportedTacs: baseline}); err != nil {
+		t.Fatalf("set operator tracking baseline: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.UpdateOperatorTracking(ctx, &client.UpdateOperatorTrackingOptions{SupportedTacs: baseline}); err != nil {
+			t.Logf("cleanup: restore operator tracking: %v", err)
+		}
+	})
+
+	cases := []struct {
+		field string
+		tacs  []string
+	}{
+		{field: "single", tacs: []string{"00000a"}},
+		{field: "multiple", tacs: []string{"000010", "000020", "000030"}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			if err := c.UpdateOperatorTracking(ctx, &client.UpdateOperatorTrackingOptions{SupportedTacs: tc.tacs}); err != nil {
+				t.Fatalf("update operator tracking: %v", err)
+			}
+
+			op, err := c.GetOperator(ctx)
+			if err != nil {
+				t.Fatalf("get operator after update: %v", err)
+			}
+
+			if !equalStringSlices(op.Tracking.SupportedTacs, tc.tacs) {
+				t.Fatalf("SupportedTacs: got %v, want %v", op.Tracking.SupportedTacs, tc.tacs)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/integration/api_matrix_operator_tracking_test.go
+++ b/integration/api_matrix_operator_tracking_test.go
@@ -7,13 +7,9 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runOperatorTrackingMatrix exercises GET /api/v1/operator (for the
-// Tracking section) and PUT /api/v1/operator/tracking, round-tripping
-// SupportedTacs. The handler (api_operator.go:246-296) requires a
-// non-empty list of 6-character hex TACs.
-//
-// The matrix sets a known baseline before mutating; see
-// api_matrix_operator_id_test.go for the rationale.
+// runOperatorTrackingMatrix sets a known baseline before mutating since
+// the operator may be freshly initialised with no TACs. Cleanup restores
+// the same baseline. TAC values are 6-character hex strings.
 func runOperatorTrackingMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	baseline := []string{"000001"}
 

--- a/integration/api_matrix_policies_test.go
+++ b/integration/api_matrix_policies_test.go
@@ -7,18 +7,13 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runPoliciesMatrix exercises CRUD for policies. Policies reference a
-// Profile, a Slice, and a Data Network; the runner sets up a primary
-// and a secondary of each so it can also round-trip the three reference
-// fields (profile_name / slice_name / data_network_name) on Update.
-// See api_matrix_profiles_test.go for the matrix shape.
+// runPoliciesMatrix stands up a primary and a secondary of each
+// referenced resource (Profile, Slice, Data Network) so it can round-trip
+// the three reference fields on Update.
 //
-// Each Update sub-case starts from the current Get state (opts := *got)
-// instead of the create-time base. This guarantees fields the sub-case
-// doesn't mutate round-trip whatever the server currently holds —
-// without this, a nil field on an UpdateOptions struct would silently
-// overwrite live state (the destructive default that hid the
-// network-rules wipe bug).
+// Each Update sub-case starts from the current Get state because a
+// zero-valued field in the Update body silently overwrites live state on
+// the server.
 func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	profileA := apiMatrixName("policy-profile-a")
 	profileB := apiMatrixName("policy-profile-b")
@@ -292,10 +287,8 @@ func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	}
 }
 
-// updateOptsFromPolicy builds an UpdatePolicyOptions that exactly
-// reflects the current Get response. Used by per-field update sub-cases
-// so each mutation starts from live server state rather than from a
-// stale create-time snapshot.
+// updateOptsFromPolicy mirrors a Get response into Update options so
+// per-field sub-cases can mutate exactly one field.
 func updateOptsFromPolicy(p *client.Policy) client.UpdatePolicyOptions {
 	return client.UpdatePolicyOptions{
 		ProfileName:         p.ProfileName,

--- a/integration/api_matrix_policies_test.go
+++ b/integration/api_matrix_policies_test.go
@@ -8,57 +8,89 @@ import (
 )
 
 // runPoliciesMatrix exercises CRUD for policies. Policies reference a
-// Profile, a Slice, and a Data Network, so the runner sets all three up
-// (with t.Cleanup teardown) before running the matrix. See
-// api_matrix_profiles_test.go for the matrix shape.
+// Profile, a Slice, and a Data Network; the runner sets up a primary
+// and a secondary of each so it can also round-trip the three reference
+// fields (profile_name / slice_name / data_network_name) on Update.
+// See api_matrix_profiles_test.go for the matrix shape.
+//
+// Each Update sub-case starts from the current Get state (opts := *got)
+// instead of the create-time base. This guarantees fields the sub-case
+// doesn't mutate round-trip whatever the server currently holds —
+// without this, a nil field on an UpdateOptions struct would silently
+// overwrite live state (the destructive default that hid the
+// network-rules wipe bug).
 func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
-	profileName := apiMatrixName("policy-profile")
-	sliceName := apiMatrixName("policy-slice")
-	dnName := apiMatrixName("policy-dn")
+	profileA := apiMatrixName("policy-profile-a")
+	profileB := apiMatrixName("policy-profile-b")
+	sliceA := apiMatrixName("policy-slice-a")
+	sliceB := apiMatrixName("policy-slice-b")
+	dnA := apiMatrixName("policy-dn-a")
+	dnB := apiMatrixName("policy-dn-b")
 	name := apiMatrixName("policy")
 
-	if err := c.CreateProfile(ctx, &client.CreateProfileOptions{
-		Name:           profileName,
-		UeAmbrUplink:   "100 Mbps",
-		UeAmbrDownlink: "100 Mbps",
-	}); err != nil {
-		t.Fatalf("create dep profile: %v", err)
+	for _, p := range []string{profileA, profileB} {
+		p := p
+
+		if err := c.CreateProfile(ctx, &client.CreateProfileOptions{
+			Name:           p,
+			UeAmbrUplink:   "100 Mbps",
+			UeAmbrDownlink: "100 Mbps",
+		}); err != nil {
+			t.Fatalf("create dep profile %q: %v", p, err)
+		}
+
+		t.Cleanup(func() {
+			if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: p}); err != nil {
+				t.Logf("cleanup: delete dep profile %q: %v", p, err)
+			}
+		})
 	}
 
-	t.Cleanup(func() {
-		if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: profileName}); err != nil {
-			t.Logf("cleanup: delete dep profile: %v", err)
-		}
-	})
+	for _, s := range []struct {
+		name string
+		sst  int
+		sd   string
+	}{
+		{sliceA, 1, "010203"},
+		{sliceB, 2, "040506"},
+	} {
+		s := s
 
-	if err := c.CreateSlice(ctx, &client.CreateSliceOptions{
-		Name: sliceName,
-		Sst:  1,
-		Sd:   "010203",
-	}); err != nil {
-		t.Fatalf("create dep slice: %v", err)
+		if err := c.CreateSlice(ctx, &client.CreateSliceOptions{Name: s.name, Sst: s.sst, Sd: s.sd}); err != nil {
+			t.Fatalf("create dep slice %q: %v", s.name, err)
+		}
+
+		t.Cleanup(func() {
+			if err := c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: s.name}); err != nil {
+				t.Logf("cleanup: delete dep slice %q: %v", s.name, err)
+			}
+		})
 	}
 
-	t.Cleanup(func() {
-		if err := c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: sliceName}); err != nil {
-			t.Logf("cleanup: delete dep slice: %v", err)
-		}
-	})
+	for _, d := range []struct {
+		name string
+		pool string
+	}{
+		{dnA, "10.252.0.0/16"},
+		{dnB, "10.249.0.0/16"},
+	} {
+		d := d
 
-	if err := c.CreateDataNetwork(ctx, &client.CreateDataNetworkOptions{
-		Name:     dnName,
-		IPv4Pool: "10.252.0.0/16",
-		DNS:      "8.8.8.8",
-		Mtu:      1500,
-	}); err != nil {
-		t.Fatalf("create dep data network: %v", err)
+		if err := c.CreateDataNetwork(ctx, &client.CreateDataNetworkOptions{
+			Name:     d.name,
+			IPv4Pool: d.pool,
+			DNS:      "8.8.8.8",
+			Mtu:      1500,
+		}); err != nil {
+			t.Fatalf("create dep data network %q: %v", d.name, err)
+		}
+
+		t.Cleanup(func() {
+			if err := c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: d.name}); err != nil {
+				t.Logf("cleanup: delete dep data network %q: %v", d.name, err)
+			}
+		})
 	}
-
-	t.Cleanup(func() {
-		if err := c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: dnName}); err != nil {
-			t.Logf("cleanup: delete dep data network: %v", err)
-		}
-	})
 
 	listAll := func() *client.ListPoliciesResponse {
 		resp, err := c.ListPolicies(ctx, &client.ListParams{Page: 1, PerPage: 100})
@@ -83,9 +115,9 @@ func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	createOpts := &client.CreatePolicyOptions{
 		Name:                name,
-		ProfileName:         profileName,
-		SliceName:           sliceName,
-		DataNetworkName:     dnName,
+		ProfileName:         profileA,
+		SliceName:           sliceA,
+		DataNetworkName:     dnA,
 		SessionAmbrUplink:   "50 Mbps",
 		SessionAmbrDownlink: "100 Mbps",
 		Var5qi:              9,
@@ -133,21 +165,44 @@ func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("list after create missing %q", name)
 	}
 
-	base := client.UpdatePolicyOptions{
-		ProfileName:         createOpts.ProfileName,
-		SliceName:           createOpts.SliceName,
-		DataNetworkName:     createOpts.DataNetworkName,
-		SessionAmbrUplink:   createOpts.SessionAmbrUplink,
-		SessionAmbrDownlink: createOpts.SessionAmbrDownlink,
-		Var5qi:              createOpts.Var5qi,
-		Arp:                 createOpts.Arp,
-	}
-
 	updateCases := []struct {
 		field  string
 		mutate func(o *client.UpdatePolicyOptions)
 		assert func(t *testing.T, p *client.Policy)
 	}{
+		{
+			field: "ProfileName",
+			mutate: func(o *client.UpdatePolicyOptions) {
+				o.ProfileName = profileB
+			},
+			assert: func(t *testing.T, p *client.Policy) {
+				if p.ProfileName != profileB {
+					t.Fatalf("ProfileName: got %q, want %q", p.ProfileName, profileB)
+				}
+			},
+		},
+		{
+			field: "SliceName",
+			mutate: func(o *client.UpdatePolicyOptions) {
+				o.SliceName = sliceB
+			},
+			assert: func(t *testing.T, p *client.Policy) {
+				if p.SliceName != sliceB {
+					t.Fatalf("SliceName: got %q, want %q", p.SliceName, sliceB)
+				}
+			},
+		},
+		{
+			field: "DataNetworkName",
+			mutate: func(o *client.UpdatePolicyOptions) {
+				o.DataNetworkName = dnB
+			},
+			assert: func(t *testing.T, p *client.Policy) {
+				if p.DataNetworkName != dnB {
+					t.Fatalf("DataNetworkName: got %q, want %q", p.DataNetworkName, dnB)
+				}
+			},
+		},
 		{
 			field: "SessionAmbrUplink",
 			mutate: func(o *client.UpdatePolicyOptions) {
@@ -197,7 +252,12 @@ func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	for _, tc := range updateCases {
 		tc := tc
 		t.Run("update_"+tc.field, func(t *testing.T) {
-			opts := base
+			current, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: name})
+			if err != nil {
+				t.Fatalf("get policy %q before update: %v", name, err)
+			}
+
+			opts := updateOptsFromPolicy(current)
 			tc.mutate(&opts)
 
 			if err := c.UpdatePolicy(ctx, name, &opts); err != nil {
@@ -229,5 +289,22 @@ func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	if contains(afterDelete.Items, name) {
 		t.Fatalf("list after delete still contains %q", name)
+	}
+}
+
+// updateOptsFromPolicy builds an UpdatePolicyOptions that exactly
+// reflects the current Get response. Used by per-field update sub-cases
+// so each mutation starts from live server state rather than from a
+// stale create-time snapshot.
+func updateOptsFromPolicy(p *client.Policy) client.UpdatePolicyOptions {
+	return client.UpdatePolicyOptions{
+		ProfileName:         p.ProfileName,
+		SliceName:           p.SliceName,
+		DataNetworkName:     p.DataNetworkName,
+		SessionAmbrUplink:   p.SessionAmbrUplink,
+		SessionAmbrDownlink: p.SessionAmbrDownlink,
+		Var5qi:              p.Var5qi,
+		Arp:                 p.Arp,
+		Rules:               p.Rules,
 	}
 }

--- a/integration/api_matrix_policies_test.go
+++ b/integration/api_matrix_policies_test.go
@@ -1,0 +1,233 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runPoliciesMatrix exercises CRUD for policies. Policies reference a
+// Profile, a Slice, and a Data Network, so the runner sets all three up
+// (with t.Cleanup teardown) before running the matrix. See
+// api_matrix_profiles_test.go for the matrix shape.
+func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	profileName := apiMatrixName("policy-profile")
+	sliceName := apiMatrixName("policy-slice")
+	dnName := apiMatrixName("policy-dn")
+	name := apiMatrixName("policy")
+
+	if err := c.CreateProfile(ctx, &client.CreateProfileOptions{
+		Name:           profileName,
+		UeAmbrUplink:   "100 Mbps",
+		UeAmbrDownlink: "100 Mbps",
+	}); err != nil {
+		t.Fatalf("create dep profile: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: profileName}); err != nil {
+			t.Logf("cleanup: delete dep profile: %v", err)
+		}
+	})
+
+	if err := c.CreateSlice(ctx, &client.CreateSliceOptions{
+		Name: sliceName,
+		Sst:  1,
+		Sd:   "010203",
+	}); err != nil {
+		t.Fatalf("create dep slice: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: sliceName}); err != nil {
+			t.Logf("cleanup: delete dep slice: %v", err)
+		}
+	})
+
+	if err := c.CreateDataNetwork(ctx, &client.CreateDataNetworkOptions{
+		Name:     dnName,
+		IPv4Pool: "10.252.0.0/16",
+		DNS:      "8.8.8.8",
+		Mtu:      1500,
+	}); err != nil {
+		t.Fatalf("create dep data network: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: dnName}); err != nil {
+			t.Logf("cleanup: delete dep data network: %v", err)
+		}
+	})
+
+	listAll := func() *client.ListPoliciesResponse {
+		resp, err := c.ListPolicies(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list policies: %v", err)
+		}
+
+		return resp
+	}
+
+	contains := func(items []client.Policy, name string) bool {
+		for _, p := range items {
+			if p.Name == name {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	baseline := listAll()
+
+	createOpts := &client.CreatePolicyOptions{
+		Name:                name,
+		ProfileName:         profileName,
+		SliceName:           sliceName,
+		DataNetworkName:     dnName,
+		SessionAmbrUplink:   "50 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 8,
+	}
+
+	if err := c.CreatePolicy(ctx, createOpts); err != nil {
+		t.Fatalf("create policy %q: %v", name, err)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeletePolicy(ctx, &client.DeletePolicyOptions{Name: name}); err != nil {
+			t.Logf("cleanup: delete policy %q: %v", name, err)
+		}
+	})
+
+	got, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: name})
+	if err != nil {
+		t.Fatalf("get policy %q after create: %v", name, err)
+	}
+
+	if got.Name != createOpts.Name ||
+		got.ProfileName != createOpts.ProfileName ||
+		got.SliceName != createOpts.SliceName ||
+		got.DataNetworkName != createOpts.DataNetworkName ||
+		got.SessionAmbrUplink != createOpts.SessionAmbrUplink ||
+		got.SessionAmbrDownlink != createOpts.SessionAmbrDownlink ||
+		got.Var5qi != createOpts.Var5qi ||
+		got.Arp != createOpts.Arp {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want %+v", got, createOpts)
+	}
+
+	afterCreate := listAll()
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if !contains(afterCreate.Items, name) {
+		t.Fatalf("list after create missing %q", name)
+	}
+
+	base := client.UpdatePolicyOptions{
+		ProfileName:         createOpts.ProfileName,
+		SliceName:           createOpts.SliceName,
+		DataNetworkName:     createOpts.DataNetworkName,
+		SessionAmbrUplink:   createOpts.SessionAmbrUplink,
+		SessionAmbrDownlink: createOpts.SessionAmbrDownlink,
+		Var5qi:              createOpts.Var5qi,
+		Arp:                 createOpts.Arp,
+	}
+
+	updateCases := []struct {
+		field  string
+		mutate func(o *client.UpdatePolicyOptions)
+		assert func(t *testing.T, p *client.Policy)
+	}{
+		{
+			field: "SessionAmbrUplink",
+			mutate: func(o *client.UpdatePolicyOptions) {
+				o.SessionAmbrUplink = "200 Mbps"
+			},
+			assert: func(t *testing.T, p *client.Policy) {
+				if p.SessionAmbrUplink != "200 Mbps" {
+					t.Fatalf("SessionAmbrUplink: got %q, want %q", p.SessionAmbrUplink, "200 Mbps")
+				}
+			},
+		},
+		{
+			field: "SessionAmbrDownlink",
+			mutate: func(o *client.UpdatePolicyOptions) {
+				o.SessionAmbrDownlink = "400 Mbps"
+			},
+			assert: func(t *testing.T, p *client.Policy) {
+				if p.SessionAmbrDownlink != "400 Mbps" {
+					t.Fatalf("SessionAmbrDownlink: got %q, want %q", p.SessionAmbrDownlink, "400 Mbps")
+				}
+			},
+		},
+		{
+			field: "Var5qi",
+			mutate: func(o *client.UpdatePolicyOptions) {
+				o.Var5qi = 8
+			},
+			assert: func(t *testing.T, p *client.Policy) {
+				if p.Var5qi != 8 {
+					t.Fatalf("Var5qi: got %d, want 8", p.Var5qi)
+				}
+			},
+		},
+		{
+			field: "Arp",
+			mutate: func(o *client.UpdatePolicyOptions) {
+				o.Arp = 5
+			},
+			assert: func(t *testing.T, p *client.Policy) {
+				if p.Arp != 5 {
+					t.Fatalf("Arp: got %d, want 5", p.Arp)
+				}
+			},
+		},
+	}
+
+	for _, tc := range updateCases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			opts := base
+			tc.mutate(&opts)
+
+			if err := c.UpdatePolicy(ctx, name, &opts); err != nil {
+				t.Fatalf("update policy %q (%s): %v", name, tc.field, err)
+			}
+
+			updated, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: name})
+			if err != nil {
+				t.Fatalf("get policy %q after update: %v", name, err)
+			}
+
+			tc.assert(t, updated)
+		})
+	}
+
+	if err := c.DeletePolicy(ctx, &client.DeletePolicyOptions{Name: name}); err != nil {
+		t.Fatalf("delete policy %q: %v", name, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetPolicy(ctx, &client.GetPolicyOptions{Name: name})
+	assertNotFound(t, err, "policy after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if contains(afterDelete.Items, name) {
+		t.Fatalf("list after delete still contains %q", name)
+	}
+}

--- a/integration/api_matrix_policy_rules_test.go
+++ b/integration/api_matrix_policy_rules_test.go
@@ -9,29 +9,13 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runPolicyRulesMatrix exercises the network rules sub-resource on a
-// Policy. Rules are embedded in the Policy payload (uplink/downlink lists
-// of {description, remote_prefix, protocol, port_low, port_high, action})
-// and are only returned in full by GetPolicy — ListPolicies omits them
-// (see api_policies.go:316-325).
+// runPolicyRulesMatrix covers the network rules sub-resource of a Policy.
+// Rules are embedded in the Policy payload and returned in full only by
+// GetPolicy (ListPolicies omits them).
 //
-// The runner stands up its own Slice/DN/Profile/Policy stack so it can
-// freely mutate Rules without interfering with the policies matrix or
-// the subscribers matrix.
-//
-// Coverage:
-//   - Create with rules → Get round-trips every field, in both directions,
-//     for IPv4 and IPv6 remote_prefix.
-//   - Update with a different rule set → old rules gone, new ones present.
-//   - Update with Rules: nil → all rules cleared (replace-on-update is the
-//     documented behaviour: client/policies.go:162-165).
-//   - Update with explicit empty PolicyRules{} → also clears.
-//   - Update a non-rules field while re-supplying Rules → rules survive.
-//     This locks in the "callers must re-supply rules to preserve them"
-//     contract and prevents a future accidental wipe.
-//   - Per-rule validation negatives: bad action, bad CIDR, out-of-range
-//     protocol, port_low > port_high, oversized description, too many
-//     rules per direction (>12).
+// Update is destructive on rules: omitting the Rules field clears them,
+// so callers must re-supply the current rule list to preserve it. This
+// matrix locks both the destructive and the preserve paths in.
 func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	sliceName := apiMatrixName("rules-slice")
 	dnName := apiMatrixName("rules-dn")
@@ -102,7 +86,6 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		_ = c.DeletePolicy(ctx, &client.DeletePolicyOptions{Name: policyName})
 	})
 
-	// Step 1: round-trip on initial Get.
 	got, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: policyName})
 	if err != nil {
 		t.Fatalf("get policy after create: %v", err)
@@ -112,7 +95,6 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("post-create rules round-trip mismatch:\ngot  %s\nwant %s", formatRules(got.Rules), formatRules(initialRules))
 	}
 
-	// Step 2: replace semantics.
 	t.Run("update_replace", func(t *testing.T) {
 		replaced := &client.PolicyRules{
 			Uplink: []client.PolicyRule{
@@ -134,7 +116,6 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		}
 	})
 
-	// Step 3: clear via Rules: nil.
 	t.Run("update_clear_nil", func(t *testing.T) {
 		if err := updatePolicyRules(ctx, c, policyName, nil); err != nil {
 			t.Fatalf("update rules (clear nil): %v", err)
@@ -146,7 +127,6 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		}
 	})
 
-	// Step 4: re-seed, then clear via explicit empty struct.
 	t.Run("update_clear_empty_struct", func(t *testing.T) {
 		if err := updatePolicyRules(ctx, c, policyName, initialRules); err != nil {
 			t.Fatalf("update rules (re-seed): %v", err)
@@ -162,7 +142,6 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		}
 	})
 
-	// Step 5: preserve rules when mutating a non-rules field.
 	t.Run("preserve_when_updating_other_field", func(t *testing.T) {
 		if err := updatePolicyRules(ctx, c, policyName, initialRules); err != nil {
 			t.Fatalf("update rules (re-seed): %v", err)
@@ -181,7 +160,7 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 			SessionAmbrDownlink: current.SessionAmbrDownlink,
 			Var5qi:              5,
 			Arp:                 current.Arp,
-			Rules:               current.Rules, // re-supply to preserve
+			Rules:               current.Rules,
 		}
 
 		if err := c.UpdatePolicy(ctx, policyName, opts); err != nil {
@@ -199,7 +178,6 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		}
 	})
 
-	// Step 6: validation negatives — each must fail with a 4xx server error.
 	negatives := []struct {
 		name  string
 		rules *client.PolicyRules
@@ -251,10 +229,8 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		},
 	}
 
-	// Make sure a clean state precedes the negative pass so a leftover
-	// rule list from step 5 doesn't get destroyed by a failing Update —
-	// failed updates may still wipe rules if validation runs after the
-	// replace path (it doesn't today, but lock in the test isolation).
+	// Clear rules first so the negative cases assert "rules unchanged"
+	// against a known-empty starting state.
 	if err := updatePolicyRules(ctx, c, policyName, nil); err != nil {
 		t.Fatalf("setup negatives: clear rules: %v", err)
 	}
@@ -284,9 +260,8 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	}
 }
 
-// updatePolicyRules sends an Update that touches only the Rules field
-// (other fields are pulled from the current policy state) so each test
-// case is independent of QoS-field mutations.
+// updatePolicyRules issues an Update that changes only Rules, pulling
+// the other fields from the current policy state.
 func updatePolicyRules(ctx context.Context, c *client.Client, name string, rules *client.PolicyRules) error {
 	current, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: name})
 	if err != nil {

--- a/integration/api_matrix_policy_rules_test.go
+++ b/integration/api_matrix_policy_rules_test.go
@@ -1,0 +1,385 @@
+package integration_test
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runPolicyRulesMatrix exercises the network rules sub-resource on a
+// Policy. Rules are embedded in the Policy payload (uplink/downlink lists
+// of {description, remote_prefix, protocol, port_low, port_high, action})
+// and are only returned in full by GetPolicy — ListPolicies omits them
+// (see api_policies.go:316-325).
+//
+// The runner stands up its own Slice/DN/Profile/Policy stack so it can
+// freely mutate Rules without interfering with the policies matrix or
+// the subscribers matrix.
+//
+// Coverage:
+//   - Create with rules → Get round-trips every field, in both directions,
+//     for IPv4 and IPv6 remote_prefix.
+//   - Update with a different rule set → old rules gone, new ones present.
+//   - Update with Rules: nil → all rules cleared (replace-on-update is the
+//     documented behaviour: client/policies.go:162-165).
+//   - Update with explicit empty PolicyRules{} → also clears.
+//   - Update a non-rules field while re-supplying Rules → rules survive.
+//     This locks in the "callers must re-supply rules to preserve them"
+//     contract and prevents a future accidental wipe.
+//   - Per-rule validation negatives: bad action, bad CIDR, out-of-range
+//     protocol, port_low > port_high, oversized description, too many
+//     rules per direction (>12).
+func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	sliceName := apiMatrixName("rules-slice")
+	dnName := apiMatrixName("rules-dn")
+	profileName := apiMatrixName("rules-profile")
+	policyName := apiMatrixName("rules-policy")
+
+	if err := c.CreateSlice(ctx, &client.CreateSliceOptions{Name: sliceName, Sst: 1, Sd: "00abcd"}); err != nil {
+		t.Fatalf("create dep slice: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: sliceName})
+	})
+
+	if err := c.CreateDataNetwork(ctx, &client.CreateDataNetworkOptions{
+		Name:     dnName,
+		IPv4Pool: "10.254.0.0/16",
+		DNS:      "8.8.8.8",
+		Mtu:      1500,
+	}); err != nil {
+		t.Fatalf("create dep data network: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: dnName})
+	})
+
+	if err := c.CreateProfile(ctx, &client.CreateProfileOptions{
+		Name:           profileName,
+		UeAmbrUplink:   "100 Mbps",
+		UeAmbrDownlink: "100 Mbps",
+	}); err != nil {
+		t.Fatalf("create dep profile: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: profileName})
+	})
+
+	prefixV4 := "192.0.2.0/24"
+	prefixV6 := "2001:db8::/32"
+
+	initialRules := &client.PolicyRules{
+		Uplink: []client.PolicyRule{
+			{Description: "uplink-allow-v4-https", RemotePrefix: &prefixV4, Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+			{Description: "uplink-deny-icmp", RemotePrefix: nil, Protocol: 1, PortLow: 0, PortHigh: 0, Action: "deny"},
+		},
+		Downlink: []client.PolicyRule{
+			{Description: "downlink-allow-v6-dns", RemotePrefix: &prefixV6, Protocol: 17, PortLow: 53, PortHigh: 53, Action: "allow"},
+		},
+	}
+
+	if err := c.CreatePolicy(ctx, &client.CreatePolicyOptions{
+		Name:                policyName,
+		ProfileName:         profileName,
+		SliceName:           sliceName,
+		DataNetworkName:     dnName,
+		SessionAmbrUplink:   "50 Mbps",
+		SessionAmbrDownlink: "100 Mbps",
+		Var5qi:              9,
+		Arp:                 8,
+		Rules:               initialRules,
+	}); err != nil {
+		t.Fatalf("create policy with rules: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = c.DeletePolicy(ctx, &client.DeletePolicyOptions{Name: policyName})
+	})
+
+	// Step 1: round-trip on initial Get.
+	got, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: policyName})
+	if err != nil {
+		t.Fatalf("get policy after create: %v", err)
+	}
+
+	if !rulesEqual(got.Rules, initialRules) {
+		t.Fatalf("post-create rules round-trip mismatch:\ngot  %s\nwant %s", formatRules(got.Rules), formatRules(initialRules))
+	}
+
+	// Step 2: replace semantics.
+	t.Run("update_replace", func(t *testing.T) {
+		replaced := &client.PolicyRules{
+			Uplink: []client.PolicyRule{
+				{Description: "uplink-allow-all-tcp", RemotePrefix: nil, Protocol: 6, PortLow: 1, PortHigh: 65535, Action: "allow"},
+			},
+			Downlink: []client.PolicyRule{
+				{Description: "downlink-deny-v4-ssh", RemotePrefix: &prefixV4, Protocol: 6, PortLow: 22, PortHigh: 22, Action: "deny"},
+				{Description: "downlink-allow-v6-https", RemotePrefix: &prefixV6, Protocol: 6, PortLow: 443, PortHigh: 443, Action: "allow"},
+			},
+		}
+
+		if err := updatePolicyRules(ctx, c, policyName, replaced); err != nil {
+			t.Fatalf("update rules (replace): %v", err)
+		}
+
+		after := mustGetPolicy(ctx, t, c, policyName)
+		if !rulesEqual(after.Rules, replaced) {
+			t.Fatalf("rules after replace:\ngot  %s\nwant %s", formatRules(after.Rules), formatRules(replaced))
+		}
+	})
+
+	// Step 3: clear via Rules: nil.
+	t.Run("update_clear_nil", func(t *testing.T) {
+		if err := updatePolicyRules(ctx, c, policyName, nil); err != nil {
+			t.Fatalf("update rules (clear nil): %v", err)
+		}
+
+		after := mustGetPolicy(ctx, t, c, policyName)
+		if after.Rules != nil {
+			t.Fatalf("expected Rules == nil after nil-clear, got %s", formatRules(after.Rules))
+		}
+	})
+
+	// Step 4: re-seed, then clear via explicit empty struct.
+	t.Run("update_clear_empty_struct", func(t *testing.T) {
+		if err := updatePolicyRules(ctx, c, policyName, initialRules); err != nil {
+			t.Fatalf("update rules (re-seed): %v", err)
+		}
+
+		if err := updatePolicyRules(ctx, c, policyName, &client.PolicyRules{}); err != nil {
+			t.Fatalf("update rules (clear empty): %v", err)
+		}
+
+		after := mustGetPolicy(ctx, t, c, policyName)
+		if after.Rules != nil {
+			t.Fatalf("expected Rules == nil after empty-struct clear, got %s", formatRules(after.Rules))
+		}
+	})
+
+	// Step 5: preserve rules when mutating a non-rules field.
+	t.Run("preserve_when_updating_other_field", func(t *testing.T) {
+		if err := updatePolicyRules(ctx, c, policyName, initialRules); err != nil {
+			t.Fatalf("update rules (re-seed): %v", err)
+		}
+
+		current := mustGetPolicy(ctx, t, c, policyName)
+		if current.Rules == nil {
+			t.Fatalf("setup: expected rules after re-seed, got nil")
+		}
+
+		opts := &client.UpdatePolicyOptions{
+			ProfileName:         current.ProfileName,
+			SliceName:           current.SliceName,
+			DataNetworkName:     current.DataNetworkName,
+			SessionAmbrUplink:   current.SessionAmbrUplink,
+			SessionAmbrDownlink: current.SessionAmbrDownlink,
+			Var5qi:              5,
+			Arp:                 current.Arp,
+			Rules:               current.Rules, // re-supply to preserve
+		}
+
+		if err := c.UpdatePolicy(ctx, policyName, opts); err != nil {
+			t.Fatalf("update policy (Var5qi with re-supplied rules): %v", err)
+		}
+
+		after := mustGetPolicy(ctx, t, c, policyName)
+
+		if after.Var5qi != 5 {
+			t.Fatalf("Var5qi: got %d, want 5", after.Var5qi)
+		}
+
+		if !rulesEqual(after.Rules, initialRules) {
+			t.Fatalf("rules dropped when updating Var5qi:\ngot  %s\nwant %s", formatRules(after.Rules), formatRules(initialRules))
+		}
+	})
+
+	// Step 6: validation negatives — each must fail with a 4xx server error.
+	negatives := []struct {
+		name  string
+		rules *client.PolicyRules
+		want  string
+	}{
+		{
+			name: "bad_action",
+			rules: &client.PolicyRules{Uplink: []client.PolicyRule{
+				{Description: "x", Protocol: 6, PortLow: 80, PortHigh: 80, Action: "reject"},
+			}},
+			want: "action must be 'allow' or 'deny'",
+		},
+		{
+			name: "bad_cidr",
+			rules: func() *client.PolicyRules {
+				p := "not-a-cidr"
+
+				return &client.PolicyRules{Uplink: []client.PolicyRule{
+					{Description: "x", RemotePrefix: &p, Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+				}}
+			}(),
+			want: "invalid CIDR",
+		},
+		{
+			name: "protocol_out_of_range",
+			rules: &client.PolicyRules{Uplink: []client.PolicyRule{
+				{Description: "x", Protocol: 999, PortLow: 80, PortHigh: 80, Action: "allow"},
+			}},
+			want: "protocol must be between 0 and 255",
+		},
+		{
+			name: "port_low_gt_port_high",
+			rules: &client.PolicyRules{Uplink: []client.PolicyRule{
+				{Description: "x", Protocol: 6, PortLow: 100, PortHigh: 50, Action: "allow"},
+			}},
+			want: "port_low must be <= port_high",
+		},
+		{
+			name: "description_oversized",
+			rules: &client.PolicyRules{Uplink: []client.PolicyRule{
+				{Description: strings.Repeat("x", 257), Protocol: 6, PortLow: 80, PortHigh: 80, Action: "allow"},
+			}},
+			want: "256 characters or fewer",
+		},
+		{
+			name:  "too_many_per_direction",
+			rules: &client.PolicyRules{Uplink: makeNRules(13)},
+			want:  "uplink rules exceed maximum",
+		},
+	}
+
+	// Make sure a clean state precedes the negative pass so a leftover
+	// rule list from step 5 doesn't get destroyed by a failing Update —
+	// failed updates may still wipe rules if validation runs after the
+	// replace path (it doesn't today, but lock in the test isolation).
+	if err := updatePolicyRules(ctx, c, policyName, nil); err != nil {
+		t.Fatalf("setup negatives: clear rules: %v", err)
+	}
+
+	for _, n := range negatives {
+		n := n
+		t.Run("negative_"+n.name, func(t *testing.T) {
+			err := updatePolicyRules(ctx, c, policyName, n.rules)
+			if err == nil {
+				t.Fatalf("expected error, got none")
+			}
+
+			msg := err.Error()
+			if !strings.Contains(msg, n.want) {
+				t.Fatalf("error message: got %q, want substring %q", msg, n.want)
+			}
+
+			if !strings.Contains(msg, "400") {
+				t.Fatalf("expected 400 status, got %q", msg)
+			}
+
+			after := mustGetPolicy(ctx, t, c, policyName)
+			if after.Rules != nil {
+				t.Fatalf("rules mutated by rejected update %s: %s", n.name, formatRules(after.Rules))
+			}
+		})
+	}
+}
+
+// updatePolicyRules sends an Update that touches only the Rules field
+// (other fields are pulled from the current policy state) so each test
+// case is independent of QoS-field mutations.
+func updatePolicyRules(ctx context.Context, c *client.Client, name string, rules *client.PolicyRules) error {
+	current, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: name})
+	if err != nil {
+		return err
+	}
+
+	return c.UpdatePolicy(ctx, name, &client.UpdatePolicyOptions{
+		ProfileName:         current.ProfileName,
+		SliceName:           current.SliceName,
+		DataNetworkName:     current.DataNetworkName,
+		SessionAmbrUplink:   current.SessionAmbrUplink,
+		SessionAmbrDownlink: current.SessionAmbrDownlink,
+		Var5qi:              current.Var5qi,
+		Arp:                 current.Arp,
+		Rules:               rules,
+	})
+}
+
+func mustGetPolicy(ctx context.Context, t *testing.T, c *client.Client, name string) *client.Policy {
+	t.Helper()
+
+	p, err := c.GetPolicy(ctx, &client.GetPolicyOptions{Name: name})
+	if err != nil {
+		t.Fatalf("get policy %q: %v", name, err)
+	}
+
+	return p
+}
+
+func rulesEqual(a, b *client.PolicyRules) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+
+	return ruleListEqual(a.Uplink, b.Uplink) && ruleListEqual(a.Downlink, b.Downlink)
+}
+
+func ruleListEqual(a, b []client.PolicyRule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if !reflect.DeepEqual(a[i], b[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func formatRules(r *client.PolicyRules) string {
+	if r == nil {
+		return "<nil>"
+	}
+
+	return "{uplink=" + formatRuleList(r.Uplink) + ", downlink=" + formatRuleList(r.Downlink) + "}"
+}
+
+func formatRuleList(rs []client.PolicyRule) string {
+	var sb strings.Builder
+
+	sb.WriteByte('[')
+
+	for i, r := range rs {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+
+		prefix := "<nil>"
+		if r.RemotePrefix != nil {
+			prefix = *r.RemotePrefix
+		}
+
+		sb.WriteString(r.Description + "/" + prefix + "/" + r.Action)
+	}
+
+	sb.WriteByte(']')
+
+	return sb.String()
+}
+
+func makeNRules(n int) []client.PolicyRule {
+	out := make([]client.PolicyRule, n)
+	for i := range out {
+		out[i] = client.PolicyRule{
+			Description: "rule",
+			Protocol:    6,
+			PortLow:     int32(1000 + i),
+			PortHigh:    int32(1000 + i),
+			Action:      "allow",
+		}
+	}
+
+	return out
+}

--- a/integration/api_matrix_profiles_test.go
+++ b/integration/api_matrix_profiles_test.go
@@ -1,0 +1,145 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runProfilesMatrix exercises every CRUD verb for the Profiles resource and
+// every settable field on Update. The matrix shape is:
+//
+//  1. List → snapshot baseline count
+//  2. Create
+//  3. Get → assert all create fields round-trip
+//  4. List → assert count == baseline+1 and entity present
+//  5. Update each settable field via a sub-table; Get after each mutation
+//  6. Delete
+//  7. Get → assert 404
+//  8. List → assert count == baseline
+func runProfilesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	name := apiMatrixName("profile")
+
+	listAll := func() *client.ListProfilesResponse {
+		resp, err := c.ListProfiles(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list profiles: %v", err)
+		}
+
+		return resp
+	}
+
+	containsProfile := func(items []client.Profile, name string) bool {
+		for _, p := range items {
+			if p.Name == name {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	baseline := listAll()
+
+	createOpts := &client.CreateProfileOptions{
+		Name:           name,
+		UeAmbrUplink:   "100 Mbps",
+		UeAmbrDownlink: "200 Mbps",
+	}
+
+	if err := c.CreateProfile(ctx, createOpts); err != nil {
+		t.Fatalf("create profile %q: %v", name, err)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: name}); err != nil {
+			t.Logf("cleanup: delete profile %q: %v", name, err)
+		}
+	})
+
+	got, err := c.GetProfile(ctx, &client.GetProfileOptions{Name: name})
+	if err != nil {
+		t.Fatalf("get profile %q after create: %v", name, err)
+	}
+
+	if got.Name != createOpts.Name ||
+		got.UeAmbrUplink != createOpts.UeAmbrUplink ||
+		got.UeAmbrDownlink != createOpts.UeAmbrDownlink {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want %+v", got, createOpts)
+	}
+
+	afterCreate := listAll()
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if !containsProfile(afterCreate.Items, name) {
+		t.Fatalf("list after create missing %q", name)
+	}
+
+	updateCases := []struct {
+		field  string
+		opts   client.UpdateProfileOptions
+		assert func(t *testing.T, p *client.Profile)
+	}{
+		{
+			field: "UeAmbrUplink",
+			opts:  client.UpdateProfileOptions{UeAmbrUplink: "500 Mbps", UeAmbrDownlink: createOpts.UeAmbrDownlink},
+			assert: func(t *testing.T, p *client.Profile) {
+				if p.UeAmbrUplink != "500 Mbps" {
+					t.Fatalf("UeAmbrUplink: got %q, want %q", p.UeAmbrUplink, "500 Mbps")
+				}
+			},
+		},
+		{
+			field: "UeAmbrDownlink",
+			opts:  client.UpdateProfileOptions{UeAmbrUplink: "500 Mbps", UeAmbrDownlink: "1 Gbps"},
+			assert: func(t *testing.T, p *client.Profile) {
+				if p.UeAmbrDownlink != "1 Gbps" {
+					t.Fatalf("UeAmbrDownlink: got %q, want %q", p.UeAmbrDownlink, "1 Gbps")
+				}
+			},
+		},
+	}
+
+	for _, tc := range updateCases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			if err := c.UpdateProfile(ctx, name, &tc.opts); err != nil {
+				t.Fatalf("update profile %q (%s): %v", name, tc.field, err)
+			}
+
+			updated, err := c.GetProfile(ctx, &client.GetProfileOptions{Name: name})
+			if err != nil {
+				t.Fatalf("get profile %q after update: %v", name, err)
+			}
+
+			tc.assert(t, updated)
+		})
+	}
+
+	if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: name}); err != nil {
+		t.Fatalf("delete profile %q: %v", name, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetProfile(ctx, &client.GetProfileOptions{Name: name})
+	assertNotFound(t, err, "profile after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if containsProfile(afterDelete.Items, name) {
+		t.Fatalf("list after delete still contains %q", name)
+	}
+}

--- a/integration/api_matrix_profiles_test.go
+++ b/integration/api_matrix_profiles_test.go
@@ -7,17 +7,6 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runProfilesMatrix exercises every CRUD verb for the Profiles resource and
-// every settable field on Update. The matrix shape is:
-//
-//  1. List → snapshot baseline count
-//  2. Create
-//  3. Get → assert all create fields round-trip
-//  4. List → assert count == baseline+1 and entity present
-//  5. Update each settable field via a sub-table; Get after each mutation
-//  6. Delete
-//  7. Get → assert 404
-//  8. List → assert count == baseline
 func runProfilesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	name := apiMatrixName("profile")
 

--- a/integration/api_matrix_retention_test.go
+++ b/integration/api_matrix_retention_test.go
@@ -1,0 +1,117 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// retentionRunner abstracts a Days-based retention-policy singleton.
+// All four (subscriber usage, radio events, flow reports, audit logs)
+// share the same {Days: int} shape, so they share one runner.
+type retentionRunner struct {
+	name   string
+	get    func(ctx context.Context) (int, error)
+	update func(ctx context.Context, days int) error
+}
+
+func (r retentionRunner) run(ctx context.Context, t *testing.T) {
+	orig, err := r.get(ctx)
+	if err != nil {
+		t.Fatalf("get %s retention (baseline): %v", r.name, err)
+	}
+
+	t.Cleanup(func() {
+		if err := r.update(ctx, orig); err != nil {
+			t.Logf("cleanup: restore %s retention: %v", r.name, err)
+		}
+	})
+
+	target := orig + 7
+	if target == orig {
+		// orig must not have been 0 here, but guard anyway.
+		target = 14
+	}
+
+	if err := r.update(ctx, target); err != nil {
+		t.Fatalf("update %s retention: %v", r.name, err)
+	}
+
+	got, err := r.get(ctx)
+	if err != nil {
+		t.Fatalf("get %s retention after update: %v", r.name, err)
+	}
+
+	if got != target {
+		t.Fatalf("%s retention Days: got %d, want %d", r.name, got, target)
+	}
+}
+
+func runSubscriberUsageRetentionMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	retentionRunner{
+		name: "subscriber-usage",
+		get: func(ctx context.Context) (int, error) {
+			p, err := c.GetUsageRetentionPolicy(ctx)
+			if err != nil {
+				return 0, err
+			}
+
+			return p.Days, nil
+		},
+		update: func(ctx context.Context, days int) error {
+			return c.UpdateUsageRetentionPolicy(ctx, &client.UpdateUsageRetentionPolicyOptions{Days: days})
+		},
+	}.run(ctx, t)
+}
+
+func runRadioEventsRetentionMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	retentionRunner{
+		name: "radio-events",
+		get: func(ctx context.Context) (int, error) {
+			p, err := c.GetRadioEventRetentionPolicy(ctx)
+			if err != nil {
+				return 0, err
+			}
+
+			return p.Days, nil
+		},
+		update: func(ctx context.Context, days int) error {
+			return c.UpdateRadioEventRetentionPolicy(ctx, &client.UpdateRadioEventsRetentionPolicyOptions{Days: days})
+		},
+	}.run(ctx, t)
+}
+
+func runFlowReportsRetentionMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	retentionRunner{
+		name: "flow-reports",
+		get: func(ctx context.Context) (int, error) {
+			p, err := c.GetFlowReportsRetentionPolicy(ctx)
+			if err != nil {
+				return 0, err
+			}
+
+			return p.Days, nil
+		},
+		update: func(ctx context.Context, days int) error {
+			return c.UpdateFlowReportsRetentionPolicy(ctx, &client.UpdateFlowReportsRetentionPolicyOptions{Days: days})
+		},
+	}.run(ctx, t)
+}
+
+func runAuditLogRetentionMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	retentionRunner{
+		name: "audit-log",
+		get: func(ctx context.Context) (int, error) {
+			p, err := c.GetAuditLogRetentionPolicy(ctx)
+			if err != nil {
+				return 0, err
+			}
+
+			return p.Days, nil
+		},
+		update: func(ctx context.Context, days int) error {
+			return c.UpdateAuditLogRetentionPolicy(ctx, &client.UpdateAuditLogsRetentionPolicyOptions{Days: days})
+		},
+	}.run(ctx, t)
+}

--- a/integration/api_matrix_retention_test.go
+++ b/integration/api_matrix_retention_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// retentionRunner abstracts a Days-based retention-policy singleton.
-// All four (subscriber usage, radio events, flow reports, audit logs)
-// share the same {Days: int} shape, so they share one runner.
+// retentionRunner abstracts a Days-based retention-policy singleton so
+// the four resources that share the {Days: int} shape can share a runner.
 type retentionRunner struct {
 	name   string
 	get    func(ctx context.Context) (int, error)
@@ -30,7 +29,6 @@ func (r retentionRunner) run(ctx context.Context, t *testing.T) {
 
 	target := orig + 7
 	if target == orig {
-		// orig must not have been 0 here, but guard anyway.
 		target = 14
 	}
 

--- a/integration/api_matrix_routes_test.go
+++ b/integration/api_matrix_routes_test.go
@@ -7,18 +7,10 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runRoutesMatrix exercises CRD for routes. The Routes API has no Update
-// verb (server.go:153-156), so this is a 4-step matrix:
-//
-//	List → Create → Get/List → Delete → Get(404)/List
-//
-// The route handler installs the route into the kernel before persisting,
-// so the destination + gateway must be reachable on the n6 interface in
-// the active IP-family topology. The runner picks an IPv4 or IPv6 pair
-// to match the compose, mirroring bootstrapTesterCore at
-// tester_env_test.go:144-166. The bootstrap installs a default route to
-// 8.8.8.8 / 2001:4860:4860::8888, so we use distinct destinations here
-// to avoid collisions.
+// runRoutesMatrix picks a destination and gateway matching the active IP
+// family because the handler installs the route into the kernel before
+// persisting, and n6 only has addresses in the family its compose
+// configures.
 func runRoutesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	listAll := func() *client.ListRoutesResponse {
 		resp, err := c.ListRoutes(ctx, &client.ListParams{Page: 1, PerPage: 100})
@@ -51,7 +43,7 @@ func runRoutesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 			Interface:   "n6",
 			Metric:      100,
 		}
-	default: // IPv4Only or DualStack — n6 has an IPv4 address in both.
+	default: // IPv4Only or DualStack
 		createOpts = &client.CreateRouteOptions{
 			Destination: "192.0.2.0/24",
 			Gateway:     N6RouterIPv4Address(),

--- a/integration/api_matrix_routes_test.go
+++ b/integration/api_matrix_routes_test.go
@@ -12,8 +12,13 @@ import (
 //
 //	List → Create → Get/List → Delete → Get(404)/List
 //
-// The bootstrap installs a default route to 8.8.8.8 (tester_env_test.go),
-// so we use a different destination here to avoid collisions.
+// The route handler installs the route into the kernel before persisting,
+// so the destination + gateway must be reachable on the n6 interface in
+// the active IP-family topology. The runner picks an IPv4 or IPv6 pair
+// to match the compose, mirroring bootstrapTesterCore at
+// tester_env_test.go:144-166. The bootstrap installs a default route to
+// 8.8.8.8 / 2001:4860:4860::8888, so we use distinct destinations here
+// to avoid collisions.
 func runRoutesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	listAll := func() *client.ListRoutesResponse {
 		resp, err := c.ListRoutes(ctx, &client.ListParams{Page: 1, PerPage: 100})
@@ -36,11 +41,23 @@ func runRoutesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	baseline := listAll()
 
-	createOpts := &client.CreateRouteOptions{
-		Destination: "192.0.2.0/24",
-		Gateway:     N6RouterIPv4Address(),
-		Interface:   "n6",
-		Metric:      100,
+	var createOpts *client.CreateRouteOptions
+
+	switch DetectIPFamily() {
+	case IPv6Only:
+		createOpts = &client.CreateRouteOptions{
+			Destination: "2001:db8:abcd::/64",
+			Gateway:     N6RouterIPv6Address(),
+			Interface:   "n6",
+			Metric:      100,
+		}
+	default: // IPv4Only or DualStack — n6 has an IPv4 address in both.
+		createOpts = &client.CreateRouteOptions{
+			Destination: "192.0.2.0/24",
+			Gateway:     N6RouterIPv4Address(),
+			Interface:   "n6",
+			Metric:      100,
+		}
 	}
 
 	if err := c.CreateRoute(ctx, createOpts); err != nil {

--- a/integration/api_matrix_routes_test.go
+++ b/integration/api_matrix_routes_test.go
@@ -1,0 +1,105 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runRoutesMatrix exercises CRD for routes. The Routes API has no Update
+// verb (server.go:153-156), so this is a 4-step matrix:
+//
+//	List → Create → Get/List → Delete → Get(404)/List
+//
+// The bootstrap installs a default route to 8.8.8.8 (tester_env_test.go),
+// so we use a different destination here to avoid collisions.
+func runRoutesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	listAll := func() *client.ListRoutesResponse {
+		resp, err := c.ListRoutes(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list routes: %v", err)
+		}
+
+		return resp
+	}
+
+	findByDestination := func(items []client.Route, dest string) *client.Route {
+		for i := range items {
+			if items[i].Destination == dest {
+				return &items[i]
+			}
+		}
+
+		return nil
+	}
+
+	baseline := listAll()
+
+	createOpts := &client.CreateRouteOptions{
+		Destination: "192.0.2.0/24",
+		Gateway:     N6RouterIPv4Address(),
+		Interface:   "n6",
+		Metric:      100,
+	}
+
+	if err := c.CreateRoute(ctx, createOpts); err != nil {
+		t.Fatalf("create route: %v", err)
+	}
+
+	afterCreate := listAll()
+
+	created := findByDestination(afterCreate.Items, createOpts.Destination)
+	if created == nil {
+		t.Fatalf("list after create missing destination %q", createOpts.Destination)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteRoute(ctx, &client.DeleteRouteOptions{ID: created.ID}); err != nil {
+			t.Logf("cleanup: delete route %d: %v", created.ID, err)
+		}
+	})
+
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if created.Gateway != createOpts.Gateway ||
+		created.Interface != createOpts.Interface ||
+		created.Metric != createOpts.Metric {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want %+v", created, createOpts)
+	}
+
+	got, err := c.GetRoute(ctx, &client.GetRouteOptions{ID: created.ID})
+	if err != nil {
+		t.Fatalf("get route %d: %v", created.ID, err)
+	}
+
+	if got.ID != created.ID || got.Destination != createOpts.Destination {
+		t.Fatalf("get route mismatch: got %+v, want id=%d destination=%q", got, created.ID, createOpts.Destination)
+	}
+
+	if err := c.DeleteRoute(ctx, &client.DeleteRouteOptions{ID: created.ID}); err != nil {
+		t.Fatalf("delete route %d: %v", created.ID, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetRoute(ctx, &client.GetRouteOptions{ID: created.ID})
+	assertNotFound(t, err, "route after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if findByDestination(afterDelete.Items, createOpts.Destination) != nil {
+		t.Fatalf("list after delete still contains destination %q", createOpts.Destination)
+	}
+}

--- a/integration/api_matrix_slices_test.go
+++ b/integration/api_matrix_slices_test.go
@@ -1,0 +1,134 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runSlicesMatrix is the slice-resource counterpart of runProfilesMatrix.
+// See api_matrix_profiles_test.go for the matrix shape.
+func runSlicesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	name := apiMatrixName("slice")
+
+	listAll := func() *client.ListSlicesResponse {
+		resp, err := c.ListSlices(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list slices: %v", err)
+		}
+
+		return resp
+	}
+
+	contains := func(items []client.Slice, name string) bool {
+		for _, s := range items {
+			if s.Name == name {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	baseline := listAll()
+
+	createOpts := &client.CreateSliceOptions{
+		Name: name,
+		Sst:  1,
+		Sd:   "010203",
+	}
+
+	if err := c.CreateSlice(ctx, createOpts); err != nil {
+		t.Fatalf("create slice %q: %v", name, err)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: name}); err != nil {
+			t.Logf("cleanup: delete slice %q: %v", name, err)
+		}
+	})
+
+	got, err := c.GetSlice(ctx, &client.GetSliceOptions{Name: name})
+	if err != nil {
+		t.Fatalf("get slice %q after create: %v", name, err)
+	}
+
+	if got.Name != createOpts.Name || got.Sst != createOpts.Sst || got.Sd != createOpts.Sd {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want %+v", got, createOpts)
+	}
+
+	afterCreate := listAll()
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if !contains(afterCreate.Items, name) {
+		t.Fatalf("list after create missing %q", name)
+	}
+
+	updateCases := []struct {
+		field  string
+		opts   client.UpdateSliceOptions
+		assert func(t *testing.T, s *client.Slice)
+	}{
+		{
+			field: "Sst",
+			opts:  client.UpdateSliceOptions{Sst: 2, Sd: createOpts.Sd},
+			assert: func(t *testing.T, s *client.Slice) {
+				if s.Sst != 2 {
+					t.Fatalf("Sst: got %d, want 2", s.Sst)
+				}
+			},
+		},
+		{
+			field: "Sd",
+			opts:  client.UpdateSliceOptions{Sst: 2, Sd: "abcdef"},
+			assert: func(t *testing.T, s *client.Slice) {
+				if s.Sd != "abcdef" {
+					t.Fatalf("Sd: got %q, want %q", s.Sd, "abcdef")
+				}
+			},
+		},
+	}
+
+	for _, tc := range updateCases {
+		tc := tc
+		t.Run("update_"+tc.field, func(t *testing.T) {
+			if err := c.UpdateSlice(ctx, name, &tc.opts); err != nil {
+				t.Fatalf("update slice %q (%s): %v", name, tc.field, err)
+			}
+
+			updated, err := c.GetSlice(ctx, &client.GetSliceOptions{Name: name})
+			if err != nil {
+				t.Fatalf("get slice %q after update: %v", name, err)
+			}
+
+			tc.assert(t, updated)
+		})
+	}
+
+	if err := c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: name}); err != nil {
+		t.Fatalf("delete slice %q: %v", name, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetSlice(ctx, &client.GetSliceOptions{Name: name})
+	assertNotFound(t, err, "slice after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if contains(afterDelete.Items, name) {
+		t.Fatalf("list after delete still contains %q", name)
+	}
+}

--- a/integration/api_matrix_slices_test.go
+++ b/integration/api_matrix_slices_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runSlicesMatrix is the slice-resource counterpart of runProfilesMatrix.
-// See api_matrix_profiles_test.go for the matrix shape.
 func runSlicesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	name := apiMatrixName("slice")
 

--- a/integration/api_matrix_subscribers_test.go
+++ b/integration/api_matrix_subscribers_test.go
@@ -7,18 +7,10 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runSubscribersMatrix exercises CRUD for subscribers. Subscribers
-// reference a Profile, and the server enforces that any Profile carrying
-// subscribers must be referenced by at least one Policy (see the 409
-// "Profile has no policy" path in CreateSubscriber). The runner sets up
-// the full dependency chain — one Slice, one Data Network, two Profiles,
-// and one Policy per Profile — so it can also round-trip the
-// profile_name field on Update.
-//
-// See api_matrix_profiles_test.go for the matrix shape. The only
-// updatable field on a subscriber is profile_name (see
-// internal/api/server/api_subscribers.go:28-30), so the update step has
-// a single case.
+// runSubscribersMatrix provisions the full dependency chain a Subscriber
+// requires: the server rejects subscriber creation against any Profile
+// not already referenced by at least one Policy. Two Profiles + Policies
+// are stood up so the profile_name update can switch targets.
 func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	sliceName := apiMatrixName("sub-slice")
 	dnName := apiMatrixName("sub-dn")
@@ -155,10 +147,8 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("post-create round-trip mismatch: got %+v, want imsi=%s profile=%s", got, imsi, profileA)
 	}
 
-	// A subscriber that has never attached has well-defined defaults on
-	// the Get response. Locking these in catches regressions where the
-	// handler accidentally populates them with non-zero values (or where
-	// the JSON contract drifts on either side).
+	// Defaults for a never-attached subscriber. Locks the contract
+	// against handler regressions and JSON-key drift.
 	if got.Status.Registered {
 		t.Fatalf("Status.Registered: got true, want false (subscriber never attached)")
 	}
@@ -173,8 +163,6 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("PDUSessions: got %d, want 0", len(got.PDUSessions))
 	}
 
-	// Credentials are stored at create and exposed via a separate endpoint;
-	// round-trip key and opc as part of the Read step.
 	creds, err := c.GetSubscriberCredentials(ctx, &client.GetSubscriberCredentialsOptions{ID: imsi})
 	if err != nil {
 		t.Fatalf("get subscriber credentials: %v", err)
@@ -197,8 +185,8 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("list after create missing %q", imsi)
 	}
 
-	// Default Status on the list-shape response (different struct from
-	// the Get-one detail response, so we assert independently).
+	// List response carries a different Status struct than Get-one, so
+	// the defaults are asserted independently.
 	for _, item := range afterCreate.Items {
 		if item.Imsi != imsi {
 			continue

--- a/integration/api_matrix_subscribers_test.go
+++ b/integration/api_matrix_subscribers_test.go
@@ -1,0 +1,151 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runSubscribersMatrix exercises CRUD for subscribers. Subscribers
+// reference a Profile, so the runner creates two profiles: the initial
+// one (set at create time) and a second one used as the Update target.
+// See api_matrix_profiles_test.go for the matrix shape.
+//
+// The only updatable field on a subscriber is profile_name (see
+// internal/api/server/api_subscribers.go:28-30), so the update step has
+// a single case.
+func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	profileA := apiMatrixName("sub-profile-a")
+	profileB := apiMatrixName("sub-profile-b")
+	imsi := "001019999999991"
+
+	for _, p := range []string{profileA, profileB} {
+		p := p
+
+		if err := c.CreateProfile(ctx, &client.CreateProfileOptions{
+			Name:           p,
+			UeAmbrUplink:   "100 Mbps",
+			UeAmbrDownlink: "100 Mbps",
+		}); err != nil {
+			t.Fatalf("create dep profile %q: %v", p, err)
+		}
+
+		t.Cleanup(func() {
+			if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: p}); err != nil {
+				t.Logf("cleanup: delete dep profile %q: %v", p, err)
+			}
+		})
+	}
+
+	listAll := func() *client.ListSubscribersResponse {
+		resp, err := c.ListSubscribers(ctx, &client.ListSubscribersParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list subscribers: %v", err)
+		}
+
+		return resp
+	}
+
+	contains := func(items []client.Subscriber, imsi string) bool {
+		for _, s := range items {
+			if s.Imsi == imsi {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	baseline := listAll()
+
+	createOpts := &client.CreateSubscriberOptions{
+		Imsi:           imsi,
+		Key:            "640f441067cd56f1474cbcacd7a0588f",
+		SequenceNumber: "000000000022",
+		ProfileName:    profileA,
+		OPc:            "cb698a2341629c3241ae01de9d89de4f",
+	}
+
+	if err := c.CreateSubscriber(ctx, createOpts); err != nil {
+		t.Fatalf("create subscriber %q: %v", imsi, err)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteSubscriber(ctx, &client.DeleteSubscriberOptions{ID: imsi}); err != nil {
+			t.Logf("cleanup: delete subscriber %q: %v", imsi, err)
+		}
+	})
+
+	got, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsi})
+	if err != nil {
+		t.Fatalf("get subscriber %q after create: %v", imsi, err)
+	}
+
+	if got.Imsi != imsi || got.ProfileName != profileA {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want imsi=%s profile=%s", got, imsi, profileA)
+	}
+
+	// Credentials are stored at create and exposed via a separate endpoint;
+	// round-trip key and opc as part of the Read step.
+	creds, err := c.GetSubscriberCredentials(ctx, &client.GetSubscriberCredentialsOptions{ID: imsi})
+	if err != nil {
+		t.Fatalf("get subscriber credentials: %v", err)
+	}
+
+	if creds.Key != createOpts.Key {
+		t.Fatalf("credentials Key: got %q, want %q", creds.Key, createOpts.Key)
+	}
+
+	if creds.Opc != createOpts.OPc {
+		t.Fatalf("credentials Opc: got %q, want %q", creds.Opc, createOpts.OPc)
+	}
+
+	afterCreate := listAll()
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if !contains(afterCreate.Items, imsi) {
+		t.Fatalf("list after create missing %q", imsi)
+	}
+
+	t.Run("update_ProfileName", func(t *testing.T) {
+		if err := c.UpdateSubscriber(ctx, imsi, &client.UpdateSubscriberOptions{ProfileName: profileB}); err != nil {
+			t.Fatalf("update subscriber: %v", err)
+		}
+
+		updated, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsi})
+		if err != nil {
+			t.Fatalf("get subscriber after update: %v", err)
+		}
+
+		if updated.ProfileName != profileB {
+			t.Fatalf("ProfileName: got %q, want %q", updated.ProfileName, profileB)
+		}
+	})
+
+	if err := c.DeleteSubscriber(ctx, &client.DeleteSubscriberOptions{ID: imsi}); err != nil {
+		t.Fatalf("delete subscriber %q: %v", imsi, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsi})
+	assertNotFound(t, err, "subscriber after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if contains(afterDelete.Items, imsi) {
+		t.Fatalf("list after delete still contains %q", imsi)
+	}
+}

--- a/integration/api_matrix_subscribers_test.go
+++ b/integration/api_matrix_subscribers_test.go
@@ -155,6 +155,24 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("post-create round-trip mismatch: got %+v, want imsi=%s profile=%s", got, imsi, profileA)
 	}
 
+	// A subscriber that has never attached has well-defined defaults on
+	// the Get response. Locking these in catches regressions where the
+	// handler accidentally populates them with non-zero values (or where
+	// the JSON contract drifts on either side).
+	if got.Status.Registered {
+		t.Fatalf("Status.Registered: got true, want false (subscriber never attached)")
+	}
+
+	if got.Status.Imei != "" || got.Status.CipheringAlgorithm != "" ||
+		got.Status.IntegrityAlgorithm != "" || got.Status.LastSeenAt != "" ||
+		got.Status.LastSeenRadio != "" {
+		t.Fatalf("Status: expected zero-valued strings on a never-attached subscriber, got %+v", got.Status)
+	}
+
+	if len(got.PDUSessions) != 0 {
+		t.Fatalf("PDUSessions: got %d, want 0", len(got.PDUSessions))
+	}
+
 	// Credentials are stored at create and exposed via a separate endpoint;
 	// round-trip key and opc as part of the Read step.
 	creds, err := c.GetSubscriberCredentials(ctx, &client.GetSubscriberCredentialsOptions{ID: imsi})
@@ -177,6 +195,28 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	if !contains(afterCreate.Items, imsi) {
 		t.Fatalf("list after create missing %q", imsi)
+	}
+
+	// Default Status on the list-shape response (different struct from
+	// the Get-one detail response, so we assert independently).
+	for _, item := range afterCreate.Items {
+		if item.Imsi != imsi {
+			continue
+		}
+
+		if item.Status.Registered {
+			t.Fatalf("list Status.Registered: got true, want false")
+		}
+
+		if item.Status.NumPDUSessions != 0 {
+			t.Fatalf("list Status.NumPDUSessions: got %d, want 0", item.Status.NumPDUSessions)
+		}
+
+		if item.Status.LastSeenAt != "" {
+			t.Fatalf("list Status.LastSeenAt: got %q, want empty", item.Status.LastSeenAt)
+		}
+
+		break
 	}
 
 	t.Run("update_ProfileName", func(t *testing.T) {

--- a/integration/api_matrix_subscribers_test.go
+++ b/integration/api_matrix_subscribers_test.go
@@ -8,17 +8,54 @@ import (
 )
 
 // runSubscribersMatrix exercises CRUD for subscribers. Subscribers
-// reference a Profile, so the runner creates two profiles: the initial
-// one (set at create time) and a second one used as the Update target.
-// See api_matrix_profiles_test.go for the matrix shape.
+// reference a Profile, and the server enforces that any Profile carrying
+// subscribers must be referenced by at least one Policy (see the 409
+// "Profile has no policy" path in CreateSubscriber). The runner sets up
+// the full dependency chain — one Slice, one Data Network, two Profiles,
+// and one Policy per Profile — so it can also round-trip the
+// profile_name field on Update.
 //
-// The only updatable field on a subscriber is profile_name (see
+// See api_matrix_profiles_test.go for the matrix shape. The only
+// updatable field on a subscriber is profile_name (see
 // internal/api/server/api_subscribers.go:28-30), so the update step has
 // a single case.
 func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	sliceName := apiMatrixName("sub-slice")
+	dnName := apiMatrixName("sub-dn")
 	profileA := apiMatrixName("sub-profile-a")
 	profileB := apiMatrixName("sub-profile-b")
+	policyA := apiMatrixName("sub-policy-a")
+	policyB := apiMatrixName("sub-policy-b")
 	imsi := "001019999999991"
+
+	if err := c.CreateSlice(ctx, &client.CreateSliceOptions{
+		Name: sliceName,
+		Sst:  1,
+		Sd:   "abcdef",
+	}); err != nil {
+		t.Fatalf("create dep slice: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: sliceName}); err != nil {
+			t.Logf("cleanup: delete dep slice: %v", err)
+		}
+	})
+
+	if err := c.CreateDataNetwork(ctx, &client.CreateDataNetworkOptions{
+		Name:     dnName,
+		IPv4Pool: "10.253.0.0/16",
+		DNS:      "8.8.8.8",
+		Mtu:      1500,
+	}); err != nil {
+		t.Fatalf("create dep data network: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: dnName}); err != nil {
+			t.Logf("cleanup: delete dep data network: %v", err)
+		}
+	})
 
 	for _, p := range []string{profileA, profileB} {
 		p := p
@@ -34,6 +71,32 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Cleanup(func() {
 			if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: p}); err != nil {
 				t.Logf("cleanup: delete dep profile %q: %v", p, err)
+			}
+		})
+	}
+
+	for _, link := range []struct{ policy, profile string }{
+		{policyA, profileA},
+		{policyB, profileB},
+	} {
+		link := link
+
+		if err := c.CreatePolicy(ctx, &client.CreatePolicyOptions{
+			Name:                link.policy,
+			ProfileName:         link.profile,
+			SliceName:           sliceName,
+			DataNetworkName:     dnName,
+			SessionAmbrUplink:   "50 Mbps",
+			SessionAmbrDownlink: "100 Mbps",
+			Var5qi:              9,
+			Arp:                 8,
+		}); err != nil {
+			t.Fatalf("create dep policy %q: %v", link.policy, err)
+		}
+
+		t.Cleanup(func() {
+			if err := c.DeletePolicy(ctx, &client.DeletePolicyOptions{Name: link.policy}); err != nil {
+				t.Logf("cleanup: delete dep policy %q: %v", link.policy, err)
 			}
 		})
 	}

--- a/integration/api_matrix_test.go
+++ b/integration/api_matrix_test.go
@@ -1,0 +1,47 @@
+package integration_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// apiMatrixRunner runs one resource's Create→Read→Update→Read→Delete→Read(404)
+// matrix against an already-bootstrapped Ella Core. Each runner owns its own
+// resource lifecycle (including t.Cleanup deletes) and asserts on round-trip
+// field fidelity.
+type apiMatrixRunner func(ctx context.Context, t *testing.T, c *client.Client)
+
+// apiMatrixResources is the registry of resources covered by TestAPIMatrix.
+// Adding a new resource means: implement its runner in
+// api_matrix_<resource>_test.go and register it here.
+var apiMatrixResources = map[string]apiMatrixRunner{
+	"profiles": runProfilesMatrix,
+}
+
+// TestAPIMatrix exercises Create/Read/Update/Delete (and List, and the
+// missing-after-delete 404) for every CRUD-capable REST resource, using the
+// Go client SDK against a live Ella Core brought up via the core-tester
+// compose. The bootstrap (admin user + API token + NAT + default routes) is
+// reused from setupTesterEnv; no gNB/UE traffic is involved.
+//
+// Each resource runs as an independent t.Run subtest so failures in one
+// resource don't mask others. Subtests run sequentially against a single
+// compose to keep total runtime bounded.
+func TestAPIMatrix(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	ctx := context.Background()
+	env := setupTesterEnv(ctx, t)
+
+	for name, run := range apiMatrixResources {
+		name, run := name, run
+		t.Run(name, func(t *testing.T) {
+			run(ctx, t, env.Client)
+		})
+	}
+}

--- a/integration/api_matrix_test.go
+++ b/integration/api_matrix_test.go
@@ -31,6 +31,7 @@ var apiMatrixResources = map[string]apiMatrixRunner{
 	"home_network_keys": runHomeNetworkKeysMatrix,
 	"policy_rules":      runPolicyRulesMatrix,
 	// Singletons + retention policies (step 4).
+	"operator_code":              runOperatorCodeMatrix,
 	"operator_id":                runOperatorIDMatrix,
 	"operator_tracking":          runOperatorTrackingMatrix,
 	"operator_nas_security":      runOperatorNASSecurityMatrix,

--- a/integration/api_matrix_test.go
+++ b/integration/api_matrix_test.go
@@ -29,6 +29,7 @@ var apiMatrixResources = map[string]apiMatrixRunner{
 	"users":             runUsersMatrix,
 	"api_tokens":        runAPITokensMatrix,
 	"home_network_keys": runHomeNetworkKeysMatrix,
+	"policy_rules":      runPolicyRulesMatrix,
 	// Singletons + retention policies (step 4).
 	"operator_id":                runOperatorIDMatrix,
 	"operator_tracking":          runOperatorTrackingMatrix,

--- a/integration/api_matrix_test.go
+++ b/integration/api_matrix_test.go
@@ -8,29 +8,23 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// apiMatrixRunner runs one resource's Create→Read→Update→Read→Delete→Read(404)
-// matrix against an already-bootstrapped Ella Core. Each runner owns its own
-// resource lifecycle (including t.Cleanup deletes) and asserts on round-trip
-// field fidelity.
 type apiMatrixRunner func(ctx context.Context, t *testing.T, c *client.Client)
 
 // apiMatrixResources is the registry of resources covered by TestAPIMatrix.
-// Adding a new resource means: implement its runner in
-// api_matrix_<resource>_test.go and register it here.
+// Adding a new resource means implementing its runner in
+// api_matrix_<resource>_test.go and registering it here.
 var apiMatrixResources = map[string]apiMatrixRunner{
-	// Full CRUD resources (step 3).
-	"profiles":          runProfilesMatrix,
-	"slices":            runSlicesMatrix,
-	"data_networks":     runDataNetworksMatrix,
-	"policies":          runPoliciesMatrix,
-	"subscribers":       runSubscribersMatrix,
-	"routes":            runRoutesMatrix,
-	"bgp_peers":         runBGPPeersMatrix,
-	"users":             runUsersMatrix,
-	"api_tokens":        runAPITokensMatrix,
-	"home_network_keys": runHomeNetworkKeysMatrix,
-	"policy_rules":      runPolicyRulesMatrix,
-	// Singletons + retention policies (step 4).
+	"profiles":                   runProfilesMatrix,
+	"slices":                     runSlicesMatrix,
+	"data_networks":              runDataNetworksMatrix,
+	"policies":                   runPoliciesMatrix,
+	"subscribers":                runSubscribersMatrix,
+	"routes":                     runRoutesMatrix,
+	"bgp_peers":                  runBGPPeersMatrix,
+	"users":                      runUsersMatrix,
+	"api_tokens":                 runAPITokensMatrix,
+	"home_network_keys":          runHomeNetworkKeysMatrix,
+	"policy_rules":               runPolicyRulesMatrix,
 	"operator_code":              runOperatorCodeMatrix,
 	"operator_id":                runOperatorIDMatrix,
 	"operator_tracking":          runOperatorTrackingMatrix,
@@ -46,15 +40,6 @@ var apiMatrixResources = map[string]apiMatrixRunner{
 	"audit_log_retention":        runAuditLogRetentionMatrix,
 }
 
-// TestAPIMatrix exercises Create/Read/Update/Delete (and List, and the
-// missing-after-delete 404) for every CRUD-capable REST resource, using the
-// Go client SDK against a live Ella Core brought up via the core-tester
-// compose. The bootstrap (admin user + API token + NAT + default routes) is
-// reused from setupTesterEnv; no gNB/UE traffic is involved.
-//
-// Each resource runs as an independent t.Run subtest so failures in one
-// resource don't mask others. Subtests run sequentially against a single
-// compose to keep total runtime bounded.
 func TestAPIMatrix(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")

--- a/integration/api_matrix_test.go
+++ b/integration/api_matrix_test.go
@@ -18,6 +18,7 @@ type apiMatrixRunner func(ctx context.Context, t *testing.T, c *client.Client)
 // Adding a new resource means: implement its runner in
 // api_matrix_<resource>_test.go and register it here.
 var apiMatrixResources = map[string]apiMatrixRunner{
+	// Full CRUD resources (step 3).
 	"profiles":          runProfilesMatrix,
 	"slices":            runSlicesMatrix,
 	"data_networks":     runDataNetworksMatrix,
@@ -28,6 +29,19 @@ var apiMatrixResources = map[string]apiMatrixRunner{
 	"users":             runUsersMatrix,
 	"api_tokens":        runAPITokensMatrix,
 	"home_network_keys": runHomeNetworkKeysMatrix,
+	// Singletons + retention policies (step 4).
+	"operator_id":                runOperatorIDMatrix,
+	"operator_tracking":          runOperatorTrackingMatrix,
+	"operator_nas_security":      runOperatorNASSecurityMatrix,
+	"operator_spn":               runOperatorSPNMatrix,
+	"nat":                        runNATMatrix,
+	"bgp_settings":               runBGPSettingsMatrix,
+	"flow_accounting":            runFlowAccountingMatrix,
+	"n3_interface":               runN3InterfaceMatrix,
+	"subscriber_usage_retention": runSubscriberUsageRetentionMatrix,
+	"radio_events_retention":     runRadioEventsRetentionMatrix,
+	"flow_reports_retention":     runFlowReportsRetentionMatrix,
+	"audit_log_retention":        runAuditLogRetentionMatrix,
 }
 
 // TestAPIMatrix exercises Create/Read/Update/Delete (and List, and the

--- a/integration/api_matrix_test.go
+++ b/integration/api_matrix_test.go
@@ -18,7 +18,16 @@ type apiMatrixRunner func(ctx context.Context, t *testing.T, c *client.Client)
 // Adding a new resource means: implement its runner in
 // api_matrix_<resource>_test.go and register it here.
 var apiMatrixResources = map[string]apiMatrixRunner{
-	"profiles": runProfilesMatrix,
+	"profiles":          runProfilesMatrix,
+	"slices":            runSlicesMatrix,
+	"data_networks":     runDataNetworksMatrix,
+	"policies":          runPoliciesMatrix,
+	"subscribers":       runSubscribersMatrix,
+	"routes":            runRoutesMatrix,
+	"bgp_peers":         runBGPPeersMatrix,
+	"users":             runUsersMatrix,
+	"api_tokens":        runAPITokensMatrix,
+	"home_network_keys": runHomeNetworkKeysMatrix,
 }
 
 // TestAPIMatrix exercises Create/Read/Update/Delete (and List, and the

--- a/integration/api_matrix_users_test.go
+++ b/integration/api_matrix_users_test.go
@@ -1,0 +1,113 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runUsersMatrix exercises full CRUD for users. Only the role_id is
+// settable via Update (internal/api/server/api_users.go:26-28); password
+// changes go through a dedicated endpoint and are out of scope here.
+//
+// The bootstrap admin (admin@ellanetworks.com from
+// tester_env_test.go:125) must not be touched, so we use a distinct
+// scoped email.
+func runUsersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	email := "apimat-user@example.com"
+
+	listAll := func() *client.ListUsersResponse {
+		resp, err := c.ListUsers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list users: %v", err)
+		}
+
+		return resp
+	}
+
+	contains := func(items []client.User, email string) bool {
+		for _, u := range items {
+			if u.Email == email {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	baseline := listAll()
+
+	createOpts := &client.CreateUserOptions{
+		Email:    email,
+		RoleID:   client.RoleReadOnly,
+		Password: "ApiMatrixPassw0rd!",
+	}
+
+	if err := c.CreateUser(ctx, createOpts); err != nil {
+		t.Fatalf("create user %q: %v", email, err)
+	}
+
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := c.DeleteUser(ctx, &client.DeleteUserOptions{Email: email}); err != nil {
+			t.Logf("cleanup: delete user %q: %v", email, err)
+		}
+	})
+
+	got, err := c.GetUser(ctx, &client.GetUserOptions{Email: email})
+	if err != nil {
+		t.Fatalf("get user %q after create: %v", email, err)
+	}
+
+	if got.Email != email || got.RoleID != createOpts.RoleID {
+		t.Fatalf("post-create round-trip mismatch: got %+v, want email=%s role=%d", got, email, createOpts.RoleID)
+	}
+
+	afterCreate := listAll()
+	if afterCreate.TotalCount != baseline.TotalCount+1 {
+		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
+	}
+
+	if !contains(afterCreate.Items, email) {
+		t.Fatalf("list after create missing %q", email)
+	}
+
+	t.Run("update_RoleID", func(t *testing.T) {
+		if err := c.UpdateUser(ctx, email, &client.UpdateUserOptions{RoleID: client.RoleNetworkManager}); err != nil {
+			t.Fatalf("update user: %v", err)
+		}
+
+		updated, err := c.GetUser(ctx, &client.GetUserOptions{Email: email})
+		if err != nil {
+			t.Fatalf("get user after update: %v", err)
+		}
+
+		if updated.RoleID != client.RoleNetworkManager {
+			t.Fatalf("RoleID: got %d, want %d", updated.RoleID, client.RoleNetworkManager)
+		}
+	})
+
+	if err := c.DeleteUser(ctx, &client.DeleteUserOptions{Email: email}); err != nil {
+		t.Fatalf("delete user %q: %v", email, err)
+	}
+
+	deleted = true
+
+	_, err = c.GetUser(ctx, &client.GetUserOptions{Email: email})
+	assertNotFound(t, err, "user after delete")
+
+	afterDelete := listAll()
+	if afterDelete.TotalCount != baseline.TotalCount {
+		t.Fatalf("list count after delete: got %d, want %d", afterDelete.TotalCount, baseline.TotalCount)
+	}
+
+	if contains(afterDelete.Items, email) {
+		t.Fatalf("list after delete still contains %q", email)
+	}
+}

--- a/integration/api_matrix_users_test.go
+++ b/integration/api_matrix_users_test.go
@@ -7,13 +7,9 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// runUsersMatrix exercises full CRUD for users. Only the role_id is
-// settable via Update (internal/api/server/api_users.go:26-28); password
-// changes go through a dedicated endpoint and are out of scope here.
-//
-// The bootstrap admin (admin@ellanetworks.com from
-// tester_env_test.go:125) must not be touched, so we use a distinct
-// scoped email.
+// runUsersMatrix uses a scoped email to keep the bootstrap admin user
+// (in use by the test client itself) untouched. Update only covers
+// role_id; password changes go through a separate endpoint.
 func runUsersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 	email := "apimat-user@example.com"
 

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -165,8 +165,8 @@ func initializeAndGetAdminToken(ctx context.Context, leader *client.Client) (str
 	}
 
 	resp, err := leader.CreateMyAPIToken(ctx, &client.CreateAPITokenOptions{
-		Name:   "ha-integration-test",
-		Expiry: "",
+		Name:      "ha-integration-test",
+		ExpiresAt: "",
 	})
 	if err != nil {
 		return "", fmt.Errorf("create API token: %w", err)

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -63,8 +63,8 @@ func configureEllaCore(ctx context.Context, cl *client.Client, c EllaCoreConfig)
 	}
 
 	createAPITokenOpts := &client.CreateAPITokenOptions{
-		Name:   "integration-test-token",
-		Expiry: "",
+		Name:      "integration-test-token",
+		ExpiresAt: "",
 	}
 
 	resp, err := cl.CreateMyAPIToken(ctx, createAPITokenOpts)


### PR DESCRIPTION
# Description

Increase coverage of integration tests by exercicing all API endpoinds via full CRUD validation in a standalone Ella Core deployment. Doing so, we identified and addressed gaps in the Go client SDK.

## Context

As we write more code with AI, the change velocity increases and we get less good at reviewing code. To balance this problem, it is critical to have a gating test suite that validate behavior. I wrote more about this topic here: [Implicit Knowledge is a Liability](https://medium.com/p/0a33442bf1a4).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
