### PR TITLE
fix: wait for FSM replay on raft startup

### DIFF
--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -334,6 +334,19 @@ func NewManager(ctx context.Context, cfg ClusterConfig, applier Applier, dataDir
 
 			return nil, err
 		}
+
+		// Post-snapshot committed entries are applied asynchronously,
+		// so the FSM can lag the durable log on startup. Barrier
+		// requires leadership, just confirmed by waitForLeader.
+		if err := m.raft.Barrier(m.ProposeTimeout()).Error(); err != nil {
+			_ = r.Shutdown().Error()
+
+			closeTransport(transport)
+
+			_ = boltStore.Close()
+
+			return nil, fmt.Errorf("post-startup barrier: %w", err)
+		}
 	}
 
 	go observer.Run(r)


### PR DESCRIPTION
# Description

After restoring from a snapshot, `hashicorp/raft` applies post-snapshot committed entries asynchronously, so `NewDatabase` could return while the FSM was still catching up — causing reads to miss committed writes. Added a Barrier() call after waitForLeader in single-server mode to block until the FSM has drained the backlog.

In practice, this lead to intermitent failure in our unit tests.

```
{"level":"info","ts":"2026-05-14T15:54:11.461Z","caller":"raft/logger.go:119","msg":"2026-05-14T15:54:11.461Z [INFO]  snapshot: creating new snapshot: path=/tmp/TestUpdatePolicyWithRules_SnapshotRestore_SurviveRestart4031759782/001/raft/snapshots/2-18-1778774051461.tmp","component":"Raft","subsystem":"snapshot"}
{"level":"info","ts":"2026-05-14T15:54:11.470Z","caller":"raft/logger.go:119","msg":"2026-05-14T15:54:11.470Z [WARN]  snapshot: failed to read metadata: name=tmp error=\"open /tmp/TestUpdatePolicyWithRules_SnapshotRestore_SurviveRestart4031759782/001/raft/snapshots/tmp/meta.json: no such file or directory\"","component":"Raft","subsystem":"snapshot"}
{"level":"info","ts":"2026-05-14T15:54:11.470Z","caller":"raft/logger.go:38","msg":"snapshot complete up to","component":"Raft","index":18}
{"level":"info","ts":"2026-05-14T15:54:11.522Z","caller":"raft/logger.go:119","msg":"2026-05-14T15:54:11.522Z [WARN]  snapshot: failed to read metadata: name=tmp error=\"open /tmp/TestUpdatePolicyWithRules_SnapshotRestore_SurviveRestart4031759782/001/raft/snapshots/tmp/meta.json: no such file or directory\"","component":"Raft","subsystem":"snapshot"}
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
