### PR TITLE
fix: Time-of-check Time-of-use bug in session management

### DIFF
--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -112,7 +112,7 @@ func (s *SMF) CreateSmContext(ctx context.Context, supi etsi.SUPI, pduSessionID 
 				}
 			}
 			smContext.Mutex.Unlock()
-			s.RemoveSession(ctx, smContext.CanonicalName())
+			s.removeSessionUnlocked(ctx, smContext.CanonicalName())
 		}
 	}()
 

--- a/internal/smf/release.go
+++ b/internal/smf/release.go
@@ -54,14 +54,14 @@ func (s *SMF) ReleaseSmContext(ctx context.Context, smContextRef string) error {
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to release tunnel")
-		s.removeSessionUnlocked(ctx, smContextRef)
-
-		return fmt.Errorf("release tunnel failed: %v", err)
 	}
 
-	s.removeSessionUnlocked(ctx, smContextRef)
+	// Remove from pool under lock after all network I/O is complete.
+	s.mu.Lock()
+	delete(s.pool, smContextRef)
+	s.mu.Unlock()
 
-	return nil
+	return err
 }
 
 // releaseTunnel deactivates the GTP data path and sends a PFCP deletion request.


### PR DESCRIPTION
# Description

This fixes an time-of-check/time-of-use bug in session management, that could potentially lead to a double-free on IP addresses. It was very unlikely to be triggered, and the tests to cover this would be too complex, so I did not add them.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
