### PR TITLE
fix: store cluster advertise-address as an opaque string and resolve IP on demand

### DIFF
--- a/integration/compose/ha/compose-fqdn.yaml
+++ b/integration/compose/ha/compose-fqdn.yaml
@@ -1,0 +1,70 @@
+services:
+  ella-core-1:
+    image: ella-core:latest
+    restart: unless-stopped
+    entrypoint: /bin/core --config /cfg/core.yaml
+    privileged: true
+    volumes:
+      - ./cfg/node1:/cfg:ro
+      - data1:/data
+    ports:
+      - "5002:5002"
+    networks:
+      cluster:
+        driver_opts:
+              com.docker.network.endpoint.ifname: eth0
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv4_address: 10.6.0.11
+  ella-core-2:
+    image: ella-core:latest
+    restart: unless-stopped
+    entrypoint: /bin/core --config /cfg/core.yaml
+    privileged: true
+    volumes:
+      - ./cfg/node2:/cfg:ro
+      - data2:/data
+    ports:
+      - "5003:5002"
+    networks:
+      cluster:
+        driver_opts:
+              com.docker.network.endpoint.ifname: eth0
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv4_address: 10.6.0.12
+  ella-core-3:
+    image: ella-core:latest
+    restart: unless-stopped
+    entrypoint: /bin/core --config /cfg/core.yaml
+    privileged: true
+    volumes:
+      - ./cfg/node3:/cfg:ro
+      - data3:/data
+    ports:
+      - "5004:5002"
+    networks:
+      cluster:
+        driver_opts:
+              com.docker.network.endpoint.ifname: eth0
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv4_address: 10.6.0.13
+
+volumes:
+  data1:
+  data2:
+  data3:
+
+networks:
+  cluster:
+    ipam:
+      config:
+        - subnet: 10.100.0.0/24
+  n6:
+    ipam:
+      config:
+        - subnet: 10.6.0.0/24

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 )
 
@@ -402,6 +404,74 @@ func (dc *DockerClient) CopyBytesToContainer(ctx context.Context, containerName 
 	})
 	if err != nil {
 		return fmt.Errorf("copy to container: %w", err)
+	}
+
+	return nil
+}
+
+// ContainerNetworkEndpoint returns the docker-network-scoped name and the
+// container's IP on that network. networkShort is the compose-file short
+// name (e.g. "cluster"); the match accepts the raw name or any
+// "<project>[_-]<short>" prefix so it works across compose v1/v2 naming.
+func (dc *DockerClient) ContainerNetworkEndpoint(ctx context.Context, containerName, networkShort string) (string, string, error) {
+	info, err := dc.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf("inspect %s: %w", containerName, err)
+	}
+
+	if info.Container.NetworkSettings == nil {
+		return "", "", fmt.Errorf("container %s has no network settings", containerName)
+	}
+
+	for name, ep := range info.Container.NetworkSettings.Networks {
+		if name == networkShort ||
+			strings.HasSuffix(name, "_"+networkShort) ||
+			strings.HasSuffix(name, "-"+networkShort) {
+			if !ep.IPAddress.IsValid() {
+				return name, "", fmt.Errorf("container %s has no IP on network %s", containerName, name)
+			}
+
+			return name, ep.IPAddress.String(), nil
+		}
+	}
+
+	return "", "", fmt.Errorf("container %s not attached to network %q", containerName, networkShort)
+}
+
+// NetworkDisconnectContainer detaches containerName from networkName,
+// releasing its IPAM lease.
+func (dc *DockerClient) NetworkDisconnectContainer(ctx context.Context, networkName, containerName string) error {
+	_, err := dc.NetworkDisconnect(ctx, networkName, client.NetworkDisconnectOptions{
+		Container: containerName,
+	})
+	if err != nil {
+		return fmt.Errorf("disconnect %s from %s: %w", containerName, networkName, err)
+	}
+
+	return nil
+}
+
+// NetworkConnectContainerWithIPv4 attaches containerName to networkName
+// with a caller-chosen IPv4 address. The address must lie in the
+// network's configured subnet and must not already be leased.
+func (dc *DockerClient) NetworkConnectContainerWithIPv4(ctx context.Context, networkName, containerName, ipv4 string) error {
+	addr, err := netip.ParseAddr(ipv4)
+	if err != nil {
+		return fmt.Errorf("parse %q: %w", ipv4, err)
+	}
+
+	if !addr.Is4() {
+		return fmt.Errorf("address %s is not IPv4", ipv4)
+	}
+
+	_, err = dc.NetworkConnect(ctx, networkName, client.NetworkConnectOptions{
+		Container: containerName,
+		EndpointConfig: &network.EndpointSettings{
+			IPAMConfig: &network.EndpointIPAMConfig{IPv4Address: addr},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("connect %s to %s at %s: %w", containerName, networkName, ipv4, err)
 	}
 
 	return nil

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -409,10 +409,9 @@ func (dc *DockerClient) CopyBytesToContainer(ctx context.Context, containerName 
 	return nil
 }
 
-// ContainerNetworkEndpoint returns the docker-network-scoped name and the
-// container's IP on that network. networkShort is the compose-file short
-// name (e.g. "cluster"); the match accepts the raw name or any
-// "<project>[_-]<short>" prefix so it works across compose v1/v2 naming.
+// ContainerNetworkEndpoint resolves networkShort against the container's
+// attached networks, accepting the raw name or any "<project>[_-]<short>"
+// prefix, and returns the matched network name and the container's IP.
 func (dc *DockerClient) ContainerNetworkEndpoint(ctx context.Context, containerName, networkShort string) (string, string, error) {
 	info, err := dc.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
 	if err != nil {
@@ -438,8 +437,6 @@ func (dc *DockerClient) ContainerNetworkEndpoint(ctx context.Context, containerN
 	return "", "", fmt.Errorf("container %s not attached to network %q", containerName, networkShort)
 }
 
-// NetworkDisconnectContainer detaches containerName from networkName,
-// releasing its IPAM lease.
 func (dc *DockerClient) NetworkDisconnectContainer(ctx context.Context, networkName, containerName string) error {
 	_, err := dc.NetworkDisconnect(ctx, networkName, client.NetworkDisconnectOptions{
 		Container: containerName,
@@ -451,9 +448,6 @@ func (dc *DockerClient) NetworkDisconnectContainer(ctx context.Context, networkN
 	return nil
 }
 
-// NetworkConnectContainerWithIPv4 attaches containerName to networkName
-// with a caller-chosen IPv4 address. The address must lie in the
-// network's configured subnet and must not already be leased.
 func (dc *DockerClient) NetworkConnectContainerWithIPv4(ctx context.Context, networkName, containerName, ipv4 string) error {
 	addr, err := netip.ParseAddr(ipv4)
 	if err != nil {

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -717,10 +717,6 @@ func membershipDiff(snapshots []string) string {
 	return ""
 }
 
-// fqdnPeers returns the cluster.peers list as compose-service-name FQDNs
-// resolved by Docker's embedded DNS — mirrors the orchestrator-managed
-// deployment pattern where peers reference stable DNS names rather than
-// IPs.
 func fqdnPeers(services []string) []string {
 	peers := make([]string, 0, len(services))
 	for _, s := range services {
@@ -730,9 +726,8 @@ func fqdnPeers(services []string) []string {
 	return peers
 }
 
-// fqdnHANodeURLs returns API URLs via the host port map. Cluster-network
-// container IPs are dynamic in the FQDN compose, so the test reaches each
-// node through compose's published ports on the loopback interface.
+// fqdnHANodeURLs returns API URLs via the host port map, since the
+// FQDN compose leaves cluster-network IPs dynamic.
 func fqdnHANodeURLs() []string {
 	return []string{
 		"http://127.0.0.1:5002",
@@ -741,10 +736,10 @@ func fqdnHANodeURLs() []string {
 	}
 }
 
-// writeFQDNNodeConfig renders a core.yaml that addresses peers and the
-// local bind-address by FQDN, and binds the API/N2 listeners on
-// 0.0.0.0 since the cluster-network IP is assigned dynamically and is
-// not known at config-write time.
+// writeFQDNNodeConfig renders a core.yaml whose cluster bind-address
+// and peers are FQDNs and whose API/N2 listeners bind on 0.0.0.0,
+// since the dynamic cluster-network IP is not known at config-write
+// time.
 func writeFQDNNodeConfig(composeDir string, nodeID int, peers []string, joinToken string) error {
 	cfgDir, err := filepath.Abs(filepath.Join(composeDir, "cfg", fmt.Sprintf("node%d", nodeID)))
 	if err != nil {
@@ -801,10 +796,6 @@ cluster:
 	return os.WriteFile(filepath.Join(cfgDir, "core.yaml"), []byte(body), 0o644)
 }
 
-// bringUpHAFQDNClusterAt is bringUpHAClusterAt with FQDN-only cluster
-// addressing. Peers and bind-address reference the compose service name
-// instead of a pinned IP, and the compose file is the caller's choice
-// (typically one without ipv4_address pins on the cluster network).
 func bringUpHAFQDNClusterAt(t *testing.T, ctx context.Context, dc *DockerClient, composeDir, composeFile string, services []string) ([]*client.Client, error) {
 	t.Helper()
 

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -730,6 +730,77 @@ func fqdnPeers(services []string) []string {
 	return peers
 }
 
+// fqdnHANodeURLs returns API URLs via the host port map. Cluster-network
+// container IPs are dynamic in the FQDN compose, so the test reaches each
+// node through compose's published ports on the loopback interface.
+func fqdnHANodeURLs() []string {
+	return []string{
+		"http://127.0.0.1:5002",
+		"http://127.0.0.1:5003",
+		"http://127.0.0.1:5004",
+	}
+}
+
+// writeFQDNNodeConfig renders a core.yaml that addresses peers and the
+// local bind-address by FQDN, and binds the API/N2 listeners on
+// 0.0.0.0 since the cluster-network IP is assigned dynamically and is
+// not known at config-write time.
+func writeFQDNNodeConfig(composeDir string, nodeID int, peers []string, joinToken string) error {
+	cfgDir, err := filepath.Abs(filepath.Join(composeDir, "cfg", fmt.Sprintf("node%d", nodeID)))
+	if err != nil {
+		return fmt.Errorf("abs path %s: %w", composeDir, err)
+	}
+
+	if err := os.MkdirAll(cfgDir, 0o777); err != nil {
+		return fmt.Errorf("mkdir %s: %w", cfgDir, err)
+	}
+
+	if err := os.Chmod(cfgDir, 0o777); err != nil {
+		return fmt.Errorf("chmod %s: %w", cfgDir, err)
+	}
+
+	var peersYAML strings.Builder
+
+	for _, p := range peers {
+		fmt.Fprintf(&peersYAML, "      - %q\n", p)
+	}
+
+	joinTokenLine := ""
+	if joinToken != "" {
+		joinTokenLine = fmt.Sprintf("  join-token: %q\n", joinToken)
+	}
+
+	body := fmt.Sprintf(`logging:
+  system:
+    level: "debug"
+    output: "stdout"
+  audit:
+    output: "stdout"
+db:
+  path: "/data/ella.db"
+interfaces:
+  n2:
+    address: "0.0.0.0"
+    port: 38412
+  n3:
+    name: "eth0"
+  n6:
+    name: "n6"
+  api:
+    address: "0.0.0.0"
+    port: 5002
+xdp:
+  attach-mode: "generic"
+cluster:
+  enabled: true
+  node-id: %d
+  bind-address: "ella-core-%d:7000"
+  peers:
+%s%s`, nodeID, nodeID, peersYAML.String(), joinTokenLine)
+
+	return os.WriteFile(filepath.Join(cfgDir, "core.yaml"), []byte(body), 0o644)
+}
+
 // bringUpHAFQDNClusterAt is bringUpHAClusterAt with FQDN-only cluster
 // addressing. Peers and bind-address reference the compose service name
 // instead of a pinned IP, and the compose file is the caller's choice
@@ -745,8 +816,9 @@ func bringUpHAFQDNClusterAt(t *testing.T, ctx context.Context, dc *DockerClient,
 	}
 
 	peers := fqdnPeers(services)
+	urls := fqdnHANodeURLs()
 
-	if err := writeNodeConfigOpts(composeDir, 1, peers, "", "", true); err != nil {
+	if err := writeFQDNNodeConfig(composeDir, 1, peers, ""); err != nil {
 		return fail(err)
 	}
 
@@ -754,7 +826,7 @@ func bringUpHAFQDNClusterAt(t *testing.T, ctx context.Context, dc *DockerClient,
 		return fail(fmt.Errorf("start node 1: %w", err))
 	}
 
-	node1, err := newInsecureClient(getHANodeURLs()[0])
+	node1, err := newInsecureClient(urls[0])
 	if err != nil {
 		return fail(err)
 	}
@@ -778,13 +850,16 @@ func bringUpHAFQDNClusterAt(t *testing.T, ctx context.Context, dc *DockerClient,
 		}
 	}
 
-	clients, err := newHANodeClients()
-	if err != nil {
-		return fail(err)
-	}
+	clients := make([]*client.Client, 0, len(urls))
 
-	for _, c := range clients {
+	for _, u := range urls {
+		c, err := newInsecureClient(u)
+		if err != nil {
+			return fail(fmt.Errorf("client for %s: %w", u, err))
+		}
+
 		c.SetToken(adminToken)
+		clients = append(clients, c)
 	}
 
 	if err := waitForClusterReady(ctx, clients); err != nil {
@@ -803,7 +878,7 @@ func stageAndStartFQDNJoiner(ctx context.Context, dc *DockerClient, leader *clie
 		return fmt.Errorf("mint join token for node %d: %w", nodeID, err)
 	}
 
-	if err := writeNodeConfigOpts(composeDir, nodeID, peers, tok.Token, "", true); err != nil {
+	if err := writeFQDNNodeConfig(composeDir, nodeID, peers, tok.Token); err != nil {
 		return err
 	}
 

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -716,3 +716,96 @@ func membershipDiff(snapshots []string) string {
 
 	return ""
 }
+
+// fqdnPeers returns the cluster.peers list as compose-service-name FQDNs
+// resolved by Docker's embedded DNS — mirrors the orchestrator-managed
+// deployment pattern where peers reference stable DNS names rather than
+// IPs.
+func fqdnPeers(services []string) []string {
+	peers := make([]string, 0, len(services))
+	for _, s := range services {
+		peers = append(peers, fmt.Sprintf("%s:7000", s))
+	}
+
+	return peers
+}
+
+// bringUpHAFQDNClusterAt is bringUpHAClusterAt with FQDN-only cluster
+// addressing. Peers and bind-address reference the compose service name
+// instead of a pinned IP, and the compose file is the caller's choice
+// (typically one without ipv4_address pins on the cluster network).
+func bringUpHAFQDNClusterAt(t *testing.T, ctx context.Context, dc *DockerClient, composeDir, composeFile string, services []string) ([]*client.Client, error) {
+	t.Helper()
+
+	dc.ComposeCleanup(ctx)
+
+	fail := func(err error) ([]*client.Client, error) {
+		captureClusterLogs(t, dc, composeDir, services)
+		return nil, err
+	}
+
+	peers := fqdnPeers(services)
+
+	if err := writeNodeConfigOpts(composeDir, 1, peers, "", "", true); err != nil {
+		return fail(err)
+	}
+
+	if err := dc.ComposeUpServicesWithFile(ctx, composeDir, composeFile, services[0]); err != nil {
+		return fail(fmt.Errorf("start node 1: %w", err))
+	}
+
+	node1, err := newInsecureClient(getHANodeURLs()[0])
+	if err != nil {
+		return fail(err)
+	}
+
+	if err := waitForNodeReady(ctx, node1); err != nil {
+		return fail(fmt.Errorf("node 1 never became ready: %w", err))
+	}
+
+	adminToken, err := initializeAndGetAdminToken(ctx, node1)
+	if err != nil {
+		return fail(err)
+	}
+
+	node1.SetToken(adminToken)
+
+	for i := 1; i < len(services); i++ {
+		nodeID := i + 1
+
+		if err := stageAndStartFQDNJoiner(ctx, dc, node1, composeDir, composeFile, services[i], nodeID, peers); err != nil {
+			return fail(err)
+		}
+	}
+
+	clients, err := newHANodeClients()
+	if err != nil {
+		return fail(err)
+	}
+
+	for _, c := range clients {
+		c.SetToken(adminToken)
+	}
+
+	if err := waitForClusterReady(ctx, clients); err != nil {
+		return fail(fmt.Errorf("cluster not ready: %w", err))
+	}
+
+	return clients, nil
+}
+
+func stageAndStartFQDNJoiner(ctx context.Context, dc *DockerClient, leader *client.Client, composeDir, composeFile, service string, nodeID int, peers []string) error {
+	tok, err := leader.MintClusterJoinToken(ctx, &client.MintJoinTokenOptions{
+		NodeID:     nodeID,
+		TTLSeconds: 600,
+	})
+	if err != nil {
+		return fmt.Errorf("mint join token for node %d: %w", nodeID, err)
+	}
+
+	if err := writeNodeConfigOpts(composeDir, nodeID, peers, tok.Token, "", true); err != nil {
+		return err
+	}
+
+	return dc.ComposeUpServicesWithFile(ctx, composeDir, composeFile, service)
+}

--- a/integration/ha_node_address_change_test.go
+++ b/integration/ha_node_address_change_test.go
@@ -10,17 +10,10 @@ import (
 
 const haFQDNComposeFile = "compose-fqdn.yaml"
 
-// rebindIPv4 is a fixed address in the cluster subnet, chosen well
-// above the default IPAM allocation range so it does not collide with
-// the leases held by the running peers.
+// rebindIPv4 sits well above the default IPAM allocation range to avoid
+// colliding with leases held by the running peers.
 const rebindIPv4 = "10.100.0.123"
 
-// TestIntegrationHAFollowerReturnsOnNewAddress brings up a 3-node
-// cluster whose peers are addressed by FQDN, then takes a follower
-// down and brings it back on a different IP — the address change a
-// pod replacement under any orchestrator would produce. The cluster
-// must reconverge, and the follower's persisted RaftAddress must
-// remain the FQDN.
 func TestIntegrationHAFollowerReturnsOnNewAddress(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")

--- a/integration/ha_node_address_change_test.go
+++ b/integration/ha_node_address_change_test.go
@@ -1,0 +1,141 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+const haFQDNComposeFile = "compose-fqdn.yaml"
+
+// rebindIPv4 is a fixed address in the cluster subnet, chosen well
+// above the default IPAM allocation range so it does not collide with
+// the leases held by the running peers.
+const rebindIPv4 = "10.100.0.123"
+
+// TestIntegrationHAFollowerReturnsOnNewAddress brings up a 3-node
+// cluster whose peers are addressed by FQDN, then takes a follower
+// down and brings it back on a different IP — the address change a
+// pod replacement under any orchestrator would produce. The cluster
+// must reconverge, and the follower's persisted RaftAddress must
+// remain the FQDN.
+func TestIntegrationHAFollowerReturnsOnNewAddress(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	if DetectIPFamily() != IPv4Only {
+		t.Skip("address rebinding helper is IPv4-only")
+	}
+
+	ctx := context.Background()
+	composeDir := haComposeDir
+	composeFile := haFQDNComposeFile
+
+	dc, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dc.Close(); err != nil {
+			t.Logf("failed to close docker client: %v", err)
+		}
+	}()
+
+	clients, err := bringUpHAFQDNClusterAt(t, ctx, dc, composeDir, composeFile, haNodeServices)
+	if err != nil {
+		t.Fatalf("bring up FQDN cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		dumpClusterDiagnostics(t, ctx, dc, composeDir, haNodeServices, clients)
+	})
+
+	leaderIdx, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("find leader: %v", err)
+	}
+
+	followerIdx := (leaderIdx + 1) % len(clients)
+	followerNodeID := followerIdx + 1
+	followerService := haNodeServices[followerIdx]
+	expectedRaftAddr := fmt.Sprintf("%s:7000", followerService)
+
+	container, err := dc.ResolveComposeContainer(ctx, haComposeProject, followerService)
+	if err != nil {
+		t.Fatalf("resolve follower container: %v", err)
+	}
+
+	networkName, oldIP, err := dc.ContainerNetworkEndpoint(ctx, container, "cluster")
+	if err != nil {
+		t.Fatalf("inspect follower: %v", err)
+	}
+
+	if oldIP == rebindIPv4 {
+		t.Fatalf("follower already at rebind target %s; pick a different IP", rebindIPv4)
+	}
+
+	t.Logf("rebinding %s (node %d) from %s to %s on %s",
+		followerService, followerNodeID, oldIP, rebindIPv4, networkName)
+
+	if err := dc.ComposeStopWithFile(ctx, composeDir, composeFile, followerService); err != nil {
+		t.Fatalf("stop follower: %v", err)
+	}
+
+	if err := dc.NetworkDisconnectContainer(ctx, networkName, container); err != nil {
+		t.Fatalf("disconnect follower: %v", err)
+	}
+
+	if err := dc.NetworkConnectContainerWithIPv4(ctx, networkName, container, rebindIPv4); err != nil {
+		t.Fatalf("reconnect follower at %s: %v", rebindIPv4, err)
+	}
+
+	if err := dc.ComposeStartWithFile(ctx, composeDir, composeFile, followerService); err != nil {
+		t.Fatalf("start follower: %v", err)
+	}
+
+	_, newIP, err := dc.ContainerNetworkEndpoint(ctx, container, "cluster")
+	if err != nil {
+		t.Fatalf("re-inspect follower: %v", err)
+	}
+
+	if newIP != rebindIPv4 {
+		t.Fatalf("rebind IP = %s, want %s", newIP, rebindIPv4)
+	}
+
+	if newIP == oldIP {
+		t.Fatalf("rebind did not change IP (still %s)", oldIP)
+	}
+
+	if err := waitForClusterReadyWithin(ctx, clients, 90*time.Second); err != nil {
+		t.Fatalf("cluster did not reconverge after follower address change: %v", err)
+	}
+
+	if _, err := waitForAutopilotHealthy(ctx, leader, 1, len(clients)); err != nil {
+		t.Fatalf("autopilot did not report healthy after follower address change: %v", err)
+	}
+
+	members, err := leader.ListClusterMembers(ctx)
+	if err != nil {
+		t.Fatalf("list cluster members: %v", err)
+	}
+
+	var got string
+
+	for _, m := range members {
+		if m.NodeID == followerNodeID {
+			got = m.RaftAddress
+			break
+		}
+	}
+
+	if got != expectedRaftAddr {
+		t.Fatalf("node %d raftAddress = %q, want %q (persisted address must remain the FQDN across IP changes)",
+			followerNodeID, got, expectedRaftAddr)
+	}
+
+	assertMembershipConsistent(t, ctx, clients)
+}

--- a/internal/raft/stream_layer.go
+++ b/internal/raft/stream_layer.go
@@ -27,17 +27,31 @@ type raftStreamLayer struct {
 
 var _ hraft.StreamLayer = (*raftStreamLayer)(nil)
 
+// fqdnAddr carries the advertise address as the operator configured it
+// (FQDN or IP literal, with port) and lets every dial re-resolve through
+// the OS resolver. Eager resolution would freeze a one-time IP into
+// every peer's persisted Raft configuration, stranding the node after a
+// pod IP change.
+type fqdnAddr string
+
+func (a fqdnAddr) Network() string { return "tcp" }
+func (a fqdnAddr) String() string  { return string(a) }
+
 func newRaftStreamLayer(ln *listener.Listener, advertiseAddr string) (*raftStreamLayer, error) {
-	addr, err := net.ResolveTCPAddr("tcp", advertiseAddr)
+	_, port, err := net.SplitHostPort(advertiseAddr)
 	if err != nil {
-		return nil, fmt.Errorf("resolve advertise address %s: %w", advertiseAddr, err)
+		return nil, fmt.Errorf("invalid advertise address %q: %w", advertiseAddr, err)
+	}
+
+	if port == "" {
+		return nil, fmt.Errorf("invalid advertise address %q: port required", advertiseAddr)
 	}
 
 	sl := &raftStreamLayer{
 		ln:      ln,
 		accepts: make(chan net.Conn, 16),
 		closeCh: make(chan struct{}),
-		addr:    addr,
+		addr:    fqdnAddr(advertiseAddr),
 	}
 
 	ln.Register(listener.ALPNRaft, sl.handleConn)

--- a/internal/raft/stream_layer.go
+++ b/internal/raft/stream_layer.go
@@ -27,11 +27,6 @@ type raftStreamLayer struct {
 
 var _ hraft.StreamLayer = (*raftStreamLayer)(nil)
 
-// fqdnAddr carries the advertise address as the operator configured it
-// (FQDN or IP literal, with port) and lets every dial re-resolve through
-// the OS resolver. Eager resolution would freeze a one-time IP into
-// every peer's persisted Raft configuration, stranding the node after a
-// pod IP change.
 type fqdnAddr string
 
 func (a fqdnAddr) Network() string { return "tcp" }

--- a/internal/raft/stream_layer_test.go
+++ b/internal/raft/stream_layer_test.go
@@ -46,6 +46,69 @@ func TestRaftStreamLayer_Addr(t *testing.T) {
 	}
 }
 
+// TestRaftStreamLayer_AddrPreservesFQDN locks in that the advertise
+// address is stored verbatim and not eagerly resolved. The persisted
+// Raft configuration must hold the symbolic name so peers re-resolve
+// it on every dial.
+func TestRaftStreamLayer_AddrPreservesFQDN(t *testing.T) {
+	pki := testutil.GenTestPKI(t, []int{1})
+
+	port := freePort(t)
+
+	ln := listener.New(listener.Config{
+		BindAddress:      fmt.Sprintf("127.0.0.1:%d", port),
+		AdvertiseAddress: fmt.Sprintf("127.0.0.1:%d", port),
+		NodeID:           1,
+		Pin:              pki.PinFunc(),
+		Leaf:             pki.LeafFunc(1),
+	})
+
+	advertise := fmt.Sprintf("ella-core-1:%d", port)
+
+	sl, err := newRaftStreamLayer(ln, advertise)
+	if err != nil {
+		t.Fatalf("newRaftStreamLayer: %v", err)
+	}
+
+	defer func() { _ = sl.Close() }()
+
+	if got := sl.Addr().String(); got != advertise {
+		t.Fatalf("Addr() = %q, want %q (FQDN must not be resolved at construction)", got, advertise)
+	}
+
+	if got := sl.Addr().Network(); got != "tcp" {
+		t.Fatalf("Network() = %q, want %q", got, "tcp")
+	}
+}
+
+func TestRaftStreamLayer_RejectsMalformedAdvertise(t *testing.T) {
+	pki := testutil.GenTestPKI(t, []int{1})
+
+	cases := []string{
+		"",
+		"missing-port",
+		"host:",
+	}
+
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			port := freePort(t)
+
+			ln := listener.New(listener.Config{
+				BindAddress:      fmt.Sprintf("127.0.0.1:%d", port),
+				AdvertiseAddress: fmt.Sprintf("127.0.0.1:%d", port),
+				NodeID:           1,
+				Pin:              pki.PinFunc(),
+				Leaf:             pki.LeafFunc(1),
+			})
+
+			if _, err := newRaftStreamLayer(ln, in); err == nil {
+				t.Fatalf("newRaftStreamLayer(%q) returned no error", in)
+			}
+		})
+	}
+}
+
 func TestRaftStreamLayer_CloseUnblocksAccept(t *testing.T) {
 	pki := testutil.GenTestPKI(t, []int{1})
 

--- a/internal/raft/stream_layer_test.go
+++ b/internal/raft/stream_layer_test.go
@@ -46,10 +46,6 @@ func TestRaftStreamLayer_Addr(t *testing.T) {
 	}
 }
 
-// TestRaftStreamLayer_AddrPreservesFQDN locks in that the advertise
-// address is stored verbatim and not eagerly resolved. The persisted
-// Raft configuration must hold the symbolic name so peers re-resolve
-// it on every dial.
 func TestRaftStreamLayer_AddrPreservesFQDN(t *testing.T) {
 	pki := testutil.GenTestPKI(t, []int{1})
 


### PR DESCRIPTION
# Description

Store the cluster advertise-address as an opaque string instead of resolving it once to an IP, so the FQDN flows verbatim through join, persistence and dial — and the OS resolver picks up the current IP on every connection. This PR addresses @infinitydon 's second comment in #1310.

We also add integration test for HA nodes changing IPs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
