### PR TITLE
fix: remove unnecessary mobility registration update rejection

### DIFF
--- a/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating.go
@@ -50,18 +50,10 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 	ue.Current().AllowedNssai = subscriberProfile.AllowedNssai
 
-	if conn.RegistrationRequest.Capability5GMM == nil {
-		if conn.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
-			UERegistrationAttempts.WithLabelValues(getRegistrationType5GSName(conn.RegistrationType5GS), RegistrationReject).Inc()
-
-			err := message.SendRegistrationReject(ctx, ranUe, nasMessage.Cause5GMMProtocolErrorUnspecified)
-			if err != nil {
-				return fmt.Errorf("error sending registration reject: %v", err)
-			}
-
-			return fmt.Errorf("Capability5GMM is nil")
-		}
-	}
+	// The 5GMM capability IE is optional (TS 24.501 Table 8.2.6.1.1) and is
+	// re-sent only when it changes (§5.5.1.3.2). Its absence is not an error:
+	// per §7.7.1 the receiver treats a missing optional IE as not present and
+	// proceeds.
 
 	if conn.RegistrationRequest.MICOIndication != nil {
 		ue.Log.Warn("Receive MICO Indication Not Supported", zap.Uint8("RAAI", conn.RegistrationRequest.GetRAAI()))

--- a/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/gmm/reg_mobility_periodic_registration_updating_test.go
@@ -182,40 +182,27 @@ func TestMobilityReg_GetOperatorInfoError(t *testing.T) {
 	}
 }
 
-func TestMobilityReg_NilCapability5GMM_Mobility_SendsReject(t *testing.T) {
+// A mobility registration update with no 5GMM capability IE is valid: the IE
+// is optional and re-sent only on change (TS 24.501 §5.5.1.3.2, §7.7.1), so the
+// AMF accepts rather than rejecting.
+func TestMobilityReg_NilCapability5GMM_Mobility_Continues(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
 	ue.NasConn().RegistrationRequest.Capability5GMM = nil
 	ue.NasConn().RegistrationType5GS = nasMessage.RegistrationType5GSMobilityRegistrationUpdating
 
 	err := HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
-	if err == nil {
-		t.Fatal("expected error for nil Capability5GMM, got nil")
-	}
-
-	if err.Error() != "Capability5GMM is nil" {
-		t.Fatalf("unexpected error: %v", err)
+	if err != nil {
+		t.Fatalf("expected no error for mobility reg with nil Capability5GMM, got: %v", err)
 	}
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
-		t.Fatalf("expected 1 DownlinkNASTransport (RegistrationReject), got %d", len(ngapSender.SentDownlinkNASTransport))
+		t.Fatalf("expected 1 DownlinkNASTransport, got %d", len(ngapSender.SentDownlinkNASTransport))
 	}
 
-	resp := ngapSender.SentDownlinkNASTransport[0]
-	nm := new(nas.Message)
-	nm.SecurityHeaderType = nas.GetSecurityHeaderType(resp.NasPdu) & 0x0f
-
-	if nm.SecurityHeaderType != nas.SecurityHeaderTypePlainNas {
-		t.Fatalf("expected plain NAS, got security header type %d", nm.SecurityHeaderType)
-	}
-
-	err = nm.PlainNasDecode(&resp.NasPdu)
-	if err != nil {
-		t.Fatalf("could not decode NAS message: %v", err)
-	}
-
-	if nm.GmmHeader.GetMessageType() != nas.MsgTypeRegistrationReject {
-		t.Fatalf("expected RegistrationReject, got %v", nm.GmmHeader.GetMessageType())
+	nm := decryptAndDecodeNasPdu(t, ue, ngapSender.SentDownlinkNASTransport[0].NasPdu, 0)
+	if nm.GmmHeader.GetMessageType() != nas.MsgTypeRegistrationAccept {
+		t.Fatalf("expected RegistrationAccept, got %v", nm.GmmHeader.GetMessageType())
 	}
 }
 


### PR DESCRIPTION
# Description

Ella Core rejected any mobility registration update that omitted the (optional, re-sent-only-on-change) 5GMM capability IE with REGISTRATION REJECT cause #111, violating TS 24.501 §7.7.1, which requires a receiver to treat a missing optional IE as not present and proceed.

Here we remove that rejection block so Ella Core accepts the update and continues normally when the 5GMM capability IE is absent.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
