### PR TITLE
fix: Update active sessions on admin changes

### DIFF
--- a/cmd/core-tester/main.go
+++ b/cmd/core-tester/main.go
@@ -24,6 +24,8 @@ var (
 	gnbCoreTargets  []string
 	verbose         bool
 	ipVersion       string
+	apiAddress      string
+	apiToken        string
 )
 
 func main() {
@@ -79,6 +81,8 @@ func runCmd() *cobra.Command {
 		"gNB spec: <name>,n2=<addr>,n3=<addr>[,n3-secondary=<addr>] (repeatable)")
 	run.PersistentFlags().StringArrayVar(&gnbCoreTargets, "gnb-core-target", nil,
 		"pair <gnb-name>=<core-n2-addr> (repeatable)")
+	run.PersistentFlags().StringVar(&apiAddress, "ella-api-address", "", "Ella Core API address")
+	run.PersistentFlags().StringVar(&apiToken, "ella-api-token", "", "Ella Core API token")
 	run.PersistentFlags().BoolVar(&verbose, "verbose", false, "verbose logging")
 	run.PersistentFlags().StringVar(&ipVersion, "ip-version", "", "IP address family: ipv4, ipv6, or dualstack")
 
@@ -127,6 +131,8 @@ func scenarioSubcommand(sc scenarios.Scenario) *cobra.Command {
 				CoreN2Addresses: coreN2Addresses,
 				GNBs:            gnbs,
 				GNBCoreTargets:  targets,
+				APIAddress:      apiAddress,
+				APIToken:        apiToken,
 			}
 
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -169,9 +169,9 @@ func bootstrapTesterCore(ctx context.Context, cl *client.Client) error {
 }
 
 // RunScenario invokes `core-tester run <scenario>` in the sidecar,
-// injecting --ella-core-n2-address, --gnb, and --ip-version from the
-// compose topology. Fails the subtest on non-zero exit. stdout/stderr
-// mirror to the test log.
+// injecting --ella-core-n2-address, --gnb, --ella-api-address, and
+// --ella-api-token from the compose topology. Fails the subtest on
+// non-zero exit. stdout/stderr mirror to the test log.
 func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario string, extraArgs ...string) {
 	t.Helper()
 
@@ -190,6 +190,8 @@ func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario stri
 		argv = append(argv, "--gnb", spec)
 	}
 
+	argv = append(argv, "--ella-api-address", APIAddress())
+	argv = append(argv, "--ella-api-token", e.Client.GetToken())
 	argv = append(argv, "--verbose")
 	argv = append(argv, extraArgs...)
 

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -57,6 +57,8 @@ type SmfSbi interface {
 	UpdateSmContextN2HandoverPrepared(ctx context.Context, smContextRef string, n2Data []byte) ([]byte, error)
 	UpdateSmContextXnHandoverPathSwitchReq(ctx context.Context, smContextRef string, n2Data []byte) ([]byte, error)
 	UpdateSmContextHandoverFailed(ctx context.Context, smContextRef string, n2Data []byte) error
+	ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error
+	GetSessionPolicy(ctx context.Context, supi etsi.SUPI, snssai *models.Snssai, dnn string) (*smf.Policy, error)
 }
 
 type NetworkFeatureSupport5GS struct {

--- a/internal/amf/amf_ran.go
+++ b/internal/amf/amf_ran.go
@@ -45,6 +45,7 @@ type NGAPSender interface {
 	SendPDUSessionResourceReleaseCommand(ctx context.Context, amfUENgapID int64, ranUENgapID int64, nasPdu []byte, pduSessionResourceReleasedList ngapType.PDUSessionResourceToReleaseListRelCmd) error
 	SendHandoverCancelAcknowledge(ctx context.Context, amfUENgapID int64, ranUENgapID int64) error
 	SendPDUSessionResourceModifyConfirm(ctx context.Context, amfUENgapID int64, ranUENgapID int64, pduSessionResourceModifyConfirmList ngapType.PDUSessionResourceModifyListModCfm, pduSessionResourceFailedToModifyList ngapType.PDUSessionResourceFailedToModifyListModCfm) error
+	SendPDUSessionResourceModifyRequest(ctx context.Context, amfUENgapID int64, ranUENgapID int64, pduSessionResourceModifyList ngapType.PDUSessionResourceModifyListModReq) error
 	SendPDUSessionResourceSetupRequest(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, ambrUplink string, ambrDownlink string, nasPdu []byte, pduSessionResourceSetupRequestList ngapType.PDUSessionResourceSetupListSUReq) error
 	SendHandoverPreparationFailure(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, cause ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error
 	SendLocationReportingControl(ctx context.Context, amfUENgapID int64, ranUENgapID int64, eventType ngapType.EventType) error

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -81,6 +81,14 @@ func (s *deregisterTestSmf) UpdateSmContextHandoverFailed(context.Context, strin
 	return nil
 }
 
+func (s *deregisterTestSmf) ReconcileSmContext(context.Context, *models.SessionReconcileRequest) error {
+	return nil
+}
+
+func (s *deregisterTestSmf) GetSessionPolicy(context.Context, etsi.SUPI, *models.Snssai, string) (*smf.Policy, error) {
+	return nil, nil
+}
+
 func TestDeregister_DoesNotHoldLockDuringSmfRelease(t *testing.T) {
 	ue := NewAmfUe()
 	ue.Log = zap.NewNop()

--- a/internal/amf/nas/gmm/handle_test.go
+++ b/internal/amf/nas/gmm/handle_test.go
@@ -243,6 +243,10 @@ func (fng *FakeNGAPSender) SendPDUSessionResourceModifyConfirm(ctx context.Conte
 	return nil
 }
 
+func (fng *FakeNGAPSender) SendPDUSessionResourceModifyRequest(ctx context.Context, amfUENGAPID int64, ranUENGAPID int64, pduSessionResourceModifyList ngapType.PDUSessionResourceModifyListModReq) error {
+	return nil
+}
+
 func (fng *FakeNGAPSender) SendPDUSessionResourceSetupRequest(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, ambrUplink string, ambrDownlink string, nasPdu []byte, pduSessionResourceSetupRequestList ngapType.PDUSessionResourceSetupListSUReq) error {
 	fng.SentPDUSessionResourceSetupRequest = append(
 		fng.SentPDUSessionResourceSetupRequest,
@@ -501,6 +505,14 @@ func (s *FakeSmf) GetSession(_ string) *smf.SMContext { return nil }
 func (s *FakeSmf) SessionsByDNN(_ string) []*smf.SMContext { return nil }
 
 func (s *FakeSmf) SessionCount() int { return 0 }
+
+func (s *FakeSmf) ReconcileSmContext(_ context.Context, _ *models.SessionReconcileRequest) error {
+	return s.Error
+}
+
+func (s *FakeSmf) GetSessionPolicy(_ context.Context, _ etsi.SUPI, _ *models.Snssai, _ string) (*smf.Policy, error) {
+	return nil, nil
+}
 
 func mustTestGuti(mcc string, mnc string, amfid string, tmsi uint32) etsi.GUTI {
 	t, err := etsi.NewTMSI(tmsi)

--- a/internal/amf/ngap/handle_pdu_session_resource_release_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_release_response.go
@@ -50,14 +50,15 @@ func HandlePDUSessionResourceReleaseResponse(ctx context.Context, amfInstance *a
 
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				logger.WithTrace(ctx, ranUe.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
-				continue
+				logger.WithTrace(ctx, ranUe.Log).Warn("SmContext not found during release response (may already be removed by SMF)",
+					zap.Uint8("PduSessionID", pduSessionID))
 			}
 
-			err := amfInstance.Smf.UpdateSmContextN2InfoPduResRelRsp(ctx, smContext.Ref)
-			if err != nil {
-				logger.WithTrace(ctx, ranUe.Log).Error("SendUpdateSmContextN2InfoPduResRelRsp failed", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
-				continue
+			if smContext != nil {
+				err := amfInstance.Smf.UpdateSmContextN2InfoPduResRelRsp(ctx, smContext.Ref)
+				if err != nil {
+					logger.WithTrace(ctx, ranUe.Log).Error("SendUpdateSmContextN2InfoPduResRelRsp failed", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+				}
 			}
 
 			amfUe.SetSmContextInactive(pduSessionID)

--- a/internal/amf/ngap/handle_test.go
+++ b/internal/amf/ngap/handle_test.go
@@ -459,6 +459,10 @@ func (fng *FakeNGAPSender) SendPDUSessionResourceModifyConfirm(ctx context.Conte
 	return nil
 }
 
+func (fng *FakeNGAPSender) SendPDUSessionResourceModifyRequest(ctx context.Context, amfUENGAPID int64, ranUENGAPID int64, pduSessionResourceModifyList ngapType.PDUSessionResourceModifyListModReq) error {
+	return nil
+}
+
 func (fng *FakeNGAPSender) SendPDUSessionResourceSetupRequest(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, ambrUplink string, ambrDownlink string, nasPdu []byte, pduSessionResourceSetupRequestList ngapType.PDUSessionResourceSetupListSUReq) error {
 	return nil
 }

--- a/internal/amf/ngap/send/build.go
+++ b/internal/amf/ngap/send/build.go
@@ -786,6 +786,54 @@ func buildPDUSessionResourceModifyConfirm(
 	return ngap.Encoder(pdu)
 }
 
+// buildPDUSessionResourceModifyRequest encodes a PDUSessionResourceModifyRequest
+// NGAP message (3GPP TS 38.413 §9.2.1.3). This is the AMF→gNB message for
+// network-initiated PDU Session Modification (TS 23.502 §4.3.3.2).
+func buildPDUSessionResourceModifyRequest(amfUENGAPID int64, ranUENGAPID int64, pduSessionResourceModifyList ngapType.PDUSessionResourceModifyListModReq) ([]byte, error) {
+	var pdu ngapType.NGAPPDU
+
+	pdu.Present = ngapType.NGAPPDUPresentInitiatingMessage
+	pdu.InitiatingMessage = new(ngapType.InitiatingMessage)
+
+	initiatingMessage := pdu.InitiatingMessage
+	initiatingMessage.ProcedureCode.Value = ngapType.ProcedureCodePDUSessionResourceModify
+	initiatingMessage.Criticality.Value = ngapType.CriticalityPresentReject
+
+	initiatingMessage.Value.Present = ngapType.InitiatingMessagePresentPDUSessionResourceModifyRequest
+	initiatingMessage.Value.PDUSessionResourceModifyRequest = new(ngapType.PDUSessionResourceModifyRequest)
+
+	modifyRequest := initiatingMessage.Value.PDUSessionResourceModifyRequest
+	modifyRequestIEs := &modifyRequest.ProtocolIEs
+
+	// AMF UE NGAP ID
+	ie := ngapType.PDUSessionResourceModifyRequestIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDAMFUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.PDUSessionResourceModifyRequestIEsPresentAMFUENGAPID
+	ie.Value.AMFUENGAPID = new(ngapType.AMFUENGAPID)
+	ie.Value.AMFUENGAPID.Value = amfUENGAPID
+	modifyRequestIEs.List = append(modifyRequestIEs.List, ie)
+
+	// RAN UE NGAP ID
+	ie = ngapType.PDUSessionResourceModifyRequestIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDRANUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.PDUSessionResourceModifyRequestIEsPresentRANUENGAPID
+	ie.Value.RANUENGAPID = new(ngapType.RANUENGAPID)
+	ie.Value.RANUENGAPID.Value = ranUENGAPID
+	modifyRequestIEs.List = append(modifyRequestIEs.List, ie)
+
+	// PDU Session Resource Modify List
+	ie = ngapType.PDUSessionResourceModifyRequestIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDPDUSessionResourceModifyListModReq
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.PDUSessionResourceModifyRequestIEsPresentPDUSessionResourceModifyListModReq
+	ie.Value.PDUSessionResourceModifyListModReq = &pduSessionResourceModifyList
+	modifyRequestIEs.List = append(modifyRequestIEs.List, ie)
+
+	return ngap.Encoder(pdu)
+}
+
 // nasPDU: from nas layer
 // pduSessionResourceSetupRequestList: provided by AMF, and transfer data is from SMF
 func buildPDUSessionResourceSetupRequest(amfUENGAPID int64, ranUENGAPID int64, bitrateUplink string, bitrateDownlink string, nasPdu []byte, pduSessionResourceSetupRequestList ngapType.PDUSessionResourceSetupListSUReq) ([]byte, error) {

--- a/internal/amf/ngap/send/send.go
+++ b/internal/amf/ngap/send/send.go
@@ -289,6 +289,20 @@ func (s *RealNGAPSender) SendPDUSessionResourceModifyConfirm(ctx context.Context
 	return nil
 }
 
+func (s *RealNGAPSender) SendPDUSessionResourceModifyRequest(ctx context.Context, amfUENgapID int64, ranUENgapID int64, pduSessionResourceModifyList ngapType.PDUSessionResourceModifyListModReq) error {
+	pkt, err := buildPDUSessionResourceModifyRequest(amfUENgapID, ranUENgapID, pduSessionResourceModifyList)
+	if err != nil {
+		return fmt.Errorf("error building pdu session resource modify request: %s", err.Error())
+	}
+
+	err = s.SendToRan(ctx, pkt, NGAPProcedurePDUSessionResourceModifyRequest)
+	if err != nil {
+		return fmt.Errorf("send error: %s", err.Error())
+	}
+
+	return nil
+}
+
 func (s *RealNGAPSender) SendPDUSessionResourceSetupRequest(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, ambrUplink string, ambrDownlink string, nasPdu []byte, pduSessionResourceSetupRequestList ngapType.PDUSessionResourceSetupListSUReq) error {
 	pkt, err := buildPDUSessionResourceSetupRequest(amfUeNgapID, ranUeNgapID, ambrUplink, ambrDownlink, nasPdu, pduSessionResourceSetupRequestList)
 	if err != nil {

--- a/internal/amf/producer/n1n2message.go
+++ b/internal/amf/producer/n1n2message.go
@@ -9,6 +9,7 @@ package producer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ellanetworks/core/etsi"
@@ -24,6 +25,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// ErrUENotReachable is returned when the UE is in CM-IDLE state and the
+// requested signaling cannot be delivered. Per TS 23.502 §4.2.3.3 step 3b,
+// the AMF may ignore the N2 SM information when the UE is not reachable and
+// the caller should defer delivery until the UE transitions to CM-CONNECTED.
+var ErrUENotReachable = errors.New("UE is in CM-IDLE state")
 
 var tracer = otel.Tracer("ella-core/amf/producer")
 
@@ -44,7 +51,7 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 
 	ranUe := ue.RanUe()
 	if ranUe == nil {
-		return fmt.Errorf("ue is not connected to RAN")
+		return storeN1N2AndPage(ctx, amfInstance, ue, req)
 	}
 
 	nasPdu, err := message.BuildDLNASTransport(ue, nasMessage.PayloadContainerTypeN1SMInfo, req.BinaryDataN1Message, req.PduSessionID, nil)
@@ -99,6 +106,159 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 	ue.Log.Info("Sent NGAP initial context setup request to UE")
 
 	ranUe.SentInitialContextSetupRequest = true
+
+	return nil
+}
+
+func storeN1N2AndPage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, req models.N1N2MessageTransferRequest) error {
+	if ue.Procedures.Active(procedure.Paging) {
+		return fmt.Errorf("higher priority request ongoing")
+	}
+
+	if ue.Procedures.Active(procedure.Registration) {
+		return fmt.Errorf("temporary reject registration ongoing")
+	}
+
+	if ue.Procedures.Active(procedure.N2Handover) {
+		return fmt.Errorf("temporary reject handover ongoing")
+	}
+
+	if ue.GetState() != amf.Registered {
+		return fmt.Errorf("ue is not in registered state")
+	}
+
+	ue.N1N2Message = &req
+
+	_, beginErr := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+	if beginErr != nil {
+		return fmt.Errorf("begin paging procedure: %w", beginErr)
+	}
+
+	pkg, err := send.BuildPaging(
+		ue.Guti,
+		ue.RegistrationArea,
+		ue.UeRadioCapabilityForPaging,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("build paging error: %v", err)
+	}
+
+	if err := amfInstance.SendPaging(ctx, ue, pkg); err != nil {
+		return fmt.Errorf("send paging error: %v", err)
+	}
+
+	return nil
+}
+
+// ModifyN1N2Message sends a PDUSessionResourceModifyRequest to the gNB,
+// carrying the N1 NAS PDU (PDU Session Modification Command) piggybacked
+// in the per-session modify item, and the N2 transfer (PDU Session Resource
+// Modify Request Transfer) as the opaque transfer blob.
+// This implements TS 23.502 §4.3.3.2 step 3 (AMF→gNB).
+func ModifyN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error {
+	ctx, span := tracer.Start(
+		ctx,
+		"AMF PDUSessionResourceModifyRequest",
+		trace.WithAttributes(
+			attribute.String("supi", supi.String()),
+			attribute.Int("pdu_session_id", int(pduSessionID)),
+		),
+	)
+	defer span.End()
+
+	ue, ok := amfInstance.FindAMFUEBySupi(supi)
+	if !ok {
+		return fmt.Errorf("ue context not found")
+	}
+
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		// Per TS 23.502 §4.2.3.3 step 3b: when the UE is in CM-IDLE, the AMF
+		// may ignore the N2 SM information. Since the gNB has released all
+		// radio resources for this session, there is nothing to "modify".
+		// The caller should commit the policy change; when the UE transitions
+		// back to CM-CONNECTED, ActivateSmContext will build a fresh
+		// PDUSessionResourceSetupRequestTransfer with the updated QoS.
+		return ErrUENotReachable
+	}
+
+	// Build the DL NAS Transport wrapping the N1 SM message.
+	nasPdu, err := message.BuildDLNASTransport(ue, nasMessage.PayloadContainerTypeN1SMInfo, n1Msg, pduSessionID, nil)
+	if err != nil {
+		return fmt.Errorf("build DL NAS Transport error: %v", err)
+	}
+
+	// Construct the modify list with a single session item.
+	list := ngapType.PDUSessionResourceModifyListModReq{
+		List: []ngapType.PDUSessionResourceModifyItemModReq{
+			{
+				PDUSessionID: ngapType.PDUSessionID{Value: int64(pduSessionID)},
+				NASPDU: &ngapType.NASPDU{
+					Value: nasPdu,
+				},
+				PDUSessionResourceModifyRequestTransfer: n2Msg,
+			},
+		},
+	}
+
+	if err := ranUe.SendPDUSessionResourceModifyRequest(ctx, list); err != nil {
+		return fmt.Errorf("send pdu session resource modify request error: %v", err)
+	}
+
+	ue.Log.Info("Sent NGAP PDU Session Resource Modify Request to gNB")
+
+	return nil
+}
+
+// ReleaseSessionMessage sends a PDUSessionResourceReleaseCommand to the gNB,
+// carrying the N1 NAS PDU (PDU Session Release Command) and the N2 transfer
+// (PDU Session Resource Release Command Transfer).
+// This implements the network-initiated PDU Session Release (TS 23.502 §4.3.4.2).
+func ReleaseSessionMessage(ctx context.Context, amfInstance *amf.AMF, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Transfer []byte) error {
+	ctx, span := tracer.Start(
+		ctx,
+		"AMF PDUSessionResourceReleaseCommand",
+		trace.WithAttributes(
+			attribute.String("supi", supi.String()),
+			attribute.Int("pdu_session_id", int(pduSessionID)),
+		),
+	)
+	defer span.End()
+
+	ue, ok := amfInstance.FindAMFUEBySupi(supi)
+	if !ok {
+		return fmt.Errorf("ue context not found")
+	}
+
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return ErrUENotReachable
+	}
+
+	// Build the DL NAS Transport wrapping the N1 SM message.
+	nasPdu, err := message.BuildDLNASTransport(ue, nasMessage.PayloadContainerTypeN1SMInfo, n1Msg, pduSessionID, nil)
+	if err != nil {
+		return fmt.Errorf("build DL NAS Transport error: %v", err)
+	}
+
+	// Construct the release list with a single session item.
+	list := ngapType.PDUSessionResourceToReleaseListRelCmd{
+		List: []ngapType.PDUSessionResourceToReleaseItemRelCmd{
+			{
+				PDUSessionID:                             ngapType.PDUSessionID{Value: int64(pduSessionID)},
+				PDUSessionResourceReleaseCommandTransfer: n2Transfer,
+			},
+		},
+	}
+
+	if err := ranUe.SendPDUSessionResourceReleaseCommand(ctx, nasPdu, list); err != nil {
+		return fmt.Errorf("send pdu session resource release command error: %v", err)
+	}
+
+	ue.Log.Info("Sent NGAP PDU Session Resource Release Command to gNB",
+		logger.PDUSessionID(pduSessionID),
+	)
 
 	return nil
 }
@@ -182,35 +342,7 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 	}
 
 	// 504: the UE in MICO mode or the UE is only registered over Non-3GPP access and its state is CM-IDLE
-	if ue.GetState() != amf.Registered {
-		return fmt.Errorf("ue is not in registered state")
-	}
-
-	var pagingPriority *ngapType.PagingPriority
-
-	ue.N1N2Message = &req
-
-	_, beginErr := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
-	if beginErr != nil {
-		return fmt.Errorf("begin paging procedure: %w", beginErr)
-	}
-
-	pkg, err := send.BuildPaging(
-		ue.Guti,
-		ue.RegistrationArea,
-		ue.UeRadioCapabilityForPaging,
-		pagingPriority,
-	)
-	if err != nil {
-		return fmt.Errorf("build paging error: %v", err)
-	}
-
-	err = amfInstance.SendPaging(ctx, ue, pkg)
-	if err != nil {
-		return fmt.Errorf("send paging error: %v", err)
-	}
-
-	return nil
+	return storeN1N2AndPage(ctx, amfInstance, ue, req)
 }
 
 func TransferN1Msg(ctx context.Context, amfInstance *amf.AMF, supi etsi.SUPI, n1Msg []byte, pduSessionID uint8) error {

--- a/internal/amf/producer/n1n2message_test.go
+++ b/internal/amf/producer/n1n2message_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
 	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/amf/producer"
+	"github.com/ellanetworks/core/internal/amf/sctp"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/smf"
@@ -28,10 +29,17 @@ type fakeNGAPSender struct {
 	pduSessionSetupCalls      int
 	initialContextSetupCalls  int
 	downlinkNasTransportCalls int
+	pagingCalls               int
 }
 
-func (f *fakeNGAPSender) SendToRan(context.Context, []byte, send.NGAPProcedure) error { return nil }
-func (f *fakeNGAPSender) SendNGSetupFailure(context.Context, *ngapType.Cause) error   { return nil }
+func (f *fakeNGAPSender) SendToRan(_ context.Context, _ []byte, proc send.NGAPProcedure) error {
+	if proc == send.NGAPProcedurePaging {
+		f.pagingCalls++
+	}
+
+	return nil
+}
+func (f *fakeNGAPSender) SendNGSetupFailure(context.Context, *ngapType.Cause) error { return nil }
 func (f *fakeNGAPSender) SendNGSetupResponse(context.Context, *models.Guami, []models.Snssai, string, int64) error {
 	return nil
 }
@@ -82,6 +90,10 @@ func (f *fakeNGAPSender) SendHandoverCancelAcknowledge(context.Context, int64, i
 }
 
 func (f *fakeNGAPSender) SendPDUSessionResourceModifyConfirm(context.Context, int64, int64, ngapType.PDUSessionResourceModifyListModCfm, ngapType.PDUSessionResourceFailedToModifyListModCfm) error {
+	return nil
+}
+
+func (f *fakeNGAPSender) SendPDUSessionResourceModifyRequest(_ context.Context, _, _ int64, _ ngapType.PDUSessionResourceModifyListModReq) error {
 	return nil
 }
 
@@ -197,6 +209,14 @@ func (f *fakeSmf) UpdateSmContextXnHandoverPathSwitchReq(context.Context, string
 }
 func (f *fakeSmf) UpdateSmContextHandoverFailed(context.Context, string, []byte) error { return nil }
 
+func (f *fakeSmf) ReconcileSmContext(context.Context, *models.SessionReconcileRequest) error {
+	return nil
+}
+
+func (f *fakeSmf) GetSessionPolicy(context.Context, etsi.SUPI, *models.Snssai, string) (*smf.Policy, error) {
+	return nil, nil
+}
+
 // --- Helpers ---
 
 func mustSUPI(t *testing.T, imsi string) etsi.SUPI {
@@ -226,6 +246,22 @@ func addUE(t *testing.T, amfInstance *amf.AMF, imsi string, setup func(*amf.AmfU
 	}
 
 	return ue
+}
+
+func testGUTI(t *testing.T) etsi.GUTI {
+	t.Helper()
+
+	tmsi, err := etsi.NewTMSI(0x01020304)
+	if err != nil {
+		t.Fatalf("build TMSI: %v", err)
+	}
+
+	guti, err := etsi.NewGUTI("001", "01", "cafe00", tmsi)
+	if err != nil {
+		t.Fatalf("build GUTI: %v", err)
+	}
+
+	return guti
 }
 
 func newReq() models.N1N2MessageTransferRequest {
@@ -313,6 +349,67 @@ func TestTransferN1N2Message_InitialContextNotYetSent(t *testing.T) {
 
 	if !ranUe.SentInitialContextSetupRequest {
 		t.Fatal("expected SentInitialContextSetupRequest to be set to true")
+	}
+}
+
+func TestModifyN1N2Message_IdleRegisteredUE_ReturnsNotReachable(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	amfInstance := amf.New(nil, nil, &fakeSmf{})
+	amfInstance.Radios = make(map[*sctp.SCTPConn]*amf.Radio)
+
+	ue := addUE(t, amfInstance, "001010000000014", func(u *amf.AmfUe) {
+		u.ForceState(amf.Registered)
+		u.Guti = testGUTI(t)
+		u.RegistrationArea = []models.Tai{{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}}
+	})
+
+	radio := &amf.Radio{
+		NGAPSender: sender,
+		RanUEs:     make(map[int64]*amf.RanUe),
+		SupportedTAIs: []amf.SupportedTAI{{
+			Tai: models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
+		}},
+	}
+	amfInstance.Radios[nil] = radio
+
+	// UE has no RanUe attached → CM-IDLE
+	err := producer.ModifyN1N2Message(context.Background(), amfInstance, ue.Supi, 1, []byte{0x01, 0x02}, []byte{0x03, 0x04})
+	if err == nil {
+		t.Fatal("expected ErrUENotReachable for idle UE")
+	}
+
+	if err != producer.ErrUENotReachable {
+		t.Fatalf("expected ErrUENotReachable, got: %v", err)
+	}
+
+	// No paging should have been triggered.
+	if sender.pagingCalls != 0 {
+		t.Fatalf("expected 0 paging calls, got %d", sender.pagingCalls)
+	}
+
+	// No N1N2 message stored on UE.
+	if ue.N1N2Message != nil {
+		t.Fatal("expected no stored N1N2 message")
+	}
+}
+
+func TestReleaseSessionMessage_IdleUE_ReturnsNotReachable(t *testing.T) {
+	amfInstance := amf.New(nil, nil, &fakeSmf{})
+
+	addUE(t, amfInstance, "001010000000015", func(u *amf.AmfUe) {
+		u.ForceState(amf.Registered)
+	})
+
+	supi := mustSUPI(t, "001010000000015")
+
+	// UE has no RanUe attached → CM-IDLE
+	err := producer.ReleaseSessionMessage(context.Background(), amfInstance, supi, 1, []byte{0x01}, []byte{0x02})
+	if err == nil {
+		t.Fatal("expected ErrUENotReachable for idle UE")
+	}
+
+	if err != producer.ErrUENotReachable {
+		t.Fatalf("expected ErrUENotReachable, got: %v", err)
 	}
 }
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -199,6 +199,23 @@ func (ranUe *RanUe) SendPDUSessionResourceModifyConfirm(
 	)
 }
 
+func (ranUe *RanUe) SendPDUSessionResourceModifyRequest(
+	ctx context.Context,
+	pduSessionResourceModifyList ngapType.PDUSessionResourceModifyListModReq,
+) error {
+	sender, err := ranUe.ngapSender()
+	if err != nil {
+		return err
+	}
+
+	return sender.SendPDUSessionResourceModifyRequest(
+		ctx,
+		ranUe.AmfUeNgapID,
+		ranUe.RanUeNgapID,
+		pduSessionResourceModifyList,
+	)
+}
+
 func (ranUe *RanUe) SendHandoverPreparationFailure(ctx context.Context, cause ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
 	sender, err := ranUe.ngapSender()
 	if err != nil {

--- a/internal/amf/session_reconciler.go
+++ b/internal/amf/session_reconciler.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Ella Networks
+
+package amf
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/smf"
+	"go.uber.org/zap"
+)
+
+const sessionReconcileBackstop = 5 * time.Minute
+
+// SessionReconciler subscribes to the session_reconcile changefeed topic and
+// reconciles every local PDU session against the current DB policy. It runs
+// on every cluster node; Raft replication guarantees each node receives the
+// wakeup after the write applies locally.
+type SessionReconciler struct {
+	amf      *AMF
+	wakeup   <-chan struct{}
+	backstop time.Duration
+	log      *zap.Logger
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewSessionReconciler creates a reconciler for the given AMF. wakeup is
+// signalled when a profile/policy/subscriber write that affects session
+// parameters has been applied; nil is fine (then only the backstop sweep
+// fires). Start must be called explicitly.
+func NewSessionReconciler(amf *AMF, wakeup <-chan struct{}) *SessionReconciler {
+	return &SessionReconciler{
+		amf:      amf,
+		wakeup:   wakeup,
+		backstop: sessionReconcileBackstop,
+		log:      logger.AmfLog.With(zap.String("component", "SessionReconciler")),
+	}
+}
+
+// Start launches the reconciler goroutine. Safe to call while already
+// running; subsequent calls without a paired Stop are no-ops. The first
+// reconcile runs synchronously in the goroutine immediately, then the
+// periodic ticker takes over.
+func (r *SessionReconciler) Start() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cancel != nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	r.done = make(chan struct{})
+
+	go r.loop(ctx, r.done)
+}
+
+// Stop signals the reconciler to exit and blocks until the goroutine
+// has drained. Safe to call when not started.
+func (r *SessionReconciler) Stop() {
+	r.mu.Lock()
+	cancel := r.cancel
+	done := r.done
+	r.cancel = nil
+	r.done = nil
+	r.mu.Unlock()
+
+	if cancel == nil {
+		return
+	}
+
+	cancel()
+	<-done
+}
+
+func (r *SessionReconciler) loop(ctx context.Context, done chan struct{}) {
+	defer close(done)
+
+	r.Reconcile()
+
+	ticker := time.NewTicker(r.backstop)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.wakeup:
+			r.Reconcile()
+		case <-ticker.C:
+			r.Reconcile()
+		}
+	}
+}
+
+// Reconcile iterates every registered UE and its PDU sessions, asking the
+// SMF to compare the current session policy against the latest DB values
+// and push updates to the UPF and UE where needed.
+func (r *SessionReconciler) Reconcile() {
+	r.amf.mu.RLock()
+	ues := make([]*AmfUe, 0, len(r.amf.UEs))
+
+	for _, ue := range r.amf.UEs {
+		if ue.GetState() == Registered {
+			ues = append(ues, ue)
+		}
+	}
+
+	r.amf.mu.RUnlock()
+
+	if len(ues) == 0 {
+		return
+	}
+
+	for _, ue := range ues {
+		r.reconcileUE(ue)
+	}
+}
+
+func (r *SessionReconciler) reconcileUE(ue *AmfUe) {
+	ue.Mutex.RLock()
+	smContextRefs := make([]string, 0, len(ue.SmContextList))
+
+	for _, smCtx := range ue.SmContextList {
+		smContextRefs = append(smContextRefs, smCtx.Ref)
+	}
+
+	ue.Mutex.RUnlock()
+
+	for _, ref := range smContextRefs {
+		if ref == "" {
+			continue
+		}
+
+		policy, reason := r.fetchSessionPolicy(ref)
+
+		// Empty reason means a transient error occurred; skip this session
+		// and let the backstop timer retry later.
+		if reason == models.ReconcileSkip {
+			continue
+		}
+
+		if err := ue.smf.ReconcileSmContext(context.Background(), &models.SessionReconcileRequest{
+			SmContextRef: ref,
+			NewPolicy:    policy,
+			Reason:       reason,
+		}); err != nil {
+			r.log.Warn("session reconcile failed",
+				zap.String("smContextRef", ref),
+				zap.Error(err))
+		}
+	}
+}
+
+// fetchSessionPolicy reads the latest policy for a session from the DB.
+// Returns (nil, ReconcileSliceMismatch) when the policy cannot be resolved
+// because the session's stored Snssai no longer matches any active slice
+// (the admin changed SST/SD). Returns (nil, ReconcileSkip) when the policy
+// cannot be determined (transient DB error, session gone, nil policy) so the
+// caller skips reconciliation and the backstop retries later.
+func (r *SessionReconciler) fetchSessionPolicy(smContextRef string) (*models.SessionPolicyDelta, models.SessionReconcileReason) {
+	sm := r.amf.Smf.GetSession(smContextRef)
+	if sm == nil {
+		// Session already removed from the SMF pool (e.g. after a
+		// network-initiated release). Skip silently; the AMF UE's
+		// SmContextList will be cleaned up when the UE deregisters or
+		// sends a PDU Session Release Complete.
+		return nil, models.ReconcileSkip
+	}
+
+	policy, err := r.amf.Smf.GetSessionPolicy(context.Background(), sm.Supi, sm.Snssai, sm.Dnn)
+	if err != nil {
+		// Distinguish "no matching policy" (genuine slice mismatch) from
+		// transient infrastructure errors (DB down, Raft timeout, etc.).
+		if errors.Is(err, smf.ErrNoPolicyMatch) || errors.Is(err, smf.ErrDNNNotFound) {
+			r.log.Debug("session policy not found, triggering slice mismatch release",
+				zap.String("smContextRef", smContextRef),
+				zap.Error(err))
+
+			return nil, models.ReconcileSliceMismatch
+		}
+
+		// Transient error — log and skip. The backstop timer will retry.
+		r.log.Warn("transient error fetching session policy, skipping reconciliation",
+			zap.String("smContextRef", smContextRef),
+			zap.Error(err))
+
+		return nil, models.ReconcileSkip
+	}
+
+	if policy == nil {
+		return nil, models.ReconcileSkip
+	}
+
+	delta := &models.SessionPolicyDelta{
+		SessionAmbrUplink:   policy.Ambr.Uplink,
+		SessionAmbrDownlink: policy.Ambr.Downlink,
+		Var5qi:              policy.QosData.Var5qi,
+	}
+	if policy.QosData.Arp != nil {
+		delta.Arp = policy.QosData.Arp.PriorityLevel
+		delta.PreemptCap = policy.QosData.Arp.PreemptCap
+		delta.PreemptVuln = policy.QosData.Arp.PreemptVuln
+	}
+
+	return delta, models.ReconcilePolicyChange
+}

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -302,6 +302,14 @@ func (f *fakeAMFCallback) TransferN1N2(ctx context.Context, supi etsi.SUPI, pduS
 	return nil
 }
 
+func (f *fakeAMFCallback) ModifyN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error {
+	return nil
+}
+
+func (f *fakeAMFCallback) ReleaseSession(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Transfer []byte) error {
+	return nil
+}
+
 func (f *fakeAMFCallback) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error {
 	return nil
 }

--- a/internal/db/changefeed.go
+++ b/internal/db/changefeed.go
@@ -25,6 +25,7 @@ const (
 	TopicDataNetworks           Topic = "data_networks"
 	TopicIPLeases               Topic = "ip_leases"
 	TopicClusterNodeCerts       Topic = "cluster_node_certs"
+	TopicSessionReconcile       Topic = "session_reconcile"
 )
 
 // Event is published once per (topic, applied-index) and carries no

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -10,6 +10,7 @@ var (
 	ErrAlreadyExists       = errors.New("already exists")
 	ErrNotFound            = errors.New("not found")
 	ErrDataNetworkNotFound = errors.New("data network not found")
+	ErrNoMatchingPolicy    = errors.New("no matching policy for slice and DNN")
 	ErrRestoreInProgress   = errors.New("a restore is already in progress")
 	ErrInvalidBackupFile   = errors.New("uploaded file is not a valid SQLite database")
 	// ErrProposeTimeout is returned when a Raft proposal cannot be committed

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -12,7 +12,7 @@ import (
 // Subscribers
 var (
 	opCreateSubscriber        = registerChangesetOp("CreateSubscriber", (*Database).applyCreateSubscriber)
-	opUpdateSubscriberProfile = registerChangesetOp("UpdateSubscriberProfile", (*Database).applyUpdateSubscriberProfile)
+	opUpdateSubscriberProfile = registerChangesetOp("UpdateSubscriberProfile", (*Database).applyUpdateSubscriberProfile, AffectsTopic(TopicSessionReconcile))
 	opEditSubscriberSeqNum    = registerChangesetOp("EditSubscriberSeqNum", (*Database).applyEditSubscriberSeqNum)
 	opDeleteSubscriber        = registerChangesetOp("DeleteSubscriber", (*Database).applyDeleteSubscriber)
 )
@@ -53,7 +53,7 @@ var (
 // Profiles
 var (
 	opCreateProfile = registerChangesetOp("CreateProfile", (*Database).applyCreateProfile)
-	opUpdateProfile = registerChangesetOp("UpdateProfile", (*Database).applyUpdateProfile)
+	opUpdateProfile = registerChangesetOp("UpdateProfile", (*Database).applyUpdateProfile, AffectsTopic(TopicSessionReconcile))
 	opDeleteProfile = registerChangesetOp("DeleteProfile", (*Database).applyDeleteProfile)
 )
 
@@ -75,8 +75,8 @@ var (
 // Network slices
 var (
 	opCreateNetworkSlice = registerChangesetOp("CreateNetworkSlice", (*Database).applyCreateNetworkSlice)
-	opUpdateNetworkSlice = registerChangesetOp("UpdateNetworkSlice", (*Database).applyUpdateNetworkSlice)
-	opDeleteNetworkSlice = registerChangesetOp("DeleteNetworkSlice", (*Database).applyDeleteNetworkSlice)
+	opUpdateNetworkSlice = registerChangesetOp("UpdateNetworkSlice", (*Database).applyUpdateNetworkSlice, AffectsTopic(TopicSessionReconcile))
+	opDeleteNetworkSlice = registerChangesetOp("DeleteNetworkSlice", (*Database).applyDeleteNetworkSlice, AffectsTopic(TopicSessionReconcile))
 )
 
 // Data networks
@@ -88,11 +88,11 @@ var (
 
 // Policies
 var (
-	opCreatePolicy          = registerChangesetOp("CreatePolicy", (*Database).applyCreatePolicy, AffectsTopic(TopicPolicies))
-	opUpdatePolicy          = registerChangesetOp("UpdatePolicy", (*Database).applyUpdatePolicy, AffectsTopic(TopicPolicies))
-	opDeletePolicy          = registerChangesetOp("DeletePolicy", (*Database).applyDeletePolicy, AffectsTopic(TopicPolicies))
-	opCreatePolicyWithRules = registerChangesetOp("CreatePolicyWithRules", (*Database).applyCreatePolicyWithRules, AffectsTopic(TopicPolicies), AffectsTopic(TopicNetworkRules))
-	opUpdatePolicyWithRules = registerChangesetOp("UpdatePolicyWithRules", (*Database).applyUpdatePolicyWithRules, AffectsTopic(TopicPolicies), AffectsTopic(TopicNetworkRules))
+	opCreatePolicy          = registerChangesetOp("CreatePolicy", (*Database).applyCreatePolicy, AffectsTopic(TopicPolicies), AffectsTopic(TopicSessionReconcile))
+	opUpdatePolicy          = registerChangesetOp("UpdatePolicy", (*Database).applyUpdatePolicy, AffectsTopic(TopicPolicies), AffectsTopic(TopicSessionReconcile))
+	opDeletePolicy          = registerChangesetOp("DeletePolicy", (*Database).applyDeletePolicy, AffectsTopic(TopicPolicies), AffectsTopic(TopicSessionReconcile))
+	opCreatePolicyWithRules = registerChangesetOp("CreatePolicyWithRules", (*Database).applyCreatePolicyWithRules, AffectsTopic(TopicPolicies), AffectsTopic(TopicNetworkRules), AffectsTopic(TopicSessionReconcile))
+	opUpdatePolicyWithRules = registerChangesetOp("UpdatePolicyWithRules", (*Database).applyUpdatePolicyWithRules, AffectsTopic(TopicPolicies), AffectsTopic(TopicNetworkRules), AffectsTopic(TopicSessionReconcile))
 )
 
 // Network rules

--- a/internal/db/policies.go
+++ b/internal/db/policies.go
@@ -424,7 +424,7 @@ func (db *Database) GetSessionPolicy(ctx context.Context, imsi string, sst int32
 
 	span.SetStatus(codes.Error, "no matching policy")
 
-	return nil, nil, nil, fmt.Errorf("no policy matching sst=%d sd=%q dnn=%q for profile %s", sst, sd, dnn, sub.ProfileID)
+	return nil, nil, nil, fmt.Errorf("no policy matching sst=%d sd=%q dnn=%q for profile %s: %w", sst, sd, dnn, sub.ProfileID, ErrNoMatchingPolicy)
 }
 
 func (db *Database) CreatePolicy(ctx context.Context, policy *Policy) error {

--- a/internal/models/session.go
+++ b/internal/models/session.go
@@ -140,7 +140,9 @@ type ModifyRequest struct {
 	UpdateFARs   []FAR
 	RemoveFARIDs []uint32
 
-	CreateQERs []QER
+	CreateQERs   []QER
+	UpdateQERs   []QER
+	RemoveQERIDs []uint32
 }
 
 // DeleteRequest asks the UPF to delete a session by its SEID.

--- a/internal/models/session_reconcile.go
+++ b/internal/models/session_reconcile.go
@@ -1,0 +1,37 @@
+package models
+
+// SessionReconcileReason identifies why a session reconciliation was triggered.
+type SessionReconcileReason string
+
+const (
+	// ReconcileSkip indicates that the reconciler could not determine the
+	// correct action (e.g. policy lookup returned nil without an error).
+	// The session is left untouched and the backstop timer will retry.
+	ReconcileSkip SessionReconcileReason = ""
+	// ReconcilePolicyChange indicates the session's policy was updated.
+	ReconcilePolicyChange SessionReconcileReason = "policy_change"
+	// ReconcileSliceMismatch indicates the session's network slice (SST/SD)
+	// no longer matches any configured slice. The session must be released
+	// with cause #39 "reactivation requested" so the UE re-establishes on
+	// the correct slice.
+	ReconcileSliceMismatch SessionReconcileReason = "slice_mismatch"
+)
+
+// SessionReconcileRequest carries the data needed to reconcile an active PDU
+// session when subscriber-related fields (profile, policy) change in the DB.
+type SessionReconcileRequest struct {
+	SmContextRef string              // canonical SM context reference
+	OldPolicy    *SessionPolicyDelta // previous policy values (may be nil for profile changes)
+	NewPolicy    *SessionPolicyDelta // new policy values
+	Reason       SessionReconcileReason
+}
+
+// SessionPolicyDelta holds the policy fields that affect an active session.
+type SessionPolicyDelta struct {
+	SessionAmbrUplink   string // e.g. "100 Mbps"
+	SessionAmbrDownlink string // e.g. "500 Mbps"
+	Var5qi              int32
+	Arp                 int32
+	PreemptCap          PreemptionCapability
+	PreemptVuln         PreemptionVulnerability
+}

--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/smf"
+	smfNas "github.com/ellanetworks/core/internal/smf/nas"
 	"github.com/free5gc/aper"
 	"github.com/free5gc/nas"
 	"github.com/free5gc/nas/nasMessage"
@@ -123,6 +124,19 @@ func setupSessionWithTunnel(t *testing.T, s *smf.SMF) (*smf.SMContext, string) {
 		},
 	}
 
+	policy := &smf.Policy{
+		Ambr:    models.Ambr{Uplink: "100 Mbps", Downlink: "200 Mbps"},
+		QosData: models.QosData{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 1}, QFI: 1},
+	}
+
+	qer, err := s.NewQER(policy)
+	if err != nil {
+		t.Fatalf("NewQER: %v", err)
+	}
+
+	ulPdr.QER = qer
+	dlPdr.QER = qer
+
 	smCtx.Tunnel = &smf.UPTunnel{
 		DataPath: &smf.DataPath{
 			UpLinkTunnel: &smf.GTPTunnel{
@@ -140,12 +154,33 @@ func setupSessionWithTunnel(t *testing.T, s *smf.SMF) (*smf.SMContext, string) {
 	smCtx.Tunnel.ANInformation.TEID = 6000
 	smCtx.PDUIPV4Address = net.ParseIP("10.0.0.1").To4()
 
-	smCtx.PolicyData = &smf.Policy{
-		Ambr:    models.Ambr{Uplink: "100 Mbps", Downlink: "200 Mbps"},
-		QosData: models.QosData{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 1}, QFI: 1},
-	}
+	smCtx.PolicyData = policy
 
 	return smCtx, smf.CanonicalName(supi, 1)
+}
+
+func modificationSMPayload(t *testing.T, n1Msg []byte) []byte {
+	t.Helper()
+
+	msg := nas.NewMessage()
+	if err := msg.GsmMessageDecode(&n1Msg); err == nil && msg.PDUSessionModificationCommand != nil {
+		return n1Msg
+	}
+
+	msg = nas.NewMessage()
+	if err := msg.PlainNasDecode(&n1Msg); err != nil {
+		t.Fatalf("decode DL NAS Transport: %v", err)
+	}
+
+	if msg.GmmHeader.GetMessageType() != nas.MsgTypeDLNASTransport || msg.DLNASTransport == nil {
+		t.Fatal("expected DL NAS Transport carrying N1 SM information")
+	}
+
+	if msg.DLNASTransport.GetPayloadContainerType() != nasMessage.PayloadContainerTypeN1SMInfo {
+		t.Fatal("expected DL NAS Transport carrying N1 SM information")
+	}
+
+	return msg.DLNASTransport.GetPayloadContainerContents()
 }
 
 // ===========================
@@ -793,9 +828,10 @@ func TestUpdateSmContextN2InfoPduResRelRsp_NotFound(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
 
+	// Idempotent: returns nil when session already removed (e.g. slice-mismatch release).
 	err := s.UpdateSmContextN2InfoPduResRelRsp(context.Background(), "nonexistent")
-	if err == nil {
-		t.Fatal("expected error for non-existent session")
+	if err != nil {
+		t.Fatalf("expected nil for already-removed session, got error: %v", err)
 	}
 }
 
@@ -1039,6 +1075,294 @@ func TestHandleDownlinkDataReport(t *testing.T) {
 		t.Fatalf("expected 1 page call, got %d", len(amfCb.pageCalls))
 	}
 	amfCb.mu.Unlock()
+}
+
+func TestReconcileSmContext_UsesNewPolicyForPFCPAndN1N2(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "200 Mbps",
+			SessionAmbrDownlink: "300 Mbps",
+			Var5qi:              8,
+			Arp:                 14,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	upf.mu.Lock()
+	if len(upf.modifyCalls) != 1 {
+		upf.mu.Unlock()
+		t.Fatalf("expected 1 PFCP modify call, got %d", len(upf.modifyCalls))
+	}
+
+	modifyReq := upf.modifyCalls[0]
+	upf.mu.Unlock()
+
+	if len(modifyReq.UpdateQERs) != 1 {
+		t.Fatalf("expected 1 QER update, got %d", len(modifyReq.UpdateQERs))
+	}
+
+	qer := modifyReq.UpdateQERs[0]
+	if qer.MBR == nil {
+		t.Fatal("expected QER MBR")
+	}
+
+	if qer.MBR.ULMBR != 200000 || qer.MBR.DLMBR != 300000 {
+		t.Fatalf("QER MBR = %d/%d, want 200000/300000", qer.MBR.ULMBR, qer.MBR.DLMBR)
+	}
+
+	amfCb.mu.Lock()
+	if len(amfCb.modifyCalls) != 1 {
+		amfCb.mu.Unlock()
+		t.Fatalf("expected 1 N1N2 modify call, got %d", len(amfCb.modifyCalls))
+	}
+
+	call := amfCb.modifyCalls[0]
+	amfCb.mu.Unlock()
+
+	oldPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "100 Mbps", Downlink: "200 Mbps"}, &models.QosData{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 1}, QFI: 1})
+	if err != nil {
+		t.Fatalf("build old policy modification command: %v", err)
+	}
+
+	newPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "200 Mbps", Downlink: "300 Mbps"}, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1})
+	if err != nil {
+		t.Fatalf("build new policy modification command: %v", err)
+	}
+
+	gotPayload := modificationSMPayload(t, call.n1Msg)
+	if string(gotPayload) == string(oldPayload) {
+		t.Fatal("N1 modification command used old policy")
+	}
+
+	if string(gotPayload) != string(newPayload) {
+		t.Fatalf("N1 modification command did not use expected new policy")
+	}
+
+	if smCtx.PolicyData.Ambr.Uplink != "200 Mbps" || smCtx.PolicyData.Ambr.Downlink != "300 Mbps" {
+		t.Fatalf("stored AMBR = %s/%s", smCtx.PolicyData.Ambr.Uplink, smCtx.PolicyData.Ambr.Downlink)
+	}
+
+	if smCtx.PolicyData.QosData.Var5qi != 8 {
+		t.Fatalf("stored 5QI = %d, want 8", smCtx.PolicyData.QosData.Var5qi)
+	}
+}
+
+func TestReconcileSmContext_AmbrOnly(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "300 Mbps",
+			SessionAmbrDownlink: "400 Mbps",
+			Var5qi:              9,
+			Arp:                 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	qer := upf.modifyCalls[0].UpdateQERs[0]
+	if qer.MBR.ULMBR != 300000 || qer.MBR.DLMBR != 400000 {
+		t.Fatalf("QER MBR = %d/%d, want 300000/400000", qer.MBR.ULMBR, qer.MBR.DLMBR)
+	}
+
+	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "300 Mbps", Downlink: "400 Mbps"}, nil)
+	if err != nil {
+		t.Fatalf("build expected N1: %v", err)
+	}
+
+	gotPayload := modificationSMPayload(t, amfCb.modifyCalls[0].n1Msg)
+	if string(gotPayload) != string(expectedPayload) {
+		t.Fatal("N1 modification command mismatch")
+	}
+}
+
+func TestReconcileSmContext_QoSOnly(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "100 Mbps",
+			SessionAmbrDownlink: "200 Mbps",
+			Var5qi:              8,
+			Arp:                 14,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	qer := upf.modifyCalls[0].UpdateQERs[0]
+	if qer.MBR.ULMBR != 100000 || qer.MBR.DLMBR != 200000 {
+		t.Fatalf("QER MBR = %d/%d, want 100000/200000", qer.MBR.ULMBR, qer.MBR.DLMBR)
+	}
+
+	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, nil, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1})
+	if err != nil {
+		t.Fatalf("build expected N1: %v", err)
+	}
+
+	gotPayload := modificationSMPayload(t, amfCb.modifyCalls[0].n1Msg)
+	if string(gotPayload) != string(expectedPayload) {
+		t.Fatal("N1 modification command mismatch")
+	}
+}
+
+// TestReconcileSmContext_SliceMismatchFullCleanup verifies that a slice-mismatch
+// release performs full data-plane cleanup (IP release, PFCP deletion, session
+// removal) per TS 23.502 §4.3.4.2 Step 2 (before signaling the UE).
+func TestReconcileSmContext_SliceMismatchFullCleanup(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcileSliceMismatch,
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	// Session should be removed from the pool after full cleanup.
+	if s.GetSession(ref) != nil {
+		t.Fatal("expected session to be removed after slice-mismatch release")
+	}
+
+	// IP addresses should have been released.
+	store.mu.Lock()
+	releasedIPs := len(store.releasedIPs)
+	store.mu.Unlock()
+
+	if releasedIPs == 0 {
+		t.Fatal("expected IP release during slice-mismatch release, got 0")
+	}
+
+	// PFCP session should have been deleted.
+	upf.mu.Lock()
+	deleteCalls := len(upf.deleteCalls)
+	upf.mu.Unlock()
+
+	if deleteCalls == 0 {
+		t.Fatal("expected PFCP session deletion during slice-mismatch release, got 0")
+	}
+
+	// AMF release signaling should have been sent.
+	amfCb.mu.Lock()
+	releaseCalls := len(amfCb.releaseCalls)
+	amfCb.mu.Unlock()
+
+	if releaseCalls != 1 {
+		t.Fatalf("expected 1 release signaling call, got %d", releaseCalls)
+	}
+}
+
+func TestReconcileSmContext_ModifyIdleUE_CommitsPolicy(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	// Simulate idle UE: ModifyN1N2 returns ErrUENotReachable.
+	amfCb.err = smf.ErrUENotReachable
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "500 Mbps",
+			SessionAmbrDownlink: "600 Mbps",
+			Var5qi:              7,
+			Arp:                 10,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext should succeed for idle UE, got: %v", err)
+	}
+
+	// PFCP should still have been updated.
+	upf.mu.Lock()
+	pfcpModifyCalls := len(upf.modifyCalls)
+	upf.mu.Unlock()
+
+	if pfcpModifyCalls != 1 {
+		t.Fatalf("expected 1 PFCP modify call, got %d", pfcpModifyCalls)
+	}
+
+	// Policy should have been committed despite N1N2 skip.
+	if smCtx.PolicyData.Ambr.Uplink != "500 Mbps" || smCtx.PolicyData.Ambr.Downlink != "600 Mbps" {
+		t.Fatalf("policy not committed: AMBR = %s/%s", smCtx.PolicyData.Ambr.Uplink, smCtx.PolicyData.Ambr.Downlink)
+	}
+
+	if smCtx.PolicyData.QosData.Var5qi != 7 {
+		t.Fatalf("policy not committed: 5QI = %d, want 7", smCtx.PolicyData.QosData.Var5qi)
+	}
+}
+
+func TestReconcileSmContext_ReleaseIdleUE_RemovesSession(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	// Simulate idle UE: ReleaseSession returns ErrUENotReachable.
+	amfCb.err = smf.ErrUENotReachable
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcileSliceMismatch,
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext should succeed for idle UE release, got: %v", err)
+	}
+
+	// Session should be removed even though UE is idle.
+	if s.GetSession(ref) != nil {
+		t.Fatal("expected session to be removed after idle-UE slice-mismatch release")
+	}
+
+	// IP should still have been released.
+	store.mu.Lock()
+	releasedIPs := len(store.releasedIPs)
+	store.mu.Unlock()
+
+	if releasedIPs == 0 {
+		t.Fatal("expected IP release during idle-UE release")
+	}
+
+	// PFCP session should still have been deleted.
+	upf.mu.Lock()
+	deleteCalls := len(upf.deleteCalls)
+	upf.mu.Unlock()
+
+	if deleteCalls == 0 {
+		t.Fatal("expected PFCP deletion during idle-UE release")
+	}
 }
 
 // ===========================

--- a/internal/smf/nas/build_network_initiated_release.go
+++ b/internal/smf/nas/build_network_initiated_release.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package nas
+
+import (
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+)
+
+// BuildNetworkInitiatedPDUSessionReleaseCommand constructs a NAS PDU Session
+// Release Command for a network-initiated release (TS 24.501 clause 8.3.12).
+//
+// The cause value indicates why the network is releasing the session.
+// Common values:
+//   - nasMessage.Cause5GSMReactivationRequested (0x27 / #39):
+//     Tells the UE to immediately re-establish the PDU session.
+//     Used when the subscriber's slice assignment has changed.
+func BuildNetworkInitiatedPDUSessionReleaseCommand(pduSessionID uint8, cause uint8) ([]byte, error) {
+	m := nas.NewMessage()
+	m.GsmMessage = nas.NewGsmMessage()
+	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionReleaseCommand)
+	m.GsmHeader.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	m.PDUSessionReleaseCommand = nasMessage.NewPDUSessionReleaseCommand(0x0)
+	m.PDUSessionReleaseCommand.SetMessageType(nas.MsgTypePDUSessionReleaseCommand)
+	m.PDUSessionReleaseCommand.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	m.PDUSessionReleaseCommand.SetPDUSessionID(pduSessionID)
+	m.PDUSessionReleaseCommand.SetPTI(0) // Network-initiated: no PTI
+	m.PDUSessionReleaseCommand.SetCauseValue(cause)
+
+	return m.PlainNasEncode()
+}

--- a/internal/smf/nas/build_pdu_session_establishment_accept.go
+++ b/internal/smf/nas/build_pdu_session_establishment_accept.go
@@ -77,7 +77,7 @@ func BuildGSMPDUSessionEstablishmentAccept(
 		m.PDUSessionEstablishmentAccept.SetCauseValue(cause)
 	}
 
-	sessAmbr, err := modelsToSessionAMBR(ambr)
+	sessAmbr, err := ModelsToSessionAMBR(ambr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert models to SessionAMBR: %v", err)
 	}
@@ -180,7 +180,8 @@ func BuildGSMPDUSessionEstablishmentAccept(
 	return m.PlainNasEncode()
 }
 
-func modelsToSessionAMBR(ambr *models.Ambr) (nasType.SessionAMBR, error) {
+// ModelsToSessionAMBR converts an Ambr model to a NAS SessionAMBR type.
+func ModelsToSessionAMBR(ambr *models.Ambr) (nasType.SessionAMBR, error) {
 	var sessAmbr nasType.SessionAMBR
 
 	uplink := strings.Split(ambr.Uplink, " ")

--- a/internal/smf/nas/build_pdu_session_modification_command.go
+++ b/internal/smf/nas/build_pdu_session_modification_command.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package nas
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/nas/nasType"
+)
+
+// BuildPDUSessionModificationCommand constructs a NAS PDU Session Modification
+// Command message (TS 24.501 clause 8.3.9). It includes:
+//   - Session-AMBR IE (when ambr is non-nil, clause 8.3.9.3)
+//   - Authorized QoS flow descriptions IE (when qosData is non-nil, clause 8.3.9.8)
+//
+// At least one of ambr or qosData must be non-nil.
+func BuildPDUSessionModificationCommand(pduSessionID uint8, ambr *models.Ambr, qosData *models.QosData) ([]byte, error) {
+	if ambr == nil && qosData == nil {
+		return nil, fmt.Errorf("at least one of ambr or qosData must be provided")
+	}
+
+	m := nas.NewMessage()
+	m.GsmMessage = nas.NewGsmMessage()
+	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionModificationCommand)
+	m.GsmHeader.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	m.PDUSessionModificationCommand = nasMessage.NewPDUSessionModificationCommand(0x0)
+	m.PDUSessionModificationCommand.SetPDUSessionID(pduSessionID)
+	m.PDUSessionModificationCommand.SetMessageType(nas.MsgTypePDUSessionModificationCommand)
+	m.PDUSessionModificationCommand.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+
+	// Session-AMBR IE (TS 24.501 clause 8.3.9.3)
+	if ambr != nil {
+		sessAmbr, err := ModelsToSessionAMBR(ambr)
+		if err != nil {
+			return nil, fmt.Errorf("convert AMBR: %v", err)
+		}
+
+		sessAmbr.SetIei(nasMessage.PDUSessionModificationCommandSessionAMBRType)
+		m.PDUSessionModificationCommand.SessionAMBR = &sessAmbr
+		m.PDUSessionModificationCommand.SessionAMBR.SetLen(uint8(len(m.PDUSessionModificationCommand.SessionAMBR.Octet)))
+	}
+
+	// Authorized QoS flow descriptions IE (TS 24.501 clause 8.3.9.8)
+	if qosData != nil {
+		authQfd, err := BuildModifyQosFlowDescription(qosData)
+		if err != nil {
+			return nil, fmt.Errorf("build QoS flow descriptions: %v", err)
+		}
+
+		m.PDUSessionModificationCommand.AuthorizedQosFlowDescriptions = nasType.NewAuthorizedQosFlowDescriptions(nasMessage.PDUSessionModificationCommandAuthorizedQosFlowDescriptionsType)
+		m.PDUSessionModificationCommand.AuthorizedQosFlowDescriptions.SetLen(authQfd.IeLen)
+		m.PDUSessionModificationCommand.SetQoSFlowDescriptions(authQfd.Content)
+	}
+
+	return m.PlainNasEncode()
+}

--- a/internal/smf/nas/build_pdu_session_modification_command_test.go
+++ b/internal/smf/nas/build_pdu_session_modification_command_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package nas_test
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+	smfNas "github.com/ellanetworks/core/internal/smf/nas"
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+)
+
+func TestBuildPDUSessionModificationCommand_AmbrAndQoS(t *testing.T) {
+	ambr := &models.Ambr{
+		Uplink:   "200 Mbps",
+		Downlink: "200 Mbps",
+	}
+	qosData := &models.QosData{
+		QFI:    1,
+		Var5qi: 8,
+		Arp:    &models.Arp{PriorityLevel: 14},
+	}
+
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(1, ambr, qosData)
+	if err != nil {
+		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
+	}
+
+	// Decode and verify round-trip.
+	m := new(nas.Message)
+	if err := m.PlainNasDecode(&encoded); err != nil {
+		t.Fatalf("PlainNasDecode failed: %v", err)
+	}
+
+	if m.GsmHeader.GetMessageType() != nas.MsgTypePDUSessionModificationCommand {
+		t.Fatalf("unexpected message type: got %d, want %d", m.GsmHeader.GetMessageType(), nas.MsgTypePDUSessionModificationCommand)
+	}
+
+	modCmd := m.PDUSessionModificationCommand
+	if modCmd == nil {
+		t.Fatal("PDUSessionModificationCommand is nil after decode")
+	}
+
+	// Verify SessionAMBR is present with correct IEI.
+	if modCmd.SessionAMBR == nil {
+		t.Fatal("SessionAMBR is nil after decode; IEI likely missing or incorrect")
+	}
+
+	if modCmd.SessionAMBR.GetIei() != nasMessage.PDUSessionModificationCommandSessionAMBRType {
+		t.Fatalf("SessionAMBR IEI: got 0x%02x, want 0x%02x",
+			modCmd.SessionAMBR.GetIei(), nasMessage.PDUSessionModificationCommandSessionAMBRType)
+	}
+
+	// Verify AMBR values: 200 Mbps = unit Mbps (0x06), value 200.
+	ulUnit := modCmd.GetUnitForSessionAMBRForUplink()
+	if ulUnit != nasMessage.SessionAMBRUnit1Mbps {
+		t.Errorf("uplink AMBR unit: got %d, want %d", ulUnit, nasMessage.SessionAMBRUnit1Mbps)
+	}
+
+	dlUnit := modCmd.GetUnitForSessionAMBRForDownlink()
+	if dlUnit != nasMessage.SessionAMBRUnit1Mbps {
+		t.Errorf("downlink AMBR unit: got %d, want %d", dlUnit, nasMessage.SessionAMBRUnit1Mbps)
+	}
+
+	// Verify QoS flow descriptions are present.
+	if modCmd.AuthorizedQosFlowDescriptions == nil {
+		t.Fatal("AuthorizedQosFlowDescriptions is nil after decode")
+	}
+}
+
+func TestBuildPDUSessionModificationCommand_AmbrOnly(t *testing.T) {
+	ambr := &models.Ambr{
+		Uplink:   "300 Mbps",
+		Downlink: "400 Mbps",
+	}
+
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(5, ambr, nil)
+	if err != nil {
+		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
+	}
+
+	m := new(nas.Message)
+	if err := m.PlainNasDecode(&encoded); err != nil {
+		t.Fatalf("PlainNasDecode failed: %v", err)
+	}
+
+	modCmd := m.PDUSessionModificationCommand
+	if modCmd == nil {
+		t.Fatal("PDUSessionModificationCommand is nil")
+	}
+
+	if modCmd.SessionAMBR == nil {
+		t.Fatal("SessionAMBR is nil; expected AMBR-only modification to include it")
+	}
+
+	if modCmd.AuthorizedQosFlowDescriptions != nil {
+		t.Fatal("AuthorizedQosFlowDescriptions should be nil for AMBR-only modification")
+	}
+}
+
+func TestBuildPDUSessionModificationCommand_QoSOnly(t *testing.T) {
+	qosData := &models.QosData{
+		QFI:    1,
+		Var5qi: 7,
+		Arp:    &models.Arp{PriorityLevel: 10},
+	}
+
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(3, nil, qosData)
+	if err != nil {
+		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
+	}
+
+	m := new(nas.Message)
+	if err := m.PlainNasDecode(&encoded); err != nil {
+		t.Fatalf("PlainNasDecode failed: %v", err)
+	}
+
+	modCmd := m.PDUSessionModificationCommand
+	if modCmd == nil {
+		t.Fatal("PDUSessionModificationCommand is nil")
+	}
+
+	if modCmd.SessionAMBR != nil {
+		t.Fatal("SessionAMBR should be nil for QoS-only modification")
+	}
+
+	if modCmd.AuthorizedQosFlowDescriptions == nil {
+		t.Fatal("AuthorizedQosFlowDescriptions is nil; expected QoS-only modification to include it")
+	}
+}

--- a/internal/smf/nas/build_qos_flow.go
+++ b/internal/smf/nas/build_qos_flow.go
@@ -93,6 +93,34 @@ func BuildAuthorizedQosFlowDescription(qosData *models.QosData) (*QosFlowDescrip
 	return &QFDescriptions, nil
 }
 
+// BuildModifyQosFlowDescription builds a QoS Flow Description with the "modify
+// existing QoS flow description" operation code (TS 24.501 Table 9.11.4.12).
+// Used in PDU Session Modification Command to update 5QI on an existing flow.
+func BuildModifyQosFlowDescription(qosData *models.QosData) (*QosFlowDescriptionsAuthorized, error) {
+	if qosData == nil {
+		return nil, fmt.Errorf("qos data is nil")
+	}
+
+	qfDescriptions := QosFlowDescriptionsAuthorized{
+		IeType:  nasMessage.PDUSessionModificationCommandAuthorizedQosFlowDescriptionsType,
+		Content: make([]byte, 0),
+	}
+
+	qfd := QoSFlowDescription{QFDLen: QFDFixLen}
+	qfd.SetQoSFlowDescQfi(qosData.QFI)
+	qfd.SetQoSFlowDescOpCode(QFDOpModify)
+	qfd.AddQosFlowParam5Qi(uint8(qosData.Var5qi))
+
+	// For "modify existing QoS flow description", set E-bit to indicate
+	// that parameters list is included and replaces all previously sent
+	// parameters (TS 24.501 Table 9.11.4.12).
+	qfd.NumOfParam |= QFDEbit
+
+	qfDescriptions.AddQFD(&qfd)
+
+	return &qfDescriptions, nil
+}
+
 func (d *QosFlowDescriptionsAuthorized) BuildAddQosFlowDescFromQoSDesc(qosData *models.QosData) error {
 	qfd := QoSFlowDescription{QFDLen: QFDFixLen}
 

--- a/internal/smf/ngap/build_pdu_session_resource_modify_request_transfer.go
+++ b/internal/smf/ngap/build_pdu_session_resource_modify_request_transfer.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package ngap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapConvert"
+	"github.com/free5gc/ngap/ngapType"
+)
+
+// BuildPDUSessionResourceModifyRequestTransfer constructs the N2 SM Information
+// for a PDU Session Resource Modify Request (TS 38.413 §9.3.4.3).
+//
+// It includes:
+//   - PDU Session Aggregate Maximum Bit Rate (when ambr is non-nil)
+//   - QoS Flow Add or Modify Request List (when qosData is non-nil)
+//
+// This is used during network-requested PDU Session Modification (TS 23.502
+// §4.3.3.2) to update the gNB with new QoS parameters and/or session AMBR.
+func BuildPDUSessionResourceModifyRequestTransfer(ambr *models.Ambr, qosData *models.QosData) ([]byte, error) {
+	transfer := ngapType.PDUSessionResourceModifyRequestTransfer{}
+
+	// PDU Session Aggregate Maximum Bit Rate (IE ID 130)
+	if ambr != nil {
+		ie := ngapType.PDUSessionResourceModifyRequestTransferIEs{}
+		ie.Id.Value = ngapType.ProtocolIEIDPDUSessionAggregateMaximumBitRate
+		ie.Criticality.Value = ngapType.CriticalityPresentReject
+		ie.Value = ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
+			Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentPDUSessionAggregateMaximumBitRate,
+			PDUSessionAggregateMaximumBitRate: &ngapType.PDUSessionAggregateMaximumBitRate{
+				PDUSessionAggregateMaximumBitRateDL: ngapType.BitRate{
+					Value: ngapConvert.UEAmbrToInt64(ambr.Downlink),
+				},
+				PDUSessionAggregateMaximumBitRateUL: ngapType.BitRate{
+					Value: ngapConvert.UEAmbrToInt64(ambr.Uplink),
+				},
+			},
+		}
+		transfer.ProtocolIEs.List = append(transfer.ProtocolIEs.List, ie)
+	}
+
+	// QoS Flow Add or Modify Request List (IE ID 135)
+	if qosData != nil {
+		arpPreemptCap := ngapType.PreEmptionCapabilityPresentMayTriggerPreEmption
+		if qosData.Arp != nil && qosData.Arp.PreemptCap == models.PreemptionCapabilityNotPreempt {
+			arpPreemptCap = ngapType.PreEmptionCapabilityPresentShallNotTriggerPreEmption
+		}
+
+		arpPreemptVul := ngapType.PreEmptionVulnerabilityPresentNotPreEmptable
+		if qosData.Arp != nil && qosData.Arp.PreemptVuln == models.PreemptionVulnerabilityPreemptable {
+			arpPreemptVul = ngapType.PreEmptionVulnerabilityPresentPreEmptable
+		}
+
+		arpLevel := int64(1)
+		if qosData.Arp != nil {
+			arpLevel = int64(qosData.Arp.PriorityLevel)
+		}
+
+		qosFlowItem := ngapType.QosFlowAddOrModifyRequestItem{
+			QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: int64(qosData.QFI)},
+			QosFlowLevelQosParameters: &ngapType.QosFlowLevelQosParameters{
+				QosCharacteristics: ngapType.QosCharacteristics{
+					Present: ngapType.QosCharacteristicsPresentNonDynamic5QI,
+					NonDynamic5QI: &ngapType.NonDynamic5QIDescriptor{
+						FiveQI: ngapType.FiveQI{
+							Value: int64(qosData.Var5qi),
+						},
+					},
+				},
+				AllocationAndRetentionPriority: ngapType.AllocationAndRetentionPriority{
+					PriorityLevelARP: ngapType.PriorityLevelARP{
+						Value: arpLevel,
+					},
+					PreEmptionCapability: ngapType.PreEmptionCapability{
+						Value: arpPreemptCap,
+					},
+					PreEmptionVulnerability: ngapType.PreEmptionVulnerability{
+						Value: arpPreemptVul,
+					},
+				},
+			},
+		}
+
+		ie := ngapType.PDUSessionResourceModifyRequestTransferIEs{}
+		ie.Id.Value = ngapType.ProtocolIEIDQosFlowAddOrModifyRequestList
+		ie.Criticality.Value = ngapType.CriticalityPresentReject
+		ie.Value = ngapType.PDUSessionResourceModifyRequestTransferIEsValue{
+			Present: ngapType.PDUSessionResourceModifyRequestTransferIEsPresentQosFlowAddOrModifyRequestList,
+			QosFlowAddOrModifyRequestList: &ngapType.QosFlowAddOrModifyRequestList{
+				List: []ngapType.QosFlowAddOrModifyRequestItem{qosFlowItem},
+			},
+		}
+		transfer.ProtocolIEs.List = append(transfer.ProtocolIEs.List, ie)
+	}
+
+	if len(transfer.ProtocolIEs.List) == 0 {
+		return nil, fmt.Errorf("no IEs to encode in PDU Session Resource Modify Request Transfer")
+	}
+
+	buf, err := aper.MarshalWithParams(transfer, "valueExt")
+	if err != nil {
+		return nil, fmt.Errorf("encode PDU Session Resource Modify Request Transfer: %w", err)
+	}
+
+	return buf, nil
+}

--- a/internal/smf/pfcp_rules.go
+++ b/internal/smf/pfcp_rules.go
@@ -153,8 +153,13 @@ func BuildModifyRequest(
 	}
 
 	for _, qer := range qers {
-		if qer.State == RuleInitial {
+		switch qer.State {
+		case RuleInitial:
 			req.CreateQERs = append(req.CreateQERs, qer.ToQER())
+		case RuleUpdate:
+			req.UpdateQERs = append(req.UpdateQERs, qer.ToQER())
+		case RuleRemove:
+			req.RemoveQERIDs = append(req.RemoveQERIDs, qer.QERID)
 		}
 
 		qer.State = RuleCreate

--- a/internal/smf/reconcile.go
+++ b/internal/smf/reconcile.go
@@ -1,0 +1,423 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package smf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/smf/nas"
+	"github.com/ellanetworks/core/internal/smf/ngap"
+	"github.com/free5gc/nas/nasMessage"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+// ReconcileSmContext applies policy changes to an active PDU session.
+// It compares the old and new policy data, updates the UPF via PFCP if QoS
+// parameters changed, and sends N1+N2 messages to the UE and gNB when session
+// QoS or AMBR changes.
+//
+// When the reason is ReconcileSliceMismatch, the session is released with
+// cause #39 "reactivation requested" (TS 24.501 table 11.4.2.1) so the UE
+// re-establishes on the correct slice.
+//
+// For QoS/AMBR changes this implements the 3GPP network-requested PDU Session
+// Modification procedure (TS 23.502 clause 4.3.3.2) triggered by an
+// OAM-initiated policy update.
+func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error {
+	if req == nil {
+		return fmt.Errorf("reconcile request is nil")
+	}
+
+	ctx, span := tracer.Start(ctx, "smf/reconcile_sm_context",
+		trace.WithAttributes(
+			attribute.String("smf.smContextRef", req.SmContextRef),
+			attribute.String("smf.reason", string(req.Reason)),
+		),
+	)
+	defer span.End()
+
+	if req.SmContextRef == "" {
+		span.SetStatus(codes.Error, "sm context reference is missing")
+
+		return fmt.Errorf("sm context reference is missing")
+	}
+
+	smContext := s.GetSession(req.SmContextRef)
+	if smContext == nil {
+		span.SetStatus(codes.Error, "sm context not found")
+
+		return fmt.Errorf("sm context not found: %s", req.SmContextRef)
+	}
+
+	smContext.Mutex.Lock()
+	defer smContext.Mutex.Unlock()
+
+	if smContext.Tunnel == nil || !smContext.Tunnel.DataPath.Activated {
+		logger.SmfLog.Debug("session not activated, skipping reconciliation",
+			logger.SUPI(smContext.Supi.String()),
+			logger.PDUSessionID(smContext.PDUSessionID),
+		)
+
+		return nil
+	}
+
+	if smContext.PolicyData == nil {
+		logger.SmfLog.Debug("session has no policy data, skipping reconciliation",
+			logger.SUPI(smContext.Supi.String()),
+			logger.PDUSessionID(smContext.PDUSessionID),
+		)
+
+		return nil
+	}
+
+	// --- Slice mismatch: network-initiated release ---
+	// When SST/SD changed, the session's stored Snssai no longer matches any
+	// slice. Per TS 23.502 §4.3.4.2, release with cause #39 so the UE
+	// automatically re-establishes on the new slice.
+	if req.Reason == models.ReconcileSliceMismatch {
+		return s.sendSessionRelease(ctx, smContext)
+	}
+
+	// --- QoS/AMBR modification path ---
+	oldQoS := smContext.PolicyData.QosData
+	oldAmbr := smContext.PolicyData.Ambr
+
+	hasQoSChange := false
+	hasAmbrChange := false
+
+	if req.NewPolicy != nil {
+		oldArp := int32(0)
+		if oldQoS.Arp != nil {
+			oldArp = oldQoS.Arp.PriorityLevel
+		}
+
+		if oldQoS.Var5qi != req.NewPolicy.Var5qi || oldArp != req.NewPolicy.Arp {
+			hasQoSChange = true
+		}
+
+		if oldAmbr.Uplink != req.NewPolicy.SessionAmbrUplink || oldAmbr.Downlink != req.NewPolicy.SessionAmbrDownlink {
+			hasAmbrChange = true
+		}
+	}
+
+	newPolicy := smContext.PolicyData
+	if (hasQoSChange || hasAmbrChange) && req.NewPolicy != nil {
+		newPolicy = &Policy{
+			PolicyID: smContext.PolicyData.PolicyID,
+			Ambr: models.Ambr{
+				Uplink:   req.NewPolicy.SessionAmbrUplink,
+				Downlink: req.NewPolicy.SessionAmbrDownlink,
+			},
+			QosData: models.QosData{
+				QFI:    smContext.PolicyData.QosData.QFI,
+				Var5qi: req.NewPolicy.Var5qi,
+				Arp: &models.Arp{
+					PriorityLevel: req.NewPolicy.Arp,
+					PreemptCap:    req.NewPolicy.PreemptCap,
+					PreemptVuln:   req.NewPolicy.PreemptVuln,
+				},
+			},
+			NetworkRules: smContext.PolicyData.NetworkRules,
+			DNS:          smContext.PolicyData.DNS,
+			MTU:          smContext.PolicyData.MTU,
+			IPv4Pool:     smContext.PolicyData.IPv4Pool,
+			IPv6Pool:     smContext.PolicyData.IPv6Pool,
+		}
+	}
+
+	// Push QoS changes to the UPF via PFCP Session Modification.
+	if hasQoSChange || hasAmbrChange {
+		if err := s.updatePFCPRules(ctx, smContext, newPolicy); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to update PFCP rules")
+
+			logger.SmfLog.Error("failed to update PFCP rules during reconciliation",
+				zap.Error(err),
+				logger.SUPI(smContext.Supi.String()),
+				logger.PDUSessionID(smContext.PDUSessionID),
+				zap.String("reason", string(req.Reason)),
+			)
+
+			return fmt.Errorf("failed to update PFCP rules: %v", err)
+		}
+
+		logger.SmfLog.Info("PFCP rules updated during reconciliation",
+			logger.SUPI(smContext.Supi.String()),
+			logger.PDUSessionID(smContext.PDUSessionID),
+			zap.Bool("qosChange", hasQoSChange),
+			zap.Bool("ambrChange", hasAmbrChange),
+			zap.String("reason", string(req.Reason)),
+		)
+	}
+
+	// Send N1 (NAS) + N2 (NGAP) messages to notify the UE and gNB of changes.
+	// Per TS 23.502 clause 4.3.3.2, the SMF sends:
+	//   - N1: PDU Session Modification Command (Session-AMBR, QoS flow descriptions)
+	//   - N2: PDU Session Resource Modify Request Transfer (PDU Session Aggregate
+	//     Maximum Bit Rate, QoS Flow Add or Modify Request List with QoS profile)
+	//
+	// If the UE is in CM-IDLE, N1N2 delivery is skipped (per TS 23.502 §4.2.3.3
+	// step 3b: the AMF may ignore the N2 SM information when the UE is not
+	// reachable). The policy is still committed so that ActivateSmContext
+	// returns updated QoS when the UE transitions back to CM-CONNECTED.
+	if (hasAmbrChange || hasQoSChange) && req.NewPolicy != nil {
+		if err := s.sendSessionModification(ctx, smContext, newPolicy, hasAmbrChange, hasQoSChange); err != nil {
+			if errors.Is(err, ErrUENotReachable) {
+				logger.SmfLog.Debug("UE is idle, skipping N1N2 delivery; policy committed for next activation",
+					logger.SUPI(smContext.Supi.String()),
+					logger.PDUSessionID(smContext.PDUSessionID),
+				)
+			} else {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "failed to send session modification to UE/gNB")
+
+				logger.SmfLog.Error("failed to send session modification to UE/gNB",
+					zap.Error(err),
+					logger.SUPI(smContext.Supi.String()),
+					logger.PDUSessionID(smContext.PDUSessionID),
+				)
+
+				return fmt.Errorf("failed to send session modification: %v", err)
+			}
+		}
+	}
+
+	// Commit policy data after PFCP succeeds. N1/N2 delivery may be skipped
+	// (UE idle) — this is intentional: ActivateSmContext rebuilds the Setup
+	// Transfer from PolicyData, so the UE gets updated QoS on reconnect.
+	// If PFCP or a real N1/N2 failure returned above, we never reach here.
+	if (hasQoSChange || hasAmbrChange) && req.NewPolicy != nil {
+		smContext.PolicyData = newPolicy
+	}
+
+	return nil
+}
+
+// sendSessionModification builds and sends N1+N2 messages for the network-
+// requested PDU Session Modification (TS 23.502 §4.3.3.2).
+//
+// N1 (to UE): PDU Session Modification Command containing:
+//   - Session-AMBR (when AMBR changed, TS 24.501 §8.3.9.3)
+//   - Authorized QoS flow descriptions (when 5QI/ARP changed, TS 24.501 §8.3.9.8)
+//
+// N2 (to gNB): PDU Session Resource Modify Request Transfer containing:
+//   - PDU Session Aggregate Maximum Bit Rate (when AMBR changed)
+//   - QoS Flow Add or Modify Request List (when 5QI/ARP changed)
+func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext, policy *Policy, hasAmbrChange, hasQoSChange bool) error {
+	// Build N1 NAS message.
+	var n1Ambr *models.Ambr
+	if hasAmbrChange {
+		n1Ambr = &policy.Ambr
+	}
+
+	var n1QoS *models.QosData
+	if hasQoSChange {
+		n1QoS = &policy.QosData
+	}
+
+	n1Msg, err := nas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, n1Ambr, n1QoS)
+	if err != nil {
+		return fmt.Errorf("build PDU Session Modification Command (N1): %w", err)
+	}
+
+	// Build N2 NGAP message.
+	var n2Ambr *models.Ambr
+	if hasAmbrChange {
+		n2Ambr = &policy.Ambr
+	}
+
+	var n2QoS *models.QosData
+	if hasQoSChange {
+		n2QoS = &policy.QosData
+	}
+
+	n2Msg, err := ngap.BuildPDUSessionResourceModifyRequestTransfer(n2Ambr, n2QoS)
+	if err != nil {
+		return fmt.Errorf("build PDU Session Resource Modify Request Transfer (N2): %w", err)
+	}
+
+	// Deliver combined N1+N2 via the AMF. The AMF will send a
+	// PDUSessionResourceModifyRequest (TS 38.413 §9.2.1.5) to the gNB,
+	// carrying the NAS PDU piggy-backed in the per-session modify item.
+	if err := s.amf.ModifyN1N2(ctx, smContext.Supi, smContext.PDUSessionID, n1Msg, n2Msg); err != nil {
+		return fmt.Errorf("transfer N1N2 message: %w", err)
+	}
+
+	logger.SmfLog.Info("session modification N1+N2 sent",
+		logger.SUPI(smContext.Supi.String()),
+		logger.PDUSessionID(smContext.PDUSessionID),
+		zap.Bool("ambrChange", hasAmbrChange),
+		zap.Bool("qosChange", hasQoSChange),
+	)
+
+	return nil
+}
+
+// updatePFCPRules rebuilds the QER with the new rate limits and sends a PFCP
+// Session Modification Request to the UPF. This enforces the updated QoS
+// parameters in the data plane (TS 29.244 clause 7.5.4).
+func (s *SMF) updatePFCPRules(ctx context.Context, smContext *SMContext, policy *Policy) error {
+	if smContext.PFCPContext == nil || smContext.PFCPContext.RemoteSEID == 0 {
+		return fmt.Errorf("PFCP session not established")
+	}
+
+	if smContext.Tunnel == nil || smContext.Tunnel.DataPath == nil {
+		return fmt.Errorf("data path not available")
+	}
+
+	dataPath := smContext.Tunnel.DataPath
+	qerList := make([]*QER, 0, 2)
+
+	// Collect QERs from both tunnel directions.
+	// Note: QER MBR is set to session AMBR because this implementation supports
+	// a single QoS flow per PDU session (non-GBR only). Per TS 23.501 §5.7.2.2,
+	// session AMBR is the aggregate limit across all non-GBR flows. With only
+	// one flow, session AMBR equals the per-flow MBR. If multiple flows or GBR
+	// flows are ever supported, this must be changed to use per-flow MBR values.
+	if dataPath.UpLinkTunnel != nil && dataPath.UpLinkTunnel.PDR != nil && dataPath.UpLinkTunnel.PDR.QER != nil {
+		qer := dataPath.UpLinkTunnel.PDR.QER
+		qer.QFI = policy.QosData.QFI
+		qer.MBR = &models.MBR{
+			ULMBR: bitRateTokbps(policy.Ambr.Uplink),
+			DLMBR: bitRateTokbps(policy.Ambr.Downlink),
+		}
+		qer.State = RuleUpdate
+		qerList = append(qerList, qer)
+	}
+
+	if dataPath.DownLinkTunnel != nil && dataPath.DownLinkTunnel.PDR != nil && dataPath.DownLinkTunnel.PDR.QER != nil {
+		found := false
+
+		for _, existing := range qerList {
+			if existing.QERID == dataPath.DownLinkTunnel.PDR.QER.QERID {
+				found = true
+
+				break
+			}
+		}
+
+		if !found && dataPath.DownLinkTunnel.PDR.QER != nil {
+			qer := dataPath.DownLinkTunnel.PDR.QER
+			qer.QFI = policy.QosData.QFI
+			qer.MBR = &models.MBR{
+				ULMBR: bitRateTokbps(policy.Ambr.Uplink),
+				DLMBR: bitRateTokbps(policy.Ambr.Downlink),
+			}
+			qer.State = RuleUpdate
+			qerList = append(qerList, qer)
+		}
+	}
+
+	if len(qerList) == 0 {
+		return fmt.Errorf("no QERs found to update")
+	}
+
+	var policyID string
+	if policy != nil {
+		policyID = policy.PolicyID
+	}
+
+	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
+		smContext.PFCPContext.RemoteSEID,
+		policyID,
+		nil, nil, qerList,
+	)); err != nil {
+		return fmt.Errorf("failed to modify PFCP session: %v", err)
+	}
+
+	return nil
+}
+
+// sendSessionRelease performs a network-initiated PDU Session Release:
+// This implements TS 23.502 §4.3.4.2 (network-requested PDU session release)
+// for the case where the subscriber's slice assignment (SST/SD) has changed.
+//
+// Per TS 23.502 §4.3.4.2:
+//  1. Releases IP addresses and tears down the data plane (PFCP session
+//     deletion + GTP tunnel release) — Step 2 in the spec.
+//  2. Builds N1 PDU Session Release Command with cause #39 "reactivation
+//     requested" and N2 PDU Session Resource Release Command Transfer.
+//  3. Sends the combined N1+N2 to UE/gNB via the AMF — Step 3 in the spec.
+//  4. Removes the session from the SMF pool.
+//
+// Upon receiving cause #39 "reactivation requested" (TS 24.501 table 5.5.10),
+// the UE is expected to initiate a new PDU session establishment
+// (TS 24.501 §6.3.3). The UE's PDU Session Release Complete and gNB's N2
+// Resource Release Ack will find the session already removed and return
+// idempotently (see UpdateSmContextN2InfoPduResRelRsp).
+//
+// Caller must hold smContext.Mutex.Lock().
+func (s *SMF) sendSessionRelease(ctx context.Context, smContext *SMContext) error {
+	// Step 2 (TS 23.502 §4.3.4.2): Release IP addresses and user plane
+	// resources before signaling the UE.
+	if smContext.PDUIPV4Address != nil {
+		if _, err := s.store.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.Dnn, smContext.PDUSessionID); err != nil {
+			logger.SmfLog.Warn("release UE IPv4 address failed during slice-mismatch release, continuing teardown",
+				zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+		}
+	}
+
+	if smContext.PDUIPV6Prefix != nil {
+		if _, err := s.store.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.Dnn, smContext.PDUSessionID); err != nil {
+			logger.SmfLog.Warn("release UE IPv6 address failed during slice-mismatch release, continuing teardown",
+				zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+		}
+	}
+
+	if err := s.releaseTunnel(ctx, smContext); err != nil {
+		logger.SmfLog.Warn("release tunnel failed during slice-mismatch release, continuing teardown",
+			zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+	}
+
+	// Step 3: Build N1+N2 and signal the UE/gNB.
+	// Per TS 23.502 §4.3.4.2 step 3: if UE is in CM-IDLE, the AMF uses the
+	// "skip indicator" — NAS delivery is not possible without radio resources.
+	// The session is released locally (data plane already torn down above).
+	// When the UE reconnects, the PDUSessionStatus IE in the Service Request
+	// or Registration Request will not include this session, confirming the
+	// release implicitly (TS 24.501 §5.4.4).
+	n1Msg, err := nas.BuildNetworkInitiatedPDUSessionReleaseCommand(
+		smContext.PDUSessionID,
+		nasMessage.Cause5GSMReactivationRequested,
+	)
+	if err != nil {
+		return fmt.Errorf("build PDU Session Release Command (N1): %w", err)
+	}
+
+	n2Transfer, err := ngap.BuildPDUSessionResourceReleaseCommandTransfer()
+	if err != nil {
+		return fmt.Errorf("build PDU Session Resource Release Command Transfer (N2): %w", err)
+	}
+
+	if err := s.amf.ReleaseSession(ctx, smContext.Supi, smContext.PDUSessionID, n1Msg, n2Transfer); err != nil {
+		if errors.Is(err, ErrUENotReachable) {
+			logger.SmfLog.Debug("UE is idle, skipping release signaling; session removed locally",
+				logger.SUPI(smContext.Supi.String()),
+				logger.PDUSessionID(smContext.PDUSessionID),
+			)
+		} else {
+			return fmt.Errorf("release session signaling: %w", err)
+		}
+	}
+
+	// Remove session from the SMF pool. When the gNB/UE response arrives at
+	// UpdateSmContextN2InfoPduResRelRsp, the session will already be gone and
+	// the handler returns nil (idempotent).
+	s.removeSessionUnlocked(ctx, smContext.CanonicalName())
+
+	logger.SmfLog.Info("network-initiated session release complete (slice mismatch)",
+		logger.SUPI(smContext.Supi.String()),
+		logger.PDUSessionID(smContext.PDUSessionID),
+		zap.String("cause", "reactivation_requested"),
+	)
+
+	return nil
+}

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -29,6 +29,18 @@ var tracer = otel.Tracer("ella-core/smf/session")
 // ErrDNNNotFound indicates that the requested data network (DNN) does not exist.
 var ErrDNNNotFound = errors.New("data network not found")
 
+// ErrNoPolicyMatch indicates that no policy matches the session's slice (SST/SD)
+// and DNN. This typically means the admin changed the slice configuration and
+// the session's stored S-NSSAI no longer maps to any configured slice.
+var ErrNoPolicyMatch = errors.New("no matching policy for slice and DNN")
+
+// ErrUENotReachable indicates that the UE is in CM-IDLE state and the requested
+// signaling cannot be delivered over the radio. AMFCallback implementations
+// must return this error (wrapping is fine) when the UE has no active RAN
+// connection. Callers should handle gracefully — e.g. commit policy locally
+// and defer radio delivery until the UE reconnects.
+var ErrUENotReachable = errors.New("UE is in CM-IDLE state")
+
 // SessionQuerier provides read-only access to active sessions.
 // External packages (API, AMF export, metrics) use this interface
 // instead of a package-level SMF singleton.
@@ -101,8 +113,19 @@ type AMFCallback interface {
 	// TransferN1 delivers a NAS message to the UE.
 	TransferN1(ctx context.Context, supi etsi.SUPI, n1Msg []byte, pduSessionID uint8) error
 
-	// TransferN1N2 delivers a combined N1+N2 message.
+	// TransferN1N2 delivers a combined N1+N2 message for PDU Session Setup.
 	TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) error
+
+	// ModifyN1N2 delivers N1 (NAS PDU Session Modification Command) + N2
+	// (PDU Session Resource Modify Request Transfer) to the UE/gNB via the
+	// NGAP PDUSessionResourceModifyRequest procedure (TS 38.413 §9.2.1.5).
+	ModifyN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error
+
+	// ReleaseSession sends a network-initiated PDU Session Release to the UE/gNB.
+	// N1 (NAS PDU Session Release Command) is delivered piggy-backed on the
+	// NGAP PDUSessionResourceReleaseCommand (TS 38.413 §9.2.1.3).
+	// n2Transfer is the PDUSessionResourceReleaseCommandTransfer IE.
+	ReleaseSession(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Transfer []byte) error
 
 	// N2TransferOrPage sends an N2 message to the radio, paging the UE if needed.
 	N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -181,11 +181,13 @@ func (f *fakeUPF) UnregisterIPv6Session(_ context.Context, _ uint32) error {
 }
 
 type fakeAMF struct {
-	mu        sync.Mutex
-	n1Calls   []n1Call
-	n1n2Calls []n1n2Call
-	pageCalls []pageCall
-	err       error
+	mu           sync.Mutex
+	n1Calls      []n1Call
+	n1n2Calls    []n1n2Call
+	modifyCalls  []n1n2Call
+	releaseCalls []releaseCall
+	pageCalls    []pageCall
+	err          error
 }
 
 type n1Call struct {
@@ -200,6 +202,13 @@ type n1n2Call struct {
 	snssai       *models.Snssai
 	n1Msg        []byte
 	n2Msg        []byte
+}
+
+type releaseCall struct {
+	supi         etsi.SUPI
+	pduSessionID uint8
+	n1Msg        []byte
+	n2Transfer   []byte
 }
 
 type pageCall struct {
@@ -223,6 +232,24 @@ func (f *fakeAMF) TransferN1N2(_ context.Context, supi etsi.SUPI, pduSessionID u
 	defer f.mu.Unlock()
 
 	f.n1n2Calls = append(f.n1n2Calls, n1n2Call{supi, pduSessionID, snssai, n1Msg, n2Msg})
+
+	return f.err
+}
+
+func (f *fakeAMF) ModifyN1N2(_ context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.modifyCalls = append(f.modifyCalls, n1n2Call{supi, pduSessionID, nil, n1Msg, n2Msg})
+
+	return f.err
+}
+
+func (f *fakeAMF) ReleaseSession(_ context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Transfer []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.releaseCalls = append(f.releaseCalls, releaseCall{supi, pduSessionID, n1Msg, n2Transfer})
 
 	return f.err
 }

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -339,10 +339,12 @@ func (s *SMF) UpdateSmContextN2InfoPduResRelRsp(ctx context.Context, smContextRe
 
 	smContext := s.GetSession(smContextRef)
 	if smContext == nil {
-		span.RecordError(fmt.Errorf("sm context not found"))
-		span.SetStatus(codes.Error, "sm context not found")
+		// Session already removed (e.g. by slice-mismatch release).
+		// Idempotent: returning nil lets the AMF complete its cleanup.
+		logger.SmfLog.Info("SM context already removed, skipping",
+			zap.String("smContextRef", smContextRef))
 
-		return fmt.Errorf("sm context not found: %s", smContextRef)
+		return nil
 	}
 
 	smContext.Mutex.Lock()
@@ -352,7 +354,11 @@ func (s *SMF) UpdateSmContextN2InfoPduResRelRsp(ctx context.Context, smContextRe
 		smContext.PDUSessionReleaseDueToDupPduID = false
 		s.RemoveSession(ctx, smContext.CanonicalName())
 	} else {
-		// N1 release path already called ReleaseIP; just remove from pool.
+		// UE-initiated release: the N1 path (UpdateSmContextN1Msg) already
+		// released IPs and tunnel; just remove from pool.
+		// Network-initiated slice-mismatch release: the session is already
+		// fully cleaned up and removed by sendSessionRelease, so this path
+		// is only reached for UE-initiated releases.
 		s.removeSessionUnlocked(ctx, smContext.CanonicalName())
 	}
 

--- a/internal/tester/gnb/build_pdu_session_resource_modify_response.go
+++ b/internal/tester/gnb/build_pdu_session_resource_modify_response.go
@@ -1,0 +1,78 @@
+package gnb
+
+import (
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapType"
+)
+
+type PDUSessionResourceModifyResponseOpts struct {
+	AMFUENGAPID   int64
+	RANUENGAPID   int64
+	PDUSessionIDs []int64
+}
+
+func BuildPDUSessionResourceModifyResponse(opts *PDUSessionResourceModifyResponseOpts) (ngapType.NGAPPDU, error) {
+	pdu := ngapType.NGAPPDU{}
+
+	pdu.Present = ngapType.NGAPPDUPresentSuccessfulOutcome
+	pdu.SuccessfulOutcome = new(ngapType.SuccessfulOutcome)
+
+	successfulOutcome := pdu.SuccessfulOutcome
+	successfulOutcome.ProcedureCode.Value = ngapType.ProcedureCodePDUSessionResourceModify
+	successfulOutcome.Criticality.Value = ngapType.CriticalityPresentReject
+
+	successfulOutcome.Value.Present = ngapType.SuccessfulOutcomePresentPDUSessionResourceModifyResponse
+	successfulOutcome.Value.PDUSessionResourceModifyResponse = new(ngapType.PDUSessionResourceModifyResponse)
+
+	modifyResponse := successfulOutcome.Value.PDUSessionResourceModifyResponse
+	ies := &modifyResponse.ProtocolIEs
+
+	// AMF UE NGAP ID
+	amfIE := ngapType.PDUSessionResourceModifyResponseIEs{}
+	amfIE.Id.Value = ngapType.ProtocolIEIDAMFUENGAPID
+	amfIE.Criticality.Value = ngapType.CriticalityPresentIgnore
+	amfIE.Value.Present = ngapType.PDUSessionResourceModifyResponseIEsPresentAMFUENGAPID
+	amfIE.Value.AMFUENGAPID = new(ngapType.AMFUENGAPID)
+	amfIE.Value.AMFUENGAPID.Value = opts.AMFUENGAPID
+	ies.List = append(ies.List, amfIE)
+
+	// RAN UE NGAP ID
+	ranIE := ngapType.PDUSessionResourceModifyResponseIEs{}
+	ranIE.Id.Value = ngapType.ProtocolIEIDRANUENGAPID
+	ranIE.Criticality.Value = ngapType.CriticalityPresentIgnore
+	ranIE.Value.Present = ngapType.PDUSessionResourceModifyResponseIEsPresentRANUENGAPID
+	ranIE.Value.RANUENGAPID = new(ngapType.RANUENGAPID)
+	ranIE.Value.RANUENGAPID.Value = opts.RANUENGAPID
+	ies.List = append(ies.List, ranIE)
+
+	// PDU Session Resource Modify Response List
+	modListIE := ngapType.PDUSessionResourceModifyResponseIEs{}
+	modListIE.Id.Value = ngapType.ProtocolIEIDPDUSessionResourceModifyListModRes
+	modListIE.Criticality.Value = ngapType.CriticalityPresentIgnore
+	modListIE.Value.Present = ngapType.PDUSessionResourceModifyResponseIEsPresentPDUSessionResourceModifyListModRes
+	modListIE.Value.PDUSessionResourceModifyListModRes = new(ngapType.PDUSessionResourceModifyListModRes)
+
+	modList := modListIE.Value.PDUSessionResourceModifyListModRes
+
+	for _, pduSessionID := range opts.PDUSessionIDs {
+		item := ngapType.PDUSessionResourceModifyItemModRes{}
+		item.PDUSessionID.Value = pduSessionID
+
+		// Build an empty Modify Response Transfer (success acknowledgement)
+		transfer := &ngapType.PDUSessionResourceModifyResponseTransfer{}
+
+		transferBytes, err := aper.MarshalWithParams(transfer, "valueExt")
+		if err != nil {
+			// If we can't encode, skip this session in the response
+			continue
+		}
+
+		item.PDUSessionResourceModifyResponseTransfer = transferBytes
+
+		modList.List = append(modList.List, item)
+	}
+
+	ies.List = append(ies.List, modListIE)
+
+	return pdu, nil
+}

--- a/internal/tester/gnb/build_pdu_session_resource_release_response.go
+++ b/internal/tester/gnb/build_pdu_session_resource_release_response.go
@@ -1,0 +1,77 @@
+package gnb
+
+import (
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapType"
+)
+
+type PDUSessionResourceReleaseResponseOpts struct {
+	AMFUENGAPID   int64
+	RANUENGAPID   int64
+	PDUSessionIDs []int64
+}
+
+func BuildPDUSessionResourceReleaseResponse(opts *PDUSessionResourceReleaseResponseOpts) (ngapType.NGAPPDU, error) {
+	pdu := ngapType.NGAPPDU{}
+
+	pdu.Present = ngapType.NGAPPDUPresentSuccessfulOutcome
+	pdu.SuccessfulOutcome = new(ngapType.SuccessfulOutcome)
+
+	successfulOutcome := pdu.SuccessfulOutcome
+	successfulOutcome.ProcedureCode.Value = ngapType.ProcedureCodePDUSessionResourceRelease
+	successfulOutcome.Criticality.Value = ngapType.CriticalityPresentReject
+
+	successfulOutcome.Value.Present = ngapType.SuccessfulOutcomePresentPDUSessionResourceReleaseResponse
+	successfulOutcome.Value.PDUSessionResourceReleaseResponse = new(ngapType.PDUSessionResourceReleaseResponse)
+
+	releaseResponse := successfulOutcome.Value.PDUSessionResourceReleaseResponse
+	ies := &releaseResponse.ProtocolIEs
+
+	// AMF UE NGAP ID
+	amfIE := ngapType.PDUSessionResourceReleaseResponseIEs{}
+	amfIE.Id.Value = ngapType.ProtocolIEIDAMFUENGAPID
+	amfIE.Criticality.Value = ngapType.CriticalityPresentIgnore
+	amfIE.Value.Present = ngapType.PDUSessionResourceReleaseResponseIEsPresentAMFUENGAPID
+	amfIE.Value.AMFUENGAPID = new(ngapType.AMFUENGAPID)
+	amfIE.Value.AMFUENGAPID.Value = opts.AMFUENGAPID
+	ies.List = append(ies.List, amfIE)
+
+	// RAN UE NGAP ID
+	ranIE := ngapType.PDUSessionResourceReleaseResponseIEs{}
+	ranIE.Id.Value = ngapType.ProtocolIEIDRANUENGAPID
+	ranIE.Criticality.Value = ngapType.CriticalityPresentIgnore
+	ranIE.Value.Present = ngapType.PDUSessionResourceReleaseResponseIEsPresentRANUENGAPID
+	ranIE.Value.RANUENGAPID = new(ngapType.RANUENGAPID)
+	ranIE.Value.RANUENGAPID.Value = opts.RANUENGAPID
+	ies.List = append(ies.List, ranIE)
+
+	// PDU Session Resource Released List
+	relListIE := ngapType.PDUSessionResourceReleaseResponseIEs{}
+	relListIE.Id.Value = ngapType.ProtocolIEIDPDUSessionResourceReleasedListRelRes
+	relListIE.Criticality.Value = ngapType.CriticalityPresentIgnore
+	relListIE.Value.Present = ngapType.PDUSessionResourceReleaseResponseIEsPresentPDUSessionResourceReleasedListRelRes
+	relListIE.Value.PDUSessionResourceReleasedListRelRes = new(ngapType.PDUSessionResourceReleasedListRelRes)
+
+	relList := relListIE.Value.PDUSessionResourceReleasedListRelRes
+
+	for _, pduSessionID := range opts.PDUSessionIDs {
+		item := ngapType.PDUSessionResourceReleasedItemRelRes{}
+		item.PDUSessionID.Value = pduSessionID
+
+		// Build an empty Release Response Transfer (success acknowledgement)
+		transfer := &ngapType.PDUSessionResourceReleaseResponseTransfer{}
+
+		transferBytes, err := aper.MarshalWithParams(transfer, "valueExt")
+		if err != nil {
+			continue
+		}
+
+		item.PDUSessionResourceReleaseResponseTransfer = transferBytes
+
+		relList.List = append(relList.List, item)
+	}
+
+	ies.List = append(ies.List, relListIE)
+
+	return pdu, nil
+}

--- a/internal/tester/gnb/handle_pdu_session_resource_modify_request.go
+++ b/internal/tester/gnb/handle_pdu_session_resource_modify_request.go
@@ -1,0 +1,159 @@
+package gnb
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapType"
+	"go.uber.org/zap"
+)
+
+func handlePDUSessionResourceModifyRequest(gnb *GnodeB, req *ngapType.PDUSessionResourceModifyRequest) error {
+	var (
+		amfueNGAPID *ngapType.AMFUENGAPID
+		ranueNGAPID *ngapType.RANUENGAPID
+		modifyList  *ngapType.PDUSessionResourceModifyListModReq
+	)
+
+	for _, ie := range req.ProtocolIEs.List {
+		switch ie.Id.Value {
+		case ngapType.ProtocolIEIDAMFUENGAPID:
+			amfueNGAPID = ie.Value.AMFUENGAPID
+		case ngapType.ProtocolIEIDRANUENGAPID:
+			ranueNGAPID = ie.Value.RANUENGAPID
+		case ngapType.ProtocolIEIDPDUSessionResourceModifyListModReq:
+			modifyList = ie.Value.PDUSessionResourceModifyListModReq
+		}
+	}
+
+	if amfueNGAPID == nil {
+		return fmt.Errorf("missing AMF UE NGAP ID in PDUSessionResourceModifyRequest")
+	}
+
+	if ranueNGAPID == nil {
+		return fmt.Errorf("missing RAN UE NGAP ID in PDUSessionResourceModifyRequest")
+	}
+
+	if modifyList == nil {
+		return fmt.Errorf("missing PDU Session Resource Modify List in PDUSessionResourceModifyRequest")
+	}
+
+	logger.GnbLogger.Debug(
+		"Received PDU Session Resource Modify Request",
+		zap.String("GNB ID", gnb.GnbID),
+		zap.Int64("RAN UE NGAP ID", ranueNGAPID.Value),
+		zap.Int64("AMF UE NGAP ID", amfueNGAPID.Value),
+	)
+
+	ue, err := gnb.LoadUE(ranueNGAPID.Value)
+	if err != nil {
+		return fmt.Errorf("could not load UE with RAN UE NGAP ID %d: %v", ranueNGAPID.Value, err)
+	}
+
+	for _, item := range modifyList.List {
+		pduSessionID := item.PDUSessionID.Value
+
+		// Forward NAS PDU to the UE if present.
+		if item.NASPDU != nil {
+			if err := ue.SendDownlinkNAS(item.NASPDU.Value, amfueNGAPID.Value, ranueNGAPID.Value); err != nil {
+				return fmt.Errorf("forward NAS PDU for PDU session %d: %v", pduSessionID, err)
+			}
+		}
+
+		// Parse the Modify Request Transfer to update stored QoS info.
+		if item.PDUSessionResourceModifyRequestTransfer != nil {
+			modInfo, err := getPDUSessionInfoFromModifyRequestTransfer(item.PDUSessionResourceModifyRequestTransfer)
+			if err != nil {
+				logger.GnbLogger.Debug("could not parse PDU Session Resource Modify Request Transfer",
+					zap.Error(err),
+					zap.Int64("PDU Session ID", pduSessionID),
+				)
+			} else {
+				// Update the stored PDU session with new QoS values.
+				gnb.UpdatePDUSessionQoS(ranueNGAPID.Value, pduSessionID, modInfo)
+
+				logger.GnbLogger.Debug(
+					"Updated PDU session QoS from Modify Request Transfer",
+					zap.Int64("PDU Session ID", pduSessionID),
+					zap.Int64("5QI", modInfo.FiveQi),
+					zap.Int64("ARP", modInfo.PriArp),
+					zap.Int64("AMBR DL", modInfo.AmbrDownlink),
+					zap.Int64("AMBR UL", modInfo.AmbrUplink),
+				)
+			}
+		}
+	}
+
+	// Send PDU Session Resource Modify Response.
+	pduSessionIDs := make([]int64, 0, len(modifyList.List))
+	for _, item := range modifyList.List {
+		pduSessionIDs = append(pduSessionIDs, item.PDUSessionID.Value)
+	}
+
+	if err := gnb.SendPDUSessionResourceModifyResponse(&PDUSessionResourceModifyResponseOpts{
+		AMFUENGAPID:   amfueNGAPID.Value,
+		RANUENGAPID:   ranueNGAPID.Value,
+		PDUSessionIDs: pduSessionIDs,
+	}); err != nil {
+		return fmt.Errorf("failed to send PDUSessionResourceModifyResponse: %v", err)
+	}
+
+	logger.GnbLogger.Debug(
+		"Sent PDU Session Resource Modify Response",
+		zap.String("GNB ID", gnb.GnbID),
+		zap.Int64("RAN UE NGAP ID", ranueNGAPID.Value),
+		zap.Int64("AMF UE NGAP ID", amfueNGAPID.Value),
+	)
+
+	return nil
+}
+
+// PDUSessionModifyInfo holds the QoS parameters extracted from a
+// PDU Session Resource Modify Request Transfer.
+type PDUSessionModifyInfo struct {
+	FiveQi       int64
+	PriArp       int64
+	QFI          int64
+	AmbrUplink   int64
+	AmbrDownlink int64
+}
+
+func getPDUSessionInfoFromModifyRequestTransfer(transfer aper.OctetString) (*PDUSessionModifyInfo, error) {
+	if transfer == nil {
+		return nil, fmt.Errorf("modify request transfer is nil")
+	}
+
+	pdu := &ngapType.PDUSessionResourceModifyRequestTransfer{}
+
+	if err := aper.UnmarshalWithParams(transfer, pdu, "valueExt"); err != nil {
+		return nil, fmt.Errorf("could not unmarshal Modify Request Transfer: %v", err)
+	}
+
+	info := &PDUSessionModifyInfo{}
+
+	for _, ie := range pdu.ProtocolIEs.List {
+		switch ie.Id.Value {
+		case ngapType.ProtocolIEIDPDUSessionAggregateMaximumBitRate:
+			if ie.Value.PDUSessionAggregateMaximumBitRate != nil {
+				info.AmbrUplink = ie.Value.PDUSessionAggregateMaximumBitRate.PDUSessionAggregateMaximumBitRateUL.Value
+				info.AmbrDownlink = ie.Value.PDUSessionAggregateMaximumBitRate.PDUSessionAggregateMaximumBitRateDL.Value
+			}
+		case ngapType.ProtocolIEIDQosFlowAddOrModifyRequestList:
+			if ie.Value.QosFlowAddOrModifyRequestList != nil {
+				for _, qosItem := range ie.Value.QosFlowAddOrModifyRequestList.List {
+					info.QFI = qosItem.QosFlowIdentifier.Value
+					if qosItem.QosFlowLevelQosParameters != nil {
+						if qosItem.QosFlowLevelQosParameters.QosCharacteristics.NonDynamic5QI != nil {
+							info.FiveQi = qosItem.QosFlowLevelQosParameters.QosCharacteristics.NonDynamic5QI.FiveQI.Value
+						}
+
+						info.PriArp = qosItem.QosFlowLevelQosParameters.AllocationAndRetentionPriority.PriorityLevelARP.Value
+					}
+				}
+			}
+		}
+	}
+
+	return info, nil
+}

--- a/internal/tester/gnb/handle_pdu_session_resource_release_command.go
+++ b/internal/tester/gnb/handle_pdu_session_resource_release_command.go
@@ -1,0 +1,102 @@
+package gnb
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/free5gc/ngap/ngapType"
+	"go.uber.org/zap"
+)
+
+func handlePDUSessionResourceReleaseCommand(gnb *GnodeB, cmd *ngapType.PDUSessionResourceReleaseCommand) error {
+	var (
+		amfueNGAPID *ngapType.AMFUENGAPID
+		ranueNGAPID *ngapType.RANUENGAPID
+		nasPDU      *ngapType.NASPDU
+		releaseList *ngapType.PDUSessionResourceToReleaseListRelCmd
+	)
+
+	for _, ie := range cmd.ProtocolIEs.List {
+		switch ie.Id.Value {
+		case ngapType.ProtocolIEIDAMFUENGAPID:
+			amfueNGAPID = ie.Value.AMFUENGAPID
+		case ngapType.ProtocolIEIDRANUENGAPID:
+			ranueNGAPID = ie.Value.RANUENGAPID
+		case ngapType.ProtocolIEIDNASPDU:
+			nasPDU = ie.Value.NASPDU
+		case ngapType.ProtocolIEIDPDUSessionResourceToReleaseListRelCmd:
+			releaseList = ie.Value.PDUSessionResourceToReleaseListRelCmd
+		}
+	}
+
+	if amfueNGAPID == nil {
+		return fmt.Errorf("missing AMF UE NGAP ID in PDUSessionResourceReleaseCommand")
+	}
+
+	if ranueNGAPID == nil {
+		return fmt.Errorf("missing RAN UE NGAP ID in PDUSessionResourceReleaseCommand")
+	}
+
+	if releaseList == nil {
+		return fmt.Errorf("missing PDU Session Resource To Release List in PDUSessionResourceReleaseCommand")
+	}
+
+	logger.GnbLogger.Debug(
+		"Received PDU Session Resource Release Command",
+		zap.String("GNB ID", gnb.GnbID),
+		zap.Int64("RAN UE NGAP ID", ranueNGAPID.Value),
+		zap.Int64("AMF UE NGAP ID", amfueNGAPID.Value),
+		zap.Int("PDU Sessions to release", len(releaseList.List)),
+	)
+
+	// Forward NAS PDU to the UE if present.
+	if nasPDU != nil {
+		ue, err := gnb.LoadUE(ranueNGAPID.Value)
+		if err != nil {
+			return fmt.Errorf("could not load UE with RAN UE NGAP ID %d: %v", ranueNGAPID.Value, err)
+		}
+
+		if err := ue.SendDownlinkNAS(nasPDU.Value, amfueNGAPID.Value, ranueNGAPID.Value); err != nil {
+			return fmt.Errorf("forward NAS PDU for release command: %v", err)
+		}
+	}
+
+	// Remove released PDU sessions from gNB state.
+	for _, item := range releaseList.List {
+		pduSessionID := item.PDUSessionID.Value
+		gnb.RemovePDUSession(ranueNGAPID.Value, pduSessionID)
+
+		logger.GnbLogger.Debug(
+			"Released PDU session",
+			zap.Int64("PDU Session ID", pduSessionID),
+			zap.Int64("RAN UE NGAP ID", ranueNGAPID.Value),
+		)
+	}
+
+	// Send PDU Session Resource Release Response.
+	if err := gnb.SendPDUSessionResourceReleaseResponse(&PDUSessionResourceReleaseResponseOpts{
+		AMFUENGAPID:   amfueNGAPID.Value,
+		RANUENGAPID:   ranueNGAPID.Value,
+		PDUSessionIDs: extractPDUSessionIDs(releaseList),
+	}); err != nil {
+		return fmt.Errorf("failed to send PDUSessionResourceReleaseResponse: %v", err)
+	}
+
+	logger.GnbLogger.Debug(
+		"Sent PDU Session Resource Release Response",
+		zap.String("GNB ID", gnb.GnbID),
+		zap.Int64("RAN UE NGAP ID", ranueNGAPID.Value),
+		zap.Int64("AMF UE NGAP ID", amfueNGAPID.Value),
+	)
+
+	return nil
+}
+
+func extractPDUSessionIDs(list *ngapType.PDUSessionResourceToReleaseListRelCmd) []int64 {
+	ids := make([]int64, 0, len(list.List))
+	for _, item := range list.List {
+		ids = append(ids, item.PDUSessionID.Value)
+	}
+
+	return ids
+}

--- a/internal/tester/gnb/handle_pdu_session_resource_setup_request.go
+++ b/internal/tester/gnb/handle_pdu_session_resource_setup_request.go
@@ -160,6 +160,8 @@ type PDUSessionInformation struct {
 	PriArp       int64
 	PduSType     uint64
 	PDUSessionID int64
+	AmbrUplink   int64
+	AmbrDownlink int64
 }
 
 func getPDUSessionInfoFromSetupRequestTransfer(gnb *GnodeB, transfer aper.OctetString) (*PDUSessionInformation, error) {

--- a/internal/tester/gnb/handlers.go
+++ b/internal/tester/gnb/handlers.go
@@ -71,6 +71,10 @@ func handleNGAPInitiatingMessage(gnb *GnodeB, pdu *ngapType.NGAPPDU) error {
 		return handleInitialContextSetupRequest(gnb, pdu.InitiatingMessage.Value.InitialContextSetupRequest)
 	case ngapType.InitiatingMessagePresentPDUSessionResourceSetupRequest:
 		return handlePDUSessionResourceSetupRequest(gnb, pdu.InitiatingMessage.Value.PDUSessionResourceSetupRequest)
+	case ngapType.InitiatingMessagePresentPDUSessionResourceModifyRequest:
+		return handlePDUSessionResourceModifyRequest(gnb, pdu.InitiatingMessage.Value.PDUSessionResourceModifyRequest)
+	case ngapType.InitiatingMessagePresentPDUSessionResourceReleaseCommand:
+		return handlePDUSessionResourceReleaseCommand(gnb, pdu.InitiatingMessage.Value.PDUSessionResourceReleaseCommand)
 	case ngapType.InitiatingMessagePresentUEContextReleaseCommand:
 		return handleUEContextReleaseCommand(gnb, pdu.InitiatingMessage.Value.UEContextReleaseCommand)
 	case ngapType.InitiatingMessagePresentPaging:

--- a/internal/tester/gnb/send.go
+++ b/internal/tester/gnb/send.go
@@ -18,13 +18,15 @@ const (
 	NGAPProcedureNGReset        NGAPProcedure = "NGReset"
 
 	// UE-associated NGAP procedures
-	NGAPProcedureInitialUEMessage                NGAPProcedure = "InitialUEMessage"
-	NGAPProcedureUplinkNASTransport              NGAPProcedure = "UplinkNASTransport"
-	NGAPProcedureInitialContextSetupResponse     NGAPProcedure = "InitialContextSetupResponse"
-	NGAPProcedurePDUSessionResourceSetupResponse NGAPProcedure = "PDUSessionResourceSetupResponse"
-	NGAPProcedureUEContextReleaseComplete        NGAPProcedure = "UEContextReleaseComplete"
-	NGAPProcedureUEContextReleaseRequest         NGAPProcedure = "UEContextReleaseRequest"
-	NGAPProcedurePathSwitchRequest               NGAPProcedure = "PathSwitchRequest"
+	NGAPProcedureInitialUEMessage                  NGAPProcedure = "InitialUEMessage"
+	NGAPProcedureUplinkNASTransport                NGAPProcedure = "UplinkNASTransport"
+	NGAPProcedureInitialContextSetupResponse       NGAPProcedure = "InitialContextSetupResponse"
+	NGAPProcedurePDUSessionResourceSetupResponse   NGAPProcedure = "PDUSessionResourceSetupResponse"
+	NGAPProcedurePDUSessionResourceModifyResponse  NGAPProcedure = "PDUSessionResourceModifyResponse"
+	NGAPProcedurePDUSessionResourceReleaseResponse NGAPProcedure = "PDUSessionResourceReleaseResponse"
+	NGAPProcedureUEContextReleaseComplete          NGAPProcedure = "UEContextReleaseComplete"
+	NGAPProcedureUEContextReleaseRequest           NGAPProcedure = "UEContextReleaseRequest"
+	NGAPProcedurePathSwitchRequest                 NGAPProcedure = "PathSwitchRequest"
 )
 
 func getSCTPStreamID(msgType NGAPProcedure) (uint16, error) {
@@ -36,6 +38,7 @@ func getSCTPStreamID(msgType NGAPProcedure) (uint16, error) {
 	// UE-associated procedures
 	case NGAPProcedureInitialUEMessage, NGAPProcedureUplinkNASTransport,
 		NGAPProcedureInitialContextSetupResponse, NGAPProcedurePDUSessionResourceSetupResponse,
+		NGAPProcedurePDUSessionResourceModifyResponse, NGAPProcedurePDUSessionResourceReleaseResponse,
 		NGAPProcedureUEContextReleaseComplete, NGAPProcedureUEContextReleaseRequest,
 		NGAPProcedurePathSwitchRequest:
 		return 1, nil
@@ -106,6 +109,24 @@ func (g *GnodeB) SendPDUSessionResourceSetupResponse(opts *PDUSessionResourceSet
 	}
 
 	return g.SendMessage(pdu, NGAPProcedurePDUSessionResourceSetupResponse)
+}
+
+func (g *GnodeB) SendPDUSessionResourceModifyResponse(opts *PDUSessionResourceModifyResponseOpts) error {
+	pdu, err := BuildPDUSessionResourceModifyResponse(opts)
+	if err != nil {
+		return fmt.Errorf("couldn't build PDUSessionResourceModifyResponse: %s", err.Error())
+	}
+
+	return g.SendMessage(pdu, NGAPProcedurePDUSessionResourceModifyResponse)
+}
+
+func (g *GnodeB) SendPDUSessionResourceReleaseResponse(opts *PDUSessionResourceReleaseResponseOpts) error {
+	pdu, err := BuildPDUSessionResourceReleaseResponse(opts)
+	if err != nil {
+		return fmt.Errorf("couldn't build PDUSessionResourceReleaseResponse: %s", err.Error())
+	}
+
+	return g.SendMessage(pdu, NGAPProcedurePDUSessionResourceReleaseResponse)
 }
 
 func (g *GnodeB) SendPathSwitchRequest(opts *PathSwitchRequestOpts) error {

--- a/internal/tester/gnb/server.go
+++ b/internal/tester/gnb/server.go
@@ -147,6 +147,67 @@ func (g *GnodeB) GetPDUSessions(ranUeId int64) map[int64]*PDUSessionInformation 
 	return g.PDUSessions[ranUeId]
 }
 
+// RemovePDUSession removes a PDU session from the gNB state for a given UE.
+func (g *GnodeB) RemovePDUSession(ranUeId int64, pduSessionID int64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.PDUSessions == nil {
+		return
+	}
+
+	sessions := g.PDUSessions[ranUeId]
+	if sessions == nil {
+		return
+	}
+
+	delete(sessions, pduSessionID)
+}
+
+// UpdatePDUSessionQoS updates the QoS parameters of an existing PDU session
+// in response to a PDU Session Resource Modify Request from the core.
+func (g *GnodeB) UpdatePDUSessionQoS(ranUeId int64, pduSessionID int64, info *PDUSessionModifyInfo) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.PDUSessions == nil {
+		return
+	}
+
+	sessions := g.PDUSessions[ranUeId]
+	if sessions == nil {
+		return
+	}
+
+	session := sessions[pduSessionID]
+	if session == nil {
+		return
+	}
+
+	if info.FiveQi != 0 {
+		session.FiveQi = info.FiveQi
+	}
+
+	if info.PriArp != 0 {
+		session.PriArp = info.PriArp
+	}
+
+	if info.QFI != 0 {
+		session.QosId = info.QFI
+		session.QFI = info.QFI
+	}
+
+	if info.AmbrUplink != 0 {
+		session.AmbrUplink = info.AmbrUplink
+	}
+
+	if info.AmbrDownlink != 0 {
+		session.AmbrDownlink = info.AmbrDownlink
+	}
+
+	g.cond.Broadcast()
+}
+
 func (g *GnodeB) WaitForPDUSession(ranUeId int64, pduSessionID int64, timeout time.Duration) (*PDUSessionInformation, error) {
 	deadline := time.Now().Add(timeout)
 

--- a/internal/tester/scenarios/env.go
+++ b/internal/tester/scenarios/env.go
@@ -41,6 +41,12 @@ type Env struct {
 	// need explicit pairing. When empty, scenarios default to pairing gNB
 	// i with CoreN2Addresses[i], or all cores for multihomed scenarios.
 	GNBCoreTargets map[string]string
+
+	// APIAddress is the Ella Core API base URL from --ella-api-address.
+	APIAddress string
+
+	// APIToken is the Ella Core API authentication token from --ella-api-token.
+	APIToken string
 }
 
 // GNB is one simulated gNB's address set.

--- a/internal/tester/scenarios/ue/session_modification.go
+++ b/internal/tester/scenarios/ue/session_modification.go
@@ -1,0 +1,353 @@
+package ue
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+	"github.com/ellanetworks/core/internal/tester/gnb"
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/internal/tester/testutil/procedure"
+	"github.com/ellanetworks/core/internal/tester/testutil/validate"
+	"github.com/free5gc/nas"
+	"github.com/free5gc/ngap/ngapType"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+)
+
+const sessionModificationIMSI = "001017271246546"
+
+type sessionModificationParams struct {
+	EllaAPIAddress string
+	EllaAPIToken   string
+}
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name: "ue/session-modification",
+		BindFlags: func(fs *pflag.FlagSet) any {
+			p := &sessionModificationParams{}
+			fs.StringVar(&p.EllaAPIAddress, "ella-api-address", "", "Ella Core API address (e.g. http://10.3.0.2:5002)")
+			fs.StringVar(&p.EllaAPIToken, "ella-api-token", "", "Ella Core API token")
+
+			return p
+		},
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			p := params.(*sessionModificationParams)
+
+			return runSessionModification(ctx, env, p, sessionModificationConfig{
+				ambrUplink:   "200 Mbps",
+				ambrDownlink: "200 Mbps",
+				var5qi:       8,
+				arp:          14,
+			})
+		},
+		Fixture: fixtureSessionModification,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name: "ue/session-modification-ambr-only",
+		BindFlags: func(fs *pflag.FlagSet) any {
+			p := &sessionModificationParams{}
+			fs.StringVar(&p.EllaAPIAddress, "ella-api-address", "", "Ella Core API address")
+			fs.StringVar(&p.EllaAPIToken, "ella-api-token", "", "Ella Core API token")
+
+			return p
+		},
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			p := params.(*sessionModificationParams)
+
+			return runSessionModification(ctx, env, p, sessionModificationConfig{
+				ambrUplink:   "300 Mbps",
+				ambrDownlink: "400 Mbps",
+			})
+		},
+		Fixture: fixtureSessionModification,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name: "ue/session-modification-qos-only",
+		BindFlags: func(fs *pflag.FlagSet) any {
+			p := &sessionModificationParams{}
+			fs.StringVar(&p.EllaAPIAddress, "ella-api-address", "", "Ella Core API address")
+			fs.StringVar(&p.EllaAPIToken, "ella-api-token", "", "Ella Core API token")
+
+			return p
+		},
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			p := params.(*sessionModificationParams)
+
+			return runSessionModification(ctx, env, p, sessionModificationConfig{
+				var5qi: 8,
+				arp:    14,
+			})
+		},
+		Fixture: fixtureSessionModification,
+	})
+}
+
+func fixtureSessionModification(env scenarios.Env) scenarios.FixtureSpec {
+	return scenarios.FixtureSpec{
+		Subscribers: []scenarios.SubscriberSpec{scenarios.DefaultSubscriber()},
+	}
+}
+
+type sessionModificationConfig struct {
+	ambrUplink   string
+	ambrDownlink string
+	var5qi       int32
+	arp          int32
+}
+
+func runSessionModification(ctx context.Context, env scenarios.Env, p *sessionModificationParams, cfg sessionModificationConfig) error {
+	if p.EllaAPIAddress == "" {
+		return fmt.Errorf("--ella-api-address is required for session modification scenario")
+	}
+
+	if p.EllaAPIToken == "" {
+		return fmt.Errorf("--ella-api-token is required for session modification scenario")
+	}
+
+	// Build Ella API client.
+	cl, err := client.New(&client.Config{BaseURL: p.EllaAPIAddress})
+	if err != nil {
+		return fmt.Errorf("failed to create Ella client: %v", err)
+	}
+
+	cl.SetToken(p.EllaAPIToken)
+
+	// Start gNB.
+	g := env.FirstGNB()
+
+	gNodeB, err := gnb.Start(&gnb.StartOpts{
+		GnbID:           scenarios.DefaultGNBID,
+		MCC:             scenarios.DefaultMCC,
+		MNC:             scenarios.DefaultMNC,
+		SST:             scenarios.DefaultSST,
+		SD:              scenarios.DefaultSD,
+		DNN:             scenarios.DefaultDNN,
+		TAC:             scenarios.DefaultTAC,
+		Name:            "Ella-Core-Tester",
+		CoreN2Addresses: env.CoreN2Addresses,
+		GnbN2Address:    g.N2Address,
+		GnbN3Address:    g.N3Address,
+	})
+	if err != nil {
+		return fmt.Errorf("error starting gNB: %v", err)
+	}
+
+	defer gNodeB.Close()
+
+	_, err = gNodeB.WaitForMessage(ngapType.NGAPPDUPresentSuccessfulOutcome, ngapType.SuccessfulOutcomePresentNGSetupResponse, 200*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("did not receive NG Setup Response: %v", err)
+	}
+
+	// Create UE and register.
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+
+	sub := subscriber{
+		IMSI:           sessionModificationIMSI,
+		Key:            scenarios.DefaultKey,
+		OPc:            scenarios.DefaultOPC,
+		SequenceNumber: scenarios.DefaultSequenceNumber,
+	}
+
+	newUE, err := newDefaultUE(gNodeB, sub.IMSI[5:], sub.Key, sub.OPc, sub.SequenceNumber, env.PDUSessionType())
+	if err != nil {
+		return fmt.Errorf("could not create UE: %v", err)
+	}
+
+	gNodeB.AddUE(ranUENGAPID, newUE)
+
+	_, err = procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: scenarios.DefaultPDUSessionID,
+		UE:           newUE,
+	})
+	if err != nil {
+		return fmt.Errorf("initial registration failed: %v", err)
+	}
+
+	logger.Logger.Info(
+		"PDU session established, proceeding to modify policy",
+		zap.String("IMSI", sub.IMSI),
+		zap.Int64("RAN UE NGAP ID", ranUENGAPID),
+	)
+
+	// Validate initial QoS.
+	gnbPDUSession := gNodeB.GetPDUSession(ranUENGAPID, int64(scenarios.DefaultPDUSessionID))
+	if gnbPDUSession == nil {
+		return fmt.Errorf("PDU session not stored on gNB after initial registration")
+	}
+
+	err = validate.PDUSessionInformation(gnbPDUSession, &validate.ExpectedPDUSessionInformation{
+		FiveQi: 9,
+		PriArp: 15,
+		QFI:    1,
+	})
+	if err != nil {
+		return fmt.Errorf("initial QoS validation failed: %v", err)
+	}
+
+	// --- Phase 2: Modify the policy via Ella API ---
+	// Build update options from config, filling in defaults for unchanged fields.
+	apiAmbrUplink := cfg.ambrUplink
+	if apiAmbrUplink == "" {
+		apiAmbrUplink = scenarios.DefaultPolicySessionAmbrUplink
+	}
+
+	apiAmbrDownlink := cfg.ambrDownlink
+	if apiAmbrDownlink == "" {
+		apiAmbrDownlink = scenarios.DefaultPolicySessionAmbrDownlink
+	}
+
+	apiVar5qi := cfg.var5qi
+	if apiVar5qi == 0 {
+		apiVar5qi = 9
+	}
+
+	apiArp := cfg.arp
+	if apiArp == 0 {
+		apiArp = 15
+	}
+
+	updateOpts := &client.UpdatePolicyOptions{
+		ProfileName:         scenarios.DefaultProfileName,
+		SliceName:           scenarios.DefaultSliceName,
+		DataNetworkName:     scenarios.DefaultDNN,
+		SessionAmbrUplink:   apiAmbrUplink,
+		SessionAmbrDownlink: apiAmbrDownlink,
+		Var5qi:              apiVar5qi,
+		Arp:                 apiArp,
+	}
+
+	err = cl.UpdatePolicy(ctx, scenarios.DefaultPolicyName, updateOpts)
+	if err != nil {
+		return fmt.Errorf("failed to update policy: %v", err)
+	}
+
+	// Restore original policy on exit so subsequent scenarios see default values.
+	defer func() {
+		_ = cl.UpdatePolicy(ctx, scenarios.DefaultPolicyName, &client.UpdatePolicyOptions{
+			ProfileName:         scenarios.DefaultProfileName,
+			SliceName:           scenarios.DefaultSliceName,
+			DataNetworkName:     scenarios.DefaultDNN,
+			SessionAmbrUplink:   scenarios.DefaultPolicySessionAmbrUplink,
+			SessionAmbrDownlink: scenarios.DefaultPolicySessionAmbrDownlink,
+			Var5qi:              9,
+			Arp:                 15,
+		})
+	}()
+
+	logger.Logger.Info("Policy updated, waiting for session modification signalling")
+
+	// --- Phase 3: Wait for N2 (NGAP) Modify Request to arrive at gNB ---
+	_, err = gNodeB.WaitForMessage(
+		ngapType.NGAPPDUPresentInitiatingMessage,
+		ngapType.InitiatingMessagePresentPDUSessionResourceModifyRequest,
+		15*time.Second,
+	)
+	if err != nil {
+		return fmt.Errorf("gNB did not receive PDUSessionResourceModifyRequest: %v", err)
+	}
+
+	logger.Logger.Info("gNB received PDUSessionResourceModifyRequest")
+
+	// --- Phase 4: Wait for N1 (NAS) PDU Session Modification Command ---
+	modCmd, err := newUE.WaitForNASGSMMessage(nas.MsgTypePDUSessionModificationCommand, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("UE did not receive PDU Session Modification Command: %v", err)
+	}
+
+	logger.Logger.Info("UE received PDU Session Modification Command")
+
+	// --- Phase 5: Validate the NAS message ---
+	if cfg.ambrUplink != "" || cfg.ambrDownlink != "" {
+		err = validate.PDUSessionModificationCommand(modCmd, &validate.ExpectedPDUSessionModificationCommand{
+			AmbrUplinkKbps:   parseKbps(cfg.ambrUplink),
+			AmbrDownlinkKbps: parseKbps(cfg.ambrDownlink),
+		})
+		if err != nil {
+			return fmt.Errorf("PDU Session Modification Command AMBR validation failed: %v", err)
+		}
+	}
+
+	// --- Phase 6: Validate updated QoS on gNB ---
+	updatedSession := gNodeB.GetPDUSession(ranUENGAPID, int64(scenarios.DefaultPDUSessionID))
+	if updatedSession == nil {
+		return fmt.Errorf("PDU session not found on gNB after modification")
+	}
+
+	if cfg.var5qi != 0 || cfg.arp != 0 {
+		err = validate.PDUSessionInformation(updatedSession, &validate.ExpectedPDUSessionInformation{
+			FiveQi: int64(cfg.var5qi),
+			PriArp: int64(cfg.arp),
+			QFI:    1,
+		})
+		if err != nil {
+			return fmt.Errorf("post-modification QoS validation failed: %v", err)
+		}
+
+		logger.Logger.Info("Session modification validated successfully",
+			zap.Int64("New 5QI", updatedSession.FiveQi),
+			zap.Int64("New ARP", updatedSession.PriArp),
+		)
+	}
+
+	// --- Cleanup: Deregister UE ---
+	pduSessionIDs := [16]bool{}
+	pduSessionIDs[scenarios.DefaultPDUSessionID] = true
+
+	err = procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
+		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(ranUENGAPID),
+		RANUENGAPID:   ranUENGAPID,
+		GnodeB:        gNodeB,
+		UE:            newUE,
+		PDUSessionIDs: pduSessionIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("UE context release failed: %v", err)
+	}
+
+	logger.Logger.Info("Session modification scenario completed successfully")
+
+	return nil
+}
+
+// parseKbps converts a human-readable bitrate string (e.g. "300 Mbps") to
+// kilobits per second, matching the kbps convention used by the validator.
+func parseKbps(s string) uint64 {
+	if s == "" {
+		return 0
+	}
+
+	re := regexp.MustCompile(`(\d+(?:\.\d+)?)\s*(bps|Kbps|Mbps|Gbps|Tbps)`)
+
+	matches := re.FindStringSubmatch(s)
+	if len(matches) < 3 {
+		return 0
+	}
+
+	value, _ := strconv.ParseFloat(matches[1], 64)
+	unit := matches[2]
+
+	switch unit {
+	case "bps":
+		return uint64(value / 1000)
+	case "Kbps":
+		return uint64(value)
+	case "Mbps":
+		return uint64(value * 1000)
+	case "Gbps":
+		return uint64(value * 1000000)
+	case "Tbps":
+		return uint64(value * 1000000000)
+	default:
+		return 0
+	}
+}

--- a/internal/tester/scenarios/ue/slice_mismatch_release.go
+++ b/internal/tester/scenarios/ue/slice_mismatch_release.go
@@ -1,0 +1,219 @@
+package ue
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+	"github.com/ellanetworks/core/internal/tester/gnb"
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/internal/tester/testutil/procedure"
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/ngap/ngapType"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+)
+
+const sliceMismatchIMSI = "001017271246547"
+
+type sliceMismatchParams struct {
+	EllaAPIAddress string
+	EllaAPIToken   string
+	SliceSST       int
+	SliceSD        string
+}
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name: "ue/slice-mismatch-release",
+		BindFlags: func(fs *pflag.FlagSet) any {
+			p := &sliceMismatchParams{}
+			fs.StringVar(&p.EllaAPIAddress, "ella-api-address", "", "Ella Core API address")
+			fs.StringVar(&p.EllaAPIToken, "ella-api-token", "", "Ella Core API token")
+			fs.IntVar(&p.SliceSST, "slice-sst", 2, "SST for the new slice that will cause mismatch")
+			fs.StringVar(&p.SliceSD, "slice-sd", "abcdef", "SD for the new slice that will cause mismatch")
+
+			return p
+		},
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			p := params.(*sliceMismatchParams)
+			return runSliceMismatchRelease(ctx, env, p)
+		},
+		Fixture: fixtureSliceMismatchRelease,
+	})
+}
+
+func fixtureSliceMismatchRelease(env scenarios.Env) scenarios.FixtureSpec {
+	return scenarios.FixtureSpec{
+		Profiles: []scenarios.ProfileSpec{
+			{Name: "alternate", UeAmbrUplink: scenarios.DefaultProfileUeAmbrUplink, UeAmbrDownlink: scenarios.DefaultProfileUeAmbrDownlink},
+		},
+		Slices: []scenarios.SliceSpec{
+			{Name: "alternate", SST: 2, SD: "abcdef"},
+		},
+		Policies: []scenarios.PolicySpec{
+			{
+				Name:                "alternate",
+				ProfileName:         "alternate",
+				SliceName:           "alternate",
+				DataNetworkName:     scenarios.DefaultDNN,
+				SessionAmbrUplink:   scenarios.DefaultPolicySessionAmbrUplink,
+				SessionAmbrDownlink: scenarios.DefaultPolicySessionAmbrDownlink,
+				Var5qi:              9,
+				Arp:                 15,
+			},
+		},
+		Subscribers: []scenarios.SubscriberSpec{scenarios.DefaultSubscriberWith(sliceMismatchIMSI, scenarios.DefaultProfileName)},
+	}
+}
+
+func runSliceMismatchRelease(ctx context.Context, env scenarios.Env, p *sliceMismatchParams) error {
+	if p.EllaAPIAddress == "" {
+		return fmt.Errorf("--ella-api-address is required")
+	}
+
+	if p.EllaAPIToken == "" {
+		return fmt.Errorf("--ella-api-token is required")
+	}
+
+	cl, err := client.New(&client.Config{BaseURL: p.EllaAPIAddress})
+	if err != nil {
+		return fmt.Errorf("failed to create Ella client: %v", err)
+	}
+
+	cl.SetToken(p.EllaAPIToken)
+
+	g := env.FirstGNB()
+
+	gNodeB, err := gnb.Start(&gnb.StartOpts{
+		GnbID:           scenarios.DefaultGNBID,
+		MCC:             scenarios.DefaultMCC,
+		MNC:             scenarios.DefaultMNC,
+		SST:             scenarios.DefaultSST,
+		SD:              scenarios.DefaultSD,
+		DNN:             scenarios.DefaultDNN,
+		TAC:             scenarios.DefaultTAC,
+		Name:            "Ella-Core-Tester",
+		CoreN2Addresses: env.CoreN2Addresses,
+		GnbN2Address:    g.N2Address,
+		GnbN3Address:    g.N3Address,
+	})
+	if err != nil {
+		return fmt.Errorf("error starting gNB: %v", err)
+	}
+
+	defer gNodeB.Close()
+
+	_, err = gNodeB.WaitForMessage(ngapType.NGAPPDUPresentSuccessfulOutcome, ngapType.SuccessfulOutcomePresentNGSetupResponse, 200*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("did not receive NG Setup Response: %v", err)
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+
+	sub := subscriber{
+		IMSI:           sliceMismatchIMSI,
+		Key:            scenarios.DefaultKey,
+		OPc:            scenarios.DefaultOPC,
+		SequenceNumber: scenarios.DefaultSequenceNumber,
+	}
+
+	newUE, err := newDefaultUE(gNodeB, sub.IMSI[5:], sub.Key, sub.OPc, sub.SequenceNumber, env.PDUSessionType())
+	if err != nil {
+		return fmt.Errorf("could not create UE: %v", err)
+	}
+
+	gNodeB.AddUE(ranUENGAPID, newUE)
+
+	_, err = procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: scenarios.DefaultPDUSessionID,
+		UE:           newUE,
+	})
+	if err != nil {
+		return fmt.Errorf("initial registration failed: %v", err)
+	}
+
+	logger.Logger.Info(
+		"PDU session established, proceeding to trigger slice mismatch release",
+		zap.String("IMSI", sub.IMSI),
+		zap.Int64("RAN UE NGAP ID", ranUENGAPID),
+	)
+
+	// --- Phase 2: Change the subscriber's slice to trigger mismatch ---
+	// Remove the default slice from the subscriber's profile so the SMF
+	// detects that the session's Snssai no longer matches any slice.
+	logger.Logger.Info("Updating subscriber profile to remove default slice",
+		zap.String("IMSI", sub.IMSI),
+	)
+
+	err = cl.UpdateSubscriber(ctx, sub.IMSI, &client.UpdateSubscriberOptions{
+		ProfileName: "alternate",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update subscriber profile: %v", err)
+	}
+
+	// --- Phase 3: Wait for N2 (NGAP) PDU Session Resource Release Command ---
+	// The SMF initiates a release with cause #39 "reactivation requested"
+	// when the slice mismatch is detected.
+	_, err = gNodeB.WaitForMessage(
+		ngapType.NGAPPDUPresentInitiatingMessage,
+		ngapType.InitiatingMessagePresentPDUSessionResourceReleaseCommand,
+		15*time.Second,
+	)
+	if err != nil {
+		return fmt.Errorf("gNB did not receive PDUSessionResourceReleaseCommand: %v", err)
+	}
+
+	logger.Logger.Info("gNB received PDUSessionResourceReleaseCommand")
+
+	// --- Phase 4: Wait for N1 (NAS) PDU Session Release Command with cause #39 ---
+	releaseCmd, err := newUE.WaitForNASGSMMessage(nas.MsgTypePDUSessionReleaseCommand, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("UE did not receive PDU Session Release Command: %v", err)
+	}
+
+	logger.Logger.Info("UE received PDU Session Release Command")
+
+	// --- Phase 5: Validate the release cause is #39 "reactivation requested" ---
+	if releaseCmd.PDUSessionReleaseCommand == nil {
+		return fmt.Errorf("PDU Session Release Command message is nil")
+	}
+
+	cause := releaseCmd.PDUSessionReleaseCommand.GetCauseValue()
+	if cause != nasMessage.Cause5GSMReactivationRequested {
+		return fmt.Errorf("expected 5GSM cause #39 (reactivation requested), got %d", cause)
+	}
+
+	logger.Logger.Info("PDU Session Release Command validated: cause = reactivation requested",
+		zap.Uint8("cause", cause),
+	)
+
+	// --- Cleanup: Restore subscriber profile ---
+	_ = cl.UpdateSubscriber(ctx, sub.IMSI, &client.UpdateSubscriberOptions{
+		ProfileName: scenarios.DefaultProfileName,
+	})
+
+	// Deregister UE.
+	pduSessionIDs := [16]bool{}
+	pduSessionIDs[scenarios.DefaultPDUSessionID] = true
+
+	err = procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
+		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(ranUENGAPID),
+		RANUENGAPID:   ranUENGAPID,
+		GnodeB:        gNodeB,
+		UE:            newUE,
+		PDUSessionIDs: pduSessionIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("UE context release failed: %v", err)
+	}
+
+	logger.Logger.Info("Slice mismatch release scenario completed successfully")
+
+	return nil
+}

--- a/internal/tester/testutil/validate/pdu_session_modification_command.go
+++ b/internal/tester/testutil/validate/pdu_session_modification_command.go
@@ -1,0 +1,102 @@
+package validate
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+)
+
+// ExpectedPDUSessionModificationCommand describes the expected content of
+// a NAS PDU Session Modification Command.
+type ExpectedPDUSessionModificationCommand struct {
+	// AmbrUplinkKbps is the expected Session-AMBR uplink in Kbps.
+	// Set to 0 to skip AMBR validation.
+	AmbrUplinkKbps uint64
+
+	// AmbrDownlinkKbps is the expected Session-AMBR downlink in Kbps.
+	// Set to 0 to skip AMBR validation.
+	AmbrDownlinkKbps uint64
+}
+
+// PDUSessionModificationCommand validates a received NAS PDU Session
+// Modification Command against expected values.
+func PDUSessionModificationCommand(msg *nas.Message, expected *ExpectedPDUSessionModificationCommand) error {
+	if msg == nil {
+		return fmt.Errorf("NAS message is nil")
+	}
+
+	msgType := msg.GsmHeader.GetMessageType()
+	if msgType != nas.MsgTypePDUSessionModificationCommand {
+		return fmt.Errorf("expected PDU Session Modification Command (0x%02x), got 0x%02x", nas.MsgTypePDUSessionModificationCommand, msgType)
+	}
+
+	modCmd := msg.PDUSessionModificationCommand
+	if modCmd == nil {
+		return fmt.Errorf("PDUSessionModificationCommand is nil in NAS message")
+	}
+
+	// Validate Session-AMBR if expected.
+	if expected.AmbrUplinkKbps > 0 || expected.AmbrDownlinkKbps > 0 {
+		if modCmd.SessionAMBR == nil {
+			return fmt.Errorf("expected Session-AMBR in Modification Command but it was absent")
+		}
+
+		ulUnit := modCmd.GetUnitForSessionAMBRForUplink()
+		ulValue := modCmd.GetSessionAMBRForUplink()
+		ulKbps := ambrToKbps(ulUnit, ulValue)
+
+		dlUnit := modCmd.GetUnitForSessionAMBRForDownlink()
+		dlValue := modCmd.GetSessionAMBRForDownlink()
+		dlKbps := ambrToKbps(dlUnit, dlValue)
+
+		if expected.AmbrUplinkKbps > 0 && ulKbps != expected.AmbrUplinkKbps {
+			return fmt.Errorf("Session-AMBR uplink mismatch: got %d Kbps, expected %d Kbps", ulKbps, expected.AmbrUplinkKbps)
+		}
+
+		if expected.AmbrDownlinkKbps > 0 && dlKbps != expected.AmbrDownlinkKbps {
+			return fmt.Errorf("Session-AMBR downlink mismatch: got %d Kbps, expected %d Kbps", dlKbps, expected.AmbrDownlinkKbps)
+		}
+	}
+
+	return nil
+}
+
+// ambrToKbps converts the NAS Session-AMBR unit + 16-bit value to Kbps.
+func ambrToKbps(unit uint8, value [2]uint8) uint64 {
+	raw := uint64(binary.BigEndian.Uint16(value[:]))
+
+	switch unit {
+	case nasMessage.SessionAMBRUnit1Kbps:
+		return raw
+	case nasMessage.SessionAMBRUnit4Kbps:
+		return raw * 4
+	case nasMessage.SessionAMBRUnit16Kbps:
+		return raw * 16
+	case nasMessage.SessionAMBRUnit64Kbps:
+		return raw * 64
+	case nasMessage.SessionAMBRUnit256Kbps:
+		return raw * 256
+	case nasMessage.SessionAMBRUnit1Mbps:
+		return raw * 1000
+	case nasMessage.SessionAMBRUnit4Mbps:
+		return raw * 4000
+	case nasMessage.SessionAMBRUnit16Mbps:
+		return raw * 16000
+	case nasMessage.SessionAMBRUnit64Mbps:
+		return raw * 64000
+	case nasMessage.SessionAMBRUnit256Mbps:
+		return raw * 256000
+	case nasMessage.SessionAMBRUnit1Gbps:
+		return raw * 1000000
+	case nasMessage.SessionAMBRUnit4Gbps:
+		return raw * 4000000
+	case nasMessage.SessionAMBRUnit16Gbps:
+		return raw * 16000000
+	case nasMessage.SessionAMBRUnit64Gbps:
+		return raw * 64000000
+	default:
+		return 0
+	}
+}

--- a/internal/upf/engine/modify_session.go
+++ b/internal/upf/engine/modify_session.go
@@ -111,6 +111,37 @@ func (conn *SessionEngine) ModifySession(ctx context.Context, req *models.Modify
 			logger.QERID(qer.QERID), zap.Any("qerInfo", qerInfo))
 	}
 
+	for _, qer := range req.UpdateQERs {
+		sQerInfo := session.GetQer(qer.QERID)
+
+		qerInfo := qerInfoFromMerge(qer, sQerInfo)
+
+		session.PutQer(qer.QERID, qerInfo)
+
+		// Re-apply all PDRs that reference this QER with the updated embedded QER.
+		for _, spdrInfo := range session.ListPDRs() {
+			if spdrInfo.PdrInfo.QerID == qer.QERID {
+				spdrInfo.PdrInfo.Qer = qerInfo
+				session.PutPDR(spdrInfo.PdrID, spdrInfo)
+
+				if err := applyPDR(spdrInfo, bpfObjects); err != nil {
+					span.RecordError(err)
+					return fmt.Errorf("can't update PDR after QER update: %w", err)
+				}
+			}
+		}
+
+		logger.WithTrace(ctx, logger.UpfLog).Info("Updated QoS Enforcement Rule",
+			logger.QERID(qer.QERID), zap.Any("qerInfo", qerInfo))
+	}
+
+	for _, qerID := range req.RemoveQERIDs {
+		session.RemoveQer(qerID)
+
+		logger.WithTrace(ctx, logger.UpfLog).Debug("Removed QoS Enforcement Rule",
+			logger.QERID(qerID))
+	}
+
 	// --- PDRs ---
 
 	// Build FAR and QER maps from session for PDR injection.
@@ -243,6 +274,23 @@ func farInfoFromMerge(far models.FAR, localIPv4 netip.Addr, localIPv6 netip.Addr
 				existing.LocalIP = ebpf.IPToIn6Addr(localIPv4)
 			}
 		}
+	}
+
+	return existing
+}
+
+// qerInfoFromMerge merges a models.QER into an existing ebpf.QerInfo.
+func qerInfoFromMerge(qer models.QER, existing ebpf.QerInfo) ebpf.QerInfo {
+	existing.Qfi = qer.QFI
+
+	if qer.GateStatus != nil {
+		existing.GateStatusDL = qer.GateStatus.DLGate
+		existing.GateStatusUL = qer.GateStatus.ULGate
+	}
+
+	if qer.MBR != nil {
+		existing.MaxBitrateDL = qer.MBR.DLMBR * 1000
+		existing.MaxBitrateUL = qer.MBR.ULMBR * 1000
 	}
 
 	return existing

--- a/internal/upf/engine/session.go
+++ b/internal/upf/engine/session.go
@@ -141,6 +141,22 @@ func (s *Session) GetQer(id uint32) ebpf.QerInfo {
 	return s.qers[id]
 }
 
+// PutQer updates a QER in the session.
+func (s *Session) PutQer(id uint32, qerInfo ebpf.QerInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.qers[id] = qerInfo
+}
+
+// RemoveQer removes a QER from the session.
+func (s *Session) RemoveQer(id uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.qers, id)
+}
+
 // ListQERs returns a snapshot copy of the QER map.
 func (s *Session) ListQERs() map[uint32]ebpf.QerInfo {
 	s.mu.RLock()

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -470,6 +470,21 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 	gmm.RegisterMetrics()
 	ngap.RegisterMetrics()
 
+	// Session reconciler: watches the session_reconcile changefeed topic
+	// and reconciles every local PDU session against the current DB policy.
+	// Triggered by profile, subscriber, and policy writes.
+	sessionReconciler := amf.NewSessionReconciler(amfInstance, func() <-chan struct{} {
+		wakeup, stop := dbInstance.Changefeed().Wakeup(db.TopicSessionReconcile)
+
+		go func() {
+			<-ctx.Done()
+			stop()
+		}()
+
+		return wakeup
+	}())
+	sessionReconciler.Start()
+
 	// --- Phase B: upgrade the API server to serve all routes now that
 	// the cluster is formed, settings are seeded, and NFs are running. ---
 	if err := apiServer.Upgrade(ctx, api.UpgradeConfig{
@@ -574,6 +589,11 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		// shutting-down service.
 		logger.EllaLog.Info("Shutting down BGP reconciler")
 		bgpReconciler.Stop()
+
+		// 4b. Stop the session reconciler so no more reconcile calls land
+		// on a shutting-down SMF.
+		logger.EllaLog.Info("Shutting down session reconciler")
+		sessionReconciler.Stop()
 
 		logger.EllaLog.Info("Shutting down BGP")
 

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -222,6 +222,10 @@ func (a *pcfDBAdapter) GetSessionPolicy(ctx context.Context, imsi string, snssai
 			return nil, fmt.Errorf("%w: %v", smf.ErrDNNNotFound, err)
 		}
 
+		if errors.Is(err, db.ErrNoMatchingPolicy) {
+			return nil, fmt.Errorf("%w: %v", smf.ErrNoPolicyMatch, err)
+		}
+
 		return nil, fmt.Errorf("get session policy: %w", err)
 	}
 
@@ -381,6 +385,24 @@ func (a *smfAMFAdapter) TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSes
 		BinaryDataN1Message:     n1Msg,
 		BinaryDataN2Information: n2Msg,
 	})
+}
+
+func (a *smfAMFAdapter) ModifyN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error {
+	err := producer.ModifyN1N2Message(ctx, a.amf, supi, pduSessionID, n1Msg, n2Msg)
+	if errors.Is(err, producer.ErrUENotReachable) {
+		return smf.ErrUENotReachable
+	}
+
+	return err
+}
+
+func (a *smfAMFAdapter) ReleaseSession(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Transfer []byte) error {
+	err := producer.ReleaseSessionMessage(ctx, a.amf, supi, pduSessionID, n1Msg, n2Transfer)
+	if errors.Is(err, producer.ErrUENotReachable) {
+		return smf.ErrUENotReachable
+	}
+
+	return err
 }
 
 func (a *smfAMFAdapter) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error {


### PR DESCRIPTION
# Description

In this PR, we correctly modify active sessions when the applicable QoS parameters are changed by an administrator. In the case of slice identifiers (SST/SD), we release the session and tell the UE it needs to reconnect.

In the case that the UE is in CM-IDLE for those changes, we only update the internal state in the core and do not send a page. When the UE reconnects, it will need to reestablish the session and will get the updated parameters.

The PR also includes integration tests that validate most of this behaviour.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
