### PR TITLE
fix: send registration reject when errors in registration request message

### DIFF
--- a/internal/amf/nas/gmm/handle_registration_request.go
+++ b/internal/amf/nas/gmm/handle_registration_request.go
@@ -259,7 +259,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	state := ue.GetState()
 
 	switch state {
-	case amf.Deregistered, amf.Registered:
+	case amf.Deregistered, amf.Registered, amf.Authentication:
 		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, msg.RegistrationRequest); err != nil {
 			return fmt.Errorf("failed handling registration request: %v", err)
 		}

--- a/internal/amf/nas/gmm/handle_registration_request_test.go
+++ b/internal/amf/nas/gmm/handle_registration_request_test.go
@@ -620,7 +620,7 @@ func TestHandleRegistrationRequest_UEStateContextSetup_ResetToDeregistered(t *te
 // TestHandleRegistrationRequest_UEStateAuthentication_Error validates that
 // a registration request for a UE in the middle of an Authentication procedure
 // triggers an error.
-func TestHandleRegistrationRequest_UEStateAuthentication_Error(t *testing.T) {
+func TestHandleRegistrationRequest_UEStateAuthentication_RestartsRegistration(t *testing.T) {
 	ctx := context.TODO()
 	amfInstance := amf.New(&FakeDBInstance{
 		Operator: &db.Operator{
@@ -628,13 +628,22 @@ func TestHandleRegistrationRequest_UEStateAuthentication_Error(t *testing.T) {
 			Mnc:           "01",
 			SupportedTACs: "[\"000001\"]",
 		},
-	}, nil, nil)
+	}, &FakeAusf{
+		AvKgAka: &ausf.AuthResult{
+			Rand: hex.EncodeToString(make([]byte, 16)),
+			Autn: hex.EncodeToString(make([]byte, 16)),
+		},
+		Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+		Kseaf: "testkey",
+	}, nil)
 
 	ue, ngapSender, err := buildUeAndRadio()
 	if err != nil {
 		t.Fatalf("could not create UE and radio: %v", err)
 	}
 
+	ue.Suci = "testsuci"
+	ue.Supi = mustSUPIFromPrefixed("imsi-001019756139935")
 	ue.ForceState(amf.Authentication)
 
 	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
@@ -643,12 +652,25 @@ func TestHandleRegistrationRequest_UEStateAuthentication_Error(t *testing.T) {
 	}
 
 	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
-	if err == nil {
-		t.Fatalf("registration request in state Authentication should return an error")
+	if err != nil {
+		t.Fatalf("registration request in state Authentication should restart, got: %v", err)
 	}
 
-	if len(ngapSender.SentDownlinkNASTransport) != 0 {
-		t.Fatalf("should not have sent a Downlink NAS Transport message")
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("should have sent a Downlink NAS Transport message (AuthenticationRequest), got %d", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	resp := ngapSender.SentDownlinkNASTransport[0]
+	nm := new(nas.Message)
+	nm.SecurityHeaderType = nas.GetSecurityHeaderType(resp.NasPdu) & 0x0f
+
+	err = nm.PlainNasDecode(&resp.NasPdu)
+	if err != nil {
+		t.Fatalf("could not decode NAS message: %v", err)
+	}
+
+	if nm.GmmHeader.GetMessageType() != nas.MsgTypeAuthenticationRequest {
+		t.Fatalf("expected AuthenticationRequest, got message type %d", nm.GmmHeader.GetMessageType())
 	}
 }
 

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/nas/gmm/message"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/ngap/ngapConvert"
 	"go.uber.org/zap"
 )
@@ -100,6 +102,21 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	err := amfInstance.NAS.HandleNAS(ctx, ranUe, msg.NASPDU)
 	if err != nil {
 		logger.WithTrace(ctx, ranUe.Log).Error("error handling NAS Message", zap.Error(err))
+		sendRegistrationRejectOnError(ctx, ranUe)
+
 		return
+	}
+}
+
+// TS 24.501 §5.5.1.2.8 case (b): protocol error in REGISTRATION REQUEST.
+func sendRegistrationRejectOnError(ctx context.Context, ranUe *amf.RanUe) {
+	rejectPdu, err := message.BuildRegistrationReject(0, nasMessage.Cause5GMMProtocolErrorUnspecified)
+	if err != nil {
+		logger.WithTrace(ctx, ranUe.Log).Error("failed to build registration reject", zap.Error(err))
+		return
+	}
+
+	if err := ranUe.SendDownlinkNasTransport(ctx, rejectPdu, nil); err != nil {
+		logger.WithTrace(ctx, ranUe.Log).Error("failed to send registration reject", zap.Error(err))
 	}
 }

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -281,7 +281,7 @@ func TestHandleInitialUEMessage_RegisteredUE_DoesNotPanic(t *testing.T) {
 	}
 }
 
-func TestHandleInitialUEMessage_NASReturnsError(t *testing.T) {
+func TestHandleInitialUEMessage_NASReturnsError_SendsRegistrationReject(t *testing.T) {
 	fakeNAS := &FakeNASHandler{Err: errors.New("nas decode failed")}
 	amfInstance := newTestAMFWithNAS(fakeNAS)
 
@@ -297,8 +297,21 @@ func TestHandleInitialUEMessage_NASReturnsError(t *testing.T) {
 		t.Fatalf("NAS calls = %d, want 1", len(fakeNAS.Calls))
 	}
 
-	// Verify no downstream side effects: ran still has the UE
-	if ran.RanUEs[1] == nil {
-		t.Error("RanUe should still exist after NAS error")
+	sender := ran.NGAPSender.(*FakeNGAPSender)
+	if len(sender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("DownlinkNASTransport sent = %d, want 1", len(sender.SentDownlinkNASTransport))
+	}
+
+	nasPdu := sender.SentDownlinkNASTransport[0].NasPdu
+	if len(nasPdu) < 4 {
+		t.Fatalf("NAS PDU too short: %d bytes", len(nasPdu))
+	}
+
+	if nasPdu[2] != 0x44 {
+		t.Errorf("NAS message type = 0x%02x, want 0x44 (RegistrationReject)", nasPdu[2])
+	}
+
+	if nasPdu[3] != 0x6f {
+		t.Errorf("5GMM cause = 0x%02x, want 0x6f (protocol error unspecified)", nasPdu[3])
 	}
 }

--- a/internal/amf/ngap/handle_test.go
+++ b/internal/amf/ngap/handle_test.go
@@ -302,6 +302,12 @@ type HandoverCancelAcknowledge struct {
 	RanUeNgapID int64
 }
 
+type DownlinkNASTransportMsg struct {
+	AmfUeNgapID int64
+	RanUeNgapID int64
+	NasPdu      []byte
+}
+
 type FakeNGAPSender struct {
 	SentNGSetupFailures                []*NGSetupFailure
 	SentNGSetupResponses               []*NGSetupResponse
@@ -318,6 +324,7 @@ type FakeNGAPSender struct {
 	SentRanConfigurationUpdateFailures []*RanConfigurationUpdateFailure
 	SentDownlinkRanConfigTransfers     []*ngapType.SONConfigurationTransfer
 	SentPDUSessionModifyConfirms       []PDUSessionModifyConfirm
+	SentDownlinkNASTransport           []*DownlinkNASTransportMsg
 }
 
 type PDUSessionModifyConfirm struct {
@@ -419,6 +426,12 @@ func (fng *FakeNGAPSender) SendUEContextReleaseCommand(
 }
 
 func (fng *FakeNGAPSender) SendDownlinkNasTransport(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, nasPdu []byte, mobilityRestrictionList *ngapType.MobilityRestrictionList) error {
+	fng.SentDownlinkNASTransport = append(fng.SentDownlinkNASTransport, &DownlinkNASTransportMsg{
+		AmfUeNgapID: amfUeNgapID,
+		RanUeNgapID: ranUeNgapID,
+		NasPdu:      nasPdu,
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR addresses minor issues with Ella Core's handling of Initial UE messages:
- When Ella Core received a RegistrationRequest with a malformed mandatory IE, it logged the error internally but never sent any response back to the UE.
- When a UE sent a new RegistrationRequest while Ella Core was still waiting for an AuthenticationResponse from a previous (abandoned) registration attempt, Ella Core rejected it instead of aborting the stale procedure and starting fresh as required by TS 24.501 §5.5.1.2.8.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
