### PR TITLE
chore: refactor AMF state

### DIFF
--- a/internal/amf/active_nas_connection.go
+++ b/internal/amf/active_nas_connection.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package amf
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ellanetworks/core/internal/amf/procedure"
+	"github.com/ellanetworks/core/internal/ausf"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/free5gc/nas/nasMessage"
+)
+
+// ActiveNasConnection is the state tied to one N1 NAS signalling
+// connection. Procedures and procedure retransmission timers live
+// here; they cannot make progress without an active NAS connection,
+// and per TS 24.501 they are aborted on lower-layer failure via
+// ctx cancellation.
+type ActiveNasConnection struct {
+	Mutex sync.RWMutex
+
+	parent *FivegmmContext
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	ranUe *RanUe
+
+	Procedures *procedure.Registry
+
+	T3513 *Timer
+	T3565 *Timer
+	T3560 *Timer
+	T3550 *Timer
+	T3555 *Timer
+	T3522 *Timer
+
+	AuthenticationCtx                 *ausf.AuthResult
+	AuthFailureCauseSynchFailureTimes int
+
+	RegistrationRequest             *nasMessage.RegistrationRequest
+	RegistrationType5GS             uint8
+	IdentityTypeUsedForRegistration uint8
+	RetransmissionOfInitialNASMsg   bool
+	N1N2Message                     *models.N1N2MessageTransferRequest
+}
+
+func newActiveNasConnection(parent *FivegmmContext, ranUe *RanUe) *ActiveNasConnection {
+	ctx, cancel := context.WithCancel(parent.ctx)
+
+	return &ActiveNasConnection{
+		parent:     parent,
+		ctx:        ctx,
+		cancel:     cancel,
+		ranUe:      ranUe,
+		Procedures: procedure.NewRegistry(logger.AmfLog),
+	}
+}
+
+func (conn *ActiveNasConnection) Ctx() context.Context {
+	return conn.ctx
+}
+
+func (conn *ActiveNasConnection) Parent() *FivegmmContext {
+	return conn.parent
+}
+
+func (conn *ActiveNasConnection) RanUe() *RanUe {
+	return conn.ranUe
+}
+
+func (conn *ActiveNasConnection) Release() {
+	conn.stopTimers()
+	conn.cancel()
+	conn.parent.active.CompareAndSwap(conn, nil)
+}
+
+// stopTimers stops every retransmission timer owned by this connection.
+// Go time.Timer values do not observe ctx cancellation; they must be
+// stopped explicitly to prevent stale firings on a released RAN UE.
+func (conn *ActiveNasConnection) stopTimers() {
+	for _, t := range []*Timer{conn.T3513, conn.T3565, conn.T3560, conn.T3550, conn.T3555, conn.T3522} {
+		if t != nil {
+			t.Stop()
+		}
+	}
+}

--- a/internal/amf/active_nas_connection.go
+++ b/internal/amf/active_nas_connection.go
@@ -5,7 +5,6 @@ package amf
 
 import (
 	"context"
-	"sync"
 
 	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/ausf"
@@ -14,14 +13,12 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 )
 
-// ActiveNasConnection is the state tied to one N1 NAS signalling
-// connection. Procedures and procedure retransmission timers live
-// here; they cannot make progress without an active NAS connection,
-// and per TS 24.501 they are aborted on lower-layer failure via
-// ctx cancellation.
+// ActiveNasConnection is the state tied to one N1 NAS signalling connection:
+// the procedure registry, NAS retransmission timers, and the connection-scoped
+// context. Release cancels the context and stops the timers; in-flight handler
+// goroutines are not pre-empted, so they must check for nil where they
+// dereference the connection.
 type ActiveNasConnection struct {
-	Mutex sync.RWMutex
-
 	parent *FivegmmContext
 
 	ctx    context.Context

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -171,7 +171,7 @@ func (amf *AMF) DeregisterAndRemoveAMFUE(ctx context.Context, ue *AmfUe) {
 	ue.Mutex.Unlock()
 
 	if ranUe != nil {
-		err := ranUe.Remove()
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.AmfLog.Error("failed to remove RAN UE", zap.Error(err))
 		}
@@ -336,7 +336,7 @@ func (amf *AMF) ClaimRanID(radio *Radio, ranNodeID *ngapType.GlobalRANNodeID) *R
 	amf.mu.Unlock()
 
 	if evicted != nil {
-		evicted.RemoveAllUeInRan()
+		evicted.RemoveAllUeInRan(context.Background())
 
 		if evicted.Conn != nil {
 			_ = evicted.Conn.Close()
@@ -402,8 +402,9 @@ func (amf *AMF) CountRegisteredSubscribers() int {
 	return count
 }
 
-func (amf *AMF) RemoveRadio(ran *Radio) {
-	ran.RemoveAllUeInRan()
+// RemoveRadio removes a radio and all UEs bound to it.
+func (amf *AMF) RemoveRadio(ctx context.Context, ran *Radio) {
+	ran.RemoveAllUeInRan(ctx)
 
 	amf.mu.Lock()
 	defer amf.mu.Unlock()
@@ -575,7 +576,7 @@ func (amf *AMF) SendPaging(ctx context.Context, ue *AmfUe, ngapBuf []byte) error
 	amf.mu.RLock()
 	defer amf.mu.RUnlock()
 
-	taiList := ue.RegistrationArea
+	taiList := ue.Current().RegistrationArea
 
 	for _, ran := range amf.Radios {
 		for _, item := range ran.SupportedTAIs {
@@ -595,7 +596,8 @@ func (amf *AMF) SendPaging(ctx context.Context, ue *AmfUe, ngapBuf []byte) error
 
 	if amf.T3513Cfg.Enable {
 		cfg := amf.T3513Cfg
-		ue.T3513 = NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
+		conn := ue.NasConn()
+		conn.T3513 = NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			ue.Log.Info("t3513 expires, retransmit paging", zap.Int32("retry", expireTimes))
 
 			for _, ran := range amf.ListRadios() {
@@ -615,7 +617,8 @@ func (amf *AMF) SendPaging(ctx context.Context, ue *AmfUe, ngapBuf []byte) error
 			}
 		}, func() {
 			ue.Log.Warn("T3513 expires, abort paging procedure", zap.Int32("retry", cfg.MaxRetryTimes))
-			ue.T3513 = nil // clear the timer
+
+			conn.T3513 = nil
 		})
 	}
 

--- a/internal/amf/amf_ran.go
+++ b/internal/amf/amf_ran.go
@@ -77,7 +77,8 @@ type SupportedTAI struct {
 	SNssaiList []models.Snssai
 }
 
-func (r *Radio) RemoveAllUeInRan() {
+// RemoveAllUeInRan removes every RAN UE bound to this radio.
+func (r *Radio) RemoveAllUeInRan(ctx context.Context) {
 	r.mu.RLock()
 
 	ues := make([]*RanUe, 0, len(r.RanUEs))
@@ -88,10 +89,29 @@ func (r *Radio) RemoveAllUeInRan() {
 	r.mu.RUnlock()
 
 	for _, ranUe := range ues {
-		err := ranUe.Remove()
+		applyStatefulNasCleanup(ctx, ranUe)
+
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.AmfLog.Error("error removing ran ue", zap.Error(err))
 		}
+	}
+}
+
+// applyStatefulNasCleanup runs the GMM state-machine cleanup that follows
+// NAS connection loss: mid-registration UEs are aborted (TS 24.501
+// §5.5.1.2.8); registered UEs start the mobile reachable timer (§5.3.7).
+func applyStatefulNasCleanup(ctx context.Context, ranUe *RanUe) {
+	ue := ranUe.AmfUe()
+	if ue == nil {
+		return
+	}
+
+	switch ue.GetState() {
+	case Registered:
+		ue.ResetMobileReachableTimer()
+	case Authentication, SecurityMode, ContextSetup:
+		ue.Deregister(ctx)
 	}
 }
 

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -14,17 +14,16 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf/procedure"
-	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/util/ueauth"
 	"github.com/free5gc/nas"
 	"github.com/free5gc/nas/nasMessage"
-	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/nas/security"
 	"go.uber.org/zap"
 )
@@ -58,11 +57,6 @@ type AmfUe struct {
 
 	/* Gmm State */
 	state StateType
-	/* Registration procedure related context */
-	RegistrationType5GS             uint8
-	IdentityTypeUsedForRegistration uint8
-	RegistrationRequest             *nasMessage.RegistrationRequest
-	RetransmissionOfInitialNASMsg   bool
 	/* Ue Identity*/
 	PlmnID  models.PlmnID
 	Suci    string
@@ -78,72 +72,86 @@ type AmfUe struct {
 	/* Last Seen — updated on every UE-specific NGAP message */
 	LastSeenAt    time.Time
 	LastSeenRadio string
-	/* context about udm */
-	Ambr                              *models.Ambr
-	AuthenticationCtx                 *ausf.AuthResult
-	AuthFailureCauseSynchFailureTimes int
-	ABBA                              []uint8
-	Kamf                              string
-	N1N2Message                       *models.N1N2MessageTransferRequest
-	SmContextList                     map[uint8]*SmContext // Key: pdu session id
-	ranUe                             *RanUe
-	Procedures                        *procedure.Registry
-	UeRadioCapability                 string // OCTET string
+	ranUe         *RanUe
 
-	/* context related to Paging */
-	UeRadioCapabilityForPaging *models.UERadioCapabilityForPaging
-	UESpecificDRX              uint8
-
-	/* Security Context */
-	SecurityContextAvailable bool
-	UESecurityCapability     *nasType.UESecurityCapability // for security command
-	NgKsi                    models.NgKsi
-	MacFailed                bool      // set to true if the integrity check of current NAS message is failed
-	KnasInt                  [16]uint8 // 16 byte
-	KnasEnc                  [16]uint8 // 16 byte
-	Kgnb                     []uint8   // 32 byte
-	NH                       []uint8   // 32 byte
-	NCC                      uint8     // 0..7
-	ULCount                  security.Count
-	DLCount                  security.Count
-	CipheringAlg             uint8
-	IntegrityAlg             uint8
-
-	RegistrationArea []models.Tai
-
-	AllowedNssai []models.Snssai
-
-	/* T3513(Paging) */
-	T3513 *Timer // for paging
-	/* T3565(Notification) */
-	T3565 *Timer // for NAS Notification
-	/* T3560 (for authentication request/security mode command retransmission) */
-	T3560 *Timer
-	/* T3550 (for registration accept retransmission) */
-	T3550 *Timer
-	/* T3555 (for configuration update command retransmission) */
-	T3555 *Timer
-	/* T3522 (for deregistration request) */
-	T3522 *Timer
-	/* T3502 (Assigned by AMF, and used by UE to initialize registration procedure) */
-	T3502Value time.Duration
-	T3512Value time.Duration
-	/* Linked to T3512, should be 4 minutes longer */
-	mobileReachableTimer        *Timer
-	implicitDeregistrationTimer *Timer
-
-	smf SmfSbi // set by AMF.AddAmfUeToUePool; used by releaseSmContexts
+	smf SmfSbi
 
 	Log *zap.Logger
+
+	current atomic.Pointer[FivegmmContext]
 }
 
 func NewAmfUe() *AmfUe {
-	return &AmfUe{
-		state:            Deregistered,
-		RegistrationArea: make([]models.Tai, 0),
-		Procedures:       procedure.NewRegistry(logger.AmfLog),
-		SmContextList:    make(map[uint8]*SmContext),
+	ue := &AmfUe{
+		state: Deregistered,
 	}
+
+	fc := newFivegmmContext(ue)
+	fc.active.Store(newActiveNasConnection(fc, nil))
+	ue.current.Store(fc)
+
+	return ue
+}
+
+func (ue *AmfUe) Current() *FivegmmContext {
+	if ue == nil {
+		return nil
+	}
+
+	return ue.current.Load()
+}
+
+// NasConn returns the active NAS connection of the current 5GMM context,
+// or nil if no NAS connection is established.
+func (ue *AmfUe) NasConn() *ActiveNasConnection {
+	fc := ue.Current()
+	if fc == nil {
+		return nil
+	}
+
+	return fc.active.Load()
+}
+
+// SwapContext atomically replaces the active 5GMM context. The previous
+// context is closed: its ActiveNasConnection is released and its ctx is
+// cancelled, unwinding procedures and in-flight RPCs derived from it.
+func (ue *AmfUe) SwapContext(fresh *FivegmmContext) *FivegmmContext {
+	old := ue.current.Swap(fresh)
+	if old != nil {
+		old.close()
+	}
+
+	return fresh
+}
+
+// RotateContext installs a fresh 5GMM context and returns it. Used when
+// a UE re-initiates registration: the prior context is discarded per
+// TS 24.501 handling of an initial registration arriving in 5GMM-REGISTERED.
+func (ue *AmfUe) RotateContext() *FivegmmContext {
+	fresh := newFivegmmContext(ue)
+	fresh.active.Store(newActiveNasConnection(fresh, nil))
+	ue.SwapContext(fresh)
+
+	return fresh
+}
+
+// AttachNasConnection installs a fresh NAS connection on the current
+// 5GMM context, replacing any prior one.
+func (ue *AmfUe) AttachNasConnection(ranUe *RanUe) *ActiveNasConnection {
+	fc := ue.current.Load()
+	if fc == nil {
+		fc = newFivegmmContext(ue)
+		if !ue.current.CompareAndSwap(nil, fc) {
+			fc = ue.current.Load()
+		}
+	}
+
+	conn := newActiveNasConnection(fc, ranUe)
+	if old := fc.active.Swap(conn); old != nil {
+		old.cancel()
+	}
+
+	return conn
 }
 
 // RanUe returns the currently attached RanUe, or nil.
@@ -220,7 +228,6 @@ func (ue *AmfUe) AttachRanUe(ranUe *RanUe) {
 	}
 
 	ue.Mutex.Lock()
-	defer ue.Mutex.Unlock()
 
 	oldRanUe := ue.ranUe
 
@@ -241,44 +248,18 @@ func (ue *AmfUe) AttachRanUe(ranUe *RanUe) {
 	}
 
 	ue.Log = logger.AmfLog.With(logger.AmfUeNgapID(ranUe.AmfUeNgapID))
-}
 
-// DetachRanUe detaches the given RanUe from this AmfUe. If target is non-nil,
-// the detach only proceeds when ue.ranUe still points to target, preventing a
-// stale RanUe cleanup from accidentally severing a newer association.
-func (ue *AmfUe) DetachRanUe(target *RanUe) {
-	if ue == nil {
-		return
+	ue.Mutex.Unlock()
+
+	if fc := ue.current.Load(); fc != nil && fc.active.Load() == nil {
+		fc.active.Store(newActiveNasConnection(fc, ranUe))
 	}
-
-	ue.Mutex.Lock()
-	defer ue.Mutex.Unlock()
-
-	if ue.ranUe == nil {
-		return
-	}
-
-	if target != nil && ue.ranUe != target {
-		logger.AmfLog.Warn("DetachRanUe: current RanUe does not match target, skipping",
-			logger.SUPI(ue.Supi.String()),
-			zap.Int64("currentAmfUeNgapID", ue.ranUe.AmfUeNgapID),
-			zap.Int64("targetAmfUeNgapID", target.AmfUeNgapID),
-		)
-
-		return
-	}
-
-	if ue.ranUe.amfUe == ue {
-		ue.ranUe.amfUe = nil
-	}
-
-	ue.ranUe = nil
 }
 
 func (ue *AmfUe) AllocateRegistrationArea(supportedTais []models.Tai) {
 	// clear the previous registration area if need
-	if len(ue.RegistrationArea) > 0 {
-		ue.RegistrationArea = nil
+	if len(ue.Current().RegistrationArea) > 0 {
+		ue.Current().RegistrationArea = nil
 	}
 
 	taiList := make([]models.Tai, len(supportedTais))
@@ -286,14 +267,14 @@ func (ue *AmfUe) AllocateRegistrationArea(supportedTais []models.Tai) {
 
 	for _, supportTai := range taiList {
 		if supportTai.Equal(ue.Tai) {
-			ue.RegistrationArea = append(ue.RegistrationArea, supportTai)
+			ue.Current().RegistrationArea = append(ue.Current().RegistrationArea, supportTai)
 			break
 		}
 	}
 }
 
 func (ue *AmfUe) IsAllowedNssai(targetSNssai *models.Snssai) bool {
-	for _, s := range ue.AllowedNssai {
+	for _, s := range ue.Current().AllowedNssai {
 		if s.Equal(*targetSNssai) {
 			return true
 		}
@@ -303,13 +284,13 @@ func (ue *AmfUe) IsAllowedNssai(targetSNssai *models.Snssai) bool {
 }
 
 func (ue *AmfUe) SecurityContextIsValid() bool {
-	return ue.SecurityContextAvailable && ue.NgKsi.Ksi != nasMessage.NasKeySetIdentifierNoKeyIsAvailable && !ue.MacFailed
+	return ue.Current().SecurityContextAvailable && ue.Current().NgKsi.Ksi != nasMessage.NasKeySetIdentifierNoKeyIsAvailable
 }
 
 // cipheringAlgName returns the human-readable name for the negotiated NAS ciphering algorithm.
 // Must be called while holding ue.Mutex.
 func (ue *AmfUe) cipheringAlgName() string {
-	switch ue.CipheringAlg {
+	switch ue.Current().CipheringAlg {
 	case security.AlgCiphering128NEA0:
 		return "NEA0"
 	case security.AlgCiphering128NEA1:
@@ -326,7 +307,7 @@ func (ue *AmfUe) cipheringAlgName() string {
 // integrityAlgName returns the human-readable name for the negotiated NAS integrity algorithm.
 // Must be called while holding ue.Mutex.
 func (ue *AmfUe) integrityAlgName() string {
-	switch ue.IntegrityAlg {
+	switch ue.Current().IntegrityAlg {
 	case security.AlgIntegrity128NIA0:
 		return "NIA0"
 	case security.AlgIntegrity128NIA1:
@@ -389,7 +370,7 @@ func (ue *AmfUe) DerivateKamf(kseaf string) error {
 
 	P0 := []byte(ue.Supi.IMSI())
 	L0 := ueauth.KDFLen(P0)
-	P1 := ue.ABBA
+	P1 := ue.Current().ABBA
 	L1 := ueauth.KDFLen(P1)
 
 	kSeafDecode, err := hex.DecodeString(kseaf)
@@ -402,7 +383,7 @@ func (ue *AmfUe) DerivateKamf(kseaf string) error {
 		return fmt.Errorf("could not get kdf value: %v", err)
 	}
 
-	ue.Kamf = hex.EncodeToString(kAmfBytes)
+	ue.Current().Kamf = hex.EncodeToString(kAmfBytes)
 
 	return nil
 }
@@ -412,10 +393,10 @@ func (ue *AmfUe) DerivateAlgKey() error {
 	// Security Key
 	P0 := []byte{security.NNASEncAlg}
 	L0 := ueauth.KDFLen(P0)
-	P1 := []byte{ue.CipheringAlg}
+	P1 := []byte{ue.Current().CipheringAlg}
 	L1 := ueauth.KDFLen(P1)
 
-	kAmfBytes, err := hex.DecodeString(ue.Kamf)
+	kAmfBytes, err := hex.DecodeString(ue.Current().Kamf)
 	if err != nil {
 		return fmt.Errorf("decode kamf error: %v", err)
 	}
@@ -425,12 +406,12 @@ func (ue *AmfUe) DerivateAlgKey() error {
 		return fmt.Errorf("get kdf value error: %v", err)
 	}
 
-	copy(ue.KnasEnc[:], kenc[16:32])
+	copy(ue.Current().KnasEnc[:], kenc[16:32])
 
 	// Integrity Key
 	P0 = []byte{security.NNASIntAlg}
 	L0 = ueauth.KDFLen(P0)
-	P1 = []byte{ue.IntegrityAlg}
+	P1 = []byte{ue.Current().IntegrityAlg}
 	L1 = ueauth.KDFLen(P1)
 
 	kint, err := ueauth.GetKDFValue(kAmfBytes, ueauth.FCForAlgorithmKeyDerivation, P0, L0, P1, L1)
@@ -438,7 +419,7 @@ func (ue *AmfUe) DerivateAlgKey() error {
 		return fmt.Errorf("get kdf value error: %v", err)
 	}
 
-	copy(ue.KnasInt[:], kint[16:32])
+	copy(ue.Current().KnasInt[:], kint[16:32])
 
 	return nil
 }
@@ -446,12 +427,12 @@ func (ue *AmfUe) DerivateAlgKey() error {
 // Access Network key Derivation function defined in TS 33.501 Annex A.9
 func (ue *AmfUe) DerivateAnKey() error {
 	P0 := make([]byte, 4)
-	binary.BigEndian.PutUint32(P0, ue.ULCount.Get())
+	binary.BigEndian.PutUint32(P0, ue.Current().ULCount.Get())
 	L0 := ueauth.KDFLen(P0)
 	P1 := []byte{security.AccessType3GPP}
 	L1 := ueauth.KDFLen(P1)
 
-	kAmfBytes, err := hex.DecodeString(ue.Kamf)
+	kAmfBytes, err := hex.DecodeString(ue.Current().Kamf)
 	if err != nil {
 		return fmt.Errorf("could not decode kamf: %v", err)
 	}
@@ -461,7 +442,7 @@ func (ue *AmfUe) DerivateAnKey() error {
 		return fmt.Errorf("could not get kdf value: %v", err)
 	}
 
-	ue.Kgnb = key
+	ue.Current().Kgnb = key
 
 	return nil
 }
@@ -471,7 +452,7 @@ func (ue *AmfUe) DerivateNH(syncInput []byte) error {
 	P0 := syncInput
 	L0 := ueauth.KDFLen(P0)
 
-	kAmfBytes, err := hex.DecodeString(ue.Kamf)
+	kAmfBytes, err := hex.DecodeString(ue.Current().Kamf)
 	if err != nil {
 		return fmt.Errorf("could not decode kamf: %v", err)
 	}
@@ -481,7 +462,7 @@ func (ue *AmfUe) DerivateNH(syncInput []byte) error {
 		return fmt.Errorf("could not get kdf value: %v", err)
 	}
 
-	ue.NH = nh
+	ue.Current().NH = nh
 
 	return nil
 }
@@ -492,20 +473,20 @@ func (ue *AmfUe) UpdateSecurityContext() error {
 		return fmt.Errorf("error deriving AnKey: %v", err)
 	}
 
-	err = ue.DerivateNH(ue.Kgnb)
+	err = ue.DerivateNH(ue.Current().Kgnb)
 	if err != nil {
 		return fmt.Errorf("error deriving NH: %v", err)
 	}
 
-	ue.NCC = 1
+	ue.Current().NCC = 1
 
 	return nil
 }
 
 func (ue *AmfUe) UpdateNH() error {
-	ue.NCC = (ue.NCC + 1) % 8
+	ue.Current().NCC = (ue.Current().NCC + 1) % 8
 
-	err := ue.DerivateNH(ue.NH)
+	err := ue.DerivateNH(ue.Current().NH)
 	if err != nil {
 		return fmt.Errorf("error deriving NH: %v", err)
 	}
@@ -514,7 +495,7 @@ func (ue *AmfUe) UpdateNH() error {
 }
 
 func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) error {
-	if ue.UESecurityCapability == nil {
+	if ue.Current().UESecurityCapability == nil {
 		return fmt.Errorf("UE security capability not available, cannot negotiate NAS security algorithms")
 	}
 
@@ -524,17 +505,17 @@ func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) error {
 	for _, intAlg := range intOrder {
 		switch intAlg {
 		case security.AlgIntegrity128NIA0:
-			ueSupported = ue.UESecurityCapability.GetIA0_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetIA0_5G()
 		case security.AlgIntegrity128NIA1:
-			ueSupported = ue.UESecurityCapability.GetIA1_128_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetIA1_128_5G()
 		case security.AlgIntegrity128NIA2:
-			ueSupported = ue.UESecurityCapability.GetIA2_128_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetIA2_128_5G()
 		case security.AlgIntegrity128NIA3:
-			ueSupported = ue.UESecurityCapability.GetIA3_128_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetIA3_128_5G()
 		}
 
 		if ueSupported == 1 {
-			ue.IntegrityAlg = intAlg
+			ue.Current().IntegrityAlg = intAlg
 			intFound = true
 
 			break
@@ -551,17 +532,17 @@ func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) error {
 	for _, encAlg := range encOrder {
 		switch encAlg {
 		case security.AlgCiphering128NEA0:
-			ueSupported = ue.UESecurityCapability.GetEA0_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetEA0_5G()
 		case security.AlgCiphering128NEA1:
-			ueSupported = ue.UESecurityCapability.GetEA1_128_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetEA1_128_5G()
 		case security.AlgCiphering128NEA2:
-			ueSupported = ue.UESecurityCapability.GetEA2_128_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetEA2_128_5G()
 		case security.AlgCiphering128NEA3:
-			ueSupported = ue.UESecurityCapability.GetEA3_128_5G()
+			ueSupported = ue.Current().UESecurityCapability.GetEA3_128_5G()
 		}
 
 		if ueSupported == 1 {
-			ue.CipheringAlg = encAlg
+			ue.Current().CipheringAlg = encAlg
 			encFound = true
 
 			break
@@ -575,30 +556,33 @@ func (ue *AmfUe) SelectSecurityAlg(intOrder, encOrder []uint8) error {
 	return nil
 }
 
-// this is clearing the transient data of registration request, this is called entrypoint of Deregistration and Registration state
+// ClearRegistrationRequestData clears transient registration fields and
+// cancels any active procedures on the current NAS connection.
 func (ue *AmfUe) ClearRegistrationRequestData() {
-	ue.RegistrationRequest = nil
-	ue.RegistrationType5GS = 0
-	ue.IdentityTypeUsedForRegistration = 0
-
-	ue.AuthFailureCauseSynchFailureTimes = 0
-	if ue.ranUe != nil {
-		ue.ranUe.UeContextRequest = false
-		ue.ranUe.RecvdInitialContextSetupResponse = false
+	conn := ue.NasConn()
+	if conn == nil {
+		return
 	}
 
-	ue.RetransmissionOfInitialNASMsg = false
+	conn.RegistrationRequest = nil
+	conn.RegistrationType5GS = 0
+	conn.IdentityTypeUsedForRegistration = 0
+	conn.AuthFailureCauseSynchFailureTimes = 0
+	conn.RetransmissionOfInitialNASMsg = false
 
-	// Clear any active procedures — this is a registration boundary.
-	for _, t := range ue.Procedures.ActiveTypes() {
-		ue.Procedures.End(procedure.Type(t))
+	if ue.ranUe != nil {
+		ue.ranUe.UeContextRequest = false
+	}
+
+	for _, t := range conn.Procedures.ActiveTypes() {
+		conn.Procedures.End(procedure.Type(t))
 	}
 }
 
 func (ue *AmfUe) ClearRegistrationData(ctx context.Context) {
 	ue.releaseSmContexts(ctx)
 
-	ue.SmContextList = make(map[uint8]*SmContext)
+	ue.Current().SmContextList = make(map[uint8]*SmContext)
 }
 
 func (ue *AmfUe) CreateSmContext(pduSessionID uint8, ref string, snssai *models.Snssai) error {
@@ -609,7 +593,7 @@ func (ue *AmfUe) CreateSmContext(pduSessionID uint8, ref string, snssai *models.
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	ue.SmContextList[pduSessionID] = &SmContext{
+	ue.Current().SmContextList[pduSessionID] = &SmContext{
 		Ref:    ref,
 		Snssai: snssai,
 	}
@@ -621,14 +605,14 @@ func (ue *AmfUe) DeleteSmContext(pduSessionID uint8) {
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	delete(ue.SmContextList, pduSessionID)
+	delete(ue.Current().SmContextList, pduSessionID)
 }
 
 func (ue *AmfUe) SmContextFindByPDUSessionID(pduSessionID uint8) (*SmContext, bool) {
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	smContext, ok := ue.SmContextList[pduSessionID]
+	smContext, ok := ue.Current().SmContextList[pduSessionID]
 
 	return smContext, ok
 }
@@ -637,7 +621,7 @@ func (ue *AmfUe) SetSmContextInactive(pduSessionID uint8) {
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	if sc, ok := ue.SmContextList[pduSessionID]; ok {
+	if sc, ok := ue.Current().SmContextList[pduSessionID]; ok {
 		sc.PduSessionInactive = true
 	}
 }
@@ -646,7 +630,7 @@ func (ue *AmfUe) HasActivePduSessions() bool {
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	for _, smContext := range ue.SmContextList {
+	for _, smContext := range ue.Current().SmContextList {
 		if !smContext.PduSessionInactive {
 			return true
 		}
@@ -668,7 +652,7 @@ func (ue *AmfUe) EncodeNASMessage(msg *nas.Message) ([]byte, error) {
 	defer ue.Mutex.Unlock()
 
 	// Plain NAS message
-	if !ue.SecurityContextAvailable {
+	if !ue.Current().SecurityContextAvailable {
 		return msg.PlainNasEncode()
 	}
 
@@ -681,8 +665,8 @@ func (ue *AmfUe) EncodeNASMessage(msg *nas.Message) ([]byte, error) {
 	case nas.SecurityHeaderTypeIntegrityProtectedAndCiphered:
 		needCiphering = true
 	case nas.SecurityHeaderTypeIntegrityProtectedWithNew5gNasSecurityContext:
-		ue.ULCount.Set(0, 0)
-		ue.DLCount.Set(0, 0)
+		ue.Current().ULCount.Set(0, 0)
+		ue.Current().DLCount.Set(0, 0)
 	default:
 		return nil, fmt.Errorf("wrong security header type: 0x%0x", msg.SecurityHeaderType)
 	}
@@ -694,15 +678,15 @@ func (ue *AmfUe) EncodeNASMessage(msg *nas.Message) ([]byte, error) {
 	}
 
 	if needCiphering {
-		if err = security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.DLCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+		if err = security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().DLCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 			return nil, fmt.Errorf("error encrypting: %+v", err)
 		}
 	}
 
 	// add sequece number
-	payload = append([]byte{ue.DLCount.SQN()}, payload[:]...)
+	payload = append([]byte{ue.Current().DLCount.SQN()}, payload[:]...)
 
-	mac32, err := security.NASMacCalculate(ue.IntegrityAlg, ue.KnasInt, ue.DLCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload)
+	mac32, err := security.NASMacCalculate(ue.Current().IntegrityAlg, ue.Current().KnasInt, ue.Current().DLCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload)
 	if err != nil {
 		return nil, fmt.Errorf("MAC calcuate error: %+v", err)
 	}
@@ -715,7 +699,7 @@ func (ue *AmfUe) EncodeNASMessage(msg *nas.Message) ([]byte, error) {
 	payload = append(msgSecurityHeader, payload[:]...)
 
 	// Increase DL Count
-	ue.DLCount.AddOne()
+	ue.Current().DLCount.AddOne()
 
 	return payload, nil
 }
@@ -724,15 +708,15 @@ func (ue *AmfUe) ResetMobileReachableTimer() {
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	if ue.implicitDeregistrationTimer != nil {
-		ue.implicitDeregistrationTimer.Stop()
-		ue.implicitDeregistrationTimer = nil
+	if ue.Current().ImplicitDeregistrationTimer != nil {
+		ue.Current().ImplicitDeregistrationTimer.Stop()
+		ue.Current().ImplicitDeregistrationTimer = nil
 	}
 
 	ue.Log.Debug("starting mobile reachable timer", logger.SUPI(ue.Supi.String()))
 
-	ue.mobileReachableTimer = NewTimer(
-		ue.T3512Value+(4*time.Minute),
+	ue.Current().MobileReachableTimer = NewTimer(
+		ue.Current().T3512Value+(4*time.Minute),
 		1,
 		func(expireTimes int32) {
 			ue.Log.Debug("mobile reachable timer expired", logger.SUPI(ue.Supi.String()))
@@ -748,9 +732,9 @@ func (ue *AmfUe) StopMobileReachableTimer() {
 
 	ue.Log.Debug("stopping mobile reachable timer")
 
-	if ue.mobileReachableTimer != nil {
-		ue.mobileReachableTimer.Stop()
-		ue.mobileReachableTimer = nil
+	if ue.Current().MobileReachableTimer != nil {
+		ue.Current().MobileReachableTimer.Stop()
+		ue.Current().MobileReachableTimer = nil
 	}
 }
 
@@ -760,9 +744,9 @@ func (ue *AmfUe) StopImplicitDeregistrationTimer() {
 
 	ue.Log.Debug("stopping implicit deregistration timer")
 
-	if ue.implicitDeregistrationTimer != nil {
-		ue.implicitDeregistrationTimer.Stop()
-		ue.implicitDeregistrationTimer = nil
+	if ue.Current().ImplicitDeregistrationTimer != nil {
+		ue.Current().ImplicitDeregistrationTimer.Stop()
+		ue.Current().ImplicitDeregistrationTimer = nil
 	}
 }
 
@@ -772,29 +756,90 @@ func (ue *AmfUe) startImplicitDeregistrationTimer() {
 
 	ue.Log.Debug("starting implicit deregistration timer")
 
-	ue.implicitDeregistrationTimer = NewTimer(2*time.Minute, 1, func(expireTimes int32) { ue.Deregister(context.Background()) }, func() {})
+	ue.Current().ImplicitDeregistrationTimer = NewTimer(2*time.Minute, 1, func(expireTimes int32) { ue.Deregister(context.Background()) }, func() {})
 }
 
-// stopAllTimersLocked stops every timer on the UE. Caller must hold ue.Mutex.
-func (ue *AmfUe) stopAllTimersLocked() {
-	for _, t := range []*Timer{ue.T3513, ue.T3565, ue.T3560, ue.T3550, ue.T3555, ue.T3522} {
+func (ue *AmfUe) StopProcedureTimers() {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	conn := ue.NasConn()
+	if conn == nil {
+		return
+	}
+
+	for _, t := range []*Timer{conn.T3513, conn.T3565, conn.T3560, conn.T3550, conn.T3555, conn.T3522} {
 		if t != nil {
 			t.Stop()
 		}
 	}
+}
 
-	if ue.implicitDeregistrationTimer != nil {
-		ue.implicitDeregistrationTimer.Stop()
-		ue.implicitDeregistrationTimer = nil
+// ReleaseNasConnection releases the NAS signalling connection between
+// this AMF UE and a RAN UE. Target, when non-nil, makes the release a
+// no-op if a newer RAN UE has already taken over.
+func (ue *AmfUe) ReleaseNasConnection(target *RanUe) {
+	if ue == nil {
+		return
 	}
 
-	if ue.mobileReachableTimer != nil {
-		ue.mobileReachableTimer.Stop()
-		ue.mobileReachableTimer = nil
+	if !ue.detachRanUeIfMatch(target) {
+		return
+	}
+
+	ue.StopProcedureTimers()
+
+	if conn := ue.NasConn(); conn != nil {
+		conn.Release()
+	}
+}
+
+func (ue *AmfUe) detachRanUeIfMatch(target *RanUe) bool {
+	ue.Mutex.Lock()
+	defer ue.Mutex.Unlock()
+
+	if ue.ranUe == nil {
+		return false
+	}
+
+	if target != nil && ue.ranUe != target {
+		return false
+	}
+
+	if ue.ranUe.amfUe == ue {
+		ue.ranUe.amfUe = nil
+	}
+
+	ue.ranUe = nil
+
+	return true
+}
+
+// stopAllTimersLocked stops every idle timer on the 5GMM context. Caller
+// must hold ue.Mutex. Procedure retransmission timers are torn down via
+// NAS-connection ctx cancellation.
+func (ue *AmfUe) stopAllTimersLocked() {
+	fc := ue.Current()
+	if fc == nil {
+		return
+	}
+
+	if fc.ImplicitDeregistrationTimer != nil {
+		fc.ImplicitDeregistrationTimer.Stop()
+		fc.ImplicitDeregistrationTimer = nil
+	}
+
+	if fc.MobileReachableTimer != nil {
+		fc.MobileReachableTimer.Stop()
+		fc.MobileReachableTimer = nil
 	}
 }
 
 func (ue *AmfUe) Deregister(ctx context.Context) {
+	if conn := ue.NasConn(); conn != nil {
+		conn.Release()
+	}
+
 	ue.Mutex.Lock()
 
 	ue.stopAllTimersLocked()
@@ -802,12 +847,12 @@ func (ue *AmfUe) Deregister(ctx context.Context) {
 	ue.transitionToLocked(Deregistered)
 
 	// Copy refs and clear map while protected by UE lock.
-	smContextRefs := make([]string, 0, len(ue.SmContextList))
-	for _, smContext := range ue.SmContextList {
+	smContextRefs := make([]string, 0, len(ue.Current().SmContextList))
+	for _, smContext := range ue.Current().SmContextList {
 		smContextRefs = append(smContextRefs, smContext.Ref)
 	}
 
-	ue.SmContextList = make(map[uint8]*SmContext)
+	ue.Current().SmContextList = make(map[uint8]*SmContext)
 	ue.Mutex.Unlock()
 
 	// External SMF calls must happen without holding UE lock.
@@ -831,12 +876,12 @@ func (ue *AmfUe) releaseSmContexts(ctx context.Context) {
 	// Copy refs under lock, then release lock before external SMF calls.
 	ue.Mutex.Lock()
 
-	smContextRefs := make([]string, 0, len(ue.SmContextList))
-	for _, smContext := range ue.SmContextList {
+	smContextRefs := make([]string, 0, len(ue.Current().SmContextList))
+	for _, smContext := range ue.Current().SmContextList {
 		smContextRefs = append(smContextRefs, smContext.Ref)
 	}
 
-	ue.SmContextList = make(map[uint8]*SmContext)
+	ue.Current().SmContextList = make(map[uint8]*SmContext)
 	ue.Mutex.Unlock()
 
 	for _, smContextRef := range smContextRefs {

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -127,9 +127,11 @@ func (ue *AmfUe) SwapContext(fresh *FivegmmContext) *FivegmmContext {
 // RotateContext installs a fresh 5GMM context and returns it. Used when
 // a UE re-initiates registration: the prior context is discarded per
 // TS 24.501 handling of an initial registration arriving in 5GMM-REGISTERED.
+// RotateContext installs a fresh 5GMM context, replacing the previous one.
+// The NAS connection is intentionally left unset: AttachRanUe creates it once
+// the RanUe is known.
 func (ue *AmfUe) RotateContext() *FivegmmContext {
 	fresh := newFivegmmContext(ue)
-	fresh.active.Store(newActiveNasConnection(fresh, nil))
 	ue.SwapContext(fresh)
 
 	return fresh
@@ -148,6 +150,7 @@ func (ue *AmfUe) AttachNasConnection(ranUe *RanUe) *ActiveNasConnection {
 
 	conn := newActiveNasConnection(fc, ranUe)
 	if old := fc.active.Swap(conn); old != nil {
+		old.stopTimers()
 		old.cancel()
 	}
 
@@ -836,11 +839,11 @@ func (ue *AmfUe) stopAllTimersLocked() {
 }
 
 func (ue *AmfUe) Deregister(ctx context.Context) {
+	ue.Mutex.Lock()
+
 	if conn := ue.NasConn(); conn != nil {
 		conn.Release()
 	}
-
-	ue.Mutex.Lock()
 
 	ue.stopAllTimersLocked()
 

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -92,8 +92,8 @@ func (s *deregisterTestSmf) GetSessionPolicy(context.Context, etsi.SUPI, *models
 func TestDeregister_DoesNotHoldLockDuringSmfRelease(t *testing.T) {
 	ue := NewAmfUe()
 	ue.Log = zap.NewNop()
-	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
-	ue.SmContextList[2] = &SmContext{Ref: "ref-2"}
+	ue.Current().SmContextList[1] = &SmContext{Ref: "ref-1"}
+	ue.Current().SmContextList[2] = &SmContext{Ref: "ref-2"}
 
 	fakeSmf := &deregisterTestSmf{}
 	relockCount := 0
@@ -125,8 +125,8 @@ func TestDeregister_DoesNotHoldLockDuringSmfRelease(t *testing.T) {
 		t.Fatalf("expected state %q, got %q", Deregistered, ue.state)
 	}
 
-	if len(ue.SmContextList) != 0 {
-		t.Fatalf("expected SmContextList to be cleared, got %d entries", len(ue.SmContextList))
+	if len(ue.Current().SmContextList) != 0 {
+		t.Fatalf("expected SmContextList to be cleared, got %d entries", len(ue.Current().SmContextList))
 	}
 
 	if len(fakeSmf.releaseCalls) != 2 {

--- a/internal/amf/amf_ue_test.go
+++ b/internal/amf/amf_ue_test.go
@@ -66,12 +66,12 @@ func TestAllocateRegistrationArea(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ue := &amf.AmfUe{}
+			ue := amf.NewAmfUe()
 			ue.Tai = tc.ueTai
 			ue.AllocateRegistrationArea(tc.supportedTais)
 
-			if !reflect.DeepEqual(tc.expected, ue.RegistrationArea) && len(tc.expected) != 0 && len(ue.RegistrationArea) != 0 {
-				t.Fatalf("expected: %v, got: %v", tc.expected, ue.RegistrationArea)
+			if !reflect.DeepEqual(tc.expected, ue.Current().RegistrationArea) && len(tc.expected) != 0 && len(ue.Current().RegistrationArea) != 0 {
+				t.Fatalf("expected: %v, got: %v", tc.expected, ue.Current().RegistrationArea)
 			}
 		})
 	}
@@ -92,7 +92,8 @@ func TestSnapshotCipheringAlgorithm(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ue := &amf.AmfUe{CipheringAlg: tc.alg}
+			ue := amf.NewAmfUe()
+			ue.Current().CipheringAlg = tc.alg
 
 			snap := ue.Snapshot()
 			if snap.CipheringAlgorithm != tc.expected {
@@ -117,7 +118,8 @@ func TestSnapshotIntegrityAlgorithm(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ue := &amf.AmfUe{IntegrityAlg: tc.alg}
+			ue := amf.NewAmfUe()
+			ue.Current().IntegrityAlg = tc.alg
 
 			snap := ue.Snapshot()
 			if snap.IntegrityAlgorithm != tc.expected {
@@ -186,7 +188,8 @@ func TestIsAllowedNssai(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ue := &amf.AmfUe{AllowedNssai: tc.allowed}
+			ue := amf.NewAmfUe()
+			ue.Current().AllowedNssai = tc.allowed
 
 			got := ue.IsAllowedNssai(tc.target)
 			if got != tc.expected {
@@ -326,7 +329,8 @@ func TestSelectSecurityAlg(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ue := &amf.AmfUe{UESecurityCapability: tc.cap}
+			ue := amf.NewAmfUe()
+			ue.Current().UESecurityCapability = tc.cap
 
 			err := ue.SelectSecurityAlg(tc.intOrder, tc.encOrder)
 
@@ -346,12 +350,12 @@ func TestSelectSecurityAlg(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if ue.IntegrityAlg != tc.wantIntAlg {
-				t.Errorf("IntegrityAlg: got %d, want %d", ue.IntegrityAlg, tc.wantIntAlg)
+			if ue.Current().IntegrityAlg != tc.wantIntAlg {
+				t.Errorf("IntegrityAlg: got %d, want %d", ue.Current().IntegrityAlg, tc.wantIntAlg)
 			}
 
-			if ue.CipheringAlg != tc.wantEncAlg {
-				t.Errorf("CipheringAlg: got %d, want %d", ue.CipheringAlg, tc.wantEncAlg)
+			if ue.Current().CipheringAlg != tc.wantEncAlg {
+				t.Errorf("CipheringAlg: got %d, want %d", ue.Current().CipheringAlg, tc.wantEncAlg)
 			}
 		})
 	}

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -18,12 +18,12 @@ import (
 // DecodeNASMessage parses a 5GS NAS PDU (plain or security-protected)
 // and returns the decoded message together with a policy Verdict. It is
 // pure with respect to UE security state: it never writes to
-// ue.SecurityContextAvailable or ue.MacFailed. The only ue mutations it
-// performs are to ue.ULCount, which is protocol state required to
+// ue.Current().SecurityContextAvailable or ue.Current().MacFailed. The only ue mutations it
+// performs are to ue.Current().ULCount, which is protocol state required to
 // advance the NAS uplink counter.
 //
 // The caller is the only site allowed to act on the verdict and mutate
-// security state (typically by setting ue.MacFailed before dispatching
+// security state (typically by setting ue.Current().MacFailed before dispatching
 // to a GMM handler).
 //
 // See TS 24.501 §4.4.4.3 and TS 33.501 §6.4.6 step 3 for the policy.
@@ -91,19 +91,19 @@ func decodeProtectedNAS(ue *AmfUe, msg *nas.Message, payload []byte) (*DecodeRes
 	case nas.SecurityHeaderTypeIntegrityProtectedAndCipheredWithNew5gNasSecurityContext:
 		ciphered = true
 
-		ue.ULCount.Set(0, 0)
+		ue.Current().ULCount.Set(0, 0)
 	default:
 		return nil, fmt.Errorf("wrong security header type: 0x%0x", msg.SecurityHeaderType)
 	}
 
-	if ue.ULCount.SQN() > sequenceNumber {
+	if ue.Current().ULCount.SQN() > sequenceNumber {
 		ue.Log.Debug("set ULCount overflow")
-		ue.ULCount.SetOverflow(ue.ULCount.Overflow() + 1)
+		ue.Current().ULCount.SetOverflow(ue.Current().ULCount.Overflow() + 1)
 	}
 
-	ue.ULCount.SetSQN(sequenceNumber)
+	ue.Current().ULCount.SetSQN(sequenceNumber)
 
-	mac32, err := security.NASMacCalculate(ue.IntegrityAlg, ue.KnasInt, ue.ULCount.Get(), security.Bearer3GPP,
+	mac32, err := security.NASMacCalculate(ue.Current().IntegrityAlg, ue.Current().KnasInt, ue.Current().ULCount.Get(), security.Bearer3GPP,
 		security.DirectionUplink, payload)
 	if err != nil {
 		return nil, fmt.Errorf("error calculating mac: %+v", err)
@@ -115,9 +115,9 @@ func decodeProtectedNAS(ue *AmfUe, msg *nas.Message, payload []byte) (*DecodeRes
 	}
 
 	if ciphered {
-		ue.Log.Debug("Decrypt NAS message", zap.Uint8("algorithm", ue.CipheringAlg), zap.Uint32("ULCount", ue.ULCount.Get()))
+		ue.Log.Debug("Decrypt NAS message", zap.Uint8("algorithm", ue.Current().CipheringAlg), zap.Uint32("ULCount", ue.Current().ULCount.Get()))
 
-		if err = security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP,
+		if err = security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP,
 			security.DirectionUplink, payload[1:]); err != nil {
 			return nil, fmt.Errorf("error encrypting: %+v", err)
 		}

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -15,16 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// DecodeNASMessage parses a 5GS NAS PDU (plain or security-protected)
-// and returns the decoded message together with a policy Verdict. It is
-// pure with respect to UE security state: it never writes to
-// ue.Current().SecurityContextAvailable or ue.Current().MacFailed. The only ue mutations it
-// performs are to ue.Current().ULCount, which is protocol state required to
-// advance the NAS uplink counter.
-//
-// The caller is the only site allowed to act on the verdict and mutate
-// security state (typically by setting ue.Current().MacFailed before dispatching
-// to a GMM handler).
+// DecodeNASMessage parses a 5GS NAS PDU (plain or security-protected) and
+// returns the decoded message together with a policy Verdict. The caller
+// dispatches to a GMM handler based on the verdict. The only ue mutation
+// performed here is advancing ue.Current().ULCount.
 //
 // See TS 24.501 §4.4.4.3 and TS 33.501 §6.4.6 step 3 for the policy.
 func DecodeNASMessage(ue *AmfUe, payload []byte) (*DecodeResult, error) {

--- a/internal/amf/decode_nas_message_purity_test.go
+++ b/internal/amf/decode_nas_message_purity_test.go
@@ -59,7 +59,6 @@ func TestDecodeNASMessage_PurityOnPlainReject(t *testing.T) {
 // so it is not a security-policy field and is not snapshotted.
 type securityStateSnapshot struct {
 	SecurityContextAvailable bool
-	MacFailed                bool
 	CipheringAlg             uint8
 	IntegrityAlg             uint8
 	UESecurityCapability     *nasType.UESecurityCapability
@@ -69,12 +68,11 @@ type securityStateSnapshot struct {
 
 func snapshotSecurityState(ue *AmfUe) securityStateSnapshot {
 	return securityStateSnapshot{
-		SecurityContextAvailable: ue.SecurityContextAvailable,
-		MacFailed:                ue.MacFailed,
-		CipheringAlg:             ue.CipheringAlg,
-		IntegrityAlg:             ue.IntegrityAlg,
-		UESecurityCapability:     ue.UESecurityCapability,
-		KnasInt:                  ue.KnasInt,
-		KnasEnc:                  ue.KnasEnc,
+		SecurityContextAvailable: ue.Current().SecurityContextAvailable,
+		CipheringAlg:             ue.Current().CipheringAlg,
+		IntegrityAlg:             ue.Current().IntegrityAlg,
+		UESecurityCapability:     ue.Current().UESecurityCapability,
+		KnasInt:                  ue.Current().KnasInt,
+		KnasEnc:                  ue.Current().KnasEnc,
 	}
 }

--- a/internal/amf/decode_nas_message_test.go
+++ b/internal/amf/decode_nas_message_test.go
@@ -21,8 +21,7 @@ func newDecoderTestUE(t *testing.T) *AmfUe {
 
 	ue := NewAmfUe()
 	ue.Log = zap.NewNop()
-	ue.SecurityContextAvailable = true
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
 
 	radio := &Radio{
 		Name:   "test-gNB",
@@ -175,11 +174,7 @@ func TestDecodeNASMessage_PlainServiceRequestRejected(t *testing.T) {
 		t.Errorf("expected TS 24.501 §4.4.4.3 rejection, got: %v", err)
 	}
 
-	if ue.MacFailed {
-		t.Error("decoder must NOT touch MacFailed on a rejected PDU")
-	}
-
-	if !ue.SecurityContextAvailable {
+	if !ue.Current().SecurityContextAvailable {
 		t.Error("decoder must NOT tear down SecurityContextAvailable on a hostile plain NAS message (DoS amplification)")
 	}
 }
@@ -199,11 +194,7 @@ func TestDecodeNASMessage_PlainULNasTransportRejected(t *testing.T) {
 		t.Errorf("expected TS 24.501 §4.4.4.3 rejection, got: %v", err)
 	}
 
-	if ue.MacFailed {
-		t.Error("decoder must NOT touch MacFailed on a rejected PDU")
-	}
-
-	if !ue.SecurityContextAvailable {
+	if !ue.Current().SecurityContextAvailable {
 		t.Error("decoder must NOT tear down SecurityContextAvailable on a hostile plain NAS message")
 	}
 }
@@ -213,7 +204,7 @@ func TestDecodeNASMessage_PlainULNasTransportRejected(t *testing.T) {
 // mutate security state.
 func TestDecodeNASMessage_PlainRegistrationRequest_Bootstrap(t *testing.T) {
 	ue := newDecoderTestUE(t)
-	ue.SecurityContextAvailable = false // fresh UE
+	ue.Current().SecurityContextAvailable = false // fresh UE
 	payload := encodePlainRegistrationRequest(t)
 
 	result, err := DecodeNASMessage(ue, payload)
@@ -229,11 +220,7 @@ func TestDecodeNASMessage_PlainRegistrationRequest_Bootstrap(t *testing.T) {
 		t.Errorf("expected VerdictPlainAllowed, got %d", result.Verdict)
 	}
 
-	if ue.MacFailed {
-		t.Error("pure decoder must NOT write to ue.MacFailed (that is the handler's job)")
-	}
-
-	if ue.SecurityContextAvailable {
+	if ue.Current().SecurityContextAvailable {
 		t.Error("a fresh UE must still have SecurityContextAvailable=false after the decoder runs")
 	}
 }
@@ -258,11 +245,7 @@ func TestDecodeNASMessage_PlainRegistrationRequest_WithExistingContext(t *testin
 		t.Errorf("expected VerdictPlainAllowed, got %d", result.Verdict)
 	}
 
-	if ue.MacFailed {
-		t.Error("pure decoder must NOT write to ue.MacFailed")
-	}
-
-	if !ue.SecurityContextAvailable {
+	if !ue.Current().SecurityContextAvailable {
 		t.Error("decoder must NOT clear SecurityContextAvailable; that is the handler's job")
 	}
 }
@@ -287,11 +270,7 @@ func TestDecodeNASMessage_PlainDeregistrationRequest_PassesDecoder(t *testing.T)
 		t.Errorf("expected VerdictPlainAllowed, got %d", result.Verdict)
 	}
 
-	if ue.MacFailed {
-		t.Error("pure decoder must NOT write to ue.MacFailed")
-	}
-
-	if !ue.SecurityContextAvailable {
+	if !ue.Current().SecurityContextAvailable {
 		t.Error("decoder must NOT clear SecurityContextAvailable")
 	}
 }

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -44,7 +44,6 @@ type UEStateExport struct {
 	GMMState                 string   `json:"gmm_state"`
 	OngoingProcedures        []string `json:"ongoing_procedures"`
 	SecurityContextAvailable bool     `json:"security_context_available"`
-	MacFailed                bool     `json:"mac_failed"`
 }
 
 // UESecurityExport contains non-sensitive security context info for a UE.
@@ -256,7 +255,7 @@ func (amf *AMF) CountUEPDUSessions(supi etsi.SUPI) int {
 	}
 
 	ue.Mutex.Lock()
-	n := len(ue.SmContextList)
+	n := len(ue.Current().SmContextList)
 	ue.Mutex.Unlock()
 
 	return n
@@ -273,8 +272,8 @@ func (amf *AMF) GetUEPDUSessions(supi etsi.SUPI) ([]PDUSessionExport, bool) {
 
 	ue.Mutex.Lock()
 
-	smCopies := make([]smContextCopy, 0, len(ue.SmContextList))
-	for _, sc := range ue.SmContextList {
+	smCopies := make([]smContextCopy, 0, len(ue.Current().SmContextList))
+	for _, sc := range ue.Current().SmContextList {
 		smCopies = append(smCopies, smContextCopy{
 			ref:      sc.Ref,
 			snssai:   copyPtr(sc.Snssai),
@@ -320,41 +319,40 @@ func (amf *AMF) exportAmfUe(ue *AmfUe) AmfUeExport {
 		},
 		State: UEStateExport{
 			GMMState:                 string(ue.state),
-			OngoingProcedures:        ue.Procedures.ActiveTypes(),
-			SecurityContextAvailable: ue.SecurityContextAvailable,
-			MacFailed:                ue.MacFailed,
+			OngoingProcedures:        ue.NasConn().Procedures.ActiveTypes(),
+			SecurityContextAvailable: ue.Current().SecurityContextAvailable,
 		},
 		Security: UESecurityExport{
 			CipheringAlgorithm: ue.cipheringAlgName(),
 			IntegrityAlgorithm: ue.integrityAlgName(),
-			NgKsi:              ue.NgKsi,
+			NgKsi:              ue.Current().NgKsi,
 		},
 		Location: UELocationExport{
 			Current:          copyUserLocation(ue.Location),
 			Tai:              ue.Tai,
-			RegistrationArea: append([]models.Tai(nil), ue.RegistrationArea...),
+			RegistrationArea: append([]models.Tai(nil), ue.Current().RegistrationArea...),
 		},
 		Subscription: UESubscriptionExport{
-			AllowedNssai: append([]models.Snssai(nil), ue.AllowedNssai...),
-			Ambr:         copyPtr(ue.Ambr),
+			AllowedNssai: append([]models.Snssai(nil), ue.Current().AllowedNssai...),
+			Ambr:         copyPtr(ue.Current().Ambr),
 		},
 		Registration: UERegistrationExport{
-			Type:                 ue.RegistrationType5GS,
-			IdentityTypeUsed:     ue.IdentityTypeUsedForRegistration,
-			Retransmission:       ue.RetransmissionOfInitialNASMsg,
-			AuthFailureSyncTimes: ue.AuthFailureCauseSynchFailureTimes,
+			Type:                 ue.NasConn().RegistrationType5GS,
+			IdentityTypeUsed:     ue.NasConn().IdentityTypeUsedForRegistration,
+			Retransmission:       ue.NasConn().RetransmissionOfInitialNASMsg,
+			AuthFailureSyncTimes: ue.NasConn().AuthFailureCauseSynchFailureTimes,
 		},
 		Timers: UETimersExport{
-			T3512ValueSeconds:   int64(ue.T3512Value / time.Second),
-			T3502ValueSeconds:   int64(ue.T3502Value / time.Second),
-			T3513Paging:         timerStatus(ue.T3513),
-			T3565Notification:   timerStatus(ue.T3565),
-			T3560Auth:           timerStatus(ue.T3560),
-			T3550Registration:   timerStatus(ue.T3550),
-			T3555ConfigUpdate:   timerStatus(ue.T3555),
-			T3522Deregistration: timerStatus(ue.T3522),
-			MobileReachable:     timerStatus(ue.mobileReachableTimer),
-			ImplicitDereg:       timerStatus(ue.implicitDeregistrationTimer),
+			T3512ValueSeconds:   int64(ue.Current().T3512Value / time.Second),
+			T3502ValueSeconds:   int64(ue.Current().T3502Value / time.Second),
+			T3513Paging:         timerStatus(ue.NasConn().T3513),
+			T3565Notification:   timerStatus(ue.NasConn().T3565),
+			T3560Auth:           timerStatus(ue.NasConn().T3560),
+			T3550Registration:   timerStatus(ue.NasConn().T3550),
+			T3555ConfigUpdate:   timerStatus(ue.NasConn().T3555),
+			T3522Deregistration: timerStatus(ue.NasConn().T3522),
+			MobileReachable:     timerStatus(ue.Current().MobileReachableTimer),
+			ImplicitDereg:       timerStatus(ue.Current().ImplicitDeregistrationTimer),
 		},
 		LastActivity: UELastActivityExport{
 			Timestamp: ue.LastSeenAt,
@@ -363,8 +361,8 @@ func (amf *AMF) exportAmfUe(ue *AmfUe) AmfUeExport {
 	}
 
 	// Copy SmContextList refs while holding the UE lock.
-	smCopies := make([]smContextCopy, 0, len(ue.SmContextList))
-	for _, sc := range ue.SmContextList {
+	smCopies := make([]smContextCopy, 0, len(ue.Current().SmContextList))
+	for _, sc := range ue.Current().SmContextList {
 		smCopies = append(smCopies, smContextCopy{
 			ref:      sc.Ref,
 			snssai:   copyPtr(sc.Snssai),

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -305,7 +305,36 @@ type smContextCopy struct {
 func (amf *AMF) exportAmfUe(ue *AmfUe) AmfUeExport {
 	ue.Mutex.Lock()
 
-	// Copy all scalar fields while holding the lock.
+	conn := ue.NasConn()
+
+	var (
+		ongoing       []string
+		regType       uint8
+		identityType  uint8
+		retransmit    bool
+		authSyncTimes int
+		t3513         *Timer
+		t3565         *Timer
+		t3560         *Timer
+		t3550         *Timer
+		t3555         *Timer
+		t3522         *Timer
+	)
+
+	if conn != nil {
+		ongoing = conn.Procedures.ActiveTypes()
+		regType = conn.RegistrationType5GS
+		identityType = conn.IdentityTypeUsedForRegistration
+		retransmit = conn.RetransmissionOfInitialNASMsg
+		authSyncTimes = conn.AuthFailureCauseSynchFailureTimes
+		t3513 = conn.T3513
+		t3565 = conn.T3565
+		t3560 = conn.T3560
+		t3550 = conn.T3550
+		t3555 = conn.T3555
+		t3522 = conn.T3522
+	}
+
 	export := AmfUeExport{
 		Identity: UEIdentityExport{
 			Supi:    ue.Supi.String(),
@@ -319,7 +348,7 @@ func (amf *AMF) exportAmfUe(ue *AmfUe) AmfUeExport {
 		},
 		State: UEStateExport{
 			GMMState:                 string(ue.state),
-			OngoingProcedures:        ue.NasConn().Procedures.ActiveTypes(),
+			OngoingProcedures:        ongoing,
 			SecurityContextAvailable: ue.Current().SecurityContextAvailable,
 		},
 		Security: UESecurityExport{
@@ -337,20 +366,20 @@ func (amf *AMF) exportAmfUe(ue *AmfUe) AmfUeExport {
 			Ambr:         copyPtr(ue.Current().Ambr),
 		},
 		Registration: UERegistrationExport{
-			Type:                 ue.NasConn().RegistrationType5GS,
-			IdentityTypeUsed:     ue.NasConn().IdentityTypeUsedForRegistration,
-			Retransmission:       ue.NasConn().RetransmissionOfInitialNASMsg,
-			AuthFailureSyncTimes: ue.NasConn().AuthFailureCauseSynchFailureTimes,
+			Type:                 regType,
+			IdentityTypeUsed:     identityType,
+			Retransmission:       retransmit,
+			AuthFailureSyncTimes: authSyncTimes,
 		},
 		Timers: UETimersExport{
 			T3512ValueSeconds:   int64(ue.Current().T3512Value / time.Second),
 			T3502ValueSeconds:   int64(ue.Current().T3502Value / time.Second),
-			T3513Paging:         timerStatus(ue.NasConn().T3513),
-			T3565Notification:   timerStatus(ue.NasConn().T3565),
-			T3560Auth:           timerStatus(ue.NasConn().T3560),
-			T3550Registration:   timerStatus(ue.NasConn().T3550),
-			T3555ConfigUpdate:   timerStatus(ue.NasConn().T3555),
-			T3522Deregistration: timerStatus(ue.NasConn().T3522),
+			T3513Paging:         timerStatus(t3513),
+			T3565Notification:   timerStatus(t3565),
+			T3560Auth:           timerStatus(t3560),
+			T3550Registration:   timerStatus(t3550),
+			T3555ConfigUpdate:   timerStatus(t3555),
+			T3522Deregistration: timerStatus(t3522),
 			MobileReachable:     timerStatus(ue.Current().MobileReachableTimer),
 			ImplicitDereg:       timerStatus(ue.Current().ImplicitDeregistrationTimer),
 		},

--- a/internal/amf/export_test.go
+++ b/internal/amf/export_test.go
@@ -124,10 +124,6 @@ func TestExportJSON_MinimalUE(t *testing.T) {
 		t.Fatalf("expected state.security_context_available to be false, got %v", state["security_context_available"])
 	}
 
-	if macFailed, ok := state["mac_failed"].(bool); !ok || macFailed != false {
-		t.Fatalf("expected state.mac_failed to be false, got %v", state["mac_failed"])
-	}
-
 	if _, ok := ueExport["ran_connection"]; ok {
 		t.Fatal("expected ran_connection to be absent")
 	}
@@ -194,10 +190,10 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 		ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 		ue.Suci = "suci-0-001-01-0000-0-0-0000000001"
 		ue.ForceState(amf.Registered)
-		ue.SecurityContextAvailable = true
-		ue.CipheringAlg = security.AlgCiphering128NEA2
-		ue.IntegrityAlg = security.AlgIntegrity128NIA2
-		ue.NgKsi = models.NgKsi{Ksi: 1}
+		ue.Current().SecurityContextAvailable = true
+		ue.Current().CipheringAlg = security.AlgCiphering128NEA2
+		ue.Current().IntegrityAlg = security.AlgIntegrity128NIA2
+		ue.Current().NgKsi = models.NgKsi{Ksi: 1}
 		ue.Location = models.UserLocation{
 			NrLocation: &models.NrLocation{
 				Tai:                      &models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
@@ -207,13 +203,13 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 			},
 		}
 		ue.Tai = models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}
-		ue.RegistrationArea = []models.Tai{
+		ue.Current().RegistrationArea = []models.Tai{
 			{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
 			{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000002"},
 		}
-		ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "000001"}}
-		ue.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "2000000"}
-		ue.SmContextList[5] = &amf.SmContext{
+		ue.Current().AllowedNssai = []models.Snssai{{Sst: 1, Sd: "000001"}}
+		ue.Current().Ambr = &models.Ambr{Uplink: "1000000", Downlink: "2000000"}
+		ue.Current().SmContextList[5] = &amf.SmContext{
 			Ref:    "imsi-001010000000002-5",
 			Snssai: &models.Snssai{Sst: 1, Sd: "000001"},
 		}
@@ -221,19 +217,19 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 		ranUe := amf.NewRanUeForTest(radio, 42, 100, zap.NewNop())
 		ranUe.Tai = models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}
 		ue.AttachRanUe(ranUe)
-		ue.T3513 = amf.NewTimer(1*time.Hour, 3, func(_ int32) {}, func() {})
-		ue.T3512Value = 3600 * time.Second
-		ue.T3502Value = 720 * time.Second
+		ue.NasConn().T3513 = amf.NewTimer(1*time.Hour, 3, func(_ int32) {}, func() {})
+		ue.Current().T3512Value = 3600 * time.Second
+		ue.Current().T3502Value = 720 * time.Second
 		ue.LastSeenAt = time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
 		ue.LastSeenRadio = "gNB-001"
-		ue.RegistrationType5GS = 1
-		ue.IdentityTypeUsedForRegistration = 1
-		ue.RetransmissionOfInitialNASMsg = true
-		ue.AuthFailureCauseSynchFailureTimes = 2
+		ue.NasConn().RegistrationType5GS = 1
+		ue.NasConn().IdentityTypeUsedForRegistration = 1
+		ue.NasConn().RetransmissionOfInitialNASMsg = true
+		ue.NasConn().AuthFailureCauseSynchFailureTimes = 2
 	})
 
 	t.Cleanup(func() {
-		ue.T3513.Stop()
+		ue.NasConn().T3513.Stop()
 	})
 
 	result := exportAndMarshal(t, amfInstance)
@@ -273,10 +269,6 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 
 	if secCtx, ok := state["security_context_available"].(bool); !ok || secCtx != true {
 		t.Fatalf("expected state.security_context_available to be true, got %v", state["security_context_available"])
-	}
-
-	if macFailed, ok := state["mac_failed"].(bool); !ok || macFailed != false {
-		t.Fatalf("expected state.mac_failed to be false, got %v", state["mac_failed"])
 	}
 
 	if ongoingProcs, ok := state["ongoing_procedures"]; ok && ongoingProcs != nil {
@@ -528,7 +520,7 @@ func TestExportJSON_NilLocationPointers(t *testing.T) {
 func TestExportJSON_PDUSessionNilSMFContext(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	addTestUE(t, amfInstance, "001010000000007", func(ue *amf.AmfUe) {
-		ue.SmContextList[1] = &amf.SmContext{
+		ue.Current().SmContextList[1] = &amf.SmContext{
 			Ref:                "nonexistent-ref",
 			Snssai:             &models.Snssai{Sst: 1, Sd: "000001"},
 			PduSessionInactive: true,
@@ -591,7 +583,7 @@ func TestExportJSON_MultipleAllowedNSSAI(t *testing.T) {
 
 	addTestUE(t, amfInstance, "001010000000099", func(ue *amf.AmfUe) {
 		ue.ForceState(amf.Registered)
-		ue.AllowedNssai = []models.Snssai{
+		ue.Current().AllowedNssai = []models.Snssai{
 			{Sst: 1, Sd: "010203"},
 			{Sst: 2, Sd: "aabbcc"},
 			{Sst: 3, Sd: ""},

--- a/internal/amf/fivegmm_context.go
+++ b/internal/amf/fivegmm_context.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package amf
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/free5gc/nas/nasType"
+	"github.com/free5gc/nas/security"
+)
+
+// FivegmmContext is the per-registration 5GMM state for one AmfUe. It
+// outlives NAS connection drops within a registration; it is replaced
+// when an initial registration succeeds for an already-registered UE.
+type FivegmmContext struct {
+	Mutex sync.RWMutex
+
+	parent *AmfUe
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	active atomic.Pointer[ActiveNasConnection]
+
+	// NAS security context per TS 33.501.
+	SecurityContextAvailable bool
+	UESecurityCapability     *nasType.UESecurityCapability
+	NgKsi                    models.NgKsi
+	KnasInt                  [16]uint8
+	KnasEnc                  [16]uint8
+	Kgnb                     []uint8
+	NH                       []uint8
+	NCC                      uint8
+	ULCount                  security.Count
+	DLCount                  security.Count
+	CipheringAlg             uint8
+	IntegrityAlg             uint8
+	Kamf                     string
+	ABBA                     []uint8
+
+	Ambr                       *models.Ambr
+	AllowedNssai               []models.Snssai
+	RegistrationArea           []models.Tai
+	UeRadioCapability          string
+	UeRadioCapabilityForPaging *models.UERadioCapabilityForPaging
+	UESpecificDRX              uint8
+	SmContextList              map[uint8]*SmContext
+
+	T3502Value time.Duration
+	T3512Value time.Duration
+
+	MobileReachableTimer        *Timer
+	ImplicitDeregistrationTimer *Timer
+}
+
+func newFivegmmContext(parent *AmfUe) *FivegmmContext {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &FivegmmContext{
+		parent:           parent,
+		ctx:              ctx,
+		cancel:           cancel,
+		SmContextList:    make(map[uint8]*SmContext),
+		RegistrationArea: make([]models.Tai, 0),
+	}
+}
+
+func (fc *FivegmmContext) Ctx() context.Context {
+	return fc.ctx
+}
+
+func (fc *FivegmmContext) Parent() *AmfUe {
+	return fc.parent
+}
+
+func (fc *FivegmmContext) ActiveConnection() *ActiveNasConnection {
+	return fc.active.Load()
+}
+
+func (fc *FivegmmContext) close() {
+	if conn := fc.active.Swap(nil); conn != nil {
+		conn.stopTimers()
+		conn.cancel()
+	}
+
+	fc.stopIdleTimers()
+	fc.cancel()
+}
+
+// stopIdleTimers stops the mobile reachable and implicit deregistration
+// timers that fire while the UE is Registered-but-idle.
+func (fc *FivegmmContext) stopIdleTimers() {
+	if fc.MobileReachableTimer != nil {
+		fc.MobileReachableTimer.Stop()
+		fc.MobileReachableTimer = nil
+	}
+
+	if fc.ImplicitDeregistrationTimer != nil {
+		fc.ImplicitDeregistrationTimer.Stop()
+		fc.ImplicitDeregistrationTimer = nil
+	}
+}
+
+func NewFivegmmContextForTest(parent *AmfUe) *FivegmmContext {
+	return newFivegmmContext(parent)
+}

--- a/internal/amf/fivegmm_context.go
+++ b/internal/amf/fivegmm_context.go
@@ -5,7 +5,6 @@ package amf
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,8 +17,6 @@ import (
 // outlives NAS connection drops within a registration; it is replaced
 // when an initial registration succeeds for an already-registered UE.
 type FivegmmContext struct {
-	Mutex sync.RWMutex
-
 	parent *AmfUe
 
 	ctx    context.Context

--- a/internal/amf/fivegmm_context_test.go
+++ b/internal/amf/fivegmm_context_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package amf_test
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/logger"
+)
+
+// NewAmfUe allocates an initial FivegmmContext.
+func TestAmfUe_Current_NewUeHasContext(t *testing.T) {
+	ue := amf.NewAmfUe()
+
+	if ue.Current() == nil {
+		t.Fatal("Current() returned nil for a freshly-constructed AmfUe")
+	}
+}
+
+// FivegmmContext.Parent returns the owning AmfUe.
+func TestFivegmmContext_Parent(t *testing.T) {
+	ue := amf.NewAmfUe()
+	fc := ue.Current()
+
+	if fc.Parent() != ue {
+		t.Errorf("Parent() = %p, want %p", fc.Parent(), ue)
+	}
+}
+
+// SwapContext replaces the current context and cancels the old one's ctx.
+func TestAmfUe_SwapContext_CancelsOldCtx(t *testing.T) {
+	ue := amf.NewAmfUe()
+	old := ue.Current()
+
+	if err := old.Ctx().Err(); err != nil {
+		t.Fatalf("fresh context already cancelled: %v", err)
+	}
+
+	fresh := amf.NewFivegmmContextForTest(ue)
+	ue.SwapContext(fresh)
+
+	if ue.Current() != fresh {
+		t.Errorf("Current() = %p, want %p", ue.Current(), fresh)
+	}
+
+	if old.Ctx().Err() == nil {
+		t.Error("old context ctx still alive after SwapContext")
+	}
+
+	if fresh.Ctx().Err() != nil {
+		t.Errorf("fresh context cancelled after install: %v", fresh.Ctx().Err())
+	}
+}
+
+// SwapContext to nil clears the active context.
+func TestAmfUe_SwapContext_Nil(t *testing.T) {
+	ue := amf.NewAmfUe()
+	old := ue.Current()
+
+	ue.SwapContext(nil)
+
+	if ue.Current() != nil {
+		t.Errorf("Current() = %p, want nil", ue.Current())
+	}
+
+	if old.Ctx().Err() == nil {
+		t.Error("old context ctx still alive after SwapContext(nil)")
+	}
+}
+
+// AttachNasConnection installs a fresh connection whose ctx is a child
+// of the 5GMM context.
+func TestAmfUe_AttachNasConnection_ChildCtx(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ranUe := amf.NewRanUeForTest(radio, 1, 10, logger.AmfLog)
+
+	ue := amf.NewAmfUe()
+	conn := ue.AttachNasConnection(ranUe)
+
+	if conn == nil {
+		t.Fatal("AttachNasConnection returned nil")
+	}
+
+	if conn.Parent() != ue.Current() {
+		t.Errorf("conn.Parent() = %p, want %p", conn.Parent(), ue.Current())
+	}
+
+	if conn.RanUe() != ranUe {
+		t.Errorf("conn.RanUe() = %p, want %p", conn.RanUe(), ranUe)
+	}
+
+	if ue.Current().ActiveConnection() != conn {
+		t.Errorf("ActiveConnection() = %p, want %p", ue.Current().ActiveConnection(), conn)
+	}
+}
+
+// Cancelling the FivegmmContext ctx (via SwapContext) cancels the
+// child ActiveNasConnection ctx.
+func TestAttachNasConnection_CtxPropagation(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ranUe := amf.NewRanUeForTest(radio, 1, 10, logger.AmfLog)
+
+	ue := amf.NewAmfUe()
+	conn := ue.AttachNasConnection(ranUe)
+
+	if err := conn.Ctx().Err(); err != nil {
+		t.Fatalf("fresh nas connection ctx already cancelled: %v", err)
+	}
+
+	ue.SwapContext(nil)
+
+	if conn.Ctx().Err() == nil {
+		t.Error("nas connection ctx not cancelled after 5GMM context swap")
+	}
+}
+
+// Release tears down the connection but leaves the 5GMM context intact.
+func TestActiveNasConnection_Release(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ranUe := amf.NewRanUeForTest(radio, 1, 10, logger.AmfLog)
+
+	ue := amf.NewAmfUe()
+	fc := ue.Current()
+	conn := ue.AttachNasConnection(ranUe)
+
+	conn.Release()
+
+	if fc.ActiveConnection() != nil {
+		t.Error("ActiveConnection() still set after Release")
+	}
+
+	if conn.Ctx().Err() == nil {
+		t.Error("connection ctx not cancelled after Release")
+	}
+
+	if fc.Ctx().Err() != nil {
+		t.Errorf("5GMM context ctx cancelled by connection Release: %v", fc.Ctx().Err())
+	}
+
+	if ue.Current() != fc {
+		t.Error("5GMM context replaced by connection Release")
+	}
+}
+
+// After ActiveNasConnection.Release, a subsequent AttachRanUe must restore
+// the NAS connection so handlers don't dereference a nil NasConn.
+func TestAmfUe_AttachRanUe_RestoresNasConnAfterRelease(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ranUe1 := amf.NewRanUeForTest(radio, 1, 10, logger.AmfLog)
+
+	ue := amf.NewAmfUe()
+	ue.AttachRanUe(ranUe1)
+
+	conn := ue.NasConn()
+	if conn == nil {
+		t.Fatal("initial NasConn is nil")
+	}
+
+	conn.Release()
+
+	if ue.NasConn() != nil {
+		t.Fatal("NasConn should be nil right after Release")
+	}
+
+	ranUe2 := amf.NewRanUeForTest(radio, 2, 20, logger.AmfLog)
+	ue.AttachRanUe(ranUe2)
+
+	if ue.NasConn() == nil {
+		t.Error("NasConn still nil after re-AttachRanUe")
+	}
+}
+
+// Reattaching cancels the old connection but does not affect the 5GMM context.
+func TestAmfUe_AttachNasConnection_ReplacesOld(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ranUe1 := amf.NewRanUeForTest(radio, 1, 10, logger.AmfLog)
+	ranUe2 := amf.NewRanUeForTest(radio, 2, 20, logger.AmfLog)
+
+	ue := amf.NewAmfUe()
+	fc := ue.Current()
+	conn1 := ue.AttachNasConnection(ranUe1)
+	conn2 := ue.AttachNasConnection(ranUe2)
+
+	if conn1.Ctx().Err() == nil {
+		t.Error("first connection ctx not cancelled after second attach")
+	}
+
+	if fc.ActiveConnection() != conn2 {
+		t.Errorf("ActiveConnection() = %p, want %p", fc.ActiveConnection(), conn2)
+	}
+
+	if fc.Ctx().Err() != nil {
+		t.Error("5GMM context cancelled by reattach")
+	}
+}

--- a/internal/amf/nas/gmm/authentication_procedure.go
+++ b/internal/amf/nas/gmm/authentication_procedure.go
@@ -65,7 +65,12 @@ func authenticationProcedure(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 		return false, fmt.Errorf("failed to send ue authentication request: %s", err)
 	}
 
-	ue.NasConn().AuthenticationCtx = response
+	conn := ue.NasConn()
+	if conn == nil {
+		return false, fmt.Errorf("no active NAS connection")
+	}
+
+	conn.AuthenticationCtx = response
 
 	ue.Current().ABBA = []uint8{0x00, 0x00} // set ABBA value as described at TS 33.501 Annex A.7.1
 

--- a/internal/amf/nas/gmm/authentication_procedure.go
+++ b/internal/amf/nas/gmm/authentication_procedure.go
@@ -65,9 +65,9 @@ func authenticationProcedure(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 		return false, fmt.Errorf("failed to send ue authentication request: %s", err)
 	}
 
-	ue.AuthenticationCtx = response
+	ue.NasConn().AuthenticationCtx = response
 
-	ue.ABBA = []uint8{0x00, 0x00} // set ABBA value as described at TS 33.501 Annex A.7.1
+	ue.Current().ABBA = []uint8{0x00, 0x00} // set ABBA value as described at TS 33.501 Annex A.7.1
 
 	err = message.SendAuthenticationRequest(ctx, amfInstance, ranUe)
 	if err != nil {

--- a/internal/amf/nas/gmm/context_setup.go
+++ b/internal/amf/nas/gmm/context_setup.go
@@ -13,9 +13,9 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg 
 	defer span.End()
 
 	ue.TransitionTo(amf.ContextSetup)
-	ue.RegistrationRequest = msg
+	ue.NasConn().RegistrationRequest = msg
 
-	switch ue.RegistrationType5GS {
+	switch ue.NasConn().RegistrationType5GS {
 	case nasMessage.RegistrationType5GSInitialRegistration:
 		if err := HandleInitialRegistration(ctx, amfInstance, ue); err != nil {
 			return fmt.Errorf("error handling initial registration: %v", err)

--- a/internal/amf/nas/gmm/context_setup.go
+++ b/internal/amf/nas/gmm/context_setup.go
@@ -13,9 +13,15 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg 
 	defer span.End()
 
 	ue.TransitionTo(amf.ContextSetup)
-	ue.NasConn().RegistrationRequest = msg
 
-	switch ue.NasConn().RegistrationType5GS {
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
+	}
+
+	conn.RegistrationRequest = msg
+
+	switch conn.RegistrationType5GS {
 	case nasMessage.RegistrationType5GSInitialRegistration:
 		if err := HandleInitialRegistration(ctx, amfInstance, ue); err != nil {
 			return fmt.Errorf("error handling initial registration: %v", err)

--- a/internal/amf/nas/gmm/handle_authentication_failure.go
+++ b/internal/amf/nas/gmm/handle_authentication_failure.go
@@ -21,9 +21,14 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
-	if ue.NasConn().T3560 != nil {
-		ue.NasConn().T3560.Stop()
-		ue.NasConn().T3560 = nil // clear the timer
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
+	}
+
+	if conn.T3560 != nil {
+		conn.T3560.Stop()
+		conn.T3560 = nil
 	}
 
 	switch msg.GetCauseValue() {
@@ -49,7 +54,9 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		return nil
 	case nasMessage.Cause5GMMngKSIAlreadyInUse:
 		ue.Log.Warn("Authentication Failure Cause: NgKSI Already In Use")
-		ue.NasConn().AuthFailureCauseSynchFailureTimes = 0
+
+		conn.AuthFailureCauseSynchFailureTimes = 0
+
 		ue.Log.Warn("Select new NgKsi")
 		ue.Current().NgKsi.Ksi = nextNgKsi(ue.Current().NgKsi.Ksi)
 
@@ -62,8 +69,8 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 	case nasMessage.Cause5GMMSynchFailure: // TS 24.501 5.4.1.3.7 case f
 		ue.Log.Warn("Authentication Failure 5GMM Cause: Synch Failure")
 
-		ue.NasConn().AuthFailureCauseSynchFailureTimes++
-		if ue.NasConn().AuthFailureCauseSynchFailureTimes >= 2 {
+		conn.AuthFailureCauseSynchFailureTimes++
+		if conn.AuthFailureCauseSynchFailureTimes >= 2 {
 			ue.Log.Warn("2 consecutive Synch Failure, terminate authentication procedure")
 			ue.Deregister(ctx)
 
@@ -89,7 +96,7 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 			return fmt.Errorf("send UE Authentication Authenticate Request Error: %s", err.Error())
 		}
 
-		ue.NasConn().AuthenticationCtx = response
+		conn.AuthenticationCtx = response
 		ue.Current().ABBA = []uint8{0x00, 0x00}
 
 		err = message.SendAuthenticationRequest(ctx, amfInstance, ranUe)

--- a/internal/amf/nas/gmm/handle_authentication_failure.go
+++ b/internal/amf/nas/gmm/handle_authentication_failure.go
@@ -21,9 +21,9 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
-	if ue.T3560 != nil {
-		ue.T3560.Stop()
-		ue.T3560 = nil // clear the timer
+	if ue.NasConn().T3560 != nil {
+		ue.NasConn().T3560.Stop()
+		ue.NasConn().T3560 = nil // clear the timer
 	}
 
 	switch msg.GetCauseValue() {
@@ -49,9 +49,9 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		return nil
 	case nasMessage.Cause5GMMngKSIAlreadyInUse:
 		ue.Log.Warn("Authentication Failure Cause: NgKSI Already In Use")
-		ue.AuthFailureCauseSynchFailureTimes = 0
+		ue.NasConn().AuthFailureCauseSynchFailureTimes = 0
 		ue.Log.Warn("Select new NgKsi")
-		ue.NgKsi.Ksi = nextNgKsi(ue.NgKsi.Ksi)
+		ue.Current().NgKsi.Ksi = nextNgKsi(ue.Current().NgKsi.Ksi)
 
 		err := message.SendAuthenticationRequest(ctx, amfInstance, ranUe)
 		if err != nil {
@@ -62,8 +62,8 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 	case nasMessage.Cause5GMMSynchFailure: // TS 24.501 5.4.1.3.7 case f
 		ue.Log.Warn("Authentication Failure 5GMM Cause: Synch Failure")
 
-		ue.AuthFailureCauseSynchFailureTimes++
-		if ue.AuthFailureCauseSynchFailureTimes >= 2 {
+		ue.NasConn().AuthFailureCauseSynchFailureTimes++
+		if ue.NasConn().AuthFailureCauseSynchFailureTimes >= 2 {
 			ue.Log.Warn("2 consecutive Synch Failure, terminate authentication procedure")
 			ue.Deregister(ctx)
 
@@ -89,8 +89,8 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 			return fmt.Errorf("send UE Authentication Authenticate Request Error: %s", err.Error())
 		}
 
-		ue.AuthenticationCtx = response
-		ue.ABBA = []uint8{0x00, 0x00}
+		ue.NasConn().AuthenticationCtx = response
+		ue.Current().ABBA = []uint8{0x00, 0x00}
 
 		err = message.SendAuthenticationRequest(ctx, amfInstance, ranUe)
 		if err != nil {

--- a/internal/amf/nas/gmm/handle_authentication_failure_test.go
+++ b/internal/amf/nas/gmm/handle_authentication_failure_test.go
@@ -63,13 +63,14 @@ func TestHandleAuthenticationFailure_T3560Stopped(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.T3560 = amf.NewTimer(10*time.Minute, 5, func(e int32) {}, func() {})
+	conn := ue.NasConn()
+	conn.T3560 = amf.NewTimer(10*time.Minute, 5, func(e int32) {}, func() {})
 
 	msg := buildTestAuthenticationFailureMessage(nasMessage.Cause5GMMMACFailure, nil)
 
 	_ = handleAuthenticationFailure(t.Context(), amf.New(nil, nil, nil), ue, msg)
 
-	if ue.T3560 != nil {
+	if conn.T3560 != nil {
 		t.Fatal("expected timer T3560 to be stopped and cleared")
 	}
 }
@@ -163,13 +164,13 @@ func TestHandleAuthenticationFailure_NgKSIAlreadyInUse_KsiIncremented_SendsAuthR
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.NgKsi = models.NgKsi{Ksi: 3}
-	ue.AuthFailureCauseSynchFailureTimes = 2
-	ue.AuthenticationCtx = &ausf.AuthResult{
+	ue.Current().NgKsi = models.NgKsi{Ksi: 3}
+	ue.NasConn().AuthFailureCauseSynchFailureTimes = 2
+	ue.NasConn().AuthenticationCtx = &ausf.AuthResult{
 		Rand: hex.EncodeToString(make([]byte, 16)),
 		Autn: hex.EncodeToString(make([]byte, 16)),
 	}
-	ue.ABBA = []uint8{0x00, 0x00}
+	ue.Current().ABBA = []uint8{0x00, 0x00}
 
 	amfInstance := amf.New(nil, nil, nil)
 
@@ -180,12 +181,12 @@ func TestHandleAuthenticationFailure_NgKSIAlreadyInUse_KsiIncremented_SendsAuthR
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if ue.NgKsi.Ksi != 4 {
-		t.Fatalf("expected NgKsi.Ksi to be 4, got: %d", ue.NgKsi.Ksi)
+	if ue.Current().NgKsi.Ksi != 4 {
+		t.Fatalf("expected NgKsi.Ksi to be 4, got: %d", ue.Current().NgKsi.Ksi)
 	}
 
-	if ue.AuthFailureCauseSynchFailureTimes != 0 {
-		t.Fatalf("expected AuthFailureCauseSynchFailureTimes to be 0, got: %d", ue.AuthFailureCauseSynchFailureTimes)
+	if ue.NasConn().AuthFailureCauseSynchFailureTimes != 0 {
+		t.Fatalf("expected AuthFailureCauseSynchFailureTimes to be 0, got: %d", ue.NasConn().AuthFailureCauseSynchFailureTimes)
 	}
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
@@ -217,12 +218,12 @@ func TestHandleAuthenticationFailure_NgKSIAlreadyInUse_KsiWrapsToZero(t *testing
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.NgKsi = models.NgKsi{Ksi: 6}
-	ue.AuthenticationCtx = &ausf.AuthResult{
+	ue.Current().NgKsi = models.NgKsi{Ksi: 6}
+	ue.NasConn().AuthenticationCtx = &ausf.AuthResult{
 		Rand: hex.EncodeToString(make([]byte, 16)),
 		Autn: hex.EncodeToString(make([]byte, 16)),
 	}
-	ue.ABBA = []uint8{0x00, 0x00}
+	ue.Current().ABBA = []uint8{0x00, 0x00}
 
 	amfInstance := amf.New(nil, nil, nil)
 
@@ -233,8 +234,8 @@ func TestHandleAuthenticationFailure_NgKSIAlreadyInUse_KsiWrapsToZero(t *testing
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if ue.NgKsi.Ksi != 0 {
-		t.Fatalf("expected NgKsi.Ksi to wrap to 0, got: %d", ue.NgKsi.Ksi)
+	if ue.Current().NgKsi.Ksi != 0 {
+		t.Fatalf("expected NgKsi.Ksi to wrap to 0, got: %d", ue.Current().NgKsi.Ksi)
 	}
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
@@ -249,7 +250,7 @@ func TestHandleAuthenticationFailure_SynchFailure_FirstTime_Success(t *testing.T
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthFailureCauseSynchFailureTimes = 0
+	ue.NasConn().AuthFailureCauseSynchFailureTimes = 0
 	ue.Suci = "suci-0-001-01-0000-0-0-0000000001"
 	ue.Tai = ue.RanUe().Tai
 
@@ -270,16 +271,16 @@ func TestHandleAuthenticationFailure_SynchFailure_FirstTime_Success(t *testing.T
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if ue.AuthFailureCauseSynchFailureTimes != 1 {
-		t.Fatalf("expected AuthFailureCauseSynchFailureTimes to be 1, got: %d", ue.AuthFailureCauseSynchFailureTimes)
+	if ue.NasConn().AuthFailureCauseSynchFailureTimes != 1 {
+		t.Fatalf("expected AuthFailureCauseSynchFailureTimes to be 1, got: %d", ue.NasConn().AuthFailureCauseSynchFailureTimes)
 	}
 
-	if ue.AuthenticationCtx != expectedAv {
+	if ue.NasConn().AuthenticationCtx != expectedAv {
 		t.Fatal("expected AuthenticationCtx to be updated from AUSF response")
 	}
 
-	if len(ue.ABBA) != 2 || ue.ABBA[0] != 0x00 || ue.ABBA[1] != 0x00 {
-		t.Fatalf("expected ABBA to be {0x00, 0x00}, got: %v", ue.ABBA)
+	if len(ue.Current().ABBA) != 2 || ue.Current().ABBA[0] != 0x00 || ue.Current().ABBA[1] != 0x00 {
+		t.Fatalf("expected ABBA to be {0x00, 0x00}, got: %v", ue.Current().ABBA)
 	}
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
@@ -311,7 +312,7 @@ func TestHandleAuthenticationFailure_SynchFailure_FirstTime_AusfError(t *testing
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthFailureCauseSynchFailureTimes = 0
+	ue.NasConn().AuthFailureCauseSynchFailureTimes = 0
 	ue.Suci = "suci-0-001-01-0000-0-0-0000000001"
 	ue.Tai = ue.RanUe().Tai
 
@@ -339,7 +340,7 @@ func TestHandleAuthenticationFailure_SynchFailure_SecondTime_DeregistersAndSends
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthFailureCauseSynchFailureTimes = 1
+	ue.NasConn().AuthFailureCauseSynchFailureTimes = 1
 
 	msg := buildTestAuthenticationFailureMessage(nasMessage.Cause5GMMSynchFailure, nil)
 
@@ -381,7 +382,7 @@ func TestHandleAuthenticationFailure_SynchFailure_NilAuthenticationFailureParame
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthFailureCauseSynchFailureTimes = 0
+	ue.NasConn().AuthFailureCauseSynchFailureTimes = 0
 
 	// Build message with SynchFailure cause but nil AuthenticationFailureParameter
 	msg := buildTestAuthenticationFailureMessage(nasMessage.Cause5GMMSynchFailure, nil)

--- a/internal/amf/nas/gmm/handle_authentication_response.go
+++ b/internal/amf/nas/gmm/handle_authentication_response.go
@@ -25,12 +25,17 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
-	if ue.NasConn().T3560 != nil {
-		ue.NasConn().T3560.Stop()
-		ue.NasConn().T3560 = nil // clear the timer
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
 	}
 
-	if ue.NasConn().AuthenticationCtx == nil {
+	if conn.T3560 != nil {
+		conn.T3560.Stop()
+		conn.T3560 = nil
+	}
+
+	if conn.AuthenticationCtx == nil {
 		return fmt.Errorf("ue Authentication Context is nil")
 	}
 
@@ -41,7 +46,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 	resStar := msg.GetRES()
 
 	// Calculate HRES* (TS 33.501 Annex A.5)
-	p0, err := hex.DecodeString(ue.NasConn().AuthenticationCtx.Rand)
+	p0, err := hex.DecodeString(conn.AuthenticationCtx.Rand)
 	if err != nil {
 		return fmt.Errorf("failed to decode RAND: %s", err)
 	}
@@ -51,10 +56,10 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 	hResStarBytes := sha256.Sum256(concat)
 	hResStar := hex.EncodeToString(hResStarBytes[16:])
 
-	if subtle.ConstantTimeCompare([]byte(hResStar), []byte(ue.NasConn().AuthenticationCtx.HxresStar)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(hResStar), []byte(conn.AuthenticationCtx.HxresStar)) != 1 {
 		ue.Log.Error("HRES* Validation Failure")
 
-		if ue.NasConn().IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
+		if conn.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
 			err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeSuci)
 			if err != nil {
 				return fmt.Errorf("send identity request error: %s", err)
@@ -79,7 +84,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 	if err != nil {
 		logger.WithTrace(ctx, logger.AmfLog).Error("5G AKA Confirmation Request Procedure failed", zap.Error(err))
 
-		if ue.NasConn().IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
+		if conn.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
 			err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeSuci)
 			if err != nil {
 				return fmt.Errorf("send identity request error: %s", err)

--- a/internal/amf/nas/gmm/handle_authentication_response.go
+++ b/internal/amf/nas/gmm/handle_authentication_response.go
@@ -25,12 +25,12 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
-	if ue.T3560 != nil {
-		ue.T3560.Stop()
-		ue.T3560 = nil // clear the timer
+	if ue.NasConn().T3560 != nil {
+		ue.NasConn().T3560.Stop()
+		ue.NasConn().T3560 = nil // clear the timer
 	}
 
-	if ue.AuthenticationCtx == nil {
+	if ue.NasConn().AuthenticationCtx == nil {
 		return fmt.Errorf("ue Authentication Context is nil")
 	}
 
@@ -41,7 +41,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 	resStar := msg.GetRES()
 
 	// Calculate HRES* (TS 33.501 Annex A.5)
-	p0, err := hex.DecodeString(ue.AuthenticationCtx.Rand)
+	p0, err := hex.DecodeString(ue.NasConn().AuthenticationCtx.Rand)
 	if err != nil {
 		return fmt.Errorf("failed to decode RAND: %s", err)
 	}
@@ -51,10 +51,10 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 	hResStarBytes := sha256.Sum256(concat)
 	hResStar := hex.EncodeToString(hResStarBytes[16:])
 
-	if subtle.ConstantTimeCompare([]byte(hResStar), []byte(ue.AuthenticationCtx.HxresStar)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(hResStar), []byte(ue.NasConn().AuthenticationCtx.HxresStar)) != 1 {
 		ue.Log.Error("HRES* Validation Failure")
 
-		if ue.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
+		if ue.NasConn().IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
 			err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeSuci)
 			if err != nil {
 				return fmt.Errorf("send identity request error: %s", err)
@@ -79,7 +79,7 @@ func handleAuthenticationResponse(ctx context.Context, amfInstance *amf.AMF, ue 
 	if err != nil {
 		logger.WithTrace(ctx, logger.AmfLog).Error("5G AKA Confirmation Request Procedure failed", zap.Error(err))
 
-		if ue.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
+		if ue.NasConn().IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
 			err := message.SendIdentityRequest(ctx, ranUe, nasMessage.MobileIdentity5GSTypeSuci)
 			if err != nil {
 				return fmt.Errorf("send identity request error: %s", err)

--- a/internal/amf/nas/gmm/handle_authentication_response_test.go
+++ b/internal/amf/nas/gmm/handle_authentication_response_test.go
@@ -22,7 +22,7 @@ func TestHandleAuthenticationResponse_NilAuthenticationResponseParameter(t *test
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthenticationCtx = &ausf.AuthResult{Rand: "DEADBEEF"}
+	ue.NasConn().AuthenticationCtx = &ausf.AuthResult{Rand: "DEADBEEF"}
 
 	msg := &nasMessage.AuthenticationResponse{
 		AuthenticationResponseParameter: nil,
@@ -74,7 +74,7 @@ func TestHandleAuthenticationResponse_PreconditionErrors(t *testing.T) {
 				}
 
 				ue.ForceState(amf.Authentication)
-				ue.AuthenticationCtx = &ausf.AuthResult{Rand: "Not hex"}
+				ue.NasConn().AuthenticationCtx = &ausf.AuthResult{Rand: "Not hex"}
 
 				return ue
 			}(),
@@ -99,16 +99,17 @@ func TestHandleAuthenticationResponse_TimerT3560Stopped(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthenticationCtx = &ausf.AuthResult{
+	conn := ue.NasConn()
+	conn.AuthenticationCtx = &ausf.AuthResult{
 		Rand:      "DEADBEEF",
 		HxresStar: "not a match",
 	}
-	ue.IdentityTypeUsedForRegistration = nasMessage.MobileIdentity5GSTypeSuci
-	ue.T3560 = amf.NewTimer(10*time.Minute, 5, func(e int32) {}, func() {})
+	conn.IdentityTypeUsedForRegistration = nasMessage.MobileIdentity5GSTypeSuci
+	conn.T3560 = amf.NewTimer(10*time.Minute, 5, func(e int32) {}, func() {})
 
 	_ = handleAuthenticationResponse(t.Context(), amf.New(nil, nil, nil), ue, &nasMessage.AuthenticationResponse{AuthenticationResponseParameter: &nasType.AuthenticationResponseParameter{}})
 
-	if ue.T3560 != nil {
+	if conn.T3560 != nil {
 		t.Fatal("expected timer T3560 to be stopped and cleared")
 	}
 }
@@ -141,11 +142,11 @@ func TestHandleAuthenticationResponse_hResStartMismatch(t *testing.T) {
 			}
 
 			ue.ForceState(amf.Authentication)
-			ue.AuthenticationCtx = &ausf.AuthResult{
+			ue.NasConn().AuthenticationCtx = &ausf.AuthResult{
 				Rand:      "DEADBEEF",
 				HxresStar: "not a match",
 			}
-			ue.IdentityTypeUsedForRegistration = tc.id_type
+			ue.NasConn().IdentityTypeUsedForRegistration = tc.id_type
 
 			err = handleAuthenticationResponse(t.Context(), amf.New(nil, nil, nil), ue, &nasMessage.AuthenticationResponse{AuthenticationResponseParameter: &nasType.AuthenticationResponseParameter{}})
 			if err != nil {
@@ -223,11 +224,11 @@ func TestHandleAuthenticationResponse_Auth5gAKA_Failure(t *testing.T) {
 			}
 
 			ue.ForceState(amf.Authentication)
-			ue.AuthenticationCtx = &ausf.AuthResult{
+			ue.NasConn().AuthenticationCtx = &ausf.AuthResult{
 				Rand:      "DEADBEEF",
 				HxresStar: "192a898722d89d0c3e4c6f2de48c796a",
 			}
-			ue.IdentityTypeUsedForRegistration = tc.id_type
+			ue.NasConn().IdentityTypeUsedForRegistration = tc.id_type
 
 			err = handleAuthenticationResponse(t.Context(), amfInstance, ue, &nasMessage.AuthenticationResponse{AuthenticationResponseParameter: &nasType.AuthenticationResponseParameter{}})
 			if err != nil {
@@ -280,7 +281,7 @@ func TestHandleAuthenticationResponse_DeriveKamf_Failure(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthenticationCtx = &ausf.AuthResult{
+	ue.NasConn().AuthenticationCtx = &ausf.AuthResult{
 		Rand:      "DEADBEEF",
 		HxresStar: "192a898722d89d0c3e4c6f2de48c796a",
 	}
@@ -321,19 +322,19 @@ func TestHandleAuthenticationResponse_DeriveKamf_Success(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.AuthenticationCtx = &ausf.AuthResult{
+	ue.NasConn().AuthenticationCtx = &ausf.AuthResult{
 		Rand:      "DEADBEEF",
 		HxresStar: "192a898722d89d0c3e4c6f2de48c796a",
 	}
-	ue.UESecurityCapability = &nasType.UESecurityCapability{
+	ue.Current().UESecurityCapability = &nasType.UESecurityCapability{
 		Iei:    nasMessage.RegistrationRequestUESecurityCapabilityType,
 		Len:    2,
 		Buffer: []uint8{0x00, 0x00},
 	}
-	ue.UESecurityCapability.SetEA0_5G(1)
-	ue.UESecurityCapability.SetEA1_128_5G(1)
-	ue.UESecurityCapability.SetIA0_5G(1)
-	ue.UESecurityCapability.SetIA1_128_5G(1)
+	ue.Current().UESecurityCapability.SetEA0_5G(1)
+	ue.Current().UESecurityCapability.SetEA1_128_5G(1)
+	ue.Current().UESecurityCapability.SetIA0_5G(1)
+	ue.Current().UESecurityCapability.SetIA1_128_5G(1)
 
 	err = handleAuthenticationResponse(t.Context(), amfInstance, ue, &nasMessage.AuthenticationResponse{AuthenticationResponseParameter: &nasType.AuthenticationResponseParameter{}})
 	if err != nil {

--- a/internal/amf/nas/gmm/handle_configuration_update_complete.go
+++ b/internal/amf/nas/gmm/handle_configuration_update_complete.go
@@ -15,9 +15,9 @@ func handleConfigurationUpdateComplete(amfInstance *amf.AMF, ue *amf.AmfUe, macF
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 
-	if ue.NasConn().T3555 != nil {
-		ue.NasConn().T3555.Stop()
-		ue.NasConn().T3555 = nil // clear the timer
+	if conn := ue.NasConn(); conn != nil && conn.T3555 != nil {
+		conn.T3555.Stop()
+		conn.T3555 = nil
 	}
 
 	amfInstance.FreeOldGuti(ue)

--- a/internal/amf/nas/gmm/handle_configuration_update_complete.go
+++ b/internal/amf/nas/gmm/handle_configuration_update_complete.go
@@ -6,18 +6,18 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 )
 
-func handleConfigurationUpdateComplete(amfInstance *amf.AMF, ue *amf.AmfUe) error {
+func handleConfigurationUpdateComplete(amfInstance *amf.AMF, ue *amf.AmfUe, macFailed bool) error {
 	if state := ue.GetState(); state != amf.Registered {
 		return fmt.Errorf("state mismatch: receive Configuration Update Complete message in state %s", state)
 	}
 
-	if ue.MacFailed {
+	if macFailed {
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 
-	if ue.T3555 != nil {
-		ue.T3555.Stop()
-		ue.T3555 = nil // clear the timer
+	if ue.NasConn().T3555 != nil {
+		ue.NasConn().T3555.Stop()
+		ue.NasConn().T3555 = nil // clear the timer
 	}
 
 	amfInstance.FreeOldGuti(ue)

--- a/internal/amf/nas/gmm/handle_configuration_update_complete_test.go
+++ b/internal/amf/nas/gmm/handle_configuration_update_complete_test.go
@@ -21,7 +21,7 @@ func TestHandleConfigurationUpdateComplete_NotRegisteredError(t *testing.T) {
 
 			amfInstance := amf.New(nil, nil, nil)
 
-			err := handleConfigurationUpdateComplete(amfInstance, ue)
+			err := handleConfigurationUpdateComplete(amfInstance, ue, true)
 			if err == nil || err.Error() != expected {
 				t.Fatalf("expected error: %s, got %v", expected, err)
 			}
@@ -32,13 +32,12 @@ func TestHandleConfigurationUpdateComplete_NotRegisteredError(t *testing.T) {
 func TestHandleConfigurationUpdateComplete_MacFailed(t *testing.T) {
 	ue := amf.NewAmfUe()
 	ue.ForceState(amf.Registered)
-	ue.MacFailed = true
 
 	expected := "NAS message integrity check failed"
 
 	amfInstance := amf.New(nil, nil, nil)
 
-	err := handleConfigurationUpdateComplete(amfInstance, ue)
+	err := handleConfigurationUpdateComplete(amfInstance, ue, true)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error: %s, got %v", expected, err)
 	}
@@ -47,18 +46,18 @@ func TestHandleConfigurationUpdateComplete_MacFailed(t *testing.T) {
 func TestHandleConfigurationUpdateComplete_T3555Stopped_OldGutiFreed(t *testing.T) {
 	ue := amf.NewAmfUe()
 	ue.ForceState(amf.Registered)
-	ue.T3555 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	ue.NasConn().T3555 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
 	ue.OldGuti = mustTestGuti("001", "01", "cafe42", 0x12345678)
 	ue.OldTmsi = mustValidTestTmsi(0x12345678)
 
 	amfInstance := amf.New(nil, nil, nil)
 
-	err := handleConfigurationUpdateComplete(amfInstance, ue)
+	err := handleConfigurationUpdateComplete(amfInstance, ue, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if ue.T3555 != nil {
+	if ue.NasConn().T3555 != nil {
 		t.Fatal("expected timer T3555 to be stopped and cleared")
 	}
 

--- a/internal/amf/nas/gmm/handle_deregistration_accept.go
+++ b/internal/amf/nas/gmm/handle_deregistration_accept.go
@@ -11,9 +11,9 @@ import (
 
 // TS 23.502 4.2.2.3
 func handleDeregistrationAccept(ctx context.Context, ue *amf.AmfUe) error {
-	if ue.T3522 != nil {
-		ue.T3522.Stop()
-		ue.T3522 = nil // clear the timer
+	if conn := ue.NasConn(); conn != nil && conn.T3522 != nil {
+		conn.T3522.Stop()
+		conn.T3522 = nil
 	}
 
 	defer ue.Deregister(ctx)

--- a/internal/amf/nas/gmm/handle_deregistration_accept_test.go
+++ b/internal/amf/nas/gmm/handle_deregistration_accept_test.go
@@ -14,7 +14,8 @@ func TestHandleDeregistrationAccept_T3522Stopped_UEContextReleaseCommand(t *test
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.T3522 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	conn := ue.NasConn()
+	conn.T3522 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
 
 	err = handleDeregistrationAccept(t.Context(), ue)
 	if err != nil {
@@ -25,7 +26,7 @@ func TestHandleDeregistrationAccept_T3522Stopped_UEContextReleaseCommand(t *test
 		t.Fatalf("expected UE to be deregistered, but was: %s", ue.GetState())
 	}
 
-	if ue.T3522 != nil {
+	if conn.T3522 != nil {
 		t.Fatal("expected timer T3522 to be stopped and cleared")
 	}
 
@@ -40,7 +41,7 @@ func TestHandleDeregistrationAccept_NilRanUE_NoMessage(t *testing.T) {
 		t.Fatalf("could not build test UE and radio: %v", err)
 	}
 
-	ue.DetachRanUe(nil)
+	ue.ReleaseNasConnection(nil)
 
 	err = handleDeregistrationAccept(t.Context(), ue)
 	if err != nil {

--- a/internal/amf/nas/gmm/handle_deregistration_request.go
+++ b/internal/amf/nas/gmm/handle_deregistration_request.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TS 23.502 4.2.2.3
-func handleDeregistrationRequestUEOriginatingDeregistration(ctx context.Context, ue *amf.AmfUe, msg *nasMessage.DeregistrationRequestUEOriginatingDeregistration) error {
+func handleDeregistrationRequestUEOriginatingDeregistration(ctx context.Context, ue *amf.AmfUe, msg *nasMessage.DeregistrationRequestUEOriginatingDeregistration, macFailed bool) error {
 	if state := ue.GetState(); state != amf.Registered {
 		return fmt.Errorf("state mismatch: receive Deregistration Request (UE Originating Deregistration) message in state %s", state)
 	}
@@ -20,7 +20,7 @@ func handleDeregistrationRequestUEOriginatingDeregistration(ctx context.Context,
 	// Reject unauthenticated Deregistration Requests while the AMF still
 	// holds a valid security context (TS 24.501 §4.4.4.3 defense in depth).
 	// A UE that lost its keys can recover via Initial Registration.
-	if ue.MacFailed && ue.SecurityContextAvailable {
+	if macFailed && ue.Current().SecurityContextAvailable {
 		return fmt.Errorf("rejecting unauthenticated Deregistration Request from UE with valid security context")
 	}
 

--- a/internal/amf/nas/gmm/handle_deregistration_request_test.go
+++ b/internal/amf/nas/gmm/handle_deregistration_request_test.go
@@ -26,7 +26,7 @@ func TestHandleRegeristrationRequest(t *testing.T) {
 
 			expected := fmt.Sprintf("state mismatch: receive Deregistration Request (UE Originating Deregistration) message in state %s", tc)
 
-			err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, nil)
+			err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, nil, false)
 			if err == nil || err.Error() != expected {
 				t.Fatalf("expected error: %s, got: %v", expected, err)
 			}
@@ -68,7 +68,7 @@ func TestHandleRegistrationRequest_AllSmContextAreReleased(t *testing.T) {
 
 	m := buildTestDeregistrationRequestUEOriginatingDeregistrationMessage()
 
-	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration)
+	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -91,11 +91,11 @@ func TestHandleDeregistrationRequest_NilRanUE(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.DetachRanUe(nil)
+	ue.ReleaseNasConnection(nil)
 
 	m := buildTestDeregistrationRequestUEOriginatingDeregistrationMessage()
 
-	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration)
+	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestHandleDeregistrationRequest_NotSwitchOff_DeregistrationAccept(t *testin
 
 	m := buildTestDeregistrationRequestUEOriginatingDeregistrationMessage()
 
-	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration)
+	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestHandleDeregistrationRequest_SwitchOff_NoDeregistrationAccept(t *testing
 	m := buildTestDeregistrationRequestUEOriginatingDeregistrationMessage()
 	m.DeregistrationRequestUEOriginatingDeregistration.SetSwitchOff(1)
 
-	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration)
+	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -185,12 +185,11 @@ func TestHandleDeregistrationRequest_MacFailed_RejectsForgery(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.SecurityContextAvailable = true
-	ue.MacFailed = true
+	ue.Current().SecurityContextAvailable = true
 
 	m := buildTestDeregistrationRequestUEOriginatingDeregistrationMessage()
 
-	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration)
+	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration, true)
 	if err == nil {
 		t.Fatal("expected handler to reject unauthenticated deregistration, got nil error")
 	}
@@ -211,7 +210,7 @@ func TestHandleDeregistrationRequest_MacFailed_RejectsForgery(t *testing.T) {
 		t.Fatalf("UE must remain Registered after rejecting forgery, got %s", ue.GetState())
 	}
 
-	if !ue.SecurityContextAvailable {
+	if !ue.Current().SecurityContextAvailable {
 		t.Error("handler must not tear down SecurityContextAvailable on a forged request")
 	}
 }
@@ -227,7 +226,7 @@ func TestHandleDeregistrationRequest_Non3GPP_DeregistrationAccept(t *testing.T) 
 	m := buildTestDeregistrationRequestUEOriginatingDeregistrationMessage()
 	m.DeregistrationRequestUEOriginatingDeregistration.SetAccessType(nasMessage.AccessTypeNon3GPP)
 
-	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration)
+	err = handleDeregistrationRequestUEOriginatingDeregistration(t.Context(), ue, m.DeregistrationRequestUEOriginatingDeregistration, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}

--- a/internal/amf/nas/gmm/handle_identity_response.go
+++ b/internal/amf/nas/gmm/handle_identity_response.go
@@ -111,7 +111,12 @@ func handleIdentityResponse(ctx context.Context, amfInstance *amf.AMF, ue *amf.A
 			return fmt.Errorf("error handling identity response: %v", err)
 		}
 
-		switch ue.NasConn().RegistrationType5GS {
+		conn := ue.NasConn()
+		if conn == nil {
+			return fmt.Errorf("no active NAS connection")
+		}
+
+		switch conn.RegistrationType5GS {
 		case nasMessage.RegistrationType5GSInitialRegistration:
 			if err := HandleInitialRegistration(ctx, amfInstance, ue); err != nil {
 				ue.Deregister(ctx)

--- a/internal/amf/nas/gmm/handle_identity_response.go
+++ b/internal/amf/nas/gmm/handle_identity_response.go
@@ -12,7 +12,7 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 )
 
-func updateUEIdentity(ue *amf.AmfUe, mobileIdentityContents []uint8) error {
+func updateUEIdentity(ue *amf.AmfUe, mobileIdentityContents []uint8, macFailed bool) error {
 	if ue == nil {
 		return fmt.Errorf("AmfUe is nil")
 	}
@@ -28,7 +28,7 @@ func updateUEIdentity(ue *amf.AmfUe, mobileIdentityContents []uint8) error {
 		ue.Suci, plmnID = nasConvert.SuciToString(mobileIdentityContents)
 		ue.PlmnID = plmnIDStringToModels(plmnID)
 	case nasMessage.MobileIdentity5GSType5gGuti:
-		if ue.MacFailed {
+		if macFailed {
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 
@@ -41,7 +41,7 @@ func updateUEIdentity(ue *amf.AmfUe, mobileIdentityContents []uint8) error {
 			return fmt.Errorf("UE sent unknown GUTI")
 		}
 	case nasMessage.MobileIdentity5GSType5gSTmsi:
-		if ue.MacFailed {
+		if macFailed {
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 
@@ -65,14 +65,14 @@ func updateUEIdentity(ue *amf.AmfUe, mobileIdentityContents []uint8) error {
 			return fmt.Errorf("UE sent unknown TMSI")
 		}
 	case nasMessage.MobileIdentity5GSTypeImei:
-		if ue.MacFailed {
+		if macFailed {
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 
 		imei := nasConvert.PeiToString(mobileIdentityContents)
 		ue.Pei = imei
 	case nasMessage.MobileIdentity5GSTypeImeisv:
-		if ue.MacFailed {
+		if macFailed {
 			return fmt.Errorf("NAS message integrity check failed")
 		}
 
@@ -83,12 +83,12 @@ func updateUEIdentity(ue *amf.AmfUe, mobileIdentityContents []uint8) error {
 	return nil
 }
 
-func handleIdentityResponse(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.IdentityResponse) error {
+func handleIdentityResponse(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.IdentityResponse, macFailed bool) error {
 	switch ue.GetState() {
 	case amf.Authentication:
 		mobileIdentityContents := msg.GetMobileIdentityContents()
 
-		if err := updateUEIdentity(ue, mobileIdentityContents); err != nil {
+		if err := updateUEIdentity(ue, mobileIdentityContents, macFailed); err != nil {
 			return fmt.Errorf("error handling identity response: %v", err)
 		}
 
@@ -107,11 +107,11 @@ func handleIdentityResponse(ctx context.Context, amfInstance *amf.AMF, ue *amf.A
 	case amf.ContextSetup:
 		mobileIdentityContents := msg.GetMobileIdentityContents()
 
-		if err := updateUEIdentity(ue, mobileIdentityContents); err != nil {
+		if err := updateUEIdentity(ue, mobileIdentityContents, macFailed); err != nil {
 			return fmt.Errorf("error handling identity response: %v", err)
 		}
 
-		switch ue.RegistrationType5GS {
+		switch ue.NasConn().RegistrationType5GS {
 		case nasMessage.RegistrationType5GSInitialRegistration:
 			if err := HandleInitialRegistration(ctx, amfInstance, ue); err != nil {
 				ue.Deregister(ctx)

--- a/internal/amf/nas/gmm/handle_identity_response_test.go
+++ b/internal/amf/nas/gmm/handle_identity_response_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ellanetworks/core/etsi"
@@ -27,6 +28,25 @@ type UpdateInputs struct {
 
 func emptyValidation(ue *amf.AmfUe) error {
 	return nil
+}
+
+func newTestUe(macFailed bool, guti, oldGuti etsi.GUTI, tmsi etsi.TMSI) *amf.AmfUe {
+	_ = macFailed
+	ue := amf.NewAmfUe()
+	ue.Guti = guti
+	ue.OldGuti = oldGuti
+	ue.Tmsi = tmsi
+
+	return ue
+}
+
+func tmsiUe(macFailed bool, tmsi, oldTmsi etsi.TMSI) *amf.AmfUe {
+	_ = macFailed
+	ue := amf.NewAmfUe()
+	ue.Tmsi = tmsi
+	ue.OldTmsi = oldTmsi
+
+	return ue
 }
 
 func mustValidTestTmsi(t uint32) etsi.TMSI {
@@ -89,98 +109,98 @@ func TestUpdateUeIdentity(t *testing.T) {
 		},
 		{
 			"Invalid GUTI sets empty GUTI",
-			&amf.AmfUe{Guti: mustTestGuti("999", "99", "cafe42", 0x00000001), MacFailed: false},
+			newTestUe(false, mustTestGuti("999", "99", "cafe42", 0x00000001), etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0},
 			fmt.Errorf("UE sent invalid GUTI: invalid GUTI length"),
 			emptyValidation,
 		},
 		{
 			"GUTI with MacFailed returns error",
-			&amf.AmfUe{MacFailed: true},
+			newTestUe(true, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0x10, 0x1f, 0, 0, 1, 0, 0, 0, 1},
 			fmt.Errorf("NAS message integrity check failed"),
 			emptyValidation,
 		},
 		{
 			"Valid GUTI matches UE GUTI",
-			&amf.AmfUe{MacFailed: false, Guti: mustTestGuti("001", "01", "cafe01", 0xdeadbeef)},
+			newTestUe(false, mustTestGuti("001", "01", "cafe01", 0xdeadbeef), etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0xf1, 0x10, 0xCA, 0xFE, 1, 0xDE, 0xAD, 0xBE, 0xEF},
 			nil,
 			emptyValidation,
 		},
 		{
 			"Valid GUTI matches UE old GUTI",
-			&amf.AmfUe{MacFailed: false, Guti: mustTestGuti("001", "01", "cafe02", 0xf00df00d), OldGuti: mustTestGuti("001", "01", "cafe01", 0xdeadbeef)},
+			newTestUe(false, mustTestGuti("001", "01", "cafe02", 0xf00df00d), mustTestGuti("001", "01", "cafe01", 0xdeadbeef), etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0xf1, 0x10, 0xCA, 0xFE, 1, 0xDE, 0xAD, 0xBE, 0xEF},
 			nil,
 			emptyValidation,
 		},
 		{
 			"Valid GUTI does not match AMF state",
-			&amf.AmfUe{MacFailed: false, Guti: mustTestGuti("001", "01", "cafe02", 0xf00df00d), OldGuti: mustTestGuti("001", "01", "cafe01", 0x12345678)},
+			newTestUe(false, mustTestGuti("001", "01", "cafe02", 0xf00df00d), mustTestGuti("001", "01", "cafe01", 0x12345678), etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gGuti, 0, 0xf1, 0x10, 0xCA, 0xFE, 1, 0xDE, 0xAD, 0xBE, 0xEF},
 			fmt.Errorf("UE sent unknown GUTI"),
 			emptyValidation,
 		},
 		{
 			"5G-S-TMSI with MacFailed returns error",
-			&amf.AmfUe{MacFailed: true},
+			newTestUe(true, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0x00, 0x12, 0x34, 0x56, 0x78, 0x90},
 			fmt.Errorf("NAS message integrity check failed"),
 			emptyValidation,
 		},
 		{
 			"5G-S-TMSI maximum value matches",
-			&amf.AmfUe{MacFailed: false, Tmsi: mustValidTestTmsi(0xFFFFFFFE)},
+			newTestUe(false, etsi.GUTI{}, etsi.GUTI{}, mustValidTestTmsi(0xFFFFFFFE)),
 			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE},
 			nil,
 			emptyValidation,
 		},
 		{
 			"5G-S-TMSI too long returns error",
-			&amf.AmfUe{MacFailed: false},
+			newTestUe(false, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
 			fmt.Errorf("wrong length for TMSI"),
 			emptyValidation,
 		},
 		{
 			"5G-S-TMSI too short returns error",
-			&amf.AmfUe{MacFailed: false},
+			newTestUe(false, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFF, 0xFF, 0x01},
 			fmt.Errorf("wrong length for TMSI"),
 			emptyValidation,
 		},
 		{
 			"Valid 5G-S-TMSI matches UE TMSI",
-			&amf.AmfUe{MacFailed: false, Tmsi: mustValidTestTmsi(0x1A345678)},
+			newTestUe(false, etsi.GUTI{}, etsi.GUTI{}, mustValidTestTmsi(0x1A345678)),
 			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFE, 0x01, 0x1A, 0x34, 0x56, 0x78},
 			nil,
 			emptyValidation,
 		},
 		{
 			"Valid 5G-S-TMSI matches UE old TMSI",
-			&amf.AmfUe{MacFailed: false, Tmsi: mustValidTestTmsi(0x22234567), OldTmsi: mustValidTestTmsi(0x1A345678)},
+			tmsiUe(false, mustValidTestTmsi(0x22234567), mustValidTestTmsi(0x1A345678)),
 			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFE, 0x01, 0x1A, 0x34, 0x56, 0x78},
 			nil,
 			emptyValidation,
 		},
 		{
 			"Valid 5G-S-TMSI does not match AMF state",
-			&amf.AmfUe{MacFailed: false, Tmsi: mustValidTestTmsi(0x22234567), OldTmsi: mustValidTestTmsi(0x5FFF5555)},
+			tmsiUe(false, mustValidTestTmsi(0x22234567), mustValidTestTmsi(0x5FFF5555)),
 			[]uint8{nasMessage.MobileIdentity5GSType5gSTmsi, 0xFE, 0x01, 0x1A, 0x34, 0x56, 0x78},
 			fmt.Errorf("UE sent unknown TMSI"),
 			emptyValidation,
 		},
 		{
 			"IMEI with MacFailed returns error",
-			&amf.AmfUe{MacFailed: true},
+			newTestUe(true, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSTypeImei + 0x08 + 0x40, 0x09, 0x51, 0x24, 0x30, 0x32, 0x57, 0x81},
 			fmt.Errorf("NAS message integrity check failed"),
 			emptyValidation,
 		},
 		{
 			"Valid IMEI sets PEI",
-			&amf.AmfUe{MacFailed: false},
+			newTestUe(false, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSTypeImei + 0x08 + 0x40, 0x09, 0x51, 0x24, 0x30, 0x32, 0x57, 0x81},
 			nil,
 			func(ue *amf.AmfUe) error {
@@ -194,14 +214,14 @@ func TestUpdateUeIdentity(t *testing.T) {
 		},
 		{
 			"IMEISV with MacFailed returns error",
-			&amf.AmfUe{MacFailed: true},
+			newTestUe(true, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSTypeImeisv + 0x30, 0x25, 0x90, 0x09, 0x10, 0x67, 0x41, 0x28, 0xF3},
 			fmt.Errorf("NAS message integrity check failed"),
 			emptyValidation,
 		},
 		{
 			"Valid IMEISV sets PEI",
-			&amf.AmfUe{MacFailed: false},
+			newTestUe(false, etsi.GUTI{}, etsi.GUTI{}, etsi.TMSI{}),
 			[]uint8{nasMessage.MobileIdentity5GSTypeImeisv + 0x30, 0x25, 0x90, 0x09, 0x10, 0x67, 0x41, 0x28, 0xF3},
 			nil,
 			func(ue *amf.AmfUe) error {
@@ -216,7 +236,8 @@ func TestUpdateUeIdentity(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := updateUEIdentity(tc.ue, tc.mi)
+			macFailed := strings.Contains(tc.name, "MacFailed")
+			err := updateUEIdentity(tc.ue, tc.mi, macFailed)
 
 			if tc.expected_err == nil && err != nil {
 				t.Fatalf("expected error to be nil, got %v", err)
@@ -241,7 +262,7 @@ func TestHandleIdentityResponse_InvalidStateError(t *testing.T) {
 			ue := amf.NewAmfUe()
 			ue.ForceState(tc)
 
-			err := handleIdentityResponse(context.TODO(), amf.New(nil, nil, nil), ue, &nasMessage.IdentityResponse{})
+			err := handleIdentityResponse(context.TODO(), amf.New(nil, nil, nil), ue, &nasMessage.IdentityResponse{}, false)
 			if err == nil {
 				t.Fatalf("expected an state mismatch error, got no error")
 			}
@@ -272,12 +293,11 @@ func TestHandleIdentityResponse_AuthenticationProcess_AuthenticationRequest(t *t
 
 	ue.Suci = ""
 	ue.ForceState(amf.Authentication)
-	ue.MacFailed = false
 	ue.Tai = ue.RanUe().Tai
 
 	m := buildTestIdentityResponseMessage()
 
-	err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse)
+	err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse, false)
 	if err != nil {
 		t.Fatalf("expected no errors but got: %v", err)
 	}
@@ -327,14 +347,13 @@ func TestHandleIdentityResponse_AuthenticationProcess_AuthenticationError(t *tes
 
 	ue.Suci = ""
 	ue.ForceState(amf.Authentication)
-	ue.MacFailed = false
 	ue.Tai = models.Tai{}
 
 	m := buildTestIdentityResponseMessage()
 
 	expected := "error in authentication procedure: failed to send ue authentication request: tai is not available in UE context"
 
-	err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse)
+	err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse, false)
 	if err == nil {
 		t.Fatalf("expected error but got none")
 	}
@@ -373,28 +392,27 @@ func TestHandleIdentityResponse_AuthenticationProcess_RegistrationAccept(t *test
 	ue.Suci = "testsuci"
 	ue.Supi = supi
 	ue.ForceState(amf.Authentication)
-	ue.MacFailed = false
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	ue.RegistrationRequest = registrationRequest.RegistrationRequest
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+	ue.NasConn().RegistrationRequest = registrationRequest.RegistrationRequest
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
 
 	m := buildTestIdentityResponseMessage()
 
-	err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse)
+	err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse, false)
 	if err != nil {
 		t.Fatalf("expected no errors but got: %v", err)
 	}
@@ -415,7 +433,7 @@ func TestHandleIdentityResponse_AuthenticationProcess_RegistrationAccept(t *test
 		t.Fatalf("expected a protected and ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -463,32 +481,31 @@ func TestHandleIdentityResponse_ContextSetup_RegistrationAccept(t *testing.T) {
 			ue.Supi = supi
 			ue.Pei = "testpei"
 			ue.ForceState(amf.ContextSetup)
-			ue.MacFailed = false
 			ue.Tai = ue.RanUe().Tai
-			ue.SecurityContextAvailable = true
-			ue.NgKsi.Ksi = 1
+			ue.Current().SecurityContextAvailable = true
+			ue.Current().NgKsi.Ksi = 1
 			key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 			algo := security.AlgCiphering128NEA2
-			ue.KnasEnc = key
-			ue.KnasInt = key
-			ue.CipheringAlg = algo
-			ue.IntegrityAlg = security.AlgIntegrity128NIA0
+			ue.Current().KnasEnc = key
+			ue.Current().KnasInt = key
+			ue.Current().CipheringAlg = algo
+			ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 			if err != nil {
 				t.Fatalf("could not build registration request message: %v", err)
 			}
 
-			ue.RegistrationRequest = registrationRequest.RegistrationRequest
+			ue.NasConn().RegistrationRequest = registrationRequest.RegistrationRequest
 
-			ue.RegistrationType5GS = tc
+			ue.NasConn().RegistrationType5GS = tc
 			if tc == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
-				ue.RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
+				ue.NasConn().RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
 			}
 
 			m := buildTestIdentityResponseMessage()
 
-			err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse)
+			err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse, false)
 			if err != nil {
 				t.Fatalf("expected no errors but got: %v", err)
 			}
@@ -509,7 +526,7 @@ func TestHandleIdentityResponse_ContextSetup_RegistrationAccept(t *testing.T) {
 				t.Fatalf("expected a protected and ciphered NAS message")
 			}
 
-			if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+			if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 				t.Fatalf("could not decrypt NAS message: %v", err)
 			}
 
@@ -553,32 +570,31 @@ func TestHandleIdentityResponse_ContextSetup_Error(t *testing.T) {
 			ue.Supi = supi
 			ue.Pei = "testpei"
 			ue.ForceState(amf.ContextSetup)
-			ue.MacFailed = false
 			ue.Tai = ue.RanUe().Tai
-			ue.SecurityContextAvailable = true
-			ue.NgKsi.Ksi = 1
+			ue.Current().SecurityContextAvailable = true
+			ue.Current().NgKsi.Ksi = 1
 			key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 			algo := security.AlgCiphering128NEA2
-			ue.KnasEnc = key
-			ue.KnasInt = key
-			ue.CipheringAlg = algo
-			ue.IntegrityAlg = security.AlgIntegrity128NIA0
+			ue.Current().KnasEnc = key
+			ue.Current().KnasInt = key
+			ue.Current().CipheringAlg = algo
+			ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 			if err != nil {
 				t.Fatalf("could not build registration request message: %v", err)
 			}
 
-			ue.RegistrationRequest = registrationRequest.RegistrationRequest
+			ue.NasConn().RegistrationRequest = registrationRequest.RegistrationRequest
 
-			ue.RegistrationType5GS = tc
+			ue.NasConn().RegistrationType5GS = tc
 			if tc == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
-				ue.RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
+				ue.NasConn().RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
 			}
 
 			m := buildTestIdentityResponseMessage()
 
-			err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse)
+			err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse, false)
 			if err == nil {
 				t.Fatalf("expected error but got none")
 			}
@@ -622,7 +638,7 @@ func TestHandleIdentityResponse_IdentityError(t *testing.T) {
 
 			expected := "error handling identity response: mobile identity is empty"
 
-			err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse)
+			err = handleIdentityResponse(context.TODO(), amfInstance, ue, m.IdentityResponse, false)
 			if err == nil {
 				t.Fatalf("expected error but got none")
 			}

--- a/internal/amf/nas/gmm/handle_notification_response.go
+++ b/internal/amf/nas/gmm/handle_notification_response.go
@@ -20,9 +20,9 @@ func handleNotificationResponse(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 
-	if ue.NasConn().T3565 != nil {
-		ue.NasConn().T3565.Stop()
-		ue.NasConn().T3565 = nil // clear the timer
+	if conn := ue.NasConn(); conn != nil && conn.T3565 != nil {
+		conn.T3565.Stop()
+		conn.T3565 = nil
 	}
 
 	if msg.PDUSessionStatus == nil {

--- a/internal/amf/nas/gmm/handle_notification_response.go
+++ b/internal/amf/nas/gmm/handle_notification_response.go
@@ -11,18 +11,18 @@ import (
 )
 
 // TS 24501 5.6.3.2
-func handleNotificationResponse(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.NotificationResponse) error {
+func handleNotificationResponse(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.NotificationResponse, macFailed bool) error {
 	if state := ue.GetState(); state != amf.Registered {
 		return fmt.Errorf("state mismatch: receive Notification Response message in state %s", state)
 	}
 
-	if ue.MacFailed {
+	if macFailed {
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 
-	if ue.T3565 != nil {
-		ue.T3565.Stop()
-		ue.T3565 = nil // clear the timer
+	if ue.NasConn().T3565 != nil {
+		ue.NasConn().T3565.Stop()
+		ue.NasConn().T3565 = nil // clear the timer
 	}
 
 	if msg.PDUSessionStatus == nil {

--- a/internal/amf/nas/gmm/handle_notification_response_test.go
+++ b/internal/amf/nas/gmm/handle_notification_response_test.go
@@ -24,7 +24,7 @@ func TestHandleNotificationResponse_NotRegisteredError(t *testing.T) {
 
 			expected := fmt.Sprintf("state mismatch: receive Notification Response message in state %s", tc)
 
-			err := handleNotificationResponse(t.Context(), nil, ue, nil)
+			err := handleNotificationResponse(t.Context(), nil, ue, nil, false)
 			if err == nil || err.Error() != expected {
 				t.Fatalf("expected error: %s, got %v", expected, err)
 			}
@@ -35,11 +35,10 @@ func TestHandleNotificationResponse_NotRegisteredError(t *testing.T) {
 func TestHandleNotificationResponse_MacFailed(t *testing.T) {
 	ue := amf.NewAmfUe()
 	ue.ForceState(amf.Registered)
-	ue.MacFailed = true
 
 	expected := "NAS message integrity check failed"
 
-	err := handleNotificationResponse(t.Context(), nil, ue, nil)
+	err := handleNotificationResponse(t.Context(), nil, ue, nil, true)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error: %s, got %v", expected, err)
 	}
@@ -61,16 +60,16 @@ func TestHandleNotificationResponse_T3565Stopped_NoPDUSessionStatus_NoSmContextR
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.T3565 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	ue.NasConn().T3565 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
 
 	m := buildTestNotifationResponse()
 
-	err = handleNotificationResponse(t.Context(), amfInstance, ue, m.NotificationResponse)
+	err = handleNotificationResponse(t.Context(), amfInstance, ue, m.NotificationResponse, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if ue.T3565 != nil {
+	if ue.NasConn().T3565 != nil {
 		t.Fatal("expected timer T3565 to be stopped and cleared")
 	}
 
@@ -95,7 +94,7 @@ func TestHandleNotificationResponse_T3565Stopped_PDUSessionStatus_SmContextRelea
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.T3565 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	ue.NasConn().T3565 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
 	_ = ue.CreateSmContext(1, "1", &models.Snssai{})
 	_ = ue.CreateSmContext(5, "5", &models.Snssai{})
 	_ = ue.CreateSmContext(8, "8", &models.Snssai{})
@@ -113,12 +112,12 @@ func TestHandleNotificationResponse_T3565Stopped_PDUSessionStatus_SmContextRelea
 	m.NotificationResponse.SetPSI11(1)
 	m.NotificationResponse.SetPSI15(0)
 
-	err = handleNotificationResponse(t.Context(), amfInstance, ue, m.NotificationResponse)
+	err = handleNotificationResponse(t.Context(), amfInstance, ue, m.NotificationResponse, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if ue.T3565 != nil {
+	if ue.NasConn().T3565 != nil {
 		t.Fatal("expected timer T3565 to be stopped and cleared")
 	}
 

--- a/internal/amf/nas/gmm/handle_registration_complete.go
+++ b/internal/amf/nas/gmm/handle_registration_complete.go
@@ -17,9 +17,9 @@ func handleRegistrationComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 
 	ue.TransitionTo(amf.Registered)
 
-	if ue.T3550 != nil {
-		ue.T3550.Stop()
-		ue.T3550 = nil // clear the timer
+	if ue.NasConn().T3550 != nil {
+		ue.NasConn().T3550.Stop()
+		ue.NasConn().T3550 = nil // clear the timer
 	}
 
 	// UE confirmed receipt of the new GUTI — free the old one (TS 24.501 5.5.1.2.4 step 20)
@@ -28,9 +28,9 @@ func handleRegistrationComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 	// Send NITZ (network name + timezone) to UE per TS 24.501
 	message.SendConfigurationUpdateCommand(ctx, amfInstance, ue, false)
 
-	forPending := ue.RegistrationRequest.GetFOR() == nasMessage.FollowOnRequestPending
+	forPending := ue.NasConn().RegistrationRequest.GetFOR() == nasMessage.FollowOnRequestPending
 
-	udsHasPending := ue.RegistrationRequest.UplinkDataStatus != nil
+	udsHasPending := ue.NasConn().RegistrationRequest.UplinkDataStatus != nil
 
 	hasActiveSessions := ue.HasActivePduSessions()
 

--- a/internal/amf/nas/gmm/handle_registration_complete.go
+++ b/internal/amf/nas/gmm/handle_registration_complete.go
@@ -17,9 +17,14 @@ func handleRegistrationComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 
 	ue.TransitionTo(amf.Registered)
 
-	if ue.NasConn().T3550 != nil {
-		ue.NasConn().T3550.Stop()
-		ue.NasConn().T3550 = nil // clear the timer
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
+	}
+
+	if conn.T3550 != nil {
+		conn.T3550.Stop()
+		conn.T3550 = nil
 	}
 
 	// UE confirmed receipt of the new GUTI — free the old one (TS 24.501 5.5.1.2.4 step 20)
@@ -28,9 +33,9 @@ func handleRegistrationComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 	// Send NITZ (network name + timezone) to UE per TS 24.501
 	message.SendConfigurationUpdateCommand(ctx, amfInstance, ue, false)
 
-	forPending := ue.NasConn().RegistrationRequest.GetFOR() == nasMessage.FollowOnRequestPending
+	forPending := conn.RegistrationRequest.GetFOR() == nasMessage.FollowOnRequestPending
 
-	udsHasPending := ue.NasConn().RegistrationRequest.UplinkDataStatus != nil
+	udsHasPending := conn.RegistrationRequest.UplinkDataStatus != nil
 
 	hasActiveSessions := ue.HasActivePduSessions()
 

--- a/internal/amf/nas/gmm/handle_registration_complete_test.go
+++ b/internal/amf/nas/gmm/handle_registration_complete_test.go
@@ -36,34 +36,33 @@ func setupRegistrationCompleteUE(t *testing.T) (*amf.AmfUe, *FakeNGAPSender) {
 
 	ue.Suci = "testsuci"
 	ue.Supi = mustSUPIFromPrefixed("imsi-001019756139935")
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
 	ue.ForceState(amf.ContextSetup)
-	ue.T3550 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	ue.RegistrationRequest = m.RegistrationRequest
-	ue.RegistrationType5GS = 42
-	ue.IdentityTypeUsedForRegistration = 42
-	ue.AuthFailureCauseSynchFailureTimes = 42
+	ue.NasConn().T3550 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	ue.NasConn().RegistrationRequest = m.RegistrationRequest
+	ue.NasConn().RegistrationType5GS = 42
+	ue.NasConn().IdentityTypeUsedForRegistration = 42
+	ue.NasConn().AuthFailureCauseSynchFailureTimes = 42
 	ue.RanUe().UeContextRequest = true
-	ue.RanUe().RecvdInitialContextSetupResponse = true
-	ue.RetransmissionOfInitialNASMsg = true
+	ue.RanUe().ICS = amf.ICSCompleted
+	ue.NasConn().RetransmissionOfInitialNASMsg = true
 
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,7 +101,7 @@ func TestHandleRegistrationComplete_T3550StoppedAndCleared_RegistrationDataClear
 		t.Fatalf("should not have sent a UE Context Release Command message")
 	}
 
-	if ue.T3550 != nil {
+	if ue.NasConn().T3550 != nil {
 		t.Fatalf("expected timer T3550 to be stopped and cleared")
 	}
 
@@ -136,7 +135,7 @@ func TestHandleRegistrationComplete_SendsConfigurationUpdateCommand(t *testing.T
 	payload := make([]byte, len(nasPdu)-7)
 	copy(payload, nasPdu[7:])
 
-	err = security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, 0, security.Bearer3GPP, security.DirectionDownlink, payload)
+	err = security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, 0, security.Bearer3GPP, security.DirectionDownlink, payload)
 	if err != nil {
 		t.Fatalf("NAS decrypt failed: %v", err)
 	}
@@ -169,9 +168,9 @@ func TestHandleRegistrationComplete_SendsConfigurationUpdateCommand(t *testing.T
 
 func TestHandleRegistrationComplete_ReleasedWhenNoFORPending_NoUDSPending_and_NoActiveSessions(t *testing.T) {
 	ue, ngapSender := setupRegistrationCompleteUE(t)
-	ue.RegistrationRequest.SetFOR(nasMessage.FollowOnRequestNoPending)
-	ue.RegistrationRequest.UplinkDataStatus = nil
-	ue.SmContextList = make(map[uint8]*amf.SmContext)
+	ue.NasConn().RegistrationRequest.SetFOR(nasMessage.FollowOnRequestNoPending)
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = nil
+	ue.Current().SmContextList = make(map[uint8]*amf.SmContext)
 
 	amfInstance := newTestAMF()
 
@@ -184,7 +183,7 @@ func TestHandleRegistrationComplete_ReleasedWhenNoFORPending_NoUDSPending_and_No
 		t.Fatalf("should have sent a UE Context Release Command message")
 	}
 
-	if ue.T3550 != nil {
+	if ue.NasConn().T3550 != nil {
 		t.Fatalf("expected timer T3550 to be stopped and cleared")
 	}
 
@@ -196,9 +195,9 @@ func TestHandleRegistrationComplete_ReleasedWhenNoFORPending_NoUDSPending_and_No
 
 func TestHandleRegistrationComplete_NotReleasedWhenFORPending(t *testing.T) {
 	ue, ngapSender := setupRegistrationCompleteUE(t)
-	ue.RegistrationRequest.SetFOR(nasMessage.FollowOnRequestPending)
-	ue.RegistrationRequest.UplinkDataStatus = nil
-	ue.SmContextList = make(map[uint8]*amf.SmContext)
+	ue.NasConn().RegistrationRequest.SetFOR(nasMessage.FollowOnRequestPending)
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = nil
+	ue.Current().SmContextList = make(map[uint8]*amf.SmContext)
 
 	amfInstance := newTestAMF()
 
@@ -211,7 +210,7 @@ func TestHandleRegistrationComplete_NotReleasedWhenFORPending(t *testing.T) {
 		t.Fatalf("should not have sent a UE Context Release Command message")
 	}
 
-	if ue.T3550 != nil {
+	if ue.NasConn().T3550 != nil {
 		t.Fatalf("expected timer T3550 to be stopped and cleared")
 	}
 
@@ -223,9 +222,9 @@ func TestHandleRegistrationComplete_NotReleasedWhenFORPending(t *testing.T) {
 
 func TestHandleRegistrationComplete_NotReleasedWhenUDSPending(t *testing.T) {
 	ue, ngapSender := setupRegistrationCompleteUE(t)
-	ue.RegistrationRequest.SetFOR(nasMessage.FollowOnRequestNoPending)
-	ue.RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{}
-	ue.SmContextList = make(map[uint8]*amf.SmContext)
+	ue.NasConn().RegistrationRequest.SetFOR(nasMessage.FollowOnRequestNoPending)
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{}
+	ue.Current().SmContextList = make(map[uint8]*amf.SmContext)
 
 	amfInstance := newTestAMF()
 
@@ -238,7 +237,7 @@ func TestHandleRegistrationComplete_NotReleasedWhenUDSPending(t *testing.T) {
 		t.Fatalf("should not have sent a UE Context Release Command message")
 	}
 
-	if ue.T3550 != nil {
+	if ue.NasConn().T3550 != nil {
 		t.Fatalf("expected timer T3550 to be stopped and cleared")
 	}
 
@@ -250,8 +249,8 @@ func TestHandleRegistrationComplete_NotReleasedWhenUDSPending(t *testing.T) {
 
 func TestHandleRegistrationComplete_NotReleasedWhenActiveSession(t *testing.T) {
 	ue, ngapSender := setupRegistrationCompleteUE(t)
-	ue.RegistrationRequest.SetFOR(nasMessage.FollowOnRequestNoPending)
-	ue.RegistrationRequest.UplinkDataStatus = nil
+	ue.NasConn().RegistrationRequest.SetFOR(nasMessage.FollowOnRequestNoPending)
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = nil
 	_ = ue.CreateSmContext(1, "testref1", &models.Snssai{})
 
 	amfInstance := newTestAMF()
@@ -265,7 +264,7 @@ func TestHandleRegistrationComplete_NotReleasedWhenActiveSession(t *testing.T) {
 		t.Fatalf("should not have sent a UE Context Release Command message")
 	}
 
-	if ue.T3550 != nil {
+	if ue.NasConn().T3550 != nil {
 		t.Fatalf("expected timer T3550 to be stopped and cleared")
 	}
 
@@ -276,35 +275,31 @@ func TestHandleRegistrationComplete_NotReleasedWhenActiveSession(t *testing.T) {
 }
 
 func checkUERegistrationDataIsCleared(ue *amf.AmfUe) error {
-	if ue.RegistrationRequest != nil {
+	if ue.NasConn().RegistrationRequest != nil {
 		return fmt.Errorf("registration request is not nil")
 	}
 
-	if ue.RegistrationType5GS != 0 {
-		return fmt.Errorf("registration type 5gs was not 0: %d", ue.RegistrationType5GS)
+	if ue.NasConn().RegistrationType5GS != 0 {
+		return fmt.Errorf("registration type 5gs was not 0: %d", ue.NasConn().RegistrationType5GS)
 	}
 
-	if ue.IdentityTypeUsedForRegistration != 0 {
-		return fmt.Errorf("identity type used for registration was not 0: %d", ue.IdentityTypeUsedForRegistration)
+	if ue.NasConn().IdentityTypeUsedForRegistration != 0 {
+		return fmt.Errorf("identity type used for registration was not 0: %d", ue.NasConn().IdentityTypeUsedForRegistration)
 	}
 
-	if ue.AuthFailureCauseSynchFailureTimes != 0 {
-		return fmt.Errorf("auth failure caush synch failure times was not 0: %d", ue.AuthFailureCauseSynchFailureTimes)
+	if ue.NasConn().AuthFailureCauseSynchFailureTimes != 0 {
+		return fmt.Errorf("auth failure caush synch failure times was not 0: %d", ue.NasConn().AuthFailureCauseSynchFailureTimes)
 	}
 
 	if ue.RanUe().UeContextRequest {
 		return fmt.Errorf("ranue context request should be false")
 	}
 
-	if ue.RanUe().RecvdInitialContextSetupResponse {
-		return fmt.Errorf("ranue recvd initial context setup response should be false")
-	}
-
-	if ue.RetransmissionOfInitialNASMsg {
+	if ue.NasConn().RetransmissionOfInitialNASMsg {
 		return fmt.Errorf("retransmission of initial NAS msg should be false")
 	}
 
-	if ue.Procedures.Active(procedure.Paging) {
+	if ue.NasConn().Procedures.Active(procedure.Paging) {
 		return fmt.Errorf("ongoing should be nothing")
 	}
 

--- a/internal/amf/nas/gmm/handle_registration_request.go
+++ b/internal/amf/nas/gmm/handle_registration_request.go
@@ -43,36 +43,38 @@ const (
 )
 
 // Handle cleartext IEs of Registration Request, which cleattext IEs defined in TS 24.501 4.4.6
-func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, registrationRequest *nasMessage.RegistrationRequest) error {
+func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, registrationRequest *nasMessage.RegistrationRequest, macFailed bool) error {
 	ranUe := ue.RanUe()
 	if ranUe == nil {
 		return fmt.Errorf("RanUe is nil")
 	}
 
-	// MacFailed is set if plain Registration Request message received with GUTI/SUCI or
-	// integrity protected Registration Reguest message received but mac verification Failed
-	if ue.MacFailed {
-		ue.SecurityContextAvailable = false
+	if macFailed {
+		ue.Current().SecurityContextAvailable = false
 	}
 
-	// Supersession: cancel any active N2 Handover before starting Registration.
-	if ue.Procedures.Active(procedure.N2Handover) {
-		_ = ue.Procedures.Cancel(ctx, procedure.N2Handover)
+	// Supersession of concurrent AMF-initiated procedures per TS 24.501.
+	// §5.4.2.7(c): abort SecurityMode when a UE-initiated registration
+	// arrives. §5.5.1.3.3, §5.5.1.2.7: abort N2 Handover similarly.
+	for _, t := range []procedure.Type{procedure.SecurityMode, procedure.N2Handover} {
+		if ue.NasConn().Procedures.Active(t) {
+			_ = ue.NasConn().Procedures.Cancel(ctx, t)
+		}
 	}
 
-	_, err := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.Registration})
+	_, err := ue.NasConn().Procedures.Begin(ue.NasConn().Ctx(), procedure.Procedure{Type: procedure.Registration})
 	if err != nil {
 		ue.Log.Warn("failed to begin registration procedure", zap.Error(err))
 	}
 
-	if ue.T3513 != nil {
-		ue.T3513.Stop()
-		ue.T3513 = nil // clear the timer
+	if ue.NasConn().T3513 != nil {
+		ue.NasConn().T3513.Stop()
+		ue.NasConn().T3513 = nil // clear the timer
 	}
 
-	if ue.T3565 != nil {
-		ue.T3565.Stop()
-		ue.T3565 = nil // clear the timer
+	if ue.NasConn().T3565 != nil {
+		ue.NasConn().T3565.Stop()
+		ue.NasConn().T3565 = nil // clear the timer
 	}
 
 	// TS 24.501 4.4.6: If NASMessageContainer is present, it contains a ciphered inner Registration Request
@@ -80,12 +82,12 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	// However, if MAC verification failed, we don't have valid security keys to decrypt the
 	// NASMessageContainer. In that case, skip it and proceed with the cleartext IEs only.
 	// The subsequent authentication procedure will re-establish the security context.
-	if registrationRequest.NASMessageContainer != nil && !ue.MacFailed {
+	if registrationRequest.NASMessageContainer != nil && !macFailed {
 		contents := registrationRequest.GetNASMessageContainerContents()
 
-		err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionUplink, contents)
+		err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionUplink, contents)
 		if err != nil {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
 
 			err1 := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 			if err1 != nil {
@@ -98,7 +100,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		m := nas.NewMessage()
 
 		if err := m.GmmMessageDecode(&contents); err != nil {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
 
 			err1 := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 			if err1 != nil {
@@ -115,21 +117,21 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 		registrationRequest = m.RegistrationRequest
 
-		ue.RetransmissionOfInitialNASMsg = ue.MacFailed
-	} else if registrationRequest.NASMessageContainer != nil && ue.MacFailed {
+		ue.NasConn().RetransmissionOfInitialNASMsg = macFailed
+	} else if registrationRequest.NASMessageContainer != nil && macFailed {
 		ue.Log.Info("Skipping NASMessageContainer decryption due to MAC verification failure, proceeding with cleartext IEs only")
-		ue.RetransmissionOfInitialNASMsg = true
+		ue.NasConn().RetransmissionOfInitialNASMsg = true
 	}
 
-	ue.RegistrationRequest = registrationRequest
-	ue.RegistrationType5GS = registrationRequest.GetRegistrationType5GS()
+	ue.NasConn().RegistrationRequest = registrationRequest
+	ue.NasConn().RegistrationType5GS = registrationRequest.GetRegistrationType5GS()
 
-	regName := getRegistrationType5GSName(ue.RegistrationType5GS)
+	regName := getRegistrationType5GSName(ue.NasConn().RegistrationType5GS)
 
 	ue.Log.Debug("Received Registration Request", zap.String("registrationType", regName))
 
-	if ue.RegistrationType5GS == nasMessage.RegistrationType5GSReserved {
-		ue.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+	if ue.NasConn().RegistrationType5GS == nasMessage.RegistrationType5GSReserved {
+		ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
 	}
 
 	mobileIdentity5GSContents := registrationRequest.GetMobileIdentity5GSContents()
@@ -142,8 +144,8 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		return fmt.Errorf("error getting operator info: %v", err)
 	}
 
-	ue.IdentityTypeUsedForRegistration = nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0])
-	switch ue.IdentityTypeUsedForRegistration { // get type of identity
+	ue.NasConn().IdentityTypeUsedForRegistration = nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0])
+	switch ue.NasConn().IdentityTypeUsedForRegistration { // get type of identity
 	case nasMessage.MobileIdentity5GSTypeNoIdentity:
 		ue.Log.Debug("No Identity used for registration")
 	case nasMessage.MobileIdentity5GSTypeSuci:
@@ -169,15 +171,15 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	// NgKsi: TS 24.501 9.11.3.32
 	switch registrationRequest.GetTSC() {
 	case nasMessage.TypeOfSecurityContextFlagNative:
-		ue.NgKsi.Tsc = models.ScTypeNative
+		ue.Current().NgKsi.Tsc = models.ScTypeNative
 	case nasMessage.TypeOfSecurityContextFlagMapped:
-		ue.NgKsi.Tsc = models.ScTypeMapped
+		ue.Current().NgKsi.Tsc = models.ScTypeMapped
 	}
 
-	ue.NgKsi.Ksi = nextNgKsi(int32(registrationRequest.NgksiAndRegistrationType5GS.GetNasKeySetIdentifiler()))
-	if ue.NgKsi.Tsc != models.ScTypeNative || ue.NgKsi.Ksi == 7 {
-		ue.NgKsi.Tsc = models.ScTypeNative
-		ue.NgKsi.Ksi = 0
+	ue.Current().NgKsi.Ksi = nextNgKsi(int32(registrationRequest.NgksiAndRegistrationType5GS.GetNasKeySetIdentifiler()))
+	if ue.Current().NgKsi.Tsc != models.ScTypeNative || ue.Current().NgKsi.Ksi == 7 {
+		ue.Current().NgKsi.Tsc = models.ScTypeNative
+		ue.Current().NgKsi.Ksi = 0
 	}
 
 	// Copy UserLocation from ranUe
@@ -186,7 +188,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 	// Check TAI
 	if !amf.InTaiList(ue.Tai, operatorInfo.Tais) {
-		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
+		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
 
 		err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMTrackingAreaNotAllowed)
 		if err != nil {
@@ -199,8 +201,8 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	// TS 24.501 §8.2.6.4: the UE shall include the UE security capability IE,
 	// unless it performs a periodic registration updating procedure.
 	if registrationRequest.UESecurityCapability == nil &&
-		ue.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
-		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
+		ue.NasConn().RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
+		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
 
 		err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
 		if err != nil {
@@ -227,7 +229,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 // the same audited write path, with downgrade protection deferred to
 // the SMC replay check.
 func acceptRegistrationUESecurityCapability(ue *amf.AmfUe, received *nasType.UESecurityCapability) {
-	switch ue.RegistrationType5GS {
+	switch ue.NasConn().RegistrationType5GS {
 	case nasMessage.RegistrationType5GSInitialRegistration,
 		nasMessage.RegistrationType5GSEmergencyRegistration:
 		ue.SetUESecurityCapability(received, amf.MintAuthProofForRegistrationRequest())
@@ -248,19 +250,19 @@ func acceptRegistrationUESecurityCapability(ue *amf.AmfUe, received *nasType.UES
 	case amf.VerifyMismatch:
 		ue.Log.Warn(
 			"UE security capabilities in Mobility/Periodic Registration differ from stored values; ignoring received values (TS 33.501 §6.7.3.1)",
-			zap.String("registrationType", getRegistrationType5GSName(ue.RegistrationType5GS)),
-			zap.Binary("stored", ue.UESecurityCapability.Buffer),
+			zap.String("registrationType", getRegistrationType5GSName(ue.NasConn().RegistrationType5GS)),
+			zap.Binary("stored", ue.Current().UESecurityCapability.Buffer),
 			zap.Binary("received", received.Buffer),
 		)
 	}
 }
 
-func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nas.GmmMessage) error {
+func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nas.GmmMessage, macFailed bool) error {
 	state := ue.GetState()
 
 	switch state {
 	case amf.Deregistered, amf.Registered, amf.Authentication:
-		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, msg.RegistrationRequest); err != nil {
+		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, msg.RegistrationRequest, macFailed); err != nil {
 			return fmt.Errorf("failed handling registration request: %v", err)
 		}
 
@@ -272,7 +274,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 			defer ue.Deregister(ctx)
 
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
 
 			ranUe := ue.RanUe()
 			if ranUe == nil {
@@ -292,16 +294,10 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 		}
 
 	case amf.SecurityMode:
-		ue.SecurityContextAvailable = false
-		if ue.T3560 != nil {
-			ue.T3560.Stop()
-			ue.T3560 = nil
-		}
-
-		ue.Procedures.End(procedure.SecurityMode)
 		ue.Deregister(ctx)
+		ue.RotateContext()
 
-		return HandleGmmMessage(ctx, amfInstance, ue, msg)
+		return HandleGmmMessage(ctx, amfInstance, ue, msg, macFailed)
 	case amf.ContextSetup:
 		defer ue.Deregister(ctx)
 

--- a/internal/amf/nas/gmm/handle_registration_request.go
+++ b/internal/amf/nas/gmm/handle_registration_request.go
@@ -49,6 +49,11 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		return fmt.Errorf("RanUe is nil")
 	}
 
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
+	}
+
 	if macFailed {
 		ue.Current().SecurityContextAvailable = false
 	}
@@ -57,24 +62,24 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	// §5.4.2.7(c): abort SecurityMode when a UE-initiated registration
 	// arrives. §5.5.1.3.3, §5.5.1.2.7: abort N2 Handover similarly.
 	for _, t := range []procedure.Type{procedure.SecurityMode, procedure.N2Handover} {
-		if ue.NasConn().Procedures.Active(t) {
-			_ = ue.NasConn().Procedures.Cancel(ctx, t)
+		if conn.Procedures.Active(t) {
+			_ = conn.Procedures.Cancel(ctx, t)
 		}
 	}
 
-	_, err := ue.NasConn().Procedures.Begin(ue.NasConn().Ctx(), procedure.Procedure{Type: procedure.Registration})
+	_, err := conn.Procedures.Begin(conn.Ctx(), procedure.Procedure{Type: procedure.Registration})
 	if err != nil {
 		ue.Log.Warn("failed to begin registration procedure", zap.Error(err))
 	}
 
-	if ue.NasConn().T3513 != nil {
-		ue.NasConn().T3513.Stop()
-		ue.NasConn().T3513 = nil // clear the timer
+	if conn.T3513 != nil {
+		conn.T3513.Stop()
+		conn.T3513 = nil
 	}
 
-	if ue.NasConn().T3565 != nil {
-		ue.NasConn().T3565.Stop()
-		ue.NasConn().T3565 = nil // clear the timer
+	if conn.T3565 != nil {
+		conn.T3565.Stop()
+		conn.T3565 = nil
 	}
 
 	// TS 24.501 4.4.6: If NASMessageContainer is present, it contains a ciphered inner Registration Request
@@ -87,7 +92,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 		err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionUplink, contents)
 		if err != nil {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationReject).Inc()
 
 			err1 := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 			if err1 != nil {
@@ -100,7 +105,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		m := nas.NewMessage()
 
 		if err := m.GmmMessageDecode(&contents); err != nil {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationReject).Inc()
 
 			err1 := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 			if err1 != nil {
@@ -117,21 +122,22 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 		registrationRequest = m.RegistrationRequest
 
-		ue.NasConn().RetransmissionOfInitialNASMsg = macFailed
+		conn.RetransmissionOfInitialNASMsg = macFailed
 	} else if registrationRequest.NASMessageContainer != nil && macFailed {
 		ue.Log.Info("Skipping NASMessageContainer decryption due to MAC verification failure, proceeding with cleartext IEs only")
-		ue.NasConn().RetransmissionOfInitialNASMsg = true
+
+		conn.RetransmissionOfInitialNASMsg = true
 	}
 
-	ue.NasConn().RegistrationRequest = registrationRequest
-	ue.NasConn().RegistrationType5GS = registrationRequest.GetRegistrationType5GS()
+	conn.RegistrationRequest = registrationRequest
+	conn.RegistrationType5GS = registrationRequest.GetRegistrationType5GS()
 
-	regName := getRegistrationType5GSName(ue.NasConn().RegistrationType5GS)
+	regName := getRegistrationType5GSName(conn.RegistrationType5GS)
 
 	ue.Log.Debug("Received Registration Request", zap.String("registrationType", regName))
 
-	if ue.NasConn().RegistrationType5GS == nasMessage.RegistrationType5GSReserved {
-		ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+	if conn.RegistrationType5GS == nasMessage.RegistrationType5GSReserved {
+		conn.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
 	}
 
 	mobileIdentity5GSContents := registrationRequest.GetMobileIdentity5GSContents()
@@ -144,8 +150,8 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		return fmt.Errorf("error getting operator info: %v", err)
 	}
 
-	ue.NasConn().IdentityTypeUsedForRegistration = nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0])
-	switch ue.NasConn().IdentityTypeUsedForRegistration { // get type of identity
+	conn.IdentityTypeUsedForRegistration = nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0])
+	switch conn.IdentityTypeUsedForRegistration { // get type of identity
 	case nasMessage.MobileIdentity5GSTypeNoIdentity:
 		ue.Log.Debug("No Identity used for registration")
 	case nasMessage.MobileIdentity5GSTypeSuci:
@@ -188,7 +194,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 	// Check TAI
 	if !amf.InTaiList(ue.Tai, operatorInfo.Tais) {
-		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
+		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationReject).Inc()
 
 		err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMTrackingAreaNotAllowed)
 		if err != nil {
@@ -201,8 +207,8 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	// TS 24.501 §8.2.6.4: the UE shall include the UE security capability IE,
 	// unless it performs a periodic registration updating procedure.
 	if registrationRequest.UESecurityCapability == nil &&
-		ue.NasConn().RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
-		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
+		conn.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
+		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationReject).Inc()
 
 		err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
 		if err != nil {
@@ -229,7 +235,12 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 // the same audited write path, with downgrade protection deferred to
 // the SMC replay check.
 func acceptRegistrationUESecurityCapability(ue *amf.AmfUe, received *nasType.UESecurityCapability) {
-	switch ue.NasConn().RegistrationType5GS {
+	conn := ue.NasConn()
+	if conn == nil {
+		return
+	}
+
+	switch conn.RegistrationType5GS {
 	case nasMessage.RegistrationType5GSInitialRegistration,
 		nasMessage.RegistrationType5GSEmergencyRegistration:
 		ue.SetUESecurityCapability(received, amf.MintAuthProofForRegistrationRequest())
@@ -250,7 +261,7 @@ func acceptRegistrationUESecurityCapability(ue *amf.AmfUe, received *nasType.UES
 	case amf.VerifyMismatch:
 		ue.Log.Warn(
 			"UE security capabilities in Mobility/Periodic Registration differ from stored values; ignoring received values (TS 33.501 §6.7.3.1)",
-			zap.String("registrationType", getRegistrationType5GSName(ue.NasConn().RegistrationType5GS)),
+			zap.String("registrationType", getRegistrationType5GSName(conn.RegistrationType5GS)),
 			zap.Binary("stored", ue.Current().UESecurityCapability.Buffer),
 			zap.Binary("received", received.Buffer),
 		)
@@ -274,7 +285,12 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 			defer ue.Deregister(ctx)
 
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
+			regType := uint8(0)
+			if conn := ue.NasConn(); conn != nil {
+				regType = conn.RegistrationType5GS
+			}
+
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(regType), RegistrationReject).Inc()
 
 			ranUe := ue.RanUe()
 			if ranUe == nil {
@@ -296,6 +312,10 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	case amf.SecurityMode:
 		ue.Deregister(ctx)
 		ue.RotateContext()
+
+		if ranUe := ue.RanUe(); ranUe != nil {
+			ue.AttachNasConnection(ranUe)
+		}
 
 		return HandleGmmMessage(ctx, amfInstance, ue, msg, macFailed)
 	case amf.ContextSetup:

--- a/internal/amf/nas/gmm/handle_registration_request_test.go
+++ b/internal/amf/nas/gmm/handle_registration_request_test.go
@@ -61,7 +61,7 @@ func TestHandleRegistrationRequest_NilRanUE(t *testing.T) {
 
 	ue := amf.NewAmfUe()
 
-	err = handleRegistrationRequest(ctx, &amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, &amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatalf("nil RanUe should error out")
 	}
@@ -88,7 +88,7 @@ func TestHandleRegistrationRequest_ErrorMissingIdentity(t *testing.T) {
 
 	expected := "mobile identity 5GS is empty"
 
-	err = handleRegistrationRequest(ctx, &amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, &amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatalf("registration request should be rejected")
 	}
@@ -122,7 +122,7 @@ func TestHandleRegistrationRequest_ErrorMissingOperatorInfo(t *testing.T) {
 
 	expected := "error getting operator info"
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatalf("registration request should be rejected")
 	}
@@ -168,7 +168,7 @@ func TestHandleRegistrationRequest_RejectTrackingAreaNotAllowed(t *testing.T) {
 
 	expected := "registration Reject [Tracking area not allowed]"
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatalf("registration request should be rejected")
 	}
@@ -225,7 +225,7 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability(t *testing.T)
 
 	expected := "registration request does not contain UE security capability"
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatalf("registration request should be rejected")
 	}
@@ -285,7 +285,7 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability_Mobility(t *t
 
 	expected := "registration request does not contain UE security capability"
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatalf("registration request should be rejected")
 	}
@@ -341,7 +341,7 @@ func TestHandleRegistrationRequest_PeriodicAllowsMissingSecurityCapability(t *te
 	m.SetRegistrationType5GS(nasMessage.RegistrationType5GSPeriodicRegistrationUpdating)
 	m.UESecurityCapability = nil
 
-	if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, m.RegistrationRequest); err != nil {
+	if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, m.RegistrationRequest, false); err != nil {
 		t.Fatalf("periodic registration without UE security capability should not be rejected here, got: %v", err)
 	}
 
@@ -380,24 +380,24 @@ func TestHandleRegistrationRequest_Timers_Stopped(t *testing.T) {
 		t.Fatalf("could not create UE and radio: %v", err)
 	}
 
-	ue.T3513 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
-	ue.T3565 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
+	ue.NasConn().T3513 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
+	ue.NasConn().T3565 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
 
 	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("timer T3513 should have been stopped")
 	}
 
-	if ue.T3565 != nil {
+	if ue.NasConn().T3565 != nil {
 		t.Fatalf("timer T3565 should have been stopped")
 	}
 }
@@ -425,7 +425,7 @@ func TestHandleRegistrationRequest_IdentityRequest_MissingSUCI_SUPI(t *testing.T
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
@@ -485,7 +485,7 @@ func TestHandleRegistrationRequest_AuthenticationRequest(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
@@ -542,16 +542,15 @@ func TestHandleRegistrationRequest_RegistrationAccepted(t *testing.T) {
 
 	ue.Suci = "testsuci"
 	ue.Supi = mustSUPIFromPrefixed("imsi-001019756139935")
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 
 	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
@@ -603,7 +602,7 @@ func TestHandleRegistrationRequest_UEStateContextSetup_ResetToDeregistered(t *te
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
@@ -651,7 +650,7 @@ func TestHandleRegistrationRequest_UEStateAuthentication_RestartsRegistration(t 
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request in state Authentication should restart, got: %v", err)
 	}
@@ -703,23 +702,22 @@ func TestHandleRegistrationRequest_SecurityMode_AuthenticationRequest(t *testing
 
 	ue.Suci = "testsuci"
 	ue.Supi = mustSUPIFromPrefixed("imsi-001019756139935")
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	ue.ForceState(amf.SecurityMode)
-	ue.T3560 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
+	ue.NasConn().T3560 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
 
 	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
 
-	if ue.T3560 != nil {
+	if ue.NasConn().T3560 != nil {
 		t.Fatalf("timer T3560 should be stopped")
 	}
 
@@ -775,23 +773,22 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationAccepted(t *testing.T
 
 	ue.Suci = "testsuci"
 	ue.Supi = supi
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
@@ -812,7 +809,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationAccepted(t *testing.T
 		t.Fatalf("expected a protected and ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -855,26 +852,25 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationRejectedWrongKey(t *t
 
 	ue.Suci = "testsuci"
 	ue.Supi = supi
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
 	key = [16]uint8{0x00, 0x00, 0x00, 0x00, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
-	ue.KnasEnc = key
+	ue.Current().KnasEnc = key
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatalf("registration request should be rejected, got: %v", err)
 	}
@@ -931,8 +927,7 @@ func TestHandleRegistrationRequest_CipheredNAS_MacFailed_SkipContainer(t *testin
 	ue.Suci = "testsuci"
 	ue.Supi = supi
 	// Simulate MAC verification failure (AMF has no valid security context)
-	ue.MacFailed = true
-	ue.SecurityContextAvailable = false
+	ue.Current().SecurityContextAvailable = false
 
 	// Build a registration request with a ciphered NASMessageContainer
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
@@ -943,7 +938,7 @@ func TestHandleRegistrationRequest_CipheredNAS_MacFailed_SkipContainer(t *testin
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, true)
 	if err != nil {
 		t.Fatalf("registration request with MAC failure should proceed with cleartext IEs, got: %v", err)
 	}
@@ -970,7 +965,7 @@ func TestHandleRegistrationRequest_CipheredNAS_MacFailed_SkipContainer(t *testin
 		t.Fatalf("expected an authentication request (re-auth after MAC failure), got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if !ue.RetransmissionOfInitialNASMsg {
+	if !ue.NasConn().RetransmissionOfInitialNASMsg {
 		t.Fatalf("RetransmissionOfInitialNASMsg should be set when MAC failed with NASMessageContainer")
 	}
 }
@@ -1008,13 +1003,13 @@ func TestHandleRegistrationRequest_NgKsi_Increment(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
 
-	if ue.NgKsi.Ksi != 4 {
-		t.Fatalf("expected ngKSI=4 (next after 3), got %d", ue.NgKsi.Ksi)
+	if ue.Current().NgKsi.Ksi != 4 {
+		t.Fatalf("expected ngKSI=4 (next after 3), got %d", ue.Current().NgKsi.Ksi)
 	}
 }
 
@@ -1051,13 +1046,13 @@ func TestHandleRegistrationRequest_NgKsi_WrapAt6(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
 
-	if ue.NgKsi.Ksi != 0 {
-		t.Fatalf("expected ngKSI=0 (wrapped from 6), got %d", ue.NgKsi.Ksi)
+	if ue.Current().NgKsi.Ksi != 0 {
+		t.Fatalf("expected ngKSI=0 (wrapped from 6), got %d", ue.Current().NgKsi.Ksi)
 	}
 }
 
@@ -1094,17 +1089,17 @@ func TestHandleRegistrationRequest_NgKsi_NoKeyAvailable(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	err = handleRegistrationRequest(ctx, amfInstance, ue, m)
+	err = handleRegistrationRequest(ctx, amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("registration request should be accepted, got: %v", err)
 	}
 
-	if ue.NgKsi.Ksi != 0 {
-		t.Fatalf("expected ngKSI=0 (reset from no-key-available=7), got %d", ue.NgKsi.Ksi)
+	if ue.Current().NgKsi.Ksi != 0 {
+		t.Fatalf("expected ngKSI=0 (reset from no-key-available=7), got %d", ue.Current().NgKsi.Ksi)
 	}
 
-	if ue.NgKsi.Tsc != models.ScTypeNative {
-		t.Fatalf("expected TSC=NATIVE, got %v", ue.NgKsi.Tsc)
+	if ue.Current().NgKsi.Tsc != models.ScTypeNative {
+		t.Fatalf("expected TSC=NATIVE, got %v", ue.Current().NgKsi.Tsc)
 	}
 }
 
@@ -1217,39 +1212,39 @@ func newUESecCaps(ea, ia uint8) *nasType.UESecurityCapability {
 
 func TestAcceptRegistrationUESecurityCapability_InitialOverwrites(t *testing.T) {
 	ue := amf.NewAmfUe()
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
-	ue.UESecurityCapability = newUESecCaps(0xE0, 0xE0) // EA1/2/3 + IA1/2/3
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+	ue.Current().UESecurityCapability = newUESecCaps(0xE0, 0xE0) // EA1/2/3 + IA1/2/3
 
 	incoming := newUESecCaps(0x80, 0x80) // only EA1 + IA1
 	acceptRegistrationUESecurityCapability(ue, incoming)
 
-	if ue.UESecurityCapability != incoming {
+	if ue.Current().UESecurityCapability != incoming {
 		t.Fatalf("Initial Registration must replace stored caps")
 	}
 }
 
 func TestAcceptRegistrationUESecurityCapability_EmergencyOverwrites(t *testing.T) {
 	ue := amf.NewAmfUe()
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSEmergencyRegistration
-	ue.UESecurityCapability = newUESecCaps(0xE0, 0xE0)
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSEmergencyRegistration
+	ue.Current().UESecurityCapability = newUESecCaps(0xE0, 0xE0)
 
 	incoming := newUESecCaps(0x00, 0x00)
 	acceptRegistrationUESecurityCapability(ue, incoming)
 
-	if ue.UESecurityCapability != incoming {
+	if ue.Current().UESecurityCapability != incoming {
 		t.Fatalf("Emergency Registration must replace stored caps")
 	}
 }
 
 func TestAcceptRegistrationUESecurityCapability_MobilityNoStored(t *testing.T) {
 	ue := amf.NewAmfUe()
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
-	ue.UESecurityCapability = nil
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
+	ue.Current().UESecurityCapability = nil
 
 	incoming := newUESecCaps(0xE0, 0xE0)
 	acceptRegistrationUESecurityCapability(ue, incoming)
 
-	if ue.UESecurityCapability != incoming {
+	if ue.Current().UESecurityCapability != incoming {
 		t.Fatalf("Mobility Update with no stored caps must adopt received caps")
 	}
 }
@@ -1262,18 +1257,18 @@ func TestAcceptRegistrationUESecurityCapability_MobilityRejectsDowngrade(t *test
 
 	ue := amf.NewAmfUe()
 	ue.Log = logger.AmfLog
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
-	ue.UESecurityCapability = stored
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
+	ue.Current().UESecurityCapability = stored
 
 	attacker := newUESecCaps(0x00, 0x00)
 	acceptRegistrationUESecurityCapability(ue, attacker)
 
-	if ue.UESecurityCapability != stored {
+	if ue.Current().UESecurityCapability != stored {
 		t.Fatalf("Mobility Update must NOT overwrite stored caps with forged downgrade (TS 33.501 §6.7.3.1)")
 	}
 
-	if !bytes.Equal(ue.UESecurityCapability.Buffer, []byte{0xE0, 0xE0}) {
-		t.Fatalf("stored caps corrupted: %#v", ue.UESecurityCapability.Buffer)
+	if !bytes.Equal(ue.Current().UESecurityCapability.Buffer, []byte{0xE0, 0xE0}) {
+		t.Fatalf("stored caps corrupted: %#v", ue.Current().UESecurityCapability.Buffer)
 	}
 }
 
@@ -1282,12 +1277,12 @@ func TestAcceptRegistrationUESecurityCapability_PeriodicRejectsDowngrade(t *test
 
 	ue := amf.NewAmfUe()
 	ue.Log = logger.AmfLog
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSPeriodicRegistrationUpdating
-	ue.UESecurityCapability = stored
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSPeriodicRegistrationUpdating
+	ue.Current().UESecurityCapability = stored
 
 	acceptRegistrationUESecurityCapability(ue, newUESecCaps(0x00, 0x00))
 
-	if ue.UESecurityCapability != stored {
+	if ue.Current().UESecurityCapability != stored {
 		t.Fatalf("Periodic Update must NOT overwrite stored caps with forged downgrade")
 	}
 }
@@ -1297,12 +1292,12 @@ func TestAcceptRegistrationUESecurityCapability_MobilityIdenticalCapsNoop(t *tes
 
 	ue := amf.NewAmfUe()
 	ue.Log = logger.AmfLog
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
-	ue.UESecurityCapability = stored
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
+	ue.Current().UESecurityCapability = stored
 
 	acceptRegistrationUESecurityCapability(ue, newUESecCaps(0xE0, 0xE0))
 
-	if ue.UESecurityCapability != stored {
+	if ue.Current().UESecurityCapability != stored {
 		t.Fatalf("Mobility Update with identical caps must be a no-op on the stored pointer")
 	}
 }

--- a/internal/amf/nas/gmm/handle_security_mode_complete.go
+++ b/internal/amf/nas/gmm/handle_security_mode_complete.go
@@ -21,12 +21,17 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 
-	if ue.NasConn().T3560 != nil {
-		ue.NasConn().T3560.Stop()
-		ue.NasConn().T3560 = nil // clear the timer
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
 	}
 
-	ue.NasConn().Procedures.End(procedure.SecurityMode)
+	if conn.T3560 != nil {
+		conn.T3560.Stop()
+		conn.T3560 = nil
+	}
+
+	conn.Procedures.End(procedure.SecurityMode)
 
 	if ue.SecurityContextIsValid() && !macFailed {
 		err := ue.UpdateSecurityContext()
@@ -55,5 +60,5 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return contextSetup(ctx, amfInstance, ue, m.RegistrationRequest)
 	}
 
-	return contextSetup(ctx, amfInstance, ue, ue.NasConn().RegistrationRequest)
+	return contextSetup(ctx, amfInstance, ue, conn.RegistrationRequest)
 }

--- a/internal/amf/nas/gmm/handle_security_mode_complete.go
+++ b/internal/amf/nas/gmm/handle_security_mode_complete.go
@@ -12,23 +12,23 @@ import (
 )
 
 // TS 33.501 6.7.2
-func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.SecurityModeComplete) error {
+func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.SecurityModeComplete, macFailed bool) error {
 	if state := ue.GetState(); state != amf.SecurityMode {
 		return fmt.Errorf("state mismatch: receive Security Mode Complete message in state %s", state)
 	}
 
-	if ue.MacFailed {
+	if macFailed {
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 
-	if ue.T3560 != nil {
-		ue.T3560.Stop()
-		ue.T3560 = nil // clear the timer
+	if ue.NasConn().T3560 != nil {
+		ue.NasConn().T3560.Stop()
+		ue.NasConn().T3560 = nil // clear the timer
 	}
 
-	ue.Procedures.End(procedure.SecurityMode)
+	ue.NasConn().Procedures.End(procedure.SecurityMode)
 
-	if ue.SecurityContextIsValid() {
+	if ue.SecurityContextIsValid() && !macFailed {
 		err := ue.UpdateSecurityContext()
 		if err != nil {
 			return fmt.Errorf("error updating security context: %v", err)
@@ -55,5 +55,5 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return contextSetup(ctx, amfInstance, ue, m.RegistrationRequest)
 	}
 
-	return contextSetup(ctx, amfInstance, ue, ue.RegistrationRequest)
+	return contextSetup(ctx, amfInstance, ue, ue.NasConn().RegistrationRequest)
 }

--- a/internal/amf/nas/gmm/handle_security_mode_complete_test.go
+++ b/internal/amf/nas/gmm/handle_security_mode_complete_test.go
@@ -38,6 +38,7 @@ func TestHandleSecurityMode_WrongUEMode(t *testing.T) {
 				amf.New(nil, nil, nil),
 				ue,
 				nil,
+				false,
 			)
 			if err == nil || err.Error() != expected.Error() {
 				t.Fatalf("expected error: %v, got: %v", expected, err)
@@ -51,13 +52,13 @@ func TestHandleSecurityMode_MacFailed(t *testing.T) {
 
 	ue := amf.NewAmfUe()
 	ue.ForceState(amf.SecurityMode)
-	ue.MacFailed = true
 
 	err := handleSecurityModeComplete(
 		t.Context(),
 		amf.New(nil, nil, nil),
 		ue,
 		nil,
+		true,
 	)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error: %v, got: %v", expected, err)
@@ -90,16 +91,16 @@ func TestHandleSecurityMode_TimerT3560Stopped(t *testing.T) {
 	}
 
 	ue.ForceState(amf.SecurityMode)
-	ue.T3560 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
+	ue.NasConn().T3560 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
 
 	msg := buildTestSecurityModeCompleteMessage()
 
-	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete)
+	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if ue.T3560 != nil {
+	if ue.NasConn().T3560 != nil {
 		t.Fatal("expected timer T3560 to be stopped and cleared")
 	}
 
@@ -134,7 +135,7 @@ func TestHandleSecurityMode_MsgIncludingIMEISV_UpdatesPEI(t *testing.T) {
 	}
 
 	ue.ForceState(amf.SecurityMode)
-	ue.T3560 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
+	ue.NasConn().T3560 = amf.NewTimer(10*time.Minute, 10, func(e int32) {}, func() {})
 
 	msg := buildTestSecurityModeCompleteMessage()
 	msg.IMEISV = &nasType.IMEISV{
@@ -142,7 +143,7 @@ func TestHandleSecurityMode_MsgIncludingIMEISV_UpdatesPEI(t *testing.T) {
 		Len:   9,
 	}
 
-	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete)
+	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -183,23 +184,22 @@ func TestHandleSecurityMode_ValidSecurityContext_UpdatesSecurityContext(t *testi
 	}
 
 	ue.ForceState(amf.SecurityMode)
-	ue.SecurityContextAvailable = true
-	ue.NgKsi = models.NgKsi{Ksi: 0}
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi = models.NgKsi{Ksi: 0}
 
-	ue.Kgnb = []uint8{}
-	ue.NH = []uint8{}
-	ue.NCC = 0
+	ue.Current().Kgnb = []uint8{}
+	ue.Current().NH = []uint8{}
+	ue.Current().NCC = 0
 
 	msg := buildTestSecurityModeCompleteMessage()
 
-	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete)
+	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if len(ue.Kgnb) == 0 || len(ue.NH) == 0 || ue.NCC == 0 {
-		t.Fatalf("expected security context to be updated, got: Kgnb: %v, NH: %v, NCC: %v", ue.Kgnb, ue.NH, ue.NCC)
+	if len(ue.Current().Kgnb) == 0 || len(ue.Current().NH) == 0 || ue.Current().NCC == 0 {
+		t.Fatalf("expected security context to be updated, got: Kgnb: %v, NH: %v, NCC: %v", ue.Current().Kgnb, ue.Current().NH, ue.Current().NCC)
 	}
 
 	if len(ngapSender.SentDownlinkNASTransport) != 0 {
@@ -233,26 +233,25 @@ func TestHandleSecurityMode_ValidSecurityContextWithBadAMFKey_UpdatesSecurityCon
 	}
 
 	ue.ForceState(amf.SecurityMode)
-	ue.SecurityContextAvailable = true
-	ue.NgKsi = models.NgKsi{Ksi: 0}
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi = models.NgKsi{Ksi: 0}
 
-	ue.Kgnb = []uint8{}
-	ue.NH = []uint8{}
-	ue.NCC = 0
-	ue.Kamf = "this is not hex"
+	ue.Current().Kgnb = []uint8{}
+	ue.Current().NH = []uint8{}
+	ue.Current().NCC = 0
+	ue.Current().Kamf = "this is not hex"
 
 	expected := "error updating security context"
 
 	msg := buildTestSecurityModeCompleteMessage()
 
-	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete)
+	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete, false)
 	if err == nil || !strings.HasPrefix(err.Error(), expected) {
 		t.Fatalf("expected error starting with: %v, got: %v", expected, err)
 	}
 
-	if len(ue.Kgnb) != 0 || len(ue.NH) != 0 || ue.NCC != 0 {
-		t.Fatalf("expected security context to be not be updated, got: Kgnb: %v, NH: %v, NCC: %v", ue.Kgnb, ue.NH, ue.NCC)
+	if len(ue.Current().Kgnb) != 0 || len(ue.Current().NH) != 0 || ue.Current().NCC != 0 {
+		t.Fatalf("expected security context to be not be updated, got: Kgnb: %v, NH: %v, NCC: %v", ue.Current().Kgnb, ue.Current().NH, ue.Current().NCC)
 	}
 
 	if len(ngapSender.SentDownlinkNASTransport) != 0 {
@@ -289,18 +288,18 @@ func TestHandleSecurityMode_NASMessageContainer_RegistrationAccepted(t *testing.
 	ue.Supi = mustSUPIFromPrefixed("imsi-001019756139935")
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
 
 	msg, err := buildTestSecurityModeCompleteMessageWithRegistrationRequest()
 	if err != nil {
 		t.Fatalf("could not build security mode complete message with registration request: %v", err)
 	}
 
-	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete)
+	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -356,11 +355,11 @@ func TestHandleSecurityMode_InvalidNASMessageContainer_Error(t *testing.T) {
 	ue.Supi = mustSUPIFromPrefixed("imsi-001019756139935")
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSInitialRegistration
 
 	msg, err := buildTestSecurityModeCompleteMessageWithRegistrationRequest()
 	if err != nil {
@@ -371,7 +370,7 @@ func TestHandleSecurityMode_InvalidNASMessageContainer_Error(t *testing.T) {
 
 	expected := "failed to decode nas message container"
 
-	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete)
+	err = handleSecurityModeComplete(t.Context(), amfInstance, ue, msg.SecurityModeComplete, false)
 	if err == nil || !strings.HasPrefix(err.Error(), expected) {
 		t.Fatalf("expected an error starting with: %v, got: %v", expected, err)
 	}

--- a/internal/amf/nas/gmm/handle_security_mode_reject.go
+++ b/internal/amf/nas/gmm/handle_security_mode_reject.go
@@ -18,16 +18,16 @@ func handleSecurityModeReject(ctx context.Context, ue *amf.AmfUe, msg *nasMessag
 
 	defer ue.Deregister(ctx)
 
-	if ue.T3560 != nil {
-		ue.T3560.Stop()
-		ue.T3560 = nil // clear the timer
+	if ue.NasConn().T3560 != nil {
+		ue.NasConn().T3560.Stop()
+		ue.NasConn().T3560 = nil // clear the timer
 	}
 
-	ue.Procedures.End(procedure.SecurityMode)
+	ue.NasConn().Procedures.End(procedure.SecurityMode)
 
 	ue.Log.Error("UE rejected the security mode command, abort the ongoing procedure", logger.Cause(nasMessage.Cause5GMMToString(msg.GetCauseValue())), logger.SUPI(ue.Supi.String()))
 
-	ue.SecurityContextAvailable = false
+	ue.Current().SecurityContextAvailable = false
 
 	ranUe := ue.RanUe()
 	if ranUe == nil {

--- a/internal/amf/nas/gmm/handle_security_mode_reject.go
+++ b/internal/amf/nas/gmm/handle_security_mode_reject.go
@@ -18,12 +18,14 @@ func handleSecurityModeReject(ctx context.Context, ue *amf.AmfUe, msg *nasMessag
 
 	defer ue.Deregister(ctx)
 
-	if ue.NasConn().T3560 != nil {
-		ue.NasConn().T3560.Stop()
-		ue.NasConn().T3560 = nil // clear the timer
-	}
+	if conn := ue.NasConn(); conn != nil {
+		if conn.T3560 != nil {
+			conn.T3560.Stop()
+			conn.T3560 = nil
+		}
 
-	ue.NasConn().Procedures.End(procedure.SecurityMode)
+		conn.Procedures.End(procedure.SecurityMode)
+	}
 
 	ue.Log.Error("UE rejected the security mode command, abort the ongoing procedure", logger.Cause(nasMessage.Cause5GMMToString(msg.GetCauseValue())), logger.SUPI(ue.Supi.String()))
 

--- a/internal/amf/nas/gmm/handle_security_mode_reject_test.go
+++ b/internal/amf/nas/gmm/handle_security_mode_reject_test.go
@@ -34,10 +34,11 @@ func TestHandleSecurityModeReject_T3560Stopped_UEContextReleased(t *testing.T) {
 		t.Fatalf("could not build test UE and radio: %v", err)
 	}
 
-	ue.SecurityContextAvailable = true
+	ue.Current().SecurityContextAvailable = true
 	ue.RanUe().ReleaseAction = amf.UeContextN2NormalRelease
 	ue.ForceState(amf.SecurityMode)
-	ue.T3560 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	conn := ue.NasConn()
+	conn.T3560 = amf.NewTimer(5*time.Minute, 5, func(expireTimes int32) {}, func() {})
 
 	m := buildTestSecurityModeReject()
 
@@ -46,7 +47,7 @@ func TestHandleSecurityModeReject_T3560Stopped_UEContextReleased(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if ue.T3560 != nil {
+	if conn.T3560 != nil {
 		t.Fatal("expected timer T3560 to be stopped and cleared")
 	}
 
@@ -54,7 +55,7 @@ func TestHandleSecurityModeReject_T3560Stopped_UEContextReleased(t *testing.T) {
 		t.Fatalf("expected UE to be deregistered but was: %v", ue.GetState())
 	}
 
-	if ue.SecurityContextAvailable {
+	if ue.Current().SecurityContextAvailable {
 		t.Fatal("expected UE security context available to be reset to false")
 	}
 

--- a/internal/amf/nas/gmm/handle_service_request.go
+++ b/internal/amf/nas/gmm/handle_service_request.go
@@ -143,19 +143,23 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		return nil
 	}
 
-	if ue.NasConn().T3513 != nil {
-		ue.NasConn().T3513.Stop()
-		ue.NasConn().T3513 = nil // clear the timer
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
 	}
 
-	if ue.NasConn().T3565 != nil {
-		ue.NasConn().T3565.Stop()
-		ue.NasConn().T3565 = nil // clear the timer
+	if conn.T3513 != nil {
+		conn.T3513.Stop()
+		conn.T3513 = nil
 	}
 
-	// Set No ongoing
-	if ue.NasConn().Procedures.Active(procedure.Paging) {
-		ue.NasConn().Procedures.End(procedure.Paging)
+	if conn.T3565 != nil {
+		conn.T3565.Stop()
+		conn.T3565 = nil
+	}
+
+	if conn.Procedures.Active(procedure.Paging) {
+		conn.Procedures.End(procedure.Paging)
 	}
 
 	// TS 24.501 8.2.6.21: if the UE is sending a REGISTRATION REQUEST message as an initial NAS message,
@@ -187,7 +191,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 			msg = m.ServiceRequest
 		}
 		// TS 33.501 6.4.6 step 3: if the initial NAS message was protected but did not pass the integrity check
-		ue.NasConn().RetransmissionOfInitialNASMsg = macFailed
+		conn.RetransmissionOfInitialNASMsg = macFailed
 	}
 
 	// Service Reject if the SecurityContext is invalid
@@ -240,9 +244,9 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		return err
 	}
 
-	if ue.NasConn().N1N2Message != nil {
-		requestData := ue.NasConn().N1N2Message
-		if ue.NasConn().N1N2Message.BinaryDataN2Information != nil {
+	if conn.N1N2Message != nil {
+		requestData := conn.N1N2Message
+		if conn.N1N2Message.BinaryDataN2Information != nil {
 			targetPduSessionID = requestData.PduSessionID
 		}
 	}
@@ -311,10 +315,10 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 	case nasMessage.ServiceTypeMobileTerminatedServices: // Triggered by Network
 		// TS 24.501 5.4.4.1 - We need to assign a new GUTI after a successful Service Request
 		// triggered by a paging request.
-		if ue.NasConn().N1N2Message != nil {
-			requestData := ue.NasConn().N1N2Message
-			n1Msg := ue.NasConn().N1N2Message.BinaryDataN1Message
-			n2Info := ue.NasConn().N1N2Message.BinaryDataN2Information
+		if conn.N1N2Message != nil {
+			requestData := conn.N1N2Message
+			n1Msg := conn.N1N2Message.BinaryDataN1Message
+			n2Info := conn.N1N2Message.BinaryDataN2Information
 
 			// Paging was triggered for downlink signaling only
 			if n2Info == nil && n1Msg != nil {
@@ -330,11 +334,11 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 
 				ue.Log.Info("sent downlink nas transport message")
 
-				ue.NasConn().N1N2Message = nil
+				conn.N1N2Message = nil
 			} else {
 				_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
 				if !exist {
-					ue.NasConn().N1N2Message = nil
+					conn.N1N2Message = nil
 					return fmt.Errorf("service Request triggered by Network for pduSessionID that does not exist")
 				}
 
@@ -389,7 +393,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		ue.Log.Info("", zap.Any("errPduSessionID", errPduSessionID), zap.Any("errCause", errCause))
 	}
 
-	ue.NasConn().N1N2Message = nil
+	conn.N1N2Message = nil
 
 	return nil
 }

--- a/internal/amf/nas/gmm/handle_service_request.go
+++ b/internal/amf/nas/gmm/handle_service_request.go
@@ -61,18 +61,18 @@ func sendServiceAccept(
 			return fmt.Errorf("error building service accept message: %v", err)
 		}
 
-		ranUe.SentInitialContextSetupRequest = true
+		ranUe.ICS = amf.ICSPending
 
 		err = ranUe.SendInitialContextSetupRequest(
 			ctx,
-			ue.Ambr.Uplink,
-			ue.Ambr.Downlink,
-			ue.AllowedNssai,
-			ue.Kgnb,
+			ue.Current().Ambr.Uplink,
+			ue.Current().Ambr.Downlink,
+			ue.Current().AllowedNssai,
+			ue.Current().Kgnb,
 			ue.PlmnID,
-			ue.UeRadioCapability,
-			ue.UeRadioCapabilityForPaging,
-			ue.UESecurityCapability,
+			ue.Current().UeRadioCapability,
+			ue.Current().UeRadioCapabilityForPaging,
+			ue.Current().UESecurityCapability,
 			nasPdu,
 			&ctxList,
 			supportedGUAMI,
@@ -90,8 +90,8 @@ func sendServiceAccept(
 
 		err = ranUe.SendPDUSessionResourceSetupRequest(
 			ctx,
-			ue.Ambr.Uplink,
-			ue.Ambr.Downlink,
+			ue.Current().Ambr.Uplink,
+			ue.Current().Ambr.Downlink,
 			nasPdu,
 			suList,
 		)
@@ -113,7 +113,7 @@ func sendServiceAccept(
 }
 
 // TS 24501 5.6.1
-func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.ServiceRequest) error {
+func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.ServiceRequest, macFailed bool) error {
 	// Validate state before accessing RanUe — state checks are cheap and
 	// independent of the RAN connection.
 	state := ue.GetState()
@@ -143,35 +143,35 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		return nil
 	}
 
-	if ue.T3513 != nil {
-		ue.T3513.Stop()
-		ue.T3513 = nil // clear the timer
+	if ue.NasConn().T3513 != nil {
+		ue.NasConn().T3513.Stop()
+		ue.NasConn().T3513 = nil // clear the timer
 	}
 
-	if ue.T3565 != nil {
-		ue.T3565.Stop()
-		ue.T3565 = nil // clear the timer
+	if ue.NasConn().T3565 != nil {
+		ue.NasConn().T3565.Stop()
+		ue.NasConn().T3565 = nil // clear the timer
 	}
 
 	// Set No ongoing
-	if ue.Procedures.Active(procedure.Paging) {
-		ue.Procedures.End(procedure.Paging)
+	if ue.NasConn().Procedures.Active(procedure.Paging) {
+		ue.NasConn().Procedures.End(procedure.Paging)
 	}
 
 	// TS 24.501 8.2.6.21: if the UE is sending a REGISTRATION REQUEST message as an initial NAS message,
 	// the UE has a valid 5G NAS security context and the UE needs to send non-cleartext IEs
 	// TS 24.501 4.4.6: When the UE sends a REGISTRATION REQUEST or SERVICE REQUEST message that includes a NAS message
 	// container IE, the UE shall set the security header type of the initial NAS message to "integrity protected"
-	if msg.NASMessageContainer != nil && ue.SecurityContextIsValid() {
+	if msg.NASMessageContainer != nil && (ue.SecurityContextIsValid() && !macFailed) {
 		contents := msg.GetNASMessageContainerContents()
 
 		// TS 24.501 4.4.6: When the UE sends a REGISTRATION REQUEST or SERVICE REQUEST message that includes a NAS
 		// message container IE, the UE shall set the security header type of the initial NAS message to
 		// "integrity protected"; then the AMF shall decipher the value part of the NAS message container IE
-		err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP,
+		err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP,
 			security.DirectionUplink, contents)
 		if err != nil {
-			ue.SecurityContextAvailable = false
+			ue.Current().SecurityContextAvailable = false
 		} else {
 			m := nas.NewMessage()
 			if err := m.GmmMessageDecode(&contents); err != nil {
@@ -187,13 +187,13 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 			msg = m.ServiceRequest
 		}
 		// TS 33.501 6.4.6 step 3: if the initial NAS message was protected but did not pass the integrity check
-		ue.RetransmissionOfInitialNASMsg = ue.MacFailed
+		ue.NasConn().RetransmissionOfInitialNASMsg = macFailed
 	}
 
 	// Service Reject if the SecurityContext is invalid
-	if !ue.SecurityContextIsValid() {
+	if !ue.SecurityContextIsValid() || macFailed {
 		ue.Log.Warn("No security context", logger.SUPI(ue.Supi.String()))
-		ue.SecurityContextAvailable = false
+		ue.Current().SecurityContextAvailable = false
 
 		err := message.SendServiceReject(ctx, ranUe, nasMessage.Cause5GMMUEIdentityCannotBeDerivedByTheNetwork)
 		if err != nil {
@@ -240,9 +240,9 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		return err
 	}
 
-	if ue.N1N2Message != nil {
-		requestData := ue.N1N2Message
-		if ue.N1N2Message.BinaryDataN2Information != nil {
+	if ue.NasConn().N1N2Message != nil {
+		requestData := ue.NasConn().N1N2Message
+		if ue.NasConn().N1N2Message.BinaryDataN2Information != nil {
 			targetPduSessionID = requestData.PduSessionID
 		}
 	}
@@ -250,8 +250,8 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 	// Copy SmContextList under lock for safe concurrent iteration.
 	ue.Mutex.Lock()
 
-	smContextSnapshot := make(map[uint8]*amf.SmContext, len(ue.SmContextList))
-	for id, sc := range ue.SmContextList {
+	smContextSnapshot := make(map[uint8]*amf.SmContext, len(ue.Current().SmContextList))
+	for id, sc := range ue.Current().SmContextList {
 		smContextSnapshot[id] = sc
 	}
 	ue.Mutex.Unlock()
@@ -311,10 +311,10 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 	case nasMessage.ServiceTypeMobileTerminatedServices: // Triggered by Network
 		// TS 24.501 5.4.4.1 - We need to assign a new GUTI after a successful Service Request
 		// triggered by a paging request.
-		if ue.N1N2Message != nil {
-			requestData := ue.N1N2Message
-			n1Msg := ue.N1N2Message.BinaryDataN1Message
-			n2Info := ue.N1N2Message.BinaryDataN2Information
+		if ue.NasConn().N1N2Message != nil {
+			requestData := ue.NasConn().N1N2Message
+			n1Msg := ue.NasConn().N1N2Message.BinaryDataN1Message
+			n2Info := ue.NasConn().N1N2Message.BinaryDataN2Information
 
 			// Paging was triggered for downlink signaling only
 			if n2Info == nil && n1Msg != nil {
@@ -330,11 +330,11 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 
 				ue.Log.Info("sent downlink nas transport message")
 
-				ue.N1N2Message = nil
+				ue.NasConn().N1N2Message = nil
 			} else {
 				_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
 				if !exist {
-					ue.N1N2Message = nil
+					ue.NasConn().N1N2Message = nil
 					return fmt.Errorf("service Request triggered by Network for pduSessionID that does not exist")
 				}
 
@@ -389,7 +389,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 		ue.Log.Info("", zap.Any("errPduSessionID", errPduSessionID), zap.Any("errCause", errCause))
 	}
 
-	ue.N1N2Message = nil
+	ue.NasConn().N1N2Message = nil
 
 	return nil
 }

--- a/internal/amf/nas/gmm/handle_service_request_test.go
+++ b/internal/amf/nas/gmm/handle_service_request_test.go
@@ -54,7 +54,7 @@ func TestHandleServiceRequest_WrongStateError(t *testing.T) {
 			ue := amf.NewAmfUe()
 			ue.ForceState(tc)
 
-			err := handleServiceRequest(t.Context(), amf.New(nil, nil, nil), ue, nil)
+			err := handleServiceRequest(t.Context(), amf.New(nil, nil, nil), ue, nil, false)
 			if err == nil || err.Error() != expected {
 				t.Fatalf("expected error: %s, got: %v", expected, err)
 			}
@@ -88,11 +88,11 @@ func TestHandleServiceRequest_InvalidSecurityContext_ServiceReject(t *testing.T)
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.SecurityContextAvailable = false
+	ue.Current().SecurityContextAvailable = false
 
 	m := buildTestServiceRequest()
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -145,12 +145,11 @@ func TestHandleServiceRequest_MacFailed_ServiceReject(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.SecurityContextAvailable = true
-	ue.MacFailed = true
+	ue.Current().SecurityContextAvailable = true
 
 	m := buildTestServiceRequest()
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, true)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -176,7 +175,7 @@ func TestHandleServiceRequest_MacFailed_ServiceReject(t *testing.T) {
 		t.Fatalf("expected a service reject essage, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.SecurityContextAvailable {
+	if ue.Current().SecurityContextAvailable {
 		t.Fatalf("expected security context to change to not available")
 	}
 }
@@ -208,23 +207,23 @@ func TestHandleServiceRequest_NASContainer_DecryptFailure_ServiceReject(t *testi
 
 	ue.ForceState(amf.Registered)
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeSignalling)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeSignalling)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	ue.CipheringAlg = 200
+	ue.Current().CipheringAlg = 200
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -283,12 +282,12 @@ func TestHandleServiceRequest_UnknownUE_NASMessage_ServiceReject(t *testing.T) {
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -341,17 +340,16 @@ func TestHandleServiceRequest_ServiceTypeSignaling_ServiceAccept(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.SecurityContextAvailable = true
-	ue.MacFailed = false
+	ue.Current().SecurityContextAvailable = true
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
 	m := buildTestServiceRequest()
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -377,11 +375,11 @@ func TestHandleServiceRequest_ServiceTypeSignaling_ServiceAccept(t *testing.T) {
 		t.Fatalf("expected a service accept message, got '%v'", decoded.Message.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
-	if ue.Procedures.Active(procedure.Paging) {
+	if ue.NasConn().Procedures.Active(procedure.Paging) {
 		t.Fatalf("expected paging procedure to be completed")
 	}
 }
@@ -411,24 +409,24 @@ func TestHandleServiceRequest_NASContainerServiceTypeSignaling_ServiceAccept(t *
 		t.Fatalf("could not build UE and radio: %v", err)
 	}
 
-	ue.T3565 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	ue.NasConn().T3565 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
 	ue.ForceState(amf.Registered)
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeSignalling)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeSignalling)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -449,7 +447,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeSignaling_ServiceAccept(t *
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -462,7 +460,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeSignaling_ServiceAccept(t *
 		t.Fatalf("expected a service accept message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3565 != nil {
+	if ue.NasConn().T3565 != nil {
 		t.Fatalf("expected timer T3565 to be stopped and cleared")
 	}
 }
@@ -492,24 +490,24 @@ func TestHandleServiceRequest_NASContainerServiceTypeData_ServiceAccept(t *testi
 		t.Fatalf("could not build UE and radio: %v", err)
 	}
 
-	ue.T3565 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	ue.NasConn().T3565 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
 	ue.ForceState(amf.Registered)
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -530,7 +528,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeData_ServiceAccept(t *testi
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -543,7 +541,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeData_ServiceAccept(t *testi
 		t.Fatalf("expected a service accept message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3565 != nil {
+	if ue.NasConn().T3565 != nil {
 		t.Fatalf("expected timer T3565 to be stopped and cleared")
 	}
 }
@@ -575,8 +573,8 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -584,21 +582,21 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -619,7 +617,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -632,7 +630,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 		t.Fatalf("expected a service accept message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
@@ -670,8 +668,8 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_NoPDUSession
 		t.Fatalf("could not build UE and radio: %v", err)
 	}
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -679,24 +677,24 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_NoPDUSession
 	ue.ForceState(amf.Registered)
 	ue.Guti = mustTestGuti("001", "01", "cafe42", 0x00000001)
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1}
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
 	expected := "service Request triggered by Network for pduSessionID that does not exist"
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error: %s, got: %v", expected, err)
 	}
@@ -736,8 +734,8 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -745,24 +743,24 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
 	_ = ue.CreateSmContext(1, "testref", &snssai)
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai}
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -783,7 +781,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -812,7 +810,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -825,11 +823,11 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 		t.Fatalf("expected a configuration update command message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
-	if ue.T3555 == nil {
+	if ue.NasConn().T3555 == nil {
 		t.Fatalf("expected timer T3555 to be started")
 	}
 
@@ -871,8 +869,8 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -880,25 +878,25 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA1
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
 	_ = ue.CreateSmContext(1, "testref", &snssai)
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai)
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}}
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -919,7 +917,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -952,7 +950,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -965,11 +963,11 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a configuration update command message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
-	if ue.T3555 == nil {
+	if ue.NasConn().T3555 == nil {
 		t.Fatalf("expected timer T3555 to be started")
 	}
 
@@ -1011,8 +1009,8 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1020,25 +1018,25 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
 	_ = ue.CreateSmContext(1, "testref", &snssai)
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai)
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}}
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -1059,7 +1057,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1100,7 +1098,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1113,11 +1111,11 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a configuration update command message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
-	if ue.T3555 == nil {
+	if ue.NasConn().T3555 == nil {
 		t.Fatalf("expected timer T3555 to be started")
 	}
 
@@ -1159,8 +1157,8 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1168,26 +1166,26 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
 	_ = ue.CreateSmContext(1, "testref", &snssai)
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai)
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}}
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}}
 	ue.RanUe().UeContextRequest = true
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -1208,7 +1206,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1237,7 +1235,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1250,11 +1248,11 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 		t.Fatalf("expected a configuration update command message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
-	if ue.T3555 == nil {
+	if ue.NasConn().T3555 == nil {
 		t.Fatalf("expected timer T3555 to be started")
 	}
 
@@ -1296,8 +1294,8 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
-	ue.T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
-	if _, err := ue.Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	ue.NasConn().T3513 = amf.NewTimer(6*time.Minute, 5, func(expireTimes int32) {}, func() {})
+	if _, err := ue.NasConn().Procedures.Begin(t.Context(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1305,15 +1303,15 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 	ue.ForceState(amf.Registered)
 	ue.Guti = oldguti
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
-	ue.Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().Ambr = &models.Ambr{Uplink: "100mbps", Downlink: "100mbps"}
 	_ = ue.CreateSmContext(1, "testref", &snssai)
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai)
 
@@ -1322,19 +1320,19 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("could not build N1 message: %v", err)
 	}
 
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{
 		PduSessionID: 1,
 		SNssai:       &snssai,
 		// BinaryDataN2Information: []byte{},
 		BinaryDataN1Message: n1msg,
 	}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Fatalf("expected no errors, got: %v", err)
 	}
@@ -1355,7 +1353,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1384,7 +1382,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1417,7 +1415,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get()+2, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get()+2, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1430,11 +1428,11 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("expected a configuration update command message, got '%v'", nm.GmmHeader.GetMessageType())
 	}
 
-	if ue.T3513 != nil {
+	if ue.NasConn().T3513 != nil {
 		t.Fatalf("expected timer T3513 to be stopped and cleared")
 	}
 
-	if ue.T3555 == nil {
+	if ue.NasConn().T3555 == nil {
 		t.Fatalf("expected timer T3555 to be started")
 	}
 
@@ -1480,27 +1478,27 @@ func TestHandleServiceRequest_OutOfRangePduSessionID_UplinkDataStatus(t *testing
 
 	ue.ForceState(amf.Registered)
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
 	// Inject an out-of-range PDU session ID (255) directly into SmContextList,
 	// bypassing CreateSmContext validation. This simulates a malicious UE that
 	// somehow stored an invalid session ID (e.g., via a hypothetical future bug).
 	// The read-side bounds checks in handleServiceRequest must still prevent a panic.
-	ue.SmContextList[255] = &amf.SmContext{Ref: "malicious-ref", Snssai: &snssai}
+	ue.Current().SmContextList[255] = &amf.SmContext{Ref: "malicious-ref", Snssai: &snssai}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Logf("handleServiceRequest returned error (acceptable): %v", err)
 	}
@@ -1538,20 +1536,20 @@ func TestHandleServiceRequest_OutOfRangePduSessionID_PDUSessionStatus(t *testing
 
 	ue.ForceState(amf.Registered)
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
 	// Inject an out-of-range PDU session ID (200) directly into SmContextList,
 	// bypassing CreateSmContext validation to test the read-side safety net.
-	ue.SmContextList[200] = &amf.SmContext{Ref: "malicious-ref", Snssai: &snssai}
+	ue.Current().SmContextList[200] = &amf.SmContext{Ref: "malicious-ref", Snssai: &snssai}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount.Get(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.Current().ULCount.Get(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -1560,7 +1558,7 @@ func TestHandleServiceRequest_OutOfRangePduSessionID_PDUSessionStatus(t *testing
 	// buildTestServiceRequestCiphered). The panic occurs when iterating SmContextList
 	// and indexing into the [16]bool psiArray with pduSessionID >= 16.
 
-	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest)
+	err = handleServiceRequest(t.Context(), amfInstance, ue, m.ServiceRequest, false)
 	if err != nil {
 		t.Logf("handleServiceRequest returned error (acceptable): %v", err)
 	}

--- a/internal/amf/nas/gmm/handle_status_5gmm.go
+++ b/internal/amf/nas/gmm/handle_status_5gmm.go
@@ -8,12 +8,12 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 )
 
-func handleStatus5GMM(ue *amf.AmfUe, msg *nasMessage.Status5GMM) error {
+func handleStatus5GMM(ue *amf.AmfUe, msg *nasMessage.Status5GMM, macFailed bool) error {
 	if ue.GetState() == amf.Deregistered {
 		return fmt.Errorf("UE is in Deregistered state, ignore Status 5GMM message")
 	}
 
-	if ue.MacFailed {
+	if macFailed {
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 

--- a/internal/amf/nas/gmm/handle_status_5gmm_test.go
+++ b/internal/amf/nas/gmm/handle_status_5gmm_test.go
@@ -21,7 +21,7 @@ func TestHandleStatus5GMM_UEDeregistered_Error(t *testing.T) {
 
 	expected := "UE is in Deregistered state, ignore Status 5GMM message"
 
-	err = handleStatus5GMM(ue, m.Status5GMM)
+	err = handleStatus5GMM(ue, m.Status5GMM, false)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error: %s, got: %v", expected, err)
 	}
@@ -34,13 +34,12 @@ func TestHandleStatus5GMM_MacFailed_Error(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.MacFailed = true
 
 	m := buildTestStatus5gmm()
 
 	expected := "NAS message integrity check failed"
 
-	err = handleStatus5GMM(ue, m.Status5GMM)
+	err = handleStatus5GMM(ue, m.Status5GMM, true)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error: %s, got: %v", expected, err)
 	}
@@ -56,7 +55,7 @@ func TestHandleStatus5GMM_NoErrror(t *testing.T) {
 
 	m := buildTestStatus5gmm()
 
-	err = handleStatus5GMM(ue, m.Status5GMM)
+	err = handleStatus5GMM(ue, m.Status5GMM, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}

--- a/internal/amf/nas/gmm/handle_ul_nas_transport.go
+++ b/internal/amf/nas/gmm/handle_ul_nas_transport.go
@@ -217,13 +217,13 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 			if ulNasTransport.SNSSAI != nil {
 				snssai = util.SnssaiToModels(ulNasTransport.SNSSAI)
 			} else {
-				if len(ue.AllowedNssai) == 0 {
+				if len(ue.Current().AllowedNssai) == 0 {
 					return fmt.Errorf("allowed nssai is empty in UE context")
 				}
 
 				// Default to the first allowed slice when the UE omits S-NSSAI.
 				// The ordering follows the policy iteration order for the subscriber's profile.
-				snssai = &ue.AllowedNssai[0]
+				snssai = &ue.Current().AllowedNssai[0]
 			}
 
 			if ulNasTransport.DNN != nil && ulNasTransport.DNN.GetLen() > 0 {
@@ -241,7 +241,24 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 
 			smContextRef, errResponse, err := amfInstance.Smf.CreateSmContext(ctx, ue.Supi, pduSessionID, dnn, snssai, smMessage)
 			if err != nil {
-				ue.Log.Error("couldn't send create sm context request", zap.Error(err), zap.Uint8("pduSessionID", pduSessionID))
+				ue.Log.Error("couldn't create sm context", zap.Error(err), zap.Uint8("pduSessionID", pduSessionID))
+
+				if errResponse != nil {
+					if sendErr := message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, errResponse, pduSessionID, 0); sendErr != nil {
+						return fmt.Errorf("error sending downlink nas transport: %s", sendErr)
+					}
+
+					return fmt.Errorf("pdu session establishment request was rejected by SMF for pdu session id %d: %w", pduSessionID, err)
+				}
+
+				// TS 24.501 §5.4.5.3: SMF could not produce an SM reject;
+				// AMF informs the UE the payload was not forwarded by echoing
+				// it back with the 5GMM cause set.
+				if sendErr := message.SendDLNASTransport(ctx, ranUe, nasMessage.PayloadContainerTypeN1SMInfo, smMessage, pduSessionID, nasMessage.Cause5GMMPayloadWasNotForwarded); sendErr != nil {
+					return fmt.Errorf("error sending downlink nas transport fallback: %s", sendErr)
+				}
+
+				return fmt.Errorf("create sm context failed for pdu session id %d: %w", pduSessionID, err)
 			}
 
 			if errResponse != nil {
@@ -275,12 +292,12 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.Amf
 	return nil
 }
 
-func handleULNASTransport(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.ULNASTransport) error {
+func handleULNASTransport(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nasMessage.ULNASTransport, macFailed bool) error {
 	if ue.GetState() != amf.Registered {
 		return fmt.Errorf("expected UE to be in state %s during UL NAS Transport, instead it was %s", amf.Registered, ue.GetState())
 	}
 
-	if ue.MacFailed {
+	if macFailed {
 		return fmt.Errorf("NAS message integrity check failed")
 	}
 

--- a/internal/amf/nas/gmm/handle_ul_nas_transport_test.go
+++ b/internal/amf/nas/gmm/handle_ul_nas_transport_test.go
@@ -64,7 +64,7 @@ func TestHandleULNASTransport_WrongState_Error(t *testing.T) {
 
 			msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeN1SMInfo, []byte{0x01}, pduSessionIDPtr(1))
 
-			err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+			err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, false)
 			if err == nil {
 				t.Fatal("expected an error, got nil")
 			}
@@ -79,13 +79,12 @@ func TestHandleULNASTransport_MacFailed_Error(t *testing.T) {
 	}
 
 	ue.ForceState(amf.Registered)
-	ue.MacFailed = true
 
 	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeN1SMInfo, []byte{0x01}, pduSessionIDPtr(1))
 
 	expected := "NAS message integrity check failed"
 
-	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, true)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected error: %s, got: %v", expected, err)
 	}
@@ -101,7 +100,7 @@ func TestHandleULNASTransport_PayloadContainerTypeSMS_Error(t *testing.T) {
 
 	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeSMS, []byte{0x01}, nil)
 
-	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, false)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
@@ -117,7 +116,7 @@ func TestHandleULNASTransport_PayloadContainerTypeLPP_Error(t *testing.T) {
 
 	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeLPP, []byte{0x01}, nil)
 
-	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, false)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
@@ -133,7 +132,7 @@ func TestHandleULNASTransport_PayloadContainerTypeSOR_Error(t *testing.T) {
 
 	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeSOR, []byte{0x01}, nil)
 
-	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, false)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
@@ -149,7 +148,7 @@ func TestHandleULNASTransport_PayloadContainerTypeMultiplePayload_Error(t *testi
 
 	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeMultiplePayload, []byte{0x01}, nil)
 
-	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, false)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
@@ -165,7 +164,7 @@ func TestHandleULNASTransport_PayloadContainerTypeUEPolicy_NoError(t *testing.T)
 
 	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeUEPolicy, []byte{0x01}, nil)
 
-	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -185,7 +184,7 @@ func TestHandleULNASTransport_PayloadContainerTypeUEParameterUpdate_NoError(t *t
 
 	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeUEParameterUpdate, upuAck, nil)
 
-	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg)
+	err = handleULNASTransport(t.Context(), amf.New(nil, nil, nil), ue, msg, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -326,7 +325,7 @@ func TestTransport5GSMMessage_ExistingPduSession_NotAllowedNssai_SendsDLNASTrans
 	}
 
 	// Set the UE's allowed NSSAI to SST=1, SD="010203"
-	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
+	ue.Current().AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
 
 	// Create an SM context with a DIFFERENT NSSAI (SST=2)
 	var pduSessionID uint8 = 5
@@ -467,7 +466,7 @@ func TestTransport5GSMMessage_SmContextExists_InitialRequest_DeletesContextAndCr
 
 	amfInstance := amf.New(&FakeDBInstance{}, nil, fakeSmf)
 
-	ue.AllowedNssai = []models.Snssai{*snssai}
+	ue.Current().AllowedNssai = []models.Snssai{*snssai}
 
 	err = transport5GSMMessage(t.Context(), amfInstance, ue, msg)
 	if err != nil {
@@ -486,6 +485,107 @@ func TestTransport5GSMMessage_SmContextExists_InitialRequest_DeletesContextAndCr
 
 	if len(fakeSmf.CreateSmContextCalls) != 1 {
 		t.Fatalf("expected 1 CreateSmContext call, got: %d", len(fakeSmf.CreateSmContextCalls))
+	}
+}
+
+// When SMF returns (err, errResponse) we must forward the SMF-provided NAS
+// reject to the UE inside DLNASTransport and NOT create a stale SmContext.
+func TestTransport5GSMMessage_InitialRequest_SmfReturnsErrorAndReject_ForwardsRejectAndNoSmContext(t *testing.T) {
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
+
+	var pduSessionID uint8 = 4
+
+	snssai := &models.Snssai{Sst: 1, Sd: "010203"}
+	ue.Current().AllowedNssai = []models.Snssai{*snssai}
+
+	smPayload := []byte{0x2E, 0x03, 0x00, 0xC1, 0x00}
+	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeN1SMInfo, smPayload, pduSessionIDPtr(pduSessionID))
+	setRequestType(msg, nasMessage.ULNASTransportRequestTypeInitialRequest)
+
+	smfReject := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	fakeSmf := &FakeSmf{
+		CreateSmContextErrResp: smfReject,
+		CreateSmContextError:   fmt.Errorf("malformed NAS in establishment request"),
+	}
+
+	amfInstance := amf.New(&FakeDBInstance{}, nil, fakeSmf)
+
+	err = transport5GSMMessage(t.Context(), amfInstance, ue, msg)
+	if err == nil {
+		t.Fatal("expected an error from transport5GSMMessage when SMF rejects")
+	}
+
+	if _, exists := ue.SmContextFindByPDUSessionID(pduSessionID); exists {
+		t.Fatal("expected no SM context to be created on SMF error")
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("expected 1 downlink NAS transport carrying the SMF reject, got: %d", len(ngapSender.SentDownlinkNASTransport))
+	}
+}
+
+// When SMF returns (err, nil) the AMF must synthesize a DLNASTransport with
+// 5GMM cause "payload was not forwarded" so the UE doesn't time out, and must
+// not create a stale SmContext.
+func TestTransport5GSMMessage_InitialRequest_SmfReturnsErrorOnly_SendsFallbackAndNoSmContext(t *testing.T) {
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
+
+	var pduSessionID uint8 = 5
+
+	snssai := &models.Snssai{Sst: 1, Sd: "010203"}
+	ue.Current().AllowedNssai = []models.Snssai{*snssai}
+
+	smPayload := []byte{0x2E, 0x03, 0x00, 0xC1, 0x00}
+	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeN1SMInfo, smPayload, pduSessionIDPtr(pduSessionID))
+	setRequestType(msg, nasMessage.ULNASTransportRequestTypeInitialRequest)
+
+	fakeSmf := &FakeSmf{
+		CreateSmContextError: fmt.Errorf("smf is unavailable"),
+	}
+
+	amfInstance := amf.New(&FakeDBInstance{}, nil, fakeSmf)
+
+	err = transport5GSMMessage(t.Context(), amfInstance, ue, msg)
+	if err == nil {
+		t.Fatal("expected an error from transport5GSMMessage when SMF fails")
+	}
+
+	if _, exists := ue.SmContextFindByPDUSessionID(pduSessionID); exists {
+		t.Fatal("expected no SM context to be created on SMF error")
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("expected 1 fallback downlink NAS transport, got: %d", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	resp := ngapSender.SentDownlinkNASTransport[0]
+	nm := new(nas.Message)
+	nm.SecurityHeaderType = nas.GetSecurityHeaderType(resp.NasPdu) & 0x0f
+
+	if err := nm.PlainNasDecode(&resp.NasPdu); err != nil {
+		t.Fatalf("could not decode plain NAS message: %v", err)
+	}
+
+	if nm.GmmHeader.GetMessageType() != nas.MsgTypeDLNASTransport {
+		t.Fatalf("expected DLNASTransport message, got: %v", nm.GmmHeader.GetMessageType())
+	}
+
+	if nm.DLNASTransport == nil || nm.DLNASTransport.Cause5GMM == nil {
+		t.Fatal("expected DLNASTransport with 5GMM cause")
+	}
+
+	if got := nm.DLNASTransport.Cause5GMM.GetCauseValue(); got != nasMessage.Cause5GMMPayloadWasNotForwarded { //nolint:staticcheck // explicit selector to avoid ambiguity with embedded message fields
+		t.Fatalf("expected 5GMM cause %d (payload was not forwarded), got %d", nasMessage.Cause5GMMPayloadWasNotForwarded, got)
 	}
 }
 
@@ -732,7 +832,7 @@ func TestTransport5GSMMessage_SmContextExists_DuplicatePDU_Success(t *testing.T)
 	amfInstance := amf.New(&FakeDBInstance{}, nil, fakeSmf)
 
 	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
-	ue.AllowedNssai = []models.Snssai{*snssai}
+	ue.Current().AllowedNssai = []models.Snssai{*snssai}
 
 	err = transport5GSMMessage(t.Context(), amfInstance, ue, msg)
 	if err != nil {
@@ -778,7 +878,7 @@ func TestTransport5GSMMessage_SmContextExists_ExistingPduSession_AllowedNssai_Fo
 	}
 
 	snssai := &models.Snssai{Sst: 1, Sd: "010203"}
-	ue.AllowedNssai = []models.Snssai{*snssai}
+	ue.Current().AllowedNssai = []models.Snssai{*snssai}
 
 	var pduSessionID uint8 = 5
 
@@ -910,7 +1010,7 @@ func TestTransport5GSMMessage_NoSmContext_InitialRequest_DefaultSNSSAIAndDNN(t *
 	}
 
 	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
-	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "aabbcc"}}
+	ue.Current().AllowedNssai = []models.Snssai{{Sst: 1, Sd: "aabbcc"}}
 
 	var pduSessionID uint8 = 2
 
@@ -965,7 +1065,7 @@ func TestTransport5GSMMessage_NoSmContext_InitialRequest_NilAllowedNssai_Error(t
 	}
 
 	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
-	ue.AllowedNssai = nil
+	ue.Current().AllowedNssai = nil
 
 	var pduSessionID uint8 = 1
 
@@ -998,7 +1098,7 @@ func TestTransport5GSMMessage_NoSmContext_InitialRequest_CreateSmContext_ErrorRe
 	}
 
 	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
-	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
+	ue.Current().AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
 
 	var pduSessionID uint8 = 1
 
@@ -1048,46 +1148,6 @@ func TestTransport5GSMMessage_NoSmContext_InitialRequest_CreateSmContext_ErrorRe
 	}
 }
 
-func TestTransport5GSMMessage_NoSmContext_InitialRequest_CreateSmContext_ErrorOnly_NoSMContext(t *testing.T) {
-	ue, _, err := buildUeAndRadio()
-	if err != nil {
-		t.Fatalf("could not build UE and radio: %v", err)
-	}
-
-	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
-	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
-
-	var pduSessionID uint8 = 1
-
-	smPayload := []byte{0x2E, 0x01, 0x00, 0xC1, 0x00}
-
-	msg := buildTestULNASTransport(nasMessage.PayloadContainerTypeN1SMInfo, smPayload, pduSessionIDPtr(pduSessionID))
-	setRequestType(msg, nasMessage.ULNASTransportRequestTypeInitialRequest)
-
-	// CreateSmContext returns error but no error response bytes
-	fakeSmf := &FakeSmf{
-		CreateSmContextError: fmt.Errorf("internal error"),
-	}
-
-	amfInstance := amf.New(&FakeDBInstance{}, nil, fakeSmf)
-
-	// The code logs the error but does not return it (creates context with empty ref)
-	err = transport5GSMMessage(t.Context(), amfInstance, ue, msg)
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-
-	// SM context still gets created (with empty ref) because errResponse is nil
-	smCtx, exists := ue.SmContextFindByPDUSessionID(pduSessionID)
-	if !exists {
-		t.Fatal("expected SM context to exist (even with error, errResponse was nil)")
-	}
-
-	if smCtx.Ref != "" {
-		t.Fatalf("expected empty SM context ref, got: %s", smCtx.Ref)
-	}
-}
-
 func TestTransport5GSMMessage_ExistingPduSession_MultiSliceAllowedNssai_MatchesSecondSlice(t *testing.T) {
 	ue, _, err := buildUeAndRadio()
 	if err != nil {
@@ -1095,7 +1155,7 @@ func TestTransport5GSMMessage_ExistingPduSession_MultiSliceAllowedNssai_MatchesS
 	}
 
 	// UE is allowed 3 slices
-	ue.AllowedNssai = []models.Snssai{
+	ue.Current().AllowedNssai = []models.Snssai{
 		{Sst: 1, Sd: "010203"},
 		{Sst: 2, Sd: "aabbcc"},
 		{Sst: 3, Sd: "ddeeff"},
@@ -1139,7 +1199,7 @@ func TestTransport5GSMMessage_ExistingPduSession_MultiSliceAllowedNssai_NotInLis
 	}
 
 	// UE is allowed 3 slices, but the SM context uses a different one
-	ue.AllowedNssai = []models.Snssai{
+	ue.Current().AllowedNssai = []models.Snssai{
 		{Sst: 1, Sd: "010203"},
 		{Sst: 2, Sd: "aabbcc"},
 		{Sst: 3, Sd: "ddeeff"},
@@ -1174,7 +1234,7 @@ func TestTransport5GSMMessage_NoSmContext_InitialRequest_MultiSliceDefaultSNSSAI
 	ue.Supi = mustSUPIFromPrefixed("imsi-001010000000001")
 
 	// UE has 3 allowed slices — default should be the first
-	ue.AllowedNssai = []models.Snssai{
+	ue.Current().AllowedNssai = []models.Snssai{
 		{Sst: 1, Sd: "aabbcc"},
 		{Sst: 2, Sd: "010203"},
 		{Sst: 3, Sd: "ddeeff"},

--- a/internal/amf/nas/gmm/handler.go
+++ b/internal/amf/nas/gmm/handler.go
@@ -11,32 +11,36 @@ import (
 
 var tracer = otel.Tracer("ella-core/amf/nas/handler")
 
-func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nas.GmmMessage) error {
+// HandleGmmMessage dispatches an inbound GMM message to its handler.
+// macFailed is set when the message arrived with a failed integrity check
+// but was admitted by the decoder verdict (plain message allowed, etc.);
+// handlers that vary their response based on integrity status receive it.
+func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, msg *nas.GmmMessage, macFailed bool) error {
 	msgType := msg.GetMessageType()
 
 	switch msgType {
 	case nas.MsgTypeRegistrationRequest:
-		return handleRegistrationRequest(ctx, amfInstance, ue, msg)
+		return handleRegistrationRequest(ctx, amfInstance, ue, msg, macFailed)
 	case nas.MsgTypeServiceRequest:
-		return handleServiceRequest(ctx, amfInstance, ue, msg.ServiceRequest)
+		return handleServiceRequest(ctx, amfInstance, ue, msg.ServiceRequest, macFailed)
 	case nas.MsgTypeULNASTransport:
-		return handleULNASTransport(ctx, amfInstance, ue, msg.ULNASTransport)
+		return handleULNASTransport(ctx, amfInstance, ue, msg.ULNASTransport, macFailed)
 	case nas.MsgTypeConfigurationUpdateComplete:
-		return handleConfigurationUpdateComplete(amfInstance, ue)
+		return handleConfigurationUpdateComplete(amfInstance, ue, macFailed)
 	case nas.MsgTypeNotificationResponse:
-		return handleNotificationResponse(ctx, amfInstance, ue, msg.NotificationResponse)
+		return handleNotificationResponse(ctx, amfInstance, ue, msg.NotificationResponse, macFailed)
 	case nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration:
-		return handleDeregistrationRequestUEOriginatingDeregistration(ctx, ue, msg.DeregistrationRequestUEOriginatingDeregistration)
+		return handleDeregistrationRequestUEOriginatingDeregistration(ctx, ue, msg.DeregistrationRequestUEOriginatingDeregistration, macFailed)
 	case nas.MsgTypeStatus5GMM:
-		return handleStatus5GMM(ue, msg.Status5GMM)
+		return handleStatus5GMM(ue, msg.Status5GMM, macFailed)
 	case nas.MsgTypeIdentityResponse:
-		return handleIdentityResponse(ctx, amfInstance, ue, msg.IdentityResponse)
+		return handleIdentityResponse(ctx, amfInstance, ue, msg.IdentityResponse, macFailed)
 	case nas.MsgTypeAuthenticationResponse:
 		return handleAuthenticationResponse(ctx, amfInstance, ue, msg.AuthenticationResponse)
 	case nas.MsgTypeAuthenticationFailure:
 		return handleAuthenticationFailure(ctx, amfInstance, ue, msg.AuthenticationFailure)
 	case nas.MsgTypeSecurityModeComplete:
-		return handleSecurityModeComplete(ctx, amfInstance, ue, msg.SecurityModeComplete)
+		return handleSecurityModeComplete(ctx, amfInstance, ue, msg.SecurityModeComplete, macFailed)
 	case nas.MsgTypeSecurityModeReject:
 		return handleSecurityModeReject(ctx, ue, msg.SecurityModeReject)
 	case nas.MsgTypeRegistrationComplete:

--- a/internal/amf/nas/gmm/handler_test.go
+++ b/internal/amf/nas/gmm/handler_test.go
@@ -20,7 +20,7 @@ func TestHandleGmmMessage_UnknownMessageType_Error(t *testing.T) {
 	m := nas.NewGmmMessage()
 	m.SetMessageType(0xFF) // unassigned message type
 
-	err := HandleGmmMessage(context.Background(), amfInstance, ue, m)
+	err := HandleGmmMessage(context.Background(), amfInstance, ue, m, false)
 	if err == nil {
 		t.Fatal("expected error for unknown message type, got nil")
 	}
@@ -54,7 +54,7 @@ func TestHandleGmmMessage_DispatchesToConfigurationUpdateComplete(t *testing.T) 
 	m.ConfigurationUpdateComplete = cuc
 	m.SetMessageType(nas.MsgTypeConfigurationUpdateComplete)
 
-	err = HandleGmmMessage(context.Background(), amfInstance, ue, m)
+	err = HandleGmmMessage(context.Background(), amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestHandleGmmMessage_DispatchesToStatus5GMM(t *testing.T) {
 
 	m := buildTestStatus5gmm()
 
-	err = HandleGmmMessage(context.Background(), amfInstance, ue, m)
+	err = HandleGmmMessage(context.Background(), amfInstance, ue, m, false)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}

--- a/internal/amf/nas/gmm/message/build.go
+++ b/internal/amf/nas/gmm/message/build.go
@@ -73,6 +73,11 @@ func BuildIdentityRequest(typeOfIdentity uint8) ([]byte, error) {
 }
 
 func BuildAuthenticationRequest(ue *amf.AmfUe) ([]byte, error) {
+	conn := ue.NasConn()
+	if conn == nil || conn.AuthenticationCtx == nil {
+		return nil, fmt.Errorf("no authentication context available")
+	}
+
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeAuthenticationRequest)
@@ -88,7 +93,7 @@ func BuildAuthenticationRequest(ue *amf.AmfUe) ([]byte, error) {
 
 	var tmpArray [16]byte
 
-	rand, err := hex.DecodeString(ue.NasConn().AuthenticationCtx.Rand)
+	rand, err := hex.DecodeString(conn.AuthenticationCtx.Rand)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +103,7 @@ func BuildAuthenticationRequest(ue *amf.AmfUe) ([]byte, error) {
 	copy(tmpArray[:], rand[0:16])
 	authenticationRequest.SetRANDValue(tmpArray)
 
-	autn, err := hex.DecodeString(ue.NasConn().AuthenticationCtx.Autn)
+	autn, err := hex.DecodeString(conn.AuthenticationCtx.Autn)
 	if err != nil {
 		return nil, err
 	}
@@ -218,6 +223,11 @@ func BuildRegistrationReject(t3502Value int, cause5GMM uint8) ([]byte, error) {
 
 // TS 24.501 8.2.25
 func BuildSecurityModeCommand(ue *amf.AmfUe) ([]byte, error) {
+	conn := ue.NasConn()
+	if conn == nil {
+		return nil, fmt.Errorf("no active NAS connection")
+	}
+
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeSecurityModeCommand)
@@ -256,13 +266,13 @@ func BuildSecurityModeCommand(ue *amf.AmfUe) ([]byte, error) {
 	securityModeCommand.Additional5GSecurityInformation = nasType.NewAdditional5GSecurityInformation(nasMessage.SecurityModeCommandAdditional5GSecurityInformationType)
 	securityModeCommand.Additional5GSecurityInformation.SetLen(1)
 
-	if ue.NasConn().RetransmissionOfInitialNASMsg {
+	if conn.RetransmissionOfInitialNASMsg {
 		securityModeCommand.SetRINMR(1)
 	} else {
 		securityModeCommand.SetRINMR(0)
 	}
 
-	if ue.NasConn().RegistrationType5GS == nasMessage.RegistrationType5GSPeriodicRegistrationUpdating || ue.NasConn().RegistrationType5GS == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
+	if conn.RegistrationType5GS == nasMessage.RegistrationType5GSPeriodicRegistrationUpdating || conn.RegistrationType5GS == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
 		securityModeCommand.SetHDP(1)
 	} else {
 		securityModeCommand.SetHDP(0)

--- a/internal/amf/nas/gmm/message/build.go
+++ b/internal/amf/nas/gmm/message/build.go
@@ -82,13 +82,13 @@ func BuildAuthenticationRequest(ue *amf.AmfUe) ([]byte, error) {
 	authenticationRequest.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
 	authenticationRequest.SpareHalfOctetAndSecurityHeaderType.SetSpareHalfOctet(0)
 	authenticationRequest.SetMessageType(nas.MsgTypeAuthenticationRequest)
-	authenticationRequest.SpareHalfOctetAndNgksi = util.SpareHalfOctetAndNgksiToNas(ue.NgKsi)
-	authenticationRequest.ABBA.SetLen(uint8(len(ue.ABBA)))
-	authenticationRequest.SetABBAContents(ue.ABBA)
+	authenticationRequest.SpareHalfOctetAndNgksi = util.SpareHalfOctetAndNgksiToNas(ue.Current().NgKsi)
+	authenticationRequest.ABBA.SetLen(uint8(len(ue.Current().ABBA)))
+	authenticationRequest.SetABBAContents(ue.Current().ABBA)
 
 	var tmpArray [16]byte
 
-	rand, err := hex.DecodeString(ue.AuthenticationCtx.Rand)
+	rand, err := hex.DecodeString(ue.NasConn().AuthenticationCtx.Rand)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func BuildAuthenticationRequest(ue *amf.AmfUe) ([]byte, error) {
 	copy(tmpArray[:], rand[0:16])
 	authenticationRequest.SetRANDValue(tmpArray)
 
-	autn, err := hex.DecodeString(ue.AuthenticationCtx.Autn)
+	autn, err := hex.DecodeString(ue.NasConn().AuthenticationCtx.Autn)
 	if err != nil {
 		return nil, err
 	}
@@ -233,17 +233,17 @@ func BuildSecurityModeCommand(ue *amf.AmfUe) ([]byte, error) {
 	securityModeCommand.SpareHalfOctetAndSecurityHeaderType.SetSpareHalfOctet(0)
 	securityModeCommand.SetMessageType(nas.MsgTypeSecurityModeCommand)
 
-	securityModeCommand.SelectedNASSecurityAlgorithms.SetTypeOfCipheringAlgorithm(ue.CipheringAlg)
-	securityModeCommand.SelectedNASSecurityAlgorithms.SetTypeOfIntegrityProtectionAlgorithm(ue.IntegrityAlg)
+	securityModeCommand.SelectedNASSecurityAlgorithms.SetTypeOfCipheringAlgorithm(ue.Current().CipheringAlg)
+	securityModeCommand.SelectedNASSecurityAlgorithms.SetTypeOfIntegrityProtectionAlgorithm(ue.Current().IntegrityAlg)
 
-	securityModeCommand.SpareHalfOctetAndNgksi = util.SpareHalfOctetAndNgksiToNas(ue.NgKsi)
+	securityModeCommand.SpareHalfOctetAndNgksi = util.SpareHalfOctetAndNgksiToNas(ue.Current().NgKsi)
 
-	if ue.UESecurityCapability == nil {
+	if ue.Current().UESecurityCapability == nil {
 		return nil, fmt.Errorf("UE security capability not available, cannot build SecurityModeCommand")
 	}
 
-	securityModeCommand.ReplayedUESecurityCapabilities.SetLen(ue.UESecurityCapability.GetLen())
-	securityModeCommand.ReplayedUESecurityCapabilities.Buffer = ue.UESecurityCapability.Buffer
+	securityModeCommand.ReplayedUESecurityCapabilities.SetLen(ue.Current().UESecurityCapability.GetLen())
+	securityModeCommand.ReplayedUESecurityCapabilities.Buffer = ue.Current().UESecurityCapability.Buffer
 
 	if ue.Pei != "" {
 		securityModeCommand.IMEISVRequest = nasType.NewIMEISVRequest(nasMessage.SecurityModeCommandIMEISVRequestType)
@@ -256,24 +256,24 @@ func BuildSecurityModeCommand(ue *amf.AmfUe) ([]byte, error) {
 	securityModeCommand.Additional5GSecurityInformation = nasType.NewAdditional5GSecurityInformation(nasMessage.SecurityModeCommandAdditional5GSecurityInformationType)
 	securityModeCommand.Additional5GSecurityInformation.SetLen(1)
 
-	if ue.RetransmissionOfInitialNASMsg {
+	if ue.NasConn().RetransmissionOfInitialNASMsg {
 		securityModeCommand.SetRINMR(1)
 	} else {
 		securityModeCommand.SetRINMR(0)
 	}
 
-	if ue.RegistrationType5GS == nasMessage.RegistrationType5GSPeriodicRegistrationUpdating || ue.RegistrationType5GS == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
+	if ue.NasConn().RegistrationType5GS == nasMessage.RegistrationType5GSPeriodicRegistrationUpdating || ue.NasConn().RegistrationType5GS == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {
 		securityModeCommand.SetHDP(1)
 	} else {
 		securityModeCommand.SetHDP(0)
 	}
 
-	ue.SecurityContextAvailable = true
+	ue.Current().SecurityContextAvailable = true
 	m.SecurityModeCommand = securityModeCommand
 
 	payload, err := ue.EncodeNASMessage(m)
 	if err != nil {
-		ue.SecurityContextAvailable = false
+		ue.Current().SecurityContextAvailable = false
 		return nil, err
 	}
 
@@ -344,10 +344,10 @@ func BuildRegistrationAccept(
 	registrationAccept.EquivalentPlmns.SetLen(uint8(len(buf)))
 	copy(registrationAccept.EquivalentPlmns.Octet[:], buf)
 
-	if len(ue.RegistrationArea) > 0 {
+	if len(ue.Current().RegistrationArea) > 0 {
 		registrationAccept.TAIList = nasType.NewTAIList(nasMessage.RegistrationAcceptTAIListType)
 
-		taiListNas, err := util.TaiListToNas(ue.RegistrationArea)
+		taiListNas, err := util.TaiListToNas(ue.Current().RegistrationArea)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert TAI list to NAS: %s", err)
 		}
@@ -356,12 +356,12 @@ func BuildRegistrationAccept(
 		registrationAccept.SetPartialTrackingAreaIdentityList(taiListNas)
 	}
 
-	if len(ue.AllowedNssai) > 0 {
+	if len(ue.Current().AllowedNssai) > 0 {
 		registrationAccept.AllowedNSSAI = nasType.NewAllowedNSSAI(nasMessage.RegistrationAcceptAllowedNSSAIType)
 
 		var buf []uint8
 
-		for _, s := range ue.AllowedNssai {
+		for _, s := range ue.Current().AllowedNssai {
 			snssai, err := util.SnssaiToNas(s)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert SNSSAI to NAS: %s", err)
@@ -410,21 +410,21 @@ func BuildRegistrationAccept(
 
 	registrationAccept.T3512Value = nasType.NewT3512Value(nasMessage.RegistrationAcceptT3512ValueType)
 	registrationAccept.T3512Value.SetLen(1)
-	t3512 := nasConvert.GPRSTimer3ToNas(int(ue.T3512Value.Seconds()))
+	t3512 := nasConvert.GPRSTimer3ToNas(int(ue.Current().T3512Value.Seconds()))
 	registrationAccept.T3512Value.Octet = t3512
 
 	// Temporary: commented this timer because UESIM is not supporting
-	/*if ue.T3502Value != 0 {
+	/*if ue.Current().T3502Value != 0 {
 		registrationAccept.T3502Value = nasType.NewT3502Value(nasMessage.RegistrationAcceptT3502ValueType)
 		registrationAccept.T3502Value.SetLen(1)
-		t3502 := nasConvert.GPRSTimer2ToNas(ue.T3502Value)
+		t3502 := nasConvert.GPRSTimer2ToNas(ue.Current().T3502Value)
 		registrationAccept.T3502Value.SetGPRSTimer2Value(t3502)
 	}*/
 
-	if ue.UESpecificDRX != nasMessage.DRXValueNotSpecified {
+	if ue.Current().UESpecificDRX != nasMessage.DRXValueNotSpecified {
 		registrationAccept.NegotiatedDRXParameters = nasType.NewNegotiatedDRXParameters(nasMessage.RegistrationAcceptNegotiatedDRXParametersType)
 		registrationAccept.NegotiatedDRXParameters.SetLen(1)
-		registrationAccept.SetDRXValue(ue.UESpecificDRX)
+		registrationAccept.SetDRXValue(ue.Current().UESpecificDRX)
 	}
 
 	m.RegistrationAccept = registrationAccept

--- a/internal/amf/nas/gmm/message/build_test.go
+++ b/internal/amf/nas/gmm/message/build_test.go
@@ -16,12 +16,12 @@ func buildTestUE(t *testing.T) *amf.AmfUe {
 	t.Helper()
 
 	ue := amf.NewAmfUe()
-	ue.SecurityContextAvailable = true
+	ue.Current().SecurityContextAvailable = true
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = security.AlgCiphering128NEA2
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = security.AlgCiphering128NEA2
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
 	return ue
 }
@@ -39,7 +39,7 @@ func decryptNAS(t *testing.T, ue *amf.AmfUe, raw []byte) *nas.Message {
 
 	// DLCount was incremented after encode, so the count used for encoding is DLCount-1.
 	// Since we start at 0 and encode once, the count used is 0.
-	err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, 0, security.Bearer3GPP, security.DirectionDownlink, payload)
+	err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, 0, security.Bearer3GPP, security.DirectionDownlink, payload)
 	if err != nil {
 		t.Fatalf("NAS decrypt failed: %v", err)
 	}
@@ -134,8 +134,8 @@ func TestBuildConfigurationUpdateCommand_WithGUTI_InvalidGUTI_Error(t *testing.T
 
 func TestBuildRegistrationAccept_MultipleAllowedNSSAI(t *testing.T) {
 	ue := buildTestUE(t)
-	ue.T3512Value = 3600 * time.Second
-	ue.AllowedNssai = []models.Snssai{
+	ue.Current().T3512Value = 3600 * time.Second
+	ue.Current().AllowedNssai = []models.Snssai{
 		{Sst: 1, Sd: "010203"},
 		{Sst: 2, Sd: "aabbcc"},
 	}
@@ -168,8 +168,8 @@ func TestBuildRegistrationAccept_MultipleAllowedNSSAI(t *testing.T) {
 
 func TestBuildRegistrationAccept_SingleAllowedNSSAI(t *testing.T) {
 	ue := buildTestUE(t)
-	ue.T3512Value = 3600 * time.Second
-	ue.AllowedNssai = []models.Snssai{
+	ue.Current().T3512Value = 3600 * time.Second
+	ue.Current().AllowedNssai = []models.Snssai{
 		{Sst: 1, Sd: "010203"},
 	}
 
@@ -200,8 +200,8 @@ func TestBuildRegistrationAccept_SingleAllowedNSSAI(t *testing.T) {
 
 func TestBuildRegistrationAccept_EmptyAllowedNSSAI(t *testing.T) {
 	ue := buildTestUE(t)
-	ue.T3512Value = 3600 * time.Second
-	ue.AllowedNssai = []models.Snssai{}
+	ue.Current().T3512Value = 3600 * time.Second
+	ue.Current().AllowedNssai = []models.Snssai{}
 
 	amfInstance := amf.New(nil, nil, nil)
 

--- a/internal/amf/nas/gmm/message/send.go
+++ b/internal/amf/nas/gmm/message/send.go
@@ -97,7 +97,7 @@ func SendAuthenticationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	defer span.End()
 
 	amfUe := ue.AmfUe()
-	if amfUe.AuthenticationCtx == nil {
+	if amfUe.NasConn().AuthenticationCtx == nil {
 		return fmt.Errorf("authentication context of UE is nil")
 	}
 
@@ -108,7 +108,8 @@ func SendAuthenticationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 	if amfInstance.T3560Cfg.Enable {
 		cfg := amfInstance.T3560Cfg
-		amfUe.T3560 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
+		conn := amfUe.NasConn()
+		conn.T3560 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.Log.Warn("T3560 expires, retransmit Authentication Request", zap.Any("expireTimes", expireTimes))
 
 			err := ue.SendDownlinkNasTransport(context.Background(), nasMsg, nil)
@@ -226,7 +227,7 @@ func SendRegistrationReject(ctx context.Context, ue *amf.RanUe, cause5GMM uint8)
 	)
 	defer span.End()
 
-	nasMsg, err := BuildRegistrationReject(int(ue.AmfUe().T3502Value.Seconds()), cause5GMM)
+	nasMsg, err := BuildRegistrationReject(int(ue.AmfUe().Current().T3502Value.Seconds()), cause5GMM)
 	if err != nil {
 		return fmt.Errorf("error building registration reject: %s", err.Error())
 	}
@@ -266,7 +267,8 @@ func SendSecurityModeCommand(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 
 	if amfInstance.T3560Cfg.Enable {
 		cfg := amfInstance.T3560Cfg
-		amfUe.T3560 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
+		conn := amfUe.NasConn()
+		conn.T3560 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.Log.Warn("T3560 expires, retransmit Security Mode Command", zap.Any("expireTimes", expireTimes))
 
 			err = ue.SendDownlinkNasTransport(context.Background(), nasMsg, nil)
@@ -278,7 +280,7 @@ func SendSecurityModeCommand(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 			amfUe.Log.Info("sent security mode command")
 		}, func() {
 			amfUe.Log.Warn("T3560 Expires, abort security mode control procedure", zap.Any("expireTimes", cfg.MaxRetryTimes))
-			amfUe.Procedures.End(procedure.SecurityMode)
+			conn.Procedures.End(procedure.SecurityMode)
 			amfInstance.DeregisterAndRemoveAMFUE(context.Background(), amfUe)
 		})
 	}
@@ -347,18 +349,18 @@ func SendRegistrationAccept(
 	}
 
 	if ranUe.UeContextRequest {
-		ranUe.SentInitialContextSetupRequest = true
+		ranUe.ICS = amf.ICSPending
 
 		err = ranUe.SendInitialContextSetupRequest(
 			ctx,
-			ue.Ambr.Uplink,
-			ue.Ambr.Downlink,
-			ue.AllowedNssai,
-			ue.Kgnb,
+			ue.Current().Ambr.Uplink,
+			ue.Current().Ambr.Downlink,
+			ue.Current().AllowedNssai,
+			ue.Current().Kgnb,
 			ue.PlmnID,
-			ue.UeRadioCapability,
-			ue.UeRadioCapabilityForPaging,
-			ue.UESecurityCapability,
+			ue.Current().UeRadioCapability,
+			ue.Current().UeRadioCapabilityForPaging,
+			ue.Current().UESecurityCapability,
 			nasMsg,
 			pduSessionResourceSetupList,
 			supportedGUAMI,
@@ -379,23 +381,25 @@ func SendRegistrationAccept(
 
 	if amfInstance.T3550Cfg.Enable {
 		cfg := amfInstance.T3550Cfg
-		ue.T3550 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
+		conn := ue.NasConn()
+		conn.T3550 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			retryRanUe := ue.RanUe()
 			if retryRanUe == nil {
 				ue.Log.Warn("[NAS] UE Context released, abort retransmission of Registration Accept")
-				ue.T3550 = nil
+
+				conn.T3550 = nil
 			} else {
-				if retryRanUe.UeContextRequest && !retryRanUe.RecvdInitialContextSetupResponse {
+				if retryRanUe.UeContextRequest && retryRanUe.ICS != amf.ICSCompleted {
 					err = retryRanUe.SendInitialContextSetupRequest(
 						context.Background(),
-						ue.Ambr.Uplink,
-						ue.Ambr.Downlink,
-						ue.AllowedNssai,
-						ue.Kgnb,
+						ue.Current().Ambr.Uplink,
+						ue.Current().Ambr.Downlink,
+						ue.Current().AllowedNssai,
+						ue.Current().Kgnb,
 						ue.PlmnID,
-						ue.UeRadioCapability,
-						ue.UeRadioCapabilityForPaging,
-						ue.UESecurityCapability,
+						ue.Current().UeRadioCapability,
+						ue.Current().UeRadioCapabilityForPaging,
+						ue.Current().UESecurityCapability,
 						nasMsg,
 						pduSessionResourceSetupList,
 						supportedGUAMI,
@@ -404,7 +408,7 @@ func SendRegistrationAccept(
 						ue.Log.Error("could not send initial context setup request", zap.Error(err))
 					}
 
-					retryRanUe.SentInitialContextSetupRequest = true
+					retryRanUe.ICS = amf.ICSPending
 
 					ue.Log.Info("Sent NGAP initial context setup request")
 				} else {
@@ -420,7 +424,8 @@ func SendRegistrationAccept(
 			}
 		}, func() {
 			ue.Log.Warn("T3550 Expires, abort retransmission of Registration Accept", zap.Any("expireTimes", cfg.MaxRetryTimes))
-			ue.T3550 = nil // clear the timer
+
+			conn.T3550 = nil
 			// TS 24.501 5.5.1.2.8 case c, 5.5.1.3.8 case c
 			ue.TransitionTo(amf.Registered)
 			ue.ClearRegistrationRequestData()
@@ -479,13 +484,15 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *amf.AMF, a
 		cfg := amfInstance.T3555Cfg
 
 		amfUe.Log.Info("start T3555 timer")
-		amfUe.T3555 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
+		conn := amfUe.NasConn()
+		conn.T3555 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.Log.Warn("timer T3555 expired, retransmit Configuration Update Command", zap.Int32("retry", expireTimes))
 
 			retryRanUe := amfUe.RanUe()
 			if retryRanUe == nil {
 				amfUe.Log.Warn("UE Context released, abort retransmission of Configuration Update Command")
-				amfUe.T3555 = nil
+
+				conn.T3555 = nil
 
 				return
 			}

--- a/internal/amf/nas/gmm/message/send.go
+++ b/internal/amf/nas/gmm/message/send.go
@@ -97,7 +97,9 @@ func SendAuthenticationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	defer span.End()
 
 	amfUe := ue.AmfUe()
-	if amfUe.NasConn().AuthenticationCtx == nil {
+
+	conn := amfUe.NasConn()
+	if conn == nil || conn.AuthenticationCtx == nil {
 		return fmt.Errorf("authentication context of UE is nil")
 	}
 
@@ -108,7 +110,6 @@ func SendAuthenticationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 	if amfInstance.T3560Cfg.Enable {
 		cfg := amfInstance.T3560Cfg
-		conn := amfUe.NasConn()
 		conn.T3560 = amf.NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
 			amfUe.Log.Warn("T3560 expires, retransmit Authentication Request", zap.Any("expireTimes", expireTimes))
 

--- a/internal/amf/nas/gmm/reg_initial.go
+++ b/internal/amf/nas/gmm/reg_initial.go
@@ -30,21 +30,21 @@ func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *am
 		return fmt.Errorf("error getting subscriber profile: %v", err)
 	}
 
-	ue.AllowedNssai = subscriberProfile.AllowedNssai
-	ue.Ambr = subscriberProfile.Ambr
+	ue.Current().AllowedNssai = subscriberProfile.AllowedNssai
+	ue.Current().Ambr = subscriberProfile.Ambr
 
-	if ue.RegistrationRequest.MICOIndication != nil {
-		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", ue.RegistrationRequest.GetRAAI()))
+	if ue.NasConn().RegistrationRequest.MICOIndication != nil {
+		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", ue.NasConn().RegistrationRequest.GetRAAI()))
 	}
 
-	if ue.RegistrationRequest.RequestedDRXParameters != nil {
-		drx := ue.RegistrationRequest.GetDRXValue()
+	if ue.NasConn().RegistrationRequest.RequestedDRXParameters != nil {
+		drx := ue.NasConn().RegistrationRequest.GetDRXValue()
 		if drx > nasMessage.DRXcycleParameterT256 {
 			ue.Log.Warn("UE requested reserved DRX value, treating as not specified", zap.Uint8("drxValue", drx))
 			drx = nasMessage.DRXValueNotSpecified
 		}
 
-		ue.UESpecificDRX = drx
+		ue.Current().UESpecificDRX = drx
 	}
 
 	ue.AllocateRegistrationArea(operatorInfo.Tais)
@@ -56,15 +56,15 @@ func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *am
 		return fmt.Errorf("error adding AMF UE to UE pool: %v", err)
 	}
 
-	ue.T3502Value = amfInstance.T3502Value
-	ue.T3512Value = amfInstance.T3512Value
+	ue.Current().T3502Value = amfInstance.T3502Value
+	ue.Current().T3512Value = amfInstance.T3512Value
 
 	err = amfInstance.ReAllocateGuti(ctx, ue, operatorInfo.Guami)
 	if err != nil {
 		return fmt.Errorf("error reallocating GUTI to UE: %v", err)
 	}
 
-	UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
+	UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
 
 	err = message.SendRegistrationAccept(ctx, amfInstance, ue, nil, nil, nil, nil, nil, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
 	if err != nil {

--- a/internal/amf/nas/gmm/reg_initial.go
+++ b/internal/amf/nas/gmm/reg_initial.go
@@ -14,6 +14,11 @@ import (
 func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) error {
 	ue.ClearRegistrationData(ctx)
 
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
+	}
+
 	// update Kgnb/Kn3iwf
 	err := ue.UpdateSecurityContext()
 	if err != nil {
@@ -33,12 +38,12 @@ func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *am
 	ue.Current().AllowedNssai = subscriberProfile.AllowedNssai
 	ue.Current().Ambr = subscriberProfile.Ambr
 
-	if ue.NasConn().RegistrationRequest.MICOIndication != nil {
-		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", ue.NasConn().RegistrationRequest.GetRAAI()))
+	if conn.RegistrationRequest.MICOIndication != nil {
+		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", conn.RegistrationRequest.GetRAAI()))
 	}
 
-	if ue.NasConn().RegistrationRequest.RequestedDRXParameters != nil {
-		drx := ue.NasConn().RegistrationRequest.GetDRXValue()
+	if conn.RegistrationRequest.RequestedDRXParameters != nil {
+		drx := conn.RegistrationRequest.GetDRXValue()
 		if drx > nasMessage.DRXcycleParameterT256 {
 			ue.Log.Warn("UE requested reserved DRX value, treating as not specified", zap.Uint8("drxValue", drx))
 			drx = nasMessage.DRXValueNotSpecified
@@ -64,7 +69,7 @@ func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *am
 		return fmt.Errorf("error reallocating GUTI to UE: %v", err)
 	}
 
-	UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
+	UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationAccept).Inc()
 
 	err = message.SendRegistrationAccept(ctx, amfInstance, ue, nil, nil, nil, nil, nil, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
 	if err != nil {

--- a/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
@@ -26,10 +26,10 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		return fmt.Errorf("error deriving AnKey: %v", err)
 	}
 
-	if ue.RegistrationRequest.UpdateType5GS != nil {
-		if ue.RegistrationRequest.GetNGRanRcu() == nasMessage.NGRanRadioCapabilityUpdateNeeded {
-			ue.UeRadioCapability = ""
-			ue.UeRadioCapabilityForPaging = nil
+	if ue.NasConn().RegistrationRequest.UpdateType5GS != nil {
+		if ue.NasConn().RegistrationRequest.GetNGRanRcu() == nasMessage.NGRanRadioCapabilityUpdateNeeded {
+			ue.Current().UeRadioCapability = ""
+			ue.Current().UeRadioCapabilityForPaging = nil
 		}
 	}
 
@@ -43,11 +43,11 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		return fmt.Errorf("error getting subscriber profile: %v", err)
 	}
 
-	ue.AllowedNssai = subscriberProfile.AllowedNssai
+	ue.Current().AllowedNssai = subscriberProfile.AllowedNssai
 
-	if ue.RegistrationRequest.Capability5GMM == nil {
-		if ue.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationReject).Inc()
+	if ue.NasConn().RegistrationRequest.Capability5GMM == nil {
+		if ue.NasConn().RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
 
 			err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
 			if err != nil {
@@ -58,18 +58,18 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		}
 	}
 
-	if ue.RegistrationRequest.MICOIndication != nil {
-		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", ue.RegistrationRequest.GetRAAI()))
+	if ue.NasConn().RegistrationRequest.MICOIndication != nil {
+		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", ue.NasConn().RegistrationRequest.GetRAAI()))
 	}
 
-	if ue.RegistrationRequest.RequestedDRXParameters != nil {
-		drx := ue.RegistrationRequest.GetDRXValue()
+	if ue.NasConn().RegistrationRequest.RequestedDRXParameters != nil {
+		drx := ue.NasConn().RegistrationRequest.GetDRXValue()
 		if drx > nasMessage.DRXcycleParameterT256 {
 			ue.Log.Warn("UE requested reserved DRX value, treating as not specified", zap.Uint8("drxValue", drx))
 			drx = nasMessage.DRXValueNotSpecified
 		}
 
-		ue.UESpecificDRX = drx
+		ue.Current().UESpecificDRX = drx
 	}
 
 	if len(ue.Pei) == 0 {
@@ -85,7 +85,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		return nil
 	}
 
-	ue.Ambr = subscriberProfile.Ambr
+	ue.Current().Ambr = subscriberProfile.Ambr
 
 	var (
 		reactivationResult        *[16]bool
@@ -95,8 +95,8 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	ctxList := ngapType.PDUSessionResourceSetupListCxtReq{}
 	suList := ngapType.PDUSessionResourceSetupListSUReq{}
 
-	if ue.RegistrationRequest.UplinkDataStatus != nil {
-		uplinkDataPsi := nasConvert.PSIToBooleanArray(ue.RegistrationRequest.UplinkDataStatus.Buffer)
+	if ue.NasConn().RegistrationRequest.UplinkDataStatus != nil {
+		uplinkDataPsi := nasConvert.PSIToBooleanArray(ue.NasConn().RegistrationRequest.UplinkDataStatus.Buffer)
 		reactivationResult = new([16]bool)
 
 		for idx, hasUplinkData := range uplinkDataPsi {
@@ -126,9 +126,9 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	}
 
 	var pduSessionStatus *[16]bool
-	if ue.RegistrationRequest.PDUSessionStatus != nil {
+	if ue.NasConn().RegistrationRequest.PDUSessionStatus != nil {
 		pduSessionStatus = new([16]bool)
-		psiArray := nasConvert.PSIToBooleanArray(ue.RegistrationRequest.PDUSessionStatus.Buffer)
+		psiArray := nasConvert.PSIToBooleanArray(ue.NasConn().RegistrationRequest.PDUSessionStatus.Buffer)
 
 		for psi := 1; psi <= 15; psi++ {
 			pduSessionID := uint8(psi)
@@ -152,11 +152,11 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		return fmt.Errorf("error reallocating GUTI to UE: %v", err)
 	}
 
-	if ue.RegistrationRequest.AllowedPDUSessionStatus != nil {
-		if ue.N1N2Message != nil {
-			requestData := ue.N1N2Message
-			n1Msg := ue.N1N2Message.BinaryDataN1Message
-			n2Info := ue.N1N2Message.BinaryDataN2Information
+	if ue.NasConn().RegistrationRequest.AllowedPDUSessionStatus != nil {
+		if ue.NasConn().N1N2Message != nil {
+			requestData := ue.NasConn().N1N2Message
+			n1Msg := ue.NasConn().N1N2Message.BinaryDataN1Message
+			n2Info := ue.NasConn().N1N2Message.BinaryDataN2Information
 
 			// downlink signalling
 			if n2Info == nil {
@@ -166,12 +166,12 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 						return err
 					}
 
-					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
+					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
 
 					err = ranUe.SendPDUSessionResourceSetupRequest(
 						ctx,
-						ue.Ambr.Uplink,
-						ue.Ambr.Downlink,
+						ue.Current().Ambr.Uplink,
+						ue.Current().Ambr.Downlink,
 						nasPdu,
 						suList,
 					)
@@ -181,7 +181,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 					ue.Log.Info("Sent NGAP pdu session resource setup request")
 				} else {
-					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
+					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
 
 					err := message.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, &ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
 					if err != nil {
@@ -196,14 +196,14 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					return fmt.Errorf("error sending downlink nas transport message: %v", err)
 				}
 
-				ue.N1N2Message = nil
+				ue.NasConn().N1N2Message = nil
 
 				return nil
 			}
 
 			_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
 			if !exist {
-				ue.N1N2Message = nil
+				ue.NasConn().N1N2Message = nil
 				return fmt.Errorf("pdu Session Id does not Exists")
 			}
 
@@ -226,7 +226,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	ue.AllocateRegistrationArea(operatorInfo.Tais)
 
 	if ranUe.UeContextRequest {
-		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
+		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
 
 		err := message.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, &ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
 		if err != nil {
@@ -243,12 +243,12 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		}
 
 		if len(suList.List) != 0 {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
 
 			err := ranUe.SendPDUSessionResourceSetupRequest(
 				ctx,
-				ue.Ambr.Uplink,
-				ue.Ambr.Downlink,
+				ue.Current().Ambr.Uplink,
+				ue.Current().Ambr.Downlink,
 				nasPdu,
 				suList,
 			)
@@ -258,7 +258,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 			ue.Log.Info("Sent NGAP pdu session resource setup request")
 		} else {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.RegistrationType5GS), RegistrationAccept).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
 
 			err := ranUe.SendDownlinkNasTransport(ctx, nasPdu, nil)
 			if err != nil {

--- a/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
@@ -21,13 +21,18 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
+	}
+
 	err := ue.DerivateAnKey()
 	if err != nil {
 		return fmt.Errorf("error deriving AnKey: %v", err)
 	}
 
-	if ue.NasConn().RegistrationRequest.UpdateType5GS != nil {
-		if ue.NasConn().RegistrationRequest.GetNGRanRcu() == nasMessage.NGRanRadioCapabilityUpdateNeeded {
+	if conn.RegistrationRequest.UpdateType5GS != nil {
+		if conn.RegistrationRequest.GetNGRanRcu() == nasMessage.NGRanRadioCapabilityUpdateNeeded {
 			ue.Current().UeRadioCapability = ""
 			ue.Current().UeRadioCapabilityForPaging = nil
 		}
@@ -45,9 +50,9 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 	ue.Current().AllowedNssai = subscriberProfile.AllowedNssai
 
-	if ue.NasConn().RegistrationRequest.Capability5GMM == nil {
-		if ue.NasConn().RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationReject).Inc()
+	if conn.RegistrationRequest.Capability5GMM == nil {
+		if conn.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationReject).Inc()
 
 			err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
 			if err != nil {
@@ -58,12 +63,12 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		}
 	}
 
-	if ue.NasConn().RegistrationRequest.MICOIndication != nil {
-		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", ue.NasConn().RegistrationRequest.GetRAAI()))
+	if conn.RegistrationRequest.MICOIndication != nil {
+		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", conn.RegistrationRequest.GetRAAI()))
 	}
 
-	if ue.NasConn().RegistrationRequest.RequestedDRXParameters != nil {
-		drx := ue.NasConn().RegistrationRequest.GetDRXValue()
+	if conn.RegistrationRequest.RequestedDRXParameters != nil {
+		drx := conn.RegistrationRequest.GetDRXValue()
 		if drx > nasMessage.DRXcycleParameterT256 {
 			ue.Log.Warn("UE requested reserved DRX value, treating as not specified", zap.Uint8("drxValue", drx))
 			drx = nasMessage.DRXValueNotSpecified
@@ -95,8 +100,8 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	ctxList := ngapType.PDUSessionResourceSetupListCxtReq{}
 	suList := ngapType.PDUSessionResourceSetupListSUReq{}
 
-	if ue.NasConn().RegistrationRequest.UplinkDataStatus != nil {
-		uplinkDataPsi := nasConvert.PSIToBooleanArray(ue.NasConn().RegistrationRequest.UplinkDataStatus.Buffer)
+	if conn.RegistrationRequest.UplinkDataStatus != nil {
+		uplinkDataPsi := nasConvert.PSIToBooleanArray(conn.RegistrationRequest.UplinkDataStatus.Buffer)
 		reactivationResult = new([16]bool)
 
 		for idx, hasUplinkData := range uplinkDataPsi {
@@ -126,9 +131,9 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	}
 
 	var pduSessionStatus *[16]bool
-	if ue.NasConn().RegistrationRequest.PDUSessionStatus != nil {
+	if conn.RegistrationRequest.PDUSessionStatus != nil {
 		pduSessionStatus = new([16]bool)
-		psiArray := nasConvert.PSIToBooleanArray(ue.NasConn().RegistrationRequest.PDUSessionStatus.Buffer)
+		psiArray := nasConvert.PSIToBooleanArray(conn.RegistrationRequest.PDUSessionStatus.Buffer)
 
 		for psi := 1; psi <= 15; psi++ {
 			pduSessionID := uint8(psi)
@@ -152,11 +157,11 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		return fmt.Errorf("error reallocating GUTI to UE: %v", err)
 	}
 
-	if ue.NasConn().RegistrationRequest.AllowedPDUSessionStatus != nil {
-		if ue.NasConn().N1N2Message != nil {
-			requestData := ue.NasConn().N1N2Message
-			n1Msg := ue.NasConn().N1N2Message.BinaryDataN1Message
-			n2Info := ue.NasConn().N1N2Message.BinaryDataN2Information
+	if conn.RegistrationRequest.AllowedPDUSessionStatus != nil {
+		if conn.N1N2Message != nil {
+			requestData := conn.N1N2Message
+			n1Msg := conn.N1N2Message.BinaryDataN1Message
+			n2Info := conn.N1N2Message.BinaryDataN2Information
 
 			// downlink signalling
 			if n2Info == nil {
@@ -166,7 +171,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 						return err
 					}
 
-					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
+					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationAccept).Inc()
 
 					err = ranUe.SendPDUSessionResourceSetupRequest(
 						ctx,
@@ -181,7 +186,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 					ue.Log.Info("Sent NGAP pdu session resource setup request")
 				} else {
-					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
+					UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationAccept).Inc()
 
 					err := message.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, &ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
 					if err != nil {
@@ -196,14 +201,14 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					return fmt.Errorf("error sending downlink nas transport message: %v", err)
 				}
 
-				ue.NasConn().N1N2Message = nil
+				conn.N1N2Message = nil
 
 				return nil
 			}
 
 			_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
 			if !exist {
-				ue.NasConn().N1N2Message = nil
+				conn.N1N2Message = nil
 				return fmt.Errorf("pdu Session Id does not Exists")
 			}
 
@@ -226,7 +231,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	ue.AllocateRegistrationArea(operatorInfo.Tais)
 
 	if ranUe.UeContextRequest {
-		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
+		UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationAccept).Inc()
 
 		err := message.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, &ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
 		if err != nil {
@@ -243,7 +248,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		}
 
 		if len(suList.List) != 0 {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationAccept).Inc()
 
 			err := ranUe.SendPDUSessionResourceSetupRequest(
 				ctx,
@@ -258,7 +263,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 			ue.Log.Info("Sent NGAP pdu session resource setup request")
 		} else {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(ue.NasConn().RegistrationType5GS), RegistrationAccept).Inc()
+			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationAccept).Inc()
 
 			err := ranUe.SendDownlinkNasTransport(ctx, nasPdu, nil)
 			if err != nil {

--- a/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating_test.go
@@ -71,7 +71,7 @@ func (fdb *failingSubscriberDB) NodeID() int { return 0 }
 // decryptAndDecodeNasPdu decrypts a ciphered NAS PDU using the UE's security context
 // and decodes it, returning the NAS message. It verifies the security header is
 // IntegrityProtectedAndCiphered. The dlCountOffset parameter specifies the offset
-// from ue.ULCount.Get() to use as the DL count (0 for the first message, 1 for
+// from ue.Current().ULCount.Get() to use as the DL count (0 for the first message, 1 for
 // the second, etc.).
 func decryptAndDecodeNasPdu(t *testing.T, ue *amf.AmfUe, nasPdu []byte, dlCountOffset uint32) *nas.Message {
 	t.Helper()
@@ -87,7 +87,7 @@ func decryptAndDecodeNasPdu(t *testing.T, ue *amf.AmfUe, nasPdu []byte, dlCountO
 	copy(payload, nasPdu)
 	payload = payload[7:]
 
-	if err := security.NASEncrypt(ue.CipheringAlg, ue.KnasEnc, ue.ULCount.Get()+dlCountOffset, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.Current().CipheringAlg, ue.Current().KnasEnc, ue.Current().ULCount.Get()+dlCountOffset, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -127,23 +127,23 @@ func buildMobilityRegUeAndAMF(t *testing.T) (*amf.AmfUe, *FakeNGAPSender, *FakeS
 	ue.Supi = supi
 	ue.Pei = "imei-490154203237518"
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	ue.RegistrationRequest = registrationRequest.RegistrationRequest
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
-	ue.RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
+	ue.NasConn().RegistrationRequest = registrationRequest.RegistrationRequest
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
+	ue.NasConn().RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
 
 	return ue, ngapSender, fakeSmf, amfInstance
 }
@@ -151,7 +151,7 @@ func buildMobilityRegUeAndAMF(t *testing.T) (*amf.AmfUe, *FakeNGAPSender, *FakeS
 func TestMobilityReg_DerivateAnKeyError(t *testing.T) {
 	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	ue.Kamf = "not-valid-hex"
+	ue.Current().Kamf = "not-valid-hex"
 
 	err := HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 	if err == nil {
@@ -185,8 +185,8 @@ func TestMobilityReg_GetOperatorInfoError(t *testing.T) {
 func TestMobilityReg_NilCapability5GMM_Mobility_SendsReject(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	ue.RegistrationRequest.Capability5GMM = nil
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
+	ue.NasConn().RegistrationRequest.Capability5GMM = nil
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
 
 	err := HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 	if err == nil {
@@ -222,8 +222,8 @@ func TestMobilityReg_NilCapability5GMM_Mobility_SendsReject(t *testing.T) {
 func TestMobilityReg_NilCapability5GMM_Periodic_Continues(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	ue.RegistrationRequest.Capability5GMM = nil
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSPeriodicRegistrationUpdating
+	ue.NasConn().RegistrationRequest.Capability5GMM = nil
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSPeriodicRegistrationUpdating
 
 	err := HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 	if err != nil {
@@ -244,23 +244,23 @@ func TestMobilityReg_NilCapability5GMM_Periodic_Continues(t *testing.T) {
 func TestMobilityReg_UpdateType5GS_ClearsRadioCapability(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	ue.UeRadioCapability = "some-capability"
-	ue.UeRadioCapabilityForPaging = &models.UERadioCapabilityForPaging{}
+	ue.Current().UeRadioCapability = "some-capability"
+	ue.Current().UeRadioCapabilityForPaging = &models.UERadioCapabilityForPaging{}
 
 	updateType := nasType.NewUpdateType5GS(nasMessage.RegistrationRequestUpdateType5GSType)
 	updateType.SetNGRanRcu(nasMessage.NGRanRadioCapabilityUpdateNeeded)
-	ue.RegistrationRequest.UpdateType5GS = updateType
+	ue.NasConn().RegistrationRequest.UpdateType5GS = updateType
 
 	err := HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if ue.UeRadioCapability != "" {
-		t.Fatalf("expected UeRadioCapability to be cleared, got %q", ue.UeRadioCapability)
+	if ue.Current().UeRadioCapability != "" {
+		t.Fatalf("expected UeRadioCapability to be cleared, got %q", ue.Current().UeRadioCapability)
 	}
 
-	if ue.UeRadioCapabilityForPaging != nil {
+	if ue.Current().UeRadioCapabilityForPaging != nil {
 		t.Fatalf("expected UeRadioCapabilityForPaging to be nil")
 	}
 
@@ -278,7 +278,7 @@ func TestMobilityReg_UpdateType5GS_ClearsRadioCapability(t *testing.T) {
 func TestMobilityReg_MICOIndication(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	ue.RegistrationRequest.MICOIndication = nasType.NewMICOIndication(nasMessage.RegistrationRequestMICOIndicationType)
+	ue.NasConn().RegistrationRequest.MICOIndication = nasType.NewMICOIndication(nasMessage.RegistrationRequestMICOIndicationType)
 
 	err := HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 	if err != nil {
@@ -301,15 +301,15 @@ func TestMobilityReg_RequestedDRXParameters(t *testing.T) {
 
 	drxParams := nasType.NewRequestedDRXParameters(nasMessage.RegistrationRequestRequestedDRXParametersType)
 	drxParams.SetDRXValue(0x03) // some DRX value
-	ue.RegistrationRequest.RequestedDRXParameters = drxParams
+	ue.NasConn().RegistrationRequest.RequestedDRXParameters = drxParams
 
 	err := HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if ue.UESpecificDRX != 0x03 {
-		t.Fatalf("expected UESpecificDRX to be 0x03, got 0x%02x", ue.UESpecificDRX)
+	if ue.Current().UESpecificDRX != 0x03 {
+		t.Fatalf("expected UESpecificDRX to be 0x03, got 0x%02x", ue.Current().UESpecificDRX)
 	}
 
 	// Should send DownlinkNasTransport with RegistrationAccept
@@ -387,7 +387,7 @@ func TestMobilityReg_UplinkDataStatus_ActivateSuccess_UeContextRequest(t *testin
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
 	// UplinkDataStatus: PSI 2 has uplink data (bit 2 in byte 0 = 0x04)
-	ue.RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
@@ -424,7 +424,7 @@ func TestMobilityReg_UplinkDataStatus_ActivateSuccess_NoUeContextRequest(t *test
 	snssai := &models.Snssai{Sst: 1}
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
-	ue.RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
@@ -457,7 +457,7 @@ func TestMobilityReg_UplinkDataStatus_ActivateError(t *testing.T) {
 	snssai := &models.Snssai{Sst: 1}
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
-	ue.RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
@@ -491,7 +491,7 @@ func TestMobilityReg_PDUSessionStatus_InactiveSession_ReleaseSmContext(t *testin
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
 	// PDUSessionStatus: PSI 2 is NOT active (bit 2 unset = 0x00)
-	ue.RegistrationRequest.PDUSessionStatus = &nasType.PDUSessionStatus{
+	ue.NasConn().RegistrationRequest.PDUSessionStatus = &nasType.PDUSessionStatus{
 		Len:    2,
 		Buffer: []uint8{0x00, 0x00},
 	}
@@ -531,7 +531,7 @@ func TestMobilityReg_PDUSessionStatus_ActiveSession_NoRelease(t *testing.T) {
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
 	// PDUSessionStatus: PSI 2 IS active (bit 2 set = 0x04)
-	ue.RegistrationRequest.PDUSessionStatus = &nasType.PDUSessionStatus{
+	ue.NasConn().RegistrationRequest.PDUSessionStatus = &nasType.PDUSessionStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
@@ -562,7 +562,7 @@ func TestMobilityReg_PDUSessionStatus_ReleaseError(t *testing.T) {
 	snssai := &models.Snssai{Sst: 1}
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
-	ue.RegistrationRequest.PDUSessionStatus = &nasType.PDUSessionStatus{
+	ue.NasConn().RegistrationRequest.PDUSessionStatus = &nasType.PDUSessionStatus{
 		Len:    2,
 		Buffer: []uint8{0x00, 0x00}, // PSI 2 inactive → triggers release
 	}
@@ -587,18 +587,18 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_NonEmptySuList(t *te
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
 	// UplinkDataStatus with PSI 2 + no UeContextRequest → populates suList
-	ue.RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
 	ue.RanUe().UeContextRequest = false
 
 	// AllowedPDUSessionStatus + N1N2Message with nil N2Info
-	ue.RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
+	ue.NasConn().RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
 		BinaryDataN2Information: nil,
@@ -635,7 +635,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_NonEmptySuList(t *te
 	}
 
 	// N1N2Message should be cleared
-	if ue.N1N2Message != nil {
+	if ue.NasConn().N1N2Message != nil {
 		t.Fatal("expected N1N2Message to be nil after processing")
 	}
 }
@@ -645,11 +645,11 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_EmptySuList(t *testi
 
 	// No UplinkDataStatus → suList remains empty
 
-	ue.RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
+	ue.NasConn().RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
 		BinaryDataN2Information: nil,
@@ -681,7 +681,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_EmptySuList(t *testi
 		t.Fatalf("expected DLNASTransport in second DLNASTransport, got %v", nmN1.GmmHeader.GetMessageType())
 	}
 
-	if ue.N1N2Message != nil {
+	if ue.NasConn().N1N2Message != nil {
 		t.Fatal("expected N1N2Message to be nil after processing")
 	}
 }
@@ -689,13 +689,13 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_EmptySuList(t *testi
 func TestMobilityReg_AllowedPDUSessionStatus_N1N2_WithN2Info_MissingSmContext(t *testing.T) {
 	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	ue.RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
+	ue.NasConn().RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
 
 	// N1N2 with N2Info, but no SmContext for PduSessionID 3
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
 		BinaryDataN2Information: []byte{0x03, 0x04},
@@ -712,7 +712,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_WithN2Info_MissingSmContext(t 
 	}
 
 	// N1N2Message should be cleared
-	if ue.N1N2Message != nil {
+	if ue.NasConn().N1N2Message != nil {
 		t.Fatal("expected N1N2Message to be nil after error")
 	}
 }
@@ -723,12 +723,12 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_WithN2Info_SmContextExists(t *
 	snssai := &models.Snssai{Sst: 1}
 	_ = ue.CreateSmContext(3, "ref-3", snssai)
 
-	ue.RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
+	ue.NasConn().RegistrationRequest.AllowedPDUSessionStatus = &nasType.AllowedPDUSessionStatus{
 		Len:    2,
 		Buffer: []uint8{0x08, 0x00}, // PSI 3
 	}
 
-	ue.N1N2Message = &models.N1N2MessageTransferRequest{
+	ue.NasConn().N1N2Message = &models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		SNssai:                  snssai,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
@@ -785,7 +785,7 @@ func TestMobilityReg_NoUeContextRequest_NonEmptySuList(t *testing.T) {
 	_ = ue.CreateSmContext(2, "ref-2", snssai)
 
 	// UplinkDataStatus with PSI 2
-	ue.RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
+	ue.NasConn().RegistrationRequest.UplinkDataStatus = &nasType.UplinkDataStatus{
 		Len:    2,
 		Buffer: []uint8{0x04, 0x00},
 	}
@@ -943,23 +943,23 @@ func TestMobilityReg_MultiSlice_AllowedNssaiContainsAllSlices(t *testing.T) {
 	ue.Supi = supi
 	ue.Pei = "imei-490154203237518"
 	ue.Tai = ue.RanUe().Tai
-	ue.SecurityContextAvailable = true
-	ue.NgKsi.Ksi = 1
+	ue.Current().SecurityContextAvailable = true
+	ue.Current().NgKsi.Ksi = 1
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
-	ue.KnasEnc = key
-	ue.KnasInt = key
-	ue.CipheringAlg = algo
-	ue.IntegrityAlg = security.AlgIntegrity128NIA0
+	ue.Current().KnasEnc = key
+	ue.Current().KnasInt = key
+	ue.Current().CipheringAlg = algo
+	ue.Current().IntegrityAlg = security.AlgIntegrity128NIA0
 
-	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount.Get())
+	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.Current().ULCount.Get())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	ue.RegistrationRequest = registrationRequest.RegistrationRequest
-	ue.RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
-	ue.RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
+	ue.NasConn().RegistrationRequest = registrationRequest.RegistrationRequest
+	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
+	ue.NasConn().RegistrationRequest.Capability5GMM = &nasType.Capability5GMM{}
 
 	err = HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 	if err != nil {
@@ -967,16 +967,16 @@ func TestMobilityReg_MultiSlice_AllowedNssaiContainsAllSlices(t *testing.T) {
 	}
 
 	// Verify AllowedNssai was populated with both slices
-	if len(ue.AllowedNssai) != 2 {
-		t.Fatalf("expected 2 allowed NSSAIs, got %d", len(ue.AllowedNssai))
+	if len(ue.Current().AllowedNssai) != 2 {
+		t.Fatalf("expected 2 allowed NSSAIs, got %d", len(ue.Current().AllowedNssai))
 	}
 
-	if ue.AllowedNssai[0].Sst != 1 || ue.AllowedNssai[0].Sd != "010203" {
-		t.Fatalf("expected first slice SST=1 SD=010203, got SST=%d SD=%s", ue.AllowedNssai[0].Sst, ue.AllowedNssai[0].Sd)
+	if ue.Current().AllowedNssai[0].Sst != 1 || ue.Current().AllowedNssai[0].Sd != "010203" {
+		t.Fatalf("expected first slice SST=1 SD=010203, got SST=%d SD=%s", ue.Current().AllowedNssai[0].Sst, ue.Current().AllowedNssai[0].Sd)
 	}
 
-	if ue.AllowedNssai[1].Sst != 2 || ue.AllowedNssai[1].Sd != "aabbcc" {
-		t.Fatalf("expected second slice SST=2 SD=aabbcc, got SST=%d SD=%s", ue.AllowedNssai[1].Sst, ue.AllowedNssai[1].Sd)
+	if ue.Current().AllowedNssai[1].Sst != 2 || ue.Current().AllowedNssai[1].Sd != "aabbcc" {
+		t.Fatalf("expected second slice SST=2 SD=aabbcc, got SST=%d SD=%s", ue.Current().AllowedNssai[1].Sst, ue.Current().AllowedNssai[1].Sd)
 	}
 
 	// Verify the RegistrationAccept was sent and contains multi-NSSAI

--- a/internal/amf/nas/gmm/security_mode.go
+++ b/internal/amf/nas/gmm/security_mode.go
@@ -20,9 +20,14 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) erro
 
 	ue.Log = ue.Log.With(logger.SUPI(ue.Supi.String()))
 
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("no active NAS connection")
+	}
+
 	if ue.SecurityContextIsValid() {
 		ue.Log.Debug("UE has a valid security context - skip security mode control procedure")
-		return contextSetup(ctx, amfInstance, ue, ue.NasConn().RegistrationRequest)
+		return contextSetup(ctx, amfInstance, ue, conn.RegistrationRequest)
 	}
 
 	integrityOrder, cipheringOrder, err := amfInstance.GetSecurityAlgorithms(ctx)
@@ -45,13 +50,13 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) erro
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
-	if _, beginErr := ue.NasConn().Procedures.Begin(ue.NasConn().Ctx(), procedure.Procedure{Type: procedure.SecurityMode}); beginErr != nil {
+	if _, beginErr := conn.Procedures.Begin(conn.Ctx(), procedure.Procedure{Type: procedure.SecurityMode}); beginErr != nil {
 		return fmt.Errorf("security mode blocked by conflict: %w", beginErr)
 	}
 
 	err = message.SendSecurityModeCommand(ctx, amfInstance, ranUe)
 	if err != nil {
-		ue.NasConn().Procedures.End(procedure.SecurityMode)
+		conn.Procedures.End(procedure.SecurityMode)
 
 		return fmt.Errorf("error sending security mode command: %v", err)
 	}

--- a/internal/amf/nas/gmm/security_mode.go
+++ b/internal/amf/nas/gmm/security_mode.go
@@ -22,7 +22,7 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) erro
 
 	if ue.SecurityContextIsValid() {
 		ue.Log.Debug("UE has a valid security context - skip security mode control procedure")
-		return contextSetup(ctx, amfInstance, ue, ue.RegistrationRequest)
+		return contextSetup(ctx, amfInstance, ue, ue.NasConn().RegistrationRequest)
 	}
 
 	integrityOrder, cipheringOrder, err := amfInstance.GetSecurityAlgorithms(ctx)
@@ -45,13 +45,13 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe) erro
 		return fmt.Errorf("ue is not connected to RAN")
 	}
 
-	if _, beginErr := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.SecurityMode}); beginErr != nil {
+	if _, beginErr := ue.NasConn().Procedures.Begin(ue.NasConn().Ctx(), procedure.Procedure{Type: procedure.SecurityMode}); beginErr != nil {
 		return fmt.Errorf("security mode blocked by conflict: %w", beginErr)
 	}
 
 	err = message.SendSecurityModeCommand(ctx, amfInstance, ranUe)
 	if err != nil {
-		ue.Procedures.End(procedure.SecurityMode)
+		ue.NasConn().Procedures.End(procedure.SecurityMode)
 
 		return fmt.Errorf("error sending security mode command: %v", err)
 	}

--- a/internal/amf/nas/handler.go
+++ b/internal/amf/nas/handler.go
@@ -65,15 +65,14 @@ func HandleNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.RanUe, nasPdu 
 		return errors.New("gsm message is not nil")
 	}
 
-	// Handlers are the only site that may mutate security-state flags.
-	// Set MacFailed according to the decoder's verdict.
+	var macFailed bool
+
 	switch result.Verdict {
 	case amf.VerdictIntegrityVerified:
-		ue.AmfUe().MacFailed = false
+		macFailed = false
 	case amf.VerdictPlainAllowed, amf.VerdictMacFailedAllowed:
-		ue.AmfUe().MacFailed = true
+		macFailed = true
 	case amf.VerdictReject:
-		// Unreachable: DecodeNASMessage returns an error for VerdictReject.
 		return fmt.Errorf("nas pdu rejected by classifier")
 	}
 
@@ -94,7 +93,7 @@ func HandleNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.RanUe, nasPdu 
 		logger.SUPI(ue.AmfUe().Supi.String()),
 	)
 
-	err = gmm.HandleGmmMessage(ctx, amfInstance, ue.AmfUe(), msg.GmmMessage)
+	err = gmm.HandleGmmMessage(ctx, amfInstance, ue.AmfUe(), msg.GmmMessage, macFailed)
 	if err != nil {
 		return fmt.Errorf("error handling NAS message for supi %s: %v", ue.AmfUe().Supi.String(), err)
 	}
@@ -150,13 +149,11 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 			logger.WithTrace(ctx, logger.AmfLog).Debug("Guti received in Registration Request Message", logger.GUTI(guti.String()))
 		} else if nasMessage.MobileIdentity5GSTypeSuci == nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0]) {
 			suci, _ := nasConvert.SuciToString(mobileIdentity5GSContents)
-			/* UeContext found based on SUCI which means context is exist in Network(AMF) but not
-			   present in UE. Hence, AMF clear the existing context
-			*/
+
 			ue, _ := amfInstance.FindAMFUEBySuci(suci)
 			if ue != nil {
 				ue.Log.Info("UE Context derived from Suci", zap.String("suci", suci))
-				ue.SecurityContextAvailable = false
+				ue.RotateContext()
 			}
 
 			return ue, nil
@@ -203,9 +200,7 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 
 	if msg.SecurityHeaderType == nas.SecurityHeaderTypePlainNas {
 		ue.Log.Info("UE identified by GUTI but NAS is plain; treating as no security context", logger.GUTI(guti.String()))
-
-		// UE likely lost keys; force fresh security setup
-		ue.SecurityContextAvailable = false
+		ue.RotateContext()
 
 		return ue, nil
 	}

--- a/internal/amf/ngap/dispatcher.go
+++ b/internal/amf/ngap/dispatcher.go
@@ -53,7 +53,7 @@ func Dispatch(ctx context.Context, amfInstance *amf.AMF, conn *sctp.SCTPConn, ms
 
 	if len(msg) == 0 {
 		ran.Log.Info("RAN close the connection.")
-		amfInstance.RemoveRadio(ran)
+		amfInstance.RemoveRadio(ctx, ran)
 
 		return
 	}
@@ -367,6 +367,8 @@ func HandleSCTPNotification(amfInstance *amf.AMF, conn *sctp.SCTPConn, notificat
 		return
 	}
 
+	ctx := context.Background()
+
 	switch notification.Type() {
 	case sctp.SCTPAssocChange:
 		ran.Log.Info("SCTPAssocChange notification")
@@ -380,16 +382,16 @@ func HandleSCTPNotification(amfInstance *amf.AMF, conn *sctp.SCTPConn, notificat
 
 		switch event.State() {
 		case sctp.SCTPCommLost:
-			amfInstance.RemoveRadio(ran)
+			amfInstance.RemoveRadio(ctx, ran)
 			ran.Log.Info("Closed connection with radio after SCTP Communication Lost")
 		case sctp.SCTPShutdownComp:
-			amfInstance.RemoveRadio(ran)
+			amfInstance.RemoveRadio(ctx, ran)
 			ran.Log.Info("Closed connection with radio after SCTP Shutdown Complete")
 		default:
 			ran.Log.Info("SCTP state is not handled", zap.Int("state", int(event.State())))
 		}
 	case sctp.SCTPShutdownEvent:
-		amfInstance.RemoveRadio(ran)
+		amfInstance.RemoveRadio(ctx, ran)
 		ran.Log.Info("Closed connection with radio after SCTP Shutdown Event")
 	default:
 		ran.Log.Warn("Unhandled SCTP notification type", zap.Any("type", notification.Type()))

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -56,7 +56,9 @@ func HandleHandoverCancel(ctx context.Context, ran *amf.Radio, msg decode.Handov
 
 	// Clear the N2 Handover procedure since it was cancelled by the source.
 	if amfUe := sourceUe.AmfUe(); amfUe != nil {
-		amfUe.NasConn().Procedures.End(procedure.N2Handover)
+		if conn := amfUe.NasConn(); conn != nil {
+			conn.Procedures.End(procedure.N2Handover)
+		}
 	}
 
 	targetUe := sourceUe.TargetUe

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -56,7 +56,7 @@ func HandleHandoverCancel(ctx context.Context, ran *amf.Radio, msg decode.Handov
 
 	// Clear the N2 Handover procedure since it was cancelled by the source.
 	if amfUe := sourceUe.AmfUe(); amfUe != nil {
-		amfUe.Procedures.End(procedure.N2Handover)
+		amfUe.NasConn().Procedures.End(procedure.N2Handover)
 	}
 
 	targetUe := sourceUe.TargetUe

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -42,7 +42,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 		logger.WithTrace(ctx, targetUe.Log).Error("N2 Handover between AMF has not been implemented yet")
 	} else {
 		if sourceAmfUe := sourceUe.AmfUe(); sourceAmfUe != nil {
-			sourceAmfUe.Procedures.End(procedure.N2Handover)
+			sourceAmfUe.NasConn().Procedures.End(procedure.N2Handover)
 		}
 
 		failureCause := ngapType.Cause{

--- a/internal/amf/ngap/handle_handover_failure_test.go
+++ b/internal/amf/ngap/handle_handover_failure_test.go
@@ -56,7 +56,7 @@ func TestHandleHandoverFailure_SourceAmfUeDetached(t *testing.T) {
 	amfInstance.Radios[new(sctp.SCTPConn)] = targetRan
 
 	// Simulate the AMF UE being detached from the source (deregistration race).
-	amfUe.DetachRanUe(nil)
+	amfUe.ReleaseNasConnection(nil)
 
 	msg := decode.HandoverFailure{
 		AMFUENGAPID: 200,

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -35,7 +35,10 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	logger.WithTrace(ctx, targetUe.Log).Info("Handle Handover notification Finshed ")
 
-	amfUe.NasConn().Procedures.End(procedure.N2Handover)
+	if conn := amfUe.NasConn(); conn != nil {
+		conn.Procedures.End(procedure.N2Handover)
+	}
+
 	amfUe.AttachRanUe(targetUe)
 
 	sourceUe.ReleaseAction = amf.UeContextReleaseHandover

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -12,23 +12,8 @@ import (
 )
 
 func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.HandoverNotify) {
-	targetUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if targetUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No RanUe Context", zap.Int64("AmfUeNgapID", msg.AMFUENGAPID), zap.Int64("RanUeNgapID", msg.RANUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-			return
-		}
-
+	targetUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 
@@ -50,7 +35,7 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	logger.WithTrace(ctx, targetUe.Log).Info("Handle Handover notification Finshed ")
 
-	amfUe.Procedures.End(procedure.N2Handover)
+	amfUe.NasConn().Procedures.End(procedure.N2Handover)
 	amfUe.AttachRanUe(targetUe)
 
 	sourceUe.ReleaseAction = amf.UeContextReleaseHandover

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -103,7 +103,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		}
 
 		if sourceAmfUe := sourceUe.AmfUe(); sourceAmfUe != nil {
-			sourceAmfUe.Procedures.End(procedure.N2Handover)
+			sourceAmfUe.NasConn().Procedures.End(procedure.N2Handover)
 		}
 
 		if sourceUe.Radio() == nil {

--- a/internal/amf/ngap/handle_handover_request_acknowledge_test.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge_test.go
@@ -55,7 +55,7 @@ func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *FakeNGAPSender, *am
 	amfUe := amf.NewAmfUe()
 	amfUe.Supi = supi
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[pduSessionID] = &amf.SmContext{
+	amfUe.Current().SmContextList[pduSessionID] = &amf.SmContext{
 		Ref:    smf.CanonicalName(supi, pduSessionID),
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -217,7 +217,7 @@ func TestHandoverRequestAcknowledge_NoPDUSessionsAdmitted_SourceAmfUeDetached(t 
 		t.Fatal("source AMF UE not found")
 	}
 
-	sourceAmfUe.DetachRanUe(nil)
+	sourceAmfUe.ReleaseNasConnection(nil)
 
 	amfID := int64(1)
 	ranID := int64(2)

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -67,7 +67,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		return
 	}
 
-	_, beginErr := amfUe.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.N2Handover})
+	_, beginErr := amfUe.NasConn().Procedures.Begin(amfUe.NasConn().Ctx(), procedure.Procedure{Type: procedure.N2Handover})
 	if beginErr != nil {
 		logger.WithTrace(ctx, sourceUe.Log).Info("N2Handover rejected by procedure registry", zap.Error(beginErr))
 		return
@@ -83,7 +83,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		sourceUe.AmfUe().Procedures.End(procedure.N2Handover)
+		sourceUe.AmfUe().NasConn().Procedures.End(procedure.N2Handover)
 
 		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 		if err != nil {
@@ -137,7 +137,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		sourceUe.AmfUe().Procedures.End(procedure.N2Handover)
+		sourceUe.AmfUe().NasConn().Procedures.End(procedure.N2Handover)
 
 		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 		if err != nil {
@@ -181,11 +181,11 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	err = targetUe.SendHandoverRequest(
 		ctx,
 		sourceUe.HandOverType,
-		amfUe.Ambr.Uplink,
-		amfUe.Ambr.Downlink,
-		amfUe.UESecurityCapability,
-		amfUe.NCC,
-		amfUe.NH,
+		amfUe.Current().Ambr.Uplink,
+		amfUe.Current().Ambr.Downlink,
+		amfUe.Current().UESecurityCapability,
+		amfUe.Current().NCC,
+		amfUe.Current().NH,
 		msg.Cause,
 		pduSessionReqList,
 		msg.SourceToTargetTransparentContainer,

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -67,7 +67,13 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		return
 	}
 
-	_, beginErr := amfUe.NasConn().Procedures.Begin(amfUe.NasConn().Ctx(), procedure.Procedure{Type: procedure.N2Handover})
+	conn := amfUe.NasConn()
+	if conn == nil {
+		logger.WithTrace(ctx, sourceUe.Log).Error("no active NAS connection")
+		return
+	}
+
+	_, beginErr := conn.Procedures.Begin(conn.Ctx(), procedure.Procedure{Type: procedure.N2Handover})
 	if beginErr != nil {
 		logger.WithTrace(ctx, sourceUe.Log).Info("N2Handover rejected by procedure registry", zap.Error(beginErr))
 		return
@@ -83,7 +89,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		sourceUe.AmfUe().NasConn().Procedures.End(procedure.N2Handover)
+		conn.Procedures.End(procedure.N2Handover)
 
 		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 		if err != nil {
@@ -137,7 +143,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		sourceUe.AmfUe().NasConn().Procedures.End(procedure.N2Handover)
+		conn.Procedures.End(procedure.N2Handover)
 
 		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 		if err != nil {

--- a/internal/amf/ngap/handle_handover_required_test.go
+++ b/internal/amf/ngap/handle_handover_required_test.go
@@ -233,14 +233,13 @@ func TestHandoverRequired(t *testing.T) {
 	// Set up the AmfUe with valid security context
 	amfUe := amf.NewAmfUe()
 	amfUe.Supi = supi
-	amfUe.SecurityContextAvailable = true
-	amfUe.NgKsi.Ksi = 1
-	amfUe.MacFailed = false
-	amfUe.Kamf = kamfHex
-	amfUe.NH = make([]byte, 32)
-	amfUe.Ambr = &models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"}
+	amfUe.Current().SecurityContextAvailable = true
+	amfUe.Current().NgKsi.Ksi = 1
+	amfUe.Current().Kamf = kamfHex
+	amfUe.Current().NH = make([]byte, 32)
+	amfUe.Current().Ambr = &models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"}
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[pduSessionID] = &amf.SmContext{
+	amfUe.Current().SmContextList[pduSessionID] = &amf.SmContext{
 		Ref:    smf.CanonicalName(supi, pduSessionID),
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -422,7 +421,7 @@ func TestHandoverRequired_InvalidSecurityContext(t *testing.T) {
 
 	// Create AmfUe with invalid security context
 	amfUe := amf.NewAmfUe()
-	amfUe.SecurityContextAvailable = false
+	amfUe.Current().SecurityContextAvailable = false
 	amfUe.Log = logger.AmfLog
 
 	sourceNGAPSender := &FakeNGAPSender{}

--- a/internal/amf/ngap/handle_initial_context_setup_failure.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure.go
@@ -26,9 +26,10 @@ func HandleInitialContextSetupFailure(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	if amfUe.NasConn().T3550 != nil {
-		amfUe.NasConn().T3550.Stop()
-		amfUe.NasConn().T3550 = nil
+	if conn := amfUe.NasConn(); conn != nil && conn.T3550 != nil {
+		conn.T3550.Stop()
+		conn.T3550 = nil
+
 		amfUe.Deregister(ctx)
 		amfUe.ClearRegistrationRequestData()
 	}

--- a/internal/amf/ngap/handle_initial_context_setup_failure.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure.go
@@ -26,9 +26,9 @@ func HandleInitialContextSetupFailure(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	if amfUe.T3550 != nil {
-		amfUe.T3550.Stop()
-		amfUe.T3550 = nil
+	if amfUe.NasConn().T3550 != nil {
+		amfUe.NasConn().T3550.Stop()
+		amfUe.NasConn().T3550 = nil
 		amfUe.Deregister(ctx)
 		amfUe.ClearRegistrationRequestData()
 	}

--- a/internal/amf/ngap/handle_initial_context_setup_failure_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure_test.go
@@ -73,7 +73,8 @@ func TestHandleInitialContextSetupFailure_T3550Running(t *testing.T) {
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
 	amfUe.ForceState(amf.ContextSetup)
-	amfUe.T3550 = amf.NewTimer(time.Hour, 4, func(int32) {}, func() {})
+	conn := amfUe.NasConn()
+	conn.T3550 = amf.NewTimer(time.Hour, 4, func(int32) {}, func() {})
 
 	ranUe := amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
 	amfUe.AttachRanUe(ranUe)
@@ -89,7 +90,7 @@ func TestHandleInitialContextSetupFailure_T3550Running(t *testing.T) {
 
 	ngap.HandleInitialContextSetupFailure(context.Background(), amfInstance, ran, msg)
 
-	if amfUe.T3550 != nil {
+	if conn.T3550 != nil {
 		t.Error("expected T3550 to be nil after failure")
 	}
 
@@ -105,7 +106,7 @@ func TestHandleInitialContextSetupFailure_PDUSessionFailureForwardedToSmf(t *tes
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}

--- a/internal/amf/ngap/handle_initial_context_setup_response.go
+++ b/internal/amf/ngap/handle_initial_context_setup_response.go
@@ -74,5 +74,5 @@ func HandleInitialContextSetupResponse(ctx context.Context, amfInstance *amf.AMF
 		}
 	}
 
-	ranUe.RecvdInitialContextSetupResponse = true
+	ranUe.ICS = amf.ICSCompleted
 }

--- a/internal/amf/ngap/handle_initial_context_setup_response_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_response_test.go
@@ -53,7 +53,7 @@ func TestInitialContextSetupResponse_SetupItemsForwardedToSmf(t *testing.T) {
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -82,8 +82,8 @@ func TestInitialContextSetupResponse_SetupItemsForwardedToSmf(t *testing.T) {
 		t.Errorf("SmContextRef = %q, want %q", fakeSmf.PduResSetupRspCalls[0].SmContextRef, "ref-session-1")
 	}
 
-	if !ranUe.RecvdInitialContextSetupResponse {
-		t.Error("expected RecvdInitialContextSetupResponse to be true")
+	if ranUe.ICS != amf.ICSCompleted {
+		t.Error("expected ranUe.ICS == ICSCompleted")
 	}
 }
 
@@ -94,7 +94,7 @@ func TestInitialContextSetupResponse_FailedItemsForwardedToSmf(t *testing.T) {
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -158,7 +158,7 @@ func TestInitialContextSetupResponse_InvalidPDUSessionID(t *testing.T) {
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -189,11 +189,11 @@ func TestInitialContextSetupResponse_MixedSetupAndFailedItems(t *testing.T) {
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
-	amfUe.SmContextList[2] = &amf.SmContext{
+	amfUe.Current().SmContextList[2] = &amf.SmContext{
 		Ref:    "ref-session-2",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -234,7 +234,7 @@ func TestInitialContextSetupResponse_MixedSetupAndFailedItems(t *testing.T) {
 		t.Errorf("setup fail SmContextRef = %q, want %q", fakeSmf.PduResSetupFailCalls[0].SmContextRef, "ref-session-2")
 	}
 
-	if !ranUe.RecvdInitialContextSetupResponse {
-		t.Error("expected RecvdInitialContextSetupResponse to be true")
+	if ranUe.ICS != amf.ICSCompleted {
+		t.Error("expected ranUe.ICS == ICSCompleted")
 	}
 }

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
-	"github.com/ellanetworks/core/internal/amf/nas/gmm/message"
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/free5gc/nas/nasMessage"
@@ -25,7 +24,7 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			zap.Int64("RanUeNgapID", ranUe.RanUeNgapID),
 			zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID))
 
-		err := ranUe.Remove()
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error(err.Error())
 		}
@@ -102,21 +101,8 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	err := amfInstance.NAS.HandleNAS(ctx, ranUe, msg.NASPDU)
 	if err != nil {
 		logger.WithTrace(ctx, ranUe.Log).Error("error handling NAS Message", zap.Error(err))
-		sendRegistrationRejectOnError(ctx, ranUe)
+		sendStatus5GMM(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
 
 		return
-	}
-}
-
-// TS 24.501 §5.5.1.2.8 case (b): protocol error in REGISTRATION REQUEST.
-func sendRegistrationRejectOnError(ctx context.Context, ranUe *amf.RanUe) {
-	rejectPdu, err := message.BuildRegistrationReject(0, nasMessage.Cause5GMMProtocolErrorUnspecified)
-	if err != nil {
-		logger.WithTrace(ctx, ranUe.Log).Error("failed to build registration reject", zap.Error(err))
-		return
-	}
-
-	if err := ranUe.SendDownlinkNasTransport(ctx, rejectPdu, nil); err != nil {
-		logger.WithTrace(ctx, ranUe.Log).Error("failed to send registration reject", zap.Error(err))
 	}
 }

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -281,7 +281,7 @@ func TestHandleInitialUEMessage_RegisteredUE_DoesNotPanic(t *testing.T) {
 	}
 }
 
-func TestHandleInitialUEMessage_NASReturnsError_SendsRegistrationReject(t *testing.T) {
+func TestHandleInitialUEMessage_NASReturnsError_SendsStatus5GMM(t *testing.T) {
 	fakeNAS := &FakeNASHandler{Err: errors.New("nas decode failed")}
 	amfInstance := newTestAMFWithNAS(fakeNAS)
 
@@ -307,8 +307,8 @@ func TestHandleInitialUEMessage_NASReturnsError_SendsRegistrationReject(t *testi
 		t.Fatalf("NAS PDU too short: %d bytes", len(nasPdu))
 	}
 
-	if nasPdu[2] != 0x44 {
-		t.Errorf("NAS message type = 0x%02x, want 0x44 (RegistrationReject)", nasPdu[2])
+	if nasPdu[2] != 0x64 {
+		t.Errorf("NAS message type = 0x%02x, want 0x64 (5GMM STATUS)", nasPdu[2])
 	}
 
 	if nasPdu[3] != 0x6f {

--- a/internal/amf/ngap/handle_ng_reset.go
+++ b/internal/amf/ngap/handle_ng_reset.go
@@ -16,7 +16,10 @@ func HandleNGReset(ctx context.Context, ran *amf.Radio, msg decode.NGReset) {
 	switch msg.ResetType.Present {
 	case ngapType.ResetTypePresentNGInterface:
 		logger.WithTrace(ctx, ran.Log).Debug("ResetType Present: NG Interface")
-		ran.RemoveAllUeInRan()
+		// TS 38.413 §8.7.4: NG Reset is initiated when one side has lost its
+		// UE-associated logical NG-connection context. Treat as lower layer
+		// failure so ongoing NAS procedures are aborted per TS 24.501.
+		ran.RemoveAllUeInRan(ctx)
 		logger.WithTrace(ctx, ran.Log).Debug("All UE Context in RAN have been removed")
 
 		err := ran.NGAPSender.SendNGResetAcknowledge(ctx, nil)
@@ -58,7 +61,7 @@ func HandleNGReset(ctx context.Context, ran *amf.Radio, msg decode.NGReset) {
 				continue
 			}
 
-			err := ranUe.Remove()
+			err := ranUe.Remove(ctx)
 			if err != nil {
 				logger.WithTrace(ctx, ranUe.Log).Error(err.Error())
 			}

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -140,9 +140,9 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 			ctx,
 			ranUe.AmfUeNgapID,
 			ranUe.RanUeNgapID,
-			amfUe.UESecurityCapability,
-			amfUe.NCC,
-			amfUe.NH,
+			amfUe.Current().UESecurityCapability,
+			amfUe.Current().NCC,
+			amfUe.Current().NH,
 			pduSessionResourceSwitchedList,
 			pduSessionResourceReleasedListPSAck,
 			snssaiList,
@@ -204,7 +204,7 @@ func verifyUESecurityCapabilitiesOnPathSwitch(
 	case amf.VerifyMismatch:
 		logger.WithTrace(ctx, ranUe.Log).Warn(
 			"UE 5G security capabilities reported by target gNB differ from locally stored values; ignoring received values (TS 33.501 §6.7.3.1)",
-			zap.Binary("stored", amfUe.UESecurityCapability.Buffer),
+			zap.Binary("stored", amfUe.Current().UESecurityCapability.Buffer),
 			zap.Binary("received", reported.Buffer),
 		)
 	}

--- a/internal/amf/ngap/handle_path_switch_request_test.go
+++ b/internal/amf/ngap/handle_path_switch_request_test.go
@@ -138,11 +138,10 @@ func newTestAMFWithSmf(smf amf.SmfSbi) *amf.AMF {
 func newValidAmfUe() *amf.AmfUe {
 	amfUe := amf.NewAmfUe()
 	amfUe.Supi, _ = etsi.NewSUPIFromPrefixed("imsi-001010000000001")
-	amfUe.SecurityContextAvailable = true
-	amfUe.NgKsi.Ksi = 1
-	amfUe.MacFailed = false
-	amfUe.Kamf = "0000000000000000000000000000000000000000000000000000000000000000"
-	amfUe.NH = make([]byte, 32)
+	amfUe.Current().SecurityContextAvailable = true
+	amfUe.Current().NgKsi.Ksi = 1
+	amfUe.Current().Kamf = "0000000000000000000000000000000000000000000000000000000000000000"
+	amfUe.Current().NH = make([]byte, 32)
 	amfUe.Log = logger.AmfLog
 
 	return amfUe
@@ -252,8 +251,8 @@ func TestPathSwitchRequest_InvalidSecurityContext(t *testing.T) {
 	}
 
 	amfUe := amf.NewAmfUe()
-	amfUe.SecurityContextAvailable = false
-	amfUe.NgKsi.Ksi = nasMessage.NasKeySetIdentifierNoKeyIsAvailable
+	amfUe.Current().SecurityContextAvailable = false
+	amfUe.Current().NgKsi.Ksi = nasMessage.NasKeySetIdentifierNoKeyIsAvailable
 	amfUe.Log = logger.AmfLog
 
 	ranUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
@@ -363,7 +362,7 @@ func TestPathSwitchRequest_SmfReturnsError(t *testing.T) {
 	}
 
 	amfUe := newValidAmfUe()
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -442,8 +441,8 @@ func TestPathSwitchRequest_HappyPath(t *testing.T) {
 	}
 
 	amfUe := newValidAmfUe()
-	amfUe.Kamf = kamfHex
-	amfUe.SmContextList[pduSessionID] = &amf.SmContext{
+	amfUe.Current().Kamf = kamfHex
+	amfUe.Current().SmContextList[pduSessionID] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -551,7 +550,7 @@ func TestPathSwitchRequest_MultiplePDUSessions_PartialSuccess(t *testing.T) {
 
 	amfUe := newValidAmfUe()
 	// Session 1 has a context, session 2 does not
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -634,11 +633,11 @@ func TestPathSwitchRequest_FailedPDUSessionsReportedToSmf(t *testing.T) {
 	}
 
 	amfUe := newValidAmfUe()
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
-	amfUe.SmContextList[2] = &amf.SmContext{
+	amfUe.Current().SmContextList[2] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-2",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -736,15 +735,15 @@ func TestPathSwitchRequest_UESecurityCapabilitiesNotOverwritten(t *testing.T) {
 	}
 
 	amfUe := newValidAmfUe()
-	amfUe.UESecurityCapability = &nasType.UESecurityCapability{}
-	amfUe.UESecurityCapability.SetLen(4)
-	amfUe.UESecurityCapability.SetEA1_128_5G(1)
-	amfUe.UESecurityCapability.SetEA2_128_5G(1)
-	amfUe.UESecurityCapability.SetEA3_128_5G(1)
-	amfUe.UESecurityCapability.SetIA1_128_5G(1)
-	amfUe.UESecurityCapability.SetIA2_128_5G(1)
-	amfUe.UESecurityCapability.SetIA3_128_5G(1)
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().UESecurityCapability = &nasType.UESecurityCapability{}
+	amfUe.Current().UESecurityCapability.SetLen(4)
+	amfUe.Current().UESecurityCapability.SetEA1_128_5G(1)
+	amfUe.Current().UESecurityCapability.SetEA2_128_5G(1)
+	amfUe.Current().UESecurityCapability.SetEA3_128_5G(1)
+	amfUe.Current().UESecurityCapability.SetIA1_128_5G(1)
+	amfUe.Current().UESecurityCapability.SetIA2_128_5G(1)
+	amfUe.Current().UESecurityCapability.SetIA3_128_5G(1)
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -805,27 +804,27 @@ func TestPathSwitchRequest_UESecurityCapabilitiesNotOverwritten(t *testing.T) {
 
 	ngap.HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, decodePathSwitchRequestOrFatal(t, msg))
 
-	if got := amfUe.UESecurityCapability.GetEA1_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetEA1_128_5G(); got != 1 {
 		t.Errorf("stored EA1_128_5G was overwritten: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetEA2_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetEA2_128_5G(); got != 1 {
 		t.Errorf("stored EA2_128_5G was overwritten: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetEA3_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetEA3_128_5G(); got != 1 {
 		t.Errorf("stored EA3_128_5G was overwritten: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetIA1_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetIA1_128_5G(); got != 1 {
 		t.Errorf("stored IA1_128_5G was overwritten: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetIA2_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetIA2_128_5G(); got != 1 {
 		t.Errorf("stored IA2_128_5G was overwritten: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetIA3_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetIA3_128_5G(); got != 1 {
 		t.Errorf("stored IA3_128_5G was overwritten: got %d, want 1", got)
 	}
 
@@ -861,11 +860,11 @@ func TestPathSwitchRequest_UESecurityCapabilitiesMatching(t *testing.T) {
 	}
 
 	amfUe := newValidAmfUe()
-	amfUe.UESecurityCapability = &nasType.UESecurityCapability{}
-	amfUe.UESecurityCapability.SetLen(4)
-	amfUe.UESecurityCapability.SetEA1_128_5G(1)
-	amfUe.UESecurityCapability.SetIA2_128_5G(1)
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().UESecurityCapability = &nasType.UESecurityCapability{}
+	amfUe.Current().UESecurityCapability.SetLen(4)
+	amfUe.Current().UESecurityCapability.SetEA1_128_5G(1)
+	amfUe.Current().UESecurityCapability.SetIA2_128_5G(1)
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -926,15 +925,15 @@ func TestPathSwitchRequest_UESecurityCapabilitiesMatching(t *testing.T) {
 
 	ngap.HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, decodePathSwitchRequestOrFatal(t, msg))
 
-	if got := amfUe.UESecurityCapability.GetEA1_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetEA1_128_5G(); got != 1 {
 		t.Errorf("stored EA1_128_5G changed after matching path switch: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetIA2_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetIA2_128_5G(); got != 1 {
 		t.Errorf("stored IA2_128_5G changed after matching path switch: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetEA2_128_5G(); got != 0 {
+	if got := amfUe.Current().UESecurityCapability.GetEA2_128_5G(); got != 0 {
 		t.Errorf("stored EA2_128_5G unexpectedly set: got %d, want 0", got)
 	}
 
@@ -966,11 +965,11 @@ func TestPathSwitchRequest_EmptySecurityCapabilityBytes(t *testing.T) {
 	}
 
 	amfUe := newValidAmfUe()
-	amfUe.UESecurityCapability = &nasType.UESecurityCapability{}
-	amfUe.UESecurityCapability.SetLen(4)
-	amfUe.UESecurityCapability.SetEA1_128_5G(1)
-	amfUe.UESecurityCapability.SetIA2_128_5G(1)
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().UESecurityCapability = &nasType.UESecurityCapability{}
+	amfUe.Current().UESecurityCapability.SetLen(4)
+	amfUe.Current().UESecurityCapability.SetEA1_128_5G(1)
+	amfUe.Current().UESecurityCapability.SetIA2_128_5G(1)
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "imsi-001010000000001-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -1028,11 +1027,11 @@ func TestPathSwitchRequest_EmptySecurityCapabilityBytes(t *testing.T) {
 
 	ngap.HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, decodePathSwitchRequestOrFatal(t, msg))
 
-	if got := amfUe.UESecurityCapability.GetEA1_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetEA1_128_5G(); got != 1 {
 		t.Errorf("stored EA1_128_5G was modified by malformed IE: got %d, want 1", got)
 	}
 
-	if got := amfUe.UESecurityCapability.GetIA2_128_5G(); got != 1 {
+	if got := amfUe.Current().UESecurityCapability.GetIA2_128_5G(); got != 1 {
 		t.Errorf("stored IA2_128_5G was modified by malformed IE: got %d, want 1", got)
 	}
 

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
@@ -11,23 +11,8 @@ import (
 )
 
 func HandlePDUSessionResourceModifyIndication(ctx context.Context, ran *amf.Radio, msg decode.PDUSessionResourceModifyIndication) {
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-			return
-		}
-
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication_test.go
@@ -35,6 +35,31 @@ func TestPDUSessionResourceModifyIndication_UnknownRanUeNgapID(t *testing.T) {
 	}
 }
 
+func TestPDUSessionResourceModifyIndication_AMFUENGAPIDMismatch(t *testing.T) {
+	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
+
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
+
+	ngap.HandlePDUSessionResourceModifyIndication(context.Background(), ran, decode.PDUSessionResourceModifyIndication{
+		RANUENGAPID: 1,
+		AMFUENGAPID: 99999,
+	})
+
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(sender.SentErrorIndications))
+	}
+
+	ei := sender.SentErrorIndications[0]
+	if ei.Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
+		t.Errorf("cause = %d, want InconsistentRemoteUENGAPID", ei.Cause.RadioNetwork.Value)
+	}
+
+	if len(sender.SentPDUSessionModifyConfirms) != 0 {
+		t.Errorf("expected no Modify Confirm on ID mismatch, got %d", len(sender.SentPDUSessionModifyConfirms))
+	}
+}
+
 func TestPDUSessionResourceModifyIndication_SendsModifyConfirm(t *testing.T) {
 	ran := newTestRadio()
 	sender := ran.NGAPSender.(*FakeNGAPSender)
@@ -43,6 +68,7 @@ func TestPDUSessionResourceModifyIndication_SendsModifyConfirm(t *testing.T) {
 
 	ngap.HandlePDUSessionResourceModifyIndication(context.Background(), ran, decode.PDUSessionResourceModifyIndication{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 	})
 
 	if len(sender.SentErrorIndications) != 0 {

--- a/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
@@ -41,7 +41,7 @@ func TestPDUSessionResourceNotify_ReleasedSessionDeactivated(t *testing.T) {
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -67,7 +67,7 @@ func TestPDUSessionResourceNotify_ReleasedSessionDeactivated(t *testing.T) {
 		t.Errorf("DeactivateSmContext ref = %q, want %q", fakeSmf.DeactivateSmContextCalls[0], "ref-session-1")
 	}
 
-	sc := amfUe.SmContextList[1]
+	sc := amfUe.Current().SmContextList[1]
 	if sc == nil {
 		t.Fatal("SmContext was removed instead of marked inactive")
 	}

--- a/internal/amf/ngap/handle_pdu_session_resource_release_response_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_release_response_test.go
@@ -35,7 +35,7 @@ func TestHandlePDUSessionResourceReleaseResponse_UEFoundWithReleasedSessions(t *
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}

--- a/internal/amf/ngap/handle_pdu_session_resource_setup_response_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_setup_response_test.go
@@ -73,7 +73,7 @@ func TestHandlePDUSessionResourceSetupResponse_HappyPath(t *testing.T) {
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}
@@ -115,7 +115,7 @@ func TestHandlePDUSessionResourceSetupResponse_FailedItemForwardedToSmf(t *testi
 
 	amfUe := amf.NewAmfUe()
 	amfUe.Log = logger.AmfLog
-	amfUe.SmContextList[1] = &amf.SmContext{
+	amfUe.Current().SmContextList[1] = &amf.SmContext{
 		Ref:    "ref-session-1",
 		Snssai: &models.Snssai{Sst: 1},
 	}

--- a/internal/amf/ngap/handle_ue_context_release_complete.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete.go
@@ -35,7 +35,7 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 	if amfUe == nil {
 		logger.WithTrace(ctx, ranUe.Log).Info("Release UE Context", zap.Int64("AmfUeNgapID", ranUe.AmfUeNgapID), zap.Int64("RanUeNgapID", *msg.RANUENGAPID))
 
-		err := ranUe.Remove()
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error(err.Error())
 		}
@@ -75,8 +75,8 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 				id  uint8
 			}
 
-			smContextRefs := make([]smCtxRef, 0, len(amfUe.SmContextList))
-			for pduSessionID, smContext := range amfUe.SmContextList {
+			smContextRefs := make([]smCtxRef, 0, len(amfUe.Current().SmContextList))
+			for pduSessionID, smContext := range amfUe.Current().SmContextList {
 				smContextRefs = append(smContextRefs, smCtxRef{ref: smContext.Ref, id: pduSessionID})
 			}
 
@@ -99,27 +99,27 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 	case amf.UeContextN2NormalRelease:
 		logger.WithTrace(ctx, ranUe.Log).Info("Release UE Context: N2 Connection Release", logger.SUPI(amfUe.Supi.String()))
 
-		err := ranUe.Remove()
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error(err.Error())
 		}
 	case amf.UeContextReleaseUeContext:
 		logger.WithTrace(ctx, ranUe.Log).Info("Release UE Context: Release Ue Context", logger.SUPI(amfUe.Supi.String()))
 
-		err := ranUe.Remove()
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error(err.Error())
 		}
 
 		// No valid security context exists for this UE, so delete the AMF UE context
-		if !amfUe.SecurityContextAvailable {
+		if !amfUe.Current().SecurityContextAvailable {
 			logger.WithTrace(ctx, ranUe.Log).Info("No valid security context for UE, deleting AMF UE context", logger.SUPI(amfUe.Supi.String()))
 			amfInstance.DeregisterAndRemoveAMFUE(ctx, amfUe)
 		}
 	case amf.UeContextReleaseDueToNwInitiatedDeregistraion:
 		logger.WithTrace(ctx, ranUe.Log).Info("Release UE Context Due to Nw Initiated: Release Ue Context", logger.SUPI(amfUe.Supi.String()))
 
-		err := ranUe.Remove()
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error(err.Error())
 		}
@@ -143,7 +143,7 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 
 		amf.DetachSourceUeTargetUe(ranUe)
 
-		err := ranUe.Remove()
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error(err.Error())
 		}

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -72,8 +72,8 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 					id  uint8
 				}
 
-				smContextRefs := make([]smCtxRef, 0, len(amfUe.SmContextList))
-				for pduSessionID, smContext := range amfUe.SmContextList {
+				smContextRefs := make([]smCtxRef, 0, len(amfUe.Current().SmContextList))
+				for pduSessionID, smContext := range amfUe.Current().SmContextList {
 					if smContext.PduSessionInactive {
 						logger.WithTrace(ctx, ranUe.Log).Info("Pdu Session is inactive so not sending deactivate to SMF", logger.PDUSessionID(pduSessionID))
 						continue
@@ -108,8 +108,8 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 				id  uint8
 			}
 
-			smContextRefs := make([]smCtxRef, 0, len(amfUe.SmContextList))
-			for pduSessionID, smContext := range amfUe.SmContextList {
+			smContextRefs := make([]smCtxRef, 0, len(amfUe.Current().SmContextList))
+			for pduSessionID, smContext := range amfUe.Current().SmContextList {
 				smContextRefs = append(smContextRefs, smCtxRef{ref: smContext.Ref, id: pduSessionID})
 			}
 

--- a/internal/amf/ngap/handle_ue_radio_capability_info_indication.go
+++ b/internal/amf/ngap/handle_ue_radio_capability_info_indication.go
@@ -28,18 +28,18 @@ func HandleUERadioCapabilityInfoIndication(ctx gocontext.Context, ran *amf.Radio
 	}
 
 	if msg.UERadioCapability != nil {
-		amfUe.UeRadioCapability = hex.EncodeToString(msg.UERadioCapability)
+		amfUe.Current().UeRadioCapability = hex.EncodeToString(msg.UERadioCapability)
 	}
 
 	if msg.UERadioCapabilityForPaging != nil {
-		amfUe.UeRadioCapabilityForPaging = &models.UERadioCapabilityForPaging{}
+		amfUe.Current().UeRadioCapabilityForPaging = &models.UERadioCapabilityForPaging{}
 		if msg.UERadioCapabilityForPaging.UERadioCapabilityForPagingOfNR != nil {
-			amfUe.UeRadioCapabilityForPaging.NR = hex.EncodeToString(
+			amfUe.Current().UeRadioCapabilityForPaging.NR = hex.EncodeToString(
 				msg.UERadioCapabilityForPaging.UERadioCapabilityForPagingOfNR.Value)
 		}
 
 		if msg.UERadioCapabilityForPaging.UERadioCapabilityForPagingOfEUTRA != nil {
-			amfUe.UeRadioCapabilityForPaging.EUTRA = hex.EncodeToString(
+			amfUe.Current().UeRadioCapabilityForPaging.EUTRA = hex.EncodeToString(
 				msg.UERadioCapabilityForPaging.UERadioCapabilityForPagingOfEUTRA.Value)
 		}
 	}

--- a/internal/amf/ngap/handle_ue_radio_capability_info_indication_test.go
+++ b/internal/amf/ngap/handle_ue_radio_capability_info_indication_test.go
@@ -43,8 +43,8 @@ func TestUERadioCapabilityInfoIndication_SetsRadioCapability(t *testing.T) {
 		UERadioCapability: []byte{0xDE, 0xAD, 0xBE, 0xEF},
 	})
 
-	if amfUe.UeRadioCapability != "deadbeef" {
-		t.Errorf("UeRadioCapability = %q, want %q", amfUe.UeRadioCapability, "deadbeef")
+	if amfUe.Current().UeRadioCapability != "deadbeef" {
+		t.Errorf("UeRadioCapability = %q, want %q", amfUe.Current().UeRadioCapability, "deadbeef")
 	}
 }
 
@@ -68,16 +68,16 @@ func TestUERadioCapabilityInfoIndication_SetsRadioCapabilityForPaging(t *testing
 		},
 	})
 
-	if amfUe.UeRadioCapabilityForPaging == nil {
+	if amfUe.Current().UeRadioCapabilityForPaging == nil {
 		t.Fatal("UeRadioCapabilityForPaging is nil")
 	}
 
-	if amfUe.UeRadioCapabilityForPaging.NR != "cafe" {
-		t.Errorf("NR = %q, want %q", amfUe.UeRadioCapabilityForPaging.NR, "cafe")
+	if amfUe.Current().UeRadioCapabilityForPaging.NR != "cafe" {
+		t.Errorf("NR = %q, want %q", amfUe.Current().UeRadioCapabilityForPaging.NR, "cafe")
 	}
 
-	if amfUe.UeRadioCapabilityForPaging.EUTRA != "babe" {
-		t.Errorf("EUTRA = %q, want %q", amfUe.UeRadioCapabilityForPaging.EUTRA, "babe")
+	if amfUe.Current().UeRadioCapabilityForPaging.EUTRA != "babe" {
+		t.Errorf("EUTRA = %q, want %q", amfUe.Current().UeRadioCapabilityForPaging.EUTRA, "babe")
 	}
 }
 
@@ -93,11 +93,11 @@ func TestUERadioCapabilityInfoIndication_NilCapabilityFieldsNoOp(t *testing.T) {
 		RANUENGAPID: 1,
 	})
 
-	if amfUe.UeRadioCapability != "" {
-		t.Errorf("UeRadioCapability = %q, want empty", amfUe.UeRadioCapability)
+	if amfUe.Current().UeRadioCapability != "" {
+		t.Errorf("UeRadioCapability = %q, want empty", amfUe.Current().UeRadioCapability)
 	}
 
-	if amfUe.UeRadioCapabilityForPaging != nil {
-		t.Errorf("UeRadioCapabilityForPaging = %+v, want nil", amfUe.UeRadioCapabilityForPaging)
+	if amfUe.Current().UeRadioCapabilityForPaging != nil {
+		t.Errorf("UeRadioCapabilityForPaging = %+v, want nil", amfUe.Current().UeRadioCapabilityForPaging)
 	}
 }

--- a/internal/amf/ngap/handle_uplink_nas_transport.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport.go
@@ -12,11 +12,8 @@ import (
 )
 
 func HandleUplinkNasTransport(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.UplinkNASTransport) {
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("unknown RAN UE NGAP ID in UplinkNASTransport", zap.Int64("ranUeNgapID", msg.RANUENGAPID))
-		sendUnknownLocalUEError(ctx, ran)
-
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 
@@ -24,7 +21,9 @@ func HandleUplinkNasTransport(ctx context.Context, amfInstance *amf.AMF, ran *am
 
 	amfUe := ranUe.AmfUe()
 	if amfUe == nil {
-		err := ranUe.Remove()
+		// No AMF UE bound, so no NAS state to clean up. Pass ReleaseNormal
+		// — the cause is moot when there is no NAS connection to release.
+		err := ranUe.Remove(ctx)
 		if err != nil {
 			logger.WithTrace(ctx, ranUe.Log).Error("error removing ran ue context", zap.Error(err))
 		}

--- a/internal/amf/ngap/handle_uplink_nas_transport_test.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport_test.go
@@ -41,6 +41,44 @@ func TestHandleUplinkNasTransport_UnknownRanUe_SendsErrorIndication(t *testing.T
 	}
 }
 
+// TestHandleUplinkNasTransport_AMFUENGAPIDMismatch_SendsErrorIndication
+// covers TS 38.413 §8.7.5.2: when the RAN UE NGAP ID identifies a known UE
+// but the AMF UE NGAP ID in the message does not match the one the AMF
+// allocated to that UE, the AMF shall respond with ErrorIndication and
+// cause "Inconsistent remote UE NGAP ID".
+func TestHandleUplinkNasTransport_AMFUENGAPIDMismatch_SendsErrorIndication(t *testing.T) {
+	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
+	fakeNAS := &FakeNASHandler{}
+	amfInstance := newTestAMFWithNAS(fakeNAS)
+
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
+
+	ngap.HandleUplinkNasTransport(context.Background(), amfInstance, ran, decode.UplinkNASTransport{
+		AMFUENGAPID: 99999,
+		RANUENGAPID: 1,
+		NASPDU:      []byte{0x7E, 0x00, 0x55},
+	})
+
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("ErrorIndications sent = %d, want 1", len(sender.SentErrorIndications))
+	}
+
+	cause := sender.SentErrorIndications[0].Cause
+	if cause == nil || cause.Present != ngapType.CausePresentRadioNetwork {
+		t.Fatal("expected RadioNetwork cause")
+	}
+
+	if cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
+		t.Errorf("cause = %d, want InconsistentRemoteUENGAPID (%d)",
+			cause.RadioNetwork.Value, ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID)
+	}
+
+	if len(fakeNAS.Calls) != 0 {
+		t.Errorf("NAS handler must not be invoked on ID mismatch, got %d calls", len(fakeNAS.Calls))
+	}
+}
+
 func TestHandleUplinkNasTransport_NilAmfUe_RemovesRanUe(t *testing.T) {
 	ran := newTestRadio()
 	amfInstance := newTestAMF()

--- a/internal/amf/ngap/send/build.go
+++ b/internal/amf/ngap/send/build.go
@@ -1455,14 +1455,14 @@ func buildInitialContextSetupRequest(
 		if ueRadioCapabilityForPaging.NR != "" {
 			uERadioCapabilityForPaging.UERadioCapabilityForPagingOfNR.Value, err = hex.DecodeString(ueRadioCapabilityForPaging.NR)
 			if err != nil {
-				return nil, fmt.Errorf("DecodeString amfUe.UeRadioCapabilityForPaging.NR error: %+v", err)
+				return nil, fmt.Errorf("DecodeString amfUe.Current().UeRadioCapabilityForPaging.NR error: %+v", err)
 			}
 		}
 
 		if ueRadioCapabilityForPaging.EUTRA != "" {
 			uERadioCapabilityForPaging.UERadioCapabilityForPagingOfEUTRA.Value, err = hex.DecodeString(ueRadioCapabilityForPaging.EUTRA)
 			if err != nil {
-				return nil, fmt.Errorf("DecodeString amfUe.UeRadioCapabilityForPaging.EUTRA error: %+v", err)
+				return nil, fmt.Errorf("DecodeString amfUe.Current().UeRadioCapabilityForPaging.EUTRA error: %+v", err)
 			}
 		}
 
@@ -1929,14 +1929,14 @@ func BuildPaging(
 		if ueRadioCapabilityForPaging.NR != "" {
 			uERadioCapabilityForPaging.UERadioCapabilityForPagingOfNR.Value, err = hex.DecodeString(ueRadioCapabilityForPaging.NR)
 			if err != nil {
-				return nil, fmt.Errorf("DecodeString ue.UeRadioCapabilityForPaging.NR error: %s", err)
+				return nil, fmt.Errorf("DecodeString ue.Current().UeRadioCapabilityForPaging.NR error: %s", err)
 			}
 		}
 
 		if ueRadioCapabilityForPaging.EUTRA != "" {
 			uERadioCapabilityForPaging.UERadioCapabilityForPagingOfEUTRA.Value, err = hex.DecodeString(ueRadioCapabilityForPaging.EUTRA)
 			if err != nil {
-				return nil, fmt.Errorf("DecodeString ue.UeRadioCapabilityForPaging.EUTRA error: %s", err)
+				return nil, fmt.Errorf("DecodeString ue.Current().UeRadioCapabilityForPaging.EUTRA error: %s", err)
 			}
 		}
 

--- a/internal/amf/procedure/procedure.go
+++ b/internal/amf/procedure/procedure.go
@@ -36,7 +36,6 @@ var nextID atomic.Uint64
 // transient state owned by handlers; the registry treats it opaquely.
 type Procedure struct {
 	Type      Type
-	State     any
 	StartedAt time.Time
 	Deadline  time.Time
 	Cancel    func(context.Context) error
@@ -296,36 +295,6 @@ func (r *Registry) CancelByID(ctx context.Context, id ID) error {
 	return nil
 }
 
-// CancelAll invokes Cancel for every active procedure in reverse-Begin
-// order (most recently started first), then clears the registry.
-func (r *Registry) CancelAll(ctx context.Context) {
-	r.mu.Lock()
-	entries := make([]entry, len(r.active))
-	copy(entries, r.active)
-	r.active = r.active[:0]
-	r.stopped = true
-	r.mu.Unlock()
-
-	for _, e := range entries {
-		if e.timer != nil {
-			e.timer.Stop()
-		}
-
-		close(e.done)
-	}
-
-	// Cancel in reverse-Begin order.
-	for i := len(entries) - 1; i >= 0; i-- {
-		e := entries[i]
-		r.log.Info("procedure cancelled",
-			zap.String("type", string(e.proc.Type)),
-			zap.Uint64("id", uint64(e.id)),
-			zap.String("reason", "teardown"),
-		)
-		r.invokeCancel(ctx, e)
-	}
-}
-
 // Active returns true if t has at least one active instance.
 func (r *Registry) Active(t Type) bool {
 	r.mu.Lock()
@@ -338,51 +307,6 @@ func (r *Registry) Active(t Type) bool {
 	}
 
 	return false
-}
-
-// Get returns the first active instance of t (oldest, FIFO).
-func (r *Registry) Get(t Type) (Procedure, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	for _, e := range r.active {
-		if e.proc.Type == t {
-			return e.proc, true
-		}
-	}
-
-	return Procedure{}, false
-}
-
-// UpdateState replaces the State of the first active instance of t.
-// Returns ErrNotActive if no instance is active.
-func (r *Registry) UpdateState(t Type, state any) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	for i := range r.active {
-		if r.active[i].proc.Type == t {
-			r.active[i].proc.State = state
-			return nil
-		}
-	}
-
-	return ErrNotActive
-}
-
-// Snapshot returns a copy of the active set for diagnostics.
-func (r *Registry) Snapshot() []Procedure {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	out := make([]Procedure, len(r.active))
-	for i, e := range r.active {
-		p := e.proc
-		p.Cancel = nil // don't leak callbacks
-		out[i] = p
-	}
-
-	return out
 }
 
 // ActiveTypes returns the set of active procedure type strings,

--- a/internal/amf/procedure/procedure.go
+++ b/internal/amf/procedure/procedure.go
@@ -32,9 +32,11 @@ type ID uint64
 
 var nextID atomic.Uint64
 
-// Procedure is the unit tracked by the registry.
+// Procedure is the unit tracked by the registry. State is procedure-specific
+// transient state owned by handlers; the registry treats it opaquely.
 type Procedure struct {
 	Type      Type
+	State     any
 	StartedAt time.Time
 	Deadline  time.Time
 	Cancel    func(context.Context) error
@@ -53,6 +55,7 @@ type entry struct {
 	proc      Procedure
 	timer     *time.Timer
 	startedAt time.Time
+	done      chan struct{}
 }
 
 // Registry tracks which procedures are active for a single UE and
@@ -114,10 +117,12 @@ func (r *Registry) Begin(ctx context.Context, p Procedure) (ID, error) {
 	}
 
 	id := ID(nextID.Add(1))
+	done := make(chan struct{})
 	e := entry{
 		id:        id,
 		proc:      p,
 		startedAt: now,
+		done:      done,
 	}
 
 	// Arm deadline timer.
@@ -141,7 +146,22 @@ func (r *Registry) Begin(ctx context.Context, p Procedure) (ID, error) {
 		zap.Time("deadline", p.Deadline),
 	)
 
+	// ctx is intentionally captured: the watcher's role is to abort the
+	// procedure when ctx is cancelled.
+	// #nosec G118 -- captured ctx is the cancellation signal we observe
+	go r.watchCtx(ctx, id, done)
+
 	return id, nil
+}
+
+// watchCtx aborts the procedure when ctx is cancelled. Exits cleanly when
+// the procedure ends (or is cancelled) by other means.
+func (r *Registry) watchCtx(ctx context.Context, id ID, done <-chan struct{}) {
+	select {
+	case <-ctx.Done():
+		_ = r.CancelByID(context.Background(), id)
+	case <-done:
+	}
 }
 
 // End marks t as finished (success path). Does not invoke Cancel.
@@ -167,6 +187,8 @@ func (r *Registry) End(t Type) {
 	r.active = append(r.active[:idx], r.active[idx+1:]...)
 	r.mu.Unlock()
 
+	close(e.done)
+
 	if e.timer != nil {
 		e.timer.Stop()
 	}
@@ -191,6 +213,8 @@ func (r *Registry) EndByID(id ID) {
 	e := r.active[idx]
 	r.active = append(r.active[:idx], r.active[idx+1:]...)
 	r.mu.Unlock()
+
+	close(e.done)
 
 	if e.timer != nil {
 		e.timer.Stop()
@@ -224,6 +248,8 @@ func (r *Registry) Cancel(ctx context.Context, t Type) error {
 	r.active = append(r.active[:idx], r.active[idx+1:]...)
 	r.mu.Unlock()
 
+	close(e.done)
+
 	if e.timer != nil {
 		e.timer.Stop()
 	}
@@ -253,6 +279,8 @@ func (r *Registry) CancelByID(ctx context.Context, id ID) error {
 	r.active = append(r.active[:idx], r.active[idx+1:]...)
 	r.mu.Unlock()
 
+	close(e.done)
+
 	if e.timer != nil {
 		e.timer.Stop()
 	}
@@ -278,11 +306,12 @@ func (r *Registry) CancelAll(ctx context.Context) {
 	r.stopped = true
 	r.mu.Unlock()
 
-	// Stop timers first.
 	for _, e := range entries {
 		if e.timer != nil {
 			e.timer.Stop()
 		}
+
+		close(e.done)
 	}
 
 	// Cancel in reverse-Begin order.
@@ -309,6 +338,36 @@ func (r *Registry) Active(t Type) bool {
 	}
 
 	return false
+}
+
+// Get returns the first active instance of t (oldest, FIFO).
+func (r *Registry) Get(t Type) (Procedure, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, e := range r.active {
+		if e.proc.Type == t {
+			return e.proc, true
+		}
+	}
+
+	return Procedure{}, false
+}
+
+// UpdateState replaces the State of the first active instance of t.
+// Returns ErrNotActive if no instance is active.
+func (r *Registry) UpdateState(t Type, state any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i := range r.active {
+		if r.active[i].proc.Type == t {
+			r.active[i].proc.State = state
+			return nil
+		}
+	}
+
+	return ErrNotActive
 }
 
 // Snapshot returns a copy of the active set for diagnostics.
@@ -363,7 +422,8 @@ func (r *Registry) expireByID(ctx context.Context, id ID) {
 	r.active = append(r.active[:idx], r.active[idx+1:]...)
 	r.mu.Unlock()
 
-	// Timer already fired; no need to stop it.
+	close(e.done)
+
 	r.log.Warn("procedure expired",
 		zap.String("type", string(e.proc.Type)),
 		zap.Uint64("id", uint64(e.id)),

--- a/internal/amf/procedure/procedure_test.go
+++ b/internal/amf/procedure/procedure_test.go
@@ -101,6 +101,103 @@ func TestConflictMatrix(t *testing.T) {
 	}
 }
 
+func TestContextCancellationAborts(t *testing.T) {
+	r := newTestRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var cancelled atomic.Bool
+
+	_, err := r.Begin(ctx, procedure.Procedure{
+		Type: procedure.N2Handover,
+		Cancel: func(context.Context) error {
+			cancelled.Store(true)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	cancel()
+
+	deadline := time.Now().Add(time.Second)
+	for !cancelled.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+
+	if !cancelled.Load() {
+		t.Fatal("expected cancel callback to fire on ctx cancellation")
+	}
+
+	if r.Active(procedure.N2Handover) {
+		t.Fatal("expected N2Handover to be removed after ctx cancellation")
+	}
+}
+
+func TestContextNotCancelledDoesNotFire(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	var cancelled atomic.Bool
+
+	_, err := r.Begin(ctx, procedure.Procedure{
+		Type: procedure.N2Handover,
+		Cancel: func(context.Context) error {
+			cancelled.Store(true)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	r.End(procedure.N2Handover)
+
+	time.Sleep(20 * time.Millisecond)
+
+	if cancelled.Load() {
+		t.Fatal("Cancel callback fired after End")
+	}
+}
+
+func TestGetAndUpdateState(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	type myState struct{ phase int }
+
+	if _, ok := r.Get(procedure.Authentication); ok {
+		t.Fatal("Get returned ok on empty registry")
+	}
+
+	_, err := r.Begin(ctx, procedure.Procedure{Type: procedure.Authentication, State: myState{phase: 1}})
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	got, ok := r.Get(procedure.Authentication)
+	if !ok {
+		t.Fatal("Get returned not ok for active procedure")
+	}
+
+	if s, _ := got.State.(myState); s.phase != 1 {
+		t.Errorf("State.phase = %d, want 1", s.phase)
+	}
+
+	if err := r.UpdateState(procedure.Authentication, myState{phase: 2}); err != nil {
+		t.Errorf("UpdateState failed: %v", err)
+	}
+
+	got, _ = r.Get(procedure.Authentication)
+	if s, _ := got.State.(myState); s.phase != 2 {
+		t.Errorf("after update, State.phase = %d, want 2", s.phase)
+	}
+
+	if err := r.UpdateState(procedure.N2Handover, myState{phase: 9}); err != procedure.ErrNotActive {
+		t.Errorf("UpdateState on inactive type: err = %v, want ErrNotActive", err)
+	}
+}
+
 func TestDeadlineExpiry(t *testing.T) {
 	r := newTestRegistry()
 	ctx := context.Background()

--- a/internal/amf/procedure/procedure_test.go
+++ b/internal/amf/procedure/procedure_test.go
@@ -160,44 +160,6 @@ func TestContextNotCancelledDoesNotFire(t *testing.T) {
 	}
 }
 
-func TestGetAndUpdateState(t *testing.T) {
-	r := newTestRegistry()
-	ctx := context.Background()
-
-	type myState struct{ phase int }
-
-	if _, ok := r.Get(procedure.Authentication); ok {
-		t.Fatal("Get returned ok on empty registry")
-	}
-
-	_, err := r.Begin(ctx, procedure.Procedure{Type: procedure.Authentication, State: myState{phase: 1}})
-	if err != nil {
-		t.Fatalf("Begin failed: %v", err)
-	}
-
-	got, ok := r.Get(procedure.Authentication)
-	if !ok {
-		t.Fatal("Get returned not ok for active procedure")
-	}
-
-	if s, _ := got.State.(myState); s.phase != 1 {
-		t.Errorf("State.phase = %d, want 1", s.phase)
-	}
-
-	if err := r.UpdateState(procedure.Authentication, myState{phase: 2}); err != nil {
-		t.Errorf("UpdateState failed: %v", err)
-	}
-
-	got, _ = r.Get(procedure.Authentication)
-	if s, _ := got.State.(myState); s.phase != 2 {
-		t.Errorf("after update, State.phase = %d, want 2", s.phase)
-	}
-
-	if err := r.UpdateState(procedure.N2Handover, myState{phase: 9}); err != procedure.ErrNotActive {
-		t.Errorf("UpdateState on inactive type: err = %v, want ErrNotActive", err)
-	}
-}
-
 func TestDeadlineExpiry(t *testing.T) {
 	r := newTestRegistry()
 	ctx := context.Background()
@@ -306,44 +268,6 @@ func TestConcurrentBeginConflict(t *testing.T) {
 	}
 }
 
-func TestCancelAllReverseOrder(t *testing.T) {
-	r := newTestRegistry()
-	ctx := context.Background()
-
-	var (
-		order []procedure.Type
-		mu    sync.Mutex
-	)
-
-	makeCancel := func(typ procedure.Type) func(context.Context) error {
-		return func(context.Context) error {
-			mu.Lock()
-			defer mu.Unlock()
-
-			order = append(order, typ)
-
-			return nil
-		}
-	}
-
-	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Registration, Cancel: makeCancel(procedure.Registration)})
-	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Authentication, Cancel: makeCancel(procedure.Authentication)})
-	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Paging, Cancel: makeCancel(procedure.Paging)})
-
-	r.CancelAll(ctx)
-
-	expected := []procedure.Type{procedure.Paging, procedure.Authentication, procedure.Registration}
-	if len(order) != len(expected) {
-		t.Fatalf("expected %d cancellations, got %d", len(expected), len(order))
-	}
-
-	for i, typ := range expected {
-		if order[i] != typ {
-			t.Fatalf("position %d: expected %s, got %s", i, typ, order[i])
-		}
-	}
-}
-
 func TestPagingReentrant(t *testing.T) {
 	r := newTestRegistry()
 	ctx := context.Background()
@@ -411,25 +335,6 @@ func TestEndDoesNotInvokeCancel(t *testing.T) {
 
 	if called.Load() {
 		t.Fatal("End should not invoke Cancel callback")
-	}
-}
-
-func TestSnapshot(t *testing.T) {
-	r := newTestRegistry()
-	ctx := context.Background()
-
-	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Registration})
-	_, _ = r.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
-
-	snap := r.Snapshot()
-	if len(snap) != 2 {
-		t.Fatalf("expected 2 entries in snapshot, got %d", len(snap))
-	}
-
-	for _, p := range snap {
-		if p.Cancel != nil {
-			t.Fatal("snapshot leaked Cancel callback")
-		}
 	}
 }
 

--- a/internal/amf/producer/n1n2message.go
+++ b/internal/amf/producer/n1n2message.go
@@ -283,15 +283,20 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 		return fmt.Errorf("ue context not found")
 	}
 
-	if ue.NasConn().Procedures.Active(procedure.Paging) {
+	conn := ue.NasConn()
+	if conn == nil {
+		return fmt.Errorf("ue has no active NAS connection")
+	}
+
+	if conn.Procedures.Active(procedure.Paging) {
 		return fmt.Errorf("higher priority request ongoing")
 	}
 
-	if ue.NasConn().Procedures.Active(procedure.Registration) {
+	if conn.Procedures.Active(procedure.Registration) {
 		return fmt.Errorf("temporary reject registration ongoing")
 	}
 
-	if ue.NasConn().Procedures.Active(procedure.N2Handover) {
+	if conn.Procedures.Active(procedure.N2Handover) {
 		return fmt.Errorf("temporary reject handover ongoing")
 	}
 

--- a/internal/amf/producer/n1n2message.go
+++ b/internal/amf/producer/n1n2message.go
@@ -61,12 +61,12 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 
 	ue.Log.Debug("AMF Transfer NGAP PDU Session Resource Setup Request from SMF")
 
-	if ranUe.SentInitialContextSetupRequest {
+	if ranUe.ICS != amf.ICSNotStarted {
 		list := ngapType.PDUSessionResourceSetupListSUReq{}
 
 		send.AppendPDUSessionResourceSetupListSUReq(&list, req.PduSessionID, req.SNssai, nasPdu, req.BinaryDataN2Information)
 
-		err := ranUe.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
+		err := ranUe.SendPDUSessionResourceSetupRequest(ctx, ue.Current().Ambr.Uplink, ue.Current().Ambr.Downlink, nil, list)
 		if err != nil {
 			return fmt.Errorf("send pdu session resource setup request error: %v", err)
 		}
@@ -87,14 +87,14 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 
 	err = ranUe.SendInitialContextSetupRequest(
 		ctx,
-		ue.Ambr.Uplink,
-		ue.Ambr.Downlink,
-		ue.AllowedNssai,
-		ue.Kgnb,
+		ue.Current().Ambr.Uplink,
+		ue.Current().Ambr.Downlink,
+		ue.Current().AllowedNssai,
+		ue.Current().Kgnb,
 		ue.PlmnID,
-		ue.UeRadioCapability,
-		ue.UeRadioCapabilityForPaging,
-		ue.UESecurityCapability,
+		ue.Current().UeRadioCapability,
+		ue.Current().UeRadioCapabilityForPaging,
+		ue.Current().UESecurityCapability,
 		nil,
 		&list,
 		operatorInfo.Guami,
@@ -105,21 +105,26 @@ func TransferN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SU
 
 	ue.Log.Info("Sent NGAP initial context setup request to UE")
 
-	ranUe.SentInitialContextSetupRequest = true
+	ranUe.ICS = amf.ICSPending
 
 	return nil
 }
 
 func storeN1N2AndPage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, req models.N1N2MessageTransferRequest) error {
-	if ue.Procedures.Active(procedure.Paging) {
+	nasConn := ue.NasConn()
+	if nasConn == nil {
+		return fmt.Errorf("ue has no active NAS connection")
+	}
+
+	if nasConn.Procedures.Active(procedure.Paging) {
 		return fmt.Errorf("higher priority request ongoing")
 	}
 
-	if ue.Procedures.Active(procedure.Registration) {
+	if nasConn.Procedures.Active(procedure.Registration) {
 		return fmt.Errorf("temporary reject registration ongoing")
 	}
 
-	if ue.Procedures.Active(procedure.N2Handover) {
+	if nasConn.Procedures.Active(procedure.N2Handover) {
 		return fmt.Errorf("temporary reject handover ongoing")
 	}
 
@@ -127,17 +132,17 @@ func storeN1N2AndPage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, 
 		return fmt.Errorf("ue is not in registered state")
 	}
 
-	ue.N1N2Message = &req
+	nasConn.N1N2Message = &req
 
-	_, beginErr := ue.Procedures.Begin(ctx, procedure.Procedure{Type: procedure.Paging})
+	_, beginErr := nasConn.Procedures.Begin(nasConn.Ctx(), procedure.Procedure{Type: procedure.Paging})
 	if beginErr != nil {
 		return fmt.Errorf("begin paging procedure: %w", beginErr)
 	}
 
 	pkg, err := send.BuildPaging(
 		ue.Guti,
-		ue.RegistrationArea,
-		ue.UeRadioCapabilityForPaging,
+		ue.Current().RegistrationArea,
+		ue.Current().UeRadioCapabilityForPaging,
 		nil,
 	)
 	if err != nil {
@@ -278,15 +283,15 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 		return fmt.Errorf("ue context not found")
 	}
 
-	if ue.Procedures.Active(procedure.Paging) {
+	if ue.NasConn().Procedures.Active(procedure.Paging) {
 		return fmt.Errorf("higher priority request ongoing")
 	}
 
-	if ue.Procedures.Active(procedure.Registration) {
+	if ue.NasConn().Procedures.Active(procedure.Registration) {
 		return fmt.Errorf("temporary reject registration ongoing")
 	}
 
-	if ue.Procedures.Active(procedure.N2Handover) {
+	if ue.NasConn().Procedures.Active(procedure.N2Handover) {
 		return fmt.Errorf("temporary reject handover ongoing")
 	}
 
@@ -294,11 +299,11 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 	if ranUe != nil {
 		ue.Log.Debug("AMF Transfer NGAP PDU Session Resource Setup Request from SMF")
 
-		if ranUe.SentInitialContextSetupRequest {
+		if ranUe.ICS != amf.ICSNotStarted {
 			list := ngapType.PDUSessionResourceSetupListSUReq{}
 			send.AppendPDUSessionResourceSetupListSUReq(&list, req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 
-			err := ranUe.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
+			err := ranUe.SendPDUSessionResourceSetupRequest(ctx, ue.Current().Ambr.Uplink, ue.Current().Ambr.Downlink, nil, list)
 			if err != nil {
 				return fmt.Errorf("send pdu session resource setup request error: %v", err)
 			}
@@ -318,14 +323,14 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 
 		err = ranUe.SendInitialContextSetupRequest(
 			ctx,
-			ue.Ambr.Uplink,
-			ue.Ambr.Downlink,
-			ue.AllowedNssai,
-			ue.Kgnb,
+			ue.Current().Ambr.Uplink,
+			ue.Current().Ambr.Downlink,
+			ue.Current().AllowedNssai,
+			ue.Current().Kgnb,
 			ue.PlmnID,
-			ue.UeRadioCapability,
-			ue.UeRadioCapabilityForPaging,
-			ue.UESecurityCapability,
+			ue.Current().UeRadioCapability,
+			ue.Current().UeRadioCapabilityForPaging,
+			ue.Current().UESecurityCapability,
 			nil,
 			&list,
 			operatorInfo.Guami,
@@ -336,7 +341,7 @@ func N2MessageTransferOrPage(ctx context.Context, amfInstance *amf.AMF, supi ets
 
 		ue.Log.Info("Sent NGAP initial context setup request to UE")
 
-		ranUe.SentInitialContextSetupRequest = true
+		ranUe.ICS = amf.ICSPending
 
 		return nil
 	}

--- a/internal/amf/producer/n1n2message_test.go
+++ b/internal/amf/producer/n1n2message_test.go
@@ -301,12 +301,12 @@ func TestTransferN1N2Message_InitialContextAlreadySent(t *testing.T) {
 	amfInstance := amf.New(nil, nil, &fakeSmf{})
 
 	ue := addUE(t, amfInstance, "001010000000003", func(u *amf.AmfUe) {
-		u.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
+		u.Current().Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
 	})
 
 	radio := &amf.Radio{NGAPSender: sender, RanUEs: make(map[int64]*amf.RanUe)}
 	ranUe := amf.NewRanUeForTest(radio, 1, 1, zap.NewNop())
-	ranUe.SentInitialContextSetupRequest = true
+	ranUe.ICS = amf.ICSPending
 	ue.AttachRanUe(ranUe)
 
 	err := producer.TransferN1N2Message(context.Background(), amfInstance, ue.Supi, newReq())
@@ -330,12 +330,12 @@ func TestTransferN1N2Message_InitialContextNotYetSent(t *testing.T) {
 	amfInstance := amf.New(fakeDB, nil, &fakeSmf{})
 
 	ue := addUE(t, amfInstance, "001010000000004", func(u *amf.AmfUe) {
-		u.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
+		u.Current().Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
 	})
 
 	radio := &amf.Radio{NGAPSender: sender, RanUEs: make(map[int64]*amf.RanUe)}
 	ranUe := amf.NewRanUeForTest(radio, 1, 1, zap.NewNop())
-	ranUe.SentInitialContextSetupRequest = false
+	ranUe.ICS = amf.ICSNotStarted
 	ue.AttachRanUe(ranUe)
 
 	err := producer.TransferN1N2Message(context.Background(), amfInstance, ue.Supi, newReq())
@@ -347,8 +347,8 @@ func TestTransferN1N2Message_InitialContextNotYetSent(t *testing.T) {
 		t.Fatalf("expected 1 InitialContextSetupRequest, got %d", sender.initialContextSetupCalls)
 	}
 
-	if !ranUe.SentInitialContextSetupRequest {
-		t.Fatal("expected SentInitialContextSetupRequest to be set to true")
+	if ranUe.ICS != amf.ICSPending {
+		t.Fatalf("expected ranUe.ICS == ICSPending, got %v", ranUe.ICS)
 	}
 }
 
@@ -360,7 +360,7 @@ func TestModifyN1N2Message_IdleRegisteredUE_ReturnsNotReachable(t *testing.T) {
 	ue := addUE(t, amfInstance, "001010000000014", func(u *amf.AmfUe) {
 		u.ForceState(amf.Registered)
 		u.Guti = testGUTI(t)
-		u.RegistrationArea = []models.Tai{{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}}
+		u.Current().RegistrationArea = []models.Tai{{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}}
 	})
 
 	radio := &amf.Radio{
@@ -388,7 +388,7 @@ func TestModifyN1N2Message_IdleRegisteredUE_ReturnsNotReachable(t *testing.T) {
 	}
 
 	// No N1N2 message stored on UE.
-	if ue.N1N2Message != nil {
+	if ue.NasConn() != nil && ue.NasConn().N1N2Message != nil {
 		t.Fatal("expected no stored N1N2 message")
 	}
 }
@@ -430,7 +430,7 @@ func TestN2MessageTransferOrPage_OnGoingPaging(t *testing.T) {
 
 	ue := addUE(t, amfInstance, "001010000000006", nil)
 
-	if _, err := ue.Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.Paging}); err != nil {
+	if _, err := ue.NasConn().Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.Paging}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -445,7 +445,7 @@ func TestN2MessageTransferOrPage_OnGoingRegistration(t *testing.T) {
 
 	ue := addUE(t, amfInstance, "001010000000007", nil)
 
-	if _, err := ue.Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.Registration}); err != nil {
+	if _, err := ue.NasConn().Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.Registration}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -460,7 +460,7 @@ func TestN2MessageTransferOrPage_OnGoingN2Handover(t *testing.T) {
 
 	ue := addUE(t, amfInstance, "001010000000008", nil)
 
-	if _, err := ue.Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.N2Handover}); err != nil {
+	if _, err := ue.NasConn().Procedures.Begin(context.Background(), procedure.Procedure{Type: procedure.N2Handover}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -475,12 +475,12 @@ func TestN2MessageTransferOrPage_ConnectedUE_InitialCtxSent(t *testing.T) {
 	amfInstance := amf.New(nil, nil, &fakeSmf{})
 
 	ue := addUE(t, amfInstance, "001010000000009", func(u *amf.AmfUe) {
-		u.Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
+		u.Current().Ambr = &models.Ambr{Uplink: "1000000", Downlink: "1000000"}
 	})
 
 	radio := &amf.Radio{NGAPSender: sender, RanUEs: make(map[int64]*amf.RanUe)}
 	ranUe := amf.NewRanUeForTest(radio, 1, 1, zap.NewNop())
-	ranUe.SentInitialContextSetupRequest = true
+	ranUe.ICS = amf.ICSPending
 	ue.AttachRanUe(ranUe)
 
 	err := producer.N2MessageTransferOrPage(context.Background(), amfInstance, ue.Supi, newReq())

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -41,22 +41,34 @@ const (
 // snapshot. Callers must capture the returned pointer in a local variable
 // and reuse it — never call RanUe() twice in the same code path.
 type RanUe struct {
-	RanUeNgapID                      int64
-	AmfUeNgapID                      int64
-	HandOverType                     ngapType.HandoverType
-	SourceUe                         *RanUe
-	TargetUe                         *RanUe
-	Tai                              models.Tai
-	Location                         models.UserLocation
-	amfUe                            *AmfUe
-	radio                            *Radio
-	ReleaseAction                    RelAction
-	UeContextRequest                 bool
-	SentInitialContextSetupRequest   bool
-	RecvdInitialContextSetupResponse bool /*Received Initial context setup response or not */
-	Log                              *zap.Logger
-	freeNgapID                       func(int64) // set by AMF.NewRanUe to release the NGAP ID
+	RanUeNgapID      int64
+	AmfUeNgapID      int64
+	HandOverType     ngapType.HandoverType
+	SourceUe         *RanUe
+	TargetUe         *RanUe
+	Tai              models.Tai
+	Location         models.UserLocation
+	amfUe            *AmfUe
+	radio            *Radio
+	ReleaseAction    RelAction
+	UeContextRequest bool
+	ICS              ICSState
+	Log              *zap.Logger
+	freeNgapID       func(int64)
 }
+
+// ICSState tracks the AMF-side progress of the NGAP Initial Context Setup
+// procedure for one RanUe.
+type ICSState int
+
+const (
+	// ICSNotStarted: AMF has not sent InitialContextSetupRequest yet.
+	ICSNotStarted ICSState = iota
+	// ICSPending: InitialContextSetupRequest sent, awaiting response.
+	ICSPending
+	// ICSCompleted: InitialContextSetupResponse received.
+	ICSCompleted
+)
 
 // Radio returns the Radio this RanUe is associated with, or nil.
 func (ranUe *RanUe) Radio() *Radio {
@@ -270,13 +282,16 @@ func (ranUe *RanUe) SendHandoverRequest(
 	)
 }
 
-func (ranUe *RanUe) Remove() error {
+// Remove tears down the RAN UE: it releases the NAS signalling connection
+// to the bound AMF UE (with the given cause), removes the RAN UE from the
+// radio's UE table, and frees its NGAP ID.
+func (ranUe *RanUe) Remove(ctx context.Context) error {
 	if ranUe == nil {
 		return fmt.Errorf("ran ue is nil")
 	}
 
 	if ranUe.amfUe != nil {
-		ranUe.amfUe.DetachRanUe(ranUe)
+		ranUe.amfUe.ReleaseNasConnection(ranUe)
 	}
 
 	ran := ranUe.radio

--- a/internal/amf/ran_ue_test.go
+++ b/internal/amf/ran_ue_test.go
@@ -1,0 +1,219 @@
+package amf_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/procedure"
+	"github.com/ellanetworks/core/internal/logger"
+)
+
+func newTestRadioForRanUe() *amf.Radio {
+	return &amf.Radio{
+		Log:    logger.AmfLog,
+		RanUEs: make(map[int64]*amf.RanUe),
+	}
+}
+
+func newBoundAmfUe(t *testing.T, radio *amf.Radio) (*amf.AmfUe, *amf.RanUe) {
+	t.Helper()
+
+	ranUe := amf.NewRanUeForTest(radio, 1, 10, logger.AmfLog)
+
+	ue := amf.NewAmfUe()
+	ue.Log = logger.AmfLog
+	ue.AttachRanUe(ranUe)
+
+	return ue, ranUe
+}
+
+// Per TS 24.501, ongoing NAS procedures shall be aborted on lower-layer
+// failure.
+func TestReleaseNasConnection_AbortsProcedures(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, ranUe := newBoundAmfUe(t, radio)
+
+	conn := ue.NasConn()
+	if _, err := conn.Procedures.Begin(conn.Ctx(), procedure.Procedure{Type: procedure.Authentication}); err != nil {
+		t.Fatalf("begin Authentication: %v", err)
+	}
+
+	ue.ReleaseNasConnection(ranUe)
+
+	if ue.NasConn() != nil {
+		t.Error("NAS connection still attached after release")
+	}
+
+	waitFor(t, func() bool {
+		return !conn.Procedures.Active(procedure.Authentication)
+	})
+
+	if ue.RanUe() != nil {
+		t.Error("RanUe still attached after release")
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for !cond() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+
+	if !cond() {
+		t.Fatal("condition not met within deadline")
+	}
+}
+
+func TestReleaseNasConnection_AbortsSecurityMode(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, ranUe := newBoundAmfUe(t, radio)
+
+	conn := ue.NasConn()
+	if _, err := conn.Procedures.Begin(conn.Ctx(), procedure.Procedure{Type: procedure.SecurityMode}); err != nil {
+		t.Fatalf("begin SecurityMode: %v", err)
+	}
+
+	ue.ReleaseNasConnection(ranUe)
+
+	waitFor(t, func() bool {
+		return !conn.Procedures.Active(procedure.SecurityMode)
+	})
+}
+
+// After the AMF UE is rebound to a new RanUe, a release for the old
+// RanUe (handover or any stale path) must be a no-op for both the
+// procedure set and the current binding.
+func TestReleaseNasConnection_AfterRebind_IsNoop(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, sourceRanUe := newBoundAmfUe(t, radio)
+
+	targetRanUe := amf.NewRanUeForTest(radio, 2, 20, logger.AmfLog)
+
+	conn := ue.NasConn()
+	if _, err := conn.Procedures.Begin(conn.Ctx(), procedure.Procedure{Type: procedure.N2Handover}); err != nil {
+		t.Fatalf("begin N2Handover: %v", err)
+	}
+
+	ue.AttachRanUe(targetRanUe)
+
+	ue.ReleaseNasConnection(sourceRanUe)
+
+	if !conn.Procedures.Active(procedure.N2Handover) {
+		t.Error("N2Handover aborted by stale source release")
+	}
+
+	if ue.RanUe() != targetRanUe {
+		t.Error("target RanUe was detached by stale source release")
+	}
+}
+
+// Verifies the target-match guard: a release for a stale RanUe must not
+// detach the current one.
+func TestReleaseNasConnection_StaleTarget_NoDetach(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, _ := newBoundAmfUe(t, radio)
+
+	staleRanUe := amf.NewRanUeForTest(radio, 99, 990, logger.AmfLog)
+
+	ue.ReleaseNasConnection(staleRanUe)
+
+	if ue.RanUe() == nil {
+		t.Error("current RanUe was detached by stale release")
+	}
+}
+
+// SCTP disconnect aborts procedures across all UEs on the radio.
+func TestRemoveAllUeInRan_AbortsProcedures(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, _ := newBoundAmfUe(t, radio)
+
+	conn := ue.NasConn()
+	if _, err := conn.Procedures.Begin(conn.Ctx(), procedure.Procedure{Type: procedure.SecurityMode}); err != nil {
+		t.Fatalf("begin SecurityMode: %v", err)
+	}
+
+	radio.RemoveAllUeInRan(context.Background())
+
+	waitFor(t, func() bool {
+		return !conn.Procedures.Active(procedure.SecurityMode)
+	})
+}
+
+// Mid-registration UEs are deregistered on lower-layer failure
+// (TS 24.501 §5.5.1.2.8(a)).
+func TestRemoveAllUeInRan_MidAuthentication_Deregisters(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, _ := newBoundAmfUe(t, radio)
+	ue.ForceState(amf.Authentication)
+
+	radio.RemoveAllUeInRan(context.Background())
+
+	if ue.GetState() != amf.Deregistered {
+		t.Errorf("state = %s, want Deregistered", ue.GetState())
+	}
+}
+
+func TestRemoveAllUeInRan_MidSecurityMode_Deregisters(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, _ := newBoundAmfUe(t, radio)
+	ue.ForceState(amf.SecurityMode)
+
+	radio.RemoveAllUeInRan(context.Background())
+
+	if ue.GetState() != amf.Deregistered {
+		t.Errorf("state = %s, want Deregistered", ue.GetState())
+	}
+}
+
+func TestRemoveAllUeInRan_MidContextSetup_Deregisters(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, _ := newBoundAmfUe(t, radio)
+	ue.ForceState(amf.ContextSetup)
+
+	radio.RemoveAllUeInRan(context.Background())
+
+	if ue.GetState() != amf.Deregistered {
+		t.Errorf("state = %s, want Deregistered", ue.GetState())
+	}
+}
+
+// Registered UEs keep their state and start the mobile reachable timer
+// (TS 24.501 §5.3.7).
+func TestRemoveAllUeInRan_Registered_StaysRegistered(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, _ := newBoundAmfUe(t, radio)
+	ue.Current().T3512Value = 1 * time.Second
+	ue.ForceState(amf.Registered)
+
+	radio.RemoveAllUeInRan(context.Background())
+
+	if ue.GetState() != amf.Registered {
+		t.Errorf("state = %s, want Registered (mobile reachable timer running)", ue.GetState())
+	}
+}
+
+func TestRemoveAllUeInRan_Deregistered_NoAction(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	ue, _ := newBoundAmfUe(t, radio)
+
+	radio.RemoveAllUeInRan(context.Background())
+
+	if ue.GetState() != amf.Deregistered {
+		t.Errorf("state = %s, want Deregistered", ue.GetState())
+	}
+}
+
+func TestRemoveAllUeInRan_NoAmfUe(t *testing.T) {
+	radio := newTestRadioForRanUe()
+	amf.NewRanUeForTest(radio, 1, 10, logger.AmfLog)
+
+	radio.RemoveAllUeInRan(context.Background())
+
+	if len(radio.RanUEs) != 0 {
+		t.Errorf("RanUEs count = %d, want 0", len(radio.RanUEs))
+	}
+}

--- a/internal/amf/security_state.go
+++ b/internal/amf/security_state.go
@@ -80,7 +80,7 @@ const (
 // never mutates ue.
 func (ue *AmfUe) VerifyUESecurityCapability(received *nasType.UESecurityCapability) VerifyResult {
 	ue.Mutex.RLock()
-	stored := ue.UESecurityCapability
+	stored := ue.Current().UESecurityCapability
 	ue.Mutex.RUnlock()
 
 	if stored == nil {
@@ -106,5 +106,5 @@ func (ue *AmfUe) SetUESecurityCapability(caps *nasType.UESecurityCapability, _ A
 	ue.Mutex.Lock()
 	defer ue.Mutex.Unlock()
 
-	ue.UESecurityCapability = caps
+	ue.Current().UESecurityCapability = caps
 }

--- a/internal/amf/session_reconciler.go
+++ b/internal/amf/session_reconciler.go
@@ -127,9 +127,9 @@ func (r *SessionReconciler) Reconcile() {
 
 func (r *SessionReconciler) reconcileUE(ue *AmfUe) {
 	ue.Mutex.RLock()
-	smContextRefs := make([]string, 0, len(ue.SmContextList))
+	smContextRefs := make([]string, 0, len(ue.Current().SmContextList))
 
-	for _, smCtx := range ue.SmContextList {
+	for _, smCtx := range ue.Current().SmContextList {
 		smContextRefs = append(smContextRefs, smCtx.Ref)
 	}
 

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -74,11 +74,21 @@ func (s *SMF) CreateSmContext(ctx context.Context, supi etsi.SUPI, pduSessionID 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to decode NAS message")
 
-		return "", nil, fmt.Errorf("error decoding NAS message: %v", err)
+		rsp, buildErr := smfNas.BuildGSMPDUSessionEstablishmentReject(pduSessionID, 0, nasMessage.Cause5GSMProtocolErrorUnspecified)
+		if buildErr != nil {
+			return "", nil, fmt.Errorf("error decoding NAS message: %v (build reject failed: %v)", err, buildErr)
+		}
+
+		return "", rsp, fmt.Errorf("error decoding NAS message: %v", err)
 	}
 
 	if m.GsmHeader.GetMessageType() != nas.MsgTypePDUSessionEstablishmentRequest {
-		return "", nil, fmt.Errorf("unexpected NAS message type: %d", m.GsmHeader.GetMessageType())
+		rsp, buildErr := smfNas.BuildGSMPDUSessionEstablishmentReject(pduSessionID, 0, nasMessage.Cause5GSMMessageTypeNotCompatibleWithTheProtocolState)
+		if buildErr != nil {
+			return "", nil, fmt.Errorf("unexpected NAS message type %d (build reject failed: %v)", m.GsmHeader.GetMessageType(), buildErr)
+		}
+
+		return "", rsp, fmt.Errorf("unexpected NAS message type: %d", m.GsmHeader.GetMessageType())
 	}
 
 	smContext := s.GetSession(CanonicalName(supi, pduSessionID))
@@ -214,13 +224,7 @@ func (s *SMF) handlePDUSessionSMContextCreate(
 	if err != nil {
 		PDUSessionEstablishmentAttempts.WithLabelValues("reject").Inc()
 
-		// Determine the appropriate reject cause based on which pools are available.
-		cause := nasMessage.Cause5GSMInsufficientResources
-		if policy.IPv4Pool != "" && policy.IPv6Pool == "" {
-			cause = nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed
-		} else if policy.IPv4Pool == "" && policy.IPv6Pool != "" {
-			cause = nasMessage.Cause5GSMPDUSessionTypeIPv6OnlyAllowed
-		}
+		cause := pduSessionTypeRejectCause(requestedType, policy)
 
 		rsp, buildErr := smfNas.BuildGSMPDUSessionEstablishmentReject(smContext.PDUSessionID, pti, cause)
 		if buildErr != nil {
@@ -370,6 +374,31 @@ func (s *SMF) handlePDUSessionSMContextCreate(
 	logger.WithTrace(ctx, logger.SmfLog).Info("Successfully created PDU session context", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
 
 	return pco, addrs, pti, policy, cause, nil, nil
+}
+
+// pduSessionTypeRejectCause maps a failed PDU session type negotiation
+// to the 5GSM cause prescribed by TS 24.501 §6.4.1.4.1.
+//
+//   - IPv6 requested, only IPv4 supported           → #50 IPv4 only allowed
+//   - IPv4 requested, only IPv6 supported           → #51 IPv6 only allowed
+//   - IPv4/IPv6/IPv4v6 requested, neither supported → #28 unknown PDU session type
+//   - Unstructured, Ethernet, reserved values       → #28 unknown PDU session type
+func pduSessionTypeRejectCause(requested uint8, policy *Policy) uint8 {
+	hasIPv4 := policy.IPv4Pool != ""
+	hasIPv6 := policy.IPv6Pool != ""
+
+	switch requested {
+	case nasMessage.PDUSessionTypeIPv6:
+		if hasIPv4 && !hasIPv6 {
+			return nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed
+		}
+	case nasMessage.PDUSessionTypeIPv4:
+		if !hasIPv4 && hasIPv6 {
+			return nasMessage.Cause5GSMPDUSessionTypeIPv6OnlyAllowed
+		}
+	}
+
+	return nasMessage.Cause5GSMUnknownPDUSessionType
 }
 
 // negotiatePDUSessionType resolves the final PDU session type based on

--- a/internal/smf/create_test.go
+++ b/internal/smf/create_test.go
@@ -227,3 +227,43 @@ func TestNegotiatePDUSessionType_CauseForDowngrade(t *testing.T) {
 		}
 	}
 }
+
+// TestPDUSessionTypeRejectCause covers TS 24.501 §6.4.1.4.1 — the 5GSM cause
+// the SMF puts into a PDU SESSION ESTABLISHMENT REJECT when the requested
+// PDU session type cannot be served.
+func TestPDUSessionTypeRejectCause(t *testing.T) {
+	const (
+		typeIPv4         = nasMessage.PDUSessionTypeIPv4
+		typeIPv6         = nasMessage.PDUSessionTypeIPv6
+		typeIPv4v6       = nasMessage.PDUSessionTypeIPv4IPv6
+		typeUnstructured = uint8(4)
+		typeEthernet     = uint8(3)
+	)
+
+	tests := []struct {
+		name      string
+		requested uint8
+		ipv4Pool  string
+		ipv6Pool  string
+		want      uint8
+	}{
+		{"IPv6 requested + IPv4-only pool", typeIPv6, "10.0.0.0/24", "", nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed},
+		{"IPv4 requested + IPv6-only pool", typeIPv4, "", "2001:db8::/32", nasMessage.Cause5GSMPDUSessionTypeIPv6OnlyAllowed},
+		{"IPv6 requested + no pools", typeIPv6, "", "", nasMessage.Cause5GSMUnknownPDUSessionType},
+		{"IPv4 requested + no pools", typeIPv4, "", "", nasMessage.Cause5GSMUnknownPDUSessionType},
+		{"IPv4v6 requested + no pools", typeIPv4v6, "", "", nasMessage.Cause5GSMUnknownPDUSessionType},
+		{"Unstructured requested + IPv4-only pool", typeUnstructured, "10.0.0.0/24", "", nasMessage.Cause5GSMUnknownPDUSessionType},
+		{"Unstructured requested + IPv6-only pool", typeUnstructured, "", "2001:db8::/32", nasMessage.Cause5GSMUnknownPDUSessionType},
+		{"Ethernet requested + IPv4-only pool", typeEthernet, "10.0.0.0/24", "", nasMessage.Cause5GSMUnknownPDUSessionType},
+		{"Ethernet requested + no pools", typeEthernet, "", "", nasMessage.Cause5GSMUnknownPDUSessionType},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := &Policy{IPv4Pool: tc.ipv4Pool, IPv6Pool: tc.ipv6Pool}
+			if got := pduSessionTypeRejectCause(tc.requested, policy); got != tc.want {
+				t.Errorf("got cause #%d, want #%d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -611,9 +611,48 @@ func TestCreateSmContext_InvalidNAS(t *testing.T) {
 	ctx := context.Background()
 	supi := testSUPI()
 
-	_, _, err := s.CreateSmContext(ctx, supi, 1, testDNN, testSnssai, []byte{0x00})
+	_, rejectN1, err := s.CreateSmContext(ctx, supi, 1, testDNN, testSnssai, []byte{0x00})
 	if err == nil {
 		t.Fatal("expected error for invalid NAS message")
+	}
+
+	if rejectN1 == nil {
+		t.Fatal("expected SMF to build a PDU Session Establishment Reject for malformed NAS")
+	}
+
+	if cause := rejectCauseCode(t, rejectN1); cause != nasMessage.Cause5GSMProtocolErrorUnspecified {
+		t.Fatalf("expected cause %d (protocol error unspecified), got %d", nasMessage.Cause5GSMProtocolErrorUnspecified, cause)
+	}
+
+	if s.SessionCount() != 0 {
+		t.Fatalf("expected no sessions to be created, got %d", s.SessionCount())
+	}
+}
+
+func TestCreateSmContext_WrongNASMessageType(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+	supi := testSUPI()
+
+	// A well-formed but inappropriate GSM message (release request rather than establishment).
+	n1Msg := buildPDUSessionReleaseRequest(1, 10)
+
+	_, rejectN1, err := s.CreateSmContext(ctx, supi, 1, testDNN, testSnssai, n1Msg)
+	if err == nil {
+		t.Fatal("expected error for unexpected NAS message type")
+	}
+
+	if rejectN1 == nil {
+		t.Fatal("expected SMF to build a PDU Session Establishment Reject for wrong NAS type")
+	}
+
+	if cause := rejectCauseCode(t, rejectN1); cause != nasMessage.Cause5GSMMessageTypeNotCompatibleWithTheProtocolState {
+		t.Fatalf("expected cause %d (message type not compatible with protocol state), got %d", nasMessage.Cause5GSMMessageTypeNotCompatibleWithTheProtocolState, cause)
+	}
+
+	if s.SessionCount() != 0 {
+		t.Fatalf("expected no sessions to be created, got %d", s.SessionCount())
 	}
 }
 

--- a/internal/tester/gnb/handle_initial_context_setup_request.go
+++ b/internal/tester/gnb/handle_initial_context_setup_request.go
@@ -45,6 +45,8 @@ func handleInitialContextSetupRequest(gnb *GnodeB, initialContextSetupRequest *n
 		zap.Int64("RANUENGAPID", ranueNGAPID.Value),
 	)
 
+	gnb.UpdateNGAPIDs(ranueNGAPID.Value, amfueNGAPID.Value)
+
 	if ueAggregateMaximumBitRate != nil {
 		gnb.StoreUEAmbr(ranueNGAPID.Value, &UEAmbrInformation{
 			UplinkBps:   ueAggregateMaximumBitRate.UEAggregateMaximumBitRateUL.Value,

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -510,7 +510,7 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		},
 		OnDisconnect: func(conn *amfsctp.SCTPConn) {
 			if ran, ok := amfInstance.FindRadioByConn(conn); ok {
-				amfInstance.RemoveRadio(ran)
+				amfInstance.RemoveRadio(context.Background(), ran)
 				logger.AmfLog.Info("removed radio on connection close", zap.Int("fd", conn.Fd()))
 			}
 		},


### PR DESCRIPTION
# Description

Split `AmfUe` into a three-layer model with context-based cancellation and a procedure registry, replacing ad-hoc flags on RanUe. Includes spec-compliance fixes that fell out of the refactor: SMF PDU session reject cause per TS 24.501, AMF UE NGAP ID validation on UplinkNASTransport per TS 38.413, plus several panic/timer/SCTP-disconnect cleanups.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
