### PR TITLE
chore!: improve HA-related integration tests

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -18,10 +18,6 @@ type ClusterMember struct {
 	DrainUpdatedAt string `json:"drainUpdatedAt,omitempty"`
 }
 
-type DrainOptions struct {
-	DeadlineSeconds int `json:"deadlineSeconds,omitempty"`
-}
-
 type DrainResponse struct {
 	DrainState string `json:"drainState"`
 }
@@ -89,26 +85,15 @@ func (c *Client) GetAutopilotState(ctx context.Context) (*AutopilotState, error)
 	return &state, nil
 }
 
-// DrainClusterMember drains the given node. When opts.DeadlineSeconds > 0 the
-// server returns as soon as the drain starts (drainState "draining") and
-// finalises asynchronously when the node's last active lease clears or the
-// deadline elapses. When opts.DeadlineSeconds == 0 (default), the drain is
-// synchronous and the response drainState is "drained".
-func (c *Client) DrainClusterMember(ctx context.Context, nodeID int, opts *DrainOptions) (*DrainResponse, error) {
-	var body bytes.Buffer
-
-	if opts != nil {
-		err := json.NewEncoder(&body).Encode(opts)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+// DrainClusterMember drains the given node. The server runs the
+// node-local side-effects (AMF Status Indication, BGP stop), commits
+// drainState=drained through Raft, and transfers leadership when the
+// target is the current leader.
+func (c *Client) DrainClusterMember(ctx context.Context, nodeID int) (*DrainResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "POST",
 		Path:   fmt.Sprintf("api/v1/cluster/members/%d/drain", nodeID),
-		Body:   &body,
 	})
 	if err != nil {
 		return nil, err
@@ -124,9 +109,9 @@ func (c *Client) DrainClusterMember(ctx context.Context, nodeID int, opts *Drain
 	return &drainResp, nil
 }
 
-// ResumeClusterMember reverses a prior drain: restarts the BGP speaker
-// (if BGP is enabled) and clears drain state. AMF Status Indication and
-// transferred Raft leadership are not reversed.
+// ResumeClusterMember restarts the BGP speaker on the target (if BGP
+// is enabled) and clears drainState back to active. AMF Status
+// Indication and Raft leadership transfers are not reversed.
 func (c *Client) ResumeClusterMember(ctx context.Context, nodeID int) error {
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,

--- a/client/cluster_test.go
+++ b/client/cluster_test.go
@@ -67,7 +67,7 @@ func TestDrainClusterMember_Success(t *testing.T) {
 	}
 	c := &client.Client{Requester: fake}
 
-	resp, err := c.DrainClusterMember(context.Background(), 3, &client.DrainOptions{DeadlineSeconds: 10})
+	resp, err := c.DrainClusterMember(context.Background(), 3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,33 +85,13 @@ func TestDrainClusterMember_Success(t *testing.T) {
 	}
 }
 
-func TestDrainClusterMember_NilOpts(t *testing.T) {
-	fake := &fakeRequester{
-		response: &client.RequestResponse{
-			StatusCode: 200,
-			Headers:    http.Header{},
-			Result:     []byte(`{"drainState":"draining"}`),
-		},
-	}
-	c := &client.Client{Requester: fake}
-
-	resp, err := c.DrainClusterMember(context.Background(), 1, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if resp.DrainState != "draining" {
-		t.Errorf("expected drainState 'draining', got %s", resp.DrainState)
-	}
-}
-
 func TestDrainClusterMember_Failure(t *testing.T) {
 	fake := &fakeRequester{
 		err: errors.New("leader unavailable"),
 	}
 	c := &client.Client{Requester: fake}
 
-	_, err := c.DrainClusterMember(context.Background(), 1, nil)
+	_, err := c.DrainClusterMember(context.Background(), 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/docs/reference/api/cluster.md
+++ b/docs/reference/api/cluster.md
@@ -136,9 +136,7 @@ None
 
 ## Drain Cluster Member
 
-This path marks a node as draining and runs the local drain side-effects: transfers Raft leadership if the target is the leader, signals connected RANs that this AMF's GUAMI is unavailable, and stops the local BGP speaker. A node must be drained before it can be removed. Requires admin privileges.
-
-When `deadlineSeconds` is 0 (default), drain is synchronous and returns once `state` is `drained`. When `deadlineSeconds > 0`, the call returns `state: draining` immediately; a background watcher flips the state to `drained` once the target's active-lease count reaches zero or the deadline elapses.
+This path drains a node and persists `drainState=drained`. The server runs the local drain side-effects on the target: signals connected RANs that this AMF's GUAMI is unavailable, stops the local BGP speaker, and transfers Raft leadership when the target is the current leader. A node must be drained before it can be removed. Requires admin privileges.
 
 | Method | Path                                            |
 | ------ | ----------------------------------------------- |
@@ -146,7 +144,7 @@ When `deadlineSeconds` is 0 (default), drain is synchronous and returns once `st
 
 ### Parameters
 
-- `deadlineSeconds` (integer, optional): Seconds to wait for the node's active-lease count to reach zero. 0 = synchronous (default).
+None.
 
 ### Sample Response
 

--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -54,6 +54,7 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
     - `propose-timeout` (duration string, optional): Maximum wait for a Raft commit before the API returns 503.
     - `snapshot-interval` (duration string, optional): Minimum interval between automatic Raft snapshots.
     - `snapshot-threshold` (int, optional): Minimum number of applied log entries between automatic snapshots.
+    - `trailing-logs` (int, optional): Number of Raft log entries retained after a snapshot so a briefly-disconnected follower can catch up by log replay instead of receiving a full snapshot. Defaults to `10240`, which is correct for the vast majority of deployments. Lower it only if the Raft log is growing unboundedly under sustained write load; raise it only if followers repeatedly fall behind and trigger snapshot installs. Setting it too low on a cluster with a large database can put followers in a loop where they keep downloading snapshots and never converge.
 
 !!! note
     When you use the Ella Core snap, the configuration file is located at `/var/snap/ella-core/common/config.yaml`. After modifying the configuration file, restart Ella Core with `sudo snap restart ella-core.cored` for the changes to take effect.

--- a/integration/ha_drain_resume_test.go
+++ b/integration/ha_drain_resume_test.go
@@ -5,38 +5,20 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/ellanetworks/core/client"
 )
 
-// TestIntegrationHADrainResumeCycle exercises the drain → resume round-trip
-// that operators run for routine maintenance (kernel patch, hardware swap,
-// config push). The drain happy path is covered by
-// TestIntegrationHADrainLeadership; the resume side has no integration
-// coverage today, even though the SDK and server handler both exist.
-//
-// What this test pins:
-//
-//  1. Drain transitions a follower's drainState through draining → drained.
-//  2. Resume clears drainState back to "active".
-//  3. After resume, the node serves a fresh write that lands on the leader
-//     (proves replication still flows to the resumed node).
-//  4. Repeating the drain/resume cycle on the same node works — catches
-//     state leaks (timers, watchdogs, BGP service holding a stale flag).
-//  5. Resume on a non-drained node is idempotent (no error, no state churn).
-//
-// The test deliberately drains a follower, not the leader. Draining the
-// leader is already covered by TestIntegrationHADrainLeadership; here the
-// goal is the resume contract, which is the same regardless of whether
-// the target is a follower or a former leader.
+// TestIntegrationHADrainResumeCycle drains a follower, resumes it,
+// confirms it accepts replicated writes again, and repeats the cycle
+// to catch state leaks across successive drains. Also asserts that
+// resuming an already-active node is a no-op.
 func TestIntegrationHADrainResumeCycle(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	dockerClient, err := NewDockerClient()
 	if err != nil {
@@ -72,9 +54,6 @@ func TestIntegrationHADrainResumeCycle(t *testing.T) {
 		t.Fatalf("find follower: %v", err)
 	}
 
-	t.Logf("draining follower node %d", followerID)
-
-	// First cycle.
 	if err := drainAndAssert(ctx, leader, followerID); err != nil {
 		t.Fatalf("first drain: %v", err)
 	}
@@ -83,11 +62,6 @@ func TestIntegrationHADrainResumeCycle(t *testing.T) {
 		t.Fatalf("first resume: %v", err)
 	}
 
-	// After resume, a fresh write on the leader must still replicate to
-	// the resumed node. This is the contract operators rely on: "I
-	// drained, did maintenance, resumed, and the node is back in
-	// service." If drain accidentally left the node fenced or paused
-	// replication, this read fails.
 	const postResumeIMSI = "001019756139950"
 
 	if err := leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
@@ -118,11 +92,6 @@ func TestIntegrationHADrainResumeCycle(t *testing.T) {
 		t.Fatalf("follower returned %q, expected %q", sub.Imsi, postResumeIMSI)
 	}
 
-	// Second cycle on the same node — catches state-leak bugs where the
-	// first drain leaves residue (timer not stopped, BGP flag stuck)
-	// that breaks a subsequent drain.
-	t.Log("running second drain/resume cycle on the same node")
-
 	if err := drainAndAssert(ctx, leader, followerID); err != nil {
 		t.Fatalf("second drain: %v", err)
 	}
@@ -131,28 +100,22 @@ func TestIntegrationHADrainResumeCycle(t *testing.T) {
 		t.Fatalf("second resume: %v", err)
 	}
 
-	// Resume on an already-active node — handler short-circuits at
-	// api_drain.go:213 with 200 OK. Pin that contract: it must not error
-	// and must not flip drainState.
-	t.Log("resuming an already-active node (idempotency check)")
-
 	if err := leader.ResumeClusterMember(ctx, followerID); err != nil {
-		t.Fatalf("idempotent resume: %v", err)
+		t.Fatalf("resume on active node: %v", err)
 	}
 
 	state, err := drainStateOf(ctx, leader, followerID)
 	if err != nil {
-		t.Fatalf("read drainState after idempotent resume: %v", err)
+		t.Fatalf("read drainState after resume: %v", err)
 	}
 
 	if state != "active" {
-		t.Fatalf("drainState after idempotent resume = %q, want active", state)
+		t.Fatalf("drainState = %q, want active", state)
 	}
 
 	assertMembershipConsistent(t, ctx, clients)
 }
 
-// findFollower returns the nodeID and client of any follower in the cluster.
 func findFollower(ctx context.Context, clients []*client.Client) (int, *client.Client, error) {
 	for _, c := range clients {
 		status, err := c.GetStatus(ctx)
@@ -172,59 +135,36 @@ func findFollower(ctx context.Context, clients []*client.Client) (int, *client.C
 	return 0, nil, fmt.Errorf("no follower found")
 }
 
-// drainAndAssert drains nodeID via the leader and waits for the member
-// list (as seen from the leader) to report drainState == "drained".
 func drainAndAssert(ctx context.Context, leader *client.Client, nodeID int) error {
-	resp, err := leader.DrainClusterMember(ctx, nodeID, &client.DrainOptions{DeadlineSeconds: 30})
+	resp, err := leader.DrainClusterMember(ctx, nodeID)
 	if err != nil {
 		return fmt.Errorf("DrainClusterMember(%d): %w", nodeID, err)
 	}
 
-	if resp.DrainState != "draining" && resp.DrainState != "drained" {
-		return fmt.Errorf("immediate drainState = %q, want draining or drained", resp.DrainState)
+	if resp.DrainState != "drained" {
+		return fmt.Errorf("drainState = %q, want drained", resp.DrainState)
 	}
 
-	return waitForDrainState(ctx, leader, nodeID, "drained", 60*time.Second)
+	return nil
 }
 
-// resumeAndAssert resumes nodeID via the leader and waits for drainState
-// to return to "active".
 func resumeAndAssert(ctx context.Context, leader *client.Client, nodeID int) error {
 	if err := leader.ResumeClusterMember(ctx, nodeID); err != nil {
 		return fmt.Errorf("ResumeClusterMember(%d): %w", nodeID, err)
 	}
 
-	return waitForDrainState(ctx, leader, nodeID, "active", 30*time.Second)
-}
-
-// waitForDrainState polls ListClusterMembers on leader until the given
-// nodeID reports the desired drainState, or timeout elapses.
-func waitForDrainState(ctx context.Context, leader *client.Client, nodeID int, want string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-
-	var last string
-
-	for time.Now().Before(deadline) {
-		state, err := drainStateOf(ctx, leader, nodeID)
-		if err == nil {
-			last = state
-			if state == want {
-				return nil
-			}
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(500 * time.Millisecond):
-		}
+	state, err := drainStateOf(ctx, leader, nodeID)
+	if err != nil {
+		return err
 	}
 
-	return fmt.Errorf("node %d drainState = %q after %s, want %q", nodeID, last, timeout, want)
+	if state != "active" {
+		return fmt.Errorf("drainState after resume = %q, want active", state)
+	}
+
+	return nil
 }
 
-// drainStateOf returns the current drainState for nodeID, sourced from
-// the leader's ListClusterMembers view (the authoritative one).
 func drainStateOf(ctx context.Context, leader *client.Client, nodeID int) (string, error) {
 	members, err := leader.ListClusterMembers(ctx)
 	if err != nil {

--- a/integration/ha_drain_resume_test.go
+++ b/integration/ha_drain_resume_test.go
@@ -1,0 +1,241 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// TestIntegrationHADrainResumeCycle exercises the drain → resume round-trip
+// that operators run for routine maintenance (kernel patch, hardware swap,
+// config push). The drain happy path is covered by
+// TestIntegrationHADrainLeadership; the resume side has no integration
+// coverage today, even though the SDK and server handler both exist.
+//
+// What this test pins:
+//
+//  1. Drain transitions a follower's drainState through draining → drained.
+//  2. Resume clears drainState back to "active".
+//  3. After resume, the node serves a fresh write that lands on the leader
+//     (proves replication still flows to the resumed node).
+//  4. Repeating the drain/resume cycle on the same node works — catches
+//     state leaks (timers, watchdogs, BGP service holding a stale flag).
+//  5. Resume on a non-drained node is idempotent (no error, no state churn).
+//
+// The test deliberately drains a follower, not the leader. Draining the
+// leader is already covered by TestIntegrationHADrainLeadership; here the
+// goal is the resume contract, which is the same regardless of whether
+// the target is a follower or a former leader.
+func TestIntegrationHADrainResumeCycle(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	dockerClient, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dockerClient.Close(); err != nil {
+			t.Logf("failed to close docker client: %v", err)
+		}
+	}()
+
+	clients, err := bringUpHACluster(t, ctx, dockerClient)
+	if err != nil {
+		t.Fatalf("bring up HA cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		dumpClusterDiagnostics(t, ctx, dockerClient, haComposeDir, haNodeServices, clients)
+	})
+
+	_, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("find leader: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("nodes not ready: %v", err)
+	}
+
+	followerID, follower, err := findFollower(ctx, clients)
+	if err != nil {
+		t.Fatalf("find follower: %v", err)
+	}
+
+	t.Logf("draining follower node %d", followerID)
+
+	// First cycle.
+	if err := drainAndAssert(ctx, leader, followerID); err != nil {
+		t.Fatalf("first drain: %v", err)
+	}
+
+	if err := resumeAndAssert(ctx, leader, followerID); err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+
+	// After resume, a fresh write on the leader must still replicate to
+	// the resumed node. This is the contract operators rely on: "I
+	// drained, did maintenance, resumed, and the node is back in
+	// service." If drain accidentally left the node fenced or paused
+	// replication, this read fails.
+	const postResumeIMSI = "001019756139950"
+
+	if err := leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+		Imsi:           postResumeIMSI,
+		Key:            "0eefb0893e6f1c2855a3a244c6db1277",
+		OPc:            "98da19bbc55e2a5b53857d10557b1d26",
+		SequenceNumber: "000000000022",
+		ProfileName:    "default",
+	}); err != nil {
+		t.Fatalf("create subscriber after resume: %v", err)
+	}
+
+	idx, err := leaderAppliedIndex(ctx, leader)
+	if err != nil {
+		t.Fatalf("leader applied index: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, []*client.Client{follower}, idx); err != nil {
+		t.Fatalf("resumed follower did not converge: %v", err)
+	}
+
+	sub, err := follower.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: postResumeIMSI})
+	if err != nil {
+		t.Fatalf("read post-resume subscriber from follower: %v", err)
+	}
+
+	if sub.Imsi != postResumeIMSI {
+		t.Fatalf("follower returned %q, expected %q", sub.Imsi, postResumeIMSI)
+	}
+
+	// Second cycle on the same node — catches state-leak bugs where the
+	// first drain leaves residue (timer not stopped, BGP flag stuck)
+	// that breaks a subsequent drain.
+	t.Log("running second drain/resume cycle on the same node")
+
+	if err := drainAndAssert(ctx, leader, followerID); err != nil {
+		t.Fatalf("second drain: %v", err)
+	}
+
+	if err := resumeAndAssert(ctx, leader, followerID); err != nil {
+		t.Fatalf("second resume: %v", err)
+	}
+
+	// Resume on an already-active node — handler short-circuits at
+	// api_drain.go:213 with 200 OK. Pin that contract: it must not error
+	// and must not flip drainState.
+	t.Log("resuming an already-active node (idempotency check)")
+
+	if err := leader.ResumeClusterMember(ctx, followerID); err != nil {
+		t.Fatalf("idempotent resume: %v", err)
+	}
+
+	state, err := drainStateOf(ctx, leader, followerID)
+	if err != nil {
+		t.Fatalf("read drainState after idempotent resume: %v", err)
+	}
+
+	if state != "active" {
+		t.Fatalf("drainState after idempotent resume = %q, want active", state)
+	}
+
+	assertMembershipConsistent(t, ctx, clients)
+}
+
+// findFollower returns the nodeID and client of any follower in the cluster.
+func findFollower(ctx context.Context, clients []*client.Client) (int, *client.Client, error) {
+	for _, c := range clients {
+		status, err := c.GetStatus(ctx)
+		if err != nil {
+			continue
+		}
+
+		if status.Cluster == nil {
+			continue
+		}
+
+		if status.Cluster.Role == "Follower" {
+			return status.Cluster.NodeID, c, nil
+		}
+	}
+
+	return 0, nil, fmt.Errorf("no follower found")
+}
+
+// drainAndAssert drains nodeID via the leader and waits for the member
+// list (as seen from the leader) to report drainState == "drained".
+func drainAndAssert(ctx context.Context, leader *client.Client, nodeID int) error {
+	resp, err := leader.DrainClusterMember(ctx, nodeID, &client.DrainOptions{DeadlineSeconds: 30})
+	if err != nil {
+		return fmt.Errorf("DrainClusterMember(%d): %w", nodeID, err)
+	}
+
+	if resp.DrainState != "draining" && resp.DrainState != "drained" {
+		return fmt.Errorf("immediate drainState = %q, want draining or drained", resp.DrainState)
+	}
+
+	return waitForDrainState(ctx, leader, nodeID, "drained", 60*time.Second)
+}
+
+// resumeAndAssert resumes nodeID via the leader and waits for drainState
+// to return to "active".
+func resumeAndAssert(ctx context.Context, leader *client.Client, nodeID int) error {
+	if err := leader.ResumeClusterMember(ctx, nodeID); err != nil {
+		return fmt.Errorf("ResumeClusterMember(%d): %w", nodeID, err)
+	}
+
+	return waitForDrainState(ctx, leader, nodeID, "active", 30*time.Second)
+}
+
+// waitForDrainState polls ListClusterMembers on leader until the given
+// nodeID reports the desired drainState, or timeout elapses.
+func waitForDrainState(ctx context.Context, leader *client.Client, nodeID int, want string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	var last string
+
+	for time.Now().Before(deadline) {
+		state, err := drainStateOf(ctx, leader, nodeID)
+		if err == nil {
+			last = state
+			if state == want {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	return fmt.Errorf("node %d drainState = %q after %s, want %q", nodeID, last, timeout, want)
+}
+
+// drainStateOf returns the current drainState for nodeID, sourced from
+// the leader's ListClusterMembers view (the authoritative one).
+func drainStateOf(ctx context.Context, leader *client.Client, nodeID int) (string, error) {
+	members, err := leader.ListClusterMembers(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list members: %w", err)
+	}
+
+	for _, m := range members {
+		if m.NodeID == nodeID {
+			return m.DrainState, nil
+		}
+	}
+
+	return "", fmt.Errorf("node %d not in cluster members", nodeID)
+}

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -468,6 +468,11 @@ func leaderAppliedIndex(ctx context.Context, leader *client.Client) (uint64, err
 
 // waitForMemberSuffrage polls ListClusterMembers until the given nodeID
 // appears with the expected suffrage value (e.g. "nonvoter" or "voter").
+//
+// scale-up join target); the helper is intentionally general so future
+// tests targeting other node IDs don't need a parallel helper.
+//
+//nolint:unparam // nodeID happens to be 4 for every existing caller (the
 func waitForMemberSuffrage(ctx context.Context, c *client.Client, nodeID int, wantSuffrage string) error {
 	timeout := 2 * time.Minute
 	deadline := time.Now().Add(timeout)

--- a/integration/ha_remove_leader_test.go
+++ b/integration/ha_remove_leader_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -10,29 +11,10 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// TestIntegrationHARemoveLeader exercises the common operator workflow
-// "retire the current leader." Today the only remove-member coverage is
-// TestIntegrationHAScaleUpDown, which removes the joiner (node 4), never
-// the leader. This test pins the contract operators rely on when they
-// decommission the node that happens to be leader at the moment.
-//
-// What this test pins:
-//
-//  1. Drain on the leader transfers leadership; a new leader emerges.
-//  2. RemoveClusterMember(leaderID) succeeds after the drain.
-//  3. Writes against the survivors continue throughout the transition
-//     with bounded transient errors and zero permanent failures.
-//  4. The removed leader is fenced from accepting writes against itself
-//     (matches the scale-down fence assertion).
-//  5. Cluster_members reports exactly 2 members after the operation,
-//     consistent across survivors.
-//  6. The 2-node survivor cluster is steady-state writable.
-//
-// The background writer targets only the surviving nodes so write
-// attempts against the soon-to-be-removed leader are not counted; the
-// removed leader's fence behaviour is asserted separately. This keeps
-// the test's transient-error bound focused on the genuine leadership-
-// transition window rather than on requests routed to a doomed peer.
+// TestIntegrationHARemoveLeader drains and removes the current leader,
+// then asserts that the cluster shrinks to 2 members, stays writable
+// throughout, and that the removed node is fenced from accepting
+// writes against itself.
 func TestIntegrationHARemoveLeader(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
@@ -77,12 +59,11 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 
 	leaderNodeID := leaderStatus.Cluster.NodeID
 
-	t.Logf("removing leader: nodeID=%d (clients[%d])", leaderNodeID, leaderIdx)
-
-	// Build the survivor client slice — every client except the current
-	// leader. Round-robin writes against these continue across the
-	// drain/remove transition without ever hitting the doomed peer's
-	// fence (which would surface as a permanent 502).
+	// The background writer cycles only over the surviving nodes: the
+	// HA client retries on 503 but not on 502 (the removed-node fence),
+	// so routing writes to the doomed leader would surface a permanent
+	// error that operators would have steered around with their own
+	// load-balancer.
 	survivors := make([]*client.Client, 0, len(clients)-1)
 
 	for i, c := range clients {
@@ -91,24 +72,20 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 		}
 	}
 
-	// Start the background writer before any membership change. IMSI
-	// base is disjoint from every other HA test's range.
 	writer := startSubscriberWriter(t, ctx, survivors, "001019756160000")
 
-	// Phase 1: drain the leader. DrainClusterMember on the leader
-	// transfers leadership; the existing TestIntegrationHADrainLeadership
-	// proves this in isolation. Here it's a precondition for the
-	// remove call (Remove without drain returns 4xx unless force=true,
-	// per client/cluster.go:157-178).
-	drainResp, err := leader.DrainClusterMember(ctx, leaderNodeID, &client.DrainOptions{DeadlineSeconds: 30})
+	const observationWindow = 3 * time.Second
+	time.Sleep(observationWindow)
+
+	drainResp, err := leader.DrainClusterMember(ctx, leaderNodeID)
 	if err != nil {
 		writer.stop()
 		t.Fatalf("drain leader: %v", err)
 	}
 
-	if drainResp.DrainState != "draining" && drainResp.DrainState != "drained" {
+	if drainResp.DrainState != "drained" {
 		writer.stop()
-		t.Fatalf("post-drain state = %q, want draining or drained", drainResp.DrainState)
+		t.Fatalf("drainState = %q, want drained", drainResp.DrainState)
 	}
 
 	newLeader, err := waitForNewLeader(ctx, survivors)
@@ -116,15 +93,6 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 		writer.stop()
 		t.Fatalf("no new leader after drain: %v", err)
 	}
-
-	if err := waitForDrainState(ctx, newLeader, leaderNodeID, "drained", 60*time.Second); err != nil {
-		writer.stop()
-		t.Fatalf("former leader did not reach drained state: %v", err)
-	}
-
-	// Phase 2: remove the (now-drained, no-longer-leader) member from
-	// the raft configuration.
-	t.Logf("removing former leader nodeID=%d from cluster", leaderNodeID)
 
 	if err := newLeader.RemoveClusterMember(ctx, leaderNodeID, false); err != nil {
 		writer.stop()
@@ -136,8 +104,8 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 		t.Fatalf("cluster did not shrink to 2 members: %v", err)
 	}
 
-	// Phase 3: stop the writer and validate. Some transient errors are
-	// expected during the leadership transition; permanent errors are not.
+	time.Sleep(observationWindow)
+
 	report, werr := writer.stopAndReport()
 	if werr != nil {
 		t.Fatalf("background writer reported a permanent failure: %v", werr)
@@ -146,21 +114,20 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 	t.Logf("background writer: success=%d transient=%d attempts=%d",
 		report.success, report.transient, report.attempts)
 
-	if report.success == 0 {
-		t.Fatal("zero successful writes during leader-remove window; cluster was permanently unwriteable")
+	const minAttempts = 20
+	if report.attempts < minAttempts {
+		t.Fatalf("writer attempts=%d (< %d); steady-state property not exercised",
+			report.attempts, minAttempts)
 	}
 
-	// Cap transient errors at half the total attempts. The leadership-
-	// transfer window is bounded (election timeout + a few RPC retries)
-	// so the steady-state survivor writes after that window should
-	// dominate.
+	if report.success == 0 {
+		t.Fatal("zero successful writes; cluster was unwriteable")
+	}
+
 	if report.transient > report.attempts/2 {
 		t.Fatalf("transient error rate too high: %d/%d", report.transient, report.attempts)
 	}
 
-	// Phase 4: the removed leader's API must reject writes against
-	// itself (matches the existing scale-down fence assertion in
-	// TestIntegrationHAScaleUpDown).
 	if _, err := leader.GetStatus(ctx); err != nil {
 		t.Fatalf("removed leader unreachable, cannot exercise fence: %v", err)
 	}
@@ -175,18 +142,14 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 		ProfileName:    "default",
 	}); err == nil {
 		t.Fatal("CreateSubscriber via removed leader succeeded; fence regression")
-	} else {
-		t.Logf("write via removed leader correctly rejected: %v", err)
 	}
 
 	if _, err := newLeader.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: fencedIMSI}); err == nil {
 		t.Fatal("subscriber written via removed leader landed on the cluster; fence is broken")
 	} else if !isExpectedNotFound(err) {
-		t.Logf("unexpected error reading fenced IMSI (acceptable but worth logging): %v", err)
+		t.Logf("unexpected error reading fenced IMSI: %v", err)
 	}
 
-	// Phase 5: cluster_members consistent across the 2 survivors and
-	// the surviving 2-node cluster accepts a fresh steady-state write.
 	assertMembershipConsistent(t, ctx, survivors)
 
 	const postRemoveIMSI = "001019756161000"
@@ -207,12 +170,10 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 	}
 
 	if err := waitForFollowerConvergence(ctx, survivors, idx); err != nil {
-		t.Fatalf("surviving follower did not converge after steady-state write: %v", err)
+		t.Fatalf("surviving follower did not converge: %v", err)
 	}
 }
 
-// waitForMemberCount polls ListClusterMembers on c until the count
-// matches want, or timeout elapses.
 func waitForMemberCount(ctx context.Context, c *client.Client, want int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
@@ -234,50 +195,9 @@ func waitForMemberCount(ctx context.Context, c *client.Client, want int, timeout
 		}
 	}
 
-	return &memberCountError{want: want, got: last, timeout: timeout}
+	return fmt.Errorf("expected %d members, got %d after %s", want, last, timeout)
 }
 
-type memberCountError struct {
-	want, got int
-	timeout   time.Duration
-}
-
-func (e *memberCountError) Error() string {
-	return "expected " + itoaInt(e.want) + " members, got " + itoaInt(e.got) + " after " + e.timeout.String()
-}
-
-func itoaInt(n int) string {
-	if n == 0 {
-		return "0"
-	}
-
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-
-	var buf [20]byte
-
-	i := len(buf)
-
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-
-	return string(buf[i:])
-}
-
-// isExpectedNotFound matches the "subscriber doesn't exist" error
-// returned by GetSubscriber. The fence assertion above prefers this
-// over a stricter equality check because the error text passes through
-// multiple wrapping layers.
 func isExpectedNotFound(err error) bool {
 	if err == nil {
 		return false

--- a/integration/ha_remove_leader_test.go
+++ b/integration/ha_remove_leader_test.go
@@ -1,0 +1,289 @@
+package integration_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// TestIntegrationHARemoveLeader exercises the common operator workflow
+// "retire the current leader." Today the only remove-member coverage is
+// TestIntegrationHAScaleUpDown, which removes the joiner (node 4), never
+// the leader. This test pins the contract operators rely on when they
+// decommission the node that happens to be leader at the moment.
+//
+// What this test pins:
+//
+//  1. Drain on the leader transfers leadership; a new leader emerges.
+//  2. RemoveClusterMember(leaderID) succeeds after the drain.
+//  3. Writes against the survivors continue throughout the transition
+//     with bounded transient errors and zero permanent failures.
+//  4. The removed leader is fenced from accepting writes against itself
+//     (matches the scale-down fence assertion).
+//  5. Cluster_members reports exactly 2 members after the operation,
+//     consistent across survivors.
+//  6. The 2-node survivor cluster is steady-state writable.
+//
+// The background writer targets only the surviving nodes so write
+// attempts against the soon-to-be-removed leader are not counted; the
+// removed leader's fence behaviour is asserted separately. This keeps
+// the test's transient-error bound focused on the genuine leadership-
+// transition window rather than on requests routed to a doomed peer.
+func TestIntegrationHARemoveLeader(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	dockerClient, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dockerClient.Close(); err != nil {
+			t.Logf("failed to close docker client: %v", err)
+		}
+	}()
+
+	clients, err := bringUpHACluster(t, ctx, dockerClient)
+	if err != nil {
+		t.Fatalf("bring up HA cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		dumpClusterDiagnostics(t, ctx, dockerClient, haComposeDir, haNodeServices, clients)
+	})
+
+	leaderIdx, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("find leader: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("nodes not ready: %v", err)
+	}
+
+	leaderStatus, err := leader.GetStatus(ctx)
+	if err != nil || leaderStatus.Cluster == nil {
+		t.Fatalf("read leader status: %v", err)
+	}
+
+	leaderNodeID := leaderStatus.Cluster.NodeID
+
+	t.Logf("removing leader: nodeID=%d (clients[%d])", leaderNodeID, leaderIdx)
+
+	// Build the survivor client slice — every client except the current
+	// leader. Round-robin writes against these continue across the
+	// drain/remove transition without ever hitting the doomed peer's
+	// fence (which would surface as a permanent 502).
+	survivors := make([]*client.Client, 0, len(clients)-1)
+
+	for i, c := range clients {
+		if i != leaderIdx {
+			survivors = append(survivors, c)
+		}
+	}
+
+	// Start the background writer before any membership change. IMSI
+	// base is disjoint from every other HA test's range.
+	writer := startSubscriberWriter(t, ctx, survivors, "001019756160000")
+
+	// Phase 1: drain the leader. DrainClusterMember on the leader
+	// transfers leadership; the existing TestIntegrationHADrainLeadership
+	// proves this in isolation. Here it's a precondition for the
+	// remove call (Remove without drain returns 4xx unless force=true,
+	// per client/cluster.go:157-178).
+	drainResp, err := leader.DrainClusterMember(ctx, leaderNodeID, &client.DrainOptions{DeadlineSeconds: 30})
+	if err != nil {
+		writer.stop()
+		t.Fatalf("drain leader: %v", err)
+	}
+
+	if drainResp.DrainState != "draining" && drainResp.DrainState != "drained" {
+		writer.stop()
+		t.Fatalf("post-drain state = %q, want draining or drained", drainResp.DrainState)
+	}
+
+	newLeader, err := waitForNewLeader(ctx, survivors)
+	if err != nil {
+		writer.stop()
+		t.Fatalf("no new leader after drain: %v", err)
+	}
+
+	if err := waitForDrainState(ctx, newLeader, leaderNodeID, "drained", 60*time.Second); err != nil {
+		writer.stop()
+		t.Fatalf("former leader did not reach drained state: %v", err)
+	}
+
+	// Phase 2: remove the (now-drained, no-longer-leader) member from
+	// the raft configuration.
+	t.Logf("removing former leader nodeID=%d from cluster", leaderNodeID)
+
+	if err := newLeader.RemoveClusterMember(ctx, leaderNodeID, false); err != nil {
+		writer.stop()
+		t.Fatalf("RemoveClusterMember(%d): %v", leaderNodeID, err)
+	}
+
+	if err := waitForMemberCount(ctx, newLeader, 2, 60*time.Second); err != nil {
+		writer.stop()
+		t.Fatalf("cluster did not shrink to 2 members: %v", err)
+	}
+
+	// Phase 3: stop the writer and validate. Some transient errors are
+	// expected during the leadership transition; permanent errors are not.
+	report, werr := writer.stopAndReport()
+	if werr != nil {
+		t.Fatalf("background writer reported a permanent failure: %v", werr)
+	}
+
+	t.Logf("background writer: success=%d transient=%d attempts=%d",
+		report.success, report.transient, report.attempts)
+
+	if report.success == 0 {
+		t.Fatal("zero successful writes during leader-remove window; cluster was permanently unwriteable")
+	}
+
+	// Cap transient errors at half the total attempts. The leadership-
+	// transfer window is bounded (election timeout + a few RPC retries)
+	// so the steady-state survivor writes after that window should
+	// dominate.
+	if report.transient > report.attempts/2 {
+		t.Fatalf("transient error rate too high: %d/%d", report.transient, report.attempts)
+	}
+
+	// Phase 4: the removed leader's API must reject writes against
+	// itself (matches the existing scale-down fence assertion in
+	// TestIntegrationHAScaleUpDown).
+	if _, err := leader.GetStatus(ctx); err != nil {
+		t.Fatalf("removed leader unreachable, cannot exercise fence: %v", err)
+	}
+
+	const fencedIMSI = "001019756160999"
+
+	if err := leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+		Imsi:           fencedIMSI,
+		Key:            "0eefb0893e6f1c2855a3a244c6db1277",
+		OPc:            "98da19bbc55e2a5b53857d10557b1d26",
+		SequenceNumber: "000000000022",
+		ProfileName:    "default",
+	}); err == nil {
+		t.Fatal("CreateSubscriber via removed leader succeeded; fence regression")
+	} else {
+		t.Logf("write via removed leader correctly rejected: %v", err)
+	}
+
+	if _, err := newLeader.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: fencedIMSI}); err == nil {
+		t.Fatal("subscriber written via removed leader landed on the cluster; fence is broken")
+	} else if !isExpectedNotFound(err) {
+		t.Logf("unexpected error reading fenced IMSI (acceptable but worth logging): %v", err)
+	}
+
+	// Phase 5: cluster_members consistent across the 2 survivors and
+	// the surviving 2-node cluster accepts a fresh steady-state write.
+	assertMembershipConsistent(t, ctx, survivors)
+
+	const postRemoveIMSI = "001019756161000"
+
+	if err := newLeader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+		Imsi:           postRemoveIMSI,
+		Key:            "0eefb0893e6f1c2855a3a244c6db1277",
+		OPc:            "98da19bbc55e2a5b53857d10557b1d26",
+		SequenceNumber: "000000000022",
+		ProfileName:    "default",
+	}); err != nil {
+		t.Fatalf("steady-state write on 2-node cluster: %v", err)
+	}
+
+	idx, err := leaderAppliedIndex(ctx, newLeader)
+	if err != nil {
+		t.Fatalf("leader applied index: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, survivors, idx); err != nil {
+		t.Fatalf("surviving follower did not converge after steady-state write: %v", err)
+	}
+}
+
+// waitForMemberCount polls ListClusterMembers on c until the count
+// matches want, or timeout elapses.
+func waitForMemberCount(ctx context.Context, c *client.Client, want int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	var last int
+
+	for time.Now().Before(deadline) {
+		members, err := c.ListClusterMembers(ctx)
+		if err == nil {
+			last = len(members)
+			if last == want {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	return &memberCountError{want: want, got: last, timeout: timeout}
+}
+
+type memberCountError struct {
+	want, got int
+	timeout   time.Duration
+}
+
+func (e *memberCountError) Error() string {
+	return "expected " + itoaInt(e.want) + " members, got " + itoaInt(e.got) + " after " + e.timeout.String()
+}
+
+func itoaInt(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+
+	var buf [20]byte
+
+	i := len(buf)
+
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+
+	return string(buf[i:])
+}
+
+// isExpectedNotFound matches the "subscriber doesn't exist" error
+// returned by GetSubscriber. The fence assertion above prefers this
+// over a stricter equality check because the error text passes through
+// multiple wrapping layers.
+func isExpectedNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "404")
+}

--- a/integration/ha_snapshot_test.go
+++ b/integration/ha_snapshot_test.go
@@ -1,0 +1,516 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// TestIntegrationHASnapshotInstallOnNewJoiner exercises the end-to-end
+// Raft snapshot pipeline: Snapshot → Persist → store → InstallSnapshot
+// RPC → Restore → Reopen → resume Apply.
+//
+// Steps:
+//
+//  1. Bring up a 3-node cluster with aggressive snapshot tunables
+//     (snapshot-threshold=50, trailing-logs=5, snapshot-interval=2s).
+//     Low TrailingLogs is essential: without it, hashicorp/raft retains
+//     10240 trailing log entries after each snapshot, and a fresh joiner
+//     could catch up via log replay alone — never exercising
+//     InstallSnapshot.
+//
+//  2. Write ~150 subscribers on the leader, deliberately overshooting
+//     the snapshot threshold so the periodic check fires at least one
+//     snapshot AND the log gets truncated past the joiner's nextIndex.
+//
+//  3. Add a 4th node as nonvoter, then promote.
+//
+//  4. Assert two things:
+//     a. The joiner's /data/raft/snapshots/ directory contains at least
+//     one snapshot directory. A node can only have a snapshot file
+//     from either taking one itself (impossible inside the 2s window
+//     between join and the assertion: it has not written anything,
+//     so its post-restore log-since-last-snapshot is 0) or receiving
+//     InstallSnapshot. Presence ⇒ InstallSnapshot fired.
+//     b. The joiner can serve a read of a pre-snapshot subscriber
+//     directly (no proxy to leader), proving the snapshot's data
+//     landed in its local SQLite.
+//
+//  5. Continue writing on the leader and assert the joiner keeps up
+//     (post-snapshot log replay after Restore).
+func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	// Snapshot test reuses the 4-service scaleup topology; the only
+	// thing that changes is per-node core.yaml content.
+	const composeDir = "compose/ha-scaleup/"
+
+	ipFamily := DetectIPFamily()
+	t.Logf("Running HA snapshot install test in %s mode", ipFamily)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	dockerClient, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dockerClient.Close(); err != nil {
+			t.Logf("failed to close docker client: %v", err)
+		}
+	}()
+
+	composeFile := ComposeFile()
+
+	dockerClient.ComposeCleanup(ctx)
+	t.Cleanup(func() {
+		dockerClient.ComposeDownWithFile(ctx, composeDir, composeFile)
+	})
+
+	t.Log("bringing up 3-node cluster with aggressive snapshot tunables")
+
+	// Include node 4's peer in every config from the start so the joiner
+	// doesn't need a separate config rewrite of existing nodes.
+	fullPeers := []string{
+		ClusterAddressWithPort(1, 7000),
+		ClusterAddressWithPort(2, 7000),
+		ClusterAddressWithPort(3, 7000),
+		ClusterAddressWithPort(4, 7000),
+	}
+
+	snapshotCfg := snapshotTunables{
+		Interval:     "2s",
+		Threshold:    50,
+		TrailingLogs: 5,
+	}
+
+	clients, err := bringUpHASnapshotCluster(t, ctx, dockerClient, composeDir, fullPeers, snapshotCfg)
+	if err != nil {
+		t.Fatalf("bring up 3-node cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		dumpClusterDiagnostics(t, ctx, dockerClient, composeDir, haNodeServices, clients)
+	})
+
+	_, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("failed to find leader: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("not all nodes became ready: %v", err)
+	}
+
+	// Phase 1: write enough subscribers to force a snapshot + log truncation.
+	const preJoinSubscribers = 150
+
+	t.Logf("writing %d subscribers to force snapshot + log truncation", preJoinSubscribers)
+
+	preJoinIMSIs := make([]string, 0, preJoinSubscribers)
+
+	for i := 0; i < preJoinSubscribers; i++ {
+		imsi := snapshotIMSI(i)
+		preJoinIMSIs = append(preJoinIMSIs, imsi)
+
+		if err := leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+			Imsi:           imsi,
+			Key:            "0eefb0893e6f1c2855a3a244c6db1277",
+			OPc:            "98da19bbc55e2a5b53857d10557b1d26",
+			SequenceNumber: "000000000022",
+			ProfileName:    "default",
+		}); err != nil {
+			t.Fatalf("create subscriber %q (i=%d): %v", imsi, i, err)
+		}
+	}
+
+	preJoinIdx, err := leaderAppliedIndex(ctx, leader)
+	if err != nil {
+		t.Fatalf("get leader applied index: %v", err)
+	}
+
+	t.Logf("leader applied index after pre-join writes: %d", preJoinIdx)
+
+	if err := waitForFollowerConvergence(ctx, clients, preJoinIdx); err != nil {
+		t.Fatalf("followers did not converge after pre-join writes: %v", err)
+	}
+
+	// Wait long enough for the periodic snapshot check (interval=2s) to
+	// fire at least once after the threshold was crossed.
+	t.Log("waiting for leader to take a snapshot")
+
+	leaderContainer, err := dockerClient.ResolveComposeContainer(ctx, "ha-scaleup", "ella-core-1")
+	if err != nil {
+		t.Fatalf("resolve leader container: %v", err)
+	}
+
+	if err := waitForSnapshotFile(ctx, dockerClient, leaderContainer, 30*time.Second); err != nil {
+		t.Fatalf("leader did not take a snapshot: %v", err)
+	}
+
+	t.Log("leader has at least one snapshot on disk; staging + starting node 4 as nonvoter")
+
+	if err := stageAndStartJoinerWithSnapshotConfig(ctx, dockerClient, leader, composeDir,
+		"ella-core-4", 4, fullPeers, "nonvoter", snapshotCfg); err != nil {
+		t.Fatalf("stage + start node 4: %v", err)
+	}
+
+	node4URL := APIAddressForCluster(4)
+
+	node4Client, err := newInsecureClient(node4URL)
+	if err != nil {
+		t.Fatalf("client for node 4: %v", err)
+	}
+
+	node4Client.SetToken(clients[0].GetToken())
+
+	if err := waitForMemberSuffrage(ctx, leader, 4, "nonvoter"); err != nil {
+		t.Fatalf("node 4 did not join as nonvoter: %v", err)
+	}
+
+	t.Log("node 4 joined as nonvoter; promoting to voter")
+
+	if err := leader.PromoteClusterMember(ctx, 4); err != nil {
+		t.Fatalf("promote node 4: %v", err)
+	}
+
+	if err := waitForMemberSuffrage(ctx, leader, 4, "voter"); err != nil {
+		t.Fatalf("node 4 did not become voter: %v", err)
+	}
+
+	// Wait for node 4 to catch up to the pre-join index. This is the
+	// path under test: the leader's log no longer contains entries
+	// before (snapshotIndex - trailingLogs), so node 4 must receive
+	// InstallSnapshot.
+	if err := waitForFollowerConvergence(ctx, []*client.Client{node4Client}, preJoinIdx); err != nil {
+		t.Fatalf("node 4 did not converge to pre-join index %d: %v", preJoinIdx, err)
+	}
+
+	t.Logf("node 4 converged to applied index %d", preJoinIdx)
+
+	// Assertion (a): node 4 has a snapshot directory on disk. It cannot
+	// have generated one itself yet — it just joined, has done zero
+	// writes locally, and the snapshot threshold check uses logs-since-
+	// last-snapshot which is at most a handful of replicated entries
+	// since Restore reset its counter. Any snapshot file therefore came
+	// from InstallSnapshot.
+	node4Container, err := dockerClient.ResolveComposeContainer(ctx, "ha-scaleup", "ella-core-4")
+	if err != nil {
+		t.Fatalf("resolve node 4 container: %v", err)
+	}
+
+	if err := assertSnapshotInstalled(ctx, dockerClient, node4Container); err != nil {
+		t.Fatalf("InstallSnapshot did not fire on node 4: %v", err)
+	}
+
+	t.Log("node 4 has snapshot directory on disk — InstallSnapshot path exercised")
+
+	// Assertion (b): a representative sample of pre-snapshot subscribers
+	// is readable from node 4 directly (read goes to local FSM, not
+	// proxied to leader). Sampling the first, middle, and last covers
+	// rows that were written well before any snapshot AND rows that
+	// straddle the snapshot boundary.
+	for _, idx := range []int{0, preJoinSubscribers / 2, preJoinSubscribers - 1} {
+		imsi := preJoinIMSIs[idx]
+
+		sub, err := node4Client.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsi})
+		if err != nil {
+			t.Fatalf("read pre-snapshot subscriber %q from node 4: %v", imsi, err)
+		}
+
+		if sub.Imsi != imsi {
+			t.Fatalf("node 4 returned IMSI %q, expected %q", sub.Imsi, imsi)
+		}
+	}
+
+	t.Log("node 4 served pre-snapshot reads locally; writing more entries to exercise post-snapshot replay")
+
+	// Phase 2: continue writing on the leader and verify node 4 keeps
+	// up. This validates the post-Restore Apply path: after Restore
+	// resets the FSM, subsequent committed log entries must still apply.
+	const postJoinSubscribers = 50
+
+	for i := 0; i < postJoinSubscribers; i++ {
+		imsi := snapshotIMSI(preJoinSubscribers + i)
+
+		if err := leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+			Imsi:           imsi,
+			Key:            "0eefb0893e6f1c2855a3a244c6db1277",
+			OPc:            "98da19bbc55e2a5b53857d10557b1d26",
+			SequenceNumber: "000000000022",
+			ProfileName:    "default",
+		}); err != nil {
+			t.Fatalf("create post-join subscriber %q (i=%d): %v", imsi, i, err)
+		}
+	}
+
+	postJoinIdx, err := leaderAppliedIndex(ctx, leader)
+	if err != nil {
+		t.Fatalf("get leader applied index post-join: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, []*client.Client{node4Client}, postJoinIdx); err != nil {
+		t.Fatalf("node 4 did not converge post-join: %v", err)
+	}
+
+	lastIMSI := snapshotIMSI(preJoinSubscribers + postJoinSubscribers - 1)
+
+	sub, err := node4Client.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: lastIMSI})
+	if err != nil {
+		t.Fatalf("read post-snapshot subscriber %q from node 4: %v", lastIMSI, err)
+	}
+
+	if sub.Imsi != lastIMSI {
+		t.Fatalf("node 4 returned post-snapshot IMSI %q, expected %q", sub.Imsi, lastIMSI)
+	}
+
+	t.Log("node 4 served post-snapshot reads locally; snapshot install + replay validated")
+
+	assertMembershipConsistent(t, ctx, clients)
+}
+
+// snapshotIMSI returns a deterministic 15-digit IMSI for index i.
+// Range chosen to be disjoint from IMSIs used by other HA tests.
+func snapshotIMSI(i int) string {
+	return fmt.Sprintf("00101975614%04d", i)
+}
+
+// snapshotTunables are the three knobs that govern when Raft snapshots
+// fire and how aggressively the log is truncated afterwards. Test-only
+// values are deliberately low — production defaults would never produce
+// a snapshot in the lifetime of an integration test.
+type snapshotTunables struct {
+	Interval     string
+	Threshold    uint64
+	TrailingLogs uint64
+}
+
+// bringUpHASnapshotCluster mirrors bringUpHAClusterAt but writes each
+// node's core.yaml via writeSnapshotNodeConfig so the snapshot tunables
+// take effect from process start. Returns admin-authed clients for the
+// 3 initial nodes (node 4 is started later by the test body).
+func bringUpHASnapshotCluster(t *testing.T, ctx context.Context, dc *DockerClient, composeDir string, peers []string, cfg snapshotTunables) ([]*client.Client, error) {
+	t.Helper()
+
+	dc.ComposeCleanup(ctx)
+
+	services := haNodeServices
+
+	fail := func(err error) ([]*client.Client, error) {
+		captureClusterLogs(t, dc, composeDir, services)
+		return nil, err
+	}
+
+	if err := writeSnapshotNodeConfig(composeDir, 1, peers, "", "", cfg); err != nil {
+		return fail(err)
+	}
+
+	composeFile := ComposeFile()
+
+	if err := dc.ComposeUpServicesWithFile(ctx, composeDir, composeFile, services[0]); err != nil {
+		return fail(fmt.Errorf("start node 1: %w", err))
+	}
+
+	node1, err := newInsecureClient(getHANodeURLs()[0])
+	if err != nil {
+		return fail(err)
+	}
+
+	if err := waitForNodeReady(ctx, node1); err != nil {
+		return fail(fmt.Errorf("node 1 never became ready: %w", err))
+	}
+
+	adminToken, err := initializeAndGetAdminToken(ctx, node1)
+	if err != nil {
+		return fail(err)
+	}
+
+	node1.SetToken(adminToken)
+
+	for i := 1; i < len(services); i++ {
+		nodeID := i + 1
+
+		if err := stageAndStartJoinerWithSnapshotConfig(ctx, dc, node1, composeDir,
+			services[i], nodeID, peers, "", cfg); err != nil {
+			return fail(err)
+		}
+	}
+
+	clients, err := newHANodeClients()
+	if err != nil {
+		return fail(err)
+	}
+
+	for _, c := range clients {
+		c.SetToken(adminToken)
+	}
+
+	if err := waitForClusterReady(ctx, clients); err != nil {
+		return fail(fmt.Errorf("cluster not ready: %w", err))
+	}
+
+	return clients, nil
+}
+
+// stageAndStartJoinerWithSnapshotConfig mints a join token, writes the
+// joiner's core.yaml with both the token and the snapshot tunables,
+// then starts the service.
+func stageAndStartJoinerWithSnapshotConfig(ctx context.Context, dc *DockerClient, leader *client.Client, composeDir, service string, nodeID int, peers []string, initialSuffrage string, cfg snapshotTunables) error {
+	tok, err := leader.MintClusterJoinToken(ctx, &client.MintJoinTokenOptions{
+		NodeID:     nodeID,
+		TTLSeconds: 600,
+	})
+	if err != nil {
+		return fmt.Errorf("mint join token for node %d: %w", nodeID, err)
+	}
+
+	if err := writeSnapshotNodeConfig(composeDir, nodeID, peers, tok.Token, initialSuffrage, cfg); err != nil {
+		return err
+	}
+
+	return dc.ComposeUpServicesWithFile(ctx, composeDir, ComposeFile(), service)
+}
+
+// writeSnapshotNodeConfig is writeNodeConfig + the three snapshot knobs.
+// Kept local to this file because no other test cares about these knobs;
+// folding them into the shared helper would clutter every other call site.
+func writeSnapshotNodeConfig(composeDir string, nodeID int, peers []string, joinToken, initialSuffrage string, cfg snapshotTunables) error {
+	cfgDir, err := filepath.Abs(filepath.Join(composeDir, "cfg", fmt.Sprintf("node%d", nodeID)))
+	if err != nil {
+		return fmt.Errorf("abs path %s: %w", composeDir, err)
+	}
+
+	if err := os.MkdirAll(cfgDir, 0o777); err != nil {
+		return fmt.Errorf("mkdir %s: %w", cfgDir, err)
+	}
+
+	if err := os.Chmod(cfgDir, 0o777); err != nil {
+		return fmt.Errorf("chmod %s: %w", cfgDir, err)
+	}
+
+	addr := ClusterAddress(nodeID)
+
+	var peersYAML strings.Builder
+
+	for _, p := range peers {
+		fmt.Fprintf(&peersYAML, "      - %q\n", p)
+	}
+
+	joinTokenLine := ""
+	if joinToken != "" {
+		joinTokenLine = fmt.Sprintf("  join-token: %q\n", joinToken)
+	}
+
+	suffrageLine := ""
+	if initialSuffrage != "" {
+		suffrageLine = fmt.Sprintf("  initial-suffrage: %q\n", initialSuffrage)
+	}
+
+	body := fmt.Sprintf(`logging:
+  system:
+    level: "debug"
+    output: "stdout"
+  audit:
+    output: "stdout"
+db:
+  path: "/data/ella.db"
+interfaces:
+  n2:
+    address: %q
+    port: 38412
+  n3:
+    name: "eth0"
+  n6:
+    name: "n6"
+  api:
+    address: %q
+    port: 5002
+xdp:
+  attach-mode: "generic"
+cluster:
+  enabled: true
+  node-id: %d
+  bind-address: %q
+  snapshot-interval: %q
+  snapshot-threshold: %d
+  trailing-logs: %d
+  peers:
+%s%s%s`,
+		addr, addr, nodeID, ClusterAddressWithPort(nodeID, 7000),
+		cfg.Interval, cfg.Threshold, cfg.TrailingLogs,
+		peersYAML.String(), joinTokenLine, suffrageLine)
+
+	return os.WriteFile(filepath.Join(cfgDir, "core.yaml"), []byte(body), 0o644)
+}
+
+// waitForSnapshotFile polls the container's /data/raft/snapshots/
+// directory until at least one snapshot subdirectory exists.
+// hashicorp/raft's FileSnapshotStore writes snapshots as
+// `<dir>/snapshots/<term>-<index>-<timestamp>/` plus an in-progress
+// `tmp/` directory; we look for any non-tmp entry.
+func waitForSnapshotFile(ctx context.Context, dc *DockerClient, container string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	var lastOut string
+
+	for time.Now().Before(deadline) {
+		out, err := dc.Exec(ctx, container, []string{"ls", "-1", "/data/raft/snapshots"}, false, 5*time.Second, nil)
+		if err == nil {
+			lastOut = out
+
+			if hasSnapshotEntry(out) {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	return fmt.Errorf("no snapshot in %s after %s; last ls output: %q", container, timeout, lastOut)
+}
+
+// assertSnapshotInstalled is the synchronous variant used after the
+// joiner has already converged. By that point, if a snapshot was
+// installed, it has been on disk for at least one full apply cycle.
+func assertSnapshotInstalled(ctx context.Context, dc *DockerClient, container string) error {
+	out, err := dc.Exec(ctx, container, []string{"ls", "-1", "/data/raft/snapshots"}, false, 5*time.Second, nil)
+	if err != nil {
+		return fmt.Errorf("ls /data/raft/snapshots on %s: %w", container, err)
+	}
+
+	if !hasSnapshotEntry(out) {
+		return fmt.Errorf("no snapshot entry in /data/raft/snapshots on %s; ls output: %q", container, out)
+	}
+
+	return nil
+}
+
+// hasSnapshotEntry returns true when the `ls` output of
+// /data/raft/snapshots contains at least one entry that is not the
+// in-progress `tmp` directory and not blank.
+func hasSnapshotEntry(out string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || name == "tmp" {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}

--- a/integration/ha_snapshot_test.go
+++ b/integration/ha_snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,49 +13,19 @@ import (
 	"github.com/ellanetworks/core/client"
 )
 
-// TestIntegrationHASnapshotInstallOnNewJoiner exercises the end-to-end
-// Raft snapshot pipeline: Snapshot → Persist → store → InstallSnapshot
-// RPC → Restore → Reopen → resume Apply.
-//
-// Steps:
-//
-//  1. Bring up a 3-node cluster with aggressive snapshot tunables
-//     (snapshot-threshold=50, trailing-logs=5, snapshot-interval=2s).
-//     Low TrailingLogs is essential: without it, hashicorp/raft retains
-//     10240 trailing log entries after each snapshot, and a fresh joiner
-//     could catch up via log replay alone — never exercising
-//     InstallSnapshot.
-//
-//  2. Write ~150 subscribers on the leader, deliberately overshooting
-//     the snapshot threshold so the periodic check fires at least one
-//     snapshot AND the log gets truncated past the joiner's nextIndex.
-//
-//  3. Add a 4th node as nonvoter, then promote.
-//
-//  4. Assert two things:
-//     a. The joiner's /data/raft/snapshots/ directory contains at least
-//     one snapshot directory. A node can only have a snapshot file
-//     from either taking one itself (impossible inside the 2s window
-//     between join and the assertion: it has not written anything,
-//     so its post-restore log-since-last-snapshot is 0) or receiving
-//     InstallSnapshot. Presence ⇒ InstallSnapshot fired.
-//     b. The joiner can serve a read of a pre-snapshot subscriber
-//     directly (no proxy to leader), proving the snapshot's data
-//     landed in its local SQLite.
-//
-//  5. Continue writing on the leader and assert the joiner keeps up
-//     (post-snapshot log replay after Restore).
+// TestIntegrationHASnapshotInstallOnNewJoiner forces a Raft snapshot
+// and log truncation on the leader, then joins a new voter and asserts
+// it receives the snapshot via InstallSnapshot (rather than catching
+// up by log replay), reads pre-snapshot rows locally, and continues to
+// replicate writes after the install.
 func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
-	// Snapshot test reuses the 4-service scaleup topology; the only
-	// thing that changes is per-node core.yaml content.
 	const composeDir = "compose/ha-scaleup/"
 
-	ipFamily := DetectIPFamily()
-	t.Logf("Running HA snapshot install test in %s mode", ipFamily)
+	t.Logf("Running HA snapshot install test in %s mode", DetectIPFamily())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
@@ -77,10 +48,6 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 		dockerClient.ComposeDownWithFile(ctx, composeDir, composeFile)
 	})
 
-	t.Log("bringing up 3-node cluster with aggressive snapshot tunables")
-
-	// Include node 4's peer in every config from the start so the joiner
-	// doesn't need a separate config rewrite of existing nodes.
 	fullPeers := []string{
 		ClusterAddressWithPort(1, 7000),
 		ClusterAddressWithPort(2, 7000),
@@ -88,6 +55,9 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 		ClusterAddressWithPort(4, 7000),
 	}
 
+	// Low TrailingLogs forces the leader's log to be truncated past a
+	// fresh joiner's nextIndex, so the joiner cannot catch up by log
+	// replay alone — it must receive an InstallSnapshot RPC.
 	snapshotCfg := snapshotTunables{
 		Interval:     "2s",
 		Threshold:    50,
@@ -105,17 +75,14 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 
 	_, leader, err := findLeader(ctx, clients)
 	if err != nil {
-		t.Fatalf("failed to find leader: %v", err)
+		t.Fatalf("find leader: %v", err)
 	}
 
 	if err := waitForAllNodesReady(ctx, clients); err != nil {
-		t.Fatalf("not all nodes became ready: %v", err)
+		t.Fatalf("nodes not ready: %v", err)
 	}
 
-	// Phase 1: write enough subscribers to force a snapshot + log truncation.
 	const preJoinSubscribers = 150
-
-	t.Logf("writing %d subscribers to force snapshot + log truncation", preJoinSubscribers)
 
 	preJoinIMSIs := make([]string, 0, preJoinSubscribers)
 
@@ -136,29 +103,25 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 
 	preJoinIdx, err := leaderAppliedIndex(ctx, leader)
 	if err != nil {
-		t.Fatalf("get leader applied index: %v", err)
+		t.Fatalf("leader applied index: %v", err)
 	}
 
 	t.Logf("leader applied index after pre-join writes: %d", preJoinIdx)
 
 	if err := waitForFollowerConvergence(ctx, clients, preJoinIdx); err != nil {
-		t.Fatalf("followers did not converge after pre-join writes: %v", err)
+		t.Fatalf("followers did not converge: %v", err)
 	}
-
-	// Wait long enough for the periodic snapshot check (interval=2s) to
-	// fire at least once after the threshold was crossed.
-	t.Log("waiting for leader to take a snapshot")
 
 	leaderContainer, err := dockerClient.ResolveComposeContainer(ctx, "ha-scaleup", "ella-core-1")
 	if err != nil {
 		t.Fatalf("resolve leader container: %v", err)
 	}
 
-	if err := waitForSnapshotFile(ctx, dockerClient, leaderContainer, 30*time.Second); err != nil {
+	hostTmp := t.TempDir()
+
+	if err := waitForSnapshotFile(ctx, leaderContainer, hostTmp, 30*time.Second); err != nil {
 		t.Fatalf("leader did not take a snapshot: %v", err)
 	}
-
-	t.Log("leader has at least one snapshot on disk; staging + starting node 4 as nonvoter")
 
 	if err := stageAndStartJoinerWithSnapshotConfig(ctx, dockerClient, leader, composeDir,
 		"ella-core-4", 4, fullPeers, "nonvoter", snapshotCfg); err != nil {
@@ -178,8 +141,6 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 		t.Fatalf("node 4 did not join as nonvoter: %v", err)
 	}
 
-	t.Log("node 4 joined as nonvoter; promoting to voter")
-
 	if err := leader.PromoteClusterMember(ctx, 4); err != nil {
 		t.Fatalf("promote node 4: %v", err)
 	}
@@ -188,38 +149,19 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 		t.Fatalf("node 4 did not become voter: %v", err)
 	}
 
-	// Wait for node 4 to catch up to the pre-join index. This is the
-	// path under test: the leader's log no longer contains entries
-	// before (snapshotIndex - trailingLogs), so node 4 must receive
-	// InstallSnapshot.
 	if err := waitForFollowerConvergence(ctx, []*client.Client{node4Client}, preJoinIdx); err != nil {
-		t.Fatalf("node 4 did not converge to pre-join index %d: %v", preJoinIdx, err)
+		t.Fatalf("node 4 did not converge to index %d: %v", preJoinIdx, err)
 	}
 
-	t.Logf("node 4 converged to applied index %d", preJoinIdx)
-
-	// Assertion (a): node 4 has a snapshot directory on disk. It cannot
-	// have generated one itself yet — it just joined, has done zero
-	// writes locally, and the snapshot threshold check uses logs-since-
-	// last-snapshot which is at most a handful of replicated entries
-	// since Restore reset its counter. Any snapshot file therefore came
-	// from InstallSnapshot.
 	node4Container, err := dockerClient.ResolveComposeContainer(ctx, "ha-scaleup", "ella-core-4")
 	if err != nil {
 		t.Fatalf("resolve node 4 container: %v", err)
 	}
 
-	if err := assertSnapshotInstalled(ctx, dockerClient, node4Container); err != nil {
+	if err := assertSnapshotInstalled(ctx, node4Container, hostTmp); err != nil {
 		t.Fatalf("InstallSnapshot did not fire on node 4: %v", err)
 	}
 
-	t.Log("node 4 has snapshot directory on disk — InstallSnapshot path exercised")
-
-	// Assertion (b): a representative sample of pre-snapshot subscribers
-	// is readable from node 4 directly (read goes to local FSM, not
-	// proxied to leader). Sampling the first, middle, and last covers
-	// rows that were written well before any snapshot AND rows that
-	// straddle the snapshot boundary.
 	for _, idx := range []int{0, preJoinSubscribers / 2, preJoinSubscribers - 1} {
 		imsi := preJoinIMSIs[idx]
 
@@ -233,11 +175,6 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 		}
 	}
 
-	t.Log("node 4 served pre-snapshot reads locally; writing more entries to exercise post-snapshot replay")
-
-	// Phase 2: continue writing on the leader and verify node 4 keeps
-	// up. This validates the post-Restore Apply path: after Restore
-	// resets the FSM, subsequent committed log entries must still apply.
 	const postJoinSubscribers = 50
 
 	for i := 0; i < postJoinSubscribers; i++ {
@@ -256,7 +193,7 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 
 	postJoinIdx, err := leaderAppliedIndex(ctx, leader)
 	if err != nil {
-		t.Fatalf("get leader applied index post-join: %v", err)
+		t.Fatalf("leader applied index post-join: %v", err)
 	}
 
 	if err := waitForFollowerConvergence(ctx, []*client.Client{node4Client}, postJoinIdx); err != nil {
@@ -271,34 +208,22 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 	}
 
 	if sub.Imsi != lastIMSI {
-		t.Fatalf("node 4 returned post-snapshot IMSI %q, expected %q", sub.Imsi, lastIMSI)
+		t.Fatalf("node 4 returned IMSI %q, expected %q", sub.Imsi, lastIMSI)
 	}
-
-	t.Log("node 4 served post-snapshot reads locally; snapshot install + replay validated")
 
 	assertMembershipConsistent(t, ctx, clients)
 }
 
-// snapshotIMSI returns a deterministic 15-digit IMSI for index i.
-// Range chosen to be disjoint from IMSIs used by other HA tests.
 func snapshotIMSI(i int) string {
 	return fmt.Sprintf("00101975614%04d", i)
 }
 
-// snapshotTunables are the three knobs that govern when Raft snapshots
-// fire and how aggressively the log is truncated afterwards. Test-only
-// values are deliberately low — production defaults would never produce
-// a snapshot in the lifetime of an integration test.
 type snapshotTunables struct {
 	Interval     string
 	Threshold    uint64
 	TrailingLogs uint64
 }
 
-// bringUpHASnapshotCluster mirrors bringUpHAClusterAt but writes each
-// node's core.yaml via writeSnapshotNodeConfig so the snapshot tunables
-// take effect from process start. Returns admin-authed clients for the
-// 3 initial nodes (node 4 is started later by the test body).
 func bringUpHASnapshotCluster(t *testing.T, ctx context.Context, dc *DockerClient, composeDir string, peers []string, cfg snapshotTunables) ([]*client.Client, error) {
 	t.Helper()
 
@@ -362,9 +287,6 @@ func bringUpHASnapshotCluster(t *testing.T, ctx context.Context, dc *DockerClien
 	return clients, nil
 }
 
-// stageAndStartJoinerWithSnapshotConfig mints a join token, writes the
-// joiner's core.yaml with both the token and the snapshot tunables,
-// then starts the service.
 func stageAndStartJoinerWithSnapshotConfig(ctx context.Context, dc *DockerClient, leader *client.Client, composeDir, service string, nodeID int, peers []string, initialSuffrage string, cfg snapshotTunables) error {
 	tok, err := leader.MintClusterJoinToken(ctx, &client.MintJoinTokenOptions{
 		NodeID:     nodeID,
@@ -381,9 +303,6 @@ func stageAndStartJoinerWithSnapshotConfig(ctx context.Context, dc *DockerClient
 	return dc.ComposeUpServicesWithFile(ctx, composeDir, ComposeFile(), service)
 }
 
-// writeSnapshotNodeConfig is writeNodeConfig + the three snapshot knobs.
-// Kept local to this file because no other test cares about these knobs;
-// folding them into the shared helper would clutter every other call site.
 func writeSnapshotNodeConfig(composeDir string, nodeID int, peers []string, joinToken, initialSuffrage string, cfg snapshotTunables) error {
 	cfgDir, err := filepath.Abs(filepath.Join(composeDir, "cfg", fmt.Sprintf("node%d", nodeID)))
 	if err != nil {
@@ -453,20 +372,19 @@ cluster:
 	return os.WriteFile(filepath.Join(cfgDir, "core.yaml"), []byte(body), 0o644)
 }
 
-// waitForSnapshotFile polls the container's /data/raft/snapshots/
-// directory until at least one snapshot subdirectory exists.
-// hashicorp/raft's FileSnapshotStore writes snapshots as
-// `<dir>/snapshots/<term>-<index>-<timestamp>/` plus an in-progress
-// `tmp/` directory; we look for any non-tmp entry.
-func waitForSnapshotFile(ctx context.Context, dc *DockerClient, container string, timeout time.Duration) error {
+func waitForSnapshotFile(ctx context.Context, container, hostTmp string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
-	var lastOut string
+	var lastOut, lastErr string
 
 	for time.Now().Before(deadline) {
-		out, err := dc.Exec(ctx, container, []string{"ls", "-1", "/data/raft/snapshots"}, false, 5*time.Second, nil)
-		if err == nil {
-			lastOut = out
+		out, err := listSnapshotDir(ctx, container, hostTmp)
+		lastOut = out
+
+		if err != nil {
+			lastErr = err.Error()
+		} else {
+			lastErr = ""
 
 			if hasSnapshotEntry(out) {
 				return nil
@@ -480,28 +398,64 @@ func waitForSnapshotFile(ctx context.Context, dc *DockerClient, container string
 		}
 	}
 
-	return fmt.Errorf("no snapshot in %s after %s; last ls output: %q", container, timeout, lastOut)
+	return fmt.Errorf("no snapshot in %s after %s; last out=%q lastErr=%q",
+		container, timeout, lastOut, lastErr)
 }
 
-// assertSnapshotInstalled is the synchronous variant used after the
-// joiner has already converged. By that point, if a snapshot was
-// installed, it has been on disk for at least one full apply cycle.
-func assertSnapshotInstalled(ctx context.Context, dc *DockerClient, container string) error {
-	out, err := dc.Exec(ctx, container, []string{"ls", "-1", "/data/raft/snapshots"}, false, 5*time.Second, nil)
+func assertSnapshotInstalled(ctx context.Context, container, hostTmp string) error {
+	out, err := listSnapshotDir(ctx, container, hostTmp)
 	if err != nil {
-		return fmt.Errorf("ls /data/raft/snapshots on %s: %w", container, err)
+		return fmt.Errorf("list /data/raft/snapshots on %s: %w (out=%q)", container, err, out)
 	}
 
 	if !hasSnapshotEntry(out) {
-		return fmt.Errorf("no snapshot entry in /data/raft/snapshots on %s; ls output: %q", container, out)
+		return fmt.Errorf("no snapshot entry in /data/raft/snapshots on %s; out=%q", container, out)
 	}
 
 	return nil
 }
 
-// hasSnapshotEntry returns true when the `ls` output of
-// /data/raft/snapshots contains at least one entry that is not the
-// in-progress `tmp` directory and not blank.
+// listSnapshotDir enumerates /data/raft/snapshots inside a container.
+// The image ships no shell utilities, so this copies the directory to
+// the host with docker cp and reads it from Go.
+func listSnapshotDir(ctx context.Context, container, hostTmp string) (string, error) {
+	dest, err := os.MkdirTemp(hostTmp, "snap-")
+	if err != nil {
+		return "", fmt.Errorf("mkdir host scratch: %w", err)
+	}
+
+	defer func() { _ = os.RemoveAll(dest) }()
+
+	cpCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(cpCtx, "docker", "cp",
+		fmt.Sprintf("%s:/data/raft/snapshots/.", container),
+		dest,
+	)
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return string(out), fmt.Errorf("docker cp: %w", err)
+	}
+
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		return "", fmt.Errorf("read copied dir: %w", err)
+	}
+
+	var b strings.Builder
+
+	for _, e := range entries {
+		b.WriteString(e.Name())
+		b.WriteByte('\n')
+	}
+
+	return b.String(), nil
+}
+
+// hasSnapshotEntry reports whether `out` contains at least one
+// snapshot directory name. The in-progress `tmp` subdirectory used by
+// hashicorp/raft's FileSnapshotStore is ignored.
 func hasSnapshotEntry(out string) bool {
 	for _, line := range strings.Split(out, "\n") {
 		name := strings.TrimSpace(line)

--- a/integration/ha_test.go
+++ b/integration/ha_test.go
@@ -502,13 +502,13 @@ func TestIntegrationHADrainLeadership(t *testing.T) {
 		t.Fatalf("failed to read leader status pre-drain: %v", err)
 	}
 
-	drainResp, err := leader.DrainClusterMember(ctx, leaderStatus.Cluster.NodeID, &client.DrainOptions{DeadlineSeconds: 30})
+	drainResp, err := leader.DrainClusterMember(ctx, leaderStatus.Cluster.NodeID)
 	if err != nil {
 		t.Fatalf("DrainClusterMember failed: %v", err)
 	}
 
-	if drainResp.DrainState != "draining" && drainResp.DrainState != "drained" {
-		t.Fatalf("expected drainState draining or drained, got %q", drainResp.DrainState)
+	if drainResp.DrainState != "drained" {
+		t.Fatalf("expected drainState drained, got %q", drainResp.DrainState)
 	}
 
 	t.Log("drain accepted, waiting for new leader")
@@ -701,7 +701,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 
 	// --- Scale down: drain and remove node 4 from the cluster (4 → 3) ---
 
-	if _, err := leader.DrainClusterMember(ctx, 4, &client.DrainOptions{DeadlineSeconds: 0}); err != nil {
+	if _, err := leader.DrainClusterMember(ctx, 4); err != nil {
 		t.Fatalf("failed to drain node 4: %v", err)
 	}
 

--- a/internal/api/server/api_drain.go
+++ b/internal/api/server/api_drain.go
@@ -26,14 +26,8 @@ const (
 )
 
 const (
-	defaultDrainStepTimeout  = 5 * time.Second
-	drainSessionPollInterval = 1 * time.Second
-	drainMaxDeadlineSeconds  = 3600
+	defaultDrainStepTimeout = 5 * time.Second
 )
-
-type DrainRequest struct {
-	DeadlineSeconds int `json:"deadlineSeconds,omitempty"`
-}
 
 type DrainResponse struct {
 	DrainState string `json:"drainState"`
@@ -41,19 +35,10 @@ type DrainResponse struct {
 
 // DrainClusterMember handles POST /api/v1/cluster/members/{id}/drain.
 //
-// Runs on the Raft leader (follower requests arrive via the standard leader
-// proxy). The leader persists drain-state transitions through Raft and
-// invokes node-local side-effects (AMF Status Indication, BGP stop) either
-// inline when the target is the leader itself or over the cluster mTLS port
-// when the target is a different node. Leadership transfer runs only when
-// the target is the leader and is the last local step, so subsequent
-// state writes all land on the new leader cleanly.
-//
-// When deadlineSeconds is 0 (default) drain is synchronous and the response
-// state is "drained". When deadlineSeconds > 0 the response returns
-// immediately with state "draining"; a background watcher on the leader
-// flips the state to "drained" once the target's active-lease count
-// reaches zero or the deadline expires.
+// Runs on the Raft leader (followers forward). The leader runs node-local
+// side-effects on the target (AMF Status Indication to RANs, BGP stop),
+// commits drainState=drained through Raft, and transfers leadership when
+// the target is the current leader.
 func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpService *bgp.BGPService, ln *listener.Listener) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if dbInstance.ClusterEnabled() && !dbInstance.IsLeader() {
@@ -81,70 +66,27 @@ func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpServic
 			return
 		}
 
-		var req DrainRequest
-		if r.Body != nil && r.ContentLength > 0 {
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				writeError(r.Context(), w, http.StatusBadRequest, "Invalid request body", err, logger.APILog)
-				return
-			}
-		}
-
-		if req.DeadlineSeconds < 0 || req.DeadlineSeconds > drainMaxDeadlineSeconds {
-			writeError(r.Context(), w, http.StatusBadRequest,
-				fmt.Sprintf("deadlineSeconds must be between 0 and %d", drainMaxDeadlineSeconds),
-				nil, logger.APILog)
-
-			return
-		}
-
-		// Idempotent: re-draining a draining/drained node just returns the
-		// current state and skips side-effects.
-		if member.DrainState == db.DrainStateDraining || member.DrainState == db.DrainStateDrained {
+		if member.DrainState == db.DrainStateDrained {
 			writeResponse(r.Context(), w, DrainResponse{
-				DrainState: member.DrainState,
+				DrainState: db.DrainStateDrained,
 			}, http.StatusOK, logger.APILog)
 
 			return
 		}
 
-		if err := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateDraining); err != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError,
-				"Failed to persist drain state", err, logger.APILog)
-
-			return
-		}
-
-		// Run node-local side-effects on the target: either inline (target
-		// is the leader) or over the cluster mTLS port (target is a
-		// follower).
 		sideEffects, sideErr := runDrainSideEffects(r.Context(), dbInstance, amfInstance, bgpService, ln, member)
 		if sideErr != nil {
-			if rbErr := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateActive); rbErr != nil {
-				logger.APILog.Warn("failed to roll back drain state after side-effects failure",
-					zap.Error(rbErr))
-			}
-
 			writeError(r.Context(), w, http.StatusInternalServerError,
 				"drain side-effects failed", sideErr, logger.APILog)
 
 			return
 		}
 
-		state := db.DrainStateDraining
+		if err := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateDrained); err != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError,
+				"Failed to persist drain state", err, logger.APILog)
 
-		if req.DeadlineSeconds == 0 {
-			if err := dbInstance.SetDrainState(r.Context(), nodeID, db.DrainStateDrained); err != nil {
-				writeError(r.Context(), w, http.StatusInternalServerError,
-					"Failed to finalise drain state", err, logger.APILog)
-
-				return
-			}
-
-			state = db.DrainStateDrained
-		} else {
-			// #nosec G118 -- the deadline watcher must outlive r.Context(),
-			// which is cancelled as soon as this handler returns.
-			go watchDrainDeadline(context.Background(), dbInstance, nodeID, time.Duration(req.DeadlineSeconds)*time.Second)
+			return
 		}
 
 		// Leadership transfer is the last local step: transferring earlier
@@ -167,22 +109,21 @@ func DrainClusterMember(dbInstance *db.Database, amfInstance *amf.AMF, bgpServic
 			DrainAction,
 			actor,
 			getClientIP(r),
-			fmt.Sprintf("Node %d drain, state=%s, leadership_transferred=%v, rans_notified=%d, bgp_stopped=%v, deadline_s=%d",
-				nodeID, state, transferred, sideEffects.RANsNotified, sideEffects.BGPStopped, req.DeadlineSeconds),
+			fmt.Sprintf("Node %d drain, leadership_transferred=%v, rans_notified=%d, bgp_stopped=%v",
+				nodeID, transferred, sideEffects.RANsNotified, sideEffects.BGPStopped),
 		)
 
 		writeResponse(r.Context(), w, DrainResponse{
-			DrainState: state,
+			DrainState: db.DrainStateDrained,
 		}, http.StatusOK, logger.APILog)
 	})
 }
 
 // ResumeClusterMember handles POST /api/v1/cluster/members/{id}/resume.
 //
-// Runs on the leader. Restarts the target's local BGP speaker (either inline
-// when target is the leader or over the cluster mTLS port) and then clears
-// the drain state. Does not reverse AMF Status Indication (no NGAP message
-// does that) or reclaim Raft leadership transferred during drain.
+// Runs on the leader. Restarts the target's local BGP speaker and clears
+// drainState back to active. Does not re-issue AMF Status Indication or
+// reclaim Raft leadership.
 func ResumeClusterMember(dbInstance *db.Database, bgpService *bgp.BGPService, ln *listener.Listener) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if dbInstance.ClusterEnabled() && !dbInstance.IsLeader() {
@@ -383,64 +324,14 @@ func parseMemberIDPath(r *http.Request) (int, bool) {
 	return id, true
 }
 
-func countLocalActiveLeases(ctx context.Context, dbInstance *db.Database, nodeID int) int {
-	leases, err := dbInstance.ListActiveLeasesByNode(ctx, nodeID)
-	if err != nil {
-		logger.APILog.Warn("failed to count local active leases", zap.Error(err))
-		return -1
-	}
-
-	return len(leases)
-}
-
-// watchDrainDeadline polls the target's active-lease count every second and
-// flips drain_state to "drained" once the count reaches zero or the deadline
-// elapses. Runs on the leader that handled the drain request. If leadership
-// changes during the wait, the final SetDrainState proposal fails with
-// ErrNotLeader and the state stays "draining"; the operator must re-drain.
-// This matches the spec's non-goal of deadline persistence across failures.
-func watchDrainDeadline(ctx context.Context, dbInstance *db.Database, nodeID int, deadline time.Duration) {
-	ctx, cancel := context.WithTimeout(ctx, deadline)
-	defer cancel()
-
-	ticker := time.NewTicker(drainSessionPollInterval)
-	defer ticker.Stop()
-
-	for countLocalActiveLeases(ctx, dbInstance, nodeID) != 0 {
-		select {
-		case <-ctx.Done():
-			logger.APILog.Info("drain deadline elapsed with active sessions still present",
-				zap.Int("nodeId", nodeID))
-
-			if err := dbInstance.SetDrainState(context.Background(), nodeID, db.DrainStateDrained); err != nil {
-				logger.APILog.Warn("failed to finalise drain state after deadline",
-					zap.Int("nodeId", nodeID), zap.Error(err))
-			}
-
-			return
-		case <-ticker.C:
-		}
-	}
-
-	if err := dbInstance.SetDrainState(context.Background(), nodeID, db.DrainStateDrained); err != nil {
-		logger.APILog.Warn("failed to finalise drain state after sessions reached zero",
-			zap.Int("nodeId", nodeID), zap.Error(err))
-	}
-}
-
-// SignalShutdownDrain marks this node as drained in the replicated
-// cluster_members table so surviving nodes see a clean "active → drained"
-// transition on operator-initiated shutdown, instead of waiting for
-// autopilot to remove a dead voter after LastContactThreshold. On the
-// leader the write is proposed locally; on a follower it is sent to the
-// current leader's cluster mTLS port. Best-effort: errors are logged and
-// do not block the rest of the shutdown sequence.
-//
-// No-op when the node's current state is "active" — an unsolicited
-// restart (systemctl restart, kernel update, ad-hoc reboot) must not
-// strand the node out of service. Operator-initiated drain (state
-// "draining" or "drained") still finalises to "drained" on shutdown
-// so the rolling-upgrade signal is preserved.
+// SignalShutdownDrain marks this node as drained on graceful shutdown
+// so surviving nodes see a clean "active → drained" transition instead
+// of waiting for autopilot to flag a dead voter after
+// LastContactThreshold. No-op when the node's current state is "active"
+// — an unsolicited restart must not strand the node out of service.
+// On the leader the write is proposed locally; on a follower it is sent
+// to the current leader's cluster mTLS port. Errors are logged and do
+// not block the shutdown sequence.
 func SignalShutdownDrain(ctx context.Context, dbInstance *db.Database, ln *listener.Listener) error {
 	if dbInstance == nil || !dbInstance.ClusterEnabled() {
 		return nil

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -2808,26 +2808,19 @@ paths:
       tags: [Cluster]
       summary: Drain a specific cluster member
       description: >-
-        Persists `drainState=draining` on the target node and runs the drain
-        side-effects on that node: transfers Raft leadership (if the target is
-        the leader), signals RANs that the node's GUAMI is unavailable (AMF
-        Status Indication, TS 38.413), and stops the local BGP speaker. The
-        target continues serving existing flows until removed or shut down.
+        Drains the target node and persists `drainState=drained`. Runs the
+        node-local drain side-effects: signals RANs that the node's GUAMI
+        is unavailable (AMF Status Indication, TS 38.413), stops the local
+        BGP speaker, and transfers Raft leadership when the target is the
+        current leader.
 
-        When `deadlineSeconds` is 0 (the default), the response returns only
-        after the drain completes and `state` is `"drained"`. When
-        `deadlineSeconds > 0` the call returns immediately with
-        `state: "draining"`; a background watcher on the leader flips the
-        state to `"drained"` once the target's active-lease count reaches
-        zero or the deadline elapses. Idempotent: re-draining a draining or
-        drained node returns the current state without re-running
-        side-effects.
+        Idempotent: re-draining a node already in `drained` returns the
+        current state without re-running side-effects.
 
         In HA mode, drain runs on the leader (followers forward the request
-        automatically). The leader persists drain state through Raft and
-        dispatches the node-local side-effects to the target node over the
-        cluster mTLS port; when the target is the leader itself, the
-        side-effects run inline. Requires admin privileges.
+        automatically); the leader dispatches the node-local side-effects
+        to the target over the cluster mTLS port, or runs them inline when
+        the target is the leader itself. Requires admin privileges.
       parameters:
         - name: id
           in: path
@@ -2835,12 +2828,6 @@ paths:
           schema:
             type: integer
           description: Node ID of the cluster member to drain.
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DrainParams"
       responses:
         "200":
           description: Drain result.
@@ -5071,12 +5058,8 @@ components:
           description: True when this member is the current Raft leader.
         drainState:
           type: string
-          enum: [active, draining, drained]
-          description: >-
-            Current drain state of the member. `active` is the default
-            (serving traffic). `draining` means drain has started and the
-            deadline has not elapsed. `drained` means the node is safe to
-            remove.
+          enum: [active, drained]
+          description: Drain state of the member.
         drainUpdatedAt:
           type: string
           format: date-time
@@ -5168,26 +5151,13 @@ components:
         result:
           $ref: "#/components/schemas/AutopilotState"
 
-    DrainParams:
-      type: object
-      properties:
-        deadlineSeconds:
-          type: integer
-          minimum: 0
-          maximum: 3600
-          description: >-
-            Seconds to wait for the target's local active-lease count to
-            reach zero before forcibly setting drainState to "drained".
-            When 0 (default) the drain is synchronous and returns with
-            drainState=drained.
-
     DrainResponse:
       type: object
       properties:
         drainState:
           type: string
-          enum: [active, draining, drained]
-          description: Drain state of the target node after the call.
+          enum: [drained]
+          description: Drain state of the target after the call.
       required: [drainState]
 
     DrainResponseEnvelope:

--- a/internal/config/cluster_test.go
+++ b/internal/config/cluster_test.go
@@ -97,6 +97,49 @@ func TestCluster_BindAddressRequired(t *testing.T) {
 	}
 }
 
+func TestCluster_SnapshotTunablesOptional(t *testing.T) {
+	cfg, err := config.Validate(writeConfig(t, baseConfigYAML))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	if cfg.Cluster.SnapshotInterval != 0 {
+		t.Fatalf("snapshot-interval default = %s, want 0", cfg.Cluster.SnapshotInterval)
+	}
+
+	if cfg.Cluster.SnapshotThreshold != 0 {
+		t.Fatalf("snapshot-threshold default = %d, want 0", cfg.Cluster.SnapshotThreshold)
+	}
+
+	if cfg.Cluster.TrailingLogs != 0 {
+		t.Fatalf("trailing-logs default = %d, want 0", cfg.Cluster.TrailingLogs)
+	}
+}
+
+func TestCluster_SnapshotTunablesParse(t *testing.T) {
+	body := baseConfigYAML + `  snapshot-interval: "2s"
+  snapshot-threshold: 50
+  trailing-logs: 5
+`
+
+	cfg, err := config.Validate(writeConfig(t, body))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	if cfg.Cluster.SnapshotInterval.String() != "2s" {
+		t.Fatalf("snapshot-interval = %s, want 2s", cfg.Cluster.SnapshotInterval)
+	}
+
+	if cfg.Cluster.SnapshotThreshold != 50 {
+		t.Fatalf("snapshot-threshold = %d, want 50", cfg.Cluster.SnapshotThreshold)
+	}
+
+	if cfg.Cluster.TrailingLogs != 5 {
+		t.Fatalf("trailing-logs = %d, want 5", cfg.Cluster.TrailingLogs)
+	}
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,6 +126,7 @@ type ClusterYaml struct {
 	ProposeTimeout    string   `yaml:"propose-timeout"`
 	SnapshotInterval  string   `yaml:"snapshot-interval"`
 	SnapshotThreshold uint64   `yaml:"snapshot-threshold"`
+	TrailingLogs      uint64   `yaml:"trailing-logs"`
 	InitialSuffrage   string   `yaml:"initial-suffrage"`
 }
 
@@ -207,6 +208,7 @@ type Cluster struct {
 	ProposeTimeout    time.Duration
 	SnapshotInterval  time.Duration
 	SnapshotThreshold uint64
+	TrailingLogs      uint64
 	InitialSuffrage   string
 }
 
@@ -723,6 +725,7 @@ func validateCluster(c ClusterYaml) (Cluster, error) {
 		ProposeTimeout:    proposeTimeout,
 		SnapshotInterval:  snapshotInterval,
 		SnapshotThreshold: c.SnapshotThreshold,
+		TrailingLogs:      c.TrailingLogs,
 		InitialSuffrage:   initialSuffrage,
 	}, nil
 }

--- a/internal/db/cluster_members.go
+++ b/internal/db/cluster_members.go
@@ -17,9 +17,8 @@ import (
 const ClusterMembersTableName = "cluster_members"
 
 const (
-	DrainStateActive   = "active"
-	DrainStateDraining = "draining"
-	DrainStateDrained  = "drained"
+	DrainStateActive  = "active"
+	DrainStateDrained = "drained"
 )
 
 const (
@@ -43,7 +42,7 @@ type ClusterMember struct {
 
 func IsValidDrainState(s string) bool {
 	switch s {
-	case DrainStateActive, DrainStateDraining, DrainStateDrained:
+	case DrainStateActive, DrainStateDrained:
 		return true
 	}
 
@@ -191,10 +190,8 @@ func (db *Database) DeleteClusterMember(ctx context.Context, nodeID int) error {
 	return nil
 }
 
-// SetDrainState persists the drain state for a cluster member. The
-// `drainUpdatedAt` column is set to the current unix timestamp. Returns
-// ErrNotFound if no row exists for nodeID. The update is replicated
-// through the Raft log like any other cluster_members mutation.
+// SetDrainState persists the drain state for a cluster member and
+// stamps drainUpdatedAt. Returns ErrNotFound if no row exists for nodeID.
 func (db *Database) SetDrainState(ctx context.Context, nodeID int, state string) error {
 	if !IsValidDrainState(state) {
 		return fmt.Errorf("invalid drain state %q", state)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -110,6 +110,7 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		ProposeTimeout:    cfg.Cluster.ProposeTimeout,
 		SnapshotInterval:  cfg.Cluster.SnapshotInterval,
 		SnapshotThreshold: cfg.Cluster.SnapshotThreshold,
+		TrailingLogs:      cfg.Cluster.TrailingLogs,
 		SchemaVersion:     db.SchemaVersion(),
 		InitialSuffrage:   cfg.Cluster.InitialSuffrage,
 		BinaryVersion:     ver.Version,


### PR DESCRIPTION
# Description

Add new HA integration tests:
- `TestIntegrationHADrainResumeCycle`: drain and resume round-trip
- `TestIntegrationHARemoveLeader`: drains and remove leader
- `TestIntegrationHASnapshotInstallOnNewJoiner`: end-to-end Raft snapshot pipeline

Doing so, we identified and addressed issues with node draining. We completely get rid of async draining, at least until we support distributing pdu sessions.

## Context

As we write more code with AI, the change velocity increases and we get less good at reviewing code. To balance this problem, it is critical to have a gating test suite that validate behavior. I wrote more about this topic here: [Implicit Knowledge is a Liability](https://medium.com/p/0a33442bf1a4).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
