### PR TITLE
fix: respond error message when invalid uplink NAS message

### DIFF
--- a/internal/amf/nas/gmm/message/build.go
+++ b/internal/amf/nas/gmm/message/build.go
@@ -527,3 +527,20 @@ func encodeNetworkName(name string) []byte {
 
 	return buf
 }
+
+func BuildStatus5GMM(cause uint8) ([]byte, error) {
+	m := nas.NewMessage()
+	m.GmmMessage = nas.NewGmmMessage()
+	m.GmmHeader.SetMessageType(nas.MsgTypeStatus5GMM)
+
+	status := nasMessage.NewStatus5GMM(0)
+	status.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	status.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	status.SetSpareHalfOctet(0)
+	status.SetMessageType(nas.MsgTypeStatus5GMM)
+	status.SetCauseValue(cause)
+
+	m.Status5GMM = status
+
+	return m.PlainNasEncode()
+}

--- a/internal/amf/ngap/handle_uplink_nas_transport.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport.go
@@ -6,13 +6,16 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/nas/nasMessage"
 	"go.uber.org/zap"
 )
 
 func HandleUplinkNasTransport(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.UplinkNASTransport) {
 	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
 	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("ran ue is nil", zap.Int64("ranUeNgapID", msg.RANUENGAPID))
+		logger.WithTrace(ctx, ran.Log).Error("unknown RAN UE NGAP ID in UplinkNASTransport", zap.Int64("ranUeNgapID", msg.RANUENGAPID))
+		sendUnknownLocalUEError(ctx, ran)
+
 		return
 	}
 
@@ -42,5 +45,19 @@ func HandleUplinkNasTransport(ctx context.Context, amfInstance *amf.AMF, ran *am
 	err := amfInstance.NAS.HandleNAS(ctx, ranUe, msg.NASPDU)
 	if err != nil {
 		logger.WithTrace(ctx, ranUe.Log).Error("error handling NAS message", zap.Error(err))
+		sendStatus5GMM(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
+	}
+}
+
+func sendStatus5GMM(ctx context.Context, ranUe *amf.RanUe, cause uint8) {
+	pdu := []byte{
+		0x7e,  // EPD: 5GS Mobility Management
+		0x00,  // Security header: plain NAS
+		0x6d,  // Message type: 5GMM STATUS
+		cause, // 5GMM cause
+	}
+
+	if err := ranUe.SendDownlinkNasTransport(ctx, pdu, nil); err != nil {
+		logger.WithTrace(ctx, ranUe.Log).Error("failed to send 5GMM STATUS", zap.Error(err))
 	}
 }

--- a/internal/amf/ngap/handle_uplink_nas_transport.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport.go
@@ -53,7 +53,7 @@ func sendStatus5GMM(ctx context.Context, ranUe *amf.RanUe, cause uint8) {
 	pdu := []byte{
 		0x7e,  // EPD: 5GS Mobility Management
 		0x00,  // Security header: plain NAS
-		0x6d,  // Message type: 5GMM STATUS
+		0x64,  // Message type: 5GMM STATUS (MsgTypeStatus5GMM = 100)
 		cause, // 5GMM cause
 	}
 

--- a/internal/amf/ngap/handle_uplink_nas_transport.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/nas/gmm/message"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/nas/nasMessage"
@@ -50,11 +51,10 @@ func HandleUplinkNasTransport(ctx context.Context, amfInstance *amf.AMF, ran *am
 }
 
 func sendStatus5GMM(ctx context.Context, ranUe *amf.RanUe, cause uint8) {
-	pdu := []byte{
-		0x7e,  // EPD: 5GS Mobility Management
-		0x00,  // Security header: plain NAS
-		0x64,  // Message type: 5GMM STATUS (MsgTypeStatus5GMM = 100)
-		cause, // 5GMM cause
+	pdu, err := message.BuildStatus5GMM(cause)
+	if err != nil {
+		logger.WithTrace(ctx, ranUe.Log).Error("failed to build 5GMM STATUS", zap.Error(err))
+		return
 	}
 
 	if err := ranUe.SendDownlinkNasTransport(ctx, pdu, nil); err != nil {

--- a/internal/amf/ngap/handle_uplink_nas_transport_test.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport_test.go
@@ -147,8 +147,8 @@ func TestHandleUplinkNasTransport_NASError_SendsStatus5GMM(t *testing.T) {
 		t.Fatalf("NAS PDU too short: %d bytes", len(nasPdu))
 	}
 
-	if nasPdu[2] != 0x6d {
-		t.Errorf("NAS message type = 0x%02x, want 0x6d (5GMM STATUS)", nasPdu[2])
+	if nasPdu[2] != 0x64 {
+		t.Errorf("NAS message type = 0x%02x, want 0x64 (5GMM STATUS)", nasPdu[2])
 	}
 
 	if nasPdu[3] != 0x6f {

--- a/internal/amf/ngap/handle_uplink_nas_transport_test.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport_test.go
@@ -5,27 +5,39 @@ package ngap_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/amf/ngap"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/ngap/ngapType"
 )
 
-func TestHandleUplinkNasTransport_UnknownRanUe(t *testing.T) {
+func TestHandleUplinkNasTransport_UnknownRanUe_SendsErrorIndication(t *testing.T) {
 	ran := newTestRadio()
 	sender := ran.NGAPSender.(*FakeNGAPSender)
-	amf := newTestAMF()
+	amfInstance := newTestAMF()
 
-	ngap.HandleUplinkNasTransport(context.Background(), amf, ran, decode.UplinkNASTransport{
+	ngap.HandleUplinkNasTransport(context.Background(), amfInstance, ran, decode.UplinkNASTransport{
 		AMFUENGAPID: 1,
 		RANUENGAPID: 1,
 		NASPDU:      []byte{0x7E, 0x00, 0x55},
 	})
 
-	if len(sender.SentErrorIndications) != 0 {
-		t.Fatalf("expected no ErrorIndication, got %d", len(sender.SentErrorIndications))
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("ErrorIndications sent = %d, want 1", len(sender.SentErrorIndications))
+	}
+
+	cause := sender.SentErrorIndications[0].Cause
+	if cause == nil || cause.Present != ngapType.CausePresentRadioNetwork {
+		t.Fatal("expected RadioNetwork cause")
+	}
+
+	if cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID {
+		t.Errorf("cause = %d, want UnknownLocalUENGAPID (%d)",
+			cause.RadioNetwork.Value, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
 	}
 }
 
@@ -100,5 +112,46 @@ func TestHandleUplinkNasTransport_LocationUpdatedBeforeNAS(t *testing.T) {
 
 	if len(fakeNAS.Calls) != 1 {
 		t.Fatalf("NAS calls = %d, want 1", len(fakeNAS.Calls))
+	}
+}
+
+func TestHandleUplinkNasTransport_NASError_SendsStatus5GMM(t *testing.T) {
+	fakeNAS := &FakeNASHandler{Err: errors.New("NAS decode failed")}
+	amfInstance := newTestAMFWithNAS(fakeNAS)
+
+	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
+
+	amfUe := amf.NewAmfUe()
+	amfUe.Log = logger.AmfLog
+
+	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
+	amfUe.AttachRanUe(ranUe)
+
+	ngap.HandleUplinkNasTransport(context.Background(), amfInstance, ran, decode.UplinkNASTransport{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 1,
+		NASPDU:      []byte{0x7E, 0x00, 0xFF},
+	})
+
+	if len(fakeNAS.Calls) != 1 {
+		t.Fatalf("NAS calls = %d, want 1", len(fakeNAS.Calls))
+	}
+
+	if len(sender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("DownlinkNASTransport sent = %d, want 1", len(sender.SentDownlinkNASTransport))
+	}
+
+	nasPdu := sender.SentDownlinkNASTransport[0].NasPdu
+	if len(nasPdu) < 4 {
+		t.Fatalf("NAS PDU too short: %d bytes", len(nasPdu))
+	}
+
+	if nasPdu[2] != 0x6d {
+		t.Errorf("NAS message type = 0x%02x, want 0x6d (5GMM STATUS)", nasPdu[2])
+	}
+
+	if nasPdu[3] != 0x6f {
+		t.Errorf("5GMM cause = 0x%02x, want 0x6f (protocol error unspecified)", nasPdu[3])
 	}
 }


### PR DESCRIPTION
# Description

Ella Core silently dropped invalid Uplink NAS Transport messages. Now it responds the correct error message.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
