### PR TITLE
fix: reject registration requests missing UE Security Capability

### DIFF
--- a/internal/amf/nas/gmm/handle_registration_request.go
+++ b/internal/amf/nas/gmm/handle_registration_request.go
@@ -196,7 +196,10 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		return fmt.Errorf("registration Reject [Tracking area not allowed]")
 	}
 
-	if ue.RegistrationType5GS == nasMessage.RegistrationType5GSInitialRegistration && registrationRequest.UESecurityCapability == nil {
+	// TS 24.501 §8.2.6.4: the UE shall include the UE security capability IE,
+	// unless it performs a periodic registration updating procedure.
+	if registrationRequest.UESecurityCapability == nil &&
+		ue.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
 		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
 
 		err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
@@ -204,7 +207,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 			return fmt.Errorf("error sending registration reject: %v", err)
 		}
 
-		return fmt.Errorf("registration request does not contain UE security capability for initial registration")
+		return fmt.Errorf("registration request does not contain UE security capability")
 	}
 
 	if registrationRequest.UESecurityCapability != nil {

--- a/internal/amf/nas/gmm/handle_registration_request_test.go
+++ b/internal/amf/nas/gmm/handle_registration_request_test.go
@@ -223,7 +223,7 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability(t *testing.T)
 
 	m.UESecurityCapability = nil
 
-	expected := "registration request does not contain UE security capability for initial registration"
+	expected := "registration request does not contain UE security capability"
 
 	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
 	if err == nil {
@@ -253,6 +253,113 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability(t *testing.T)
 
 	if nm.GmmHeader.GetMessageType() != nas.MsgTypeRegistrationReject {
 		t.Fatalf("expected a registration reject message, got '%v'", nm.GmmHeader.GetMessageType())
+	}
+}
+
+// TestHandleRegistrationRequest_RejectMissingSecurityCapability_Mobility
+// validates that a Mobility Registration Updating without UE Security
+// Capability is rejected. Per TS 24.501 §8.2.6.4 the UE shall include the
+// IE for every registration type except periodic registration updating.
+func TestHandleRegistrationRequest_RejectMissingSecurityCapability_Mobility(t *testing.T) {
+	ctx := context.TODO()
+	amfInstance := amf.New(&FakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}, nil, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	m.SetRegistrationType5GS(nasMessage.RegistrationType5GSMobilityRegistrationUpdating)
+	m.UESecurityCapability = nil
+
+	expected := "registration request does not contain UE security capability"
+
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	if err == nil {
+		t.Fatalf("registration request should be rejected")
+	}
+
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected '%s', got '%v'", expected, err)
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("should have sent a Downlink NAS Transport message")
+	}
+
+	resp := ngapSender.SentDownlinkNASTransport[0]
+	nm := new(nas.Message)
+	nm.SecurityHeaderType = nas.GetSecurityHeaderType(resp.NasPdu) & 0x0f
+
+	if nm.SecurityHeaderType != nas.SecurityHeaderTypePlainNas {
+		t.Fatalf("expected a plain NAS message")
+	}
+
+	if err := nm.PlainNasDecode(&resp.NasPdu); err != nil {
+		t.Fatalf("could not decode plain NAS message")
+	}
+
+	if nm.GmmHeader.GetMessageType() != nas.MsgTypeRegistrationReject {
+		t.Fatalf("expected a registration reject message, got '%v'", nm.GmmHeader.GetMessageType())
+	}
+}
+
+// TestHandleRegistrationRequest_PeriodicAllowsMissingSecurityCapability
+// validates that a periodic registration updating may omit the UE Security
+// Capability IE per TS 24.501 §8.2.6.4.
+func TestHandleRegistrationRequest_PeriodicAllowsMissingSecurityCapability(t *testing.T) {
+	ctx := context.TODO()
+	amfInstance := amf.New(&FakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}, nil, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	m.SetRegistrationType5GS(nasMessage.RegistrationType5GSPeriodicRegistrationUpdating)
+	m.UESecurityCapability = nil
+
+	if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, m.RegistrationRequest); err != nil {
+		t.Fatalf("periodic registration without UE security capability should not be rejected here, got: %v", err)
+	}
+
+	for _, sent := range ngapSender.SentDownlinkNASTransport {
+		nm := new(nas.Message)
+
+		nm.SecurityHeaderType = nas.GetSecurityHeaderType(sent.NasPdu) & 0x0f
+		if nm.SecurityHeaderType != nas.SecurityHeaderTypePlainNas {
+			continue
+		}
+
+		if err := nm.PlainNasDecode(&sent.NasPdu); err != nil {
+			continue
+		}
+
+		if nm.GmmHeader.GetMessageType() == nas.MsgTypeRegistrationReject {
+			t.Fatalf("periodic registration should not produce a RegistrationReject for missing UE security capability")
+		}
 	}
 }
 

--- a/internal/amf/nas/gmm/message/build.go
+++ b/internal/amf/nas/gmm/message/build.go
@@ -238,6 +238,10 @@ func BuildSecurityModeCommand(ue *amf.AmfUe) ([]byte, error) {
 
 	securityModeCommand.SpareHalfOctetAndNgksi = util.SpareHalfOctetAndNgksiToNas(ue.NgKsi)
 
+	if ue.UESecurityCapability == nil {
+		return nil, fmt.Errorf("UE security capability not available, cannot build SecurityModeCommand")
+	}
+
 	securityModeCommand.ReplayedUESecurityCapabilities.SetLen(ue.UESecurityCapability.GetLen())
 	securityModeCommand.ReplayedUESecurityCapabilities.Buffer = ue.UESecurityCapability.Buffer
 


### PR DESCRIPTION
# Description

Ella Core accepted Mobility and Emergency Registration Requests that omitted the UE Security Capability information element — which the spec (TS 124 501) forbids — and then aborted the registration silently mid-flow instead of returning a Registration Reject to the UE.

Now, Ella Core rejects any registration request missing the UE Security Capability IE up front, except for periodic registration updates where the spec allows it to be omitted, so the UE receives a proper Registration Reject and Ella Core never reaches code paths that assume the capability is present.

## Reference

- https://www.etsi.org/deliver/etsi_ts/124500_124599/124501/17.07.01_60/ts_124501v170701p.pdf

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
