### PR TITLE
chore: add BPF unit tests with netns

### DIFF
--- a/internal/upf/ebpf/attach_test.go
+++ b/internal/upf/ebpf/attach_test.go
@@ -8,7 +8,10 @@ package ebpf
 import (
 	"context"
 	"net"
+	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,118 +19,266 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func ipLink(args ...string) ([]byte, error) {
-	return exec.CommandContext(context.Background(), "ip", append([]string{"link"}, args...)...).CombinedOutput()
-}
-
-// Real-attach (T2) harness: create a veth pair, attach the program to one end in
-// generic XDP mode, and inject frames on the peer so they are received (and run
-// through XDP) on the attached end. Unlike BPF_PROG_TEST_RUN this exercises the
-// real RX path, with the attached interface's real ifindex as ingress_ifindex.
+// Real-attach (T2) test fixture.
+//
+// Unlike BPF_PROG_TEST_RUN (T1), these tests attach the program to real
+// interfaces and drive it with packets injected over AF_PACKET, so the program
+// runs on the kernel RX path with a real ingress_ifindex and its egress
+// (XDP_REDIRECT) actually leaves the interface. This is what lets us observe
+// FIB routing and the NAT rewrites on the wire.
+//
+// The fixture models the UPF's two sides with two veth pairs:
+//
+//	uplink:   inject on n3Peer ─▶ n3Dev (N3, ingress) ─▶ [XDP] ─▶ redirect ─▶ n6Dev ─▶ n6Peer (capture)
+//	downlink: inject on n6Peer ─▶ n6Dev (N6, ingress) ─▶ [XDP] ─▶ redirect ─▶ n3Dev ─▶ n3Peer (capture)
+//
+// n3_ifindex and n6_ifindex are the real device indices, so the entrypoint
+// classifies a packet by the interface it arrives on. The N6 device carries the
+// source-NAT egress address and a route to the test server; the N3 device
+// carries the UPF's N3 address and a neighbor for the gNB, so bpf_fib_lookup
+// resolves deterministically in both directions.
 
 const (
-	t2VethRx = "ellt2rx" // program attaches here; ingress_ifindex of injected frames
-	t2VethTx = "ellt2tx" // peer; frames sent here arrive on t2VethRx
+	t2N3Dev  = "ellt2n3"
+	t2N3Peer = "ellt2n3p"
+	t2N6Dev  = "ellt2n6"
+	t2N6Peer = "ellt2n6p"
+
+	t2VethMTU = "3000" // headroom for the payload sweep plus GTP encapsulation
 )
 
-// attachProgram brings up a veth pair, loads+configures the program via loader
-// (passed the attached interface's ifindex), attaches it to that interface, and
-// returns the objects plus an inject function. All resources are torn down via
-// t.Cleanup.
-func attachProgram(t *testing.T, loader func(rxIfindex int) *BpfObjects) (*BpfObjects, func(frame []byte)) {
+var (
+	ueIP        = [4]byte{10, 45, 0, 1}     // inner UE address
+	natPublicIP = [4]byte{192, 0, 2, 1}     // N6 egress address; source-NAT target
+	serverIP    = [4]byte{198, 51, 100, 50} // remote server (RFC 5737 TEST-NET-2)
+)
+
+func htons(v uint16) uint16 { return v<<8 | v>>8 }
+
+func ipCmd(args ...string) ([]byte, error) {
+	return exec.CommandContext(context.Background(), "ip", args...).CombinedOutput()
+}
+
+// t2 is a running real-attach fixture: two veth pairs with the program attached
+// to the N3 and N6 devices.
+type t2 struct {
+	obj    *BpfObjects
+	n3Dev  *net.Interface
+	n3Peer *net.Interface
+	n6Dev  *net.Interface
+	n6Peer *net.Interface
+}
+
+// setupT2 builds the topology, configures routing, loads the program with the
+// given NAT setting, and attaches it to both the N3 and N6 devices.
+func setupT2(t *testing.T, masquerade bool) *t2 {
 	t.Helper()
 
-	_, _ = ipLink("del", t2VethRx)
+	_, _ = ipCmd("link", "del", t2N3Dev)
+	_, _ = ipCmd("link", "del", t2N6Dev)
 
-	if out, err := ipLink("add", t2VethRx, "type", "veth", "peer", "name", t2VethTx); err != nil {
-		t.Fatalf("create veth pair: %v: %s", err, out)
+	addVethPair(t, t2N3Dev, t2N3Peer)
+	addVethPair(t, t2N6Dev, t2N6Peer)
+
+	if err := writeSysctl("net.ipv4.ip_forward", "1"); err != nil {
+		t.Fatalf("enable ip_forward: %v", err)
 	}
 
-	t.Cleanup(func() { _, _ = ipLink("del", t2VethRx) })
+	// N3 side: the UPF's N3 address and a neighbor for the gNB, so a
+	// re-encapsulated downlink packet routes out toward the gNB.
+	addAddr(t, t2N3Dev, addrCIDR(testUPFN3IP, 24))
+	addNeigh(t, t2N3Dev, testGNBIP, "02:00:00:00:00:aa")
 
-	for _, dev := range []string{t2VethRx, t2VethTx} {
-		if out, err := ipLink("set", dev, "up"); err != nil {
-			t.Fatalf("set %s up: %v: %s", dev, err, out)
+	// N6 side: the source-NAT egress address, a route to the server, and a
+	// neighbor, so an uplink packet routes out with src = natPublicIP.
+	addAddr(t, t2N6Dev, addrCIDR(natPublicIP, 24))
+	addRoute(t, "198.51.100.0/24", t2N6Dev, natPublicIP)
+	addNeigh(t, t2N6Dev, serverIP, "02:00:00:00:00:bb")
+
+	f := &t2{
+		obj:    loadProgramConfig(t, false, masquerade, ifByName(t, t2N3Dev).Index, ifByName(t, t2N6Dev).Index, 0, 0),
+		n3Dev:  ifByName(t, t2N3Dev),
+		n3Peer: ifByName(t, t2N3Peer),
+		n6Dev:  ifByName(t, t2N6Dev),
+		n6Peer: ifByName(t, t2N6Peer),
+	}
+
+	attachXDP(t, f.obj, f.n3Dev.Index)
+	attachXDP(t, f.obj, f.n6Dev.Index)
+
+	return f
+}
+
+func (f *t2) injectUplink(t *testing.T, frame []byte)   { inject(t, f.n3Peer.Index, frame) }
+func (f *t2) injectDownlink(t *testing.T, frame []byte) { inject(t, f.n6Peer.Index, frame) }
+
+// captureN6 and captureN3 capture frames leaving the program on each side
+// (redirected, or reflected via XDP_TX). They are named by physical side, not
+// direction: an uplink packet egresses on N6, a downlink packet on N3, but a
+// downlink that triggers an ICMP error reflects back out N6.
+func (f *t2) captureN6(t *testing.T) int { return openCapture(t, f.n6Peer.Index) }
+func (f *t2) captureN3(t *testing.T) int { return openCapture(t, f.n3Peer.Index) }
+
+func addVethPair(t *testing.T, dev, peer string) {
+	t.Helper()
+
+	if out, err := ipCmd("link", "add", dev, "type", "veth", "peer", "name", peer); err != nil {
+		t.Fatalf("create veth %s/%s: %v: %s", dev, peer, err, out)
+	}
+
+	t.Cleanup(func() { _, _ = ipCmd("link", "del", dev) })
+
+	for _, d := range []string{dev, peer} {
+		if out, err := ipCmd("link", "set", d, "mtu", t2VethMTU, "up"); err != nil {
+			t.Fatalf("set %s up: %v: %s", d, err, out)
 		}
-	}
 
-	rx, err := net.InterfaceByName(t2VethRx)
-	if err != nil {
-		t.Fatalf("lookup %s: %v", t2VethRx, err)
+		_ = writeSysctl("net.ipv4.conf."+d+".forwarding", "1")
 	}
+}
 
-	tx, err := net.InterfaceByName(t2VethTx)
-	if err != nil {
-		t.Fatalf("lookup %s: %v", t2VethTx, err)
+func addAddr(t *testing.T, dev, cidr string) {
+	t.Helper()
+
+	if out, err := ipCmd("addr", "add", cidr, "dev", dev); err != nil {
+		t.Fatalf("add addr %s on %s: %v: %s", cidr, dev, err, out)
 	}
+}
 
-	obj := loader(rx.Index)
+func addRoute(t *testing.T, prefix, dev string, src [4]byte) {
+	t.Helper()
+
+	if out, err := ipCmd("route", "add", prefix, "dev", dev, "src", ip4String(src)); err != nil {
+		t.Fatalf("add route %s: %v: %s", prefix, err, out)
+	}
+}
+
+func addNeigh(t *testing.T, dev string, addr [4]byte, lladdr string) {
+	t.Helper()
+
+	if out, err := ipCmd("neigh", "add", ip4String(addr), "dev", dev, "lladdr", lladdr, "nud", "permanent"); err != nil {
+		t.Fatalf("add neigh %s: %v: %s", ip4String(addr), err, out)
+	}
+}
+
+func attachXDP(t *testing.T, obj *BpfObjects, ifindex int) {
+	t.Helper()
 
 	l, err := link.AttachXDP(link.XDPOptions{
 		Program:   obj.UpfN3N6EntrypointFunc,
-		Interface: rx.Index,
+		Interface: ifindex,
 		Flags:     link.XDPGenericMode,
 	})
 	if err != nil {
-		t.Fatalf("attach XDP to %s: %v", t2VethRx, err)
+		t.Fatalf("attach XDP to ifindex %d: %v", ifindex, err)
 	}
 
 	t.Cleanup(func() { _ = l.Close() })
+}
+
+func inject(t *testing.T, ifindex int, frame []byte) {
+	t.Helper()
 
 	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, 0)
 	if err != nil {
-		t.Fatalf("AF_PACKET socket: %v", err)
+		t.Fatalf("AF_PACKET inject socket: %v", err)
+	}
+
+	defer func() { _ = unix.Close(fd) }()
+
+	addr := &unix.SockaddrLinklayer{Ifindex: ifindex, Halen: 6}
+	copy(addr.Addr[:6], []byte{0x02, 0, 0, 0, 0, 0x02})
+
+	if err := unix.Sendto(fd, frame, 0, addr); err != nil {
+		t.Fatalf("inject frame on ifindex %d: %v", ifindex, err)
+	}
+}
+
+func openCapture(t *testing.T, ifindex int) int {
+	t.Helper()
+
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
+	if err != nil {
+		t.Fatalf("AF_PACKET capture socket: %v", err)
 	}
 
 	t.Cleanup(func() { _ = unix.Close(fd) })
 
-	addr := &unix.SockaddrLinklayer{Ifindex: tx.Index, Halen: 6}
-	copy(addr.Addr[:6], []byte{0x02, 0, 0, 0, 0, 0x02})
+	if err := unix.Bind(fd, &unix.SockaddrLinklayer{Protocol: htons(unix.ETH_P_ALL), Ifindex: ifindex}); err != nil {
+		t.Fatalf("bind capture: %v", err)
+	}
 
-	inject := func(frame []byte) {
-		if err := unix.Sendto(fd, frame, 0, addr); err != nil {
-			t.Fatalf("inject frame: %v", err)
+	_ = unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Usec: 200_000})
+
+	return fd
+}
+
+// captureMatching reads frames until match returns true or the timeout elapses.
+func captureMatching(fd int, timeout time.Duration, match func([]byte) bool) []byte { //nolint:unparam // general helper; timeout is configurable
+	buf := make([]byte, 9000)
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		n, _, err := unix.Recvfrom(fd, buf, 0)
+		if err != nil {
+			continue // RCVTIMEO slice elapsed; retry until the overall deadline
+		}
+
+		frame := make([]byte, n)
+		copy(frame, buf[:n])
+
+		if match(frame) {
+			return frame
 		}
 	}
 
-	return obj, inject
+	return nil
 }
 
+func writeSysctl(key, value string) error {
+	return os.WriteFile("/proc/sys/"+strings.ReplaceAll(key, ".", "/"), []byte(value), 0o644)
+}
+
+func ifByName(t *testing.T, name string) *net.Interface {
+	t.Helper()
+
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", name, err)
+	}
+
+	return iface
+}
+
+func ip4String(a [4]byte) string { return net.IP(a[:]).String() }
+
+func addrCIDR(a [4]byte, prefix int) string { return ip4String(a) + "/" + strconv.Itoa(prefix) }
+
 // TestDownlinkStatisticsAttached checks that downlink byte accounting lands in
-// downlink_statistics when the program is really attached. This is the
-// counterpart to TestUplinkStatistics for the N6 side, which the test-run
-// harness cannot reach (it needs a distinct ingress interface != the n3 MTU
-// device).
+// downlink_statistics on a real attach. It is the N6-side counterpart to
+// TestUplinkStatistics, which the test-run harness cannot reach because it needs
+// a distinct ingress interface.
 func TestDownlinkStatisticsAttached(t *testing.T) {
 	requireProgTestRun(t)
 
-	ueIP := [4]byte{10, 45, 0, 2}
-
 	const packets = 5
 
-	obj, inject := attachProgram(t, func(rxIfindex int) *BpfObjects {
-		// n6_ifindex == the attached interface, so injected frames (ingress ==
-		// that ifindex) are classified N6; n3_ifindex == 1 (loopback) is the
-		// encap MTU/egress device.
-		o := loadProgramConfig(t, false, false, 1, rxIfindex, 0, 0)
-		putDownlinkPDR(t, o, ueIP, 0x42, [4]byte{192, 168, 100, 1}, [4]byte{192, 168, 100, 9}, 5)
+	f := setupT2(t, false)
+	putDownlinkPDR(t, f.obj, ueIP, 0x42, testUPFN3IP, testGNBIP, 5)
 
-		return o
-	})
-
-	frame := ethFrame(0x0800, ipv4Packet([4]byte{8, 8, 8, 8}, ueIP, 17, udpDatagram(4000, 4001, nil)))
+	frame := ethFrame(0x0800, ipv4Packet(serverIP, ueIP, 17, udpDatagram(4000, 4001, nil)))
 	for i := 0; i < packets; i++ {
-		inject(frame)
+		f.injectDownlink(t, frame)
 	}
 
 	time.Sleep(300 * time.Millisecond)
 
-	dlBytes, _ := sumStats(t, obj.DownlinkStatistics)
+	dlBytes, _ := sumStats(t, f.obj.DownlinkStatistics)
 	if want := uint64(packets * len(frame)); dlBytes != want {
 		t.Errorf("downlink byte_counter = %d, want %d", dlBytes, want)
 	}
 
-	if ulBytes, _ := sumStats(t, obj.UplinkStatistics); ulBytes != 0 {
+	if ulBytes, _ := sumStats(t, f.obj.UplinkStatistics); ulBytes != 0 {
 		t.Errorf("uplink byte_counter = %d, want 0", ulBytes)
 	}
 }

--- a/internal/upf/ebpf/attach_test.go
+++ b/internal/upf/ebpf/attach_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"context"
+	"net"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
+)
+
+func ipLink(args ...string) ([]byte, error) {
+	return exec.CommandContext(context.Background(), "ip", append([]string{"link"}, args...)...).CombinedOutput()
+}
+
+// Real-attach (T2) harness: create a veth pair, attach the program to one end in
+// generic XDP mode, and inject frames on the peer so they are received (and run
+// through XDP) on the attached end. Unlike BPF_PROG_TEST_RUN this exercises the
+// real RX path, with the attached interface's real ifindex as ingress_ifindex.
+
+const (
+	t2VethRx = "ellt2rx" // program attaches here; ingress_ifindex of injected frames
+	t2VethTx = "ellt2tx" // peer; frames sent here arrive on t2VethRx
+)
+
+// attachProgram brings up a veth pair, loads+configures the program via loader
+// (passed the attached interface's ifindex), attaches it to that interface, and
+// returns the objects plus an inject function. All resources are torn down via
+// t.Cleanup.
+func attachProgram(t *testing.T, loader func(rxIfindex int) *BpfObjects) (*BpfObjects, func(frame []byte)) {
+	t.Helper()
+
+	_, _ = ipLink("del", t2VethRx)
+
+	if out, err := ipLink("add", t2VethRx, "type", "veth", "peer", "name", t2VethTx); err != nil {
+		t.Fatalf("create veth pair: %v: %s", err, out)
+	}
+
+	t.Cleanup(func() { _, _ = ipLink("del", t2VethRx) })
+
+	for _, dev := range []string{t2VethRx, t2VethTx} {
+		if out, err := ipLink("set", dev, "up"); err != nil {
+			t.Fatalf("set %s up: %v: %s", dev, err, out)
+		}
+	}
+
+	rx, err := net.InterfaceByName(t2VethRx)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", t2VethRx, err)
+	}
+
+	tx, err := net.InterfaceByName(t2VethTx)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", t2VethTx, err)
+	}
+
+	obj := loader(rx.Index)
+
+	l, err := link.AttachXDP(link.XDPOptions{
+		Program:   obj.UpfN3N6EntrypointFunc,
+		Interface: rx.Index,
+		Flags:     link.XDPGenericMode,
+	})
+	if err != nil {
+		t.Fatalf("attach XDP to %s: %v", t2VethRx, err)
+	}
+
+	t.Cleanup(func() { _ = l.Close() })
+
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, 0)
+	if err != nil {
+		t.Fatalf("AF_PACKET socket: %v", err)
+	}
+
+	t.Cleanup(func() { _ = unix.Close(fd) })
+
+	addr := &unix.SockaddrLinklayer{Ifindex: tx.Index, Halen: 6}
+	copy(addr.Addr[:6], []byte{0x02, 0, 0, 0, 0, 0x02})
+
+	inject := func(frame []byte) {
+		if err := unix.Sendto(fd, frame, 0, addr); err != nil {
+			t.Fatalf("inject frame: %v", err)
+		}
+	}
+
+	return obj, inject
+}
+
+// TestDownlinkStatisticsAttached checks that downlink byte accounting lands in
+// downlink_statistics when the program is really attached. This is the
+// counterpart to TestUplinkStatistics for the N6 side, which the test-run
+// harness cannot reach (it needs a distinct ingress interface != the n3 MTU
+// device).
+func TestDownlinkStatisticsAttached(t *testing.T) {
+	requireProgTestRun(t)
+
+	ueIP := [4]byte{10, 45, 0, 2}
+
+	const packets = 5
+
+	obj, inject := attachProgram(t, func(rxIfindex int) *BpfObjects {
+		// n6_ifindex == the attached interface, so injected frames (ingress ==
+		// that ifindex) are classified N6; n3_ifindex == 1 (loopback) is the
+		// encap MTU/egress device.
+		o := loadProgramConfig(t, false, false, 1, rxIfindex, 0, 0)
+		putDownlinkPDR(t, o, ueIP, 0x42, [4]byte{192, 168, 100, 1}, [4]byte{192, 168, 100, 9}, 5)
+
+		return o
+	})
+
+	frame := ethFrame(0x0800, ipv4Packet([4]byte{8, 8, 8, 8}, ueIP, 17, udpDatagram(4000, 4001, nil)))
+	for i := 0; i < packets; i++ {
+		inject(frame)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	dlBytes, _ := sumStats(t, obj.DownlinkStatistics)
+	if want := uint64(packets * len(frame)); dlBytes != want {
+		t.Errorf("downlink byte_counter = %d, want %d", dlBytes, want)
+	}
+
+	if ulBytes, _ := sumStats(t, obj.UplinkStatistics); ulBytes != 0 {
+		t.Errorf("uplink byte_counter = %d, want 0", ulBytes)
+	}
+}

--- a/internal/upf/ebpf/control_test.go
+++ b/internal/upf/ebpf/control_test.go
@@ -9,6 +9,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/ringbuf"
 )
 
 // GTP-U control-message handling and ICMPv6 Router Solicitation interception.
@@ -79,8 +82,10 @@ func TestGTPControlMessages(t *testing.T) {
 }
 
 // TestRouterSolicitationIntercept checks that an inner ICMPv6 Router
-// Solicitation, after decapsulation, is intercepted and dropped (the RA is
-// generated in userspace).
+// Solicitation, after decapsulation, is intercepted: the packet is dropped AND
+// its TEID and UE source address are emitted to userspace on rs_event_map. The
+// event is the contract that drives the RA responder, so asserting it (not just
+// the drop) is what proves SLAAC would actually fire.
 func TestRouterSolicitationIntercept(t *testing.T) {
 	requireProgTestRun(t)
 
@@ -89,9 +94,35 @@ func TestRouterSolicitationIntercept(t *testing.T) {
 	obj := loadN3N6Program(t)
 	putForwardingUplinkPDR(t, obj, teid, 0)
 
-	action := runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, innerIPv6ICMPv6RS(testUEv6)))
+	rd, err := ringbuf.NewReader(obj.RsEventMap)
+	if err != nil {
+		t.Fatalf("open rs_event ring buffer: %v", err)
+	}
 
+	defer func() { _ = rd.Close() }()
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, innerIPv6ICMPv6RS(testUEv6)))
 	if action != XDP_DROP {
 		t.Fatalf("Router Solicitation not intercepted: got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+
+	rd.SetDeadline(time.Now().Add(time.Second))
+
+	rec, err := rd.Read()
+	if err != nil {
+		t.Fatalf("no RS event emitted to userspace (RA responder would never fire): %v", err)
+	}
+
+	var ev RSEvent
+	if err := binary.Read(bytes.NewReader(rec.RawSample), binary.NativeEndian, &ev); err != nil {
+		t.Fatalf("decode RS event: %v", err)
+	}
+
+	if ev.TEID != teid {
+		t.Errorf("RS event TEID = %#x, want %#x", ev.TEID, uint32(teid))
+	}
+
+	if ev.UEIPv6 != testUEv6 {
+		t.Errorf("RS event UE IPv6 = %x, want %x", ev.UEIPv6, testUEv6)
 	}
 }

--- a/internal/upf/ebpf/encap_test.go
+++ b/internal/upf/ebpf/encap_test.go
@@ -217,6 +217,42 @@ func TestGTPEncapsulationDownlinkIPv6Transport(t *testing.T) {
 	}
 }
 
+// TestTransportLevelMarking checks that a FAR's transport-level marking is
+// written to the outer IPv4 TOS byte of the encapsulated downlink packet.
+func TestTransportLevelMarking(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid    = 0x544F5301
+		qfi     = 5
+		wantTOS = 0xB8 // DSCP EF
+	)
+
+	obj := loadProgram(t, 1, 0)
+
+	pdr := ipv4OuterDownlinkPDR(teid, testUPFN3IP, testGNBIP, qfi)
+	pdr.Far.TransportLevelMarking = uint16(wantTOS) << 8
+
+	if err := obj.PutPdrDownlink(netip.AddrFrom4(ueIP), pdr); err != nil {
+		t.Fatalf("install downlink PDR: %v", err)
+	}
+
+	inner := ipv4Packet(serverIP, ueIP, 17, udpDatagram(4000, 53, nil))
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+	if action == XDP_ABORTED {
+		t.Fatal("downlink packet got XDP_ABORTED")
+	}
+
+	if tos := out[ethHdrLen+1]; tos != wantTOS {
+		t.Errorf("outer IPv4 TOS = %#02x, want %#02x (FAR transport-level marking)", tos, wantTOS)
+	}
+
+	if f := parseGTPv4Frame(t, out); !f.outerChecksumOK {
+		t.Error("outer IPv4 header checksum invalid after marking")
+	}
+}
+
 // ipv4OuterDownlinkPDR builds a downlink PDR that forwards and encapsulates into
 // a GTP-U/IPv4 tunnel toward remote with the given TEID and QFI.
 func ipv4OuterDownlinkPDR(teid uint32, local, remote [4]byte, qfi uint8) PdrInfo {

--- a/internal/upf/ebpf/far_test.go
+++ b/internal/upf/ebpf/far_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// TestFARDropUplink checks that an uplink PDR whose FAR action is DROP (no
+// FORW bit) drops the packet, regardless of an otherwise-forwardable session.
+func TestFARDropUplink(t *testing.T) {
+	requireProgTestRun(t)
+
+	const teid = 0x44524F50 // "DROP"
+
+	obj := loadN3N6Program(t)
+
+	pdr := PdrInfo{
+		IMSI: "001010000000001",
+		Far:  FarInfo{Action: 0x01 /* FAR_DROP */},
+		Qer:  QerInfo{GateStatusUL: 0 /* open */, MaxBitrateUL: 0 /* unlimited */},
+	}
+	if err := obj.PutPdrUplink(teid, pdr); err != nil {
+		t.Fatalf("install drop uplink PDR: %v", err)
+	}
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)))
+	if action != XDP_DROP {
+		t.Fatalf("uplink packet with FAR DROP got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+}
+
+// TestFARDropDownlink checks that a downlink PDR whose FAR action is DROP drops
+// the packet instead of encapsulating it.
+func TestFARDropDownlink(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadProgram(t, 1, 0)
+
+	dropUE := [4]byte{10, 45, 0, 2}
+
+	pdr := ipv4OuterDownlinkPDR(0x1234, [4]byte{192, 168, 100, 1}, [4]byte{192, 168, 100, 9}, 5)
+	pdr.Far.Action = 0x01 // FAR_DROP
+
+	if err := obj.PutPdrDownlink(netip.AddrFrom4(dropUE), pdr); err != nil {
+		t.Fatalf("install drop downlink PDR: %v", err)
+	}
+
+	inner := ipv4Packet([4]byte{8, 8, 8, 8}, dropUE, 17, udpDatagram(4000, 4001, nil))
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+	if action != XDP_DROP {
+		t.Fatalf("downlink packet with FAR DROP got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+}
+
+// TestFARDropDownlinkIPv6 checks the FAR DROP action on the IPv6 downlink path.
+func TestFARDropDownlinkIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadProgram(t, 1, 0)
+
+	pdr := ipv4OuterDownlinkPDR(0x1234, testUPFN3IP, testGNBIP, 5)
+	pdr.Far.Action = 0x01 // FAR_DROP
+
+	if err := obj.PutPdrDownlink(netip.MustParseAddr("2001:db8::"), pdr); err != nil {
+		t.Fatalf("install drop downlink IPv6 PDR: %v", err)
+	}
+
+	serverV6 := [16]byte{0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88}
+	inner := ipv6Packet(serverV6, testUEv6, 17, udpDatagram(4000, 53, nil))
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x86DD, inner))
+	if action != XDP_DROP {
+		t.Fatalf("downlink IPv6 packet with FAR DROP got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+}

--- a/internal/upf/ebpf/flow_test.go
+++ b/internal/upf/ebpf/flow_test.go
@@ -144,6 +144,12 @@ func TestFlowReportDownlink(t *testing.T) {
 		t.Fatalf("no flow_stats entry recorded (iterate err=%v)", it.Err())
 	}
 
+	const wantIMSI = 1010000000001 // "001010000000001"
+
+	if key.Imsi != wantIMSI {
+		t.Errorf("flow IMSI = %d, want %d", key.Imsi, uint64(wantIMSI))
+	}
+
 	if key.Proto != 17 {
 		t.Errorf("flow protocol = %d, want 17 (UDP)", key.Proto)
 	}
@@ -166,6 +172,10 @@ func TestFlowReportDownlink(t *testing.T) {
 
 	if val.Packets != 1 {
 		t.Errorf("flow packets = %d, want 1", val.Packets)
+	}
+
+	if val.Bytes == 0 {
+		t.Error("flow bytes = 0, want > 0")
 	}
 }
 

--- a/internal/upf/ebpf/flow_test.go
+++ b/internal/upf/ebpf/flow_test.go
@@ -117,6 +117,98 @@ func TestURRByteAccounting(t *testing.T) {
 	}
 }
 
+// TestFlowReportDownlink is the downlink counterpart to TestFlowReportUplink: a
+// forwarded downlink packet records a flow with the server as source, the UE as
+// destination, and the N3 egress interface.
+func TestFlowReportDownlink(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid = 0x464C4F58
+		qfi  = 5
+	)
+
+	obj := loadProgramFlow(t, 1, 0)
+	putDownlinkPDR(t, obj, ueIP, teid, testUPFN3IP, testGNBIP, qfi)
+
+	inner := ipv4Packet(serverIP, ueIP, 17, udpDatagram(4000, 53, nil))
+	runXDP(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x0800, inner))
+
+	var (
+		key N3N6EntrypointFlow
+		val N3N6EntrypointFlowStats
+	)
+
+	it := obj.FlowStats.Iterate()
+	if !it.Next(&key, &val) {
+		t.Fatalf("no flow_stats entry recorded (iterate err=%v)", it.Err())
+	}
+
+	if key.Proto != 17 {
+		t.Errorf("flow protocol = %d, want 17 (UDP)", key.Proto)
+	}
+
+	if key.Action != 0 {
+		t.Errorf("flow action = %d, want 0 (ALLOW)", key.Action)
+	}
+
+	if key.EgressIfindex != 1 {
+		t.Errorf("flow egress ifindex = %d, want 1 (N3)", key.EgressIfindex)
+	}
+
+	if want := IPToIn6Addr(netip.AddrFrom4(serverIP)); key.Saddr.In6U.U6Addr8 != want {
+		t.Errorf("flow saddr = %v, want %v (server)", key.Saddr.In6U.U6Addr8, want)
+	}
+
+	if want := IPToIn6Addr(netip.AddrFrom4(ueIP)); key.Daddr.In6U.U6Addr8 != want {
+		t.Errorf("flow daddr = %v, want %v (UE)", key.Daddr.In6U.U6Addr8, want)
+	}
+
+	if val.Packets != 1 {
+		t.Errorf("flow packets = %d, want 1", val.Packets)
+	}
+}
+
+// TestURRByteAccountingDownlink checks that a downlink URR accumulates the
+// forwarded byte count.
+func TestURRByteAccountingDownlink(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid  = 0x55525203
+		urrID = 11
+		qfi   = 5
+	)
+
+	obj := loadProgram(t, 1, 0)
+	if err := obj.NewUrr(urrID); err != nil {
+		t.Fatalf("NewUrr: %v", err)
+	}
+
+	pdr := ipv4OuterDownlinkPDR(teid, testUPFN3IP, testGNBIP, qfi)
+	pdr.UrrID = urrID
+
+	if err := obj.PutPdrDownlink(netip.AddrFrom4(ueIP), pdr); err != nil {
+		t.Fatalf("install downlink PDR: %v", err)
+	}
+
+	inner := ipv4Packet(serverIP, ueIP, 17, udpDatagram(4000, 53, nil))
+	frame := ethFrame(0x0800, inner)
+	perPacket := uint64(len(frame)) // URR counts the pre-encapsulation frame
+
+	runXDP(t, obj.UpfN3N6EntrypointFunc, frame)
+
+	if got := sumURR(t, obj, urrID); got != perPacket {
+		t.Fatalf("URR after 1 packet = %d, want %d", got, perPacket)
+	}
+
+	runXDP(t, obj.UpfN3N6EntrypointFunc, frame)
+
+	if got := sumURR(t, obj, urrID); got != 2*perPacket {
+		t.Fatalf("URR after 2 packets = %d, want %d", got, 2*perPacket)
+	}
+}
+
 func sumURR(t *testing.T, obj *BpfObjects, urrID uint32) uint64 {
 	t.Helper()
 

--- a/internal/upf/ebpf/gtp_parse_test.go
+++ b/internal/upf/ebpf/gtp_parse_test.go
@@ -110,7 +110,7 @@ func loadProgramFlow(t *testing.T, n3Ifindex, n6Ifindex int) *BpfObjects {
 	return loadProgramConfig(t, true, false, n3Ifindex, n6Ifindex, 0, 0)
 }
 
-func loadProgramConfig(t *testing.T, flowAccounting, masquerade bool, n3Ifindex, n6Ifindex int, n3Vlan, n6Vlan uint32) *BpfObjects { //nolint:unparam // general loader; masquerade is used once NAT (T2) lands
+func loadProgramConfig(t *testing.T, flowAccounting, masquerade bool, n3Ifindex, n6Ifindex int, n3Vlan, n6Vlan uint32) *BpfObjects {
 	t.Helper()
 
 	obj := NewBpfObjects(flowAccounting, masquerade, n3Ifindex, n6Ifindex, n3Vlan, n6Vlan)

--- a/internal/upf/ebpf/nat_test.go
+++ b/internal/upf/ebpf/nat_test.go
@@ -1,0 +1,380 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// natProto describes one transport protocol for the NAT tests: how to build an
+// inner L4 segment between two IPv4 endpoints and how to validate its checksum
+// after rewrite.
+type natProto struct {
+	name  string
+	num   uint8
+	build func(src, dst [4]byte, payload []byte) []byte
+	valid func(src, dst [4]byte, l4 []byte) bool
+}
+
+var natProtos = []natProto{
+	{
+		name:  "tcp",
+		num:   6,
+		build: func(src, dst [4]byte, p []byte) []byte { return tcpSegmentChecksummed(src, dst, 1234, 80, p) },
+		valid: func(src, dst [4]byte, l4 []byte) bool { return validIPv4L4Checksum(src, dst, 6, l4) },
+	},
+	{
+		name:  "udp",
+		num:   17,
+		build: func(src, dst [4]byte, p []byte) []byte { return udpDatagramChecksummed(src, dst, 1234, 53, p) },
+		valid: func(src, dst [4]byte, l4 []byte) bool { return validIPv4L4Checksum(src, dst, 17, l4) },
+	},
+	{
+		name:  "icmp",
+		num:   1,
+		build: func(_, _ [4]byte, p []byte) []byte { return icmpEchoRequest(0xbeef, 1, p) },
+		valid: func(_, _ [4]byte, l4 []byte) bool { return validICMPChecksum(l4) },
+	},
+}
+
+// payloadSizes brackets the historical bpf_csum_diff 512-byte limit and pushes
+// past a typical MTU, so a size-dependent checksum defect cannot hide.
+var payloadSizes = []int{0, 100, 500, 512, 600, 1000, 1400}
+
+// TestSourceNATUplink verifies uplink source-NAT across protocols and payload
+// sizes: the decapsulated inner packet leaves the N6 side with its source
+// rewritten to the egress address and valid IPv4 and L4 checksums.
+func TestSourceNATUplink(t *testing.T) {
+	requireProgTestRun(t)
+
+	const teid = 0x4E415431
+
+	f := setupT2(t, true)
+	putForwardingUplinkPDR(t, f.obj, teid, 0)
+
+	for _, proto := range natProtos {
+		for _, size := range payloadSizes {
+			t.Run(proto.name+"/"+sizeLabel(size), func(t *testing.T) {
+				capFD := f.captureN6(t)
+
+				inner := ipv4Packet(ueIP, serverIP, proto.num, proto.build(ueIP, serverIP, bytesOf(size)))
+				f.injectUplink(t, uplinkGPDU(teid, inner))
+
+				got := captureMatching(capFD, time.Second, func(fr []byte) bool {
+					return isInnerIPv4(fr, proto.num, serverIP)
+				})
+				if got == nil {
+					t.Fatal("did not capture a NAT'd packet on the N6 side")
+				}
+
+				assertSourceNATd(t, got, proto)
+			})
+		}
+	}
+}
+
+// TestNATRoundTrip verifies the full NAT conntrack cycle: an uplink packet
+// establishes the mapping, then the matching downlink reply is destination-NAT'd
+// back to the UE address, re-encapsulated toward the gNB, and leaves the N3 side
+// with valid checksums and the UE as the inner destination.
+func TestNATRoundTrip(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		ulTEID = 0x52545431
+		dlTEID = 0x52545432
+		qfi    = 7
+	)
+
+	f := setupT2(t, true)
+	putForwardingUplinkPDR(t, f.obj, ulTEID, 0)
+	putDownlinkPDR(t, f.obj, ueIP, dlTEID, testUPFN3IP, testGNBIP, qfi)
+
+	for _, proto := range natProtos {
+		for _, size := range []int{40, 1000} {
+			t.Run(proto.name+"/"+sizeLabel(size), func(t *testing.T) {
+				// Uplink first: establish the conntrack mapping.
+				uplinkInner := ipv4Packet(ueIP, serverIP, proto.num, proto.build(ueIP, serverIP, bytesOf(40)))
+				f.injectUplink(t, uplinkGPDU(ulTEID, uplinkInner))
+
+				time.Sleep(100 * time.Millisecond)
+
+				// Capture on N3 only after the uplink egress (which lands on N6)
+				// has drained, so this socket sees only the downlink reply.
+				capFD := f.captureN3(t)
+
+				reply := ipv4Packet(serverIP, natPublicIP, proto.num, downlinkReply(proto, bytesOf(size)))
+				f.injectDownlink(t, ethFrame(0x0800, reply))
+
+				got := captureMatching(capFD, time.Second, func(fr []byte) bool {
+					inner := gtpInner(fr)
+
+					return inner != nil && inner[9] == proto.num && bytes.Equal(inner[16:20], ueIP[:])
+				})
+				if got == nil {
+					t.Fatal("did not capture a re-encapsulated downlink packet on the N3 side")
+				}
+
+				assertDestinationNATd(t, got, proto)
+			})
+		}
+	}
+}
+
+// TestNATIPv6PassThrough checks that with NAT enabled, an uplink IPv6 packet is
+// decapsulated unchanged: IPv6 traffic is never source-NAT'd (each UE owns its
+// own /64). This is a T1 verdict/transform check; routing is host-dependent.
+func TestNATIPv6PassThrough(t *testing.T) {
+	requireProgTestRun(t)
+
+	const teid = 0x4E363650 // "N66P"
+
+	obj := loadProgramConfig(t, false, true /* masquerade */, 0, 1, 0, 0)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	inner := innerIPv6UDP(testUEv6, 53)
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+	if action == XDP_DROP || action == XDP_ABORTED {
+		t.Fatalf("IPv6 uplink with NAT enabled got XDP action %d, want a forwarding action", action)
+	}
+
+	if !bytes.Equal(out[ethHdrLen:], inner) {
+		t.Errorf("IPv6 inner packet altered with NAT enabled (must be untouched):\n got %x\nwant %x", out[ethHdrLen:], inner)
+	}
+}
+
+// TestNATPortCollision checks source-port remapping: when two UEs use the same
+// source port to the same destination, the second flow is rewritten to a
+// different egress port (the first keeps its port).
+func TestNATPortCollision(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid1   = 0x4E415401
+		teid2   = 0x4E415402
+		srcPort = 1234
+	)
+
+	ue1 := ueIP
+	ue2 := [4]byte{10, 45, 0, 2}
+
+	f := setupT2(t, true)
+	putForwardingUplinkPDR(t, f.obj, teid1, 0)
+	putForwardingUplinkPDR(t, f.obj, teid2, 0)
+
+	egressPort := func(t *testing.T, ueSrc [4]byte, teid uint32) uint16 {
+		t.Helper()
+
+		capFD := f.captureN6(t)
+
+		inner := ipv4Packet(ueSrc, serverIP, 6, tcpSegmentChecksummed(ueSrc, serverIP, srcPort, 80, []byte{1, 2}))
+		f.injectUplink(t, uplinkGPDU(teid, inner))
+
+		got := captureMatching(capFD, time.Second, func(fr []byte) bool {
+			return isInnerIPv4(fr, 6, serverIP)
+		})
+		if got == nil {
+			t.Fatal("did not capture a NAT'd packet on the N6 side")
+		}
+
+		tcp := got[ethHdrLen+20:]
+
+		if !bytes.Equal(got[ethHdrLen+12:ethHdrLen+16], natPublicIP[:]) {
+			t.Errorf("inner src = %v, want %v (source-NAT'd)", got[ethHdrLen+12:ethHdrLen+16], natPublicIP)
+		}
+
+		if !validIPv4L4Checksum(natPublicIP, serverIP, 6, tcp) {
+			t.Error("inner TCP checksum invalid after NAT")
+		}
+
+		return binary.BigEndian.Uint16(tcp[0:2])
+	}
+
+	port1 := egressPort(t, ue1, teid1)
+	if port1 != srcPort {
+		t.Errorf("first UE egress port = %d, want %d (no remap needed)", port1, srcPort)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	port2 := egressPort(t, ue2, teid2)
+	if port2 == srcPort {
+		t.Errorf("second UE egress port = %d, want a remapped port (collision not resolved)", port2)
+	}
+}
+
+// TestNATICMPError checks that an inbound ICMP error (destination unreachable)
+// is destination-NAT'd: the outer destination and the embedded original packet
+// are both rewritten to the UE so the UE can match the error to its flow.
+func TestNATICMPError(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		ulTEID = 0x4E415403
+		dlTEID = 0x4E415404
+		qfi    = 7
+		ueSP   = 1234
+		srvDP  = 53
+	)
+
+	f := setupT2(t, true)
+	putForwardingUplinkPDR(t, f.obj, ulTEID, 0)
+	putDownlinkPDR(t, f.obj, ueIP, dlTEID, testUPFN3IP, testGNBIP, qfi)
+
+	// Establish the conntrack mapping with an uplink UDP packet.
+	uplinkInner := ipv4Packet(ueIP, serverIP, 17, udpDatagramChecksummed(ueIP, serverIP, ueSP, srvDP, []byte{9, 9}))
+	f.injectUplink(t, uplinkGPDU(ulTEID, uplinkInner))
+
+	time.Sleep(100 * time.Millisecond)
+
+	capFD := f.captureN3(t)
+
+	// Server returns an ICMP port-unreachable embedding the NAT'd packet
+	// (src = the public address, the UDP header the server saw).
+	embeddedUDP := udpDatagramChecksummed(natPublicIP, serverIP, ueSP, srvDP, nil)
+	embeddedIP := ipv4Packet(natPublicIP, serverIP, 17, embeddedUDP)
+
+	icmpErr := make([]byte, 8+len(embeddedIP))
+	icmpErr[0] = 3 // destination unreachable
+	icmpErr[1] = 3 // port unreachable
+	copy(icmpErr[8:], embeddedIP)
+	binary.BigEndian.PutUint16(icmpErr[2:4], onesComplement16(icmpErr))
+
+	f.injectDownlink(t, ethFrame(0x0800, ipv4Packet(serverIP, natPublicIP, 1, icmpErr)))
+
+	got := captureMatching(capFD, time.Second, func(fr []byte) bool {
+		inner := gtpInner(fr)
+
+		return inner != nil && inner[9] == 1 && bytes.Equal(inner[16:20], ueIP[:])
+	})
+	if got == nil {
+		t.Fatal("did not capture a re-encapsulated ICMP error on the N3 side")
+	}
+
+	inner := gtpInner(got)
+	icmp := inner[20:]
+
+	if !validIPv4Checksum(inner[:20]) {
+		t.Error("inner IPv4 header checksum invalid after NAT")
+	}
+
+	if !validICMPChecksum(icmp) {
+		t.Error("ICMP checksum invalid after NAT")
+	}
+
+	// The embedded original packet's source must be rewritten to the UE.
+	embedded := icmp[8:]
+	if len(embedded) < 28 || !bytes.Equal(embedded[12:16], ueIP[:]) {
+		t.Fatalf("embedded packet source not rewritten to the UE: %x", embedded)
+	}
+
+	if !validIPv4Checksum(embedded[:20]) {
+		t.Error("embedded IPv4 header checksum invalid after NAT")
+	}
+
+	if !validIPv4L4Checksum(ueIP, serverIP, 17, embedded[20:28]) {
+		t.Error("embedded UDP checksum invalid after NAT")
+	}
+}
+
+// downlinkReply builds the L4 segment of a server→UE reply: ports are the
+// mirror of the uplink segment so the conntrack reverse lookup matches.
+func downlinkReply(proto natProto, payload []byte) []byte {
+	switch proto.num {
+	case 6:
+		return tcpSegmentChecksummed(serverIP, natPublicIP, 80, 1234, payload)
+	case 17:
+		return udpDatagramChecksummed(serverIP, natPublicIP, 53, 1234, payload)
+	default:
+		return icmpEchoReply(0xbeef, 1, payload)
+	}
+}
+
+func assertSourceNATd(t *testing.T, frame []byte, proto natProto) {
+	t.Helper()
+
+	ip := frame[ethHdrLen : ethHdrLen+20]
+	l4 := frame[ethHdrLen+20:]
+
+	if !bytes.Equal(ip[12:16], natPublicIP[:]) {
+		t.Errorf("inner src = %v, want %v (source-NAT'd)", ip[12:16], natPublicIP)
+	}
+
+	if !validIPv4Checksum(ip) {
+		t.Error("inner IPv4 header checksum invalid after NAT")
+	}
+
+	if !proto.valid(natPublicIP, serverIP, l4) {
+		t.Errorf("inner %s checksum invalid after NAT", proto.name)
+	}
+}
+
+func assertDestinationNATd(t *testing.T, frame []byte, proto natProto) {
+	t.Helper()
+
+	inner := gtpInner(frame)
+	if inner == nil {
+		t.Fatal("captured frame is not a GTP-U G-PDU")
+	}
+
+	ip := inner[:20]
+	l4 := inner[20:]
+
+	if !bytes.Equal(ip[16:20], ueIP[:]) {
+		t.Errorf("inner dst = %v, want %v (destination-NAT'd)", ip[16:20], ueIP)
+	}
+
+	if !validIPv4Checksum(ip) {
+		t.Error("inner IPv4 header checksum invalid after NAT")
+	}
+
+	if !proto.valid(serverIP, ueIP, l4) {
+		t.Errorf("inner %s checksum invalid after NAT", proto.name)
+	}
+}
+
+// isInnerIPv4 reports whether frame is an Ethernet/IPv4 packet of the given
+// protocol addressed to dst.
+func isInnerIPv4(frame []byte, proto uint8, dst [4]byte) bool {
+	if len(frame) < ethHdrLen+20 || frame[12] != 0x08 || frame[13] != 0x00 {
+		return false
+	}
+
+	ip := frame[ethHdrLen : ethHdrLen+20]
+
+	return ip[9] == proto && bytes.Equal(ip[16:20], dst[:])
+}
+
+// gtpInner returns the inner IPv4 packet of a captured GTP-U/IPv4 G-PDU frame,
+// or nil if frame is not one.
+func gtpInner(frame []byte) []byte {
+	const headersLen = ethHdrLen + gtpV4EncapLen
+	if len(frame) < headersLen+20 || frame[12] != 0x08 || frame[13] != 0x00 {
+		return nil
+	}
+
+	if frame[ethHdrLen+9] != 17 || binary.BigEndian.Uint16(frame[ethHdrLen+22:ethHdrLen+24]) != GTPUDPPort {
+		return nil
+	}
+
+	return frame[headersLen:]
+}
+
+func bytesOf(n int) []byte {
+	p := make([]byte, n)
+	for i := range p {
+		p[i] = byte(i)
+	}
+
+	return p
+}
+
+func sizeLabel(n int) string { return strconv.Itoa(n) + "B" }

--- a/internal/upf/ebpf/nat_test.go
+++ b/internal/upf/ebpf/nat_test.go
@@ -116,7 +116,7 @@ func TestNATRoundTrip(t *testing.T) {
 				got := captureMatching(capFD, time.Second, func(fr []byte) bool {
 					inner := gtpInner(fr)
 
-					return inner != nil && inner[9] == proto.num && bytes.Equal(inner[16:20], ueIP[:])
+					return inner != nil && inner[9] == proto.num
 				})
 				if got == nil {
 					t.Fatal("did not capture a re-encapsulated downlink packet on the N3 side")
@@ -253,7 +253,7 @@ func TestNATICMPError(t *testing.T) {
 	got := captureMatching(capFD, time.Second, func(fr []byte) bool {
 		inner := gtpInner(fr)
 
-		return inner != nil && inner[9] == 1 && bytes.Equal(inner[16:20], ueIP[:])
+		return inner != nil && inner[9] == 1 // ICMP
 	})
 	if got == nil {
 		t.Fatal("did not capture a re-encapsulated ICMP error on the N3 side")
@@ -261,6 +261,10 @@ func TestNATICMPError(t *testing.T) {
 
 	inner := gtpInner(got)
 	icmp := inner[20:]
+
+	if !bytes.Equal(inner[16:20], ueIP[:]) {
+		t.Errorf("ICMP error inner dst = %v, want %v (destination-NAT'd to UE)", inner[16:20], ueIP)
+	}
 
 	if !validIPv4Checksum(inner[:20]) {
 		t.Error("inner IPv4 header checksum invalid after NAT")

--- a/internal/upf/ebpf/nat_test.go
+++ b/internal/upf/ebpf/nat_test.go
@@ -13,35 +13,81 @@ import (
 	"time"
 )
 
-// natProto describes one transport protocol for the NAT tests: how to build an
-// inner L4 segment between two IPv4 endpoints and how to validate its checksum
-// after rewrite.
+// natProto describes one transport protocol for the NAT tests: the UE-side L4
+// ports, how to build an inner L4 segment, and how to validate its checksum.
 type natProto struct {
 	name  string
 	num   uint8
-	build func(src, dst [4]byte, payload []byte) []byte
+	sport uint16 // UE source port (uplink); 0 for ICMP
+	dport uint16 // server port (uplink destination); 0 for ICMP
+	build func(src, dst [4]byte, sport, dport uint16, payload []byte) []byte
 	valid func(src, dst [4]byte, l4 []byte) bool
 }
+
+const natICMPID = 0xbeef
 
 var natProtos = []natProto{
 	{
 		name:  "tcp",
 		num:   6,
-		build: func(src, dst [4]byte, p []byte) []byte { return tcpSegmentChecksummed(src, dst, 1234, 80, p) },
+		sport: 1234,
+		dport: 80,
+		build: func(src, dst [4]byte, sp, dp uint16, p []byte) []byte {
+			return tcpSegmentChecksummed(src, dst, sp, dp, p)
+		},
 		valid: func(src, dst [4]byte, l4 []byte) bool { return validIPv4L4Checksum(src, dst, 6, l4) },
 	},
 	{
 		name:  "udp",
 		num:   17,
-		build: func(src, dst [4]byte, p []byte) []byte { return udpDatagramChecksummed(src, dst, 1234, 53, p) },
+		sport: 1234,
+		dport: 53,
+		build: func(src, dst [4]byte, sp, dp uint16, p []byte) []byte {
+			return udpDatagramChecksummed(src, dst, sp, dp, p)
+		},
 		valid: func(src, dst [4]byte, l4 []byte) bool { return validIPv4L4Checksum(src, dst, 17, l4) },
 	},
 	{
 		name:  "icmp",
 		num:   1,
-		build: func(_, _ [4]byte, p []byte) []byte { return icmpEchoRequest(0xbeef, 1, p) },
+		build: func(_, _ [4]byte, _, _ uint16, p []byte) []byte { return icmpEchoRequest(natICMPID, 1, p) },
 		valid: func(_, _ [4]byte, l4 []byte) bool { return validICMPChecksum(l4) },
 	},
+}
+
+// l4ChecksumOffset returns the byte offset of the L4 checksum field for proto,
+// or -1 if not applicable.
+func l4ChecksumOffset(num uint8) int {
+	switch num {
+	case 6:
+		return 16 // TCP
+	case 17:
+		return 6 // UDP
+	case 1:
+		return 2 // ICMP
+	default:
+		return -1
+	}
+}
+
+// l4PreservedExceptChecksum reports whether got equals orig once the L4
+// checksum field (the only L4 byte source-NAT legitimately rewrites) is masked.
+// It catches corruption of ports, sequence numbers, flags, or payload that a
+// checksum-only assertion would miss.
+func l4PreservedExceptChecksum(num uint8, got, orig []byte) bool {
+	if len(got) != len(orig) {
+		return false
+	}
+
+	g := bytes.Clone(got)
+	o := bytes.Clone(orig)
+
+	if off := l4ChecksumOffset(num); off >= 0 && off+2 <= len(g) {
+		g[off], g[off+1] = 0, 0
+		o[off], o[off+1] = 0, 0
+	}
+
+	return bytes.Equal(g, o)
 }
 
 // payloadSizes brackets the historical bpf_csum_diff 512-byte limit and pushes
@@ -64,7 +110,8 @@ func TestSourceNATUplink(t *testing.T) {
 			t.Run(proto.name+"/"+sizeLabel(size), func(t *testing.T) {
 				capFD := f.captureN6(t)
 
-				inner := ipv4Packet(ueIP, serverIP, proto.num, proto.build(ueIP, serverIP, bytesOf(size)))
+				origL4 := proto.build(ueIP, serverIP, proto.sport, proto.dport, bytesOf(size))
+				inner := ipv4Packet(ueIP, serverIP, proto.num, origL4)
 				f.injectUplink(t, uplinkGPDU(teid, inner))
 
 				got := captureMatching(capFD, time.Second, func(fr []byte) bool {
@@ -74,7 +121,7 @@ func TestSourceNATUplink(t *testing.T) {
 					t.Fatal("did not capture a NAT'd packet on the N6 side")
 				}
 
-				assertSourceNATd(t, got, proto)
+				assertSourceNATd(t, got, proto, origL4)
 			})
 		}
 	}
@@ -101,7 +148,7 @@ func TestNATRoundTrip(t *testing.T) {
 		for _, size := range []int{40, 1000} {
 			t.Run(proto.name+"/"+sizeLabel(size), func(t *testing.T) {
 				// Uplink first: establish the conntrack mapping.
-				uplinkInner := ipv4Packet(ueIP, serverIP, proto.num, proto.build(ueIP, serverIP, bytesOf(40)))
+				uplinkInner := ipv4Packet(ueIP, serverIP, proto.num, proto.build(ueIP, serverIP, proto.sport, proto.dport, bytesOf(40)))
 				f.injectUplink(t, uplinkGPDU(ulTEID, uplinkInner))
 
 				time.Sleep(100 * time.Millisecond)
@@ -185,10 +232,19 @@ func TestNATPortCollision(t *testing.T) {
 			t.Fatal("did not capture a NAT'd packet on the N6 side")
 		}
 
+		ip := got[ethHdrLen : ethHdrLen+20]
 		tcp := got[ethHdrLen+20:]
 
-		if !bytes.Equal(got[ethHdrLen+12:ethHdrLen+16], natPublicIP[:]) {
-			t.Errorf("inner src = %v, want %v (source-NAT'd)", got[ethHdrLen+12:ethHdrLen+16], natPublicIP)
+		if !bytes.Equal(ip[12:16], natPublicIP[:]) {
+			t.Errorf("inner src = %v, want %v (source-NAT'd)", ip[12:16], natPublicIP)
+		}
+
+		if !bytes.Equal(ip[16:20], serverIP[:]) {
+			t.Errorf("inner dst = %v, want %v (preserved)", ip[16:20], serverIP)
+		}
+
+		if dp := binary.BigEndian.Uint16(tcp[2:4]); dp != 80 {
+			t.Errorf("inner dest port = %d, want 80 (only the source port may be remapped)", dp)
 		}
 
 		if !validIPv4L4Checksum(natPublicIP, serverIP, 6, tcp) {
@@ -274,10 +330,15 @@ func TestNATICMPError(t *testing.T) {
 		t.Error("ICMP checksum invalid after NAT")
 	}
 
-	// The embedded original packet's source must be rewritten to the UE.
+	// The embedded original packet's source must be rewritten to the UE, and
+	// its destination (the server) left untouched.
 	embedded := icmp[8:]
 	if len(embedded) < 28 || !bytes.Equal(embedded[12:16], ueIP[:]) {
 		t.Fatalf("embedded packet source not rewritten to the UE: %x", embedded)
+	}
+
+	if !bytes.Equal(embedded[16:20], serverIP[:]) {
+		t.Errorf("embedded packet dst = %v, want %v (must be preserved)", embedded[16:20], serverIP)
 	}
 
 	if !validIPv4Checksum(embedded[:20]) {
@@ -294,15 +355,18 @@ func TestNATICMPError(t *testing.T) {
 func downlinkReply(proto natProto, payload []byte) []byte {
 	switch proto.num {
 	case 6:
-		return tcpSegmentChecksummed(serverIP, natPublicIP, 80, 1234, payload)
+		return tcpSegmentChecksummed(serverIP, natPublicIP, proto.dport, proto.sport, payload)
 	case 17:
-		return udpDatagramChecksummed(serverIP, natPublicIP, 53, 1234, payload)
+		return udpDatagramChecksummed(serverIP, natPublicIP, proto.dport, proto.sport, payload)
 	default:
-		return icmpEchoReply(0xbeef, 1, payload)
+		return icmpEchoReply(natICMPID, 1, payload)
 	}
 }
 
-func assertSourceNATd(t *testing.T, frame []byte, proto natProto) {
+// assertSourceNATd checks an uplink source-NAT egress packet: the source is
+// rewritten to the egress address, the destination and the whole L4 segment
+// (beyond the checksum) are preserved, and both checksums are valid.
+func assertSourceNATd(t *testing.T, frame []byte, proto natProto, origL4 []byte) {
 	t.Helper()
 
 	ip := frame[ethHdrLen : ethHdrLen+20]
@@ -312,6 +376,10 @@ func assertSourceNATd(t *testing.T, frame []byte, proto natProto) {
 		t.Errorf("inner src = %v, want %v (source-NAT'd)", ip[12:16], natPublicIP)
 	}
 
+	if !bytes.Equal(ip[16:20], serverIP[:]) {
+		t.Errorf("inner dst = %v, want %v (source-NAT must not touch the destination)", ip[16:20], serverIP)
+	}
+
 	if !validIPv4Checksum(ip) {
 		t.Error("inner IPv4 header checksum invalid after NAT")
 	}
@@ -319,8 +387,17 @@ func assertSourceNATd(t *testing.T, frame []byte, proto natProto) {
 	if !proto.valid(natPublicIP, serverIP, l4) {
 		t.Errorf("inner %s checksum invalid after NAT", proto.name)
 	}
+
+	if !l4PreservedExceptChecksum(proto.num, l4, origL4) {
+		t.Errorf("source-NAT altered the L4 segment beyond its checksum:\n got %x\nwant %x (except checksum)", l4, origL4)
+	}
 }
 
+// assertDestinationNATd checks a downlink destination-NAT egress packet (inside
+// the re-encapsulated GTP frame): the destination is rewritten to the UE, the
+// source (server) is preserved, the L4 port semantics hold (server source port
+// preserved; destination port restored to the UE's original source port), and
+// the checksums are valid.
 func assertDestinationNATd(t *testing.T, frame []byte, proto natProto) {
 	t.Helper()
 
@@ -336,12 +413,31 @@ func assertDestinationNATd(t *testing.T, frame []byte, proto natProto) {
 		t.Errorf("inner dst = %v, want %v (destination-NAT'd)", ip[16:20], ueIP)
 	}
 
+	if !bytes.Equal(ip[12:16], serverIP[:]) {
+		t.Errorf("inner src = %v, want %v (destination-NAT must not touch the source)", ip[12:16], serverIP)
+	}
+
 	if !validIPv4Checksum(ip) {
 		t.Error("inner IPv4 header checksum invalid after NAT")
 	}
 
 	if !proto.valid(serverIP, ueIP, l4) {
 		t.Errorf("inner %s checksum invalid after NAT", proto.name)
+	}
+
+	switch proto.num {
+	case 6, 17:
+		if sp := binary.BigEndian.Uint16(l4[0:2]); sp != proto.dport {
+			t.Errorf("inner L4 source port = %d, want %d (server port, preserved)", sp, proto.dport)
+		}
+
+		if dp := binary.BigEndian.Uint16(l4[2:4]); dp != proto.sport {
+			t.Errorf("inner L4 dest port = %d, want %d (restored to UE's original source port)", dp, proto.sport)
+		}
+	case 1:
+		if id := binary.BigEndian.Uint16(l4[4:6]); id != natICMPID {
+			t.Errorf("inner ICMP echo id = %#x, want %#x (preserved)", id, natICMPID)
+		}
 	}
 }
 

--- a/internal/upf/ebpf/packet_test.go
+++ b/internal/upf/ebpf/packet_test.go
@@ -64,6 +64,82 @@ func ipv4HeaderChecksum(header []byte) uint16 { return onesComplement16(header) 
 
 func validIPv4Checksum(header []byte) bool { return onesComplement16(header) == 0 }
 
+// ipv4L4Checksum computes a TCP/UDP checksum over the IPv4 pseudo-header + l4.
+func ipv4L4Checksum(src, dst [4]byte, proto uint8, l4 []byte) uint16 {
+	pseudo := make([]byte, 12, 12+len(l4))
+	copy(pseudo[0:4], src[:])
+	copy(pseudo[4:8], dst[:])
+	pseudo[9] = proto
+	binary.BigEndian.PutUint16(pseudo[10:12], uint16(len(l4)))
+
+	return onesComplement16(append(pseudo, l4...))
+}
+
+func validIPv4L4Checksum(src, dst [4]byte, proto uint8, l4 []byte) bool {
+	return ipv4L4Checksum(src, dst, proto, l4) == 0
+}
+
+// tcpSegmentChecksummed builds a 20-byte-header TCP segment with a valid
+// checksum for the given IPv4 endpoints (so incremental NAT updates stay valid).
+func tcpSegmentChecksummed(src, dst [4]byte, srcPort, dstPort uint16, payload []byte) []byte {
+	seg := make([]byte, 20+len(payload))
+
+	binary.BigEndian.PutUint16(seg[0:2], srcPort)
+	binary.BigEndian.PutUint16(seg[2:4], dstPort)
+	seg[12] = 0x50 // data offset = 5
+	copy(seg[20:], payload)
+	binary.BigEndian.PutUint16(seg[16:18], ipv4L4Checksum(src, dst, 6, seg))
+
+	return seg
+}
+
+// udpDatagramChecksummed builds a UDP datagram with a valid (non-zero) checksum
+// for the given IPv4 endpoints, exercising the incremental UDP checksum fix-up
+// (the zero-checksum case skips it).
+func udpDatagramChecksummed(src, dst [4]byte, srcPort, dstPort uint16, payload []byte) []byte {
+	d := make([]byte, 8+len(payload))
+
+	binary.BigEndian.PutUint16(d[0:2], srcPort)
+	binary.BigEndian.PutUint16(d[2:4], dstPort)
+	binary.BigEndian.PutUint16(d[4:6], uint16(8+len(payload)))
+	copy(d[8:], payload)
+
+	csum := ipv4L4Checksum(src, dst, 17, d)
+	if csum == 0 {
+		csum = 0xffff // a zero UDP checksum means "no checksum"; avoid it
+	}
+
+	binary.BigEndian.PutUint16(d[6:8], csum)
+
+	return d
+}
+
+// icmpEchoRequest builds an ICMP echo request (type 8) with a valid checksum.
+func icmpEchoRequest(id, seq uint16, payload []byte) []byte {
+	m := make([]byte, 8+len(payload))
+
+	m[0] = 8 // echo request
+	binary.BigEndian.PutUint16(m[4:6], id)
+	binary.BigEndian.PutUint16(m[6:8], seq)
+	copy(m[8:], payload)
+	binary.BigEndian.PutUint16(m[2:4], onesComplement16(m))
+
+	return m
+}
+
+// icmpEchoReply builds an ICMP echo reply (type 0) with a valid checksum. It is
+// the conntrack-matching downlink counterpart to icmpEchoRequest.
+func icmpEchoReply(id, seq uint16, payload []byte) []byte {
+	m := icmpEchoRequest(id, seq, payload)
+	m[0] = 0 // echo reply
+	binary.BigEndian.PutUint16(m[2:4], 0)
+	binary.BigEndian.PutUint16(m[2:4], onesComplement16(m))
+
+	return m
+}
+
+func validICMPChecksum(msg []byte) bool { return onesComplement16(msg) == 0 }
+
 // ethFrame prepends an Ethernet header (fixed locally-administered MACs) with
 // the given ethertype to l3.
 func ethFrame(etherType uint16, l3 []byte) []byte {
@@ -75,6 +151,35 @@ func ethFrame(etherType uint16, l3 []byte) []byte {
 	copy(frame[14:], l3)
 
 	return frame
+}
+
+// vlanFrame prepends an Ethernet header with an 802.1Q tag (the given VLAN ID
+// and inner ethertype) to l3.
+func vlanFrame(vlanID, innerEtherType uint16, l3 []byte) []byte {
+	frame := make([]byte, ethHdrLen+4+len(l3))
+
+	copy(frame[0:6], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x02})
+	copy(frame[6:12], []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x01})
+	binary.BigEndian.PutUint16(frame[12:14], 0x8100) // 802.1Q
+	binary.BigEndian.PutUint16(frame[14:16], vlanID&0x0fff)
+	binary.BigEndian.PutUint16(frame[16:18], innerEtherType)
+	copy(frame[18:], l3)
+
+	return frame
+}
+
+// validICMPv6Checksum verifies an ICMPv6 checksum (RFC 4443 pseudo-header:
+// src + dst + upper-layer length + next-header 58).
+func validICMPv6Checksum(src, dst [16]byte, icmp6 []byte) bool {
+	pseudo := make([]byte, 40+len(icmp6))
+
+	copy(pseudo[0:16], src[:])
+	copy(pseudo[16:32], dst[:])
+	binary.BigEndian.PutUint32(pseudo[32:36], uint32(len(icmp6)))
+	pseudo[39] = 58 // next header = ICMPv6
+	copy(pseudo[40:], icmp6)
+
+	return onesComplement16(pseudo) == 0
 }
 
 // ipv4Packet builds an IPv4 packet (with a valid header checksum) carrying
@@ -92,6 +197,16 @@ func ipv4Packet(src, dst [4]byte, proto uint8, payload []byte) []byte {
 	copy(pkt[16:20], dst[:])
 	binary.BigEndian.PutUint16(pkt[10:12], ipv4HeaderChecksum(pkt[:hdrLen]))
 	copy(pkt[hdrLen:], payload)
+
+	return pkt
+}
+
+// withDF sets the IPv4 Don't-Fragment flag on an IPv4 packet and recomputes the
+// header checksum.
+func withDF(pkt []byte) []byte {
+	pkt[6] |= 0x40
+	binary.BigEndian.PutUint16(pkt[10:12], 0)
+	binary.BigEndian.PutUint16(pkt[10:12], ipv4HeaderChecksum(pkt[:20]))
 
 	return pkt
 }
@@ -154,7 +269,7 @@ func ipv6Packet(src, dst [16]byte, nextHdr uint8, payload []byte) []byte {
 }
 
 // innerIPv6UDP builds a UE inner packet: an IPv6/UDP datagram to dst:dport.
-func innerIPv6UDP(dst [16]byte, dport uint16) []byte {
+func innerIPv6UDP(dst [16]byte, dport uint16) []byte { //nolint:unparam // general-purpose builder; dport varies across callers
 	src := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x09}
 
 	return ipv6Packet(src, dst, 17, udpDatagram(0, dport, nil))

--- a/internal/upf/ebpf/packet_test.go
+++ b/internal/upf/ebpf/packet_test.go
@@ -276,12 +276,12 @@ func innerIPv6UDP(dst [16]byte, dport uint16) []byte { //nolint:unparam // gener
 }
 
 // innerIPv6ICMPv6RS builds a UE inner packet: an ICMPv6 Router Solicitation
-// (type 133) to dst.
-func innerIPv6ICMPv6RS(dst [16]byte) []byte {
-	src := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x09}
+// (type 133) sent from the UE's address ueSrc to the all-routers multicast.
+func innerIPv6ICMPv6RS(ueSrc [16]byte) []byte {
+	allRouters := [16]byte{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02}
 	rs := []byte{133, 0, 0, 0, 0, 0, 0, 0} // type=133 (Router Solicitation)
 
-	return ipv6Packet(src, dst, 58 /* IPPROTO_ICMPV6 */, rs)
+	return ipv6Packet(ueSrc, allRouters, 58 /* IPPROTO_ICMPV6 */, rs)
 }
 
 // gtpControlFrame builds an N3 frame carrying an 8-byte GTP-U control message of

--- a/internal/upf/ebpf/pmtu_test.go
+++ b/internal/upf/ebpf/pmtu_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Ella Networks
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+// TestDownlinkPMTU checks the path-MTU safety net: a downlink packet that would
+// exceed the N3 MTU once GTP-encapsulated, with the Don't-Fragment bit set, is
+// answered with an ICMP "fragmentation needed" toward the sender instead of
+// being forwarded. The advertised next-hop MTU is the N3 MTU minus the GTP
+// encapsulation overhead.
+func TestDownlinkPMTU(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid  = 0x504D5455 // "PMTU"
+		n3MTU = 1280
+	)
+
+	f := setupT2(t, false)
+	putDownlinkPDR(t, f.obj, ueIP, teid, testUPFN3IP, testGNBIP, 7)
+
+	// Shrink the N3 MTU so the oversized downlink packet trips bpf_check_mtu.
+	// The runtime check reads the live device MTU, so no reload is needed.
+	if out, err := ipCmd("link", "set", t2N3Dev, "mtu", "1280"); err != nil {
+		t.Fatalf("shrink N3 MTU: %v: %s", err, out)
+	}
+
+	// The ICMP error reflects back out the N6 side toward the sender.
+	capFD := f.captureN6(t)
+
+	big := withDF(ipv4Packet(serverIP, ueIP, 17, udpDatagram(4000, 4001, bytesOf(1400))))
+	f.injectDownlink(t, ethFrame(0x0800, big))
+
+	got := captureMatching(capFD, time.Second, func(fr []byte) bool {
+		if !isInnerIPv4(fr, 1 /* ICMP */, serverIP) {
+			return false
+		}
+
+		icmp := fr[ethHdrLen+20:]
+
+		return len(icmp) >= 8 && icmp[0] == 3 && icmp[1] == 4 // dest-unreach / frag-needed
+	})
+	if got == nil {
+		t.Fatal("did not capture an ICMP fragmentation-needed on the N6 side")
+	}
+
+	ip := got[ethHdrLen : ethHdrLen+20]
+	icmp := got[ethHdrLen+20:]
+
+	if !bytes.Equal(ip[12:16], ueIP[:]) {
+		t.Errorf("ICMP source = %v, want %v (the address the sender targeted)", ip[12:16], ueIP)
+	}
+
+	if !validIPv4Checksum(ip) {
+		t.Error("ICMP IPv4 header checksum invalid")
+	}
+
+	if !validICMPChecksum(icmp) {
+		t.Error("ICMP checksum invalid")
+	}
+
+	if adv := binary.BigEndian.Uint16(icmp[6:8]); adv != n3MTU-gtpV4EncapLen {
+		t.Errorf("advertised next-hop MTU = %d, want %d (N3 MTU - GTP overhead)", adv, n3MTU-gtpV4EncapLen)
+	}
+
+	// The ICMP embeds the original IPv4 header so the sender can match the flow.
+	if embedded := icmp[8:]; len(embedded) < 20 || !bytes.Equal(embedded[16:20], ueIP[:]) {
+		t.Error("ICMP does not embed the original packet's IPv4 header")
+	}
+}
+
+// TestDownlinkPMTUIPv6 is the IPv6 counterpart: an oversized downlink IPv6
+// packet is answered with an ICMPv6 "packet too big" toward the sender.
+func TestDownlinkPMTUIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid  = 0x504D5436
+		qfi   = 7
+		n3MTU = 1280
+	)
+
+	serverV6 := [16]byte{0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88}
+
+	f := setupT2(t, false)
+	putDownlinkPDRv6UE(t, f.obj, netip.MustParseAddr("2001:db8::"), teid, testUPFN3IP, testGNBIP, qfi)
+
+	if out, err := ipCmd("link", "set", t2N3Dev, "mtu", "1280"); err != nil {
+		t.Fatalf("shrink N3 MTU: %v: %s", err, out)
+	}
+
+	capFD := f.captureN6(t)
+
+	big := ipv6Packet(serverV6, testUEv6, 17, udpDatagram(4000, 53, bytesOf(1300)))
+	f.injectDownlink(t, ethFrame(0x86DD, big))
+
+	got := captureMatching(capFD, time.Second, func(fr []byte) bool {
+		if len(fr) < ethHdrLen+40+8 || fr[12] != 0x86 || fr[13] != 0xDD {
+			return false
+		}
+
+		return fr[ethHdrLen+6] == 58 && fr[ethHdrLen+40] == 2 // ICMPv6 Packet Too Big
+	})
+	if got == nil {
+		t.Fatal("did not capture an ICMPv6 packet-too-big on the N6 side")
+	}
+
+	var src, dst [16]byte
+	copy(src[:], got[ethHdrLen+8:ethHdrLen+24])
+	copy(dst[:], got[ethHdrLen+24:ethHdrLen+40])
+	icmp6 := got[ethHdrLen+40:]
+
+	if src != testUEv6 {
+		t.Errorf("ICMPv6 source = %x, want %x (the address the sender targeted)", src, testUEv6)
+	}
+
+	if dst != serverV6 {
+		t.Errorf("ICMPv6 dest = %x, want %x (the sender)", dst, serverV6)
+	}
+
+	if !validICMPv6Checksum(src, dst, icmp6) {
+		t.Error("ICMPv6 checksum invalid")
+	}
+
+	if adv := binary.BigEndian.Uint32(icmp6[4:8]); adv != n3MTU-gtpV4EncapLen {
+		t.Errorf("advertised MTU = %d, want %d (N3 MTU - GTP overhead)", adv, n3MTU-gtpV4EncapLen)
+	}
+
+	// The ICMPv6 embeds the original IPv6 header (dst = the UE prefix address).
+	if embedded := icmp6[8:]; len(embedded) < 40 || !bytes.Equal(embedded[24:40], testUEv6[:]) {
+		t.Error("ICMPv6 does not embed the original packet's IPv6 header")
+	}
+}

--- a/internal/upf/ebpf/qer_test.go
+++ b/internal/upf/ebpf/qer_test.go
@@ -67,3 +67,32 @@ func TestQERGateDownlinkClosed(t *testing.T) {
 		t.Fatalf("closed downlink gate: got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
 	}
 }
+
+// TestQERGateDownlinkClosedIPv6 checks that a closed downlink gate drops an IPv6
+// packet on the separate IPv6 downlink code path.
+func TestQERGateDownlinkClosedIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid = 0x51455203
+		qfi  = 4
+	)
+
+	obj := loadProgram(t, 1, 0)
+
+	pdr := ipv4OuterDownlinkPDR(teid, testUPFN3IP, testGNBIP, qfi)
+	pdr.Qer.GateStatusDL = 1 // GATE_STATUS_CLOSED
+
+	if err := obj.PutPdrDownlink(netip.MustParseAddr("2001:db8::"), pdr); err != nil {
+		t.Fatalf("install downlink IPv6 PDR: %v", err)
+	}
+
+	serverV6 := [16]byte{0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88}
+	inner := ipv6Packet(serverV6, testUEv6, 17, udpDatagram(4000, 53, nil))
+
+	action := runXDP(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x86DD, inner))
+
+	if action != XDP_DROP {
+		t.Fatalf("closed downlink gate (IPv6): got XDP action %d, want XDP_DROP (%d)", action, XDP_DROP)
+	}
+}

--- a/internal/upf/ebpf/sdf_test.go
+++ b/internal/upf/ebpf/sdf_test.go
@@ -244,6 +244,55 @@ func TestSDFIPv6(t *testing.T) {
 	}
 }
 
+// TestSDFDownlinkIPv6 checks IPv6 downlink SDF matching on the remote (the
+// packet source), the IPv6 counterpart to TestSDFDownlinkDirection.
+func TestSDFDownlinkIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid        = 0x53444604
+		filterIndex = 1
+		qfi         = 3
+	)
+
+	obj := loadProgram(t, 1, 0)
+
+	uePrefix := netip.MustParseAddr("2001:db8::")
+	serverV6 := [16]byte{0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88}
+
+	pdr := ipv4OuterDownlinkPDR(teid, testUPFN3IP, testGNBIP, qfi)
+	pdr.FilterMapIndex = filterIndex
+
+	if err := obj.PutPdrDownlink(uePrefix, pdr); err != nil {
+		t.Fatalf("install downlink IPv6 PDR: %v", err)
+	}
+
+	inner := ipv6Packet(serverV6, testUEv6, 17, udpDatagram(4000, 53, nil))
+
+	t.Run("deny by source drops", func(t *testing.T) {
+		putSDFFilter(t, obj, filterIndex, []SdfRule{sdfRuleIPv6(serverV6, 128, 0, 0, 17, SdfActionDeny)})
+
+		action, _ := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x86DD, inner))
+		if action != XDP_DROP {
+			t.Fatalf("got XDP action %d, want XDP_DROP", action)
+		}
+	})
+
+	t.Run("non-matching source passes and encapsulates", func(t *testing.T) {
+		other := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+		putSDFFilter(t, obj, filterIndex, []SdfRule{sdfRuleIPv6(other, 128, 0, 0, 17, SdfActionDeny)})
+
+		action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x86DD, inner))
+		if action == XDP_DROP {
+			t.Fatal("allowed downlink packet was dropped")
+		}
+
+		if f := parseGTPv4Frame(t, out); !bytes.Equal(f.inner, inner) {
+			t.Fatalf("inner packet altered by encapsulation:\n got %x\nwant %x", f.inner, inner)
+		}
+	})
+}
+
 // sdfRuleIPv4 builds an SDF rule for an IPv4 remote prefix, port range, and
 // protocol. A prefixLen or port bound of 0 is a wildcard in the data plane.
 func sdfRuleIPv4(remote [4]byte, prefixLen uint8, portLow, portHigh uint16, proto, action uint8) SdfRule {
@@ -258,7 +307,7 @@ func sdfRuleIPv4(remote [4]byte, prefixLen uint8, portLow, portHigh uint16, prot
 }
 
 // sdfRuleIPv6 builds an SDF rule for a native IPv6 remote prefix.
-func sdfRuleIPv6(remote [16]byte, prefixLen uint8, portLow, portHigh uint16, proto, action uint8) SdfRule {
+func sdfRuleIPv6(remote [16]byte, prefixLen uint8, portLow, portHigh uint16, proto, action uint8) SdfRule { //nolint:unparam // general-purpose builder; port bounds vary across callers
 	return SdfRule{
 		RemoteIP:  remote,
 		PrefixLen: prefixLen,

--- a/internal/upf/ebpf/stats_test.go
+++ b/internal/upf/ebpf/stats_test.go
@@ -52,6 +52,35 @@ func TestUplinkStatistics(t *testing.T) {
 	}
 }
 
+// TestUplinkStatisticsIPv6 checks that uplink accounting also works for an inner
+// IPv6 packet (the byte counter and per-action counter are version-independent).
+func TestUplinkStatisticsIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid    = 0x57415436
+		packets = 5
+	)
+
+	obj := loadProgramConfig(t, false, false, 1, 1, 0, 0)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	inner := innerIPv6UDP(testUEv6, 53)
+	for i := 0; i < packets; i++ {
+		runXDP(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+	}
+
+	bytesSum, actionsSum := sumStats(t, obj.UplinkStatistics)
+
+	if want := uint64(packets * (ethHdrLen + len(inner))); bytesSum != want {
+		t.Errorf("uplink byte_counter = %d, want %d", bytesSum, want)
+	}
+
+	if actionsSum != packets {
+		t.Errorf("uplink xdp_actions total = %d, want %d", actionsSum, packets)
+	}
+}
+
 func sumStats(t *testing.T, m *ebpf.Map) (bytes, actions uint64) {
 	t.Helper()
 

--- a/internal/upf/ebpf/vlan_test.go
+++ b/internal/upf/ebpf/vlan_test.go
@@ -8,6 +8,7 @@ package ebpf
 import (
 	"bytes"
 	"encoding/binary"
+	"net/netip"
 	"testing"
 )
 
@@ -59,5 +60,110 @@ func TestVLANDownlinkInsertion(t *testing.T) {
 
 	if !bytes.Equal(out[ethHdrLen+vlanLen+gtpV4EncapLen:], inner) {
 		t.Errorf("inner packet altered by encapsulation:\n got %x\nwant %x", out[ethHdrLen+vlanLen+gtpV4EncapLen:], inner)
+	}
+}
+
+// TestVLANDownlinkInsertionInnerIPv6 checks N3 VLAN insertion when the inner
+// packet is IPv6.
+func TestVLANDownlinkInsertionInnerIPv6(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid    = 0x564C4136
+		qfi     = 2
+		vlanID  = 100
+		vlanLen = 4
+	)
+
+	obj := loadProgramVLAN(t, 1, 0, vlanID, 0)
+
+	server := [16]byte{0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88}
+
+	pdr := ipv4OuterDownlinkPDR(teid, testUPFN3IP, testGNBIP, qfi)
+	if err := obj.PutPdrDownlink(netip.MustParseAddr("2001:db8::"), pdr); err != nil {
+		t.Fatalf("install downlink IPv6 PDR: %v", err)
+	}
+
+	inner := ipv6Packet(server, testUEv6, 17, udpDatagram(4000, 53, nil))
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, ethFrame(0x86DD, inner))
+	if action == XDP_ABORTED {
+		t.Fatal("downlink IPv6 packet got XDP_ABORTED; VLAN encapsulation failed")
+	}
+
+	if len(out) != ethHdrLen+vlanLen+gtpV4EncapLen+len(inner) {
+		t.Fatalf("VLAN-tagged frame length = %d, want %d", len(out), ethHdrLen+vlanLen+gtpV4EncapLen+len(inner))
+	}
+
+	if et := binary.BigEndian.Uint16(out[12:14]); et != 0x8100 {
+		t.Errorf("Ethernet protocol = %#04x, want 0x8100 (802.1Q)", et)
+	}
+
+	if !bytes.Equal(out[ethHdrLen+vlanLen+gtpV4EncapLen:], inner) {
+		t.Errorf("inner IPv6 packet altered by encapsulation:\n got %x\nwant %x", out[ethHdrLen+vlanLen+gtpV4EncapLen:], inner)
+	}
+}
+
+// TestVLANUplinkStrip checks that a VLAN-tagged uplink GTP-U frame is parsed and
+// decapsulated to its inner packet (the ingress VLAN tag is stripped).
+func TestVLANUplinkStrip(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid   = 0x564C4153
+		vlanID = 100
+	)
+
+	obj := loadN3N6Program(t)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	inner := innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)
+	gtp := ipv4Packet(testGNBIP, testUPFN3IP, 17, udpDatagram(GTPUDPPort, GTPUDPPort, gtpHeader(teid, inner)))
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, vlanFrame(vlanID, 0x0800, gtp))
+	if action == XDP_DROP || action == XDP_ABORTED {
+		t.Fatalf("VLAN-tagged uplink got XDP action %d, want a forwarding action", action)
+	}
+
+	if len(out) != ethHdrLen+len(inner) || !bytes.Equal(out[ethHdrLen:], inner) {
+		t.Fatalf("VLAN-tagged uplink not decapsulated to its inner packet:\n got %x\nwant %x", out, inner)
+	}
+}
+
+// TestVLANUplinkN6Insertion checks that when an N6 VLAN is configured, the
+// decapsulated uplink packet egresses with the N6 VLAN tag inserted.
+func TestVLANUplinkN6Insertion(t *testing.T) {
+	requireProgTestRun(t)
+
+	const (
+		teid    = 0x564C4136 + 1
+		n6VLAN  = 200
+		vlanLen = 4
+	)
+
+	obj := loadProgramVLAN(t, 0, 1, 0, n6VLAN)
+	putForwardingUplinkPDR(t, obj, teid, 0)
+
+	inner := innerIPv4UDP([4]byte{8, 8, 8, 8}, 53)
+
+	action, out := runXDPOut(t, obj.UpfN3N6EntrypointFunc, uplinkGPDU(teid, inner))
+	if action == XDP_DROP || action == XDP_ABORTED {
+		t.Fatalf("uplink got XDP action %d, want a forwarding action", action)
+	}
+
+	if len(out) != ethHdrLen+vlanLen+len(inner) {
+		t.Fatalf("decapsulated frame length = %d, want %d (with N6 VLAN)", len(out), ethHdrLen+vlanLen+len(inner))
+	}
+
+	if et := binary.BigEndian.Uint16(out[12:14]); et != 0x8100 {
+		t.Errorf("Ethernet protocol = %#04x, want 0x8100 (802.1Q)", et)
+	}
+
+	if tci := binary.BigEndian.Uint16(out[14:16]); tci&0x0fff != n6VLAN {
+		t.Errorf("VLAN ID = %d, want %d", tci&0x0fff, n6VLAN)
+	}
+
+	if !bytes.Equal(out[ethHdrLen+vlanLen:], inner) {
+		t.Errorf("inner packet altered by decapsulation:\n got %x\nwant %x", out[ethHdrLen+vlanLen:], inner)
 	}
 }


### PR DESCRIPTION
# Description

Add unit tests for our BPF program leveraging  `BPF_PROG_TEST_RUN`, which allows to run a loaded eBPF program in the kernel with a supplied input and records the output.

This follow-up to #1380 includes the use of `netns` to manipulate network context. This allows to write tests for NAT, MTU and improve our statistics tests.

## Reference
- https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
