### PR TITLE
chore: add BGP integration tests

### DIFF
--- a/.github/workflows/integration-tests-bgp.yaml
+++ b/.github/workflows/integration-tests-bgp.yaml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   integration-test-bgp:
+    strategy:
+      fail-fast: false
+      matrix:
+        ip_version: [ipv4, ipv6]
     runs-on: ubuntu-24.04
 
     steps:
@@ -45,13 +49,13 @@ jobs:
 
       - name: Run BGP integration tests
         run: |
-          INTEGRATION=1 go test ./integration/... -run TestIntegrationBGP -timeout 15m -v
+          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -run TestIntegrationBGP -timeout 15m -v
 
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: integration-bgp-logs
+          name: integration-bgp-logs-${{ matrix.ip_version }}
           path: ${{ runner.temp }}/bgp-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-bgp.yaml
+++ b/.github/workflows/integration-tests-bgp.yaml
@@ -1,0 +1,57 @@
+name: Integration tests (BGP)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+
+jobs:
+  integration-test-bgp:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Docker registry
+        run: |
+          docker run -d -p 5000:5000 --name registry registry:2
+
+      - name: Download Ella Core image from GitHub Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ellacore-image-amd64
+
+      - name: Download Ella Core Tester image from GitHub Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ellacore-tester-image-amd64
+
+      - name: Load images into Docker
+        run: |
+          docker load -i ellacore_latest-amd64.tar
+          docker tag ella-core:latest localhost:5000/ella-core:latest
+          docker push localhost:5000/ella-core:latest
+          docker load -i ellacore_tester_latest-amd64.tar
+
+      - name: Build GoBGP peer image
+        run: |
+          docker build -t gobgp-peer:latest -f integration/compose/bgp/Dockerfile.gobgp integration/compose/bgp/
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run BGP integration tests
+        run: |
+          INTEGRATION=1 go test ./integration/... -run TestIntegrationBGP -timeout 15m -v
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-bgp-logs
+          path: ${{ runner.temp }}/bgp-logs
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         env:
           HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -skip 'TestIntegrationHA|TestIntegration3GPPHAFailover|TestAPIMatrix' -timeout 30m -v
+          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -skip 'TestIntegrationHA|TestIntegration3GPPHAFailover|TestAPIMatrix|TestIntegrationBGP' -timeout 30m -v
 
       - name: Upload cluster logs
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,9 @@ jobs:
   integration-tests-ha3gpp:
     needs: [image-build, image-build-tester]
     uses: ./.github/workflows/integration-tests-ha3gpp.yaml
+  integration-tests-bgp:
+    needs: [image-build, image-build-tester]
+    uses: ./.github/workflows/integration-tests-bgp.yaml
   integration-tests-rolling-upgrade:
     needs: [image-build]
     uses: ./.github/workflows/integration-tests-rolling-upgrade.yaml

--- a/integration/bgp_test.go
+++ b/integration/bgp_test.go
@@ -16,21 +16,140 @@ import (
 )
 
 const (
-	bgpComposeDir  = "compose/bgp/"
-	bgpComposeFile = "compose.yaml"
+	bgpComposeDir = "compose/bgp/"
+	bgpPeerAS     = 65001
 
-	gobgpPeerAddress = "10.6.0.4"
-	gobgpPeerAS      = 65001
-
-	ellaCoreBGPAS       = 64512
-	ellaCoreRouterID    = "10.6.0.2"
-	ellaCoreListenAddr  = ":179"
-	ellaCoreN6IP        = "10.6.0.2"
-	ellaCoreN2IP        = "10.3.0.2"
-	routerN6IP          = "10.6.0.3"
-	testerN3IP          = "10.3.0.3"
-	testerN3SecondaryIP = "10.3.0.4"
+	bgpEllaCoreBGPAS      = 64512
+	bgpEllaCoreListenAddr = ":179"
 )
+
+func bgpComposeFile() string {
+	if DetectIPFamily() == IPv6Only {
+		return "compose-ipv6.yaml"
+	}
+
+	return "compose.yaml"
+}
+
+func bgpGoBGPPeerAddress() string {
+	if DetectIPFamily() == IPv6Only {
+		return "fd00:6::4"
+	}
+
+	return "10.6.0.4"
+}
+
+func bgpEllaCoreN6IP() string {
+	if DetectIPFamily() == IPv6Only {
+		return "fd00:6::2"
+	}
+
+	return "10.6.0.2"
+}
+
+func bgpEllaCoreN2IP() string {
+	if DetectIPFamily() == IPv6Only {
+		return "2001:db8:1::10"
+	}
+
+	return "10.3.0.2"
+}
+
+func bgpRouterN6IP() string {
+	if DetectIPFamily() == IPv6Only {
+		return "fd00:6::3"
+	}
+
+	return "10.6.0.3"
+}
+
+func bgpTesterN3IP() string {
+	if DetectIPFamily() == IPv6Only {
+		return "2001:db8:3::11"
+	}
+
+	return "10.3.0.3"
+}
+
+func bgpTesterN3SecondaryIP() string {
+	if DetectIPFamily() == IPv6Only {
+		return "2001:db8:3::13"
+	}
+
+	return "10.3.0.4"
+}
+
+func bgpTesterDefaultIP() string {
+	if DetectIPFamily() == IPv6Only {
+		return "2001:db8:1::11"
+	}
+
+	return "10.3.0.3"
+}
+
+func bgpAPIAddress() string {
+	addr := bgpEllaCoreN2IP()
+	if DetectIPFamily() == IPv6Only {
+		addr = "[" + addr + "]"
+	}
+
+	return fmt.Sprintf("http://%s:5002", addr)
+}
+
+func bgpDefaultRoute() (destination, gateway string) {
+	if DetectIPFamily() == IPv6Only {
+		return "2001:4860:4860::8888/128", bgpRouterN6IP()
+	}
+
+	return "8.8.8.8/32", bgpRouterN6IP()
+}
+
+func bgpUEPool() string {
+	if DetectIPFamily() == IPv6Only {
+		return "fd45::/48"
+	}
+
+	return "10.45.0.0/16"
+}
+
+func bgpAddressFamily() string {
+	if DetectIPFamily() == IPv6Only {
+		return "ipv6"
+	}
+
+	return "ipv4"
+}
+
+type bgpTestPrefixes struct {
+	learnable   string
+	filtered    string
+	benign      string
+	dangerous   []string
+	importAllow client.BGPImportPrefix
+	importAll   client.BGPImportPrefix
+}
+
+func bgpPrefixes() bgpTestPrefixes {
+	if DetectIPFamily() == IPv6Only {
+		return bgpTestPrefixes{
+			learnable:   "2001:db8:100::/48",
+			filtered:    "2001:db8:200::/48",
+			benign:      "2001:db8:300::/48",
+			dangerous:   []string{"fe80::/64", "ff02::/64", "::1/128"},
+			importAllow: client.BGPImportPrefix{Prefix: "2001:db8:100::/48", MaxLength: 64},
+			importAll:   client.BGPImportPrefix{Prefix: "::/0", MaxLength: 128},
+		}
+	}
+
+	return bgpTestPrefixes{
+		learnable:   "192.168.100.0/24",
+		filtered:    "172.16.50.0/24",
+		benign:      "192.168.200.0/24",
+		dangerous:   []string{"169.254.1.0/24", "224.0.0.0/24", "127.0.0.1/32"},
+		importAllow: client.BGPImportPrefix{Prefix: "192.168.100.0/24", MaxLength: 32},
+		importAll:   client.BGPImportPrefix{Prefix: "0.0.0.0/0", MaxLength: 32},
+	}
+}
 
 func TestIntegrationBGP(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
@@ -38,6 +157,11 @@ func TestIntegrationBGP(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	family := DetectIPFamily()
+	prefixes := bgpPrefixes()
+	af := bgpAddressFamily()
+	peerAddr := bgpGoBGPPeerAddress()
+	n6IP := bgpEllaCoreN6IP()
 
 	dc, err := NewDockerClient()
 	if err != nil {
@@ -48,7 +172,9 @@ func TestIntegrationBGP(t *testing.T) {
 
 	dc.ComposeCleanup(ctx)
 
-	if err := dc.ComposeUpWithFile(ctx, bgpComposeDir, bgpComposeFile); err != nil {
+	composeFile := bgpComposeFile()
+
+	if err := dc.ComposeUpWithFile(ctx, bgpComposeDir, composeFile); err != nil {
 		t.Fatalf("compose up: %v", err)
 	}
 
@@ -60,10 +186,10 @@ func TestIntegrationBGP(t *testing.T) {
 			}
 		}
 
-		dc.ComposeDownWithFile(ctx, bgpComposeDir, bgpComposeFile)
+		dc.ComposeDownWithFile(ctx, bgpComposeDir, composeFile)
 	})
 
-	cl, err := client.New(&client.Config{BaseURL: fmt.Sprintf("http://%s:5002", ellaCoreN2IP)})
+	cl, err := client.New(&client.Config{BaseURL: bgpAPIAddress()})
 	if err != nil {
 		t.Fatalf("ella client: %v", err)
 	}
@@ -92,9 +218,11 @@ func TestIntegrationBGP(t *testing.T) {
 		t.Fatalf("disable NAT: %v", err)
 	}
 
+	routeDst, routeGw := bgpDefaultRoute()
+
 	if err := cl.CreateRoute(ctx, &client.CreateRouteOptions{
-		Destination: "8.8.8.8/32",
-		Gateway:     routerN6IP,
+		Destination: routeDst,
+		Gateway:     routeGw,
 		Interface:   "n6",
 		Metric:      0,
 	}); err != nil && !strings.Contains(err.Error(), "already exists") {
@@ -108,21 +236,26 @@ func TestIntegrationBGP(t *testing.T) {
 	baseline.DataNetwork(fixture.DefaultDataNetworkSpec())
 	baseline.Policy(fixture.DefaultPolicySpec())
 
+	routerID := bgpEllaCoreN6IP()
+	if family == IPv6Only {
+		routerID = "10.6.0.99"
+	}
+
 	if err := cl.UpdateBGPSettings(ctx, &client.UpdateBGPSettingsOptions{
 		Enabled:       true,
-		LocalAS:       ellaCoreBGPAS,
-		RouterID:      ellaCoreRouterID,
-		ListenAddress: ellaCoreListenAddr,
+		LocalAS:       bgpEllaCoreBGPAS,
+		RouterID:      routerID,
+		ListenAddress: bgpEllaCoreListenAddr,
 	}); err != nil {
 		t.Fatalf("enable BGP: %v", err)
 	}
 
 	if err := cl.CreateBGPPeer(ctx, &client.CreateBGPPeerOptions{
-		Address:  gobgpPeerAddress,
-		RemoteAS: gobgpPeerAS,
+		Address:  peerAddr,
+		RemoteAS: bgpPeerAS,
 		HoldTime: 90,
 		ImportPrefixes: []client.BGPImportPrefix{
-			{Prefix: "192.168.100.0/24", MaxLength: 32},
+			prefixes.importAllow,
 		},
 	}); err != nil {
 		t.Fatalf("create BGP peer: %v", err)
@@ -139,7 +272,7 @@ func TestIntegrationBGP(t *testing.T) {
 	}
 
 	waitForGoBGPReady(ctx, t, dc, gobgpContainer, 60*time.Second)
-	waitForBGPSession(ctx, t, cl, gobgpPeerAddress, 60*time.Second)
+	waitForBGPSession(ctx, t, cl, peerAddr, 60*time.Second)
 
 	// --- Subtests ---
 
@@ -149,9 +282,9 @@ func TestIntegrationBGP(t *testing.T) {
 			t.Fatalf("list peers: %v", err)
 		}
 
-		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		peer := findPeerByAddress(peers.Items, peerAddr)
 		if peer == nil {
-			t.Fatalf("peer %s not found", gobgpPeerAddress)
+			t.Fatalf("peer %s not found", peerAddr)
 		}
 
 		if peer.State != "established" {
@@ -167,8 +300,8 @@ func TestIntegrationBGP(t *testing.T) {
 			t.Fatalf("gobgp neighbor: %v", err)
 		}
 
-		if !strings.Contains(out, ellaCoreN6IP) {
-			t.Fatalf("gobgp neighbor does not contain %s:\n%s", ellaCoreN6IP, out)
+		if !strings.Contains(out, n6IP) {
+			t.Fatalf("gobgp neighbor does not contain %s:\n%s", n6IP, out)
 		}
 	})
 
@@ -179,11 +312,19 @@ func TestIntegrationBGP(t *testing.T) {
 		fx := fixture.New(t, ctx, cl)
 		fx.Apply(spec)
 
+		n2Addr := bgpEllaCoreN2IP()
+		n3Addr := bgpTesterN3IP()
+		n3Sec := bgpTesterN3SecondaryIP()
+
 		argv := []string{
 			"core-tester", "run", "ue/session_hold",
-			"--ella-core-n2-address", net.JoinHostPort(ellaCoreN2IP, "38412"),
-			"--gnb", fmt.Sprintf("gnb1,n2=%s,n3=%s,n3-secondary=%s", testerN3IP, testerN3IP, testerN3SecondaryIP),
+			"--ella-core-n2-address", net.JoinHostPort(n2Addr, "38412"),
+			"--gnb", fmt.Sprintf("gnb1,n2=%s,n3=%s,n3-secondary=%s", bgpTesterDefaultIP(), n3Addr, n3Sec),
 			"--verbose",
+		}
+
+		if family == IPv6Only {
+			argv = append(argv, "--ip-version", "ipv6")
 		}
 
 		if _, err := dc.Exec(ctx, testerContainer, argv, true, 10*time.Second, nil); err != nil {
@@ -194,15 +335,19 @@ func TestIntegrationBGP(t *testing.T) {
 			_, _ = dc.Exec(ctx, testerContainer, []string{"pkill", "-f", "ue/session_hold"}, true, 5*time.Second, nil)
 		})
 
-		advertised := waitForAdvertisedRouteInPool(ctx, t, cl, "10.45.0.0/16", 60*time.Second)
+		advertised := waitForAdvertisedRouteInPool(ctx, t, cl, bgpUEPool(), 60*time.Second)
 		t.Logf("advertised UE route: %s (subscriber %s, next-hop %s)", advertised.Prefix, advertised.Subscriber, advertised.NextHop)
 
-		out, err := gobgpCmd(ctx, dc, gobgpContainer, "global", "rib", "-a", "ipv4")
+		out, err := gobgpCmd(ctx, dc, gobgpContainer, "global", "rib", "-a", af)
 		if err != nil {
 			t.Fatalf("gobgp global rib: %v", err)
 		}
 
-		uePrefix := strings.TrimSuffix(advertised.Prefix, "/32")
+		uePrefix := advertised.Prefix
+		if strings.Contains(uePrefix, "/") {
+			uePrefix = strings.Split(uePrefix, "/")[0]
+		}
+
 		if !strings.Contains(out, uePrefix) {
 			t.Fatalf("gobgp did not receive UE route %s:\n%s", advertised.Prefix, out)
 		}
@@ -212,9 +357,9 @@ func TestIntegrationBGP(t *testing.T) {
 			t.Fatalf("list peers: %v", err)
 		}
 
-		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		peer := findPeerByAddress(peers.Items, peerAddr)
 		if peer == nil {
-			t.Fatalf("peer %s not found", gobgpPeerAddress)
+			t.Fatalf("peer %s not found", peerAddr)
 		}
 
 		if peer.PrefixesSent < 1 {
@@ -224,47 +369,43 @@ func TestIntegrationBGP(t *testing.T) {
 
 	t.Run("RouteLearning", func(t *testing.T) {
 		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
-			"global", "rib", "add", "192.168.100.0/24", "-a", "ipv4",
+			"global", "rib", "add", prefixes.learnable, "-a", af,
 		); err != nil {
 			t.Fatalf("gobgp announce route: %v", err)
 		}
 
 		t.Cleanup(func() {
 			_, _ = gobgpCmd(ctx, dc, gobgpContainer,
-				"global", "rib", "del", "192.168.100.0/24", "-a", "ipv4",
+				"global", "rib", "del", prefixes.learnable, "-a", af,
 			)
 		})
 
-		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
+		waitForLearnedRoute(ctx, t, cl, prefixes.learnable)
 
 		routes, err := cl.GetBGPLearnedRoutes(ctx)
 		if err != nil {
 			t.Fatalf("get learned routes: %v", err)
 		}
 
-		found := findLearnedRoute(routes.Routes, "192.168.100.0/24")
+		found := findLearnedRoute(routes.Routes, prefixes.learnable)
 		if found == nil {
-			t.Fatalf("learned route 192.168.100.0/24 not found")
+			t.Fatalf("learned route %s not found", prefixes.learnable)
 		}
 
-		if found.NextHop != gobgpPeerAddress {
-			t.Fatalf("NextHop: got %q, want %q", found.NextHop, gobgpPeerAddress)
+		if found.NextHop != peerAddr {
+			t.Fatalf("NextHop: got %q, want %q", found.NextHop, peerAddr)
 		}
 
-		if found.Peer != gobgpPeerAddress {
-			t.Fatalf("Peer: got %q, want %q", found.Peer, gobgpPeerAddress)
+		if found.Peer != peerAddr {
+			t.Fatalf("Peer: got %q, want %q", found.Peer, peerAddr)
 		}
-
-		// Kernel route assertions omitted: the ella-core rock image does not
-		// include the ip tool. Route installation is validated by the learned
-		// routes API (which reads the in-memory map of kernel-installed routes).
 
 		peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
 		if err != nil {
 			t.Fatalf("list peers: %v", err)
 		}
 
-		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		peer := findPeerByAddress(peers.Items, peerAddr)
 		if peer == nil {
 			t.Fatalf("peer not found")
 		}
@@ -276,14 +417,14 @@ func TestIntegrationBGP(t *testing.T) {
 
 	t.Run("ImportPrefixFiltering", func(t *testing.T) {
 		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
-			"global", "rib", "add", "172.16.50.0/24", "-a", "ipv4",
+			"global", "rib", "add", prefixes.filtered, "-a", af,
 		); err != nil {
 			t.Fatalf("gobgp announce filtered route: %v", err)
 		}
 
 		t.Cleanup(func() {
 			_, _ = gobgpCmd(ctx, dc, gobgpContainer,
-				"global", "rib", "del", "172.16.50.0/24", "-a", "ipv4",
+				"global", "rib", "del", prefixes.filtered, "-a", af,
 			)
 		})
 
@@ -294,21 +435,21 @@ func TestIntegrationBGP(t *testing.T) {
 			t.Fatalf("get learned routes: %v", err)
 		}
 
-		if findLearnedRoute(routes.Routes, "172.16.50.0/24") != nil {
-			t.Fatalf("172.16.50.0/24 should NOT be learned (not in import prefix list)")
+		if findLearnedRoute(routes.Routes, prefixes.filtered) != nil {
+			t.Fatalf("%s should NOT be learned (not in import prefix list)", prefixes.filtered)
 		}
 	})
 
 	t.Run("SafetyFilter", func(t *testing.T) {
-		peerID := findPeerIDByAddress(ctx, t, cl, gobgpPeerAddress)
+		peerID := findPeerIDByAddress(ctx, t, cl, peerAddr)
 
 		if err := cl.UpdateBGPPeer(ctx, &client.UpdateBGPPeerOptions{
 			ID:       peerID,
-			Address:  gobgpPeerAddress,
-			RemoteAS: gobgpPeerAS,
+			Address:  peerAddr,
+			RemoteAS: bgpPeerAS,
 			HoldTime: 90,
 			ImportPrefixes: []client.BGPImportPrefix{
-				{Prefix: "0.0.0.0/0", MaxLength: 32},
+				prefixes.importAll,
 			},
 		}); err != nil {
 			t.Fatalf("update peer import prefixes: %v", err)
@@ -317,112 +458,101 @@ func TestIntegrationBGP(t *testing.T) {
 		t.Cleanup(func() {
 			_ = cl.UpdateBGPPeer(ctx, &client.UpdateBGPPeerOptions{
 				ID:       peerID,
-				Address:  gobgpPeerAddress,
-				RemoteAS: gobgpPeerAS,
+				Address:  peerAddr,
+				RemoteAS: bgpPeerAS,
 				HoldTime: 90,
 				ImportPrefixes: []client.BGPImportPrefix{
-					{Prefix: "192.168.100.0/24", MaxLength: 32},
+					prefixes.importAllow,
 				},
 			})
 		})
 
-		dangerous := []string{
-			"169.254.1.0/24",
-			"224.0.0.0/24",
-			"127.0.0.1/32",
-		}
-
-		benign := "192.168.200.0/24"
-
-		for _, prefix := range append(dangerous, benign) {
+		for _, prefix := range append(prefixes.dangerous, prefixes.benign) {
 			if _, err := gobgpCmd(ctx, dc, gobgpContainer,
-				"global", "rib", "add", prefix, "-a", "ipv4",
+				"global", "rib", "add", prefix, "-a", af,
 			); err != nil {
 				t.Fatalf("gobgp announce %s: %v", prefix, err)
 			}
 		}
 
 		t.Cleanup(func() {
-			for _, prefix := range append(dangerous, benign) {
+			for _, prefix := range append(prefixes.dangerous, prefixes.benign) {
 				_, _ = gobgpCmd(ctx, dc, gobgpContainer,
-					"global", "rib", "del", prefix, "-a", "ipv4",
+					"global", "rib", "del", prefix, "-a", af,
 				)
 			}
 		})
 
-		waitForLearnedRoute(ctx, t, cl, benign)
+		waitForLearnedRoute(ctx, t, cl, prefixes.benign)
 
 		routes, err := cl.GetBGPLearnedRoutes(ctx)
 		if err != nil {
 			t.Fatalf("get learned routes: %v", err)
 		}
 
-		for _, prefix := range dangerous {
+		for _, prefix := range prefixes.dangerous {
 			if findLearnedRoute(routes.Routes, prefix) != nil {
 				t.Errorf("dangerous prefix %s should NOT be learned", prefix)
 			}
 		}
 
-		if findLearnedRoute(routes.Routes, benign) == nil {
-			t.Fatalf("benign prefix %s should be learned", benign)
+		if findLearnedRoute(routes.Routes, prefixes.benign) == nil {
+			t.Fatalf("benign prefix %s should be learned", prefixes.benign)
 		}
 	})
 
 	t.Run("RouteWithdrawal", func(t *testing.T) {
 		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
-			"global", "rib", "add", "192.168.100.0/24", "-a", "ipv4",
+			"global", "rib", "add", prefixes.learnable, "-a", af,
 		); err != nil {
 			t.Fatalf("gobgp announce route: %v", err)
 		}
 
-		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
-		// Kernel route assertions omitted: the ella-core rock image does not
-		// include the ip tool. Route installation is validated by the learned
-		// routes API (which reads the in-memory map of kernel-installed routes).
+		waitForLearnedRoute(ctx, t, cl, prefixes.learnable)
 
 		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
-			"global", "rib", "del", "192.168.100.0/24", "-a", "ipv4",
+			"global", "rib", "del", prefixes.learnable, "-a", af,
 		); err != nil {
 			t.Fatalf("gobgp withdraw route: %v", err)
 		}
 
-		waitForNoLearnedRoute(ctx, t, cl, "192.168.100.0/24", 30*time.Second)
+		waitForNoLearnedRoute(ctx, t, cl, prefixes.learnable, 30*time.Second)
 	})
 
 	t.Run("PeerDeletion", func(t *testing.T) {
 		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
-			"global", "rib", "add", "192.168.100.0/24", "-a", "ipv4",
+			"global", "rib", "add", prefixes.learnable, "-a", af,
 		); err != nil {
 			t.Fatalf("gobgp announce route: %v", err)
 		}
 
-		peerID := findPeerIDByAddress(ctx, t, cl, gobgpPeerAddress)
+		peerID := findPeerIDByAddress(ctx, t, cl, peerAddr)
 
-		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
+		waitForLearnedRoute(ctx, t, cl, prefixes.learnable)
 
 		if err := cl.DeleteBGPPeer(ctx, &client.DeleteBGPPeerOptions{ID: peerID}); err != nil {
 			t.Fatalf("delete peer: %v", err)
 		}
 
-		waitForNoLearnedRoute(ctx, t, cl, "192.168.100.0/24", 15*time.Second)
+		waitForNoLearnedRoute(ctx, t, cl, prefixes.learnable, 15*time.Second)
 
 		if err := cl.CreateBGPPeer(ctx, &client.CreateBGPPeerOptions{
-			Address:  gobgpPeerAddress,
-			RemoteAS: gobgpPeerAS,
+			Address:  peerAddr,
+			RemoteAS: bgpPeerAS,
 			HoldTime: 90,
 			ImportPrefixes: []client.BGPImportPrefix{
-				{Prefix: "192.168.100.0/24", MaxLength: 32},
+				prefixes.importAllow,
 			},
 		}); err != nil {
 			t.Fatalf("re-create peer: %v", err)
 		}
 
-		waitForBGPSession(ctx, t, cl, gobgpPeerAddress, 60*time.Second)
-		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
+		waitForBGPSession(ctx, t, cl, peerAddr, 60*time.Second)
+		waitForLearnedRoute(ctx, t, cl, prefixes.learnable)
 
 		t.Cleanup(func() {
 			_, _ = gobgpCmd(ctx, dc, gobgpContainer,
-				"global", "rib", "del", "192.168.100.0/24", "-a", "ipv4",
+				"global", "rib", "del", prefixes.learnable, "-a", af,
 			)
 		})
 	})
@@ -443,9 +573,9 @@ func TestIntegrationBGP(t *testing.T) {
 			t.Fatalf("list peers: %v", err)
 		}
 
-		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		peer := findPeerByAddress(peers.Items, peerAddr)
 		if peer == nil {
-			t.Fatalf("peer %s not found", gobgpPeerAddress)
+			t.Fatalf("peer %s not found", peerAddr)
 		}
 
 		if peer.State != "established" {
@@ -472,9 +602,9 @@ func TestIntegrationBGP(t *testing.T) {
 			t.Fatalf("list peers after NAT disable: %v", err)
 		}
 
-		peer = findPeerByAddress(peers.Items, gobgpPeerAddress)
+		peer = findPeerByAddress(peers.Items, peerAddr)
 		if peer == nil {
-			t.Fatalf("peer %s not found after NAT disable", gobgpPeerAddress)
+			t.Fatalf("peer %s not found after NAT disable", peerAddr)
 		}
 
 		if peer.State != "established" {

--- a/integration/bgp_test.go
+++ b/integration/bgp_test.go
@@ -1,0 +1,670 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+	"github.com/ellanetworks/core/integration/fixture"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	_ "github.com/ellanetworks/core/internal/tester/scenarios/all"
+)
+
+const (
+	bgpComposeDir  = "compose/bgp/"
+	bgpComposeFile = "compose.yaml"
+
+	gobgpPeerAddress = "10.6.0.4"
+	gobgpPeerAS      = 65001
+
+	ellaCoreBGPAS       = 64512
+	ellaCoreRouterID    = "10.6.0.2"
+	ellaCoreListenAddr  = ":179"
+	ellaCoreN6IP        = "10.6.0.2"
+	ellaCoreN2IP        = "10.3.0.2"
+	routerN6IP          = "10.6.0.3"
+	testerN3IP          = "10.3.0.3"
+	testerN3SecondaryIP = "10.3.0.4"
+)
+
+func TestIntegrationBGP(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	ctx := context.Background()
+
+	dc, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+
+	t.Cleanup(func() { _ = dc.Close() })
+
+	dc.ComposeCleanup(ctx)
+
+	if err := dc.ComposeUpWithFile(ctx, bgpComposeDir, bgpComposeFile); err != nil {
+		t.Fatalf("compose up: %v", err)
+	}
+
+	t.Cleanup(func() {
+		for _, svc := range []string{"ella-core", "gobgp"} {
+			logs, err := dc.ComposeLogs(ctx, bgpComposeDir, svc)
+			if err == nil {
+				t.Logf("=== %s container logs ===\n%s", svc, logs)
+			}
+		}
+
+		dc.ComposeDownWithFile(ctx, bgpComposeDir, bgpComposeFile)
+	})
+
+	cl, err := client.New(&client.Config{BaseURL: fmt.Sprintf("http://%s:5002", ellaCoreN2IP)})
+	if err != nil {
+		t.Fatalf("ella client: %v", err)
+	}
+
+	if err := waitForEllaCoreReady(ctx, cl); err != nil {
+		t.Fatalf("wait for ella core: %v", err)
+	}
+
+	if err := cl.Initialize(ctx, &client.InitializeOptions{
+		Email:    "admin@ellanetworks.com",
+		Password: "admin",
+	}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	resp, err := cl.CreateMyAPIToken(ctx, &client.CreateAPITokenOptions{
+		Name: "bgp-integration-test-token",
+	})
+	if err != nil {
+		t.Fatalf("create API token: %v", err)
+	}
+
+	cl.SetToken(resp.Token)
+
+	if err := cl.UpdateNATInfo(ctx, &client.UpdateNATInfoOptions{Enabled: false}); err != nil {
+		t.Fatalf("disable NAT: %v", err)
+	}
+
+	if err := cl.CreateRoute(ctx, &client.CreateRouteOptions{
+		Destination: "8.8.8.8/32",
+		Gateway:     routerN6IP,
+		Interface:   "n6",
+		Metric:      0,
+	}); err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("create route: %v", err)
+	}
+
+	baseline := fixture.New(t, ctx, cl)
+	baseline.OperatorDefault()
+	baseline.Profile(fixture.DefaultProfileSpec())
+	baseline.Slice(fixture.DefaultSliceSpec())
+	baseline.DataNetwork(fixture.DefaultDataNetworkSpec())
+	baseline.Policy(fixture.DefaultPolicySpec())
+
+	if err := cl.UpdateBGPSettings(ctx, &client.UpdateBGPSettingsOptions{
+		Enabled:       true,
+		LocalAS:       ellaCoreBGPAS,
+		RouterID:      ellaCoreRouterID,
+		ListenAddress: ellaCoreListenAddr,
+	}); err != nil {
+		t.Fatalf("enable BGP: %v", err)
+	}
+
+	if err := cl.CreateBGPPeer(ctx, &client.CreateBGPPeerOptions{
+		Address:  gobgpPeerAddress,
+		RemoteAS: gobgpPeerAS,
+		HoldTime: 90,
+		ImportPrefixes: []client.BGPImportPrefix{
+			{Prefix: "192.168.100.0/24", MaxLength: 32},
+		},
+	}); err != nil {
+		t.Fatalf("create BGP peer: %v", err)
+	}
+
+	gobgpContainer, err := dc.ResolveComposeContainer(ctx, "bgp", "gobgp")
+	if err != nil {
+		t.Fatalf("resolve gobgp container: %v", err)
+	}
+
+	testerContainer, err := dc.ResolveComposeContainer(ctx, "bgp", "ella-core-tester")
+	if err != nil {
+		t.Fatalf("resolve tester container: %v", err)
+	}
+
+	waitForGoBGPReady(ctx, t, dc, gobgpContainer, 60*time.Second)
+	waitForBGPSession(ctx, t, cl, gobgpPeerAddress, 60*time.Second)
+
+	// --- Subtests ---
+
+	t.Run("SessionEstablishment", func(t *testing.T) {
+		peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list peers: %v", err)
+		}
+
+		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		if peer == nil {
+			t.Fatalf("peer %s not found", gobgpPeerAddress)
+		}
+
+		if peer.State != "established" {
+			t.Fatalf("peer state: got %q, want %q", peer.State, "established")
+		}
+
+		if peer.Uptime == "" {
+			t.Fatalf("peer uptime is empty")
+		}
+
+		out, err := gobgpCmd(ctx, dc, gobgpContainer, "neighbor")
+		if err != nil {
+			t.Fatalf("gobgp neighbor: %v", err)
+		}
+
+		if !strings.Contains(out, ellaCoreN6IP) {
+			t.Fatalf("gobgp neighbor does not contain %s:\n%s", ellaCoreN6IP, out)
+		}
+	})
+
+	t.Run("RouteAdvertisement", func(t *testing.T) {
+		sc, _ := scenarios.Get("ue/session_hold")
+		spec := sc.Fixture(scenarios.Env{})
+
+		fx := fixture.New(t, ctx, cl)
+		fx.Apply(spec)
+
+		argv := []string{
+			"core-tester", "run", "ue/session_hold",
+			"--ella-core-n2-address", net.JoinHostPort(ellaCoreN2IP, "38412"),
+			"--gnb", fmt.Sprintf("gnb1,n2=%s,n3=%s,n3-secondary=%s", testerN3IP, testerN3IP, testerN3SecondaryIP),
+			"--verbose",
+		}
+
+		if _, err := dc.Exec(ctx, testerContainer, argv, true, 10*time.Second, nil); err != nil {
+			t.Fatalf("start session_hold scenario: %v", err)
+		}
+
+		t.Cleanup(func() {
+			_, _ = dc.Exec(ctx, testerContainer, []string{"pkill", "-f", "ue/session_hold"}, true, 5*time.Second, nil)
+		})
+
+		advertised := waitForAdvertisedRouteInPool(ctx, t, cl, "10.45.0.0/16", 60*time.Second)
+		t.Logf("advertised UE route: %s (subscriber %s, next-hop %s)", advertised.Prefix, advertised.Subscriber, advertised.NextHop)
+
+		out, err := gobgpCmd(ctx, dc, gobgpContainer, "global", "rib", "-a", "ipv4")
+		if err != nil {
+			t.Fatalf("gobgp global rib: %v", err)
+		}
+
+		uePrefix := strings.TrimSuffix(advertised.Prefix, "/32")
+		if !strings.Contains(out, uePrefix) {
+			t.Fatalf("gobgp did not receive UE route %s:\n%s", advertised.Prefix, out)
+		}
+
+		peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list peers: %v", err)
+		}
+
+		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		if peer == nil {
+			t.Fatalf("peer %s not found", gobgpPeerAddress)
+		}
+
+		if peer.PrefixesSent < 1 {
+			t.Fatalf("PrefixesSent: got %d, want >= 1", peer.PrefixesSent)
+		}
+	})
+
+	t.Run("RouteLearning", func(t *testing.T) {
+		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
+			"global", "rib", "add", "192.168.100.0/24", "-a", "ipv4",
+		); err != nil {
+			t.Fatalf("gobgp announce route: %v", err)
+		}
+
+		t.Cleanup(func() {
+			_, _ = gobgpCmd(ctx, dc, gobgpContainer,
+				"global", "rib", "del", "192.168.100.0/24", "-a", "ipv4",
+			)
+		})
+
+		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
+
+		routes, err := cl.GetBGPLearnedRoutes(ctx)
+		if err != nil {
+			t.Fatalf("get learned routes: %v", err)
+		}
+
+		found := findLearnedRoute(routes.Routes, "192.168.100.0/24")
+		if found == nil {
+			t.Fatalf("learned route 192.168.100.0/24 not found")
+		}
+
+		if found.NextHop != gobgpPeerAddress {
+			t.Fatalf("NextHop: got %q, want %q", found.NextHop, gobgpPeerAddress)
+		}
+
+		if found.Peer != gobgpPeerAddress {
+			t.Fatalf("Peer: got %q, want %q", found.Peer, gobgpPeerAddress)
+		}
+
+		// Kernel route assertions omitted: the ella-core rock image does not
+		// include the ip tool. Route installation is validated by the learned
+		// routes API (which reads the in-memory map of kernel-installed routes).
+
+		peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list peers: %v", err)
+		}
+
+		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		if peer == nil {
+			t.Fatalf("peer not found")
+		}
+
+		if peer.PrefixesReceived < 1 {
+			t.Fatalf("PrefixesReceived: got %d, want >= 1", peer.PrefixesReceived)
+		}
+	})
+
+	t.Run("ImportPrefixFiltering", func(t *testing.T) {
+		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
+			"global", "rib", "add", "172.16.50.0/24", "-a", "ipv4",
+		); err != nil {
+			t.Fatalf("gobgp announce filtered route: %v", err)
+		}
+
+		t.Cleanup(func() {
+			_, _ = gobgpCmd(ctx, dc, gobgpContainer,
+				"global", "rib", "del", "172.16.50.0/24", "-a", "ipv4",
+			)
+		})
+
+		time.Sleep(10 * time.Second)
+
+		routes, err := cl.GetBGPLearnedRoutes(ctx)
+		if err != nil {
+			t.Fatalf("get learned routes: %v", err)
+		}
+
+		if findLearnedRoute(routes.Routes, "172.16.50.0/24") != nil {
+			t.Fatalf("172.16.50.0/24 should NOT be learned (not in import prefix list)")
+		}
+	})
+
+	t.Run("SafetyFilter", func(t *testing.T) {
+		peerID := findPeerIDByAddress(ctx, t, cl, gobgpPeerAddress)
+
+		if err := cl.UpdateBGPPeer(ctx, &client.UpdateBGPPeerOptions{
+			ID:       peerID,
+			Address:  gobgpPeerAddress,
+			RemoteAS: gobgpPeerAS,
+			HoldTime: 90,
+			ImportPrefixes: []client.BGPImportPrefix{
+				{Prefix: "0.0.0.0/0", MaxLength: 32},
+			},
+		}); err != nil {
+			t.Fatalf("update peer import prefixes: %v", err)
+		}
+
+		t.Cleanup(func() {
+			_ = cl.UpdateBGPPeer(ctx, &client.UpdateBGPPeerOptions{
+				ID:       peerID,
+				Address:  gobgpPeerAddress,
+				RemoteAS: gobgpPeerAS,
+				HoldTime: 90,
+				ImportPrefixes: []client.BGPImportPrefix{
+					{Prefix: "192.168.100.0/24", MaxLength: 32},
+				},
+			})
+		})
+
+		dangerous := []string{
+			"169.254.1.0/24",
+			"224.0.0.0/24",
+			"127.0.0.1/32",
+		}
+
+		benign := "192.168.200.0/24"
+
+		for _, prefix := range append(dangerous, benign) {
+			if _, err := gobgpCmd(ctx, dc, gobgpContainer,
+				"global", "rib", "add", prefix, "-a", "ipv4",
+			); err != nil {
+				t.Fatalf("gobgp announce %s: %v", prefix, err)
+			}
+		}
+
+		t.Cleanup(func() {
+			for _, prefix := range append(dangerous, benign) {
+				_, _ = gobgpCmd(ctx, dc, gobgpContainer,
+					"global", "rib", "del", prefix, "-a", "ipv4",
+				)
+			}
+		})
+
+		waitForLearnedRoute(ctx, t, cl, benign)
+
+		routes, err := cl.GetBGPLearnedRoutes(ctx)
+		if err != nil {
+			t.Fatalf("get learned routes: %v", err)
+		}
+
+		for _, prefix := range dangerous {
+			if findLearnedRoute(routes.Routes, prefix) != nil {
+				t.Errorf("dangerous prefix %s should NOT be learned", prefix)
+			}
+		}
+
+		if findLearnedRoute(routes.Routes, benign) == nil {
+			t.Fatalf("benign prefix %s should be learned", benign)
+		}
+	})
+
+	t.Run("RouteWithdrawal", func(t *testing.T) {
+		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
+			"global", "rib", "add", "192.168.100.0/24", "-a", "ipv4",
+		); err != nil {
+			t.Fatalf("gobgp announce route: %v", err)
+		}
+
+		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
+		// Kernel route assertions omitted: the ella-core rock image does not
+		// include the ip tool. Route installation is validated by the learned
+		// routes API (which reads the in-memory map of kernel-installed routes).
+
+		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
+			"global", "rib", "del", "192.168.100.0/24", "-a", "ipv4",
+		); err != nil {
+			t.Fatalf("gobgp withdraw route: %v", err)
+		}
+
+		waitForNoLearnedRoute(ctx, t, cl, "192.168.100.0/24", 30*time.Second)
+	})
+
+	t.Run("PeerDeletion", func(t *testing.T) {
+		if _, err := gobgpCmd(ctx, dc, gobgpContainer,
+			"global", "rib", "add", "192.168.100.0/24", "-a", "ipv4",
+		); err != nil {
+			t.Fatalf("gobgp announce route: %v", err)
+		}
+
+		peerID := findPeerIDByAddress(ctx, t, cl, gobgpPeerAddress)
+
+		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
+
+		if err := cl.DeleteBGPPeer(ctx, &client.DeleteBGPPeerOptions{ID: peerID}); err != nil {
+			t.Fatalf("delete peer: %v", err)
+		}
+
+		waitForNoLearnedRoute(ctx, t, cl, "192.168.100.0/24", 15*time.Second)
+
+		if err := cl.CreateBGPPeer(ctx, &client.CreateBGPPeerOptions{
+			Address:  gobgpPeerAddress,
+			RemoteAS: gobgpPeerAS,
+			HoldTime: 90,
+			ImportPrefixes: []client.BGPImportPrefix{
+				{Prefix: "192.168.100.0/24", MaxLength: 32},
+			},
+		}); err != nil {
+			t.Fatalf("re-create peer: %v", err)
+		}
+
+		waitForBGPSession(ctx, t, cl, gobgpPeerAddress, 60*time.Second)
+		waitForLearnedRoute(ctx, t, cl, "192.168.100.0/24")
+
+		t.Cleanup(func() {
+			_, _ = gobgpCmd(ctx, dc, gobgpContainer,
+				"global", "rib", "del", "192.168.100.0/24", "-a", "ipv4",
+			)
+		})
+	})
+
+	t.Run("NATToggleSuppressesAdvertising", func(t *testing.T) {
+		if err := cl.UpdateNATInfo(ctx, &client.UpdateNATInfoOptions{Enabled: true}); err != nil {
+			t.Fatalf("enable NAT: %v", err)
+		}
+
+		t.Cleanup(func() {
+			_ = cl.UpdateNATInfo(ctx, &client.UpdateNATInfoOptions{Enabled: false})
+		})
+
+		time.Sleep(5 * time.Second)
+
+		peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list peers: %v", err)
+		}
+
+		peer := findPeerByAddress(peers.Items, gobgpPeerAddress)
+		if peer == nil {
+			t.Fatalf("peer %s not found", gobgpPeerAddress)
+		}
+
+		if peer.State != "established" {
+			t.Fatalf("peer state after NAT enable: got %q, want %q", peer.State, "established")
+		}
+
+		advertised, err := cl.GetBGPAdvertisedRoutes(ctx)
+		if err != nil {
+			t.Fatalf("get advertised routes: %v", err)
+		}
+
+		if len(advertised.Routes) != 0 {
+			t.Fatalf("advertised routes after NAT enable: got %d, want 0", len(advertised.Routes))
+		}
+
+		if err := cl.UpdateNATInfo(ctx, &client.UpdateNATInfoOptions{Enabled: false}); err != nil {
+			t.Fatalf("disable NAT: %v", err)
+		}
+
+		time.Sleep(5 * time.Second)
+
+		peers, err = cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+		if err != nil {
+			t.Fatalf("list peers after NAT disable: %v", err)
+		}
+
+		peer = findPeerByAddress(peers.Items, gobgpPeerAddress)
+		if peer == nil {
+			t.Fatalf("peer %s not found after NAT disable", gobgpPeerAddress)
+		}
+
+		if peer.State != "established" {
+			t.Fatalf("peer state after NAT disable: got %q, want %q", peer.State, "established")
+		}
+	})
+}
+
+// --- Helper functions ---
+
+func waitForGoBGPReady(ctx context.Context, t *testing.T, dc *DockerClient, container string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.After(timeout)
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for GoBGP to be ready")
+		case <-ticker.C:
+			if _, err := gobgpCmd(ctx, dc, container, "global"); err == nil {
+				return
+			}
+		}
+	}
+}
+
+func waitForBGPSession(ctx context.Context, t *testing.T, cl *client.Client, peerAddr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.After(timeout)
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for BGP session with %s to reach established", peerAddr)
+		case <-ticker.C:
+			peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+			if err != nil {
+				continue
+			}
+
+			peer := findPeerByAddress(peers.Items, peerAddr)
+			if peer != nil && peer.State == "established" {
+				return
+			}
+		}
+	}
+}
+
+func gobgpCmd(ctx context.Context, dc *DockerClient, container string, args ...string) (string, error) {
+	argv := append([]string{"gobgp"}, args...)
+
+	return dc.Exec(ctx, container, argv, false, 10*time.Second, nil)
+}
+
+func waitForLearnedRoute(ctx context.Context, t *testing.T, cl *client.Client, prefix string) {
+	t.Helper()
+
+	deadline := time.After(30 * time.Second)
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for learned route %s", prefix)
+		case <-ticker.C:
+			routes, err := cl.GetBGPLearnedRoutes(ctx)
+			if err != nil {
+				continue
+			}
+
+			if findLearnedRoute(routes.Routes, prefix) != nil {
+				return
+			}
+		}
+	}
+}
+
+func waitForNoLearnedRoute(ctx context.Context, t *testing.T, cl *client.Client, prefix string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.After(timeout)
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for learned route %s to be removed", prefix)
+		case <-ticker.C:
+			routes, err := cl.GetBGPLearnedRoutes(ctx)
+			if err != nil {
+				continue
+			}
+
+			if findLearnedRoute(routes.Routes, prefix) == nil {
+				return
+			}
+		}
+	}
+}
+
+func waitForAdvertisedRouteInPool(ctx context.Context, t *testing.T, cl *client.Client, pool string, timeout time.Duration) client.BGPAdvertisedRoute {
+	t.Helper()
+
+	deadline := time.After(timeout)
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for advertised route in pool %s", pool)
+
+			return client.BGPAdvertisedRoute{}
+		case <-ticker.C:
+			routes, err := cl.GetBGPAdvertisedRoutes(ctx)
+			if err != nil {
+				continue
+			}
+
+			for _, r := range routes.Routes {
+				if routeInPool(r.Prefix, pool) {
+					return r
+				}
+			}
+		}
+	}
+}
+
+func routeInPool(prefix, pool string) bool {
+	_, poolNet, err := net.ParseCIDR(pool)
+	if err != nil {
+		return false
+	}
+
+	ip, _, err := net.ParseCIDR(prefix)
+	if err != nil {
+		ip = net.ParseIP(prefix)
+		if ip == nil {
+			return false
+		}
+	}
+
+	return poolNet.Contains(ip)
+}
+
+func findPeerByAddress(peers []client.BGPPeer, addr string) *client.BGPPeer {
+	for i := range peers {
+		if peers[i].Address == addr {
+			return &peers[i]
+		}
+	}
+
+	return nil
+}
+
+func findPeerIDByAddress(ctx context.Context, t *testing.T, cl *client.Client, addr string) int {
+	t.Helper()
+
+	peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
+	if err != nil {
+		t.Fatalf("list peers: %v", err)
+	}
+
+	peer := findPeerByAddress(peers.Items, addr)
+	if peer == nil {
+		t.Fatalf("peer %s not found", addr)
+	}
+
+	return peer.ID
+}
+
+func findLearnedRoute(routes []client.BGPLearnedRoute, prefix string) *client.BGPLearnedRoute {
+	for i := range routes {
+		if routes[i].Prefix == prefix {
+			return &routes[i]
+		}
+	}
+
+	return nil
+}

--- a/integration/compose/bgp/Dockerfile.gobgp
+++ b/integration/compose/bgp/Dockerfile.gobgp
@@ -1,0 +1,16 @@
+FROM golang:1.24-bookworm AS builder
+
+RUN go install github.com/osrg/gobgp/v4/cmd/gobgpd@latest && \
+    go install github.com/osrg/gobgp/v4/cmd/gobgp@latest
+
+FROM debian:bookworm-slim
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends iproute2 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/bin/gobgpd /usr/local/bin/gobgpd
+COPY --from=builder /go/bin/gobgp /usr/local/bin/gobgp
+
+ENTRYPOINT ["gobgpd"]
+CMD ["-f", "/etc/gobgp/gobgpd.conf", "--log-level=info"]

--- a/integration/compose/bgp/compose-ipv6.yaml
+++ b/integration/compose/bgp/compose-ipv6.yaml
@@ -1,0 +1,130 @@
+configs:
+  ella_config:
+    content: |
+      logging:
+        system:
+          level: "debug"
+          output: "stdout"
+        audit:
+          output: "stdout"
+      db:
+        path: "core.db"
+      interfaces:
+        n2:
+          address: "2001:db8:1::10"
+          port: 38412
+        n3:
+          name: "n3"
+        n6:
+          name: "n6"
+        api:
+          address: "2001:db8:1::10"
+          port: 5002
+      xdp:
+        attach-mode: "generic"
+  gobgp_config:
+    content: |
+      [global.config]
+        as = 65001
+        router-id = "10.6.0.4"
+        port = 179
+
+      [[neighbors]]
+        [neighbors.config]
+          neighbor-address = "fd00:6::2"
+          peer-as = 64512
+        [[neighbors.afi-safis]]
+          [neighbors.afi-safis.config]
+            afi-safi-name = "ipv6-unicast"
+
+services:
+  ella-core:
+    image: ella-core:latest
+    configs:
+      - source: ella_config
+        target: /core.yaml
+    restart: unless-stopped
+    entrypoint: /bin/core --config /core.yaml
+    privileged: true
+    ports:
+      - "5002:5002"
+    networks:
+      default:
+        driver_opts:
+              com.docker.network.endpoint.ifname: eth0
+        ipv6_address: 2001:db8:1::10
+      n3:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n3
+        ipv6_address: 2001:db8:3::10
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv6_address: fd00:6::2
+  ella-core-tester:
+    image: ella-core-tester:latest
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "ip -6 addr add 2001:db8:3::13/64 dev n3 || true; sleep infinity"
+    restart: unless-stopped
+    privileged: true
+    networks:
+      default:
+        driver_opts:
+              com.docker.network.endpoint.ifname: eth0
+        ipv6_address: 2001:db8:1::11
+      n3:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n3
+        ipv6_address: 2001:db8:3::11
+  router:
+    image: ghcr.io/ellanetworks/ubuntu-router:0.1
+    command:
+      - exec
+      - /bin/bash
+      - -lc
+      - >
+        ip -6 route add fd45::/48 dev n6 via fd00:6::2;
+        trap : TERM INT;
+        python3 /responder.py 34242 & wait
+    restart: unless-stopped
+    privileged: true
+    networks:
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv6_address: fd00:6::3
+  gobgp:
+    build:
+      context: .
+      dockerfile: Dockerfile.gobgp
+    configs:
+      - source: gobgp_config
+        target: /gobgpd.toml
+    entrypoint: ["gobgpd", "-f", "/gobgpd.toml", "--log-level=info"]
+    restart: unless-stopped
+    privileged: true
+    networks:
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv6_address: fd00:6::4
+
+networks:
+  default:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: 2001:db8:1::/64
+  n3:
+    internal: true
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: 2001:db8:3::/64
+  n6:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: fd00:6::/64

--- a/integration/compose/bgp/compose.yaml
+++ b/integration/compose/bgp/compose.yaml
@@ -1,0 +1,118 @@
+configs:
+  ella_config:
+    content: |
+      logging:
+        system:
+          level: "debug"
+          output: "stdout"
+        audit:
+          output: "stdout"
+      db:
+        path: "core.db"
+      interfaces:
+        n2:
+          address: "10.3.0.2"
+          port: 38412
+        n3:
+          name: "n3"
+        n6:
+          name: "n6"
+        api:
+          address: "10.3.0.2"
+          port: 5002
+      xdp:
+        attach-mode: "generic"
+  gobgp_config:
+    content: |
+      [global.config]
+        as = 65001
+        router-id = "10.6.0.4"
+        port = 179
+
+      [[neighbors]]
+        [neighbors.config]
+          neighbor-address = "10.6.0.2"
+          peer-as = 64512
+
+services:
+  ella-core:
+    image: ella-core:latest
+    configs:
+      - source: ella_config
+        target: /core.yaml
+    restart: unless-stopped
+    entrypoint: /bin/core --config /core.yaml
+    privileged: true
+    ports:
+      - "5002:5002"
+    networks:
+      default:
+        driver_opts:
+              com.docker.network.endpoint.ifname: eth0
+      n3:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n3
+        ipv4_address: 10.3.0.2
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv4_address: 10.6.0.2
+  ella-core-tester:
+    image: ella-core-tester:latest
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "ip addr add 10.3.0.4/24 dev n3 || true; sleep infinity"
+    restart: unless-stopped
+    privileged: true
+    networks:
+      default:
+        driver_opts:
+              com.docker.network.endpoint.ifname: eth0
+      n3:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n3
+        ipv4_address: 10.3.0.3
+  router:
+    image: ghcr.io/ellanetworks/ubuntu-router:0.1
+    command:
+      - exec
+      - /bin/bash
+      - -lc
+      - >
+        ip route add 10.45.0.0/22 dev n6 via 10.6.0.2;
+        trap : TERM INT;
+        python3 /responder.py 34242 & wait
+    restart: unless-stopped
+    privileged: true
+    networks:
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv4_address: 10.6.0.3
+  gobgp:
+    build:
+      context: .
+      dockerfile: Dockerfile.gobgp
+    configs:
+      - source: gobgp_config
+        target: /gobgpd.toml
+    entrypoint: ["gobgpd", "-f", "/gobgpd.toml", "--log-level=info"]
+    restart: unless-stopped
+    privileged: true
+    networks:
+      n6:
+        driver_opts:
+              com.docker.network.endpoint.ifname: n6
+        ipv4_address: 10.6.0.4
+
+networks:
+  n3:
+    internal: true
+    ipam:
+      config:
+        - subnet: 10.3.0.0/24
+  n6:
+    ipam:
+      config:
+        - subnet: 10.6.0.0/24

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -24,6 +24,7 @@ var scenariosSkipped = map[string]string{
 	"ue/connectivity_expect_allowed":      "test-only harness; minimal allow-path",
 	"ue/connectivity_expect_blocked_ipv6": "test-only harness; requires a pre-installed deny rule",
 	"ue/connectivity_expect_allowed_ipv6": "test-only harness; minimal allow-path",
+	"ue/session_hold":                     "long-lived session for BGP tests; covered by TestIntegrationBGP",
 }
 
 // scenarioIPFamilyRestrictions returns a map of scenario name → required IP

--- a/internal/tester/scenarios/ue/session_hold.go
+++ b/internal/tester/scenarios/ue/session_hold.go
@@ -1,0 +1,108 @@
+package ue
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ellanetworks/core/internal/tester/gnb"
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/internal/tester/testutil/procedure"
+	"github.com/free5gc/ngap/ngapType"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+)
+
+const sessionHoldIMSI = "001017271246590"
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "ue/session_hold",
+		BindFlags: func(fs *pflag.FlagSet) any { return struct{}{} },
+		Run: func(ctx context.Context, env scenarios.Env, _ any) error {
+			return runSessionHold(ctx, env)
+		},
+		Fixture: func(_ scenarios.Env) scenarios.FixtureSpec {
+			return scenarios.FixtureSpec{
+				Subscribers: []scenarios.SubscriberSpec{
+					scenarios.DefaultSubscriberWith(sessionHoldIMSI, ""),
+				},
+			}
+		},
+	})
+}
+
+// runSessionHold registers a single UE, establishes a PDU session, and
+// blocks until ctx is cancelled. The PDU session (and its IP lease)
+// remains active for the lifetime of the process, which lets external
+// tests observe the BGP route advertisement before tear-down.
+func runSessionHold(ctx context.Context, env scenarios.Env) error {
+	g := env.FirstGNB()
+
+	gNodeB, err := gnb.Start(&gnb.StartOpts{
+		GnbID:           scenarios.DefaultGNBID,
+		MCC:             scenarios.DefaultMCC,
+		MNC:             scenarios.DefaultMNC,
+		SST:             scenarios.DefaultSST,
+		SD:              scenarios.DefaultSD,
+		DNN:             scenarios.DefaultDNN,
+		TAC:             scenarios.DefaultTAC,
+		Name:            "Ella-Core-Tester",
+		CoreN2Addresses: env.CoreN2Addresses,
+		GnbN2Address:    g.N2Address,
+		GnbN3Address:    g.N3Address,
+	})
+	if err != nil {
+		return fmt.Errorf("error starting gNB: %v", err)
+	}
+
+	defer gNodeB.Close()
+
+	_, err = gNodeB.WaitForMessage(ngapType.NGAPPDUPresentSuccessfulOutcome, ngapType.SuccessfulOutcomePresentNGSetupResponse, 200*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("did not receive NG Setup Response: %v", err)
+	}
+
+	newUE, err := newDefaultUE(gNodeB, sessionHoldIMSI[5:], scenarios.DefaultKey, scenarios.DefaultOPC, scenarios.DefaultSequenceNumber, env.PDUSessionType())
+	if err != nil {
+		return fmt.Errorf("could not create UE: %v", err)
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+	gNodeB.AddUE(ranUENGAPID, newUE)
+
+	if _, err := procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: scenarios.DefaultPDUSessionID,
+		UE:           newUE,
+	}); err != nil {
+		return fmt.Errorf("initial registration failed: %v", err)
+	}
+
+	uePDUSession, err := newUE.WaitForPDUSession(scenarios.DefaultPDUSessionID, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("timeout waiting for PDU session: %v", err)
+	}
+
+	logger.Logger.Info("session established, holding until cancelled",
+		zap.String("IMSI", sessionHoldIMSI),
+		zap.String("UE IP", uePDUSession.UEIP),
+	)
+
+	<-ctx.Done()
+
+	logger.Logger.Info("context cancelled, tearing down session",
+		zap.String("IMSI", sessionHoldIMSI),
+	)
+
+	if err := procedure.Deregistration(&procedure.DeregistrationOpts{
+		UE:          newUE,
+		AMFUENGAPID: gNodeB.GetAMFUENGAPID(ranUENGAPID),
+		RANUENGAPID: ranUENGAPID,
+	}); err != nil {
+		logger.Logger.Warn("deregistration failed during teardown", zap.Error(err))
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

Add integration tests that fully validate the BGP feature within Ella Core for both IPv4 and IPv6 address families.

## Context

As we write more code with AI, the change velocity increases and we get less good at reviewing code. To balance this problem, it is critical to have a gating test suite that validate behavior. I wrote more about this topic here: [Implicit Knowledge is a Liability](https://medium.com/p/0a33442bf1a4).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
