### PR TITLE
fix: send UE ngap ID in error indication

### DIFF
--- a/internal/amf/amf_ran.go
+++ b/internal/amf/amf_ran.go
@@ -34,7 +34,7 @@ type NGAPSender interface {
 	SendNGSetupFailure(ctx context.Context, cause *ngapType.Cause) error
 	SendNGSetupResponse(ctx context.Context, guami *models.Guami, snssaiList []models.Snssai, amfName string, amfRelativeCapacity int64) error
 	SendNGResetAcknowledge(ctx context.Context, partOfNGInterface *ngapType.UEAssociatedLogicalNGConnectionList) error
-	SendErrorIndication(ctx context.Context, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error
+	SendErrorIndication(ctx context.Context, amfUeNgapID, ranUeNgapID *int64, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error
 	SendRanConfigurationUpdateAcknowledge(ctx context.Context, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error
 	SendRanConfigurationUpdateFailure(ctx context.Context, cause ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error
 	SendDownlinkRanConfigurationTransfer(ctx context.Context, transfer *ngapType.SONConfigurationTransfer) error

--- a/internal/amf/nas/gmm/handle_test.go
+++ b/internal/amf/nas/gmm/handle_test.go
@@ -165,7 +165,7 @@ func (fng *FakeNGAPSender) SendNGResetAcknowledge(ctx context.Context, partOfNGI
 	return nil
 }
 
-func (fng *FakeNGAPSender) SendErrorIndication(ctx context.Context, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
+func (fng *FakeNGAPSender) SendErrorIndication(ctx context.Context, amfUeNgapID, ranUeNgapID *int64, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
 	return nil
 }
 

--- a/internal/amf/ngap/decode_dispatch.go
+++ b/internal/amf/ngap/decode_dispatch.go
@@ -23,7 +23,7 @@ func handleDecodeReport(ctx context.Context, ran *amf.Radio, report *decode.Repo
 	if report.Fatal() {
 		cd := report.ToCriticalityDiagnostics()
 
-		if err := ran.NGAPSender.SendErrorIndication(ctx, nil, &cd); err != nil {
+		if err := ran.NGAPSender.SendErrorIndication(ctx, nil, nil, nil, &cd); err != nil {
 			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
 		}
 

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -12,41 +12,8 @@ import (
 )
 
 func HandleHandoverCancel(ctx context.Context, ran *amf.Radio, msg decode.HandoverCancel) {
-	sourceUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if sourceUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err), zap.Int64("RAN_UE_NGAP_ID", msg.RANUENGAPID))
-			return
-		}
-
-		return
-	}
-
-	if sourceUe.AmfUeNgapID != msg.AMFUENGAPID {
-		logger.WithTrace(ctx, sourceUe.Log).Error("AMF UE NGAP ID mismatch", zap.Int64("expected", sourceUe.AmfUeNgapID), zap.Int64("received", msg.AMFUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending error indication", zap.Error(err))
-		}
-
+	sourceUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_handover_cancel_test.go
+++ b/internal/amf/ngap/handle_handover_cancel_test.go
@@ -46,11 +46,11 @@ func TestHandleHandoverCancel_UnknownRanUeNgapID(t *testing.T) {
 	}
 }
 
-// TestHandleHandoverCancel_InconsistentAmfUeNgapID verifies that a
-// HandoverCancel whose AMF UE NGAP ID does not match the value stored for the UE
-// draws an Error Indication and is not acted upon (TS 38.413 §10.6): no
-// acknowledge to the source and no release toward the target.
-func TestHandleHandoverCancel_InconsistentAmfUeNgapID(t *testing.T) {
+// TestHandleHandoverCancel_UnknownAmfUeNgapID verifies that a HandoverCancel
+// whose AMF UE NGAP ID the AMF never allocated is treated as an unknown local AP
+// ID (TS 38.413 §10.6): an Error Indication carrying the received AP IDs is sent,
+// with no acknowledge to the source and no release toward the target.
+func TestHandleHandoverCancel_UnknownAmfUeNgapID(t *testing.T) {
 	sourceRan := newTestRadio()
 	sourceSender := sourceRan.NGAPSender.(*FakeNGAPSender)
 
@@ -74,15 +74,8 @@ func TestHandleHandoverCancel_InconsistentAmfUeNgapID(t *testing.T) {
 
 	ngap.HandleHandoverCancel(context.Background(), sourceRan, msg)
 
-	if len(sourceSender.SentErrorIndications) != 1 {
-		t.Fatalf("expected 1 ErrorIndication, got %d", len(sourceSender.SentErrorIndications))
-	}
-
-	errInd := sourceSender.SentErrorIndications[0]
-	if errInd.Cause == nil || errInd.Cause.Present != ngapType.CausePresentRadioNetwork ||
-		errInd.Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
-		t.Fatalf("expected InconsistentRemoteUENGAPID cause, got %+v", errInd.Cause)
-	}
+	errInd := assertSingleErrorIndication(t, sourceSender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 1)
 
 	if len(sourceSender.SentHandoverCancelAcknowledges) != 0 {
 		t.Errorf("expected no HandoverCancelAcknowledge, got %d", len(sourceSender.SentHandoverCancelAcknowledges))

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -30,7 +30,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 	targetUe := ran.FindUEByAmfUeNgapID(msg.AMFUENGAPID)
 	if targetUe == nil {
 		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Int64("AmfUeNgapID", msg.AMFUENGAPID))
-		sendUnknownLocalUEError(ctx, ran)
+		sendUnknownLocalUEError(ctx, ran, &msg.AMFUENGAPID, nil)
 
 		return
 	}

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -48,7 +48,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 	targetUe := ran.FindUEByAmfUeNgapID(*msg.AMFUENGAPID)
 	if targetUe == nil {
 		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Int64("AmfUeNgapID", *msg.AMFUENGAPID))
-		sendUnknownLocalUEError(ctx, ran)
+		sendUnknownLocalUEError(ctx, ran, msg.AMFUENGAPID, msg.RANUENGAPID)
 
 		return
 	}

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -15,42 +15,8 @@ import (
 )
 
 func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.HandoverRequired) {
-	sourceUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if sourceUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("Cannot find UE", zap.Int64("RAN_UE_NGAP_ID", msg.RANUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err), zap.Int64("RAN_UE_NGAP_ID", msg.RANUENGAPID))
-			return
-		}
-
-		return
-	}
-
-	if sourceUe.AmfUeNgapID != msg.AMFUENGAPID {
-		logger.WithTrace(ctx, sourceUe.Log).Error("AMF UE NGAP ID mismatch", zap.Int64("expected", sourceUe.AmfUeNgapID), zap.Int64("received", msg.AMFUENGAPID))
-
-		cause := ngapType.Cause{
-			Present: ngapType.CausePresentRadioNetwork,
-			RadioNetwork: &ngapType.CauseRadioNetwork{
-				Value: ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID,
-			},
-		}
-
-		err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending error indication", zap.Error(err))
-			return
-		}
-
+	sourceUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_initial_context_setup_failure.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure.go
@@ -12,9 +12,8 @@ import (
 func HandleInitialContextSetupFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.InitialContextSetupFailure) {
 	logger.WithTrace(ctx, ran.Log).Warn("Initial Context Setup Failure received", logger.Cause(causeToString(msg.Cause)))
 
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID))
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_initial_context_setup_failure_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure_test.go
@@ -31,12 +31,13 @@ func TestHandleInitialContextSetupFailure_MissingCause(t *testing.T) {
 	}
 }
 
-func TestHandleInitialContextSetupFailure_UnknownRanUeNgapID(t *testing.T) {
+func TestHandleInitialContextSetupFailure_UnknownAmfUeNgapID(t *testing.T) {
 	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
 	amfInstance := newTestAMF()
 
 	msg := decode.InitialContextSetupFailure{
-		AMFUENGAPID: 1,
+		AMFUENGAPID: 999,
 		RANUENGAPID: 99,
 		Cause: ngapType.Cause{
 			Present:      ngapType.CausePresentRadioNetwork,
@@ -45,6 +46,9 @@ func TestHandleInitialContextSetupFailure_UnknownRanUeNgapID(t *testing.T) {
 	}
 
 	ngap.HandleInitialContextSetupFailure(context.Background(), amfInstance, ran, msg)
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 99)
 }
 
 func TestHandleInitialContextSetupFailure_NilAmfUe(t *testing.T) {

--- a/internal/amf/ngap/handle_initial_context_setup_response.go
+++ b/internal/amf/ngap/handle_initial_context_setup_response.go
@@ -10,9 +10,8 @@ import (
 )
 
 func HandleInitialContextSetupResponse(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.InitialContextSetupResponse) {
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID), zap.Int64("AmfUeNgapID", msg.AMFUENGAPID))
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_initial_context_setup_response_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_response_test.go
@@ -15,14 +15,18 @@ import (
 	"github.com/free5gc/ngap/ngapType"
 )
 
-func TestInitialContextSetupResponse_UnknownRanUeNgapID(t *testing.T) {
+func TestInitialContextSetupResponse_UnknownAmfUeNgapID(t *testing.T) {
 	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
 	amfInstance := newTestAMFWithSmf(&FakeSmfSbi{})
 
 	ngap.HandleInitialContextSetupResponse(context.Background(), amfInstance, ran, decode.InitialContextSetupResponse{
 		RANUENGAPID: 99,
-		AMFUENGAPID: 1,
+		AMFUENGAPID: 999,
 	})
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 99)
 }
 
 func TestInitialContextSetupResponse_NilAmfUe(t *testing.T) {

--- a/internal/amf/ngap/handle_location_report.go
+++ b/internal/amf/ngap/handle_location_report.go
@@ -16,9 +16,8 @@ func HandleLocationReport(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID))
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_location_report_test.go
+++ b/internal/amf/ngap/handle_location_report_test.go
@@ -32,6 +32,29 @@ func TestHandleLocationReport_MissingLocationReportingRequestType(t *testing.T) 
 	}
 }
 
+// TestHandleLocationReport_UnknownAmfUeNgapID verifies that a Location Report
+// whose AMF UE NGAP ID the AMF never allocated draws an Error Indication with the
+// received AP IDs (TS 38.413 §10.6).
+func TestHandleLocationReport_UnknownAmfUeNgapID(t *testing.T) {
+	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
+	amfInstance := newTestAMF()
+
+	msg := decode.LocationReport{
+		AMFUENGAPID: 999,
+		RANUENGAPID: 99,
+		LocationReportingRequestType: &ngapType.LocationReportingRequestType{
+			EventType:  ngapType.EventType{Value: ngapType.EventTypePresentDirect},
+			ReportArea: ngapType.ReportArea{Value: ngapType.ReportAreaPresentCell},
+		},
+	}
+
+	ngap.HandleLocationReport(context.Background(), amfInstance, ran, msg)
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 99)
+}
+
 // TestHandleLocationReport_UePresenceInAreaOfInterest_NilList verifies that
 // a LocationReport with EventType=UePresenceInAreaOfInterest but without the
 // optional UEPresenceInAreaOfInterestList IE does NOT panic.

--- a/internal/amf/ngap/handle_nas_non_delivery_indication.go
+++ b/internal/amf/ngap/handle_nas_non_delivery_indication.go
@@ -10,9 +10,8 @@ import (
 )
 
 func HandleNasNonDeliveryIndication(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.NASNonDeliveryIndication) {
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID))
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_nas_non_delivery_indication_test.go
+++ b/internal/amf/ngap/handle_nas_non_delivery_indication_test.go
@@ -14,13 +14,18 @@ import (
 	"github.com/free5gc/ngap/ngapType"
 )
 
-func TestNasNonDeliveryIndication_UnknownRanUeNgapID(t *testing.T) {
+func TestNasNonDeliveryIndication_UnknownAmfUeNgapID(t *testing.T) {
 	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
 	amfInstance := newTestAMF()
 
 	ngap.HandleNasNonDeliveryIndication(context.Background(), amfInstance, ran, decode.NASNonDeliveryIndication{
 		RANUENGAPID: 99,
+		AMFUENGAPID: 999,
 	})
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 99)
 }
 
 func TestNasNonDeliveryIndication_UEFoundDispatchesNAS(t *testing.T) {
@@ -38,6 +43,7 @@ func TestNasNonDeliveryIndication_UEFoundDispatchesNAS(t *testing.T) {
 	// just logs the error. We verify no panic and the UE lookup succeeds.
 	ngap.HandleNasNonDeliveryIndication(context.Background(), amfInstance, ran, decode.NASNonDeliveryIndication{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 		NASPDU:      []byte{0x7E, 0x00, 0x00},
 		Cause: ngapType.Cause{
 			Present:      ngapType.CausePresentRadioNetwork,
@@ -62,6 +68,7 @@ func TestNasNonDeliveryIndication_VerifyNASCalledWithPDU(t *testing.T) {
 
 	ngap.HandleNasNonDeliveryIndication(context.Background(), amfInstance, ran, decode.NASNonDeliveryIndication{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 		NASPDU:      nasPDU,
 		Cause: ngapType.Cause{
 			Present:      ngapType.CausePresentRadioNetwork,
@@ -96,6 +103,7 @@ func TestNasNonDeliveryIndication_NilPDU_PropagatesCorrectly(t *testing.T) {
 
 	ngap.HandleNasNonDeliveryIndication(context.Background(), amfInstance, ran, decode.NASNonDeliveryIndication{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 		NASPDU:      nil,
 		Cause: ngapType.Cause{
 			Present:      ngapType.CausePresentRadioNetwork,

--- a/internal/amf/ngap/handle_pdu_session_resource_modify.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify.go
@@ -10,9 +10,8 @@ import (
 )
 
 func HandlePDUSessionResourceNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.PDUSessionResourceNotify) {
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID), zap.Int64("AmfUeNgapID", msg.AMFUENGAPID))
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication_test.go
@@ -35,7 +35,7 @@ func TestPDUSessionResourceModifyIndication_UnknownRanUeNgapID(t *testing.T) {
 	}
 }
 
-func TestPDUSessionResourceModifyIndication_AMFUENGAPIDMismatch(t *testing.T) {
+func TestPDUSessionResourceModifyIndication_UnknownAmfUeNgapID(t *testing.T) {
 	ran := newTestRadio()
 	sender := ran.NGAPSender.(*FakeNGAPSender)
 
@@ -46,14 +46,8 @@ func TestPDUSessionResourceModifyIndication_AMFUENGAPIDMismatch(t *testing.T) {
 		AMFUENGAPID: 99999,
 	})
 
-	if len(sender.SentErrorIndications) != 1 {
-		t.Fatalf("expected 1 ErrorIndication, got %d", len(sender.SentErrorIndications))
-	}
-
-	ei := sender.SentErrorIndications[0]
-	if ei.Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
-		t.Errorf("cause = %d, want InconsistentRemoteUENGAPID", ei.Cause.RadioNetwork.Value)
-	}
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 99999, 1)
 
 	if len(sender.SentPDUSessionModifyConfirms) != 0 {
 		t.Errorf("expected no Modify Confirm on ID mismatch, got %d", len(sender.SentPDUSessionModifyConfirms))

--- a/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
@@ -14,13 +14,18 @@ import (
 	"github.com/free5gc/ngap/ngapType"
 )
 
-func TestPDUSessionResourceNotify_UnknownRanUeNgapID(t *testing.T) {
+func TestPDUSessionResourceNotify_UnknownAmfUeNgapID(t *testing.T) {
 	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
 	amfInstance := newTestAMF()
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 99,
+		AMFUENGAPID: 999,
 	})
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 99)
 }
 
 func TestPDUSessionResourceNotify_NilAmfUe(t *testing.T) {
@@ -31,6 +36,7 @@ func TestPDUSessionResourceNotify_NilAmfUe(t *testing.T) {
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 	})
 }
 
@@ -51,6 +57,7 @@ func TestPDUSessionResourceNotify_ReleasedSessionDeactivated(t *testing.T) {
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 		PDUSessionResourceReleasedItems: []ngapType.PDUSessionResourceReleasedItemNot{
 			{
 				PDUSessionID:                             ngapType.PDUSessionID{Value: 1},
@@ -90,6 +97,7 @@ func TestPDUSessionResourceNotify_ReleasedSessionSmContextNotFound(t *testing.T)
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 		PDUSessionResourceReleasedItems: []ngapType.PDUSessionResourceReleasedItemNot{
 			{
 				PDUSessionID:                             ngapType.PDUSessionID{Value: 5},
@@ -116,6 +124,7 @@ func TestPDUSessionResourceNotify_InvalidPDUSessionID(t *testing.T) {
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 		PDUSessionResourceReleasedItems: []ngapType.PDUSessionResourceReleasedItemNot{
 			{
 				PDUSessionID:                             ngapType.PDUSessionID{Value: 0},
@@ -142,6 +151,7 @@ func TestPDUSessionResourceNotify_NotifyListLogsWarning(t *testing.T) {
 
 	ngap.HandlePDUSessionResourceNotify(context.Background(), amfInstance, ran, decode.PDUSessionResourceNotify{
 		RANUENGAPID:   1,
+		AMFUENGAPID:   10,
 		HasNotifyList: true,
 	})
 

--- a/internal/amf/ngap/handle_test.go
+++ b/internal/amf/ngap/handle_test.go
@@ -250,6 +250,8 @@ type NGResetAcknowledge struct {
 }
 
 type ErrorIndication struct {
+	AmfUeNgapID            *int64
+	RanUeNgapID            *int64
 	Cause                  *ngapType.Cause
 	CriticalityDiagnostics *ngapType.CriticalityDiagnostics
 }
@@ -371,8 +373,10 @@ func (fng *FakeNGAPSender) SendNGResetAcknowledge(ctx context.Context, partOfNGI
 	return nil
 }
 
-func (fng *FakeNGAPSender) SendErrorIndication(ctx context.Context, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
+func (fng *FakeNGAPSender) SendErrorIndication(ctx context.Context, amfUeNgapID, ranUeNgapID *int64, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
 	fng.SentErrorIndications = append(fng.SentErrorIndications, &ErrorIndication{
+		AmfUeNgapID:            amfUeNgapID,
+		RanUeNgapID:            ranUeNgapID,
 		Cause:                  cause,
 		CriticalityDiagnostics: criticalityDiagnostics,
 	})

--- a/internal/amf/ngap/handle_ue_radio_capability_info_indication.go
+++ b/internal/amf/ngap/handle_ue_radio_capability_info_indication.go
@@ -12,9 +12,8 @@ import (
 )
 
 func HandleUERadioCapabilityInfoIndication(ctx gocontext.Context, ran *amf.Radio, msg decode.UERadioCapabilityInfoIndication) {
-	ranUe := ran.FindUEByRanUeNgapID(msg.RANUENGAPID)
-	if ranUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context", zap.Int64("RanUeNgapID", msg.RANUENGAPID))
+	ranUe, ok := resolveUE(ctx, ran, &msg.RANUENGAPID, &msg.AMFUENGAPID)
+	if !ok {
 		return
 	}
 

--- a/internal/amf/ngap/handle_ue_radio_capability_info_indication_test.go
+++ b/internal/amf/ngap/handle_ue_radio_capability_info_indication_test.go
@@ -13,12 +13,17 @@ import (
 	"github.com/free5gc/ngap/ngapType"
 )
 
-func TestUERadioCapabilityInfoIndication_UnknownRanUeNgapID(t *testing.T) {
+func TestUERadioCapabilityInfoIndication_UnknownAmfUeNgapID(t *testing.T) {
 	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID: 99,
+		AMFUENGAPID: 999,
 	})
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 99)
 }
 
 func TestUERadioCapabilityInfoIndication_NilAmfUe(t *testing.T) {
@@ -27,6 +32,7 @@ func TestUERadioCapabilityInfoIndication_NilAmfUe(t *testing.T) {
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 	})
 }
 
@@ -40,6 +46,7 @@ func TestUERadioCapabilityInfoIndication_SetsRadioCapability(t *testing.T) {
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID:       1,
+		AMFUENGAPID:       10,
 		UERadioCapability: []byte{0xDE, 0xAD, 0xBE, 0xEF},
 	})
 
@@ -58,6 +65,7 @@ func TestUERadioCapabilityInfoIndication_SetsRadioCapabilityForPaging(t *testing
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 		UERadioCapabilityForPaging: &ngapType.UERadioCapabilityForPaging{
 			UERadioCapabilityForPagingOfNR: &ngapType.UERadioCapabilityForPagingOfNR{
 				Value: []byte{0xCA, 0xFE},
@@ -91,6 +99,7 @@ func TestUERadioCapabilityInfoIndication_NilCapabilityFieldsNoOp(t *testing.T) {
 
 	ngap.HandleUERadioCapabilityInfoIndication(context.Background(), ran, decode.UERadioCapabilityInfoIndication{
 		RANUENGAPID: 1,
+		AMFUENGAPID: 10,
 	})
 
 	if amfUe.Current().UeRadioCapability != "" {

--- a/internal/amf/ngap/handle_uplink_nas_transport_test.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport_test.go
@@ -41,12 +41,11 @@ func TestHandleUplinkNasTransport_UnknownRanUe_SendsErrorIndication(t *testing.T
 	}
 }
 
-// TestHandleUplinkNasTransport_AMFUENGAPIDMismatch_SendsErrorIndication
-// covers TS 38.413 §8.7.5.2: when the RAN UE NGAP ID identifies a known UE
-// but the AMF UE NGAP ID in the message does not match the one the AMF
-// allocated to that UE, the AMF shall respond with ErrorIndication and
-// cause "Inconsistent remote UE NGAP ID".
-func TestHandleUplinkNasTransport_AMFUENGAPIDMismatch_SendsErrorIndication(t *testing.T) {
+// TestHandleUplinkNasTransport_UnknownAmfUeNgapID_SendsErrorIndication covers
+// TS 38.413 §10.6: an AMF UE NGAP ID the AMF never allocated is an unknown local
+// AP ID, so the AMF answers with an Error Indication carrying the received AP IDs
+// (§8.7.5.2) and cause "Unknown local UE NGAP ID".
+func TestHandleUplinkNasTransport_UnknownAmfUeNgapID_SendsErrorIndication(t *testing.T) {
 	ran := newTestRadio()
 	sender := ran.NGAPSender.(*FakeNGAPSender)
 	fakeNAS := &FakeNASHandler{}
@@ -60,19 +59,35 @@ func TestHandleUplinkNasTransport_AMFUENGAPIDMismatch_SendsErrorIndication(t *te
 		NASPDU:      []byte{0x7E, 0x00, 0x55},
 	})
 
-	if len(sender.SentErrorIndications) != 1 {
-		t.Fatalf("ErrorIndications sent = %d, want 1", len(sender.SentErrorIndications))
-	}
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 99999, 1)
 
-	cause := sender.SentErrorIndications[0].Cause
-	if cause == nil || cause.Present != ngapType.CausePresentRadioNetwork {
-		t.Fatal("expected RadioNetwork cause")
+	if len(fakeNAS.Calls) != 0 {
+		t.Errorf("NAS handler must not be invoked on ID mismatch, got %d calls", len(fakeNAS.Calls))
 	}
+}
 
-	if cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
-		t.Errorf("cause = %d, want InconsistentRemoteUENGAPID (%d)",
-			cause.RadioNetwork.Value, ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID)
-	}
+// TestHandleUplinkNasTransport_InconsistentRanUeNgapID_SendsErrorIndication
+// covers TS 38.413 §10.6: a RAN UE NGAP ID different from the one stored for the
+// connection is an inconsistent remote AP ID, so the AMF answers with an Error
+// Indication carrying the received AP IDs and cause "Inconsistent remote UE NGAP
+// ID".
+func TestHandleUplinkNasTransport_InconsistentRanUeNgapID_SendsErrorIndication(t *testing.T) {
+	ran := newTestRadio()
+	sender := ran.NGAPSender.(*FakeNGAPSender)
+	fakeNAS := &FakeNASHandler{}
+	amfInstance := newTestAMFWithNAS(fakeNAS)
+
+	amf.NewRanUeForTest(ran, 1, 10, logger.AmfLog)
+
+	ngap.HandleUplinkNasTransport(context.Background(), amfInstance, ran, decode.UplinkNASTransport{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 2,
+		NASPDU:      []byte{0x7E, 0x00, 0x55},
+	})
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 10, 2)
 
 	if len(fakeNAS.Calls) != 0 {
 		t.Errorf("NAS handler must not be invoked on ID mismatch, got %d calls", len(fakeNAS.Calls))

--- a/internal/amf/ngap/resolve_ue.go
+++ b/internal/amf/ngap/resolve_ue.go
@@ -9,32 +9,34 @@ import (
 	"go.uber.org/zap"
 )
 
-// resolveUE looks up a UE context scoped to the sending radio, following
-// TS 38.413 clause 10.6 (Handling of AP ID).
+// resolveUE looks up a UE context on the sending radio per TS 38.413 clause
+// 10.6 (Handling of AP ID). At the AMF the local AP ID is the AMF UE NGAP ID and
+// the remote AP ID is the RAN UE NGAP ID, so the connection is identified by the
+// AMF UE NGAP ID and the RAN UE NGAP ID is then cross-checked.
 //
-// When both IDs are present it looks up by RAN-UE-NGAP-ID (scoped to the
-// sender) and cross-checks AMF-UE-NGAP-ID. When only AMF-UE-NGAP-ID is
-// present it looks up by that ID, still scoped to the sender.
+//   - An AMF UE NGAP ID the AMF does not hold is an unknown local AP ID.
+//   - A RAN UE NGAP ID different from the stored one is an inconsistent remote
+//     AP ID.
 //
-// On any mismatch an Error Indication is sent to the sender and the
-// function returns (nil, false).
+// On either error an Error Indication carrying the received AP IDs is sent to
+// the sender (clause 10.6, clause 8.7.5.2) and the function returns (nil, false).
 func resolveUE(ctx context.Context, ran *amf.Radio, ranID *int64, amfID *int64) (*amf.RanUe, bool) {
-	if ranID != nil {
-		ranUe := ran.FindUEByRanUeNgapID(*ranID)
+	if amfID != nil {
+		ranUe := ran.FindUEByAmfUeNgapID(*amfID)
 		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("No UE context for RAN-UE-NGAP-ID on this radio",
-				zap.Int64("RanUeNgapID", *ranID))
-			sendUnknownLocalUEError(ctx, ran)
+			logger.WithTrace(ctx, ran.Log).Warn("Unknown local AMF-UE-NGAP-ID on this radio",
+				zap.Int64("AmfUeNgapID", *amfID))
+			sendUnknownLocalUEError(ctx, ran, amfID, ranID)
 
 			return nil, false
 		}
 
-		if amfID != nil && ranUe.AmfUeNgapID != *amfID {
-			logger.WithTrace(ctx, ran.Log).Warn("Inconsistent AMF-UE-NGAP-ID",
-				zap.Int64("RanUeNgapID", *ranID),
-				zap.Int64("storedAmfUeNgapID", ranUe.AmfUeNgapID),
-				zap.Int64("receivedAmfUeNgapID", *amfID))
-			sendInconsistentRemoteUEError(ctx, ran)
+		if ranID != nil && ranUe.RanUeNgapID != *ranID {
+			logger.WithTrace(ctx, ran.Log).Warn("Inconsistent remote RAN-UE-NGAP-ID",
+				zap.Int64("AmfUeNgapID", *amfID),
+				zap.Int64("storedRanUeNgapID", ranUe.RanUeNgapID),
+				zap.Int64("receivedRanUeNgapID", *ranID))
+			sendInconsistentRemoteUEError(ctx, ran, amfID, ranID)
 
 			return nil, false
 		}
@@ -42,12 +44,12 @@ func resolveUE(ctx context.Context, ran *amf.Radio, ranID *int64, amfID *int64) 
 		return ranUe, true
 	}
 
-	if amfID != nil {
-		ranUe := ran.FindUEByAmfUeNgapID(*amfID)
+	if ranID != nil {
+		ranUe := ran.FindUEByRanUeNgapID(*ranID)
 		if ranUe == nil {
-			logger.WithTrace(ctx, ran.Log).Warn("No UE context for AMF-UE-NGAP-ID on this radio",
-				zap.Int64("AmfUeNgapID", *amfID))
-			sendUnknownLocalUEError(ctx, ran)
+			logger.WithTrace(ctx, ran.Log).Warn("Unknown remote RAN-UE-NGAP-ID on this radio",
+				zap.Int64("RanUeNgapID", *ranID))
+			sendInconsistentRemoteUEError(ctx, ran, amfID, ranID)
 
 			return nil, false
 		}
@@ -58,7 +60,7 @@ func resolveUE(ctx context.Context, ran *amf.Radio, ranID *int64, amfID *int64) 
 	return nil, false
 }
 
-func sendUnknownLocalUEError(ctx context.Context, ran *amf.Radio) {
+func sendUnknownLocalUEError(ctx context.Context, ran *amf.Radio, amfID, ranID *int64) {
 	cause := ngapType.Cause{
 		Present: ngapType.CausePresentRadioNetwork,
 		RadioNetwork: &ngapType.CauseRadioNetwork{
@@ -66,13 +68,13 @@ func sendUnknownLocalUEError(ctx context.Context, ran *amf.Radio) {
 		},
 	}
 
-	err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
+	err := ran.NGAPSender.SendErrorIndication(ctx, amfID, ranID, &cause, nil)
 	if err != nil {
 		logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
 	}
 }
 
-func sendInconsistentRemoteUEError(ctx context.Context, ran *amf.Radio) {
+func sendInconsistentRemoteUEError(ctx context.Context, ran *amf.Radio, amfID, ranID *int64) {
 	cause := ngapType.Cause{
 		Present: ngapType.CausePresentRadioNetwork,
 		RadioNetwork: &ngapType.CauseRadioNetwork{
@@ -80,7 +82,7 @@ func sendInconsistentRemoteUEError(ctx context.Context, ran *amf.Radio) {
 		},
 	}
 
-	err := ran.NGAPSender.SendErrorIndication(ctx, &cause, nil)
+	err := ran.NGAPSender.SendErrorIndication(ctx, amfID, ranID, &cause, nil)
 	if err != nil {
 		logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
 	}

--- a/internal/amf/ngap/resolve_ue_test.go
+++ b/internal/amf/ngap/resolve_ue_test.go
@@ -13,8 +13,44 @@ import (
 	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/amf/sctp"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/aper"
 	"github.com/free5gc/ngap/ngapType"
 )
+
+// assertSingleErrorIndication checks that exactly one Error Indication was sent
+// with the given radio-network cause, and returns it.
+func assertSingleErrorIndication(t *testing.T, sender *FakeNGAPSender, wantCause aper.Enumerated) *ErrorIndication {
+	t.Helper()
+
+	if len(sender.SentErrorIndications) != 1 {
+		t.Fatalf("ErrorIndications sent = %d, want 1", len(sender.SentErrorIndications))
+	}
+
+	errInd := sender.SentErrorIndications[0]
+	if errInd.Cause == nil || errInd.Cause.Present != ngapType.CausePresentRadioNetwork {
+		t.Fatalf("expected RadioNetwork cause, got %+v", errInd.Cause)
+	}
+
+	if errInd.Cause.RadioNetwork.Value != wantCause {
+		t.Errorf("cause = %d, want %d", errInd.Cause.RadioNetwork.Value, wantCause)
+	}
+
+	return errInd
+}
+
+// assertErrorIndicationEchoesIDs checks the Error Indication carries the received
+// AP IDs (TS 38.413 §8.7.5.2, §10.6).
+func assertErrorIndicationEchoesIDs(t *testing.T, errInd *ErrorIndication, wantAmf, wantRan int64) {
+	t.Helper()
+
+	if errInd.AmfUeNgapID == nil || *errInd.AmfUeNgapID != wantAmf {
+		t.Errorf("Error Indication AMF UE NGAP ID = %v, want %d", errInd.AmfUeNgapID, wantAmf)
+	}
+
+	if errInd.RanUeNgapID == nil || *errInd.RanUeNgapID != wantRan {
+		t.Errorf("Error Indication RAN UE NGAP ID = %v, want %d", errInd.RanUeNgapID, wantRan)
+	}
+}
 
 // setupCrossRadioScenario creates:
 //   - legitimateRan: the radio the UE is actually registered on
@@ -193,15 +229,13 @@ func TestCrossRadio_HandoverFailure(t *testing.T) {
 	}
 }
 
-// TestCrossRadio_InconsistentAmfUeNgapID verifies that when the RAN-UE-NGAP-ID
-// matches but the AMF-UE-NGAP-ID does not, an InconsistentRemoteUENGAPID error
-// is sent back.
-func TestCrossRadio_InconsistentAmfUeNgapID(t *testing.T) {
+// TestResolveUE_UnknownAmfUeNgapID verifies that an AMF UE NGAP ID the AMF never
+// allocated is reported as an unknown local AP ID (TS 38.413 §10.6), with the
+// received AP IDs echoed back.
+func TestResolveUE_UnknownAmfUeNgapID(t *testing.T) {
 	legitimateRan, _, _, amfInstance := setupCrossRadioScenario(t)
 	sender := legitimateRan.NGAPSender.(*FakeNGAPSender)
 
-	// RAN-UE-NGAP-ID=1 exists on legitimateRan with AMF-UE-NGAP-ID=10,
-	// but we claim AMF-UE-NGAP-ID=999.
 	ranID := int64(1)
 	wrongAmfID := int64(999)
 	ngap.HandlePDUSessionResourceSetupResponse(context.Background(), amfInstance, legitimateRan, decode.PDUSessionResourceSetupResponse{
@@ -209,11 +243,24 @@ func TestCrossRadio_InconsistentAmfUeNgapID(t *testing.T) {
 		AMFUENGAPID: &wrongAmfID,
 	})
 
-	if len(sender.SentErrorIndications) != 1 {
-		t.Fatalf("expected 1 ErrorIndication, got %d", len(sender.SentErrorIndications))
-	}
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 999, 1)
+}
 
-	if sender.SentErrorIndications[0].Cause.RadioNetwork.Value != ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID {
-		t.Errorf("expected InconsistentRemoteUENGAPID, got %d", sender.SentErrorIndications[0].Cause.RadioNetwork.Value)
-	}
+// TestResolveUE_InconsistentRanUeNgapID verifies that a known AMF UE NGAP ID with
+// a RAN UE NGAP ID different from the stored one is reported as an inconsistent
+// remote AP ID (TS 38.413 §10.6), with the received AP IDs echoed back.
+func TestResolveUE_InconsistentRanUeNgapID(t *testing.T) {
+	legitimateRan, _, _, amfInstance := setupCrossRadioScenario(t)
+	sender := legitimateRan.NGAPSender.(*FakeNGAPSender)
+
+	amfID := int64(10)
+	wrongRanID := int64(2)
+	ngap.HandlePDUSessionResourceSetupResponse(context.Background(), amfInstance, legitimateRan, decode.PDUSessionResourceSetupResponse{
+		RANUENGAPID: &wrongRanID,
+		AMFUENGAPID: &amfID,
+	})
+
+	errInd := assertSingleErrorIndication(t, sender, ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID)
+	assertErrorIndicationEchoesIDs(t, errInd, 10, 2)
 }

--- a/internal/amf/ngap/send/build.go
+++ b/internal/amf/ngap/send/build.go
@@ -193,7 +193,7 @@ func buildNGResetAcknowledge(partOfNGInterface *ngapType.UEAssociatedLogicalNGCo
 	return ngap.Encoder(pdu)
 }
 
-func buildErrorIndication(cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) ([]byte, error) {
+func buildErrorIndication(amfUeNgapID, ranUeNgapID *int64, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) ([]byte, error) {
 	var pdu ngapType.NGAPPDU
 
 	pdu.Present = ngapType.NGAPPDUPresentInitiatingMessage
@@ -212,6 +212,26 @@ func buildErrorIndication(cause *ngapType.Cause, criticalityDiagnostics *ngapTyp
 	if cause == nil && criticalityDiagnostics == nil {
 		logger.AmfLog.Error(
 			"[Build Error Indication] shall contain at least either the Cause or the Criticality Diagnostics")
+	}
+
+	if amfUeNgapID != nil {
+		ie := ngapType.ErrorIndicationIEs{}
+		ie.Id.Value = ngapType.ProtocolIEIDAMFUENGAPID
+		ie.Criticality.Value = ngapType.CriticalityPresentIgnore
+		ie.Value.Present = ngapType.ErrorIndicationIEsPresentAMFUENGAPID
+		ie.Value.AMFUENGAPID = &ngapType.AMFUENGAPID{Value: *amfUeNgapID}
+
+		errorIndicationIEs.List = append(errorIndicationIEs.List, ie)
+	}
+
+	if ranUeNgapID != nil {
+		ie := ngapType.ErrorIndicationIEs{}
+		ie.Id.Value = ngapType.ProtocolIEIDRANUENGAPID
+		ie.Criticality.Value = ngapType.CriticalityPresentIgnore
+		ie.Value.Present = ngapType.ErrorIndicationIEsPresentRANUENGAPID
+		ie.Value.RANUENGAPID = &ngapType.RANUENGAPID{Value: *ranUeNgapID}
+
+		errorIndicationIEs.List = append(errorIndicationIEs.List, ie)
 	}
 
 	if cause != nil {

--- a/internal/amf/ngap/send/send.go
+++ b/internal/amf/ngap/send/send.go
@@ -122,8 +122,8 @@ func (s *RealNGAPSender) SendNGResetAcknowledge(ctx context.Context, partOfNGInt
 	return nil
 }
 
-func (s *RealNGAPSender) SendErrorIndication(ctx context.Context, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
-	pkt, err := buildErrorIndication(cause, criticalityDiagnostics)
+func (s *RealNGAPSender) SendErrorIndication(ctx context.Context, amfUeNgapID, ranUeNgapID *int64, cause *ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
+	pkt, err := buildErrorIndication(amfUeNgapID, ranUeNgapID, cause, criticalityDiagnostics)
 	if err != nil {
 		return fmt.Errorf("error building error indication: %s", err.Error())
 	}

--- a/internal/amf/producer/n1n2message_test.go
+++ b/internal/amf/producer/n1n2message_test.go
@@ -48,7 +48,7 @@ func (f *fakeNGAPSender) SendNGResetAcknowledge(context.Context, *ngapType.UEAss
 	return nil
 }
 
-func (f *fakeNGAPSender) SendErrorIndication(context.Context, *ngapType.Cause, *ngapType.CriticalityDiagnostics) error {
+func (f *fakeNGAPSender) SendErrorIndication(context.Context, *int64, *int64, *ngapType.Cause, *ngapType.CriticalityDiagnostics) error {
 	return nil
 }
 


### PR DESCRIPTION
# Description

Ella Core returns the correct UE NGAP ID's in error indication messages.

## Reference
- https://www.etsi.org/deliver/etsi_ts/138400_138499/138413/18.05.00_60/ts_138413v180500p.pdf

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
