### PR TITLE
fix: NG Setup edge cases

### DIFF
--- a/internal/amf/common_function.go
+++ b/internal/amf/common_function.go
@@ -14,7 +14,7 @@ import (
 
 func InTaiList(servedTai models.Tai, taiList []models.Tai) bool {
 	for _, tai := range taiList {
-		if tai.Tac == servedTai.Tac && plmnIDEqual(tai.PlmnID, servedTai.PlmnID) {
+		if tai.Tac == servedTai.Tac && PlmnIDEqual(tai.PlmnID, servedTai.PlmnID) {
 			return true
 		}
 	}
@@ -22,7 +22,7 @@ func InTaiList(servedTai models.Tai, taiList []models.Tai) bool {
 	return false
 }
 
-func plmnIDEqual(a, b *models.PlmnID) bool {
+func PlmnIDEqual(a, b *models.PlmnID) bool {
 	if a == b {
 		return true
 	}
@@ -32,6 +32,16 @@ func plmnIDEqual(a, b *models.PlmnID) bool {
 	}
 
 	return a.Mcc == b.Mcc && a.Mnc == b.Mnc
+}
+
+func AnyPLMNMatch(supportedTAIs []SupportedTAI, operatorPLMN *models.PlmnID) bool {
+	for _, tai := range supportedTAIs {
+		if PlmnIDEqual(tai.Tai.PlmnID, operatorPLMN) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func AttachSourceUeTargetUe(sourceUe, targetUe *RanUe) error {

--- a/internal/amf/ngap/decode_dispatch.go
+++ b/internal/amf/ngap/decode_dispatch.go
@@ -12,21 +12,21 @@ import (
 	"go.uber.org/zap"
 )
 
-// handleDecodeReport sends an ErrorIndication for any items in report
-// and returns false iff report.Fatal(), in which case the dispatcher
-// must skip the handler.
+// handleDecodeReport sends ErrorIndication for fatal decode errors and
+// returns false so the dispatcher skips the handler. Non-fatal errors
+// (ignore-criticality) are logged without sending ErrorIndication.
 func handleDecodeReport(ctx context.Context, ran *amf.Radio, report *decode.Report) bool {
 	if !report.HasItems() {
 		return true
 	}
 
-	cd := report.ToCriticalityDiagnostics()
-
-	if err := ran.NGAPSender.SendErrorIndication(ctx, nil, &cd); err != nil {
-		logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-	}
-
 	if report.Fatal() {
+		cd := report.ToCriticalityDiagnostics()
+
+		if err := ran.NGAPSender.SendErrorIndication(ctx, nil, &cd); err != nil {
+			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
+		}
+
 		logger.WithTrace(ctx, ran.Log).Error("fatal NGAP decode error",
 			zap.Int64("procedureCode", report.ProcedureCode),
 			zap.Int("ieErrors", len(report.Items)))
@@ -34,7 +34,7 @@ func handleDecodeReport(ctx context.Context, ran *amf.Radio, report *decode.Repo
 		return false
 	}
 
-	logger.WithTrace(ctx, ran.Log).Warn("non-fatal NGAP decode error",
+	logger.WithTrace(ctx, ran.Log).Warn("non-fatal NGAP decode error, ignoring",
 		zap.Int64("procedureCode", report.ProcedureCode),
 		zap.Int("ieErrors", len(report.Items)))
 

--- a/internal/amf/ngap/handle_ng_setup_request.go
+++ b/internal/amf/ngap/handle_ng_setup_request.go
@@ -66,34 +66,53 @@ func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	operatorInfo, err := amfInstance.GetOperatorInfo(ctx)
 	if err != nil {
 		logger.WithTrace(ctx, ran.Log).Error("Could not get operator info", zap.Error(err))
+
+		_ = ran.NGAPSender.SendNGSetupFailure(ctx, &ngapType.Cause{
+			Present: ngapType.CausePresentMisc,
+			Misc:    &ngapType.CauseMisc{Value: ngapType.CauseMiscPresentUnspecified},
+		})
+
 		return
 	}
 
-	var found bool
-
-	for i, tai := range ran.SupportedTAIs {
-		if amf.InTaiList(tai.Tai, operatorInfo.Tais) {
-			logger.WithTrace(ctx, ran.Log).Debug("Found served TAI in Core", zap.Any("served_tai", tai.Tai), zap.Int("index", i))
-
-			found = true
-
-			break
-		}
-	}
-
-	if !found {
+	if !amf.AnyPLMNMatch(ran.SupportedTAIs, operatorInfo.Guami.PlmnID) {
 		err := ran.NGAPSender.SendNGSetupFailure(ctx, &ngapType.Cause{
 			Present: ngapType.CausePresentMisc,
-			Misc: &ngapType.CauseMisc{
-				Value: ngapType.CauseMiscPresentUnknownPLMN,
-			},
+			Misc:    &ngapType.CauseMisc{Value: ngapType.CauseMiscPresentUnknownPLMN},
 		})
 		if err != nil {
 			logger.WithTrace(ctx, ran.Log).Error("error sending NG Setup Failure", zap.Error(err))
 			return
 		}
 
-		logger.WithTrace(ctx, ran.Log).Warn("Could not find Served TAI in Core", zap.Any("gnb_tai_list", ran.SupportedTAIs), zap.Any("core_tai_list", operatorInfo.Tais))
+		logger.WithTrace(ctx, ran.Log).Warn("No broadcast PLMN matches operator", zap.Any("gnb_tai_list", ran.SupportedTAIs), zap.Any("operator_plmn", operatorInfo.Guami.PlmnID))
+
+		return
+	}
+
+	var taiFound bool
+
+	for i, tai := range ran.SupportedTAIs {
+		if amf.InTaiList(tai.Tai, operatorInfo.Tais) {
+			logger.WithTrace(ctx, ran.Log).Debug("Found served TAI in Core", zap.Any("served_tai", tai.Tai), zap.Int("index", i))
+
+			taiFound = true
+
+			break
+		}
+	}
+
+	if !taiFound {
+		err := ran.NGAPSender.SendNGSetupFailure(ctx, &ngapType.Cause{
+			Present: ngapType.CausePresentMisc,
+			Misc:    &ngapType.CauseMisc{Value: ngapType.CauseMiscPresentUnspecified},
+		})
+		if err != nil {
+			logger.WithTrace(ctx, ran.Log).Error("error sending NG Setup Failure", zap.Error(err))
+			return
+		}
+
+		logger.WithTrace(ctx, ran.Log).Warn("PLMN matches but no served TAC found", zap.Any("gnb_tai_list", ran.SupportedTAIs), zap.Any("core_tai_list", operatorInfo.Tais))
 
 		return
 	}
@@ -101,7 +120,40 @@ func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	snssaiList, err := amfInstance.ListOperatorSnssai(ctx)
 	if err != nil {
 		logger.WithTrace(ctx, ran.Log).Error("Could not list operator SNSSAI", zap.Error(err))
+
+		_ = ran.NGAPSender.SendNGSetupFailure(ctx, &ngapType.Cause{
+			Present: ngapType.CausePresentMisc,
+			Misc:    &ngapType.CauseMisc{Value: ngapType.CauseMiscPresentUnspecified},
+		})
+
 		return
+	}
+
+	hasSliceOverlap := false
+	for _, tai := range ran.SupportedTAIs {
+		for _, gnbSlice := range tai.SNssaiList {
+			for _, coreSlice := range snssaiList {
+				if gnbSlice.Equal(coreSlice) {
+					hasSliceOverlap = true
+
+					break
+				}
+			}
+
+			if hasSliceOverlap {
+				break
+			}
+		}
+
+		if hasSliceOverlap {
+			break
+		}
+	}
+
+	if !hasSliceOverlap {
+		logger.WithTrace(ctx, ran.Log).Warn("gNB advertises no S-NSSAIs overlapping with operator",
+			zap.Any("gnb_tai_list", ran.SupportedTAIs),
+			zap.Any("core_slices", snssaiList))
 	}
 
 	// Claim RanID only after validation passes; the dispatcher's

--- a/internal/amf/ngap/handle_ng_setup_request.go
+++ b/internal/amf/ngap/handle_ng_setup_request.go
@@ -130,6 +130,7 @@ func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	}
 
 	hasSliceOverlap := false
+
 	for _, tai := range ran.SupportedTAIs {
 		for _, gnbSlice := range tai.SNssaiList {
 			for _, coreSlice := range snssaiList {

--- a/internal/amf/ngap/handle_ng_setup_request_test.go
+++ b/internal/amf/ngap/handle_ng_setup_request_test.go
@@ -281,8 +281,8 @@ func TestHandleNGSetupRequest_NGSetupFailure_gNodeBSupportsDifferentTAC(t *testi
 		t.Fatalf("expected Cause Present to be Miscellaneous, but got %v", cause.Present)
 	}
 
-	if cause.Misc.Value != ngapType.CauseMiscPresentUnknownPLMN {
-		t.Errorf("expected Cause Miscellaneous Value to be CauseMiscPresentUnknownPLMN, but got %v", cause.Misc.Value)
+	if cause.Misc.Value != ngapType.CauseMiscPresentUnspecified {
+		t.Errorf("expected CauseMiscPresentUnspecified for TAC mismatch, got %v", cause.Misc.Value)
 	}
 
 	if ran.RanID != nil {
@@ -543,5 +543,173 @@ func TestHandleNGSetupRequest_ResponseContainsAllConfiguredSlices(t *testing.T) 
 		if response.SnssaiList[i].Sd != expected.sd {
 			t.Errorf("SnssaiList[%d]: expected SD %q, got %q", i, expected.sd, response.SnssaiList[i].Sd)
 		}
+	}
+}
+
+func TestHandleNGSetupRequest_NGSetupFailure_PLMNMismatch(t *testing.T) {
+	fakeNGAPSender := &FakeNGAPSender{}
+
+	ran := &amf.Radio{
+		Log:           logger.AmfLog,
+		NGAPSender:    fakeNGAPSender,
+		SupportedTAIs: make([]amf.SupportedTAI, 0),
+	}
+
+	msg, err := buildNGSetupRequest(&NGSetupRequestOpts{
+		Name:  "TestRAN",
+		GnbID: "ABCDE1",
+		ID:    12345,
+		Mcc:   "310",
+		Mnc:   "410",
+		Tac:   "000064",
+		Sst:   1,
+	})
+	if err != nil {
+		t.Fatalf("failed to build NGSetupRequest: %v", err)
+	}
+
+	op := &db.Operator{Mcc: "001", Mnc: "01"}
+
+	err = op.SetSupportedTacs([]string{"000064"})
+	if err != nil {
+		t.Fatalf("failed to set supported TACs: %v", err)
+	}
+
+	amfInstance := amf.New(&FakeDBInstance{Operator: op}, nil, nil)
+
+	ngap.HandleNGSetupRequest(context.Background(), amfInstance, ran, decodeNGSetupRequestOrFatal(t, msg))
+
+	if len(fakeNGAPSender.SentNGSetupFailures) != 1 {
+		t.Fatalf("expected 1 NGSetupFailure, got %d", len(fakeNGAPSender.SentNGSetupFailures))
+	}
+
+	cause := fakeNGAPSender.SentNGSetupFailures[0].Cause
+	if cause.Present != ngapType.CausePresentMisc || cause.Misc.Value != ngapType.CauseMiscPresentUnknownPLMN {
+		t.Errorf("expected UnknownPLMN cause for PLMN mismatch, got present=%d misc=%d", cause.Present, cause.Misc.Value)
+	}
+}
+
+func TestHandleNGSetupRequest_DBFailure_SendsNGSetupFailure(t *testing.T) {
+	fakeNGAPSender := &FakeNGAPSender{}
+
+	ran := &amf.Radio{
+		Log:           logger.AmfLog,
+		NGAPSender:    fakeNGAPSender,
+		SupportedTAIs: make([]amf.SupportedTAI, 0),
+	}
+
+	msg, err := buildNGSetupRequest(&NGSetupRequestOpts{
+		Name:  "TestRAN",
+		GnbID: "ABCDE1",
+		ID:    12345,
+		Mcc:   "001",
+		Mnc:   "01",
+		Tac:   "000064",
+		Sst:   1,
+	})
+	if err != nil {
+		t.Fatalf("failed to build NGSetupRequest: %v", err)
+	}
+
+	amfInstance := amf.New(&FakeDBInstance{
+		OperatorErr: fmt.Errorf("database unavailable"),
+	}, nil, nil)
+
+	ngap.HandleNGSetupRequest(context.Background(), amfInstance, ran, decodeNGSetupRequestOrFatal(t, msg))
+
+	if len(fakeNGAPSender.SentNGSetupFailures) != 1 {
+		t.Fatalf("expected NGSetupFailure on DB error, got %d", len(fakeNGAPSender.SentNGSetupFailures))
+	}
+
+	cause := fakeNGAPSender.SentNGSetupFailures[0].Cause
+	if cause.Present != ngapType.CausePresentMisc || cause.Misc.Value != ngapType.CauseMiscPresentUnspecified {
+		t.Errorf("expected Unspecified cause on DB failure, got present=%d misc=%d", cause.Present, cause.Misc.Value)
+	}
+}
+
+func TestHandleNGSetupRequest_SliceDBFailure_SendsNGSetupFailure(t *testing.T) {
+	fakeNGAPSender := &FakeNGAPSender{}
+
+	ran := &amf.Radio{
+		Log:           logger.AmfLog,
+		NGAPSender:    fakeNGAPSender,
+		SupportedTAIs: make([]amf.SupportedTAI, 0),
+	}
+
+	msg, err := buildNGSetupRequest(&NGSetupRequestOpts{
+		Name:  "TestRAN",
+		GnbID: "ABCDE1",
+		ID:    12345,
+		Mcc:   "001",
+		Mnc:   "01",
+		Tac:   "000064",
+		Sst:   1,
+	})
+	if err != nil {
+		t.Fatalf("failed to build NGSetupRequest: %v", err)
+	}
+
+	op := &db.Operator{Mcc: "001", Mnc: "01"}
+
+	err = op.SetSupportedTacs([]string{"000064"})
+	if err != nil {
+		t.Fatalf("failed to set supported TACs: %v", err)
+	}
+
+	amfInstance := amf.New(&FakeDBInstance{
+		Operator:  op,
+		SlicesErr: fmt.Errorf("slice query failed"),
+	}, nil, nil)
+
+	ngap.HandleNGSetupRequest(context.Background(), amfInstance, ran, decodeNGSetupRequestOrFatal(t, msg))
+
+	if len(fakeNGAPSender.SentNGSetupFailures) != 1 {
+		t.Fatalf("expected NGSetupFailure on slice DB error, got %d", len(fakeNGAPSender.SentNGSetupFailures))
+	}
+}
+
+func TestHandleNGSetupRequest_NoSliceOverlap_SucceedsWithWarning(t *testing.T) {
+	fakeNGAPSender := &FakeNGAPSender{}
+
+	ran := &amf.Radio{
+		Log:           logger.AmfLog,
+		NGAPSender:    fakeNGAPSender,
+		SupportedTAIs: make([]amf.SupportedTAI, 0),
+	}
+
+	msg, err := buildNGSetupRequest(&NGSetupRequestOpts{
+		Name:  "TestRAN",
+		GnbID: "ABCDE1",
+		ID:    12345,
+		Mcc:   "001",
+		Mnc:   "01",
+		Tac:   "000064",
+		Sst:   2,
+	})
+	if err != nil {
+		t.Fatalf("failed to build NGSetupRequest: %v", err)
+	}
+
+	op := &db.Operator{Mcc: "001", Mnc: "01"}
+
+	err = op.SetSupportedTacs([]string{"000064"})
+	if err != nil {
+		t.Fatalf("failed to set supported TACs: %v", err)
+	}
+
+	amfInstance := amf.New(&FakeDBInstance{
+		Operator: op,
+		Slices:   []db.NetworkSlice{{ID: "s1", Name: "eMBB", Sst: 1}},
+	}, nil, nil)
+	amfInstance.Name = "ella-core"
+
+	ngap.HandleNGSetupRequest(context.Background(), amfInstance, ran, decodeNGSetupRequestOrFatal(t, msg))
+
+	if len(fakeNGAPSender.SentNGSetupResponses) != 1 {
+		t.Fatalf("expected NGSetupResponse even with no slice overlap, got %d responses", len(fakeNGAPSender.SentNGSetupResponses))
+	}
+
+	if len(fakeNGAPSender.SentNGSetupFailures) != 0 {
+		t.Errorf("expected no NGSetupFailure for slice mismatch, got %d", len(fakeNGAPSender.SentNGSetupFailures))
 	}
 }

--- a/internal/amf/ngap/handle_test.go
+++ b/internal/amf/ngap/handle_test.go
@@ -67,8 +67,10 @@ func getSliceInBytes(sst int32, sd string) ([]byte, []byte, error) {
 }
 
 type FakeDBInstance struct {
-	Operator *db.Operator
-	Slices   []db.NetworkSlice
+	Operator    *db.Operator
+	OperatorErr error
+	Slices      []db.NetworkSlice
+	SlicesErr   error
 }
 
 type SmfPathSwitchCall struct {
@@ -166,6 +168,10 @@ func (f *FakeSmfSbi) UpdateSmContextN2HandoverPrepared(_ context.Context, _ stri
 }
 
 func (fdb *FakeDBInstance) GetOperator(ctx context.Context) (*db.Operator, error) {
+	if fdb.OperatorErr != nil {
+		return nil, fdb.OperatorErr
+	}
+
 	return fdb.Operator, nil
 }
 
@@ -200,6 +206,10 @@ func (fdb *FakeDBInstance) GetProfileByID(ctx context.Context, id string) (*db.P
 }
 
 func (fdb *FakeDBInstance) ListAllNetworkSlices(ctx context.Context) ([]db.NetworkSlice, error) {
+	if fdb.SlicesErr != nil {
+		return nil, fdb.SlicesErr
+	}
+
 	if fdb.Slices != nil {
 		return fdb.Slices, nil
 	}


### PR DESCRIPTION
# Description

This PR addresses minor issues with Ella Core's handling of NG Setup messages:
- TAC mismatch uses wrong cause code
- Zero slice overlap silently accepted
- ErrorIndication sent for missing ignore-criticality IE
- DB failure leaves gNB hanging with no response

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
