### PR TITLE
fix: panic on invalid n2 handover

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -435,16 +435,9 @@ func (amf *AMF) FindRanUeByAmfUeNgapID(amfUeNgapID int64) *RanUe {
 	defer amf.mu.RUnlock()
 
 	for _, ran := range amf.Radios {
-		ran.mu.RLock()
-
-		for _, ranUe := range ran.RanUEs {
-			if ranUe.AmfUeNgapID == amfUeNgapID {
-				ran.mu.RUnlock()
-				return ranUe
-			}
+		if ranUe := ran.FindUEByAmfUeNgapID(amfUeNgapID); ranUe != nil {
+			return ranUe
 		}
-
-		ran.mu.RUnlock()
 	}
 
 	return nil
@@ -511,7 +504,7 @@ func (a *AMF) NewRanUe(radio *Radio, ranUeNgapID int64) (*RanUe, error) {
 	}
 
 	radio.mu.Lock()
-	radio.RanUEs[ranUeNgapID] = ranUe
+	radio.RanUEs[amfUeNgapID] = ranUe
 	radio.mu.Unlock()
 
 	return ranUe, nil

--- a/internal/amf/amf_ran.go
+++ b/internal/amf/amf_ran.go
@@ -68,7 +68,7 @@ type Radio struct {
 	lastSeenAt    atomic.Int64 // Unix nanoseconds; use GetLastSeenAt()/TouchLastSeen()
 	SupportedTAIs []SupportedTAI
 	mu            sync.RWMutex     // protects RanUEs
-	RanUEs        map[int64]*RanUe // Key: RanUeNgapID
+	RanUEs        map[int64]*RanUe // Key: AMF UE NGAP ID (unique and set for the UE's whole lifetime; the RAN UE NGAP ID is unassigned until a handover target is acknowledged)
 	Log           *zap.Logger
 }
 
@@ -119,32 +119,23 @@ func (r *Radio) FindUEByRanUeNgapID(ranUeNgapID int64) *RanUe {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	ranUe, ok := r.RanUEs[ranUeNgapID]
-	if ok {
-		return ranUe
+	for _, ranUe := range r.RanUEs {
+		if ranUe.RanUeNgapID == ranUeNgapID {
+			return ranUe
+		}
 	}
 
 	return nil
 }
 
-// UpdateUERanNgapID re-keys a RanUe in the radio's map from its current
-// RanUeNgapID to the new value. This is needed during N2 handover when
-// the target gNB reports its assigned RAN UE NGAP ID in
-// HandoverRequestAcknowledge.
+// UpdateUERanNgapID records the RAN UE NGAP ID the target gNB assigned to a UE
+// in HandoverRequestAcknowledge. The UE is keyed by its AMF UE NGAP ID, so only
+// the field is updated.
 func (r *Radio) UpdateUERanNgapID(ranUe *RanUe, newRanUeNgapID int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if existing, ok := r.RanUEs[newRanUeNgapID]; ok && existing != ranUe {
-		logger.AmfLog.Warn("UpdateUERanNgapID: newRanUeNgapID already in use, overwriting",
-			zap.Int64("newRanUeNgapID", newRanUeNgapID),
-			zap.Int64("existingAmfUeNgapID", existing.AmfUeNgapID),
-		)
-	}
-
-	delete(r.RanUEs, ranUe.RanUeNgapID)
 	ranUe.RanUeNgapID = newRanUeNgapID
-	r.RanUEs[newRanUeNgapID] = ranUe
 }
 
 // FindUEByAmfUeNgapID returns the RAN UE with the given AMF UE NGAP ID, or nil.
@@ -152,13 +143,7 @@ func (r *Radio) FindUEByAmfUeNgapID(amfUeNgapID int64) *RanUe {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	for _, ranUe := range r.RanUEs {
-		if ranUe.AmfUeNgapID == amfUeNgapID {
-			return ranUe
-		}
-	}
-
-	return nil
+	return r.RanUEs[amfUeNgapID]
 }
 
 func (r *Radio) TouchLastSeen() {

--- a/internal/amf/amf_ran_test.go
+++ b/internal/amf/amf_ran_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 )
 
@@ -125,5 +126,40 @@ func TestRadioNodeID(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expectedID, got)
 			}
 		})
+	}
+}
+
+// TestRadioConcurrentHandoverTargetsCoexist guards against the regression where
+// concurrent N2 handover targets to one gNB evicted each other: a target has no
+// RAN UE NGAP ID until its Handover Request Acknowledge, so targets are keyed by
+// their distinct AMF UE NGAP IDs and must coexist, then each becomes reachable
+// by its assigned RAN UE NGAP ID.
+func TestRadioConcurrentHandoverTargetsCoexist(t *testing.T) {
+	radio := &amf.Radio{Log: logger.AmfLog, RanUEs: make(map[int64]*amf.RanUe)}
+
+	target1 := amf.NewRanUeForTest(radio, models.RanUeNgapIDUnspecified, 500, logger.AmfLog)
+	target2 := amf.NewRanUeForTest(radio, models.RanUeNgapIDUnspecified, 501, logger.AmfLog)
+
+	if got := radio.FindUEByAmfUeNgapID(500); got != target1 {
+		t.Errorf("FindUEByAmfUeNgapID(500) = %v, want first target", got)
+	}
+
+	if got := radio.FindUEByAmfUeNgapID(501); got != target2 {
+		t.Errorf("FindUEByAmfUeNgapID(501) = %v, want second target", got)
+	}
+
+	radio.UpdateUERanNgapID(target1, 100)
+	radio.UpdateUERanNgapID(target2, 101)
+
+	if got := radio.FindUEByRanUeNgapID(100); got != target1 {
+		t.Errorf("FindUEByRanUeNgapID(100) = %v, want first target", got)
+	}
+
+	if got := radio.FindUEByRanUeNgapID(101); got != target2 {
+		t.Errorf("FindUEByRanUeNgapID(101) = %v, want second target", got)
+	}
+
+	if got := radio.FindUEByAmfUeNgapID(500); got != target1 {
+		t.Errorf("after RAN ID assignment, FindUEByAmfUeNgapID(500) = %v, want first target", got)
 	}
 }

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -33,7 +33,21 @@ func HandleHandoverCancel(ctx context.Context, ran *amf.Radio, msg decode.Handov
 	}
 
 	if sourceUe.AmfUeNgapID != msg.AMFUENGAPID {
-		logger.WithTrace(ctx, sourceUe.Log).Warn("Conflict AMF_UE_NGAP_ID", zap.Int64("sourceUe.AmfUeNgapID", sourceUe.AmfUeNgapID), zap.Int64("aMFUENGAPID.Value", msg.AMFUENGAPID))
+		logger.WithTrace(ctx, sourceUe.Log).Error("AMF UE NGAP ID mismatch", zap.Int64("expected", sourceUe.AmfUeNgapID), zap.Int64("received", msg.AMFUENGAPID))
+
+		cause := ngapType.Cause{
+			Present: ngapType.CausePresentRadioNetwork,
+			RadioNetwork: &ngapType.CauseRadioNetwork{
+				Value: ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID,
+			},
+		}
+
+		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
+		if err != nil {
+			logger.WithTrace(ctx, sourceUe.Log).Error("error sending error indication", zap.Error(err))
+		}
+
+		return
 	}
 
 	logger.WithTrace(ctx, sourceUe.Log).Debug("Handle Handover Cancel", zap.Int64("sourceRanUeNgapID", sourceUe.RanUeNgapID), zap.Int64("sourceAmfUeNgapID", sourceUe.AmfUeNgapID))

--- a/internal/amf/ngap/handle_handover_cancel_test.go
+++ b/internal/amf/ngap/handle_handover_cancel_test.go
@@ -46,6 +46,53 @@ func TestHandleHandoverCancel_UnknownRanUeNgapID(t *testing.T) {
 	}
 }
 
+// TestHandleHandoverCancel_InconsistentAmfUeNgapID verifies that a
+// HandoverCancel whose AMF UE NGAP ID does not match the value stored for the UE
+// draws an Error Indication and is not acted upon (TS 38.413 §10.6): no
+// acknowledge to the source and no release toward the target.
+func TestHandleHandoverCancel_InconsistentAmfUeNgapID(t *testing.T) {
+	sourceRan := newTestRadio()
+	sourceSender := sourceRan.NGAPSender.(*FakeNGAPSender)
+
+	targetRan := newTestRadio()
+	targetSender := targetRan.NGAPSender.(*FakeNGAPSender)
+
+	sourceUe := amf.NewRanUeForTest(sourceRan, 1, 10, logger.AmfLog)
+	targetUe := amf.NewRanUeForTest(targetRan, 2, 20, logger.AmfLog)
+
+	sourceUe.TargetUe = targetUe
+	targetUe.SourceUe = sourceUe
+
+	msg := decode.HandoverCancel{
+		AMFUENGAPID: 999, // does not match sourceUe.AmfUeNgapID (10)
+		RANUENGAPID: 1,
+		Cause: &ngapType.Cause{
+			Present:      ngapType.CausePresentRadioNetwork,
+			RadioNetwork: &ngapType.CauseRadioNetwork{Value: ngapType.CauseRadioNetworkPresentHoFailureInTarget5GCNgranNodeOrTargetSystem},
+		},
+	}
+
+	ngap.HandleHandoverCancel(context.Background(), sourceRan, msg)
+
+	if len(sourceSender.SentErrorIndications) != 1 {
+		t.Fatalf("expected 1 ErrorIndication, got %d", len(sourceSender.SentErrorIndications))
+	}
+
+	errInd := sourceSender.SentErrorIndications[0]
+	if errInd.Cause == nil || errInd.Cause.Present != ngapType.CausePresentRadioNetwork ||
+		errInd.Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
+		t.Fatalf("expected InconsistentRemoteUENGAPID cause, got %+v", errInd.Cause)
+	}
+
+	if len(sourceSender.SentHandoverCancelAcknowledges) != 0 {
+		t.Errorf("expected no HandoverCancelAcknowledge, got %d", len(sourceSender.SentHandoverCancelAcknowledges))
+	}
+
+	if len(targetSender.SentUEContextReleaseCommands) != 0 {
+		t.Errorf("expected no UEContextReleaseCommand on target, got %d", len(targetSender.SentUEContextReleaseCommands))
+	}
+}
+
 func TestHandleHandoverCancel_HappyPath(t *testing.T) {
 	sourceRan := newTestRadio()
 	sourceSender := sourceRan.NGAPSender.(*FakeNGAPSender)

--- a/internal/amf/ngap/handle_handover_failure_test.go
+++ b/internal/amf/ngap/handle_handover_failure_test.go
@@ -50,8 +50,6 @@ func TestHandleHandoverFailure_SourceAmfUeDetached(t *testing.T) {
 		t.Fatalf("AttachSourceUeTargetUe: %v", err)
 	}
 
-	targetRan.RanUEs[2] = targetUe
-
 	amfInstance.Radios[new(sctp.SCTPConn)] = sourceRan
 	amfInstance.Radios[new(sctp.SCTPConn)] = targetRan
 

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -7,9 +7,39 @@ import (
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/aper"
 	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
 )
+
+// buildPDUSessionResourceToReleaseItemHOCmd builds the Handover Command
+// to-release item for a PDU session the target did not admit. The failure cause
+// the target reported (in the Handover Resource Allocation Unsuccessful
+// Transfer) is relayed to the source when it can be decoded, otherwise a
+// generic target-failure cause is used.
+func buildPDUSessionResourceToReleaseItemHOCmd(pduSessionID ngapType.PDUSessionID, unsuccessful aper.OctetString) (ngapType.PDUSessionResourceToReleaseItemHOCmd, error) {
+	cause := ngapType.Cause{
+		Present: ngapType.CausePresentRadioNetwork,
+		RadioNetwork: &ngapType.CauseRadioNetwork{
+			Value: ngapType.CauseRadioNetworkPresentHoFailureInTarget5GCNgranNodeOrTargetSystem,
+		},
+	}
+
+	var received ngapType.HandoverResourceAllocationUnsuccessfulTransfer
+	if err := aper.UnmarshalWithParams(unsuccessful, &received, "valueExt"); err == nil {
+		cause = received.Cause
+	}
+
+	transfer, err := aper.MarshalWithParams(ngapType.HandoverPreparationUnsuccessfulTransfer{Cause: cause}, "valueExt")
+	if err != nil {
+		return ngapType.PDUSessionResourceToReleaseItemHOCmd{}, err
+	}
+
+	return ngapType.PDUSessionResourceToReleaseItemHOCmd{
+		PDUSessionID:                            pduSessionID,
+		HandoverPreparationUnsuccessfulTransfer: transfer,
+	}, nil
+}
 
 func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.HandoverRequestAcknowledge) {
 	if msg.AMFUENGAPID == nil {
@@ -67,20 +97,22 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		}
 	}
 
+	// PDU sessions the target could not admit are listed for release so the
+	// source NG-RAN frees their resources (TS 38.413 §8.4.1.2). They are not
+	// switched to the target, so their SMF context is left on the source path.
 	for _, item := range msg.FailedToSetupItems {
-		pduSessionIDUint8, ok := validPDUSessionID(item.PDUSessionID.Value)
-		if !ok {
+		if _, ok := validPDUSessionID(item.PDUSessionID.Value); !ok {
 			logger.WithTrace(ctx, targetUe.Log).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", item.PDUSessionID.Value))
 			continue
 		}
 
-		transfer := item.HandoverResourceAllocationUnsuccessfulTransfer
-		if smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionIDUint8); exist {
-			_, err := amfInstance.Smf.UpdateSmContextN2HandoverPrepared(ctx, smContext.Ref, transfer)
-			if err != nil {
-				logger.WithTrace(ctx, targetUe.Log).Error("Send HandoverResourceAllocationUnsuccessfulTransfer error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionIDUint8))
-			}
+		releaseItem, err := buildPDUSessionResourceToReleaseItemHOCmd(item.PDUSessionID, item.HandoverResourceAllocationUnsuccessfulTransfer)
+		if err != nil {
+			logger.WithTrace(ctx, targetUe.Log).Error("failed to build PDU session to-release item", zap.Error(err), zap.Int64("pduSessionID", item.PDUSessionID.Value))
+			continue
 		}
+
+		pduSessionResourceToReleaseList.List = append(pduSessionResourceToReleaseList.List, releaseItem)
 	}
 
 	sourceUe := targetUe.SourceUe

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -13,10 +13,8 @@ import (
 )
 
 // buildPDUSessionResourceToReleaseItemHOCmd builds the Handover Command
-// to-release item for a PDU session the target did not admit. The failure cause
-// the target reported (in the Handover Resource Allocation Unsuccessful
-// Transfer) is relayed to the source when it can be decoded, otherwise a
-// generic target-failure cause is used.
+// to-release item for a non-admitted PDU session, relaying the target's
+// reported failure cause when decodable, otherwise a generic one.
 func buildPDUSessionResourceToReleaseItemHOCmd(pduSessionID ngapType.PDUSessionID, unsuccessful aper.OctetString) (ngapType.PDUSessionResourceToReleaseItemHOCmd, error) {
 	cause := ngapType.Cause{
 		Present: ngapType.CausePresentRadioNetwork,
@@ -97,9 +95,8 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		}
 	}
 
-	// PDU sessions the target could not admit are listed for release so the
-	// source NG-RAN frees their resources (TS 38.413 §8.4.1.2). They are not
-	// switched to the target, so their SMF context is left on the source path.
+	// Sessions the target did not admit go in the to-release list so the source
+	// frees them (TS 38.413 §8.4.1.2); they stay on the source, so no SMF update.
 	for _, item := range msg.FailedToSetupItems {
 		if _, ok := validPDUSessionID(item.PDUSessionID.Value); !ok {
 			logger.WithTrace(ctx, targetUe.Log).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", item.PDUSessionID.Value))

--- a/internal/amf/ngap/handle_handover_request_acknowledge_test.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge_test.go
@@ -313,3 +313,86 @@ func TestHandoverRequestAcknowledge_HappyPath(t *testing.T) {
 		t.Fatalf("expected no HandoverPreparationFailure, got %d", len(sourceNGAPSender.SentHandoverPreparationFailures))
 	}
 }
+
+// TestHandoverRequestAcknowledge_PartialAdmission verifies that when the target
+// admits some PDU sessions and fails others, the Handover Command confirms the
+// admitted ones in the Handover List and lists the failed ones in the PDU
+// Session Resource To Release List (TS 38.413 §8.4.1.2 / §8.4.2.2).
+func TestHandoverRequestAcknowledge_PartialAdmission(t *testing.T) {
+	targetRan, sourceNGAPSender, amfInstance := setupHandoverAckTestContext(t)
+
+	admittedTransfer := ngapType.HandoverRequestAcknowledgeTransfer{
+		DLNGUUPTNLInformation: ngapType.UPTransportLayerInformation{
+			Present: ngapType.UPTransportLayerInformationPresentGTPTunnel,
+			GTPTunnel: &ngapType.GTPTunnel{
+				TransportLayerAddress: ngapType.TransportLayerAddress{
+					Value: aper.BitString{Bytes: []byte{10, 0, 0, 2}, BitLength: 32},
+				},
+				GTPTEID: ngapType.GTPTEID{Value: []byte{0x00, 0x00, 0x04, 0xD2}},
+			},
+		},
+		QosFlowSetupResponseList: ngapType.QosFlowListWithDataForwarding{
+			List: []ngapType.QosFlowItemWithDataForwarding{
+				{QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: 1}},
+			},
+		},
+	}
+
+	admittedBytes, err := aper.MarshalWithParams(admittedTransfer, "valueExt")
+	if err != nil {
+		t.Fatalf("failed to marshal admitted transfer: %v", err)
+	}
+
+	unsuccessfulTransfer := ngapType.HandoverResourceAllocationUnsuccessfulTransfer{
+		Cause: ngapType.Cause{
+			Present:      ngapType.CausePresentRadioNetwork,
+			RadioNetwork: &ngapType.CauseRadioNetwork{Value: ngapType.CauseRadioNetworkPresentRadioResourcesNotAvailable},
+		},
+	}
+
+	unsuccessfulBytes, err := aper.MarshalWithParams(unsuccessfulTransfer, "valueExt")
+	if err != nil {
+		t.Fatalf("failed to marshal unsuccessful transfer: %v", err)
+	}
+
+	amfID := int64(1)
+	ranID := int64(2)
+	msg := decode.HandoverRequestAcknowledge{
+		AMFUENGAPID: &amfID,
+		RANUENGAPID: &ranID,
+		AdmittedItems: []ngapType.PDUSessionResourceAdmittedItem{
+			{PDUSessionID: ngapType.PDUSessionID{Value: 1}, HandoverRequestAcknowledgeTransfer: admittedBytes},
+		},
+		FailedToSetupItems: []ngapType.PDUSessionResourceFailedToSetupItemHOAck{
+			{PDUSessionID: ngapType.PDUSessionID{Value: 2}, HandoverResourceAllocationUnsuccessfulTransfer: unsuccessfulBytes},
+		},
+		TargetToSourceTransparentContainer: ngapType.TargetToSourceTransparentContainer{Value: []byte{0xAA, 0xBB, 0xCC}},
+	}
+
+	ngap.HandleHandoverRequestAcknowledge(context.Background(), amfInstance, targetRan, msg)
+
+	if len(sourceNGAPSender.SentHandoverCommands) != 1 {
+		t.Fatalf("expected 1 HandoverCommand, got %d", len(sourceNGAPSender.SentHandoverCommands))
+	}
+
+	cmd := sourceNGAPSender.SentHandoverCommands[0]
+
+	if len(cmd.HandoverList.List) != 1 || cmd.HandoverList.List[0].PDUSessionID.Value != 1 {
+		t.Errorf("expected handover list to confirm session 1, got %+v", cmd.HandoverList.List)
+	}
+
+	if len(cmd.ToReleaseList.List) != 1 || cmd.ToReleaseList.List[0].PDUSessionID.Value != 2 {
+		t.Fatalf("expected to-release list to contain session 2 (TS 38.413 §8.4.1.2), got %+v", cmd.ToReleaseList.List)
+	}
+
+	// The to-release item must carry a decodable HandoverPreparationUnsuccessfulTransfer.
+	var relayed ngapType.HandoverPreparationUnsuccessfulTransfer
+	if err := aper.UnmarshalWithParams(cmd.ToReleaseList.List[0].HandoverPreparationUnsuccessfulTransfer, &relayed, "valueExt"); err != nil {
+		t.Fatalf("to-release transfer does not decode: %v", err)
+	}
+
+	if relayed.Cause.Present != ngapType.CausePresentRadioNetwork ||
+		relayed.Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentRadioResourcesNotAvailable {
+		t.Errorf("expected relayed cause RadioResourcesNotAvailable, got %+v", relayed.Cause)
+	}
+}

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -104,10 +104,26 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 	targetRan, ok := amfInstance.FindRadioByRanID(targetRanNodeID)
 	if !ok {
-		// handover between different AMF
-		logger.WithTrace(ctx, sourceUe.Log).Warn("Handover required : cannot find target Ran Node Id in this AMF. Handover between different AMF has not been implemented yet", zap.Any("targetRanNodeID", targetRanNodeID))
+		// The target gNB is not served by this AMF. Inter-AMF handover (TS 23.502
+		// §4.9.1.3.2) is not implemented, so preparation cannot proceed; the
+		// source must be told it failed rather than left waiting for its
+		// TNGRELOCprep timer to expire (TS 38.413 §8.4.1.3).
+		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [Unknown Target ID]", zap.Any("targetRanNodeID", targetRanNodeID))
+
+		failureCause := ngapType.Cause{
+			Present: ngapType.CausePresentRadioNetwork,
+			RadioNetwork: &ngapType.CauseRadioNetwork{
+				Value: ngapType.CauseRadioNetworkPresentUnknownTargetID,
+			},
+		}
+
+		conn.Procedures.End(procedure.N2Handover)
+
+		if err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil); err != nil {
+			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(err))
+		}
+
 		return
-		// Described in (23.502 4.9.1.3.2) step 3.Namf_Communication_CreateUEContext Request
 	}
 
 	// Handover in same AMF

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -104,10 +104,9 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 	targetRan, ok := amfInstance.FindRadioByRanID(targetRanNodeID)
 	if !ok {
-		// The target gNB is not served by this AMF. Inter-AMF handover (TS 23.502
-		// §4.9.1.3.2) is not implemented, so preparation cannot proceed; the
-		// source must be told it failed rather than left waiting for its
-		// TNGRELOCprep timer to expire (TS 38.413 §8.4.1.3).
+		// The target gNB is not served by this AMF, so preparation cannot
+		// proceed; fail it explicitly rather than leave the source waiting
+		// (TS 38.413 §8.4.1.3).
 		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [Unknown Target ID]", zap.Any("targetRanNodeID", targetRanNodeID))
 
 		failureCause := ngapType.Cause{

--- a/internal/amf/ngap/handle_handover_required_test.go
+++ b/internal/amf/ngap/handle_handover_required_test.go
@@ -456,3 +456,112 @@ func TestHandoverRequired_InvalidSecurityContext(t *testing.T) {
 		t.Fatalf("expected no HandoverRequest to be sent, got %d", len(sourceNGAPSender.SentHandoverRequests))
 	}
 }
+
+// TestHandoverRequired_UnknownTarget verifies that when the target gNB is not
+// served by this AMF, handover preparation fails gracefully: the source UE
+// receives a HandoverPreparationFailure with cause UnknownTargetID rather than
+// being left without a response (TS 38.413 §8.4.1.3).
+func TestHandoverRequired_UnknownTarget(t *testing.T) {
+	const (
+		targetGnbID  = "000102"
+		pduSessionID = uint8(1)
+		supiStr      = "imsi-001010000000001"
+		dnn          = "internet"
+		kamfHex      = "0000000000000000000000000000000000000000000000000000000000000000"
+	)
+
+	supi, _ := etsi.NewSUPIFromPrefixed(supiStr)
+
+	hoRequiredTransferBytes, err := aper.MarshalWithParams(ngapType.HandoverRequiredTransfer{}, "valueExt")
+	if err != nil {
+		t.Fatalf("failed to marshal HandoverRequiredTransfer: %v", err)
+	}
+
+	plmnID, err := getMccAndMncInOctets("001", "01")
+	if err != nil {
+		t.Fatalf("failed to get PLMN ID octets: %v", err)
+	}
+
+	targetGnbBitString := ngapConvert.HexToBitString(targetGnbID, 24)
+	targetID := &ngapType.TargetID{
+		Present: ngapType.TargetIDPresentTargetRANNodeID,
+		TargetRANNodeID: &ngapType.TargetRANNodeID{
+			GlobalRANNodeID: ngapType.GlobalRANNodeID{
+				Present: ngapType.GlobalRANNodeIDPresentGlobalGNBID,
+				GlobalGNBID: &ngapType.GlobalGNBID{
+					PLMNIdentity: ngapType.PLMNIdentity{Value: plmnID},
+					GNBID: ngapType.GNBID{
+						Present: ngapType.GNBIDPresentGNBID,
+						GNBID:   &targetGnbBitString,
+					},
+				},
+			},
+			SelectedTAI: ngapType.TAI{
+				PLMNIdentity: ngapType.PLMNIdentity{Value: plmnID},
+				TAC:          ngapType.TAC{Value: aper.OctetString{0x00, 0x00, 0x01}},
+			},
+		},
+	}
+
+	msg, err := buildHandoverRequired(&HandoverRequiredOpts{
+		AMFUENGAPID: ngapType.AMFUENGAPID{Value: 1},
+		RANUENGAPID: ngapType.RANUENGAPID{Value: 1},
+		TargetID:    targetID,
+		PDUSessionResourceListHORqd: &ngapType.PDUSessionResourceListHORqd{
+			List: []ngapType.PDUSessionResourceItemHORqd{
+				{PDUSessionID: ngapType.PDUSessionID{Value: int64(pduSessionID)}, HandoverRequiredTransfer: hoRequiredTransferBytes},
+			},
+		},
+		SourceToTargetTransparentContainer: &ngapType.SourceToTargetTransparentContainer{Value: []byte{0x01, 0x02, 0x03}},
+	})
+	if err != nil {
+		t.Fatalf("failed to build HandoverRequired: %v", err)
+	}
+
+	smfInstance := smf.New(nil, nil, nil, nil)
+	smfInstance.NewSession(supi, pduSessionID, dnn, &models.Snssai{Sst: 1})
+
+	amfUe := amf.NewAmfUe()
+	amfUe.Supi = supi
+	amfUe.Current().SecurityContextAvailable = true
+	amfUe.Current().NgKsi.Ksi = 1
+	amfUe.Current().Kamf = kamfHex
+	amfUe.Current().NH = make([]byte, 32)
+	amfUe.Log = logger.AmfLog
+	amfUe.Current().SmContextList[pduSessionID] = &amf.SmContext{
+		Ref:    smf.CanonicalName(supi, pduSessionID),
+		Snssai: &models.Snssai{Sst: 1},
+	}
+
+	sourceNGAPSender := &FakeNGAPSender{}
+	sourceRan := &amf.Radio{
+		Log:           logger.AmfLog,
+		NGAPSender:    sourceNGAPSender,
+		RanUEs:        make(map[int64]*amf.RanUe),
+		SupportedTAIs: make([]amf.SupportedTAI, 0),
+	}
+
+	sourceUe := amf.NewRanUeForTest(sourceRan, 1, 1, logger.AmfLog)
+	amfUe.AttachRanUe(sourceUe)
+
+	amfInstance := amf.New(&FakeDBInstance{
+		Operator: &db.Operator{Mcc: "001", Mnc: "01"},
+	}, nil, &FakeSmfSbi{SMF: smfInstance})
+	// No target gNB registered with this AMF.
+	amfInstance.Radios = map[*sctp.SCTPConn]*amf.Radio{}
+
+	ngap.HandleHandoverRequired(context.Background(), amfInstance, sourceRan, decodeHandoverRequiredOrFatal(t, msg.InitiatingMessage.Value.HandoverRequired))
+
+	if len(sourceNGAPSender.SentHandoverPreparationFailures) != 1 {
+		t.Fatalf("expected 1 HandoverPreparationFailure, got %d", len(sourceNGAPSender.SentHandoverPreparationFailures))
+	}
+
+	failure := sourceNGAPSender.SentHandoverPreparationFailures[0]
+	if failure.Cause.Present != ngapType.CausePresentRadioNetwork {
+		t.Fatalf("expected RadioNetwork cause, got present=%d", failure.Cause.Present)
+	}
+
+	if failure.Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentUnknownTargetID {
+		t.Fatalf("expected UnknownTargetID cause, got %d", failure.Cause.RadioNetwork.Value)
+	}
+}

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -37,9 +37,9 @@ func TestHandleInitialUEMessage_CreatesNewRanUe(t *testing.T) {
 		t.Fatalf("len(ran.RanUEs) = %d, want 1", len(ran.RanUEs))
 	}
 
-	ranUe := ran.RanUEs[1]
+	ranUe := ran.FindUEByRanUeNgapID(1)
 	if ranUe == nil {
-		t.Fatal("ran.RanUEs[1] is nil")
+		t.Fatal("ran.FindUEByRanUeNgapID(1) is nil")
 	}
 
 	if ranUe.RanUeNgapID != 1 {
@@ -73,9 +73,9 @@ func TestHandleInitialUEMessage_ReusedRanUeNgapID_EvictsStale(t *testing.T) {
 		t.Fatalf("len(ran.RanUEs) = %d, want 1", len(ran.RanUEs))
 	}
 
-	newRanUe := ran.RanUEs[1]
+	newRanUe := ran.FindUEByRanUeNgapID(1)
 	if newRanUe == nil {
-		t.Fatal("ran.RanUEs[1] is nil")
+		t.Fatal("ran.FindUEByRanUeNgapID(1) is nil")
 	}
 
 	if newRanUe.AmfUeNgapID == 99 {
@@ -141,9 +141,9 @@ func TestHandleInitialUEMessage_5GSTMSI_KnownUE_AttachesAmfUe(t *testing.T) {
 		},
 	})
 
-	ranUe := ran.RanUEs[1]
+	ranUe := ran.FindUEByRanUeNgapID(1)
 	if ranUe == nil {
-		t.Fatal("ran.RanUEs[1] is nil")
+		t.Fatal("ran.FindUEByRanUeNgapID(1) is nil")
 	}
 
 	if ranUe.AmfUe() != amfUe {
@@ -187,9 +187,9 @@ func TestHandleInitialUEMessage_5GSTMSI_UnknownUE_NASStillCalled(t *testing.T) {
 		t.Fatalf("NAS calls = %d, want 1", len(fakeNAS.Calls))
 	}
 
-	ranUe := ran.RanUEs[1]
+	ranUe := ran.FindUEByRanUeNgapID(1)
 	if ranUe == nil {
-		t.Fatal("ran.RanUEs[1] is nil")
+		t.Fatal("ran.FindUEByRanUeNgapID(1) is nil")
 	}
 
 	if ranUe.AmfUe() != nil {
@@ -210,9 +210,9 @@ func TestHandleInitialUEMessage_SetsUeContextRequest(t *testing.T) {
 		UEContextRequest: true,
 	})
 
-	ranUe := ran.RanUEs[1]
+	ranUe := ran.FindUEByRanUeNgapID(1)
 	if ranUe == nil {
-		t.Fatal("ran.RanUEs[1] is nil")
+		t.Fatal("ran.FindUEByRanUeNgapID(1) is nil")
 	}
 
 	if !ranUe.UeContextRequest {

--- a/internal/amf/ngap/handle_test.go
+++ b/internal/amf/ngap/handle_test.go
@@ -274,9 +274,11 @@ type HandoverRequest struct {
 }
 
 type HandoverCommand struct {
-	AmfUeNgapID int64
-	RanUeNgapID int64
-	Container   ngapType.TargetToSourceTransparentContainer
+	AmfUeNgapID   int64
+	RanUeNgapID   int64
+	HandoverList  ngapType.PDUSessionResourceHandoverList
+	ToReleaseList ngapType.PDUSessionResourceToReleaseListHOCmd
+	Container     ngapType.TargetToSourceTransparentContainer
 }
 
 type UEContextReleaseCommand struct {
@@ -490,9 +492,11 @@ func (fng *FakeNGAPSender) SendLocationReportingControl(ctx context.Context, amf
 
 func (fng *FakeNGAPSender) SendHandoverCommand(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, handOverType ngapType.HandoverType, pduSessionResourceHandoverList ngapType.PDUSessionResourceHandoverList, pduSessionResourceToReleaseList ngapType.PDUSessionResourceToReleaseListHOCmd, container ngapType.TargetToSourceTransparentContainer) error {
 	fng.SentHandoverCommands = append(fng.SentHandoverCommands, &HandoverCommand{
-		AmfUeNgapID: amfUeNgapID,
-		RanUeNgapID: ranUeNgapID,
-		Container:   container,
+		AmfUeNgapID:   amfUeNgapID,
+		RanUeNgapID:   ranUeNgapID,
+		HandoverList:  pduSessionResourceHandoverList,
+		ToReleaseList: pduSessionResourceToReleaseList,
+		Container:     container,
 	})
 
 	return nil

--- a/internal/amf/ngap/handle_ue_context_release_complete_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete_test.go
@@ -48,7 +48,7 @@ func TestHandleUEContextReleaseComplete_HandoverTargetNilTargetUe(t *testing.T) 
 
 	ngap.HandleUEContextReleaseComplete(context.Background(), amfInstance, ran, msg)
 
-	if _, exists := ran.RanUEs[targetRanUe.RanUeNgapID]; exists {
+	if ran.FindUEByRanUeNgapID(targetRanUe.RanUeNgapID) != nil {
 		t.Fatal("expected target RanUe to be removed after release complete")
 	}
 }
@@ -85,7 +85,7 @@ func TestHandleUEContextReleaseComplete_SmContextNotFound(t *testing.T) {
 
 	ngap.HandleUEContextReleaseComplete(context.Background(), amfInstance, ran, msg)
 
-	if _, exists := ran.RanUEs[ranUe.RanUeNgapID]; exists {
+	if ran.FindUEByRanUeNgapID(ranUe.RanUeNgapID) != nil {
 		t.Fatal("expected RanUe to be removed after release complete")
 	}
 }

--- a/internal/amf/ngap/handle_uplink_nas_transport_test.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport_test.go
@@ -91,7 +91,7 @@ func TestHandleUplinkNasTransport_NilAmfUe_RemovesRanUe(t *testing.T) {
 		NASPDU:      []byte{0x7E, 0x00, 0x55},
 	})
 
-	if _, exists := ran.RanUEs[1]; exists {
+	if ran.FindUEByRanUeNgapID(1) != nil {
 		t.Error("expected RanUe to be removed from radio's map")
 	}
 }

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -300,7 +300,7 @@ func (ranUe *RanUe) Remove(ctx context.Context) error {
 	}
 
 	ran.mu.Lock()
-	delete(ran.RanUEs, ranUe.RanUeNgapID)
+	delete(ran.RanUEs, ranUe.AmfUeNgapID)
 	ran.mu.Unlock()
 
 	if ranUe.freeNgapID != nil {
@@ -326,14 +326,13 @@ func (ranUe *RanUe) SwitchToRan(newRan *Radio, ranUeNgapID int64) error {
 
 	oldRan := ranUe.radio
 
-	// remove ranUe from oldRan
+	// move ranUe from oldRan to newRan (keyed by the unchanged AMF UE NGAP ID)
 	oldRan.mu.Lock()
-	delete(oldRan.RanUEs, ranUe.RanUeNgapID)
+	delete(oldRan.RanUEs, ranUe.AmfUeNgapID)
 	oldRan.mu.Unlock()
 
-	// add ranUe to newRan
 	newRan.mu.Lock()
-	newRan.RanUEs[ranUeNgapID] = ranUe
+	newRan.RanUEs[ranUe.AmfUeNgapID] = ranUe
 	newRan.mu.Unlock()
 
 	// switch to newRan
@@ -486,7 +485,7 @@ func NewRanUeForTest(radio *Radio, ranUeNgapID, amfUeNgapID int64, log *zap.Logg
 	}
 
 	radio.mu.Lock()
-	radio.RanUEs[ranUeNgapID] = ranUe
+	radio.RanUEs[amfUeNgapID] = ranUe
 	radio.mu.Unlock()
 
 	return ranUe

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -599,9 +599,8 @@ func handleHandoverRequestAcknowledgeTransfer(b []byte, smContext *SMContext) er
 	if smContext.Tunnel.DataPath.Activated {
 		dlFAR := smContext.Tunnel.DataPath.DownLinkTunnel.PDR.FAR
 
-		// The forwarding parameters are only populated once the downlink tunnel
-		// is known (TS 23.502 §4.9.1.3); on handover the target supplies it, so
-		// create the structure if the prior data path had none.
+		// A data path activated before its downlink endpoint was known has no
+		// forwarding parameters; the handover target supplies them now.
 		if dlFAR.ForwardingParameters == nil {
 			dlFAR.ForwardingParameters = &models.ForwardingParameters{}
 		}

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -584,8 +584,10 @@ func handleHandoverRequestAcknowledgeTransfer(b []byte, smContext *SMContext) er
 		return fmt.Errorf("failed to unmarshall handover request acknowledge transfer: %s", err.Error())
 	}
 
-	DLNGUUPTNLInformation := handoverRequestAcknowledgeTransfer.DLNGUUPTNLInformation
-	GTPTunnel := DLNGUUPTNLInformation.GTPTunnel
+	GTPTunnel := handoverRequestAcknowledgeTransfer.DLNGUUPTNLInformation.GTPTunnel
+	if GTPTunnel == nil || len(GTPTunnel.GTPTEID.Value) < 4 {
+		return fmt.Errorf("handover request acknowledge transfer is missing the DL GTP tunnel")
+	}
 
 	teid := binary.BigEndian.Uint32(GTPTunnel.GTPTEID.Value)
 
@@ -595,8 +597,17 @@ func handleHandoverRequestAcknowledgeTransfer(b []byte, smContext *SMContext) er
 	smContext.Tunnel.ANInformation.TEID = teid
 
 	if smContext.Tunnel.DataPath.Activated {
+		dlFAR := smContext.Tunnel.DataPath.DownLinkTunnel.PDR.FAR
+
+		// The forwarding parameters are only populated once the downlink tunnel
+		// is known (TS 23.502 §4.9.1.3); on handover the target supplies it, so
+		// create the structure if the prior data path had none.
+		if dlFAR.ForwardingParameters == nil {
+			dlFAR.ForwardingParameters = &models.ForwardingParameters{}
+		}
+
 		if anIPv6 != nil {
-			smContext.Tunnel.DataPath.DownLinkTunnel.PDR.FAR.ForwardingParameters.OuterHeaderCreation = &models.OuterHeaderCreation{
+			dlFAR.ForwardingParameters.OuterHeaderCreation = &models.OuterHeaderCreation{
 				Description: models.OuterHeaderCreationGtpUUdpIpv6,
 				TEID:        teid,
 				IPv6Address: anIPv6,
@@ -604,7 +615,7 @@ func handleHandoverRequestAcknowledgeTransfer(b []byte, smContext *SMContext) er
 			ohr := models.OuterHeaderRemovalGtpUUdpIpv6
 			smContext.Tunnel.DataPath.UpLinkTunnel.PDR.OuterHeaderRemoval = &ohr
 		} else {
-			smContext.Tunnel.DataPath.DownLinkTunnel.PDR.FAR.ForwardingParameters.OuterHeaderCreation = &models.OuterHeaderCreation{
+			dlFAR.ForwardingParameters.OuterHeaderCreation = &models.OuterHeaderCreation{
 				Description: models.OuterHeaderCreationGtpUUdpIpv4,
 				TEID:        teid,
 				IPv4Address: anIPv4,
@@ -613,7 +624,7 @@ func handleHandoverRequestAcknowledgeTransfer(b []byte, smContext *SMContext) er
 			smContext.Tunnel.DataPath.UpLinkTunnel.PDR.OuterHeaderRemoval = &ohr
 		}
 
-		smContext.Tunnel.DataPath.DownLinkTunnel.PDR.FAR.State = RuleUpdate
+		dlFAR.State = RuleUpdate
 	}
 
 	return nil

--- a/internal/smf/update_test.go
+++ b/internal/smf/update_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+package smf
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapType"
+)
+
+const testHandoverTEID = 0x1234
+
+// validHandoverRequestAcknowledgeTransfer marshals a transfer carrying an IPv4
+// downlink GTP tunnel with TEID testHandoverTEID.
+func validHandoverRequestAcknowledgeTransfer(t *testing.T) []byte {
+	t.Helper()
+
+	teid := make([]byte, 4)
+	binary.BigEndian.PutUint32(teid, testHandoverTEID)
+
+	transfer := ngapType.HandoverRequestAcknowledgeTransfer{}
+	transfer.DLNGUUPTNLInformation.Present = ngapType.UPTransportLayerInformationPresentGTPTunnel
+	transfer.DLNGUUPTNLInformation.GTPTunnel = &ngapType.GTPTunnel{
+		TransportLayerAddress: ngapType.TransportLayerAddress{
+			Value: aper.BitString{Bytes: []byte{10, 0, 0, 1}, BitLength: 32},
+		},
+		GTPTEID: ngapType.GTPTEID{Value: teid},
+	}
+	transfer.QosFlowSetupResponseList.List = append(transfer.QosFlowSetupResponseList.List,
+		ngapType.QosFlowItemWithDataForwarding{QosFlowIdentifier: ngapType.QosFlowIdentifier{Value: 1}})
+
+	b, err := aper.MarshalWithParams(transfer, "valueExt")
+	if err != nil {
+		t.Fatalf("marshal transfer: %v", err)
+	}
+
+	return b
+}
+
+// An activated data path whose downlink FAR has no forwarding parameters must
+// gain them from the handover target's tunnel, without panicking.
+func TestHandleHandoverRequestAcknowledgeTransfer_ActivatedNilForwarding(t *testing.T) {
+	dlFAR := &FAR{}
+	smContext := &SMContext{
+		Tunnel: &UPTunnel{
+			DataPath: &DataPath{
+				Activated:      true,
+				DownLinkTunnel: &GTPTunnel{PDR: &PDR{FAR: dlFAR}},
+				UpLinkTunnel:   &GTPTunnel{PDR: &PDR{}},
+			},
+		},
+	}
+
+	if err := handleHandoverRequestAcknowledgeTransfer(validHandoverRequestAcknowledgeTransfer(t), smContext); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if smContext.Tunnel.ANInformation.TEID != testHandoverTEID {
+		t.Errorf("ANInformation.TEID = %#x, want %#x", smContext.Tunnel.ANInformation.TEID, testHandoverTEID)
+	}
+
+	if dlFAR.ForwardingParameters == nil || dlFAR.ForwardingParameters.OuterHeaderCreation == nil {
+		t.Fatal("downlink FAR forwarding parameters were not populated")
+	}
+
+	ohc := dlFAR.ForwardingParameters.OuterHeaderCreation
+	if ohc.TEID != testHandoverTEID {
+		t.Errorf("OuterHeaderCreation.TEID = %#x, want %#x", ohc.TEID, testHandoverTEID)
+	}
+
+	if ohc.Description != models.OuterHeaderCreationGtpUUdpIpv4 {
+		t.Errorf("OuterHeaderCreation.Description = %v, want IPv4 GTP-U", ohc.Description)
+	}
+
+	if dlFAR.State != RuleUpdate {
+		t.Errorf("downlink FAR State = %v, want RuleUpdate", dlFAR.State)
+	}
+}
+
+// With no active data path the tunnel endpoint is recorded but no FAR is
+// touched, so a nil downlink tunnel must not panic.
+func TestHandleHandoverRequestAcknowledgeTransfer_NotActivated(t *testing.T) {
+	smContext := &SMContext{Tunnel: &UPTunnel{DataPath: &DataPath{Activated: false}}}
+
+	if err := handleHandoverRequestAcknowledgeTransfer(validHandoverRequestAcknowledgeTransfer(t), smContext); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if smContext.Tunnel.ANInformation.TEID != testHandoverTEID {
+		t.Errorf("ANInformation.TEID = %#x, want %#x", smContext.Tunnel.ANInformation.TEID, testHandoverTEID)
+	}
+}
+
+// Undecodable input is rejected with an error rather than a panic.
+func TestHandleHandoverRequestAcknowledgeTransfer_BadInput(t *testing.T) {
+	smContext := &SMContext{Tunnel: &UPTunnel{DataPath: &DataPath{Activated: true}}}
+
+	if err := handleHandoverRequestAcknowledgeTransfer([]byte{0xff, 0xff}, smContext); err == nil {
+		t.Fatal("expected an error for undecodable transfer, got nil")
+	}
+}


### PR DESCRIPTION
# Description

Address a few bugs with n2 handover:
- Panic on invalid Handover Request Acknowledge Transfer
- Silent drop on unknown target in Handover Required
- Empty to-release list on partial admission in Handover Request Acknowledge 
- Concurrent targets overwrite each other because key'd by Ran Ue Ngap ID 
- Warning instead of error indication on AMF UE NGAP ID mismatch during Handover Cancel

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
