### PR TITLE
docs: backups contain sensitive secrets

### DIFF
--- a/docs/how_to/backup_and_restore.md
+++ b/docs/how_to/backup_and_restore.md
@@ -12,7 +12,10 @@ Ella Core stores all persistent data in an embedded database. You can create bac
     2. Navigate to the **Backup and Restore** tab in the left-hand menu.
     3. Click on the **Backup** button.
     4. The backup file will be downloaded to your computer. Store this file in a safe location.
-   
+
+    !!! warning
+        The backup archive contains sensitive secrets. Store and transfer it encrypted, and treat it as you would an admin credential.
+
     !!! note
         This operation can also be done using the API. Please see the [backup API documentation](../reference/api/backup.md) for more information.
 

--- a/docs/reference/api/backup.md
+++ b/docs/reference/api/backup.md
@@ -6,6 +6,8 @@ description: RESTful API reference for managing database backups.
 
 This path creates a backup of the Ella Core database.
 
+The backup archive contains sensitive secrets. Store and transfer it encrypted, and treat it as you would an admin credential.
+
 ## Create a Backup
 
 | Method | Path             |

--- a/docs/reference/production_hardening.md
+++ b/docs/reference/production_hardening.md
@@ -16,5 +16,5 @@ This reference document provides guidelines for operating Ella Core in a product
 - **Set logging level to info**: Configure system logging level to `info` and use file output.
 - **Disable telemetry**: Disable telemetry in the configuration file.
 - **Rotate logs**: Implement log rotation for system and audit logs.
-- **Back up the database**: Back up the database file on a **daily** basis. Retain backups for at least **7 days**.
+- **Back up the database**: Back up the database file on a **daily** basis. Retain backups for at least **7 days**. Backup archives contain sensitive secrets; store and transfer them encrypted and treat them as admin credentials.
 - **Monitor metrics**: Operate an external Observability stack to collect and visualize metrics exposed by Ella Core.

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -2617,6 +2617,9 @@ paths:
         Downloads a complete backup of the Ella Core database as a gzipped tar
         archive (`.tar.gz`) containing `ella.db` and a `manifest.json`
         describing the backup format version.
+
+        The archive contains sensitive secrets. Store and transfer it
+        encrypted, and treat it as an admin credential.
       responses:
         "200":
           description: Database backup archive.

--- a/ui/src/pages/BackupRestore.tsx
+++ b/ui/src/pages/BackupRestore.tsx
@@ -220,6 +220,11 @@ const BackupRestore = () => {
                   your system if needed.
                 </Typography>
 
+                <Alert severity="warning">
+                  This archive contains sensitive secrets. Store and transfer it
+                  encrypted, and treat it as you would an admin credential.
+                </Alert>
+
                 <Box sx={{ flexGrow: 1 }} />
                 <Box sx={{ display: "flex", justifyContent: "center" }}>
                   <Button


### PR DESCRIPTION
# Description

Clearly document that Ella Core backups contain sensitive secrets and that those files should be handled as if there were credentials.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
