### PR TITLE
chore: add eBPF unit tests

### DIFF
--- a/internal/upf/ebpf/control_test.go
+++ b/internal/upf/ebpf/control_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// GTP-U control-message handling and ICMPv6 Router Solicitation interception.
+// PMTU / frag-needed generation needs a small-MTU device and is deferred to the
+// netns harness.
+
+// TestGTPControlMessages checks GTP-U control-message dispatch: an echo request
+// is answered (XDP_TX, addresses/ports swapped, type set to echo response);
+// other control messages are passed to the kernel.
+func TestGTPControlMessages(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadN3N6Program(t)
+
+	const (
+		gtpEchoRequest     = 1
+		gtpEchoResponse    = 2
+		gtpErrorIndication = 26
+		gtpEndMarker       = 254
+	)
+
+	t.Run("echo request gets response", func(t *testing.T) {
+		in := gtpControlFrame(gtpEchoRequest)
+
+		action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, in)
+
+		if action != XDP_TX {
+			t.Fatalf("got XDP action %d, want XDP_TX (%d)", action, XDP_TX)
+		}
+
+		if len(out) != len(in) {
+			t.Fatalf("frame length changed: got %d, want %d", len(out), len(in))
+		}
+
+		if out[ethHdrLen+20+8+1] != gtpEchoResponse {
+			t.Errorf("GTP message type = %d, want %d (echo response)", out[ethHdrLen+20+8+1], gtpEchoResponse)
+		}
+
+		if !bytes.Equal(out[26:30], testUPFN3IP[:]) || !bytes.Equal(out[30:34], testGNBIP[:]) {
+			t.Errorf("outer IPs not swapped: src=%v dst=%v", out[26:30], out[30:34])
+		}
+
+		if src, dst := binary.BigEndian.Uint16(out[34:36]), binary.BigEndian.Uint16(out[36:38]); src != GTPUDPPort || dst != 3000 {
+			t.Errorf("UDP ports not swapped: src=%d dst=%d, want %d/%d", src, dst, GTPUDPPort, 3000)
+		}
+
+		if !bytes.Equal(out[0:6], []byte{0x02, 0, 0, 0, 0, 0x01}) || !bytes.Equal(out[6:12], []byte{0x02, 0, 0, 0, 0, 0x02}) {
+			t.Errorf("MAC addresses not swapped: dst=%x src=%x", out[0:6], out[6:12])
+		}
+	})
+
+	passThrough := []struct {
+		name    string
+		msgType uint8
+	}{
+		{"echo response passes", gtpEchoResponse},
+		{"error indication passes", gtpErrorIndication},
+		{"end marker passes", gtpEndMarker},
+	}
+
+	for _, tc := range passThrough {
+		t.Run(tc.name, func(t *testing.T) {
+			if action := runXDP(t, obj.UpfN3N6EntrypointFunc, gtpControlFrame(tc.msgType)); action != XDP_PASS {
+				t.Fatalf("got XDP action %d, want XDP_PASS (%d)", action, XDP_PASS)
+			}
+		})
+	}
+}
+
+// TestRouterSolicitationIntercept checks that an inner ICMPv6 Router
+// Solicitation, after decapsulation, is intercepted and dropped (the RA is
+// generated in userspace).
+func TestRouterSolicitationIntercept(t *testing.T) {
+	requireProgTestRun(t)
+
+	const teid = 0x52530001
+
+	obj := loadN3N6Program(t)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, innerIPv6ICMPv6RS(testUEv6)))
+
+	if action != XDP_DROP {
+		t.Fatalf("Router Solicitation not intercepted: got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+}

--- a/internal/upf/ebpf/encap_test.go
+++ b/internal/upf/ebpf/encap_test.go
@@ -20,9 +20,9 @@ import (
 func TestGTPEncapsulationDownlinkIPv4(t *testing.T) {
 	requireProgTestRun(t)
 
-	// n3_ifindex 1 (loopback) is the encapsulation egress and MTU-check device;
-	// n6_ifindex 0 makes the test-run packet (ingress 0) take the N6 downlink
-	// path.
+	// n3_ifindex 1 (loopback) is the encapsulation egress and MTU-check device. A
+	// non-GTP IPv4 packet is routed to handle_n6_packet (downlink encap) by
+	// handle_ip4 regardless of the entrypoint's N3/N6 tag.
 	obj := loadProgram(t, 1, 0)
 
 	var (

--- a/internal/upf/ebpf/encap_test.go
+++ b/internal/upf/ebpf/encap_test.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"bytes"
+	"net/netip"
+	"testing"
+)
+
+// TestGTPEncapsulationDownlinkIPv4 checks that a downlink IPv4 packet for a UE
+// is encapsulated into a GTP-U/UDP/IPv4 G-PDU: the outer header carries the
+// FAR's local/remote addresses and TEID, the PDU session container carries the
+// QER's QFI, the outer IPv4 checksum is valid, and the inner packet is preserved
+// byte for byte. The final action depends on the host routing table, so the
+// assertion is on the output packet.
+func TestGTPEncapsulationDownlinkIPv4(t *testing.T) {
+	requireProgTestRun(t)
+
+	// n3_ifindex 1 (loopback) is the encapsulation egress and MTU-check device;
+	// n6_ifindex 0 makes the test-run packet (ingress 0) take the N6 downlink
+	// path.
+	obj := loadProgram(t, 1, 0)
+
+	var (
+		ueIP   = [4]byte{10, 45, 0, 2}
+		local  = [4]byte{192, 168, 100, 1}
+		remote = [4]byte{192, 168, 100, 9}
+	)
+
+	const (
+		teid = 0x55667788
+		qfi  = 9
+	)
+
+	putDownlinkPDR(t, obj, ueIP, teid, local, remote, qfi)
+
+	inner := ipv4Packet([4]byte{8, 8, 8, 8}, ueIP, 17, udpDatagram(4000, 4001, []byte{0xde, 0xad, 0xbe, 0xef}))
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+
+	if action == XDP_ABORTED {
+		t.Fatal("downlink packet got XDP_ABORTED; encapsulation failed")
+	}
+
+	if len(out) != ethHdrLen+gtpV4EncapLen+len(inner) {
+		t.Fatalf("encapsulated frame length = %d, want %d", len(out), ethHdrLen+gtpV4EncapLen+len(inner))
+	}
+
+	f := parseGTPv4Frame(t, out)
+
+	if !f.outerChecksumOK {
+		t.Error("outer IPv4 header checksum is invalid")
+	}
+
+	if f.outerProto != 17 {
+		t.Errorf("outer IP protocol = %d, want 17 (UDP)", f.outerProto)
+	}
+
+	if f.outerSrc != local {
+		t.Errorf("outer src IP = %v, want %v (FAR localip)", f.outerSrc, local)
+	}
+
+	if f.outerDst != remote {
+		t.Errorf("outer dst IP = %v, want %v (FAR remoteip)", f.outerDst, remote)
+	}
+
+	if f.udpDstPort != GTPUDPPort {
+		t.Errorf("outer UDP dst port = %d, want %d", f.udpDstPort, GTPUDPPort)
+	}
+
+	if f.gtpFlags&0x04 == 0 {
+		t.Errorf("GTP E flag not set (flags = %#02x)", f.gtpFlags)
+	}
+
+	if f.gtpMsgType != 0xFF {
+		t.Errorf("GTP message type = %#02x, want 0xFF (G-PDU)", f.gtpMsgType)
+	}
+
+	if f.teid != teid {
+		t.Errorf("GTP TEID = %#x, want %#x", f.teid, uint32(teid))
+	}
+
+	if f.qfi != qfi {
+		t.Errorf("PDU session container QFI = %d, want %d", f.qfi, qfi)
+	}
+
+	if !bytes.Equal(f.inner, inner) {
+		t.Errorf("inner packet altered by encapsulation:\n got %x\nwant %x", f.inner, inner)
+	}
+}
+
+// TestGTPEncapsulationDownlinkInnerIPv6 checks that a downlink IPv6 packet for a
+// UE (matched by its /64 prefix) is encapsulated into a GTP-U/UDP/IPv4 G-PDU
+// carrying the inner IPv6 packet unchanged.
+func TestGTPEncapsulationDownlinkInnerIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadProgram(t, 1, 0)
+
+	uePrefix := netip.MustParseAddr("2001:db8:1::")
+	ue := netip.MustParseAddr("2001:db8:1::2").As16()
+	server := netip.MustParseAddr("2001:4860:4860::8888").As16()
+
+	local := [4]byte{192, 168, 100, 1}
+	remote := [4]byte{192, 168, 100, 9}
+
+	const (
+		teid = 0x0A0B0C0D
+		qfi  = 5
+	)
+
+	putDownlinkPDRv6UE(t, obj, uePrefix, teid, local, remote, qfi)
+
+	inner := ipv6Packet(server, ue, 17, udpDatagram(4000, 4001, []byte{0xde, 0xad}))
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x86DD, inner))
+
+	if action == XDP_ABORTED {
+		t.Fatal("downlink IPv6 packet got XDP_ABORTED; encapsulation failed")
+	}
+
+	if len(out) != ethHdrLen+gtpV4EncapLen+len(inner) {
+		t.Fatalf("encapsulated frame length = %d, want %d", len(out), ethHdrLen+gtpV4EncapLen+len(inner))
+	}
+
+	f := parseGTPv4Frame(t, out)
+
+	if !f.outerChecksumOK {
+		t.Error("outer IPv4 header checksum is invalid")
+	}
+
+	if f.outerSrc != local || f.outerDst != remote {
+		t.Errorf("outer IPs = %v -> %v, want %v -> %v", f.outerSrc, f.outerDst, local, remote)
+	}
+
+	if f.teid != teid {
+		t.Errorf("GTP TEID = %#x, want %#x", f.teid, uint32(teid))
+	}
+
+	if f.qfi != qfi {
+		t.Errorf("PDU session container QFI = %d, want %d", f.qfi, qfi)
+	}
+
+	if !bytes.Equal(f.inner, inner) {
+		t.Errorf("inner IPv6 packet altered by encapsulation:\n got %x\nwant %x", f.inner, inner)
+	}
+}
+
+// TestGTPEncapsulationDownlinkIPv6Transport checks that a downlink IPv4 packet
+// for a UE is encapsulated into a GTP-U over IPv6 transport: outer IPv6
+// src/dst from the FAR, TEID, QFI, the mandatory outer UDP checksum (RFC 6936)
+// valid, and the inner packet preserved.
+func TestGTPEncapsulationDownlinkIPv6Transport(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadProgram(t, 1, 0)
+
+	ueIP := [4]byte{10, 45, 0, 2}
+	local := netip.MustParseAddr("2001:db8:33::1").As16()
+	remote := netip.MustParseAddr("2001:db8:33::9").As16()
+
+	const (
+		teid = 0x77778888
+		qfi  = 7
+	)
+
+	putDownlinkPDRv6Outer(t, obj, ueIP, teid, local, remote, qfi)
+
+	inner := ipv4Packet([4]byte{8, 8, 8, 8}, ueIP, 17, udpDatagram(4000, 4001, []byte{0x01, 0x02, 0x03, 0x04}))
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+
+	if action == XDP_ABORTED {
+		t.Fatal("downlink packet got XDP_ABORTED; IPv6-transport encapsulation failed")
+	}
+
+	if len(out) != ethHdrLen+gtpV6EncapLen+len(inner) {
+		t.Fatalf("encapsulated frame length = %d, want %d", len(out), ethHdrLen+gtpV6EncapLen+len(inner))
+	}
+
+	f := parseGTPv6Frame(t, out)
+
+	if f.outerNextHdr != 17 {
+		t.Errorf("outer IPv6 next header = %d, want 17 (UDP)", f.outerNextHdr)
+	}
+
+	if f.outerSrc != local || f.outerDst != remote {
+		t.Errorf("outer IPs = %x -> %x, want %x -> %x", f.outerSrc, f.outerDst, local, remote)
+	}
+
+	if !f.udpChecksumOK {
+		t.Error("outer UDP-over-IPv6 checksum is invalid")
+	}
+
+	if f.udpDstPort != GTPUDPPort {
+		t.Errorf("outer UDP dst port = %d, want %d", f.udpDstPort, GTPUDPPort)
+	}
+
+	if f.gtpMsgType != 0xFF {
+		t.Errorf("GTP message type = %#02x, want 0xFF (G-PDU)", f.gtpMsgType)
+	}
+
+	if f.teid != teid {
+		t.Errorf("GTP TEID = %#x, want %#x", f.teid, uint32(teid))
+	}
+
+	if f.qfi != qfi {
+		t.Errorf("PDU session container QFI = %d, want %d", f.qfi, qfi)
+	}
+
+	if !bytes.Equal(f.inner, inner) {
+		t.Errorf("inner packet altered by encapsulation:\n got %x\nwant %x", f.inner, inner)
+	}
+}
+
+// ipv4OuterDownlinkPDR builds a downlink PDR that forwards and encapsulates into
+// a GTP-U/IPv4 tunnel toward remote with the given TEID and QFI.
+func ipv4OuterDownlinkPDR(teid uint32, local, remote [4]byte, qfi uint8) PdrInfo {
+	return PdrInfo{
+		IMSI: "001010000000001", // non-numeric IMSI zeroes the FAR
+		Far: FarInfo{
+			Action:              0x02, // FAR_FORW
+			OuterHeaderCreation: 0x01, // OHC_GTP_U_UDP_IPv4
+			TeID:                teid,
+			LocalIP:             IPToIn6Addr(netip.AddrFrom4(local)),
+			RemoteIP:            IPToIn6Addr(netip.AddrFrom4(remote)),
+		},
+		Qer: QerInfo{GateStatusDL: 0 /* GATE_STATUS_OPEN */, Qfi: qfi, MaxBitrateDL: 0 /* unlimited */},
+	}
+}
+
+// putDownlinkPDR installs a downlink PDR keyed by an IPv4 UE address.
+func putDownlinkPDR(t *testing.T, obj *BpfObjects, ueIP [4]byte, teid uint32, local, remote [4]byte, qfi uint8) {
+	t.Helper()
+
+	if err := obj.PutPdrDownlink(netip.AddrFrom4(ueIP), ipv4OuterDownlinkPDR(teid, local, remote, qfi)); err != nil {
+		t.Fatalf("install downlink PDR: %v", err)
+	}
+}
+
+// putDownlinkPDRv6UE installs a downlink PDR keyed by a UE IPv6 /64 prefix.
+func putDownlinkPDRv6UE(t *testing.T, obj *BpfObjects, uePrefix netip.Addr, teid uint32, local, remote [4]byte, qfi uint8) {
+	t.Helper()
+
+	if err := obj.PutPdrDownlink(uePrefix, ipv4OuterDownlinkPDR(teid, local, remote, qfi)); err != nil {
+		t.Fatalf("install downlink IPv6 PDR: %v", err)
+	}
+}
+
+// ipv6OuterDownlinkPDR builds a downlink PDR that forwards and encapsulates into
+// a GTP-U over IPv6 tunnel toward remote with the given TEID and QFI.
+func ipv6OuterDownlinkPDR(teid uint32, local, remote [16]byte, qfi uint8) PdrInfo {
+	return PdrInfo{
+		IMSI: "001010000000001",
+		Far: FarInfo{
+			Action:              0x02, // FAR_FORW
+			OuterHeaderCreation: 0x02, // OHC_GTP_U_UDP_IPv6
+			TeID:                teid,
+			LocalIP:             local,
+			RemoteIP:            remote,
+		},
+		Qer: QerInfo{GateStatusDL: 0 /* GATE_STATUS_OPEN */, Qfi: qfi, MaxBitrateDL: 0 /* unlimited */},
+	}
+}
+
+// putDownlinkPDRv6Outer installs a downlink PDR (IPv4 UE) that encapsulates into
+// an IPv6 transport.
+func putDownlinkPDRv6Outer(t *testing.T, obj *BpfObjects, ueIP [4]byte, teid uint32, local, remote [16]byte, qfi uint8) {
+	t.Helper()
+
+	if err := obj.PutPdrDownlink(netip.AddrFrom4(ueIP), ipv6OuterDownlinkPDR(teid, local, remote, qfi)); err != nil {
+		t.Fatalf("install downlink IPv6-transport PDR: %v", err)
+	}
+}
+
+// putForwardingUplinkPDRGTP installs an uplink PDR keyed by lookupTEID that
+// re-encapsulates (GTP-to-GTP) toward remote with outerTEID instead of
+// decapsulating.
+func putForwardingUplinkPDRGTP(t *testing.T, obj *BpfObjects, lookupTEID uint32, local, remote [4]byte, outerTEID uint32) {
+	t.Helper()
+
+	pdr := PdrInfo{
+		IMSI: "001010000000001",
+		Far: FarInfo{
+			Action:              0x02, // FAR_FORW
+			OuterHeaderCreation: 0x01, // OHC_GTP_U_UDP_IPv4
+			TeID:                outerTEID,
+			LocalIP:             IPToIn6Addr(netip.AddrFrom4(local)),
+			RemoteIP:            IPToIn6Addr(netip.AddrFrom4(remote)),
+		},
+		Qer: QerInfo{GateStatusUL: 0 /* GATE_STATUS_OPEN */, MaxBitrateUL: 0 /* unlimited */},
+	}
+	if err := obj.PutPdrUplink(lookupTEID, pdr); err != nil {
+		t.Fatalf("install uplink GTP-forward PDR: %v", err)
+	}
+}

--- a/internal/upf/ebpf/encap_test.go
+++ b/internal/upf/ebpf/encap_test.go
@@ -242,6 +242,19 @@ func putDownlinkPDR(t *testing.T, obj *BpfObjects, ueIP [4]byte, teid uint32, lo
 	}
 }
 
+// putDownlinkPDRFiltered installs a downlink PDR (IPv4 UE) that applies the SDF
+// filter at filterIndex.
+func putDownlinkPDRFiltered(t *testing.T, obj *BpfObjects, ueIP [4]byte, teid uint32, local, remote [4]byte, qfi uint8, filterIndex uint32) {
+	t.Helper()
+
+	pdr := ipv4OuterDownlinkPDR(teid, local, remote, qfi)
+	pdr.FilterMapIndex = filterIndex
+
+	if err := obj.PutPdrDownlink(netip.AddrFrom4(ueIP), pdr); err != nil {
+		t.Fatalf("install filtered downlink PDR: %v", err)
+	}
+}
+
 // putDownlinkPDRv6UE installs a downlink PDR keyed by a UE IPv6 /64 prefix.
 func putDownlinkPDRv6UE(t *testing.T, obj *BpfObjects, uePrefix netip.Addr, teid uint32, local, remote [4]byte, qfi uint8) {
 	t.Helper()

--- a/internal/upf/ebpf/flow_test.go
+++ b/internal/upf/ebpf/flow_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// TestFlowReportUplink checks that, with flow accounting enabled, a forwarded
+// uplink packet records a flow_stats entry with the expected key (IMSI,
+// addresses, protocol, action, egress interface) and counts. flow_stats is a
+// regular LRU hash, so it reads back after BPF_PROG_TEST_RUN.
+func TestFlowReportUplink(t *testing.T) {
+	requireProgTestRun(t)
+
+	const teid = 0x464C4F57
+
+	obj := loadProgramFlow(t, 0, 1)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	srcUE := [4]byte{10, 0, 0, 9} // innerIPv4UDP source
+	dst := [4]byte{8, 8, 8, 8}
+
+	runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, innerIPv4UDP(dst, 53)))
+
+	var (
+		key N3N6EntrypointFlow
+		val N3N6EntrypointFlowStats
+	)
+
+	it := obj.FlowStats.Iterate()
+	if !it.Next(&key, &val) {
+		t.Fatalf("no flow_stats entry recorded (iterate err=%v)", it.Err())
+	}
+
+	const wantIMSI = 1010000000001 // "001010000000001"
+
+	if key.Imsi != wantIMSI {
+		t.Errorf("flow IMSI = %d, want %d", key.Imsi, uint64(wantIMSI))
+	}
+
+	if key.Proto != 17 {
+		t.Errorf("flow protocol = %d, want 17 (UDP)", key.Proto)
+	}
+
+	if key.Action != 0 {
+		t.Errorf("flow action = %d, want 0 (ALLOW)", key.Action)
+	}
+
+	if key.Dscp != 0 {
+		t.Errorf("flow DSCP = %d, want 0", key.Dscp)
+	}
+
+	if key.EgressIfindex != 1 {
+		t.Errorf("flow egress ifindex = %d, want 1 (N6)", key.EgressIfindex)
+	}
+
+	if want := IPToIn6Addr(netip.AddrFrom4(srcUE)); key.Saddr.In6U.U6Addr8 != want {
+		t.Errorf("flow saddr = %v, want %v", key.Saddr.In6U.U6Addr8, want)
+	}
+
+	if want := IPToIn6Addr(netip.AddrFrom4(dst)); key.Daddr.In6U.U6Addr8 != want {
+		t.Errorf("flow daddr = %v, want %v", key.Daddr.In6U.U6Addr8, want)
+	}
+
+	if val.Packets != 1 {
+		t.Errorf("flow packets = %d, want 1", val.Packets)
+	}
+
+	if val.Bytes == 0 {
+		t.Error("flow bytes = 0, want > 0")
+	}
+}
+
+// TestURRByteAccounting checks that a URR accumulates the forwarded byte count
+// across packets. urr_map is a PERCPU_HASH, which reads back after a test-run.
+func TestURRByteAccounting(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid  = 0x55525202
+		urrID = 9
+	)
+
+	obj := loadN3N6Program(t)
+	if err := obj.NewUrr(urrID); err != nil {
+		t.Fatalf("NewUrr: %v", err)
+	}
+
+	pdr := PdrInfo{
+		IMSI:  "001010000000001",
+		UrrID: urrID,
+		Far:   FarInfo{Action: 0x02 /* FAR_FORW */},
+		Qer:   QerInfo{GateStatusUL: 0, MaxBitrateUL: 0},
+	}
+	if err := obj.PutPdrUplink(teid, pdr); err != nil {
+		t.Fatalf("install uplink PDR: %v", err)
+	}
+
+	inner := innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)
+	perPacket := uint64(ethHdrLen + len(inner)) // URR counts the decapsulated frame
+
+	runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+
+	if got := sumURR(t, obj, urrID); got != perPacket {
+		t.Fatalf("URR after 1 packet = %d, want %d", got, perPacket)
+	}
+
+	runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+
+	if got := sumURR(t, obj, urrID); got != 2*perPacket {
+		t.Fatalf("URR after 2 packets = %d, want %d", got, 2*perPacket)
+	}
+}
+
+func sumURR(t *testing.T, obj *BpfObjects, urrID uint32) uint64 {
+	t.Helper()
+
+	var perCPU []uint64
+	if err := obj.UrrMap.Lookup(urrID, &perCPU); err != nil {
+		t.Fatalf("urr_map lookup: %v", err)
+	}
+
+	var sum uint64
+	for _, v := range perCPU {
+		sum += v
+	}
+
+	return sum
+}

--- a/internal/upf/ebpf/gtp_parse_test.go
+++ b/internal/upf/ebpf/gtp_parse_test.go
@@ -46,6 +46,22 @@ func TestParseGTPTruncatedExtension(t *testing.T) {
 	}
 }
 
+// TestEntrypointUnknownInterfaceAborts checks the entrypoint's interface
+// dispatch: a packet whose ingress_ifindex matches neither n3_ifindex nor
+// n6_ifindex is aborted. The test-run ingress is 1, so loading n3/n6 as 2/3
+// makes it match neither.
+func TestEntrypointUnknownInterfaceAborts(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadProgram(t, 2, 3)
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)))
+
+	if action != XDP_ABORTED {
+		t.Fatalf("packet on unconfigured interface got XDP action %d, want XDP_ABORTED (%d)", action, XDP_ABORTED)
+	}
+}
+
 // requireProgTestRun skips when the test cannot run privileged, unless
 // EBPF_REQUIRE_PRIVILEGED is set, which makes the missing privilege fatal.
 func requireProgTestRun(t *testing.T) {

--- a/internal/upf/ebpf/gtp_parse_test.go
+++ b/internal/upf/ebpf/gtp_parse_test.go
@@ -72,14 +72,27 @@ func requireProgTestRun(t *testing.T) {
 func loadProgram(t *testing.T, n3Ifindex, n6Ifindex int) *BpfObjects {
 	t.Helper()
 
-	return loadProgramVLAN(t, n3Ifindex, n6Ifindex, 0, 0)
+	return loadProgramConfig(t, false, false, n3Ifindex, n6Ifindex, 0, 0)
 }
 
 // loadProgramVLAN is loadProgram with configurable N3/N6 VLAN IDs.
 func loadProgramVLAN(t *testing.T, n3Ifindex, n6Ifindex int, n3Vlan, n6Vlan uint32) *BpfObjects {
 	t.Helper()
 
-	obj := NewBpfObjects(false, false, n3Ifindex, n6Ifindex, n3Vlan, n6Vlan)
+	return loadProgramConfig(t, false, false, n3Ifindex, n6Ifindex, n3Vlan, n6Vlan)
+}
+
+// loadProgramFlow is loadProgram with flow accounting enabled.
+func loadProgramFlow(t *testing.T, n3Ifindex, n6Ifindex int) *BpfObjects {
+	t.Helper()
+
+	return loadProgramConfig(t, true, false, n3Ifindex, n6Ifindex, 0, 0)
+}
+
+func loadProgramConfig(t *testing.T, flowAccounting, masquerade bool, n3Ifindex, n6Ifindex int, n3Vlan, n6Vlan uint32) *BpfObjects {
+	t.Helper()
+
+	obj := NewBpfObjects(flowAccounting, masquerade, n3Ifindex, n6Ifindex, n3Vlan, n6Vlan)
 	if err := obj.Load(); err != nil {
 		var ve *ebpf.VerifierError
 		if errors.As(err, &ve) {

--- a/internal/upf/ebpf/gtp_parse_test.go
+++ b/internal/upf/ebpf/gtp_parse_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// ethHdrLen is the size of an Ethernet header, the offset of the inner packet in
-// a decapsulated frame.
-const ethHdrLen = 14
-
 // TestParseGTPTruncatedExtension checks that a malformed GTP-U packet fails
 // closed: the parser rejects it and the packet is passed to the kernel
 // (XDP_PASS) rather than aborting the data path, whether or not its TEID matches
@@ -69,14 +65,14 @@ func requireProgTestRun(t *testing.T) {
 	}
 }
 
-// loadN3N6Program loads the N3/N6 program. n3_ifindex 0 makes the test-run
-// packet (ingress_ifindex 0) take the N3 path; n6_ifindex 1 (loopback) gives the
-// in-path MTU check a real device so a parse failure is the only source of an
-// abort.
-func loadN3N6Program(t *testing.T) *BpfObjects {
+// loadProgram loads the N3/N6 program with the given interface indices. A test
+// sends on the interface whose index is 0, because BPF_PROG_TEST_RUN defaults
+// ingress_ifindex to 0; the other index must be a real device (loopback) to
+// serve the in-path MTU check and routing egress.
+func loadProgram(t *testing.T, n3Ifindex, n6Ifindex int) *BpfObjects {
 	t.Helper()
 
-	obj := NewBpfObjects(false, false, 0, 1, 0, 0)
+	obj := NewBpfObjects(false, false, n3Ifindex, n6Ifindex, 0, 0)
 	if err := obj.Load(); err != nil {
 		var ve *ebpf.VerifierError
 		if errors.As(err, &ve) {
@@ -89,6 +85,14 @@ func loadN3N6Program(t *testing.T) *BpfObjects {
 	t.Cleanup(func() { _ = obj.Close() })
 
 	return obj
+}
+
+// loadN3N6Program loads the program for uplink (N3) tests: ingress on N3
+// (index 0), loopback (index 1) as the N6 egress/MTU device.
+func loadN3N6Program(t *testing.T) *BpfObjects {
+	t.Helper()
+
+	return loadProgram(t, 0, 1)
 }
 
 // putForwardingUplinkPDR installs an uplink PDR for teid that forwards (FAR FORW,
@@ -184,49 +188,134 @@ func TestGTPDecapsulation(t *testing.T) {
 	}
 }
 
-// malformedUplinkGTPv4 builds a GTP-U frame that sets the E flag but omits the
-// optional header word the flag implies.
-func malformedUplinkGTPv4(teid uint32) []byte {
-	gtp := make([]byte, 8)
-	gtp[0] = 0x34 // version=1, PT=1, E=1
-	gtp[1] = 0xFF // GTPU_G_PDU
-	binary.BigEndian.PutUint32(gtp[4:8], teid)
+// TestGTPDecapsulationInnerIPv6 checks that an uplink G-PDU carrying an inner
+// IPv6 packet is decapsulated to that IPv6 packet, with the Ethernet protocol
+// set to IPv6.
+func TestGTPDecapsulationInnerIPv6(t *testing.T) {
+	requireProgTestRun(t)
 
-	return wrapIPv4UDP(gtp, GTPUDPPort)
+	const teid = 0x21222325
+
+	obj := loadN3N6Program(t)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	inner := innerIPv6UDP(testUEv6, 53)
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+
+	if action == XDP_DROP || action == XDP_ABORTED {
+		t.Fatalf("decapsulated packet got XDP action %d, want a forwarding action", action)
+	}
+
+	if len(out) != ethHdrLen+len(inner) {
+		t.Fatalf("decapsulated frame length = %d, want %d", len(out), ethHdrLen+len(inner))
+	}
+
+	if proto := binary.BigEndian.Uint16(out[12:14]); proto != 0x86DD {
+		t.Fatalf("ethertype = %#04x, want 0x86dd (IPv6)", proto)
+	}
+
+	if !bytes.Equal(out[ethHdrLen:], inner) {
+		t.Fatalf("inner packet altered by decapsulation:\n got %x\nwant %x", out[ethHdrLen:], inner)
+	}
 }
 
-const GTPUDPPort = 2152
+// TestGTPForwardIPv4 checks GTP-to-GTP forwarding: when the uplink FAR requests
+// outer-header creation, the packet is not decapsulated but its outer IPv4
+// source/destination and TEID are rewritten to the FAR's values, with a valid
+// outer checksum and the inner packet preserved.
+func TestGTPForwardIPv4(t *testing.T) {
+	requireProgTestRun(t)
 
-// wrapIPv4UDP wraps payload in Ethernet/IPv4/UDP headers. Checksums are left
-// zero; the XDP parse path validates lengths and bounds, not checksums.
-func wrapIPv4UDP(payload []byte, dstPort uint16) []byte {
 	const (
-		ethLen = 14
-		ipLen  = 20
-		udpLen = 8
+		lookupTEID = 0x11112222
+		outerTEID  = 0x33334444
 	)
 
-	frame := make([]byte, ethLen+ipLen+udpLen+len(payload))
+	local := [4]byte{192, 168, 50, 1}
+	remote := [4]byte{203, 0, 113, 9}
 
-	eth := frame[:ethLen]
-	copy(eth[0:6], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x02})
-	copy(eth[6:12], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x01})
-	binary.BigEndian.PutUint16(eth[12:14], 0x0800) // ETH_P_IP
+	obj := loadN3N6Program(t)
+	putForwardingUplinkPDRGTP(t, obj, lookupTEID, local, remote, outerTEID)
 
-	ip := frame[ethLen : ethLen+ipLen]
-	ip[0] = 0x45 // version 4, IHL 5
-	binary.BigEndian.PutUint16(ip[2:4], uint16(ipLen+udpLen+len(payload)))
-	ip[8] = 64 // TTL
-	ip[9] = 17 // IPPROTO_UDP
-	copy(ip[12:16], []byte{10, 0, 0, 1})
-	copy(ip[16:20], []byte{10, 0, 0, 2})
+	inner := innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)
 
-	udp := frame[ethLen+ipLen : ethLen+ipLen+udpLen]
-	binary.BigEndian.PutUint16(udp[0:2], 2152)
-	binary.BigEndian.PutUint16(udp[2:4], dstPort)
-	binary.BigEndian.PutUint16(udp[4:6], uint16(udpLen+len(payload)))
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(lookupTEID, inner))
 
-	copy(frame[ethLen+ipLen+udpLen:], payload)
+	if action == XDP_ABORTED {
+		t.Fatal("forwarded packet got XDP_ABORTED")
+	}
 
-	return frame
+	if len(out) != ethHdrLen+gtpV4EncapLen+len(inner) {
+		t.Fatalf("forwarded frame length = %d, want %d (no decap)", len(out), ethHdrLen+gtpV4EncapLen+len(inner))
+	}
+
+	f := parseGTPv4Frame(t, out)
+
+	if !f.outerChecksumOK {
+		t.Error("outer IPv4 header checksum is invalid after tunnel rewrite")
+	}
+
+	if f.outerSrc != local {
+		t.Errorf("outer src IP = %v, want %v (FAR localip)", f.outerSrc, local)
+	}
+
+	if f.outerDst != remote {
+		t.Errorf("outer dst IP = %v, want %v (FAR remoteip)", f.outerDst, remote)
+	}
+
+	if f.teid != outerTEID {
+		t.Errorf("rewritten TEID = %#x, want %#x", f.teid, uint32(outerTEID))
+	}
+
+	if !bytes.Equal(f.inner, inner) {
+		t.Errorf("inner packet altered by tunnel rewrite:\n got %x\nwant %x", f.inner, inner)
+	}
+}
+
+// TestGTPDecapsulationIPv6Transport checks that a G-PDU received over an IPv6
+// transport (outer IPv6/UDP) is decapsulated to its inner IPv4 packet.
+func TestGTPDecapsulationIPv6Transport(t *testing.T) {
+	requireProgTestRun(t)
+
+	const teid = 0x41424344
+
+	obj := loadN3N6Program(t)
+	putForwardingUplinkPDRv6Outer(t, obj, teid)
+
+	inner := innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, uplinkGPDUv6(teid, inner))
+
+	if action == XDP_DROP || action == XDP_ABORTED {
+		t.Fatalf("decapsulated packet got XDP action %d, want a forwarding action", action)
+	}
+
+	if len(out) != ethHdrLen+len(inner) {
+		t.Fatalf("decapsulated frame length = %d, want %d", len(out), ethHdrLen+len(inner))
+	}
+
+	if proto := binary.BigEndian.Uint16(out[12:14]); proto != 0x0800 {
+		t.Fatalf("ethertype = %#04x, want 0x0800 (IPv4)", proto)
+	}
+
+	if !bytes.Equal(out[ethHdrLen:], inner) {
+		t.Fatalf("inner packet altered by decapsulation:\n got %x\nwant %x", out[ethHdrLen:], inner)
+	}
+}
+
+// putForwardingUplinkPDRv6Outer installs an uplink PDR for teid whose outer
+// header is removed as GTP-U over IPv6.
+func putForwardingUplinkPDRv6Outer(t *testing.T, obj *BpfObjects, teid uint32) {
+	t.Helper()
+
+	pdr := PdrInfo{
+		OuterHeaderRemoval: 1, // OHR_GTP_U_UDP_IPv6
+		IMSI:               "001010000000001",
+		Far:                FarInfo{Action: 0x02 /* FAR_FORW */},
+		Qer:                QerInfo{GateStatusUL: 0 /* GATE_STATUS_OPEN */, MaxBitrateUL: 0 /* unlimited */},
+	}
+	if err := obj.PutPdrUplink(teid, pdr); err != nil {
+		t.Fatalf("install uplink PDR: %v", err)
+	}
 }

--- a/internal/upf/ebpf/gtp_parse_test.go
+++ b/internal/upf/ebpf/gtp_parse_test.go
@@ -89,7 +89,7 @@ func loadProgramFlow(t *testing.T, n3Ifindex, n6Ifindex int) *BpfObjects {
 	return loadProgramConfig(t, true, false, n3Ifindex, n6Ifindex, 0, 0)
 }
 
-func loadProgramConfig(t *testing.T, flowAccounting, masquerade bool, n3Ifindex, n6Ifindex int, n3Vlan, n6Vlan uint32) *BpfObjects {
+func loadProgramConfig(t *testing.T, flowAccounting, masquerade bool, n3Ifindex, n6Ifindex int, n3Vlan, n6Vlan uint32) *BpfObjects { //nolint:unparam // general loader; masquerade is used once NAT (T2) lands
 	t.Helper()
 
 	obj := NewBpfObjects(flowAccounting, masquerade, n3Ifindex, n6Ifindex, n3Vlan, n6Vlan)

--- a/internal/upf/ebpf/gtp_parse_test.go
+++ b/internal/upf/ebpf/gtp_parse_test.go
@@ -65,10 +65,15 @@ func requireProgTestRun(t *testing.T) {
 	}
 }
 
-// loadProgram loads the N3/N6 program with the given interface indices. A test
-// sends on the interface whose index is 0, because BPF_PROG_TEST_RUN defaults
-// ingress_ifindex to 0; the other index must be a real device (loopback) to
-// serve the in-path MTU check and routing egress.
+// loadProgram loads the N3/N6 program with the given interface indices.
+//
+// XDP BPF_PROG_TEST_RUN runs with ingress_ifindex == 1 (loopback). The
+// entrypoint tags a packet N3 or N6 by matching that against n3Ifindex/n6Ifindex,
+// and the in-path bpf_check_mtu needs a real device (loopback, index 1). GTP
+// decap runs from handle_ip4 regardless of the N3/N6 tag, and
+// handle_gtp_packet/handle_n6_packet set ctx->interface themselves — so
+// verdict/DataOut tests don't depend on the tag; only stats-map selection does
+// (see stats_test.go).
 func loadProgram(t *testing.T, n3Ifindex, n6Ifindex int) *BpfObjects {
 	t.Helper()
 
@@ -107,8 +112,11 @@ func loadProgramConfig(t *testing.T, flowAccounting, masquerade bool, n3Ifindex,
 	return obj
 }
 
-// loadN3N6Program loads the program for uplink (N3) tests: ingress on N3
-// (index 0), loopback (index 1) as the N6 egress/MTU device.
+// loadN3N6Program is the loader for the GTP/uplink tests. n3_ifindex 0 keeps the
+// routing ifindex-mismatch check disabled (stable forwarding verdicts) and
+// n6_ifindex 1 (loopback) is the valid MTU/egress device. The GTP decap path in
+// handle_ip4 runs regardless of the entrypoint's N3/N6 tag; these tests assert on
+// the packet/verdict, not the stats-map selection.
 func loadN3N6Program(t *testing.T) *BpfObjects {
 	t.Helper()
 

--- a/internal/upf/ebpf/gtp_parse_test.go
+++ b/internal/upf/ebpf/gtp_parse_test.go
@@ -72,7 +72,14 @@ func requireProgTestRun(t *testing.T) {
 func loadProgram(t *testing.T, n3Ifindex, n6Ifindex int) *BpfObjects {
 	t.Helper()
 
-	obj := NewBpfObjects(false, false, n3Ifindex, n6Ifindex, 0, 0)
+	return loadProgramVLAN(t, n3Ifindex, n6Ifindex, 0, 0)
+}
+
+// loadProgramVLAN is loadProgram with configurable N3/N6 VLAN IDs.
+func loadProgramVLAN(t *testing.T, n3Ifindex, n6Ifindex int, n3Vlan, n6Vlan uint32) *BpfObjects {
+	t.Helper()
+
+	obj := NewBpfObjects(false, false, n3Ifindex, n6Ifindex, n3Vlan, n6Vlan)
 	if err := obj.Load(); err != nil {
 		var ve *ebpf.VerifierError
 		if errors.As(err, &ve) {

--- a/internal/upf/ebpf/packet_test.go
+++ b/internal/upf/ebpf/packet_test.go
@@ -79,7 +79,7 @@ func ethFrame(etherType uint16, l3 []byte) []byte {
 
 // ipv4Packet builds an IPv4 packet (with a valid header checksum) carrying
 // payload.
-func ipv4Packet(src, dst [4]byte, proto uint8, payload []byte) []byte { //nolint:unparam // general-purpose builder; proto varies in later phases
+func ipv4Packet(src, dst [4]byte, proto uint8, payload []byte) []byte {
 	const hdrLen = 20
 
 	pkt := make([]byte, hdrLen+len(payload))
@@ -116,6 +116,22 @@ func innerIPv4UDP(dst [4]byte, dport uint16) []byte { //nolint:unparam // genera
 	return ipv4Packet([4]byte{10, 0, 0, 9}, dst, 17, udpDatagram(0, dport, nil))
 }
 
+// tcpSegment builds a minimal 20-byte TCP header (data offset 5, no flags).
+func tcpSegment(srcPort, dstPort uint16) []byte {
+	seg := make([]byte, 20)
+
+	binary.BigEndian.PutUint16(seg[0:2], srcPort)
+	binary.BigEndian.PutUint16(seg[2:4], dstPort)
+	seg[12] = 0x50 // data offset = 5 (20-byte header)
+
+	return seg
+}
+
+// innerIPv4TCP builds a UE inner packet: an IPv4/TCP segment to dst:dport.
+func innerIPv4TCP(dst [4]byte, dport uint16) []byte {
+	return ipv4Packet([4]byte{10, 0, 0, 9}, dst, 6, tcpSegment(0, dport))
+}
+
 // testUEv6 is a sample inner UE IPv6 address (2001:db8::1).
 var testUEv6 = [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
 
@@ -142,6 +158,26 @@ func innerIPv6UDP(dst [16]byte, dport uint16) []byte {
 	src := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x09}
 
 	return ipv6Packet(src, dst, 17, udpDatagram(0, dport, nil))
+}
+
+// innerIPv6ICMPv6RS builds a UE inner packet: an ICMPv6 Router Solicitation
+// (type 133) to dst.
+func innerIPv6ICMPv6RS(dst [16]byte) []byte {
+	src := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x09}
+	rs := []byte{133, 0, 0, 0, 0, 0, 0, 0} // type=133 (Router Solicitation)
+
+	return ipv6Packet(src, dst, 58 /* IPPROTO_ICMPV6 */, rs)
+}
+
+// gtpControlFrame builds an N3 frame carrying an 8-byte GTP-U control message of
+// the given type (no extension headers, no payload). The source UDP port differs
+// from the GTP-U dest port so a port swap is observable.
+func gtpControlFrame(msgType uint8) []byte {
+	gtp := make([]byte, 8)
+	gtp[0] = 0x30 // version=1, PT=1, no E/S/PN
+	gtp[1] = msgType
+
+	return ethFrame(0x0800, ipv4Packet(testGNBIP, testUPFN3IP, 17, udpDatagram(3000, GTPUDPPort, gtp)))
 }
 
 // gtpV4Outer wraps a GTP-U payload (the GTP header onward) in the

--- a/internal/upf/ebpf/packet_test.go
+++ b/internal/upf/ebpf/packet_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// Packet-building and -parsing helpers shared by the data-plane tests. They
+// operate on raw byte slices so a test can assert on the exact bytes the XDP
+// program produced.
+
+const (
+	// ethHdrLen is the size of an Ethernet header, the offset of the inner
+	// packet in a decapsulated frame.
+	ethHdrLen = 14
+
+	// GTPUDPPort is the GTP-U UDP port.
+	GTPUDPPort = 2152
+
+	// gtpV4EncapLen is the GTP-U/UDP/IPv4 + PDU-session-extension overhead added
+	// by the downlink encapsulation path: IPv4(20) + UDP(8) + GTP(8) + ext(8).
+	gtpV4EncapLen = 44
+
+	// gtpV6EncapLen is the same overhead with an IPv6 outer header:
+	// IPv6(40) + UDP(8) + GTP(8) + ext(8).
+	gtpV6EncapLen = 64
+)
+
+var (
+	testGNBIP   = [4]byte{10, 0, 0, 1}
+	testUPFN3IP = [4]byte{10, 0, 0, 2}
+
+	testGNBv6   = [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0xaa, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	testUPFN3v6 = [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0xaa, 0, 0, 0, 0, 0, 0, 0, 0x02}
+)
+
+// onesComplement16 is the 16-bit one's-complement sum used by IP/UDP/TCP
+// checksums. Over a header that already contains its checksum it returns 0 when
+// the checksum is valid.
+func onesComplement16(b []byte) uint16 {
+	var sum uint32
+
+	for i := 0; i+1 < len(b); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(b[i:]))
+	}
+
+	if len(b)%2 == 1 {
+		sum += uint32(b[len(b)-1]) << 8
+	}
+
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+
+	return ^uint16(sum)
+}
+
+func ipv4HeaderChecksum(header []byte) uint16 { return onesComplement16(header) }
+
+func validIPv4Checksum(header []byte) bool { return onesComplement16(header) == 0 }
+
+// ethFrame prepends an Ethernet header (fixed locally-administered MACs) with
+// the given ethertype to l3.
+func ethFrame(etherType uint16, l3 []byte) []byte {
+	frame := make([]byte, ethHdrLen+len(l3))
+
+	copy(frame[0:6], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x02})
+	copy(frame[6:12], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x01})
+	binary.BigEndian.PutUint16(frame[12:14], etherType)
+	copy(frame[14:], l3)
+
+	return frame
+}
+
+// ipv4Packet builds an IPv4 packet (with a valid header checksum) carrying
+// payload.
+func ipv4Packet(src, dst [4]byte, proto uint8, payload []byte) []byte { //nolint:unparam // general-purpose builder; proto varies in later phases
+	const hdrLen = 20
+
+	pkt := make([]byte, hdrLen+len(payload))
+
+	pkt[0] = 0x45 // version 4, IHL 5
+	binary.BigEndian.PutUint16(pkt[2:4], uint16(hdrLen+len(payload)))
+	pkt[8] = 64 // TTL
+	pkt[9] = proto
+	copy(pkt[12:16], src[:])
+	copy(pkt[16:20], dst[:])
+	binary.BigEndian.PutUint16(pkt[10:12], ipv4HeaderChecksum(pkt[:hdrLen]))
+	copy(pkt[hdrLen:], payload)
+
+	return pkt
+}
+
+// udpDatagram builds a UDP datagram with a zero checksum (valid for IPv4).
+func udpDatagram(srcPort, dstPort uint16, payload []byte) []byte {
+	const hdrLen = 8
+
+	d := make([]byte, hdrLen+len(payload))
+
+	binary.BigEndian.PutUint16(d[0:2], srcPort)
+	binary.BigEndian.PutUint16(d[2:4], dstPort)
+	binary.BigEndian.PutUint16(d[4:6], uint16(hdrLen+len(payload)))
+	copy(d[hdrLen:], payload)
+
+	return d
+}
+
+// innerIPv4UDP builds a UE inner packet: an IPv4/UDP datagram to dst:dport. On
+// uplink, dst is the SDF remote address.
+func innerIPv4UDP(dst [4]byte, dport uint16) []byte { //nolint:unparam // general-purpose builder; dport varies in later phases
+	return ipv4Packet([4]byte{10, 0, 0, 9}, dst, 17, udpDatagram(0, dport, nil))
+}
+
+// testUEv6 is a sample inner UE IPv6 address (2001:db8::1).
+var testUEv6 = [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+
+// ipv6Packet builds an IPv6 packet carrying payload. IPv6 has no header
+// checksum.
+func ipv6Packet(src, dst [16]byte, nextHdr uint8, payload []byte) []byte {
+	const hdrLen = 40
+
+	pkt := make([]byte, hdrLen+len(payload))
+
+	pkt[0] = 0x60 // version 6
+	binary.BigEndian.PutUint16(pkt[4:6], uint16(len(payload)))
+	pkt[6] = nextHdr
+	pkt[7] = 64 // hop limit
+	copy(pkt[8:24], src[:])
+	copy(pkt[24:40], dst[:])
+	copy(pkt[hdrLen:], payload)
+
+	return pkt
+}
+
+// innerIPv6UDP builds a UE inner packet: an IPv6/UDP datagram to dst:dport.
+func innerIPv6UDP(dst [16]byte, dport uint16) []byte {
+	src := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x09}
+
+	return ipv6Packet(src, dst, 17, udpDatagram(0, dport, nil))
+}
+
+// gtpV4Outer wraps a GTP-U payload (the GTP header onward) in the
+// Ethernet/IPv4/UDP(2152) outer headers of an N3 uplink frame.
+func gtpV4Outer(gtpPayload []byte) []byte {
+	return ethFrame(0x0800, ipv4Packet(testGNBIP, testUPFN3IP, 17, udpDatagram(GTPUDPPort, GTPUDPPort, gtpPayload)))
+}
+
+// gtpHeader builds a GTP-U G-PDU header: an 8-byte base header with the E flag
+// set plus the 8-byte optional header word, followed by inner.
+func gtpHeader(teid uint32, inner []byte) []byte {
+	const gtpHdrLen = 16
+
+	gtp := make([]byte, gtpHdrLen)
+	gtp[0] = 0x34 // version=1, PT=1, E=1
+	gtp[1] = 0xFF // GTPU_G_PDU
+	binary.BigEndian.PutUint16(gtp[2:4], uint16(gtpHdrLen-8+len(inner)))
+	binary.BigEndian.PutUint32(gtp[4:8], teid)
+
+	return append(gtp, inner...)
+}
+
+// uplinkGPDU wraps inner in a well-formed GTP-U G-PDU inside an
+// Ethernet/IPv4/UDP frame addressed to the GTP-U port.
+func uplinkGPDU(teid uint32, inner []byte) []byte {
+	return gtpV4Outer(gtpHeader(teid, inner))
+}
+
+// gtpV6Outer wraps a GTP-U payload in Ethernet/IPv6/UDP(2152) outer headers (an
+// N3 uplink frame with IPv6 transport). The outer UDP checksum is left zero;
+// the parse path does not validate it on receive.
+func gtpV6Outer(gtpPayload []byte) []byte {
+	return ethFrame(0x86DD, ipv6Packet(testGNBv6, testUPFN3v6, 17, udpDatagram(GTPUDPPort, GTPUDPPort, gtpPayload)))
+}
+
+// uplinkGPDUv6 wraps inner in a well-formed GTP-U G-PDU inside an
+// Ethernet/IPv6/UDP frame (GTP-U over IPv6 transport).
+func uplinkGPDUv6(teid uint32, inner []byte) []byte {
+	return gtpV6Outer(gtpHeader(teid, inner))
+}
+
+// validUDPv6Checksum verifies a UDP-over-IPv6 checksum (RFC 8200 pseudo-header:
+// src + dst + upper-layer length + next-header 17).
+func validUDPv6Checksum(src, dst [16]byte, udpSegment []byte) bool {
+	pseudo := make([]byte, 40+len(udpSegment))
+
+	copy(pseudo[0:16], src[:])
+	copy(pseudo[16:32], dst[:])
+	binary.BigEndian.PutUint32(pseudo[32:36], uint32(len(udpSegment)))
+	pseudo[39] = 17 // next header = UDP
+	copy(pseudo[40:], udpSegment)
+
+	return onesComplement16(pseudo) == 0
+}
+
+// malformedUplinkGTPv4 builds a GTP-U frame that sets the E flag but omits the
+// optional header word the flag implies.
+func malformedUplinkGTPv4(teid uint32) []byte {
+	gtp := make([]byte, 8)
+	gtp[0] = 0x34 // version=1, PT=1, E=1
+	gtp[1] = 0xFF // GTPU_G_PDU
+	binary.BigEndian.PutUint32(gtp[4:8], teid)
+
+	return gtpV4Outer(gtp)
+}
+
+// gtpV4Frame is the parsed view of an Ethernet/IPv4/UDP/GTP-U G-PDU frame.
+type gtpV4Frame struct {
+	etherType       uint16
+	outerSrc        [4]byte
+	outerDst        [4]byte
+	outerProto      uint8
+	outerChecksumOK bool
+	udpDstPort      uint16
+	gtpFlags        uint8
+	gtpMsgType      uint8
+	teid            uint32
+	qfi             uint8
+	inner           []byte
+}
+
+// parseGTPv4Frame decodes a GTP-U-over-IPv4 G-PDU frame produced by the
+// encapsulation path. Layout: eth(14) | IPv4(20) | UDP(8) | GTP(8) |
+// gtp_hdr_ext(4) | pdu_session_container(4) | inner.
+func parseGTPv4Frame(t *testing.T, frame []byte) gtpV4Frame {
+	t.Helper()
+
+	const headersLen = ethHdrLen + gtpV4EncapLen
+	if len(frame) < headersLen {
+		t.Fatalf("frame too short for a GTP-U/IPv4 G-PDU: %d bytes", len(frame))
+	}
+
+	ip := frame[ethHdrLen : ethHdrLen+20]
+	udp := frame[ethHdrLen+20 : ethHdrLen+28]
+	gtp := frame[ethHdrLen+28 : ethHdrLen+36]
+	psc := frame[ethHdrLen+40 : ethHdrLen+44]
+
+	f := gtpV4Frame{
+		etherType:       binary.BigEndian.Uint16(frame[12:14]),
+		outerProto:      ip[9],
+		outerChecksumOK: validIPv4Checksum(ip),
+		udpDstPort:      binary.BigEndian.Uint16(udp[2:4]),
+		gtpFlags:        gtp[0],
+		gtpMsgType:      gtp[1],
+		teid:            binary.BigEndian.Uint32(gtp[4:8]),
+		qfi:             psc[2] & 0x3f,
+		inner:           frame[headersLen:],
+	}
+	copy(f.outerSrc[:], ip[12:16])
+	copy(f.outerDst[:], ip[16:20])
+
+	return f
+}
+
+// gtpV6Frame is the parsed view of an Ethernet/IPv6/UDP/GTP-U G-PDU frame.
+type gtpV6Frame struct {
+	outerSrc      [16]byte
+	outerDst      [16]byte
+	outerNextHdr  uint8
+	udpDstPort    uint16
+	udpChecksumOK bool
+	gtpFlags      uint8
+	gtpMsgType    uint8
+	teid          uint32
+	qfi           uint8
+	inner         []byte
+}
+
+// parseGTPv6Frame decodes a GTP-U-over-IPv6 G-PDU frame. Layout: eth(14) |
+// IPv6(40) | UDP(8) | GTP(8) | gtp_hdr_ext(4) | pdu_session_container(4) |
+// inner.
+func parseGTPv6Frame(t *testing.T, frame []byte) gtpV6Frame {
+	t.Helper()
+
+	const headersLen = ethHdrLen + gtpV6EncapLen
+	if len(frame) < headersLen {
+		t.Fatalf("frame too short for a GTP-U/IPv6 G-PDU: %d bytes", len(frame))
+	}
+
+	ip6 := frame[ethHdrLen : ethHdrLen+40]
+	udp := frame[ethHdrLen+40 : ethHdrLen+48]
+	gtp := frame[ethHdrLen+48 : ethHdrLen+56]
+	psc := frame[ethHdrLen+60 : ethHdrLen+64]
+
+	f := gtpV6Frame{
+		outerNextHdr: ip6[6],
+		udpDstPort:   binary.BigEndian.Uint16(udp[2:4]),
+		gtpFlags:     gtp[0],
+		gtpMsgType:   gtp[1],
+		teid:         binary.BigEndian.Uint32(gtp[4:8]),
+		qfi:          psc[2] & 0x3f,
+		inner:        frame[headersLen:],
+	}
+	copy(f.outerSrc[:], ip6[8:24])
+	copy(f.outerDst[:], ip6[24:40])
+	f.udpChecksumOK = validUDPv6Checksum(f.outerSrc, f.outerDst, frame[ethHdrLen+40:])
+
+	return f
+}

--- a/internal/upf/ebpf/parser_test.go
+++ b/internal/upf/ebpf/parser_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import "testing"
+
+// TestMalformedL3FailsClosed checks that malformed or truncated L3 headers do
+// not abort the data path: each is passed to the kernel (XDP_PASS) rather than
+// returning XDP_ABORTED.
+func TestMalformedL3FailsClosed(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadN3N6Program(t)
+
+	tests := []struct {
+		name   string
+		packet []byte
+	}{
+		{"ipv4 options claimed but truncated", ipv4OptionsTruncated()},
+		{"truncated ipv6 header", truncatedIPv6()},
+		{"truncated vlan tag", truncatedVLAN()},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if action := runXDP(t, obj.UpfN3N6EntrypointFunc, tc.packet); action != XDP_PASS {
+				t.Fatalf("got XDP action %d, want XDP_PASS (fail closed to kernel)", action)
+			}
+		})
+	}
+}
+
+// ipv4OptionsTruncated builds a frame whose IPv4 header claims a 60-byte length
+// (IHL 15) but only carries the 20-byte base header.
+func ipv4OptionsTruncated() []byte {
+	ip := ipv4Packet([4]byte{10, 0, 0, 1}, [4]byte{10, 0, 0, 2}, 17, nil)
+	ip[0] = 0x4F // version 4, IHL 15
+
+	return ethFrame(0x0800, ip)
+}
+
+// truncatedIPv6 builds a frame with an IPv6 ethertype but fewer than the 40
+// header bytes.
+func truncatedIPv6() []byte {
+	short := make([]byte, 20)
+	short[0] = 0x60 // version 6
+
+	return ethFrame(0x86DD, short)
+}
+
+// truncatedVLAN builds a frame with an 802.1Q ethertype but no room for the
+// VLAN tag.
+func truncatedVLAN() []byte {
+	return ethFrame(0x8100, []byte{0x00, 0x64})
+}

--- a/internal/upf/ebpf/qer_test.go
+++ b/internal/upf/ebpf/qer_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// QER gate enforcement. A non-open gate must drop the packet before it is
+// forwarded. The QFI marking is asserted by the encapsulation tests, and rate
+// limiting is timing/state dependent (deferred to the netns harness).
+
+// TestQERGateUplinkClosed checks that a closed uplink QER gate drops the packet.
+func TestQERGateUplinkClosed(t *testing.T) {
+	requireProgTestRun(t)
+
+	const teid = 0x51455201
+
+	obj := loadN3N6Program(t)
+
+	pdr := PdrInfo{
+		IMSI: "001010000000001",
+		Far:  FarInfo{Action: 0x02 /* FAR_FORW */},
+		Qer:  QerInfo{GateStatusUL: 1 /* GATE_STATUS_CLOSED */, MaxBitrateUL: 0},
+	}
+	if err := obj.PutPdrUplink(teid, pdr); err != nil {
+		t.Fatalf("install uplink PDR: %v", err)
+	}
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)))
+
+	if action != XDP_DROP {
+		t.Fatalf("closed uplink gate: got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+}
+
+// TestQERGateDownlinkClosed checks that a closed downlink QER gate drops the
+// packet.
+func TestQERGateDownlinkClosed(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid = 0x51455202
+		qfi  = 4
+	)
+
+	obj := loadProgram(t, 1, 0)
+
+	ueIP := [4]byte{10, 45, 0, 2}
+
+	pdr := ipv4OuterDownlinkPDR(teid, [4]byte{192, 168, 100, 1}, [4]byte{192, 168, 100, 9}, qfi)
+
+	pdr.Qer.GateStatusDL = 1 // GATE_STATUS_CLOSED
+	if err := obj.PutPdrDownlink(netip.AddrFrom4(ueIP), pdr); err != nil {
+		t.Fatalf("install downlink PDR: %v", err)
+	}
+
+	inner := ipv4Packet([4]byte{8, 8, 8, 8}, ueIP, 17, udpDatagram(4000, 4001, nil))
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+
+	if action != XDP_DROP {
+		t.Fatalf("closed downlink gate: got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+}

--- a/internal/upf/ebpf/sdf_test.go
+++ b/internal/upf/ebpf/sdf_test.go
@@ -7,7 +7,6 @@ package ebpf
 
 import (
 	"bytes"
-	"encoding/binary"
 	"net/netip"
 	"testing"
 )
@@ -108,41 +107,4 @@ func putSDFFilter(t *testing.T, obj *BpfObjects, index uint32, rules []SdfRule) 
 	if err := obj.PutSdfFilterList(index, list); err != nil {
 		t.Fatalf("install SDF filter: %v", err)
 	}
-}
-
-// innerIPv4UDP builds the decapsulated inner packet: an IPv4/UDP datagram to
-// dst:dport. On uplink, dst is the SDF remote address.
-func innerIPv4UDP(dst [4]byte, dport uint16) []byte {
-	const ipLen, udpLen = 20, 8
-
-	pkt := make([]byte, ipLen+udpLen)
-
-	ip := pkt[:ipLen]
-	ip[0] = 0x45 // version 4, IHL 5
-	binary.BigEndian.PutUint16(ip[2:4], uint16(ipLen+udpLen))
-	ip[8] = 64 // TTL
-	ip[9] = 17 // IPPROTO_UDP
-	copy(ip[12:16], []byte{10, 0, 0, 9})
-	copy(ip[16:20], dst[:])
-
-	udp := pkt[ipLen:]
-	binary.BigEndian.PutUint16(udp[2:4], dport)
-	binary.BigEndian.PutUint16(udp[4:6], udpLen)
-
-	return pkt
-}
-
-// uplinkGPDU wraps inner in a well-formed GTP-U G-PDU (8-byte base header with
-// the E flag set plus the 8-byte optional header word) inside an
-// Ethernet/IPv4/UDP frame addressed to the GTP-U port.
-func uplinkGPDU(teid uint32, inner []byte) []byte {
-	const gtpLen = 16 // base header + optional header word
-
-	gtp := make([]byte, gtpLen)
-	gtp[0] = 0x34 // version=1, PT=1, E=1
-	gtp[1] = 0xFF // GTPU_G_PDU
-	binary.BigEndian.PutUint16(gtp[2:4], uint16(gtpLen-8+len(inner)))
-	binary.BigEndian.PutUint32(gtp[4:8], teid)
-
-	return wrapIPv4UDP(append(gtp, inner...), GTPUDPPort)
 }

--- a/internal/upf/ebpf/sdf_test.go
+++ b/internal/upf/ebpf/sdf_test.go
@@ -83,6 +83,167 @@ func TestSDFFilterEnforcement(t *testing.T) {
 	}
 }
 
+// TestSDFRuleMatching exercises the uplink SDF rule-matching dimensions:
+// protocol (wildcard/match/mismatch), port range, address prefix (CIDR and
+// wildcard), and first-match ordering. Deny => XDP_DROP; allow => forwarded with
+// the inner packet intact.
+func TestSDFRuleMatching(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid        = 0x53444601
+		filterIndex = 1
+		protoTCP    = 6
+		protoUDP    = 17
+	)
+
+	obj := loadN3N6Program(t)
+	putForwardingUplinkPDR(t, obj, teid, filterIndex)
+
+	dst := [4]byte{8, 8, 8, 8}
+	udp53 := innerIPv4UDP(dst, 53)
+	tcp80 := innerIPv4TCP(dst, 80)
+
+	tests := []struct {
+		name     string
+		rules    []SdfRule
+		inner    []byte
+		wantDrop bool
+	}{
+		{"protocol wildcard denies", []SdfRule{sdfRuleIPv4(dst, 32, 0, 0, SdfProtoAny, SdfActionDeny)}, udp53, true},
+		{"protocol mismatch passes", []SdfRule{sdfRuleIPv4(dst, 32, 0, 0, protoTCP, SdfActionDeny)}, udp53, false},
+		{"protocol match denies (tcp)", []SdfRule{sdfRuleIPv4(dst, 32, 0, 0, protoTCP, SdfActionDeny)}, tcp80, true},
+		{"port in range denies", []SdfRule{sdfRuleIPv4(dst, 32, 50, 60, protoUDP, SdfActionDeny)}, udp53, true},
+		{"port out of range passes", []SdfRule{sdfRuleIPv4(dst, 32, 100, 200, protoUDP, SdfActionDeny)}, udp53, false},
+		{"port wildcard denies", []SdfRule{sdfRuleIPv4(dst, 32, 0, 0, protoUDP, SdfActionDeny)}, udp53, true},
+		{"cidr match denies", []SdfRule{sdfRuleIPv4([4]byte{8, 8, 0, 0}, 16, 0, 0, protoUDP, SdfActionDeny)}, udp53, true},
+		{"cidr miss passes", []SdfRule{sdfRuleIPv4([4]byte{9, 9, 0, 0}, 16, 0, 0, protoUDP, SdfActionDeny)}, udp53, false},
+		{"prefix wildcard denies", []SdfRule{sdfRuleIPv4([4]byte{}, 0, 0, 0, protoUDP, SdfActionDeny)}, udp53, true},
+		{"first match allow wins", []SdfRule{sdfRuleIPv4(dst, 32, 0, 0, protoUDP, SdfActionAllow), sdfRuleIPv4(dst, 32, 0, 0, protoUDP, SdfActionDeny)}, udp53, false},
+		{"first match deny wins", []SdfRule{sdfRuleIPv4(dst, 32, 0, 0, protoUDP, SdfActionDeny), sdfRuleIPv4(dst, 32, 0, 0, protoUDP, SdfActionAllow)}, udp53, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			putSDFFilter(t, obj, filterIndex, tc.rules)
+
+			action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, tc.inner))
+
+			if tc.wantDrop {
+				if action != XDP_DROP {
+					t.Fatalf("got XDP action %d, want XDP_DROP", action)
+				}
+
+				return
+			}
+
+			if action == XDP_DROP {
+				t.Fatal("allowed packet was dropped")
+			}
+
+			if !bytes.Equal(out[ethHdrLen:], tc.inner) {
+				t.Fatalf("allowed inner packet altered:\n got %x\nwant %x", out[ethHdrLen:], tc.inner)
+			}
+		})
+	}
+}
+
+// TestSDFDownlinkDirection checks that downlink SDF matches the remote (the
+// packet source), the opposite of the uplink direction.
+func TestSDFDownlinkDirection(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid        = 0x53444602
+		filterIndex = 1
+		qfi         = 3
+	)
+
+	obj := loadProgram(t, 1, 0)
+
+	ueIP := [4]byte{10, 45, 0, 2}
+	server := [4]byte{8, 8, 8, 8}
+	local := [4]byte{192, 168, 100, 1}
+	remote := [4]byte{192, 168, 100, 9}
+
+	putDownlinkPDRFiltered(t, obj, ueIP, teid, local, remote, qfi, filterIndex)
+
+	inner := ipv4Packet(server, ueIP, 17, udpDatagram(4000, 4001, nil))
+
+	t.Run("deny by source drops", func(t *testing.T) {
+		putSDFFilter(t, obj, filterIndex, []SdfRule{sdfRuleIPv4(server, 32, 0, 0, 17, SdfActionDeny)})
+
+		action, _ := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+		if action != XDP_DROP {
+			t.Fatalf("got XDP action %d, want XDP_DROP", action)
+		}
+	})
+
+	t.Run("non-matching source passes and encapsulates", func(t *testing.T) {
+		putSDFFilter(t, obj, filterIndex, []SdfRule{sdfRuleIPv4([4]byte{1, 1, 1, 1}, 32, 0, 0, 17, SdfActionDeny)})
+
+		action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+		if action == XDP_DROP {
+			t.Fatal("allowed downlink packet was dropped")
+		}
+
+		if f := parseGTPv4Frame(t, out); !bytes.Equal(f.inner, inner) {
+			t.Fatalf("inner packet altered by encapsulation:\n got %x\nwant %x", f.inner, inner)
+		}
+	})
+}
+
+// TestSDFIPv6 checks IPv6 prefix matching (uplink, inner IPv6).
+func TestSDFIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid        = 0x53444603
+		filterIndex = 1
+	)
+
+	obj := loadN3N6Program(t)
+	putForwardingUplinkPDR(t, obj, teid, filterIndex)
+
+	dst := testUEv6 // inner daddr is the SDF remote on uplink
+	other := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	inner := innerIPv6UDP(dst, 53)
+
+	tests := []struct {
+		name     string
+		rules    []SdfRule
+		wantDrop bool
+	}{
+		{"/128 match denies", []SdfRule{sdfRuleIPv6(dst, 128, 0, 0, 17, SdfActionDeny)}, true},
+		{"/64 match denies", []SdfRule{sdfRuleIPv6(dst, 64, 0, 0, 17, SdfActionDeny)}, true},
+		{"/128 mismatch passes", []SdfRule{sdfRuleIPv6(other, 128, 0, 0, 17, SdfActionDeny)}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			putSDFFilter(t, obj, filterIndex, tc.rules)
+
+			action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+
+			if tc.wantDrop {
+				if action != XDP_DROP {
+					t.Fatalf("got XDP action %d, want XDP_DROP", action)
+				}
+
+				return
+			}
+
+			if action == XDP_DROP {
+				t.Fatal("allowed packet was dropped")
+			}
+
+			if !bytes.Equal(out[ethHdrLen:], inner) {
+				t.Fatalf("allowed inner packet altered:\n got %x\nwant %x", out[ethHdrLen:], inner)
+			}
+		})
+	}
+}
+
 // sdfRuleIPv4 builds an SDF rule for an IPv4 remote prefix, port range, and
 // protocol. A prefixLen or port bound of 0 is a wildcard in the data plane.
 func sdfRuleIPv4(remote [4]byte, prefixLen uint8, portLow, portHigh uint16, proto, action uint8) SdfRule {
@@ -96,7 +257,19 @@ func sdfRuleIPv4(remote [4]byte, prefixLen uint8, portLow, portHigh uint16, prot
 	}
 }
 
-func putSDFFilter(t *testing.T, obj *BpfObjects, index uint32, rules []SdfRule) {
+// sdfRuleIPv6 builds an SDF rule for a native IPv6 remote prefix.
+func sdfRuleIPv6(remote [16]byte, prefixLen uint8, portLow, portHigh uint16, proto, action uint8) SdfRule {
+	return SdfRule{
+		RemoteIP:  remote,
+		PrefixLen: prefixLen,
+		PortLow:   portLow,
+		PortHigh:  portHigh,
+		Protocol:  proto,
+		Action:    action,
+	}
+}
+
+func putSDFFilter(t *testing.T, obj *BpfObjects, index uint32, rules []SdfRule) { //nolint:unparam // general helper; the filter index is configurable
 	t.Helper()
 
 	var list SdfFilterList

--- a/internal/upf/ebpf/stats_test.go
+++ b/internal/upf/ebpf/stats_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// TestUplinkStatistics checks that uplink byte and action counters accumulate in
+// uplink_statistics.
+//
+// XDP BPF_PROG_TEST_RUN runs with ingress_ifindex == 1, and the entrypoint
+// selects the stats map from ingress_ifindex == n3_ifindex/n6_ifindex. So the
+// program is loaded with n3_ifindex == 1 (matching the test-run ingress) to
+// classify the packets as N3; n6_ifindex == 1 (loopback) serves the in-path MTU
+// check. The byte counter is recorded before routing, so the count is
+// deterministic regardless of the (host-dependent) forwarding verdict.
+func TestUplinkStatistics(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid    = 0x57415453
+		packets = 5
+	)
+
+	obj := loadProgramConfig(t, false, false, 1, 1, 0, 0)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	inner := innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)
+	for i := 0; i < packets; i++ {
+		runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+	}
+
+	bytesSum, actionsSum := sumStats(t, obj.UplinkStatistics)
+
+	if want := uint64(packets * (ethHdrLen + len(inner))); bytesSum != want {
+		t.Errorf("uplink byte_counter = %d, want %d", bytesSum, want)
+	}
+
+	if actionsSum != packets {
+		t.Errorf("uplink xdp_actions total = %d, want %d", actionsSum, packets)
+	}
+
+	// Nothing should have been classified as downlink.
+	if d, _ := sumStats(t, obj.DownlinkStatistics); d != 0 {
+		t.Errorf("downlink byte_counter = %d, want 0", d)
+	}
+}
+
+func sumStats(t *testing.T, m *ebpf.Map) (bytes, actions uint64) {
+	t.Helper()
+
+	var stats []N3N6EntrypointUpfStatistic
+	if err := m.Lookup(uint32(0), &stats); err != nil {
+		t.Fatalf("read statistics map: %v", err)
+	}
+
+	for _, s := range stats {
+		bytes += s.ByteCounter.Bytes
+		for _, a := range s.XdpActions {
+			actions += a
+		}
+	}
+
+	return bytes, actions
+}

--- a/internal/upf/ebpf/vlan_test.go
+++ b/internal/upf/ebpf/vlan_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestVLANDownlinkInsertion checks that when an N3 VLAN is configured, the
+// downlink encapsulation tags the egress frame: the Ethernet protocol becomes
+// 802.1Q, the VLAN tag carries the configured ID and an IPv4 inner protocol, and
+// the GTP-U/IPv4 packet plus inner payload follow.
+func TestVLANDownlinkInsertion(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid    = 0x564C414E
+		qfi     = 2
+		vlanID  = 100
+		vlanLen = 4
+	)
+
+	obj := loadProgramVLAN(t, 1, 0, vlanID, 0)
+
+	ueIP := [4]byte{10, 45, 0, 2}
+	local := [4]byte{192, 168, 100, 1}
+	remote := [4]byte{192, 168, 100, 9}
+
+	putDownlinkPDR(t, obj, ueIP, teid, local, remote, qfi)
+
+	inner := ipv4Packet([4]byte{8, 8, 8, 8}, ueIP, 17, udpDatagram(4000, 4001, nil))
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+
+	if action == XDP_ABORTED {
+		t.Fatal("downlink packet got XDP_ABORTED; VLAN encapsulation failed")
+	}
+
+	if len(out) != ethHdrLen+vlanLen+gtpV4EncapLen+len(inner) {
+		t.Fatalf("VLAN-tagged frame length = %d, want %d", len(out), ethHdrLen+vlanLen+gtpV4EncapLen+len(inner))
+	}
+
+	if et := binary.BigEndian.Uint16(out[12:14]); et != 0x8100 {
+		t.Errorf("Ethernet protocol = %#04x, want 0x8100 (802.1Q)", et)
+	}
+
+	if tci := binary.BigEndian.Uint16(out[14:16]); tci&0x0fff != vlanID {
+		t.Errorf("VLAN ID = %d, want %d", tci&0x0fff, vlanID)
+	}
+
+	if ep := binary.BigEndian.Uint16(out[16:18]); ep != 0x0800 {
+		t.Errorf("VLAN encapsulated protocol = %#04x, want 0x0800 (IPv4)", ep)
+	}
+
+	if !bytes.Equal(out[ethHdrLen+vlanLen+gtpV4EncapLen:], inner) {
+		t.Errorf("inner packet altered by encapsulation:\n got %x\nwant %x", out[ethHdrLen+vlanLen+gtpV4EncapLen:], inner)
+	}
+}


### PR DESCRIPTION
# Description

Add unit tests for our BPF program leveraging  `BPF_PROG_TEST_RUN`, which allows to run a loaded eBPF program in the kernel with a supplied input and records the output.

## Reference
- https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
