### PR TITLE
feat: Changes to DNN impact active sessions

### DIFF
--- a/internal/amf/producer/n1n2message.go
+++ b/internal/amf/producer/n1n2message.go
@@ -156,15 +156,23 @@ func storeN1N2AndPage(ctx context.Context, amfInstance *amf.AMF, ue *amf.AmfUe, 
 	return nil
 }
 
-// ModifyN1N2Message sends a PDUSessionResourceModifyRequest to the gNB,
-// carrying the N1 NAS PDU (PDU Session Modification Command) piggybacked
-// in the per-session modify item, and the N2 transfer (PDU Session Resource
-// Modify Request Transfer) as the opaque transfer blob.
-// This implements TS 23.502 §4.3.3.2 step 3 (AMF→gNB).
+// ModifyN1N2Message delivers a PDU Session Modification Command (N1) to the
+// UE, optionally accompanied by a PDU Session Resource Modify Request (N2) to
+// the gNB when radio-resource changes are needed.
+//
+// When n2Msg is nil (e.g. DNS-only change carried in Extended PCO), the NAS
+// message is delivered transparently via Downlink NAS Transport (TS 38.413
+// §8.6.2) — no gNB resource modification is required.
+//
+// When n2Msg is present (AMBR/QoS changes), the AMF sends a
+// PDUSessionResourceModifyRequest (TS 38.413 §9.2.1.5) which carries both the
+// N1 NAS PDU and the mandatory N2 transfer IE for the gNB.
+//
+// This implements TS 23.502 §4.3.3.2 steps 3–5.
 func ModifyN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error {
 	ctx, span := tracer.Start(
 		ctx,
-		"AMF PDUSessionResourceModifyRequest",
+		"AMF PDUSessionModification",
 		trace.WithAttributes(
 			attribute.String("supi", supi.String()),
 			attribute.Int("pdu_session_id", int(pduSessionID)),
@@ -194,7 +202,24 @@ func ModifyN1N2Message(ctx context.Context, amfInstance *amf.AMF, supi etsi.SUPI
 		return fmt.Errorf("build DL NAS Transport error: %v", err)
 	}
 
-	// Construct the modify list with a single session item.
+	if n2Msg == nil {
+		// N1-only delivery (e.g. DNS update via Extended PCO).
+		// Per TS 23.502 §4.3.3.2: "When the SMF sends the PDU Session
+		// Modification Command transparently through NG-RAN, the N2 SM
+		// information is not included." The RAN forwards the NAS PDU to
+		// the UE without modifying any radio resources.
+		if err := ranUe.SendDownlinkNasTransport(ctx, nasPdu, nil); err != nil {
+			return fmt.Errorf("send downlink NAS transport: %w", err)
+		}
+
+		ue.Log.Info("Sent DL NAS Transport (N1-only session modification) to gNB")
+
+		return nil
+	}
+
+	// N1+N2 delivery: gNB resource modification required (AMBR/QoS change).
+	// The PDUSessionResourceModifyRequestTransfer IE is mandatory per
+	// TS 38.413 §9.2.1.5, so this path must only be taken when n2Msg is set.
 	list := ngapType.PDUSessionResourceModifyListModReq{
 		List: []ngapType.PDUSessionResourceModifyItemModReq{
 			{

--- a/internal/amf/session_reconciler.go
+++ b/internal/amf/session_reconciler.go
@@ -200,10 +200,19 @@ func (r *SessionReconciler) fetchSessionPolicy(smContextRef string) (*models.Ses
 		return nil, models.ReconcileSkip
 	}
 
+	dnsStr := ""
+	if policy.DNS != nil {
+		dnsStr = policy.DNS.String()
+	}
+
 	delta := &models.SessionPolicyDelta{
 		SessionAmbrUplink:   policy.Ambr.Uplink,
 		SessionAmbrDownlink: policy.Ambr.Downlink,
 		Var5qi:              policy.QosData.Var5qi,
+		DNS:                 dnsStr,
+		MTU:                 policy.MTU,
+		IPv4Pool:            policy.IPv4Pool,
+		IPv6Pool:            policy.IPv6Pool,
 	}
 	if policy.QosData.Arp != nil {
 		delta.Arp = policy.QosData.Arp.PriorityLevel

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -81,9 +81,9 @@ var (
 
 // Data networks
 var (
-	opCreateDataNetwork = registerChangesetOp("CreateDataNetwork", (*Database).applyCreateDataNetwork, AffectsTopic(TopicDataNetworks))
-	opUpdateDataNetwork = registerChangesetOp("UpdateDataNetwork", (*Database).applyUpdateDataNetwork, AffectsTopic(TopicDataNetworks))
-	opDeleteDataNetwork = registerChangesetOp("DeleteDataNetwork", (*Database).applyDeleteDataNetwork, AffectsTopic(TopicDataNetworks))
+	opCreateDataNetwork = registerChangesetOp("CreateDataNetwork", (*Database).applyCreateDataNetwork, AffectsTopic(TopicDataNetworks), AffectsTopic(TopicSessionReconcile))
+	opUpdateDataNetwork = registerChangesetOp("UpdateDataNetwork", (*Database).applyUpdateDataNetwork, AffectsTopic(TopicDataNetworks), AffectsTopic(TopicSessionReconcile))
+	opDeleteDataNetwork = registerChangesetOp("DeleteDataNetwork", (*Database).applyDeleteDataNetwork, AffectsTopic(TopicDataNetworks), AffectsTopic(TopicSessionReconcile))
 )
 
 // Policies

--- a/internal/models/session_reconcile.go
+++ b/internal/models/session_reconcile.go
@@ -34,4 +34,8 @@ type SessionPolicyDelta struct {
 	Arp                 int32
 	PreemptCap          PreemptionCapability
 	PreemptVuln         PreemptionVulnerability
+	DNS                 string // DNS server IP address (from data network)
+	MTU                 uint16 // MTU for the PDU session (from data network)
+	IPv4Pool            string // IPv4 pool CIDR (from data network)
+	IPv6Pool            string // IPv6 prefix delegation pool CIDR (from data network)
 }

--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -1168,12 +1168,12 @@ func TestReconcileSmContext_UsesNewPolicyForPFCPAndN1N2(t *testing.T) {
 	call := amfCb.modifyCalls[0]
 	amfCb.mu.Unlock()
 
-	oldPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "100 Mbps", Downlink: "200 Mbps"}, &models.QosData{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 1}, QFI: 1})
+	oldPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "100 Mbps", Downlink: "200 Mbps"}, &models.QosData{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 1}, QFI: 1}, nil)
 	if err != nil {
 		t.Fatalf("build old policy modification command: %v", err)
 	}
 
-	newPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "200 Mbps", Downlink: "300 Mbps"}, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1})
+	newPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "200 Mbps", Downlink: "300 Mbps"}, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1}, nil)
 	if err != nil {
 		t.Fatalf("build new policy modification command: %v", err)
 	}
@@ -1222,7 +1222,7 @@ func TestReconcileSmContext_AmbrOnly(t *testing.T) {
 		t.Fatalf("QER MBR = %d/%d, want 300000/400000", qer.MBR.ULMBR, qer.MBR.DLMBR)
 	}
 
-	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "300 Mbps", Downlink: "400 Mbps"}, nil)
+	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: "300 Mbps", Downlink: "400 Mbps"}, nil, nil)
 	if err != nil {
 		t.Fatalf("build expected N1: %v", err)
 	}
@@ -1259,7 +1259,7 @@ func TestReconcileSmContext_QoSOnly(t *testing.T) {
 		t.Fatalf("QER MBR = %d/%d, want 100000/200000", qer.MBR.ULMBR, qer.MBR.DLMBR)
 	}
 
-	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, nil, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1})
+	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, nil, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1}, nil)
 	if err != nil {
 		t.Fatalf("build expected N1: %v", err)
 	}
@@ -1402,6 +1402,309 @@ func TestReconcileSmContext_ReleaseIdleUE_RemovesSession(t *testing.T) {
 	if deleteCalls == 0 {
 		t.Fatal("expected PFCP deletion during idle-UE release")
 	}
+}
+
+// TestReconcileSmContext_DNSChange verifies that a DNS change triggers a PDU
+// Session Modification Command carrying the new DNS in Extended PCO (TS 24.501
+// §6.3.2), without releasing the session.
+func TestReconcileSmContext_DNSChange(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "100 Mbps",
+			SessionAmbrDownlink: "200 Mbps",
+			Var5qi:              9,
+			Arp:                 1,
+			DNS:                 "8.8.4.4",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	// No PFCP modify should be called for DNS-only change.
+	upf.mu.Lock()
+	if len(upf.modifyCalls) != 0 {
+		upf.mu.Unlock()
+		t.Fatalf("expected 0 PFCP modify calls for DNS-only change, got %d", len(upf.modifyCalls))
+	}
+	upf.mu.Unlock()
+
+	// AMF ModifyN1N2 should have been called with DNS in PCO.
+	amfCb.mu.Lock()
+	if len(amfCb.modifyCalls) != 1 {
+		amfCb.mu.Unlock()
+		t.Fatalf("expected 1 N1N2 modify call, got %d", len(amfCb.modifyCalls))
+	}
+
+	call := amfCb.modifyCalls[0]
+	amfCb.mu.Unlock()
+
+	// N2 must be nil for DNS-only changes: no gNB resource modification is
+	// needed; the NAS message is delivered via DL NAS Transport per
+	// TS 23.502 §4.3.3.2.
+	if call.n2Msg != nil {
+		t.Fatalf("expected nil N2 message for DNS-only change, got %d bytes", len(call.n2Msg))
+	}
+
+	n1Payload := modificationSMPayload(t, call.n1Msg)
+
+	// Decode and verify Extended PCO contains DNS server IE.
+	msg := nas.NewMessage()
+	if err := msg.PlainNasDecode(&n1Payload); err != nil {
+		t.Fatalf("decode N1 modification command: %v", err)
+	}
+
+	if msg.PDUSessionModificationCommand == nil {
+		t.Fatal("PDUSessionModificationCommand is nil")
+	}
+
+	pco := msg.PDUSessionModificationCommand.ExtendedProtocolConfigurationOptions
+	if pco == nil {
+		t.Fatal("ExtendedProtocolConfigurationOptions is nil; DNS should be in PCO")
+	}
+
+	contents := pco.GetExtendedProtocolConfigurationOptionsContents()
+	if len(contents) == 0 {
+		t.Fatal("PCO contents is empty")
+	}
+
+	// Verify the session policy was updated with new DNS.
+	smCtx.Mutex.Lock()
+	if smCtx.PolicyData.DNS == nil || !smCtx.PolicyData.DNS.Equal(net.ParseIP("8.8.4.4")) {
+		smCtx.Mutex.Unlock()
+		t.Fatalf("expected DNS 8.8.4.4, got %v", smCtx.PolicyData.DNS)
+	}
+	smCtx.Mutex.Unlock()
+}
+
+// TestReconcileSmContext_InvalidDNS verifies that an invalid DNS address in the
+// new policy is rejected with an error rather than silently producing a nil IP.
+func TestReconcileSmContext_InvalidDNS(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "100 Mbps",
+			SessionAmbrDownlink: "200 Mbps",
+			Var5qi:              9,
+			Arp:                 1,
+			DNS:                 "not-a-valid-ip",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid DNS address, got nil")
+	}
+
+	// No PFCP or AMF calls should have been made.
+	upf.mu.Lock()
+	if len(upf.modifyCalls) != 0 {
+		upf.mu.Unlock()
+		t.Fatalf("expected 0 PFCP modify calls, got %d", len(upf.modifyCalls))
+	}
+	upf.mu.Unlock()
+
+	amfCb.mu.Lock()
+	if len(amfCb.modifyCalls) != 0 {
+		amfCb.mu.Unlock()
+		t.Fatalf("expected 0 AMF modify calls, got %d", len(amfCb.modifyCalls))
+	}
+	amfCb.mu.Unlock()
+}
+
+// TestReconcileSmContext_MTUChange verifies that an MTU change triggers a
+// session release with cause #39 (TS 23.501 §5.6.10.4 NOTE 3).
+func TestReconcileSmContext_MTUChange(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "100 Mbps",
+			SessionAmbrDownlink: "200 Mbps",
+			Var5qi:              9,
+			Arp:                 1,
+			MTU:                 1400,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	// Session should be removed from the pool after release.
+	if s.GetSession(ref) != nil {
+		t.Fatal("expected session to be removed after MTU-change release")
+	}
+
+	// IP addresses should have been released.
+	store.mu.Lock()
+	releasedIPs := len(store.releasedIPs)
+	store.mu.Unlock()
+
+	if releasedIPs == 0 {
+		t.Fatal("expected IP release during MTU-change release, got 0")
+	}
+
+	// PFCP session should have been deleted.
+	upf.mu.Lock()
+	deleteCalls := len(upf.deleteCalls)
+	upf.mu.Unlock()
+
+	if deleteCalls == 0 {
+		t.Fatal("expected PFCP session deletion during MTU-change release, got 0")
+	}
+
+	// AMF release signaling should have been sent.
+	amfCb.mu.Lock()
+	releaseCalls := len(amfCb.releaseCalls)
+	amfCb.mu.Unlock()
+
+	if releaseCalls != 1 {
+		t.Fatalf("expected 1 release signaling call, got %d", releaseCalls)
+	}
+}
+
+// TestReconcileSmContext_PoolChange verifies that an IP pool change triggers a
+// session release with cause #39.
+func TestReconcileSmContext_PoolChange(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "100 Mbps",
+			SessionAmbrDownlink: "200 Mbps",
+			Var5qi:              9,
+			Arp:                 1,
+			IPv4Pool:            "10.0.1.0/24",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	// Session should be removed from the pool after release.
+	if s.GetSession(ref) != nil {
+		t.Fatal("expected session to be removed after pool-change release")
+	}
+
+	// IP addresses should have been released.
+	store.mu.Lock()
+	releasedIPs := len(store.releasedIPs)
+	store.mu.Unlock()
+
+	if releasedIPs == 0 {
+		t.Fatal("expected IP release during pool-change release, got 0")
+	}
+
+	// PFCP session should have been deleted.
+	upf.mu.Lock()
+	deleteCalls := len(upf.deleteCalls)
+	upf.mu.Unlock()
+
+	if deleteCalls == 0 {
+		t.Fatal("expected PFCP session deletion during pool-change release, got 0")
+	}
+
+	// AMF release signaling should have been sent.
+	amfCb.mu.Lock()
+	releaseCalls := len(amfCb.releaseCalls)
+	amfCb.mu.Unlock()
+
+	if releaseCalls != 1 {
+		t.Fatalf("expected 1 release signaling call, got %d", releaseCalls)
+	}
+}
+
+// TestReconcileSmContext_DNSUnchanged verifies that no N1N2 call is made when
+// nothing in the delta actually changed.
+func TestReconcileSmContext_DNSUnchanged(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	// Send the same values that are already in the session (no actual change).
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "100 Mbps",
+			SessionAmbrDownlink: "200 Mbps",
+			Var5qi:              9,
+			Arp:                 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	// No session modification should be called when nothing changed.
+	amfCb.mu.Lock()
+	modifyCalls := len(amfCb.modifyCalls)
+	amfCb.mu.Unlock()
+
+	if modifyCalls != 0 {
+		t.Fatalf("expected 0 modify calls when nothing changed, got %d", modifyCalls)
+	}
+}
+
+// TestReconcileSmContext_DNSIdleUE verifies that DNS policy is committed even
+// when the UE is idle (N1N2 delivery skipped).
+func TestReconcileSmContext_DNSIdleUE(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	amfCb.err = smf.ErrUENotReachable
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+		NewPolicy: &models.SessionPolicyDelta{
+			SessionAmbrUplink:   "100 Mbps",
+			SessionAmbrDownlink: "200 Mbps",
+			Var5qi:              9,
+			Arp:                 1,
+			DNS:                 "1.1.1.1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileSmContext should succeed for idle UE, got: %v", err)
+	}
+
+	// Policy should have been committed despite N1N2 skip.
+	smCtx.Mutex.Lock()
+	if smCtx.PolicyData.DNS == nil || !smCtx.PolicyData.DNS.Equal(net.ParseIP("1.1.1.1")) {
+		smCtx.Mutex.Unlock()
+		t.Fatalf("policy not committed: DNS = %v", smCtx.PolicyData.DNS)
+	}
+	smCtx.Mutex.Unlock()
 }
 
 // ===========================

--- a/internal/smf/nas/build_pdu_session_modification_command.go
+++ b/internal/smf/nas/build_pdu_session_modification_command.go
@@ -5,9 +5,11 @@ package nas
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasConvert"
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/nas/nasType"
 )
@@ -16,11 +18,12 @@ import (
 // Command message (TS 24.501 clause 8.3.9). It includes:
 //   - Session-AMBR IE (when ambr is non-nil, clause 8.3.9.3)
 //   - Authorized QoS flow descriptions IE (when qosData is non-nil, clause 8.3.9.8)
+//   - Extended PCO with DNS server address(es) (when dns is non-nil, clause 6.3.2)
 //
-// At least one of ambr or qosData must be non-nil.
-func BuildPDUSessionModificationCommand(pduSessionID uint8, ambr *models.Ambr, qosData *models.QosData) ([]byte, error) {
-	if ambr == nil && qosData == nil {
-		return nil, fmt.Errorf("at least one of ambr or qosData must be provided")
+// At least one of ambr, qosData, or dns must be non-nil.
+func BuildPDUSessionModificationCommand(pduSessionID uint8, ambr *models.Ambr, qosData *models.QosData, dns net.IP) ([]byte, error) {
+	if ambr == nil && qosData == nil && dns == nil {
+		return nil, fmt.Errorf("at least one of ambr, qosData, or dns must be provided")
 	}
 
 	m := nas.NewMessage()
@@ -54,6 +57,29 @@ func BuildPDUSessionModificationCommand(pduSessionID uint8, ambr *models.Ambr, q
 		m.PDUSessionModificationCommand.AuthorizedQosFlowDescriptions = nasType.NewAuthorizedQosFlowDescriptions(nasMessage.PDUSessionModificationCommandAuthorizedQosFlowDescriptionsType)
 		m.PDUSessionModificationCommand.AuthorizedQosFlowDescriptions.SetLen(authQfd.IeLen)
 		m.PDUSessionModificationCommand.SetQoSFlowDescriptions(authQfd.Content)
+	}
+
+	// Extended PCO with DNS server address(es) (TS 24.501 clause 6.3.2)
+	if dns != nil {
+		m.PDUSessionModificationCommand.ExtendedProtocolConfigurationOptions = nasType.NewExtendedProtocolConfigurationOptions(
+			nasMessage.PDUSessionModificationCommandExtendedProtocolConfigurationOptionsType,
+		)
+		protocolConfigurationOptions := nasConvert.NewProtocolConfigurationOptions()
+
+		if dns.To4() != nil {
+			if err := protocolConfigurationOptions.AddDNSServerIPv4Address(dns); err != nil {
+				return nil, fmt.Errorf("encode DNS IPv4 address in PCO: %w", err)
+			}
+		} else {
+			if err := protocolConfigurationOptions.AddDNSServerIPv6Address(dns); err != nil {
+				return nil, fmt.Errorf("encode DNS IPv6 address in PCO: %w", err)
+			}
+		}
+
+		pcoContents := protocolConfigurationOptions.Marshal()
+		pcoContentsLength := len(pcoContents)
+		m.PDUSessionModificationCommand.ExtendedProtocolConfigurationOptions.SetLen(uint16(pcoContentsLength))
+		m.PDUSessionModificationCommand.SetExtendedProtocolConfigurationOptionsContents(pcoContents)
 	}
 
 	return m.PlainNasEncode()

--- a/internal/smf/nas/build_pdu_session_modification_command_test.go
+++ b/internal/smf/nas/build_pdu_session_modification_command_test.go
@@ -4,6 +4,7 @@
 package nas_test
 
 import (
+	"net"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/models"
@@ -23,7 +24,7 @@ func TestBuildPDUSessionModificationCommand_AmbrAndQoS(t *testing.T) {
 		Arp:    &models.Arp{PriorityLevel: 14},
 	}
 
-	encoded, err := smfNas.BuildPDUSessionModificationCommand(1, ambr, qosData)
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(1, ambr, qosData, nil)
 	if err != nil {
 		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestBuildPDUSessionModificationCommand_AmbrOnly(t *testing.T) {
 		Downlink: "400 Mbps",
 	}
 
-	encoded, err := smfNas.BuildPDUSessionModificationCommand(5, ambr, nil)
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(5, ambr, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestBuildPDUSessionModificationCommand_QoSOnly(t *testing.T) {
 		Arp:    &models.Arp{PriorityLevel: 10},
 	}
 
-	encoded, err := smfNas.BuildPDUSessionModificationCommand(3, nil, qosData)
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(3, nil, qosData, nil)
 	if err != nil {
 		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
 	}
@@ -128,5 +129,70 @@ func TestBuildPDUSessionModificationCommand_QoSOnly(t *testing.T) {
 
 	if modCmd.AuthorizedQosFlowDescriptions == nil {
 		t.Fatal("AuthorizedQosFlowDescriptions is nil; expected QoS-only modification to include it")
+	}
+}
+
+func TestBuildPDUSessionModificationCommand_WithDNS(t *testing.T) {
+	dns := net.ParseIP("8.8.8.8")
+
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(2, nil, nil, dns)
+	if err != nil {
+		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
+	}
+
+	m := new(nas.Message)
+	if err := m.PlainNasDecode(&encoded); err != nil {
+		t.Fatalf("PlainNasDecode failed: %v", err)
+	}
+
+	modCmd := m.PDUSessionModificationCommand
+	if modCmd == nil {
+		t.Fatal("PDUSessionModificationCommand is nil")
+	}
+
+	pco := modCmd.ExtendedProtocolConfigurationOptions
+	if pco == nil {
+		t.Fatal("ExtendedProtocolConfigurationOptions is nil; DNS should be in PCO")
+	}
+
+	contents := pco.GetExtendedProtocolConfigurationOptionsContents()
+	if len(contents) == 0 {
+		t.Fatal("PCO contents is empty")
+	}
+}
+
+func TestBuildPDUSessionModificationCommand_WithIPv6DNS(t *testing.T) {
+	dns := net.ParseIP("2001:4860:4860::8888")
+
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(4, nil, nil, dns)
+	if err != nil {
+		t.Fatalf("BuildPDUSessionModificationCommand failed: %v", err)
+	}
+
+	m := new(nas.Message)
+	if err := m.PlainNasDecode(&encoded); err != nil {
+		t.Fatalf("PlainNasDecode failed: %v", err)
+	}
+
+	modCmd := m.PDUSessionModificationCommand
+	if modCmd == nil {
+		t.Fatal("PDUSessionModificationCommand is nil")
+	}
+
+	pco := modCmd.ExtendedProtocolConfigurationOptions
+	if pco == nil {
+		t.Fatal("ExtendedProtocolConfigurationOptions is nil; DNS should be in PCO")
+	}
+
+	contents := pco.GetExtendedProtocolConfigurationOptionsContents()
+	if len(contents) == 0 {
+		t.Fatal("PCO contents is empty")
+	}
+}
+
+func TestBuildPDUSessionModificationCommand_AllNil(t *testing.T) {
+	_, err := smfNas.BuildPDUSessionModificationCommand(1, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when all inputs are nil")
 	}
 }

--- a/internal/smf/reconcile.go
+++ b/internal/smf/reconcile.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
@@ -28,9 +29,14 @@ import (
 // cause #39 "reactivation requested" (TS 24.501 table 11.4.2.1) so the UE
 // re-establishes on the correct slice.
 //
-// For QoS/AMBR changes this implements the 3GPP network-requested PDU Session
+// For QoS/AMBR/DNS changes this implements the 3GPP network-requested PDU Session
 // Modification procedure (TS 23.502 clause 4.3.3.2) triggered by an
 // OAM-initiated policy update.
+//
+// For MTU or IP pool changes the session is released with cause #39 so the UE
+// re-establishes with the updated configuration (TS 23.501 §5.6.10.4 does not
+// address dynamic MTU adjustment; IP pools have no in-place modification
+// mechanism).
 func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error {
 	if req == nil {
 		return fmt.Errorf("reconcile request is nil")
@@ -86,12 +92,41 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 		return s.sendSessionRelease(ctx, smContext)
 	}
 
-	// --- QoS/AMBR modification path ---
+	// --- MTU or IP pool change: network-initiated release ---
+	// Per TS 23.501 §5.6.10.4 NOTE 3, dynamic MTU adjustment during an active
+	// session is not addressed. IP pool changes would invalidate already-
+	// assigned addresses. Release with cause #39 so the UE re-establishes.
+	//
+	// Zero/empty values in the delta are treated as "not specified" (unchanged)
+	// to avoid spurious releases when the caller provides a partial delta.
+	if req.NewPolicy != nil {
+		mtuChanged := req.NewPolicy.MTU != 0 && smContext.PolicyData.MTU != req.NewPolicy.MTU
+		ipv4PoolChanged := req.NewPolicy.IPv4Pool != "" && smContext.PolicyData.IPv4Pool != req.NewPolicy.IPv4Pool
+		ipv6PoolChanged := req.NewPolicy.IPv6Pool != "" && smContext.PolicyData.IPv6Pool != req.NewPolicy.IPv6Pool
+
+		if mtuChanged || ipv4PoolChanged || ipv6PoolChanged {
+			logger.SmfLog.Info("MTU or IP pool changed, releasing session for re-establishment",
+				logger.SUPI(smContext.Supi.String()),
+				logger.PDUSessionID(smContext.PDUSessionID),
+				zap.Uint16("oldMTU", smContext.PolicyData.MTU),
+				zap.Uint16("newMTU", req.NewPolicy.MTU),
+				zap.String("oldIPv4Pool", smContext.PolicyData.IPv4Pool),
+				zap.String("newIPv4Pool", req.NewPolicy.IPv4Pool),
+				zap.String("oldIPv6Pool", smContext.PolicyData.IPv6Pool),
+				zap.String("newIPv6Pool", req.NewPolicy.IPv6Pool),
+			)
+
+			return s.sendSessionRelease(ctx, smContext)
+		}
+	}
+
+	// --- QoS/AMBR/DNS modification path ---
 	oldQoS := smContext.PolicyData.QosData
 	oldAmbr := smContext.PolicyData.Ambr
 
 	hasQoSChange := false
 	hasAmbrChange := false
+	hasDNSChange := false
 
 	if req.NewPolicy != nil {
 		oldArp := int32(0)
@@ -106,10 +141,27 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 		if oldAmbr.Uplink != req.NewPolicy.SessionAmbrUplink || oldAmbr.Downlink != req.NewPolicy.SessionAmbrDownlink {
 			hasAmbrChange = true
 		}
+
+		oldDNS := ""
+		if smContext.PolicyData.DNS != nil {
+			oldDNS = smContext.PolicyData.DNS.String()
+		}
+
+		if req.NewPolicy.DNS != "" && oldDNS != req.NewPolicy.DNS {
+			hasDNSChange = true
+		}
 	}
 
 	newPolicy := smContext.PolicyData
-	if (hasQoSChange || hasAmbrChange) && req.NewPolicy != nil {
+	if (hasQoSChange || hasAmbrChange || hasDNSChange) && req.NewPolicy != nil {
+		dns := smContext.PolicyData.DNS
+		if hasDNSChange {
+			dns = net.ParseIP(req.NewPolicy.DNS)
+			if dns == nil {
+				return fmt.Errorf("invalid DNS address %q in new policy", req.NewPolicy.DNS)
+			}
+		}
+
 		newPolicy = &Policy{
 			PolicyID: smContext.PolicyData.PolicyID,
 			Ambr: models.Ambr{
@@ -126,7 +178,7 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 				},
 			},
 			NetworkRules: smContext.PolicyData.NetworkRules,
-			DNS:          smContext.PolicyData.DNS,
+			DNS:          dns,
 			MTU:          smContext.PolicyData.MTU,
 			IPv4Pool:     smContext.PolicyData.IPv4Pool,
 			IPv6Pool:     smContext.PolicyData.IPv6Pool,
@@ -160,16 +212,17 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 
 	// Send N1 (NAS) + N2 (NGAP) messages to notify the UE and gNB of changes.
 	// Per TS 23.502 clause 4.3.3.2, the SMF sends:
-	//   - N1: PDU Session Modification Command (Session-AMBR, QoS flow descriptions)
-	//   - N2: PDU Session Resource Modify Request Transfer (PDU Session Aggregate
-	//     Maximum Bit Rate, QoS Flow Add or Modify Request List with QoS profile)
+	//   - N1: PDU Session Modification Command (Session-AMBR, QoS flow
+	//     descriptions, DNS server addresses via Extended PCO)
+	//   - N2: PDU Session Resource Modify Request Transfer (PDU Session
+	//     Aggregate Maximum Bit Rate, QoS Flow Add or Modify Request List)
 	//
 	// If the UE is in CM-IDLE, N1N2 delivery is skipped (per TS 23.502 §4.2.3.3
 	// step 3b: the AMF may ignore the N2 SM information when the UE is not
 	// reachable). The policy is still committed so that ActivateSmContext
 	// returns updated QoS when the UE transitions back to CM-CONNECTED.
-	if (hasAmbrChange || hasQoSChange) && req.NewPolicy != nil {
-		if err := s.sendSessionModification(ctx, smContext, newPolicy, hasAmbrChange, hasQoSChange); err != nil {
+	if (hasAmbrChange || hasQoSChange || hasDNSChange) && req.NewPolicy != nil {
+		if err := s.sendSessionModification(ctx, smContext, newPolicy, hasAmbrChange, hasQoSChange, hasDNSChange); err != nil {
 			if errors.Is(err, ErrUENotReachable) {
 				logger.SmfLog.Debug("UE is idle, skipping N1N2 delivery; policy committed for next activation",
 					logger.SUPI(smContext.Supi.String()),
@@ -194,7 +247,7 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 	// (UE idle) — this is intentional: ActivateSmContext rebuilds the Setup
 	// Transfer from PolicyData, so the UE gets updated QoS on reconnect.
 	// If PFCP or a real N1/N2 failure returned above, we never reach here.
-	if (hasQoSChange || hasAmbrChange) && req.NewPolicy != nil {
+	if (hasQoSChange || hasAmbrChange || hasDNSChange) && req.NewPolicy != nil {
 		smContext.PolicyData = newPolicy
 	}
 
@@ -205,13 +258,17 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 // requested PDU Session Modification (TS 23.502 §4.3.3.2).
 //
 // N1 (to UE): PDU Session Modification Command containing:
-//   - Session-AMBR (when AMBR changed, TS 24.501 §8.3.9.3)
-//   - Authorized QoS flow descriptions (when 5QI/ARP changed, TS 24.501 §8.3.9.8)
+//   - Session-AMBR IE (when ambr changed, TS 24.501 §8.3.9.3)
+//   - Authorized QoS flow descriptions IE (when 5QI/ARP changed, TS 24.501 §8.3.9.8)
+//   - Extended PCO with DNS server address(es) (when DNS changed, TS 24.501 §6.3.2)
 //
 // N2 (to gNB): PDU Session Resource Modify Request Transfer containing:
 //   - PDU Session Aggregate Maximum Bit Rate (when AMBR changed)
 //   - QoS Flow Add or Modify Request List (when 5QI/ARP changed)
-func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext, policy *Policy, hasAmbrChange, hasQoSChange bool) error {
+//
+// When only DNS changes (no AMBR/QoS), only N1 is sent since DNS is a NAS-level
+// parameter that does not affect the gNB.
+func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext, policy *Policy, hasAmbrChange, hasQoSChange, hasDNSChange bool) error {
 	// Build N1 NAS message.
 	var n1Ambr *models.Ambr
 	if hasAmbrChange {
@@ -223,30 +280,40 @@ func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext,
 		n1QoS = &policy.QosData
 	}
 
-	n1Msg, err := nas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, n1Ambr, n1QoS)
+	var n1DNS net.IP
+	if hasDNSChange && policy.DNS != nil {
+		n1DNS = policy.DNS
+	}
+
+	n1Msg, err := nas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, n1Ambr, n1QoS, n1DNS)
 	if err != nil {
 		return fmt.Errorf("build PDU Session Modification Command (N1): %w", err)
 	}
 
-	// Build N2 NGAP message.
-	var n2Ambr *models.Ambr
-	if hasAmbrChange {
-		n2Ambr = &policy.Ambr
+	// Build N2 NGAP message only when AMBR or QoS changed.
+	// DNS is carried in the NAS Extended PCO and does not require N2 signaling.
+	var n2Msg []byte
+
+	if hasAmbrChange || hasQoSChange {
+		var n2Ambr *models.Ambr
+		if hasAmbrChange {
+			n2Ambr = &policy.Ambr
+		}
+
+		var n2QoS *models.QosData
+		if hasQoSChange {
+			n2QoS = &policy.QosData
+		}
+
+		n2Msg, err = ngap.BuildPDUSessionResourceModifyRequestTransfer(n2Ambr, n2QoS)
+		if err != nil {
+			return fmt.Errorf("build PDU Session Resource Modify Request Transfer (N2): %w", err)
+		}
 	}
 
-	var n2QoS *models.QosData
-	if hasQoSChange {
-		n2QoS = &policy.QosData
-	}
-
-	n2Msg, err := ngap.BuildPDUSessionResourceModifyRequestTransfer(n2Ambr, n2QoS)
-	if err != nil {
-		return fmt.Errorf("build PDU Session Resource Modify Request Transfer (N2): %w", err)
-	}
-
-	// Deliver combined N1+N2 via the AMF. The AMF will send a
-	// PDUSessionResourceModifyRequest (TS 38.413 §9.2.1.5) to the gNB,
-	// carrying the NAS PDU piggy-backed in the per-session modify item.
+	// Deliver combined N1+N2 (or N1-only for DNS changes) via the AMF.
+	// The AMF will send a PDUSessionResourceModifyRequest (TS 38.413 §9.2.1.5)
+	// to the gNB, carrying the NAS PDU piggy-backed in the per-session modify item.
 	if err := s.amf.ModifyN1N2(ctx, smContext.Supi, smContext.PDUSessionID, n1Msg, n2Msg); err != nil {
 		return fmt.Errorf("transfer N1N2 message: %w", err)
 	}
@@ -256,6 +323,7 @@ func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext,
 		logger.PDUSessionID(smContext.PDUSessionID),
 		zap.Bool("ambrChange", hasAmbrChange),
 		zap.Bool("qosChange", hasQoSChange),
+		zap.Bool("dnsChange", hasDNSChange),
 	)
 
 	return nil

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -116,9 +116,12 @@ type AMFCallback interface {
 	// TransferN1N2 delivers a combined N1+N2 message for PDU Session Setup.
 	TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) error
 
-	// ModifyN1N2 delivers N1 (NAS PDU Session Modification Command) + N2
-	// (PDU Session Resource Modify Request Transfer) to the UE/gNB via the
-	// NGAP PDUSessionResourceModifyRequest procedure (TS 38.413 §9.2.1.5).
+	// ModifyN1N2 delivers a PDU Session Modification Command (N1) to the UE.
+	// When n2Msg is non-nil (AMBR/QoS change), the AMF uses the NGAP
+	// PDUSessionResourceModifyRequest procedure (TS 38.413 §9.2.1.5).
+	// When n2Msg is nil (e.g. DNS-only change via Extended PCO), the AMF
+	// delivers the NAS message via Downlink NAS Transport (TS 38.413 §8.6.2)
+	// since no gNB resource modification is needed.
 	ModifyN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error
 
 	// ReleaseSession sends a network-initiated PDU Session Release to the UE/gNB.

--- a/internal/tester/scenarios/ue/data_network_changes.go
+++ b/internal/tester/scenarios/ue/data_network_changes.go
@@ -1,0 +1,502 @@
+package ue
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+	"github.com/ellanetworks/core/internal/tester/gnb"
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/internal/tester/testutil/procedure"
+	"github.com/ellanetworks/core/internal/tester/testutil/validate"
+	"github.com/free5gc/nas"
+	"github.com/free5gc/ngap/ngapType"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+)
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name: "ue/data-network-dns-change",
+		BindFlags: func(fs *pflag.FlagSet) any {
+			p := &dataNetworkChangeParams{}
+			fs.StringVar(&p.EllaAPIAddress, "ella-api-address", "", "Ella Core API address (e.g. http://10.3.0.2:5002)")
+			fs.StringVar(&p.EllaAPIToken, "ella-api-token", "", "Ella Core API token")
+
+			return p
+		},
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			return runDataNetworkDNSChange(ctx, env, params.(*dataNetworkChangeParams))
+		},
+		Fixture: fixtureDataNetworkDNSChange,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name: "ue/data-network-mtu-change",
+		BindFlags: func(fs *pflag.FlagSet) any {
+			p := &dataNetworkChangeParams{}
+			fs.StringVar(&p.EllaAPIAddress, "ella-api-address", "", "Ella Core API address")
+			fs.StringVar(&p.EllaAPIToken, "ella-api-token", "", "Ella Core API token")
+
+			return p
+		},
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			return runDataNetworkMTUChange(ctx, env, params.(*dataNetworkChangeParams))
+		},
+		Fixture: fixtureDataNetworkMTUChange,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name: "ue/data-network-pool-change",
+		BindFlags: func(fs *pflag.FlagSet) any {
+			p := &dataNetworkChangeParams{}
+			fs.StringVar(&p.EllaAPIAddress, "ella-api-address", "", "Ella Core API address")
+			fs.StringVar(&p.EllaAPIToken, "ella-api-token", "", "Ella Core API token")
+
+			return p
+		},
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			return runDataNetworkPoolChange(ctx, env, params.(*dataNetworkChangeParams))
+		},
+		Fixture: fixtureDataNetworkPoolChange,
+	})
+}
+
+type dataNetworkChangeParams struct {
+	EllaAPIAddress string
+	EllaAPIToken   string
+}
+
+func fixtureDataNetworkDNSChange(env scenarios.Env) scenarios.FixtureSpec {
+	return scenarios.FixtureSpec{
+		Subscribers: []scenarios.SubscriberSpec{scenarios.DefaultSubscriber()},
+	}
+}
+
+func fixtureDataNetworkMTUChange(env scenarios.Env) scenarios.FixtureSpec {
+	return scenarios.FixtureSpec{
+		Subscribers: []scenarios.SubscriberSpec{scenarios.DefaultSubscriber()},
+	}
+}
+
+func fixtureDataNetworkPoolChange(env scenarios.Env) scenarios.FixtureSpec {
+	return scenarios.FixtureSpec{
+		Subscribers: []scenarios.SubscriberSpec{scenarios.DefaultSubscriber()},
+	}
+}
+
+// runDataNetworkDNSChange verifies that changing the DNS server in a data
+// network triggers a PDU Session Modification Command carrying the new DNS
+// in Extended PCO (TS 24.501 §6.3.2), without releasing the session.
+func runDataNetworkDNSChange(ctx context.Context, env scenarios.Env, p *dataNetworkChangeParams) error {
+	if p.EllaAPIAddress == "" {
+		return fmt.Errorf("--ella-api-address is required")
+	}
+
+	if p.EllaAPIToken == "" {
+		return fmt.Errorf("--ella-api-token is required")
+	}
+
+	cl, err := client.New(&client.Config{BaseURL: p.EllaAPIAddress})
+	if err != nil {
+		return fmt.Errorf("failed to create Ella client: %v", err)
+	}
+
+	cl.SetToken(p.EllaAPIToken)
+
+	g := env.FirstGNB()
+
+	gNodeB, err := gnb.Start(&gnb.StartOpts{
+		GnbID:           scenarios.DefaultGNBID,
+		MCC:             scenarios.DefaultMCC,
+		MNC:             scenarios.DefaultMNC,
+		SST:             scenarios.DefaultSST,
+		SD:              scenarios.DefaultSD,
+		DNN:             scenarios.DefaultDNN,
+		TAC:             scenarios.DefaultTAC,
+		Name:            "Ella-Core-Tester",
+		CoreN2Addresses: env.CoreN2Addresses,
+		GnbN2Address:    g.N2Address,
+		GnbN3Address:    g.N3Address,
+	})
+	if err != nil {
+		return fmt.Errorf("error starting gNB: %v", err)
+	}
+
+	defer gNodeB.Close()
+
+	_, err = gNodeB.WaitForMessage(ngapType.NGAPPDUPresentSuccessfulOutcome, ngapType.SuccessfulOutcomePresentNGSetupResponse, 200*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("did not receive NG Setup Response: %v", err)
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+
+	sub := subscriber{
+		IMSI:           scenarios.DefaultIMSI,
+		Key:            scenarios.DefaultKey,
+		OPc:            scenarios.DefaultOPC,
+		SequenceNumber: scenarios.DefaultSequenceNumber,
+	}
+
+	newUE, err := newDefaultUE(gNodeB, sub.IMSI[5:], sub.Key, sub.OPc, sub.SequenceNumber, env.PDUSessionType())
+	if err != nil {
+		return fmt.Errorf("could not create UE: %v", err)
+	}
+
+	gNodeB.AddUE(ranUENGAPID, newUE)
+
+	_, err = procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: scenarios.DefaultPDUSessionID,
+		UE:           newUE,
+	})
+	if err != nil {
+		return fmt.Errorf("initial registration failed: %v", err)
+	}
+
+	logger.Logger.Info("PDU session established, proceeding to change DNS in data network",
+		zap.String("IMSI", sub.IMSI),
+		zap.Int64("RAN UE NGAP ID", ranUENGAPID),
+	)
+
+	// --- Phase 2: Change DNS in the data network via API ---
+	newDNS := "1.1.1.1"
+
+	err = cl.UpdateDataNetwork(ctx, &client.UpdateDataNetworkOptions{
+		Name:     scenarios.DefaultDNN,
+		DNS:      newDNS,
+		IPv4Pool: scenarios.DefaultUEIPv4Pool,
+		IPv6Pool: scenarios.DefaultUEIPv6Pool,
+		Mtu:      scenarios.DefaultMTU,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update data network DNS: %v", err)
+	}
+
+	defer func() {
+		_ = cl.UpdateDataNetwork(ctx, &client.UpdateDataNetworkOptions{
+			Name:     scenarios.DefaultDNN,
+			DNS:      scenarios.DefaultDNS,
+			IPv4Pool: scenarios.DefaultUEIPv4Pool,
+			IPv6Pool: scenarios.DefaultUEIPv6Pool,
+			Mtu:      scenarios.DefaultMTU,
+		})
+	}()
+
+	logger.Logger.Info("Data network DNS updated, waiting for session modification signalling")
+
+	// --- Phase 3: Wait for N1 (NAS) PDU Session Modification Command ---
+	modCmd, err := newUE.WaitForNASGSMMessage(nas.MsgTypePDUSessionModificationCommand, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("UE did not receive PDU Session Modification Command: %v", err)
+	}
+
+	logger.Logger.Info("UE received PDU Session Modification Command")
+
+	// --- Phase 4: Validate the NAS message contains new DNS in PCO ---
+	err = validate.PCODNS(modCmd, &validate.ExpectedPCODNS{
+		IPv4: newDNS,
+	})
+	if err != nil {
+		return fmt.Errorf("PCO DNS validation failed: %v", err)
+	}
+
+	logger.Logger.Info("DNS change validated successfully", zap.String("New DNS", newDNS))
+
+	// Cleanup
+	pduSessionIDs := [16]bool{}
+	pduSessionIDs[scenarios.DefaultPDUSessionID] = true
+
+	err = procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
+		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(ranUENGAPID),
+		RANUENGAPID:   ranUENGAPID,
+		GnodeB:        gNodeB,
+		UE:            newUE,
+		PDUSessionIDs: pduSessionIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("UE context release failed: %v", err)
+	}
+
+	logger.Logger.Info("DNS change scenario completed successfully")
+
+	return nil
+}
+
+// runDataNetworkMTUChange verifies that changing the MTU in a data network
+// triggers a PDU Session Release with cause #39 "reactivation requested"
+// (TS 23.501 §5.6.10.4 NOTE 3).
+func runDataNetworkMTUChange(ctx context.Context, env scenarios.Env, p *dataNetworkChangeParams) error {
+	if p.EllaAPIAddress == "" {
+		return fmt.Errorf("--ella-api-address is required")
+	}
+
+	if p.EllaAPIToken == "" {
+		return fmt.Errorf("--ella-api-token is required")
+	}
+
+	cl, err := client.New(&client.Config{BaseURL: p.EllaAPIAddress})
+	if err != nil {
+		return fmt.Errorf("failed to create Ella client: %v", err)
+	}
+
+	cl.SetToken(p.EllaAPIToken)
+
+	g := env.FirstGNB()
+
+	gNodeB, err := gnb.Start(&gnb.StartOpts{
+		GnbID:           scenarios.DefaultGNBID,
+		MCC:             scenarios.DefaultMCC,
+		MNC:             scenarios.DefaultMNC,
+		SST:             scenarios.DefaultSST,
+		SD:              scenarios.DefaultSD,
+		DNN:             scenarios.DefaultDNN,
+		TAC:             scenarios.DefaultTAC,
+		Name:            "Ella-Core-Tester",
+		CoreN2Addresses: env.CoreN2Addresses,
+		GnbN2Address:    g.N2Address,
+		GnbN3Address:    g.N3Address,
+	})
+	if err != nil {
+		return fmt.Errorf("error starting gNB: %v", err)
+	}
+
+	defer gNodeB.Close()
+
+	_, err = gNodeB.WaitForMessage(ngapType.NGAPPDUPresentSuccessfulOutcome, ngapType.SuccessfulOutcomePresentNGSetupResponse, 200*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("did not receive NG Setup Response: %v", err)
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+
+	sub := subscriber{
+		IMSI:           scenarios.DefaultIMSI,
+		Key:            scenarios.DefaultKey,
+		OPc:            scenarios.DefaultOPC,
+		SequenceNumber: scenarios.DefaultSequenceNumber,
+	}
+
+	newUE, err := newDefaultUE(gNodeB, sub.IMSI[5:], sub.Key, sub.OPc, sub.SequenceNumber, env.PDUSessionType())
+	if err != nil {
+		return fmt.Errorf("could not create UE: %v", err)
+	}
+
+	gNodeB.AddUE(ranUENGAPID, newUE)
+
+	_, err = procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: scenarios.DefaultPDUSessionID,
+		UE:           newUE,
+	})
+	if err != nil {
+		return fmt.Errorf("initial registration failed: %v", err)
+	}
+
+	logger.Logger.Info("PDU session established, proceeding to change MTU in data network",
+		zap.String("IMSI", sub.IMSI),
+		zap.Int64("RAN UE NGAP ID", ranUENGAPID),
+	)
+
+	// --- Phase 2: Change MTU in the data network via API ---
+	newMTU := int32(1400)
+
+	err = cl.UpdateDataNetwork(ctx, &client.UpdateDataNetworkOptions{
+		Name:     scenarios.DefaultDNN,
+		DNS:      scenarios.DefaultDNS,
+		IPv4Pool: scenarios.DefaultUEIPv4Pool,
+		IPv6Pool: scenarios.DefaultUEIPv6Pool,
+		Mtu:      newMTU,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update data network MTU: %v", err)
+	}
+
+	defer func() {
+		_ = cl.UpdateDataNetwork(ctx, &client.UpdateDataNetworkOptions{
+			Name:     scenarios.DefaultDNN,
+			DNS:      scenarios.DefaultDNS,
+			IPv4Pool: scenarios.DefaultUEIPv4Pool,
+			IPv6Pool: scenarios.DefaultUEIPv6Pool,
+			Mtu:      scenarios.DefaultMTU,
+		})
+	}()
+
+	logger.Logger.Info("Data network MTU updated, waiting for session release")
+
+	// --- Phase 3: Wait for PDU Session Release Command from SMF ---
+	releaseCmd, err := newUE.WaitForNASGSMMessage(nas.MsgTypePDUSessionReleaseCommand, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("UE did not receive PDU Session Release Command: %v", err)
+	}
+
+	logger.Logger.Info("UE received PDU Session Release Command")
+
+	// --- Phase 4: Validate cause #39 "reactivation requested" ---
+	if releaseCmd.PDUSessionReleaseCommand == nil {
+		return fmt.Errorf("PDUSessionReleaseCommand is nil")
+	}
+
+	cause := releaseCmd.PDUSessionReleaseCommand.GetCauseValue()
+	if cause != 39 {
+		return fmt.Errorf("expected cause #39 (reactivation requested), got %d", cause)
+	}
+
+	logger.Logger.Info("MTU change triggered session release with cause #39 as expected")
+
+	// Cleanup
+	err = procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
+		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(ranUENGAPID),
+		RANUENGAPID:   ranUENGAPID,
+		GnodeB:        gNodeB,
+		UE:            newUE,
+		PDUSessionIDs: [16]bool{},
+	})
+	if err != nil {
+		return fmt.Errorf("UE context release failed: %v", err)
+	}
+
+	logger.Logger.Info("MTU change scenario completed successfully")
+
+	return nil
+}
+
+// runDataNetworkPoolChange verifies that changing the IP pool in a data network
+// triggers a PDU Session Release with cause #39 "reactivation requested".
+func runDataNetworkPoolChange(ctx context.Context, env scenarios.Env, p *dataNetworkChangeParams) error {
+	if p.EllaAPIAddress == "" {
+		return fmt.Errorf("--ella-api-address is required")
+	}
+
+	if p.EllaAPIToken == "" {
+		return fmt.Errorf("--ella-api-token is required")
+	}
+
+	cl, err := client.New(&client.Config{BaseURL: p.EllaAPIAddress})
+	if err != nil {
+		return fmt.Errorf("failed to create Ella client: %v", err)
+	}
+
+	cl.SetToken(p.EllaAPIToken)
+
+	g := env.FirstGNB()
+
+	gNodeB, err := gnb.Start(&gnb.StartOpts{
+		GnbID:           scenarios.DefaultGNBID,
+		MCC:             scenarios.DefaultMCC,
+		MNC:             scenarios.DefaultMNC,
+		SST:             scenarios.DefaultSST,
+		SD:              scenarios.DefaultSD,
+		DNN:             scenarios.DefaultDNN,
+		TAC:             scenarios.DefaultTAC,
+		Name:            "Ella-Core-Tester",
+		CoreN2Addresses: env.CoreN2Addresses,
+		GnbN2Address:    g.N2Address,
+		GnbN3Address:    g.N3Address,
+	})
+	if err != nil {
+		return fmt.Errorf("error starting gNB: %v", err)
+	}
+
+	defer gNodeB.Close()
+
+	_, err = gNodeB.WaitForMessage(ngapType.NGAPPDUPresentSuccessfulOutcome, ngapType.SuccessfulOutcomePresentNGSetupResponse, 200*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("did not receive NG Setup Response: %v", err)
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+
+	sub := subscriber{
+		IMSI:           scenarios.DefaultIMSI,
+		Key:            scenarios.DefaultKey,
+		OPc:            scenarios.DefaultOPC,
+		SequenceNumber: scenarios.DefaultSequenceNumber,
+	}
+
+	newUE, err := newDefaultUE(gNodeB, sub.IMSI[5:], sub.Key, sub.OPc, sub.SequenceNumber, env.PDUSessionType())
+	if err != nil {
+		return fmt.Errorf("could not create UE: %v", err)
+	}
+
+	gNodeB.AddUE(ranUENGAPID, newUE)
+
+	_, err = procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: scenarios.DefaultPDUSessionID,
+		UE:           newUE,
+	})
+	if err != nil {
+		return fmt.Errorf("initial registration failed: %v", err)
+	}
+
+	logger.Logger.Info("PDU session established, proceeding to change IP pool in data network",
+		zap.String("IMSI", sub.IMSI),
+		zap.Int64("RAN UE NGAP ID", ranUENGAPID),
+	)
+
+	// --- Phase 2: Change IPv4 pool in the data network via API ---
+	newIPv4Pool := "10.46.0.0/16"
+
+	err = cl.UpdateDataNetwork(ctx, &client.UpdateDataNetworkOptions{
+		Name:     scenarios.DefaultDNN,
+		DNS:      scenarios.DefaultDNS,
+		IPv4Pool: newIPv4Pool,
+		IPv6Pool: scenarios.DefaultUEIPv6Pool,
+		Mtu:      scenarios.DefaultMTU,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update data network IP pool: %v", err)
+	}
+
+	defer func() {
+		_ = cl.UpdateDataNetwork(ctx, &client.UpdateDataNetworkOptions{
+			Name:     scenarios.DefaultDNN,
+			DNS:      scenarios.DefaultDNS,
+			IPv4Pool: scenarios.DefaultUEIPv4Pool,
+			IPv6Pool: scenarios.DefaultUEIPv6Pool,
+			Mtu:      scenarios.DefaultMTU,
+		})
+	}()
+
+	logger.Logger.Info("Data network IP pool updated, waiting for session release")
+
+	// --- Phase 3: Wait for PDU Session Release Command from SMF ---
+	releaseCmd, err := newUE.WaitForNASGSMMessage(nas.MsgTypePDUSessionReleaseCommand, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("UE did not receive PDU Session Release Command: %v", err)
+	}
+
+	logger.Logger.Info("UE received PDU Session Release Command")
+
+	// --- Phase 4: Validate cause #39 "reactivation requested" ---
+	if releaseCmd.PDUSessionReleaseCommand == nil {
+		return fmt.Errorf("PDUSessionReleaseCommand is nil")
+	}
+
+	cause := releaseCmd.PDUSessionReleaseCommand.GetCauseValue()
+	if cause != 39 {
+		return fmt.Errorf("expected cause #39 (reactivation requested), got %d", cause)
+	}
+
+	logger.Logger.Info("IP pool change triggered session release with cause #39 as expected")
+
+	// Cleanup
+	err = procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
+		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(ranUENGAPID),
+		RANUENGAPID:   ranUENGAPID,
+		GnodeB:        gNodeB,
+		UE:            newUE,
+		PDUSessionIDs: [16]bool{},
+	})
+	if err != nil {
+		return fmt.Errorf("UE context release failed: %v", err)
+	}
+
+	logger.Logger.Info("IP pool change scenario completed successfully")
+
+	return nil
+}

--- a/internal/tester/scenarios/ue/data_network_changes.go
+++ b/internal/tester/scenarios/ue/data_network_changes.go
@@ -348,12 +348,15 @@ func runDataNetworkMTUChange(ctx context.Context, env scenarios.Env, p *dataNetw
 	logger.Logger.Info("MTU change triggered session release with cause #39 as expected")
 
 	// Cleanup
+	pduSessionIDs := [16]bool{}
+	pduSessionIDs[scenarios.DefaultPDUSessionID] = true
+
 	err = procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
 		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(ranUENGAPID),
 		RANUENGAPID:   ranUENGAPID,
 		GnodeB:        gNodeB,
 		UE:            newUE,
-		PDUSessionIDs: [16]bool{},
+		PDUSessionIDs: pduSessionIDs,
 	})
 	if err != nil {
 		return fmt.Errorf("UE context release failed: %v", err)
@@ -485,12 +488,15 @@ func runDataNetworkPoolChange(ctx context.Context, env scenarios.Env, p *dataNet
 	logger.Logger.Info("IP pool change triggered session release with cause #39 as expected")
 
 	// Cleanup
+	pduSessionIDs := [16]bool{}
+	pduSessionIDs[scenarios.DefaultPDUSessionID] = true
+
 	err = procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
 		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(ranUENGAPID),
 		RANUENGAPID:   ranUENGAPID,
 		GnodeB:        gNodeB,
 		UE:            newUE,
-		PDUSessionIDs: [16]bool{},
+		PDUSessionIDs: pduSessionIDs,
 	})
 	if err != nil {
 		return fmt.Errorf("UE context release failed: %v", err)

--- a/internal/tester/testutil/nas.go
+++ b/internal/tester/testutil/nas.go
@@ -83,3 +83,37 @@ func MTUFromExtendProtocolConfigurationOptionsContents(pco_buf []byte) (uint16, 
 func SDFromNAS(sd [3]uint8) string {
 	return fmt.Sprintf("%x%x%x", sd[0], sd[1], sd[2])
 }
+
+// DNSFromExtendProtocolConfigurationOptionsContents extracts DNS server
+// addresses from Extended Protocol Configuration Options contents.
+// Returns (nil, nil) when no DNS servers are present.
+func DNSFromExtendProtocolConfigurationOptionsContents(pco_buf []byte) ([]string, error) {
+	pco := nasConvert.NewProtocolConfigurationOptions()
+
+	err := pco.UnMarshal(pco_buf)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode Extended Protocol Configuration Options: %v", err)
+	}
+
+	var dnsServers []string
+
+	for _, o := range pco.ProtocolOrContainerList {
+		switch o.ProtocolOrContainerID {
+		case nasMessage.DNSServerIPv4AddressRequestUL:
+			if len(o.Contents) >= 4 {
+				dnsServers = append(dnsServers, fmt.Sprintf("%d.%d.%d.%d",
+					o.Contents[0], o.Contents[1], o.Contents[2], o.Contents[3]))
+			}
+		case nasMessage.DNSServerIPv6AddressRequestUL:
+			if len(o.Contents) >= 16 {
+				var addr [16]byte
+				copy(addr[:], o.Contents[:16])
+				dnsServers = append(dnsServers, netip.AddrFrom16(addr).String())
+			}
+		default:
+			continue
+		}
+	}
+
+	return dnsServers, nil
+}

--- a/internal/tester/testutil/validate/pco_dns.go
+++ b/internal/tester/testutil/validate/pco_dns.go
@@ -1,0 +1,98 @@
+package validate
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/ellanetworks/core/internal/tester/testutil"
+	"github.com/free5gc/nas"
+)
+
+// ExpectedPCODNS describes expected DNS servers in an Extended PCO.
+type ExpectedPCODNS struct {
+	// IPv4 is the expected IPv4 DNS server address.
+	// Set to "" to skip IPv4 DNS validation.
+	IPv4 string
+
+	// IPv6 is the expected IPv6 DNS server address.
+	// Set to "" to skip IPv6 DNS validation.
+	IPv6 string
+}
+
+// PCODNS validates DNS server addresses in an Extended Protocol Configuration
+// Options IE inside a NAS message.
+func PCODNS(msg *nas.Message, expected *ExpectedPCODNS) error {
+	if msg == nil {
+		return fmt.Errorf("NAS message is nil")
+	}
+
+	var pcoContents []byte
+
+	switch {
+	case msg.PDUSessionModificationCommand != nil:
+		pco := msg.PDUSessionModificationCommand.ExtendedProtocolConfigurationOptions
+		if pco == nil {
+			return fmt.Errorf("ExtendedProtocolConfigurationOptions is nil in PDU Session Modification Command")
+		}
+
+		pcoContents = pco.GetExtendedProtocolConfigurationOptionsContents()
+
+	case msg.PDUSessionEstablishmentAccept != nil:
+		pco := msg.PDUSessionEstablishmentAccept.ExtendedProtocolConfigurationOptions
+		if pco == nil {
+			return fmt.Errorf("ExtendedProtocolConfigurationOptions is nil in PDU Session Establishment Accept")
+		}
+
+		pcoContents = pco.GetExtendedProtocolConfigurationOptionsContents()
+
+	default:
+		return fmt.Errorf("message does not contain PCO: expected Modification Command or Establishment Accept")
+	}
+
+	if len(pcoContents) == 0 {
+		return fmt.Errorf("PCO contents is empty")
+	}
+
+	dnsServers, err := testutil.DNSFromExtendProtocolConfigurationOptionsContents(pcoContents)
+	if err != nil {
+		return fmt.Errorf("could not parse DNS from PCO: %v", err)
+	}
+
+	if len(dnsServers) == 0 {
+		return fmt.Errorf("no DNS servers found in PCO")
+	}
+
+	foundIPv4 := false
+	foundIPv6 := false
+
+	for _, dns := range dnsServers {
+		ip := net.ParseIP(dns)
+		if ip == nil {
+			continue
+		}
+
+		if ip.To4() != nil {
+			foundIPv4 = true
+
+			if expected.IPv4 != "" && dns != expected.IPv4 {
+				return fmt.Errorf("IPv4 DNS mismatch: got %s, expected %s", dns, expected.IPv4)
+			}
+		} else {
+			foundIPv6 = true
+
+			if expected.IPv6 != "" && dns != expected.IPv6 {
+				return fmt.Errorf("IPv6 DNS mismatch: got %s, expected %s", dns, expected.IPv6)
+			}
+		}
+	}
+
+	if expected.IPv4 != "" && !foundIPv4 {
+		return fmt.Errorf("expected IPv4 DNS %s but none found in PCO", expected.IPv4)
+	}
+
+	if expected.IPv6 != "" && !foundIPv6 {
+		return fmt.Errorf("expected IPv6 DNS %s but none found in PCO", expected.IPv6)
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

When an administrator changes a DNN (IPv4/IPv6 pools, DNS, MTU), active sessions were not immediately impacted. With this PR, a DNS change will trigger a modification message sent to the UE, and the other values will trigger a release to get the UE to reconnect.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
