### PR TITLE
chore: Improve integration tests reporting

### DIFF
--- a/.github/workflows/integration-tests-api-matrix-ha.yaml
+++ b/.github/workflows/integration-tests-api-matrix-ha.yaml
@@ -33,9 +33,11 @@ jobs:
 
       - name: Run API matrix HA integration test
         env:
+          INTEGRATION: "1"
+          IP_VERSION: ipv4
           HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 IP_VERSION=ipv4 go test ./integration -run TestAPIMatrixHA -v -timeout 15m
+          go test ./integration -run TestAPIMatrixHA -v -timeout 15m
 
       - name: Upload cluster logs
         if: always()

--- a/.github/workflows/integration-tests-api-matrix.yaml
+++ b/.github/workflows/integration-tests-api-matrix.yaml
@@ -44,5 +44,9 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Run API matrix integration test
+        env:
+          INTEGRATION: "1"
+          IP_VERSION: ipv4
+          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 IP_VERSION=ipv4 go test ./integration -run '^TestAPIMatrix$' -timeout 10m -v
+          go test ./integration -run '^TestAPIMatrix$' -timeout 10m -v

--- a/.github/workflows/integration-tests-bgp.yaml
+++ b/.github/workflows/integration-tests-bgp.yaml
@@ -48,8 +48,12 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Run BGP integration tests
+        env:
+          INTEGRATION: "1"
+          IP_VERSION: ${{ matrix.ip_version }}
+          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -run TestIntegrationBGP -timeout 15m -v
+          go test ./integration/... -run TestIntegrationBGP -timeout 15m -v
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/integration-tests-ha.yaml
+++ b/.github/workflows/integration-tests-ha.yaml
@@ -33,9 +33,11 @@ jobs:
 
       - name: Run HA integration tests
         env:
+          INTEGRATION: "1"
+          IP_VERSION: ${{ matrix.ip_version }}
           HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -run TestIntegrationHA -skip TestIntegrationHARollingUpgrade -v -timeout 15m
+          go test ./integration/... -run TestIntegrationHA -skip TestIntegrationHARollingUpgrade -v -timeout 15m
 
       - name: Upload cluster logs
         if: always()

--- a/.github/workflows/integration-tests-ha3gpp.yaml
+++ b/.github/workflows/integration-tests-ha3gpp.yaml
@@ -38,9 +38,10 @@ jobs:
 
       - name: Run HA+3GPP integration tests
         env:
+          INTEGRATION: "1"
           HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 go test ./integration/... -run TestIntegration3GPPHAFailover -v -timeout 15m
+          go test ./integration/... -run TestIntegration3GPPHAFailover -v -timeout 15m
 
       - name: Upload cluster logs
         if: always()

--- a/.github/workflows/integration-tests-n2-handover.yaml
+++ b/.github/workflows/integration-tests-n2-handover.yaml
@@ -37,8 +37,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 
       - name: Run N2 Handover integration tests
+        env:
+          INTEGRATION: "1"
+          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 go test ./integration/... -run TestIntegrationN2Handover -v -timeout 10m
+          go test ./integration/... -run TestIntegrationN2Handover -v -timeout 10m
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/integration-tests-rolling-upgrade.yaml
+++ b/.github/workflows/integration-tests-rolling-upgrade.yaml
@@ -34,9 +34,10 @@ jobs:
 
       - name: Run rolling-upgrade integration test
         env:
+          INTEGRATION: "1"
           HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 go test ./integration/... -run TestIntegrationHARollingUpgrade -v -timeout 15m
+          go test ./integration/... -run TestIntegrationHARollingUpgrade -v -timeout 15m
 
       - name: Upload cluster logs
         if: always()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -46,9 +46,11 @@ jobs:
 
       - name: Run integration tests
         env:
+          INTEGRATION: "1"
+          IP_VERSION: ${{ matrix.ip_version }}
           HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
         run: |
-          INTEGRATION=1 IP_VERSION=${{ matrix.ip_version }} go test ./integration/... -skip 'TestIntegrationHA|TestIntegration3GPPHAFailover|TestAPIMatrix|TestIntegrationBGP' -timeout 30m -v
+          go test ./integration/... -skip 'TestIntegrationHA|TestIntegration3GPPHAFailover|TestAPIMatrix|TestIntegrationBGP' -timeout 30m -v
 
       - name: Upload cluster logs
         if: always()

--- a/integration/api_matrix_api_tokens_test.go
+++ b/integration/api_matrix_api_tokens_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -114,9 +115,7 @@ func runAPITokensMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 				}
 
 				want, _ := time.Parse(time.RFC3339, tc.wantExpiry)
-				if !got.Equal(want) {
-					t.Fatalf("ExpiresAt: got %q, want %q", created.ExpiresAt, tc.wantExpiry)
-				}
+				Assert(t, got.Equal(want), fmt.Sprintf("ExpiresAt: got %q, want %q", created.ExpiresAt, tc.wantExpiry))
 			}
 
 			if err := c.DeleteUserAPIToken(ctx, email, created.ID); err != nil {

--- a/integration/api_matrix_bgp_peers_test.go
+++ b/integration/api_matrix_bgp_peers_test.go
@@ -155,9 +155,7 @@ func runBGPPeersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 				o.Password = &secret
 			},
 			assert: func(t *testing.T, p *client.BGPPeer) {
-				if !p.HasPassword {
-					t.Fatalf("HasPassword after set: got false, want true")
-				}
+				Assert(t, p.HasPassword, "HasPassword after set: got false, want true")
 			},
 		},
 		{

--- a/integration/api_matrix_data_networks_test.go
+++ b/integration/api_matrix_data_networks_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -73,9 +74,7 @@ func runDataNetworksMatrix(ctx context.Context, t *testing.T, c *client.Client) 
 		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
 	}
 
-	if !contains(afterCreate.Items, name) {
-		t.Fatalf("list after create missing %q", name)
-	}
+	Assert(t, contains(afterCreate.Items, name), fmt.Sprintf("list after create missing %q", name))
 
 	base := *createOpts
 

--- a/integration/api_matrix_ha_api_tokens_test.go
+++ b/integration/api_matrix_ha_api_tokens_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -119,9 +120,7 @@ func runAPITokensHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 					}
 
 					wantExp, _ := time.Parse(time.RFC3339, tc.wantExpiry)
-					if !gotExp.Equal(wantExp) {
-						t.Fatalf("node %d ExpiresAt: got %q, want %q", i+1, found.ExpiresAt, tc.wantExpiry)
-					}
+					Assert(t, gotExp.Equal(wantExp), fmt.Sprintf("node %d ExpiresAt: got %q, want %q", i+1, found.ExpiresAt, tc.wantExpiry))
 				}
 			}
 

--- a/integration/api_matrix_ha_bgp_peers_test.go
+++ b/integration/api_matrix_ha_bgp_peers_test.go
@@ -174,9 +174,7 @@ func runBGPPeersHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 				o.Password = &secret
 			},
 			assert: func(t *testing.T, p *client.BGPPeer) {
-				if !p.HasPassword {
-					t.Fatalf("HasPassword after set: got false, want true")
-				}
+				Assert(t, p.HasPassword, "HasPassword after set: got false, want true")
 			},
 		},
 		{

--- a/integration/api_matrix_ha_data_networks_test.go
+++ b/integration/api_matrix_ha_data_networks_test.go
@@ -78,9 +78,7 @@ func runDataNetworksHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) 
 			t.Fatalf("node %d count after create: got %d, want %d", i+1, list.TotalCount, baseline+1)
 		}
 
-		if !contains(list.Items, name) {
-			t.Fatalf("node %d list after create missing %q", i+1, name)
-		}
+		Assert(t, contains(list.Items, name), fmt.Sprintf("node %d list after create missing %q", i+1, name))
 	}
 
 	base := *createOpts

--- a/integration/api_matrix_ha_operator_code_test.go
+++ b/integration/api_matrix_ha_operator_code_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -62,13 +63,9 @@ func runOperatorCodeHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) 
 			}
 
 			msg := err.Error()
-			if !strings.Contains(msg, n.want) {
-				t.Fatalf("error message: got %q, want substring %q", msg, n.want)
-			}
+			Assert(t, strings.Contains(msg, n.want), fmt.Sprintf("error message: got %q, want substring %q", msg, n.want))
 
-			if !strings.Contains(msg, "400") {
-				t.Fatalf("expected 400 status, got %q", msg)
-			}
+			Assert(t, strings.Contains(msg, "400"), fmt.Sprintf("expected 400 status, got %q", msg))
 		})
 	}
 }

--- a/integration/api_matrix_ha_operator_nas_security_test.go
+++ b/integration/api_matrix_ha_operator_nas_security_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -73,13 +74,9 @@ func runOperatorNASSecurityHAMatrix(ctx context.Context, t *testing.T, h *haMatr
 					t.Fatalf("node %d get operator after update: %v", i+1, err)
 				}
 
-				if !equalStringSlices(op.NASSecurity.Ciphering, tc.opts.Ciphering) {
-					t.Fatalf("node %d Ciphering: got %v, want %v", i+1, op.NASSecurity.Ciphering, tc.opts.Ciphering)
-				}
+				Assert(t, equalStringSlices(op.NASSecurity.Ciphering, tc.opts.Ciphering), fmt.Sprintf("node %d Ciphering: got %v, want %v", i+1, op.NASSecurity.Ciphering, tc.opts.Ciphering))
 
-				if !equalStringSlices(op.NASSecurity.Integrity, tc.opts.Integrity) {
-					t.Fatalf("node %d Integrity: got %v, want %v", i+1, op.NASSecurity.Integrity, tc.opts.Integrity)
-				}
+				Assert(t, equalStringSlices(op.NASSecurity.Integrity, tc.opts.Integrity), fmt.Sprintf("node %d Integrity: got %v, want %v", i+1, op.NASSecurity.Integrity, tc.opts.Integrity))
 			}
 		})
 	}

--- a/integration/api_matrix_ha_operator_tracking_test.go
+++ b/integration/api_matrix_ha_operator_tracking_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -47,9 +48,7 @@ func runOperatorTrackingHAMatrix(ctx context.Context, t *testing.T, h *haMatrixE
 					t.Fatalf("node %d get operator after update: %v", i+1, err)
 				}
 
-				if !equalStringSlices(op.Tracking.SupportedTacs, tc.tacs) {
-					t.Fatalf("node %d SupportedTacs: got %v, want %v", i+1, op.Tracking.SupportedTacs, tc.tacs)
-				}
+				Assert(t, equalStringSlices(op.Tracking.SupportedTacs, tc.tacs), fmt.Sprintf("node %d SupportedTacs: got %v, want %v", i+1, op.Tracking.SupportedTacs, tc.tacs))
 			}
 		})
 	}

--- a/integration/api_matrix_ha_policies_test.go
+++ b/integration/api_matrix_ha_policies_test.go
@@ -158,9 +158,7 @@ func runPoliciesHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			t.Fatalf("node %d count after create: got %d, want %d", i+1, list.TotalCount, baseline+1)
 		}
 
-		if !contains(list.Items, name) {
-			t.Fatalf("node %d list after create missing %q", i+1, name)
-		}
+		Assert(t, contains(list.Items, name), fmt.Sprintf("node %d list after create missing %q", i+1, name))
 	}
 
 	updateCases := []struct {

--- a/integration/api_matrix_ha_policy_rules_test.go
+++ b/integration/api_matrix_ha_policy_rules_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -89,10 +90,8 @@ func runPolicyRulesHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			t.Fatalf("node %d get after create: %v", i+1, err)
 		}
 
-		if !rulesEqual(got.Rules, initialRules) {
-			t.Fatalf("node %d post-create rules mismatch:\ngot  %s\nwant %s",
-				i+1, formatRules(got.Rules), formatRules(initialRules))
-		}
+		Assert(t, rulesEqual(got.Rules, initialRules), fmt.Sprintf("node %d post-create rules mismatch:\ngot  %s\nwant %s",
+			i+1, formatRules(got.Rules), formatRules(initialRules)))
 	}
 
 	t.Run("update_replace", func(t *testing.T) {
@@ -114,10 +113,8 @@ func runPolicyRulesHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 
 		for i, c := range nodes {
 			got := mustGetPolicy(ctx, t, c, policyName)
-			if !rulesEqual(got.Rules, replaced) {
-				t.Fatalf("node %d rules after replace:\ngot  %s\nwant %s",
-					i+1, formatRules(got.Rules), formatRules(replaced))
-			}
+			Assert(t, rulesEqual(got.Rules, replaced), fmt.Sprintf("node %d rules after replace:\ngot  %s\nwant %s",
+				i+1, formatRules(got.Rules), formatRules(replaced)))
 		}
 	})
 
@@ -195,10 +192,8 @@ func runPolicyRulesHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 				t.Fatalf("node %d Var5qi: got %d, want 5", i+1, got.Var5qi)
 			}
 
-			if !rulesEqual(got.Rules, initialRules) {
-				t.Fatalf("node %d rules dropped when updating Var5qi:\ngot  %s\nwant %s",
-					i+1, formatRules(got.Rules), formatRules(initialRules))
-			}
+			Assert(t, rulesEqual(got.Rules, initialRules), fmt.Sprintf("node %d rules dropped when updating Var5qi:\ngot  %s\nwant %s",
+				i+1, formatRules(got.Rules), formatRules(initialRules)))
 		}
 	})
 
@@ -275,13 +270,9 @@ func runPolicyRulesHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			}
 
 			msg := err.Error()
-			if !strings.Contains(msg, n.want) {
-				t.Fatalf("error message: got %q, want substring %q", msg, n.want)
-			}
+			Assert(t, strings.Contains(msg, n.want), fmt.Sprintf("error message: got %q, want substring %q", msg, n.want))
 
-			if !strings.Contains(msg, "400") {
-				t.Fatalf("expected 400 status, got %q", msg)
-			}
+			Assert(t, strings.Contains(msg, "400"), fmt.Sprintf("expected 400 status, got %q", msg))
 
 			for i, c := range nodes {
 				got := mustGetPolicy(ctx, t, c, policyName)

--- a/integration/api_matrix_ha_profiles_test.go
+++ b/integration/api_matrix_ha_profiles_test.go
@@ -74,9 +74,7 @@ func runProfilesHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			t.Fatalf("node %d count after create: got %d, want %d", i+1, list.TotalCount, baseline+1)
 		}
 
-		if !contains(list.Items, name) {
-			t.Fatalf("node %d list after create missing %q", i+1, name)
-		}
+		Assert(t, contains(list.Items, name), fmt.Sprintf("node %d list after create missing %q", i+1, name))
 	}
 
 	updateCases := []struct {

--- a/integration/api_matrix_ha_slices_test.go
+++ b/integration/api_matrix_ha_slices_test.go
@@ -68,9 +68,7 @@ func runSlicesHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			t.Fatalf("node %d count after create: got %d, want %d", i+1, list.TotalCount, baseline+1)
 		}
 
-		if !contains(list.Items, name) {
-			t.Fatalf("node %d list after create missing %q", i+1, name)
-		}
+		Assert(t, contains(list.Items, name), fmt.Sprintf("node %d list after create missing %q", i+1, name))
 	}
 
 	updateCases := []struct {

--- a/integration/api_matrix_ha_subscribers_test.go
+++ b/integration/api_matrix_ha_subscribers_test.go
@@ -188,9 +188,7 @@ func runSubscribersHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			t.Fatalf("node %d count after create: got %d, want %d", i+1, list.TotalCount, baseline+1)
 		}
 
-		if !subscribersContains(list.Items, imsi) {
-			t.Fatalf("node %d list missing %q after create", i+1, imsi)
-		}
+		Assert(t, subscribersContains(list.Items, imsi), fmt.Sprintf("node %d list missing %q after create", i+1, imsi))
 
 		// List response carries a different Status struct than Get-one,
 		// so the defaults are asserted independently.

--- a/integration/api_matrix_ha_users_test.go
+++ b/integration/api_matrix_ha_users_test.go
@@ -73,9 +73,7 @@ func runUsersHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			t.Fatalf("node %d count after create: got %d, want %d", i+1, list.TotalCount, baseline+1)
 		}
 
-		if !contains(list.Items, email) {
-			t.Fatalf("node %d list after create missing %q", i+1, email)
-		}
+		Assert(t, contains(list.Items, email), fmt.Sprintf("node %d list after create missing %q", i+1, email))
 	}
 
 	t.Run("update_RoleID", func(t *testing.T) {

--- a/integration/api_matrix_helpers_test.go
+++ b/integration/api_matrix_helpers_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -19,7 +20,5 @@ func assertNotFound(t *testing.T, err error, what string) {
 	}
 
 	msg := err.Error()
-	if !strings.Contains(msg, "404") && !strings.Contains(strings.ToLower(msg), "not found") {
-		t.Fatalf("expected %s lookup to fail with not-found, got: %v", what, err)
-	}
+	Assert(t, strings.Contains(msg, "404") || strings.Contains(strings.ToLower(msg), "not found"), fmt.Sprintf("expected %s lookup to fail with not-found, got: %v", what, err))
 }

--- a/integration/api_matrix_operator_code_test.go
+++ b/integration/api_matrix_operator_code_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -69,13 +70,9 @@ func runOperatorCodeMatrix(ctx context.Context, t *testing.T, c *client.Client) 
 			}
 
 			msg := err.Error()
-			if !strings.Contains(msg, n.want) {
-				t.Fatalf("error message: got %q, want substring %q", msg, n.want)
-			}
+			Assert(t, strings.Contains(msg, n.want), fmt.Sprintf("error message: got %q, want substring %q", msg, n.want))
 
-			if !strings.Contains(msg, "400") {
-				t.Fatalf("expected 400 status, got %q", msg)
-			}
+			Assert(t, strings.Contains(msg, "400"), fmt.Sprintf("expected 400 status, got %q", msg))
 		})
 	}
 }

--- a/integration/api_matrix_operator_nas_security_test.go
+++ b/integration/api_matrix_operator_nas_security_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -65,13 +66,9 @@ func runOperatorNASSecurityMatrix(ctx context.Context, t *testing.T, c *client.C
 				t.Fatalf("get operator after update: %v", err)
 			}
 
-			if !equalStringSlices(op.NASSecurity.Ciphering, tc.opts.Ciphering) {
-				t.Fatalf("Ciphering: got %v, want %v", op.NASSecurity.Ciphering, tc.opts.Ciphering)
-			}
+			Assert(t, equalStringSlices(op.NASSecurity.Ciphering, tc.opts.Ciphering), fmt.Sprintf("Ciphering: got %v, want %v", op.NASSecurity.Ciphering, tc.opts.Ciphering))
 
-			if !equalStringSlices(op.NASSecurity.Integrity, tc.opts.Integrity) {
-				t.Fatalf("Integrity: got %v, want %v", op.NASSecurity.Integrity, tc.opts.Integrity)
-			}
+			Assert(t, equalStringSlices(op.NASSecurity.Integrity, tc.opts.Integrity), fmt.Sprintf("Integrity: got %v, want %v", op.NASSecurity.Integrity, tc.opts.Integrity))
 		})
 	}
 }

--- a/integration/api_matrix_operator_tracking_test.go
+++ b/integration/api_matrix_operator_tracking_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -43,9 +44,7 @@ func runOperatorTrackingMatrix(ctx context.Context, t *testing.T, c *client.Clie
 				t.Fatalf("get operator after update: %v", err)
 			}
 
-			if !equalStringSlices(op.Tracking.SupportedTacs, tc.tacs) {
-				t.Fatalf("SupportedTacs: got %v, want %v", op.Tracking.SupportedTacs, tc.tacs)
-			}
+			Assert(t, equalStringSlices(op.Tracking.SupportedTacs, tc.tacs), fmt.Sprintf("SupportedTacs: got %v, want %v", op.Tracking.SupportedTacs, tc.tacs))
 		})
 	}
 }

--- a/integration/api_matrix_policies_test.go
+++ b/integration/api_matrix_policies_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -156,9 +157,7 @@ func runPoliciesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
 	}
 
-	if !contains(afterCreate.Items, name) {
-		t.Fatalf("list after create missing %q", name)
-	}
+	Assert(t, contains(afterCreate.Items, name), fmt.Sprintf("list after create missing %q", name))
 
 	updateCases := []struct {
 		field  string

--- a/integration/api_matrix_policy_rules_test.go
+++ b/integration/api_matrix_policy_rules_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -91,9 +92,7 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("get policy after create: %v", err)
 	}
 
-	if !rulesEqual(got.Rules, initialRules) {
-		t.Fatalf("post-create rules round-trip mismatch:\ngot  %s\nwant %s", formatRules(got.Rules), formatRules(initialRules))
-	}
+	Assert(t, rulesEqual(got.Rules, initialRules), fmt.Sprintf("post-create rules round-trip mismatch:\ngot  %s\nwant %s", formatRules(got.Rules), formatRules(initialRules)))
 
 	t.Run("update_replace", func(t *testing.T) {
 		replaced := &client.PolicyRules{
@@ -111,9 +110,7 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		}
 
 		after := mustGetPolicy(ctx, t, c, policyName)
-		if !rulesEqual(after.Rules, replaced) {
-			t.Fatalf("rules after replace:\ngot  %s\nwant %s", formatRules(after.Rules), formatRules(replaced))
-		}
+		Assert(t, rulesEqual(after.Rules, replaced), fmt.Sprintf("rules after replace:\ngot  %s\nwant %s", formatRules(after.Rules), formatRules(replaced)))
 	})
 
 	t.Run("update_clear_nil", func(t *testing.T) {
@@ -173,9 +170,7 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 			t.Fatalf("Var5qi: got %d, want 5", after.Var5qi)
 		}
 
-		if !rulesEqual(after.Rules, initialRules) {
-			t.Fatalf("rules dropped when updating Var5qi:\ngot  %s\nwant %s", formatRules(after.Rules), formatRules(initialRules))
-		}
+		Assert(t, rulesEqual(after.Rules, initialRules), fmt.Sprintf("rules dropped when updating Var5qi:\ngot  %s\nwant %s", formatRules(after.Rules), formatRules(initialRules)))
 	})
 
 	negatives := []struct {
@@ -244,13 +239,9 @@ func runPolicyRulesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 			}
 
 			msg := err.Error()
-			if !strings.Contains(msg, n.want) {
-				t.Fatalf("error message: got %q, want substring %q", msg, n.want)
-			}
+			Assert(t, strings.Contains(msg, n.want), fmt.Sprintf("error message: got %q, want substring %q", msg, n.want))
 
-			if !strings.Contains(msg, "400") {
-				t.Fatalf("expected 400 status, got %q", msg)
-			}
+			Assert(t, strings.Contains(msg, "400"), fmt.Sprintf("expected 400 status, got %q", msg))
 
 			after := mustGetPolicy(ctx, t, c, policyName)
 			if after.Rules != nil {

--- a/integration/api_matrix_profiles_test.go
+++ b/integration/api_matrix_profiles_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -69,9 +70,7 @@ func runProfilesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
 	}
 
-	if !containsProfile(afterCreate.Items, name) {
-		t.Fatalf("list after create missing %q", name)
-	}
+	Assert(t, containsProfile(afterCreate.Items, name), fmt.Sprintf("list after create missing %q", name))
 
 	updateCases := []struct {
 		field  string

--- a/integration/api_matrix_slices_test.go
+++ b/integration/api_matrix_slices_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -67,9 +68,7 @@ func runSlicesMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
 	}
 
-	if !contains(afterCreate.Items, name) {
-		t.Fatalf("list after create missing %q", name)
-	}
+	Assert(t, contains(afterCreate.Items, name), fmt.Sprintf("list after create missing %q", name))
 
 	updateCases := []struct {
 		field  string

--- a/integration/api_matrix_subscribers_test.go
+++ b/integration/api_matrix_subscribers_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -181,9 +182,7 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
 	}
 
-	if !contains(afterCreate.Items, imsi) {
-		t.Fatalf("list after create missing %q", imsi)
-	}
+	Assert(t, contains(afterCreate.Items, imsi), fmt.Sprintf("list after create missing %q", imsi))
 
 	// List response carries a different Status struct than Get-one, so
 	// the defaults are asserted independently.

--- a/integration/api_matrix_users_test.go
+++ b/integration/api_matrix_users_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/client"
@@ -70,9 +71,7 @@ func runUsersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("list count after create: got %d, want %d", afterCreate.TotalCount, baseline.TotalCount+1)
 	}
 
-	if !contains(afterCreate.Items, email) {
-		t.Fatalf("list after create missing %q", email)
-	}
+	Assert(t, contains(afterCreate.Items, email), fmt.Sprintf("list after create missing %q", email))
 
 	t.Run("update_RoleID", func(t *testing.T) {
 		if err := c.UpdateUser(ctx, email, &client.UpdateUserOptions{RoleID: client.RoleNetworkManager}); err != nil {

--- a/integration/bgp_test.go
+++ b/integration/bgp_test.go
@@ -300,9 +300,7 @@ func TestIntegrationBGP(t *testing.T) {
 			t.Fatalf("gobgp neighbor: %v", err)
 		}
 
-		if !strings.Contains(out, n6IP) {
-			t.Fatalf("gobgp neighbor does not contain %s:\n%s", n6IP, out)
-		}
+		Assert(t, strings.Contains(out, n6IP), fmt.Sprintf("gobgp neighbor does not contain %s:\n%s", n6IP, out))
 	})
 
 	t.Run("RouteAdvertisement", func(t *testing.T) {
@@ -348,9 +346,7 @@ func TestIntegrationBGP(t *testing.T) {
 			uePrefix = strings.Split(uePrefix, "/")[0]
 		}
 
-		if !strings.Contains(out, uePrefix) {
-			t.Fatalf("gobgp did not receive UE route %s:\n%s", advertised.Prefix, out)
-		}
+		Assert(t, strings.Contains(out, uePrefix), fmt.Sprintf("gobgp did not receive UE route %s:\n%s", advertised.Prefix, out))
 
 		peers, err := cl.ListBGPPeers(ctx, &client.ListParams{Page: 1, PerPage: 100})
 		if err != nil {

--- a/integration/bgp_test.go
+++ b/integration/bgp_test.go
@@ -181,7 +181,7 @@ func TestIntegrationBGP(t *testing.T) {
 	t.Cleanup(func() {
 		for _, svc := range []string{"ella-core", "gobgp"} {
 			logs, err := dc.ComposeLogs(ctx, bgpComposeDir, svc)
-			if err == nil {
+			if err == nil && t.Failed() {
 				t.Logf("=== %s container logs ===\n%s", svc, logs)
 			}
 		}

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -76,7 +76,7 @@ func TestIntegrationTester(t *testing.T) {
 	ctx := context.Background()
 	env := setupTesterEnv(ctx, t)
 
-	VerboseLog(t, "core-tester compose up in "+string(DetectIPFamily())+" mode")
+	VerboseLogf(t, "core-tester compose up in %s mode", string(DetectIPFamily()))
 
 	// Baseline resources shared across all subtests.
 	baseline := fixture.New(t, ctx, env.Client)

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -127,7 +128,8 @@ func TestIntegrationTester(t *testing.T) {
 			}
 		}
 
-		sc, _ := scenarios.Get(name)
+		sc, ok := scenarios.Get(name)
+		Assert(t, ok, fmt.Sprintf("scenario %q not registered", name))
 
 		// Build a scenarios.Env from the tester environment so that
 		// IP-family-aware fixtures can inspect address family details.
@@ -144,7 +146,6 @@ func TestIntegrationTester(t *testing.T) {
 		tr := registerScenarioTest(name)
 
 		t.Run(name, func(t *testing.T) {
-			captureFailureReason(t)
 			defer finishScenarioTest(t, tr)
 
 			fx := fixture.New(t, ctx, env.Client)

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -76,7 +76,7 @@ func TestIntegrationTester(t *testing.T) {
 	ctx := context.Background()
 	env := setupTesterEnv(ctx, t)
 
-	t.Logf("core-tester compose up in %s mode", DetectIPFamily())
+	VerboseLog(t, "core-tester compose up in "+string(DetectIPFamily())+" mode")
 
 	// Baseline resources shared across all subtests.
 	baseline := fixture.New(t, ctx, env.Client)
@@ -86,19 +86,30 @@ func TestIntegrationTester(t *testing.T) {
 	baseline.DataNetwork(fixture.DefaultDataNetworkSpec())
 	baseline.Policy(fixture.DefaultPolicySpec())
 
-	for _, name := range scenarios.List() {
+	// Track which scenarios to run (filtering skipped/restricted ones).
+	var scenarioNames []string
+
+	scenarioNames = append(scenarioNames, scenarios.List()...)
+
+	// Run each scenario with reporter tracking.
+	for _, name := range scenarioNames {
 		name := name
 
 		if reason, skip := scenariosSkipped[name]; skip {
+			tr := registerScenarioTest(name)
 			t.Run(name, func(t *testing.T) { t.Skipf("%s: %s", name, reason) })
+			finishScenarioTest(t, tr)
+
 			continue
 		}
 
 		if requiredFamily, ok := scenarioIPFamilyRestrictions[name]; ok {
 			if DetectIPFamily() != requiredFamily {
+				tr := registerScenarioTest(name)
 				t.Run(name, func(t *testing.T) {
 					t.Skipf("skipping %s: requires %s mode, running %s", name, requiredFamily, DetectIPFamily())
 				})
+				finishScenarioTest(t, tr)
 
 				continue
 			}
@@ -106,9 +117,11 @@ func TestIntegrationTester(t *testing.T) {
 
 		if exclusions, ok := scenarioIPFamilyExclusions[name]; ok {
 			if exclusions[DetectIPFamily()] {
+				tr := registerScenarioTest(name)
 				t.Run(name, func(t *testing.T) {
 					t.Skipf("skipping %s: N6 does not support this address family in %s mode", name, DetectIPFamily())
 				})
+				finishScenarioTest(t, tr)
 
 				continue
 			}
@@ -128,6 +141,8 @@ func TestIntegrationTester(t *testing.T) {
 			spec = sc.Fixture(scenariosEnv)
 		}
 
+		tr := registerScenarioTest(name)
+
 		t.Run(name, func(t *testing.T) {
 			fx := fixture.New(t, ctx, env.Client)
 			fx.Apply(spec)
@@ -142,13 +157,18 @@ func TestIntegrationTester(t *testing.T) {
 
 			extraArgs = append(extraArgs, spec.ExtraArgs...)
 
-			env.RunScenario(ctx, t, name, extraArgs...)
+			env.RunScenario(ctx, t, name, tr, extraArgs...)
 
 			if len(spec.AssertUsageForIMSIs) > 0 {
 				fixture.AssertUsagePositive(ctx, t, env.Client, spec.AssertUsageForIMSIs, 30*time.Second)
 			}
 		})
+
+		finishScenarioTest(t, tr)
 	}
+
+	// Print summary at the end.
+	printTesterSummary(t)
 }
 
 // buildScenariosEnv converts a *testerEnv into a scenarios.Env so that

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -144,6 +144,7 @@ func TestIntegrationTester(t *testing.T) {
 		tr := registerScenarioTest(name)
 
 		t.Run(name, func(t *testing.T) {
+			captureFailureReason(t)
 			defer finishScenarioTest(t, tr)
 
 			fx := fixture.New(t, ctx, env.Client)

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -144,6 +144,8 @@ func TestIntegrationTester(t *testing.T) {
 		tr := registerScenarioTest(name)
 
 		t.Run(name, func(t *testing.T) {
+			defer finishScenarioTest(t, tr)
+
 			fx := fixture.New(t, ctx, env.Client)
 			fx.Apply(spec)
 
@@ -163,8 +165,6 @@ func TestIntegrationTester(t *testing.T) {
 				fixture.AssertUsagePositive(ctx, t, env.Client, spec.AssertUsageForIMSIs, 30*time.Second)
 			}
 		})
-
-		finishScenarioTest(t, tr)
 	}
 
 	// Print summary at the end.

--- a/integration/flow_reports_smoke_test.go
+++ b/integration/flow_reports_smoke_test.go
@@ -35,9 +35,7 @@ func TestFlowReportsSmoke(t *testing.T) {
 	baseline.Policy(fixture.DefaultPolicySpec())
 
 	sc, ok := scenarios.Get(fp.scenarioAllowed)
-	if !ok {
-		t.Fatalf("scenario %q not registered", fp.scenarioAllowed)
-	}
+	Assert(t, ok, fmt.Sprintf("scenario %q not registered", fp.scenarioAllowed))
 
 	scenariosEnv := buildScenariosEnv(env)
 

--- a/integration/flow_reports_smoke_test.go
+++ b/integration/flow_reports_smoke_test.go
@@ -73,7 +73,7 @@ func TestFlowReportsSmoke(t *testing.T) {
 		tr := globalReporter.Start(scenarioName)
 		QuietLog(t, tr, "running "+scenarioName)
 		env.RunScenario(ctx, t, fp.scenarioAllowed, tr, scenarioRunArgs(fp.scenarioAllowed, spec, pp)...)
-		globalReporter.Pass(tr)
+		finishScenarioTest(t, tr)
 	}
 
 	scenarioEnd := time.Now()

--- a/integration/flow_reports_smoke_test.go
+++ b/integration/flow_reports_smoke_test.go
@@ -69,7 +69,7 @@ func TestFlowReportsSmoke(t *testing.T) {
 		pp := pps[p]
 		scenarioName := fmt.Sprintf("%s/%s", fp.scenarioAllowed, p)
 		tr := globalReporter.Start(scenarioName)
-		QuietLog(t, tr, "running "+scenarioName)
+		QuietLogf(t, tr, "running %s", scenarioName)
 		env.RunScenario(ctx, t, fp.scenarioAllowed, tr, scenarioRunArgs(fp.scenarioAllowed, spec, pp)...)
 		finishScenarioTest(t, tr)
 	}

--- a/integration/flow_reports_smoke_test.go
+++ b/integration/flow_reports_smoke_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -67,7 +68,12 @@ func TestFlowReportsSmoke(t *testing.T) {
 	scenarioStart := time.Now()
 
 	for _, p := range protocols {
-		env.RunScenario(ctx, t, fp.scenarioAllowed, scenarioRunArgs(fp.scenarioAllowed, spec, pps[p])...)
+		pp := pps[p]
+		scenarioName := fmt.Sprintf("%s/%s", fp.scenarioAllowed, p)
+		tr := globalReporter.Start(scenarioName)
+		QuietLog(t, tr, "running "+scenarioName)
+		env.RunScenario(ctx, t, fp.scenarioAllowed, tr, scenarioRunArgs(fp.scenarioAllowed, spec, pp)...)
+		globalReporter.Pass(tr)
 	}
 
 	scenarioEnd := time.Now()

--- a/integration/ha_3gpp_test.go
+++ b/integration/ha_3gpp_test.go
@@ -156,9 +156,7 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 	// subscriber). Apply it via the spec so this test stays aligned with
 	// the scenario's declared needs.
 	sc, ok := scenarios.Get("ha/failover_connectivity")
-	if !ok {
-		t.Fatalf("scenario ha/failover_connectivity not registered")
-	}
+	Assert(t, ok, "scenario ha/failover_connectivity not registered")
 
 	scenariosEnv := scenarios.Env{
 		CoreN2Addresses: nodeN2Addrs[:],

--- a/integration/ha_3gpp_test.go
+++ b/integration/ha_3gpp_test.go
@@ -92,22 +92,22 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 		for i, svc := range nodeServices {
 			logs, logErr := dc.ComposeLogs(cleanupCtx, composeDir, svc)
 			if logErr != nil {
-				t.Logf("=== %s logs: collection failed: %v ===", svc, logErr)
+				HALogf(t, "=== %s logs: collection failed: %v ===", svc, logErr)
 			} else {
-				t.Logf("=== %s logs ===\n%s", svc, logs)
+				HALogf(t, "=== %s logs ===\n%s", svc, logs)
 			}
 
 			if i < len(nodeClients) {
 				status, statusErr := nodeClients[i].GetStatus(cleanupCtx)
 				if statusErr != nil {
-					t.Logf("%s status: unreachable (%v)", svc, statusErr)
+					HALogf(t, "%s status: unreachable (%v)", svc, statusErr)
 				} else {
 					role := "standalone"
 					if status.Cluster != nil {
 						role = status.Cluster.Role
 					}
 
-					t.Logf("%s status: role=%s initialized=%v ready=%v",
+					HALogf(t, "%s status: role=%s initialized=%v ready=%v",
 						svc, role, status.Initialized, status.Ready)
 				}
 			}
@@ -119,10 +119,10 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 				continue
 			}
 
-			t.Logf("cluster members (from node %d):", i+1)
+			HALogf(t, "cluster members (from node %d):", i+1)
 
 			for _, m := range members {
-				t.Logf("  node=%d raft=%s api=%s suffrage=%s isLeader=%v",
+				HALogf(t, "  node=%d raft=%s api=%s suffrage=%s isLeader=%v",
 					m.NodeID, m.RaftAddress, m.APIAddress, m.Suffrage, m.IsLeader)
 			}
 
@@ -185,7 +185,7 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 	leaderService := nodeServices[leaderIdx]
 	orderedN2 := orderLeaderFirst(nodeN2Addrs[:], leaderIdx)
 
-	t.Logf("leader is %s; gNB primary N2 = %s", leaderService, orderedN2[0])
+	HALogf(t, "leader is %s; gNB primary N2 = %s", leaderService, orderedN2[0])
 
 	// Kick off the scenario. Stdout is mirrored to the test log AND
 	// scanned for the PHASE1_DONE marker so we can synchronise the kill.
@@ -212,7 +212,7 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 
 	select {
 	case <-markerCh:
-		t.Logf("phase 1 complete; killing leader %s", leaderService)
+		HALogf(t, "phase 1 complete; killing leader %s", leaderService)
 	case <-ctx.Done():
 		t.Fatalf("timed out waiting for phase-1 marker: %v", ctx.Err())
 	case runErr := <-scenarioErr:
@@ -243,7 +243,7 @@ func TestIntegration3GPPHAFailover(t *testing.T) {
 		t.Fatalf("scenario did not exit: %v", ctx.Err())
 	}
 
-	t.Log("failover scenario passed both phases")
+	HALog(t, "failover scenario passed both phases")
 }
 
 // bringUpHA3GPPCluster stages a 3-node HA cluster specifically for this

--- a/integration/ha_3gpp_test.go
+++ b/integration/ha_3gpp_test.go
@@ -311,7 +311,7 @@ func bringUpHA3GPPCluster(t *testing.T, ctx context.Context, dc *DockerClient, c
 	dc.ComposeCleanup(ctx)
 
 	fail := func(err error) (string, []*client.Client, error) {
-		captureClusterLogs(t, dc, composeDir, nodeServices)
+		captureClusterLogs(t, dc, composeDir, nodeServices, true)
 		return "", nil, err
 	}
 

--- a/integration/ha_concurrent_bootstrap_test.go
+++ b/integration/ha_concurrent_bootstrap_test.go
@@ -43,7 +43,7 @@ func TestIntegrationHAFreshClusterConcurrentBootstrap(t *testing.T) {
 
 	defer func() {
 		if err := dc.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
@@ -62,7 +62,7 @@ func TestIntegrationHAFreshClusterConcurrentBootstrap(t *testing.T) {
 
 	// --- Phase A: founder up, mint tokens for nodes 2 and 3. ---
 
-	t.Log("phase A: starting node 1 as founder")
+	HALog(t, "phase A: starting node 1 as founder")
 
 	if err := writeNodeConfigOpts(composeDir, 1, fqdnPeers, "", "", true); err != nil {
 		t.Fatalf("write node 1 config: %v", err)
@@ -118,7 +118,7 @@ func TestIntegrationHAFreshClusterConcurrentBootstrap(t *testing.T) {
 
 	// --- Phase B: cold-restart node 1 alongside nodes 2 and 3. ---
 
-	t.Log("phase B: stopping node 1 and starting all three concurrently")
+	HALog(t, "phase B: stopping node 1 and starting all three concurrently")
 
 	if err := dc.ComposeStopWithFile(ctx, composeDir, composeFile, "ella-core-1"); err != nil {
 		t.Fatalf("stop node 1: %v", err)

--- a/integration/ha_concurrent_bootstrap_test.go
+++ b/integration/ha_concurrent_bootstrap_test.go
@@ -57,7 +57,7 @@ func TestIntegrationHAFreshClusterConcurrentBootstrap(t *testing.T) {
 
 	defer func() {
 		// Best-effort log capture before the next test tears containers down.
-		captureClusterLogs(t, dc, composeDir, haNodeServices)
+		captureClusterLogs(t, dc, composeDir, haNodeServices, t.Failed())
 	}()
 
 	// --- Phase A: founder up, mint tokens for nodes 2 and 3. ---

--- a/integration/ha_drain_resume_test.go
+++ b/integration/ha_drain_resume_test.go
@@ -18,6 +18,8 @@ func TestIntegrationHADrainResumeCycle(t *testing.T) {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
+	beginHATest(t)
+
 	ctx := context.Background()
 
 	dockerClient, err := NewDockerClient()
@@ -27,7 +29,7 @@ func TestIntegrationHADrainResumeCycle(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -18,11 +18,11 @@ const haComposeDir = "compose/ha/"
 
 var haNodeServices = []string{"ella-core-1", "ella-core-2", "ella-core-3"}
 
-// captureClusterLogs emits each service's container logs via t.Logf
-// and, if HA_CLUSTER_LOG_DIR is set, also writes them to
-// <dir>/<test-name>/<service>.log for CI artifact upload. Safe to call
-// with no clients (e.g. on bring-up failure).
-func captureClusterLogs(t *testing.T, dc *DockerClient, composeDir string, services []string) {
+// captureClusterLogs collects each service's container logs and writes
+// them to <HA_CLUSTER_LOG_DIR>/<test-name>/<service>.log for CI artifact
+// upload. If printLogs is true, logs are also emitted via t.Logf.
+// Safe to call with no clients (e.g. on bring-up failure).
+func captureClusterLogs(t *testing.T, dc *DockerClient, composeDir string, services []string, printLogs bool) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -42,11 +42,16 @@ func captureClusterLogs(t *testing.T, dc *DockerClient, composeDir string, servi
 	for _, svc := range services {
 		logs, err := dc.ComposeLogs(ctx, composeDir, svc)
 		if err != nil {
-			t.Logf("=== %s logs: collection failed: %v ===", svc, err)
+			if printLogs {
+				t.Logf("=== %s logs: collection failed: %v ===", svc, err)
+			}
+
 			continue
 		}
 
-		t.Logf("=== %s logs ===\n%s", svc, logs)
+		if printLogs {
+			t.Logf("=== %s logs ===\n%s", svc, logs)
+		}
 
 		if diskDir != "" {
 			path := filepath.Join(diskDir, svc+".log")
@@ -92,7 +97,7 @@ func bringUpHAClusterAt(t *testing.T, ctx context.Context, dc *DockerClient, com
 	dc.ComposeCleanup(ctx)
 
 	fail := func(err error) ([]*client.Client, error) {
-		captureClusterLogs(t, dc, composeDir, services)
+		captureClusterLogs(t, dc, composeDir, services, true)
 		return nil, err
 	}
 
@@ -588,7 +593,7 @@ func waitForAutopilotReportsUnhealthy(ctx context.Context, leader *client.Client
 func dumpClusterDiagnostics(t *testing.T, ctx context.Context, dc *DockerClient, composeDir string, services []string, clients []*client.Client) {
 	t.Helper()
 
-	captureClusterLogs(t, dc, composeDir, services)
+	captureClusterLogs(t, dc, composeDir, services, t.Failed())
 
 	for i, svc := range services {
 		if i >= len(clients) {
@@ -802,7 +807,7 @@ func bringUpHAFQDNClusterAt(t *testing.T, ctx context.Context, dc *DockerClient,
 	dc.ComposeCleanup(ctx)
 
 	fail := func(err error) ([]*client.Client, error) {
-		captureClusterLogs(t, dc, composeDir, services)
+		captureClusterLogs(t, dc, composeDir, services, true)
 		return nil, err
 	}
 

--- a/integration/ha_multi_gnb_test.go
+++ b/integration/ha_multi_gnb_test.go
@@ -111,9 +111,9 @@ func TestIntegration3GPPMultiGNB(t *testing.T) {
 		for _, svc := range []string{"ella-core-1", "ella-core-2", "ella-core-3"} {
 			logs, logErr := dc.ComposeLogs(cleanupCtx, composeDir, svc)
 			if logErr != nil {
-				t.Logf("=== %s logs: collection failed: %v ===", svc, logErr)
+				HALogf(t, "=== %s logs: collection failed: %v ===", svc, logErr)
 			} else {
-				t.Logf("=== %s logs ===\n%s", svc, logs)
+				HALogf(t, "=== %s logs ===\n%s", svc, logs)
 			}
 		}
 
@@ -210,7 +210,7 @@ func TestIntegration3GPPMultiGNB(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			t.Logf("starting scenario on %s (target core %s)", gn.service, gn.coreN2)
+			HALogf(t, "starting scenario on %s (target core %s)", gn.service, gn.coreN2)
 
 			out, execErr := dc.Exec(ctx, testerContainers[i], argv, false, 5*time.Minute, nil)
 			if execErr != nil {
@@ -222,7 +222,7 @@ func TestIntegration3GPPMultiGNB(t *testing.T) {
 				return
 			}
 
-			t.Logf("%s scenario completed", gn.service)
+			HALogf(t, "%s scenario completed", gn.service)
 		}()
 	}
 
@@ -233,7 +233,7 @@ func TestIntegration3GPPMultiGNB(t *testing.T) {
 			len(errs), len(gnbs), strings.Join(errs, "\n\n"))
 	}
 
-	t.Log("all 3 scenarios passed; verifying cluster state")
+	HALog(t, "all 3 scenarios passed; verifying cluster state")
 
 	// AMF state is per-node (UE context is not replicated; see
 	// spec_security_ha.md). Query each gNB's home core for its own

--- a/integration/ha_node_address_change_test.go
+++ b/integration/ha_node_address_change_test.go
@@ -34,7 +34,7 @@ func TestIntegrationHAFollowerReturnsOnNewAddress(t *testing.T) {
 
 	defer func() {
 		if err := dc.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
@@ -71,7 +71,7 @@ func TestIntegrationHAFollowerReturnsOnNewAddress(t *testing.T) {
 		t.Fatalf("follower already at rebind target %s; pick a different IP", rebindIPv4)
 	}
 
-	t.Logf("rebinding %s (node %d) from %s to %s on %s",
+	HALogf(t, "rebinding %s (node %d) from %s to %s on %s",
 		followerService, followerNodeID, oldIP, rebindIPv4, networkName)
 
 	if err := dc.ComposeStopWithFile(ctx, composeDir, composeFile, followerService); err != nil {

--- a/integration/ha_remove_leader_test.go
+++ b/integration/ha_remove_leader_test.go
@@ -30,7 +30,7 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
@@ -111,7 +111,7 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 		t.Fatalf("background writer reported a permanent failure: %v", werr)
 	}
 
-	t.Logf("background writer: success=%d transient=%d attempts=%d",
+	HALogf(t, "background writer: success=%d transient=%d attempts=%d",
 		report.success, report.transient, report.attempts)
 
 	const minAttempts = 20
@@ -147,7 +147,7 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 	if _, err := newLeader.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: fencedIMSI}); err == nil {
 		t.Fatal("subscriber written via removed leader landed on the cluster; fence is broken")
 	} else if !isExpectedNotFound(err) {
-		t.Logf("unexpected error reading fenced IMSI: %v", err)
+		HALogf(t, "unexpected error reading fenced IMSI: %v", err)
 	}
 
 	assertMembershipConsistent(t, ctx, survivors)

--- a/integration/ha_rolling_test.go
+++ b/integration/ha_rolling_test.go
@@ -79,7 +79,7 @@ func TestIntegrationHARollingUpgrade(t *testing.T) {
 	// Discovered after the first swap.
 	var targetSchema int
 
-	t.Logf("baseline schema = %d", baselineSchema)
+	HALogf(t, "baseline schema = %d", baselineSchema)
 
 	for i, c := range clients {
 		assertSchemaState(t, ctx, c, fmt.Sprintf("node %d (initial)", i+1), schemaState{
@@ -113,7 +113,7 @@ func TestIntegrationHARollingUpgrade(t *testing.T) {
 		nodeNum := nodeIdx + 1
 		isLast := step == len(upgradeOrder)-1
 
-		t.Logf("=== rolling step %d/%d: upgrade node %d (was %s) ===",
+		HALogf(t, "=== rolling step %d/%d: upgrade node %d (was %s) ===",
 			step+1, len(upgradeOrder), nodeNum,
 			roleAt(ctx, clients[nodeIdx]))
 
@@ -131,7 +131,7 @@ func TestIntegrationHARollingUpgrade(t *testing.T) {
 					targetSchema, baselineSchema)
 			}
 
-			t.Logf("target schema = %d (delta from baseline = %d)",
+			HALogf(t, "target schema = %d (delta from baseline = %d)",
 				targetSchema, targetSchema-baselineSchema)
 		}
 
@@ -149,7 +149,7 @@ func TestIntegrationHARollingUpgrade(t *testing.T) {
 		if !isLast && targetSchema > baselineSchema {
 			expectedLaggards := remainingBaselineNodes(upgradeOrder, step+1)
 
-			t.Logf("intermediate: expecting applied=%d, laggard ∈ %v",
+			HALogf(t, "intermediate: expecting applied=%d, laggard ∈ %v",
 				baselineSchema, expectedLaggards)
 
 			waitForPending := func(c *client.Client, label string) {
@@ -207,7 +207,7 @@ func TestIntegrationHARollingUpgrade(t *testing.T) {
 		}
 	}
 
-	t.Log("=== final: all nodes on target; waiting for migrations to apply ===")
+	HALog(t, "=== final: all nodes on target; waiting for migrations to apply ===")
 
 	for i, c := range clients {
 		if err := waitForSchemaCondition(ctx, c, func(s *client.Status) error {
@@ -241,7 +241,7 @@ func TestIntegrationHARollingUpgrade(t *testing.T) {
 		t.Fatalf("background writer reported a permanent failure: %v", err)
 	}
 
-	t.Logf("background writer: %d successes, %d transient failures, %d total attempts",
+	HALogf(t, "background writer: %d successes, %d transient failures, %d total attempts",
 		writeReport.success, writeReport.transient, writeReport.attempts)
 
 	if writeReport.success == 0 {
@@ -390,13 +390,13 @@ func capturePreSwapLogs(t *testing.T, ctx context.Context, dc *DockerClient, ser
 
 	subdir := filepath.Join(dir, sanitizeTestName(t.Name()))
 	if err := os.MkdirAll(subdir, 0o755); err != nil {
-		t.Logf("capturePreSwapLogs: mkdir %s: %v", subdir, err)
+		HALogf(t, "capturePreSwapLogs: mkdir %s: %v", subdir, err)
 		return
 	}
 
 	logs, err := dc.ComposeLogs(ctx, haRollingComposeDir, service)
 	if err != nil {
-		t.Logf("capturePreSwapLogs: %s: %v", service, err)
+		HALogf(t, "capturePreSwapLogs: %s: %v", service, err)
 		return
 	}
 
@@ -404,7 +404,7 @@ func capturePreSwapLogs(t *testing.T, ctx context.Context, dc *DockerClient, ser
 	// (or repeated test runs) don't clobber prior captures.
 	path := filepath.Join(subdir, fmt.Sprintf("%s.pre-swap-%s.log", service, time.Now().UTC().Format("150405.000")))
 	if err := os.WriteFile(path, []byte(logs), 0o644); err != nil {
-		t.Logf("capturePreSwapLogs: write %s: %v", path, err)
+		HALogf(t, "capturePreSwapLogs: write %s: %v", path, err)
 	}
 }
 

--- a/integration/ha_snapshot_test.go
+++ b/integration/ha_snapshot_test.go
@@ -25,7 +25,7 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 
 	const composeDir = "compose/ha-scaleup/"
 
-	t.Logf("Running HA snapshot install test in %s mode", DetectIPFamily())
+	HALogf(t, "Running HA snapshot install test in %s mode", DetectIPFamily())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
@@ -37,7 +37,7 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
@@ -106,7 +106,7 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 		t.Fatalf("leader applied index: %v", err)
 	}
 
-	t.Logf("leader applied index after pre-join writes: %d", preJoinIdx)
+	HALogf(t, "leader applied index after pre-join writes: %d", preJoinIdx)
 
 	if err := waitForFollowerConvergence(ctx, clients, preJoinIdx); err != nil {
 		t.Fatalf("followers did not converge: %v", err)

--- a/integration/ha_snapshot_test.go
+++ b/integration/ha_snapshot_test.go
@@ -232,7 +232,7 @@ func bringUpHASnapshotCluster(t *testing.T, ctx context.Context, dc *DockerClien
 	services := haNodeServices
 
 	fail := func(err error) ([]*client.Client, error) {
-		captureClusterLogs(t, dc, composeDir, services)
+		captureClusterLogs(t, dc, composeDir, services, true)
 		return nil, err
 	}
 

--- a/integration/ha_test.go
+++ b/integration/ha_test.go
@@ -17,6 +17,8 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
+	beginHATest(t)
+
 	ctx := context.Background()
 
 	dockerClient, err := NewDockerClient()
@@ -26,11 +28,11 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
-	t.Log("bringing up staged HA cluster")
+	HALog(t, "bringing up staged HA cluster")
 
 	clients, err := bringUpHACluster(t, ctx, dockerClient)
 	if err != nil {
@@ -41,7 +43,7 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 		dumpClusterDiagnostics(t, ctx, dockerClient, haComposeDir, haNodeServices, clients)
 	})
 
-	t.Log("cluster is ready, verifying roles")
+	HALog(t, "cluster is ready, verifying roles")
 
 	leaderCount := 0
 	followerCount := 0
@@ -87,21 +89,21 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 		t.Fatalf("expected 2 followers, got %d", followerCount)
 	}
 
-	t.Log("roles verified: 1 leader, 2 followers")
+	HALog(t, "roles verified: 1 leader, 2 followers")
 
 	_, leader, err := findLeader(ctx, clients)
 	if err != nil {
 		t.Fatalf("failed to find leader: %v", err)
 	}
 
-	t.Log("cluster initialized, waiting for all nodes to become ready")
+	HALog(t, "cluster initialized, waiting for all nodes to become ready")
 
 	err = waitForAllNodesReady(ctx, clients)
 	if err != nil {
 		t.Fatalf("not all nodes became ready: %v", err)
 	}
 
-	t.Log("all nodes ready, verifying autopilot reports cluster healthy")
+	HALog(t, "all nodes ready, verifying autopilot reports cluster healthy")
 
 	apState, err := waitForAutopilotHealthy(ctx, leader, 1, 3)
 	if err != nil {
@@ -112,10 +114,10 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 		t.Fatalf("autopilot reports unknown leader: %+v", apState)
 	}
 
-	t.Logf("autopilot healthy: leaderNodeId=%d failureTolerance=%d voters=%v",
+	HALogf(t, "autopilot healthy: leaderNodeId=%d failureTolerance=%d voters=%v",
 		apState.LeaderNodeID, apState.FailureTolerance, apState.Voters)
 
-	t.Log("creating subscriber on leader")
+	HALog(t, "creating subscriber on leader")
 
 	err = leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139935",
@@ -128,7 +130,7 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 		t.Fatalf("failed to create subscriber on leader: %v", err)
 	}
 
-	t.Log("subscriber created, waiting for follower convergence")
+	HALog(t, "subscriber created, waiting for follower convergence")
 
 	idx, err := leaderAppliedIndex(ctx, leader)
 	if err != nil {
@@ -140,7 +142,7 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 		t.Fatalf("followers did not converge: %v", err)
 	}
 
-	t.Log("followers converged, reading subscriber from each follower")
+	HALog(t, "followers converged, reading subscriber from each follower")
 
 	for i, c := range clients {
 		status, err := c.GetStatus(ctx)
@@ -164,7 +166,7 @@ func TestIntegrationHAClusterFormation(t *testing.T) {
 				i+1, sub.Imsi, "001019756139935")
 		}
 
-		t.Logf("follower node %d returned subscriber correctly", i+1)
+		HALogf(t, "follower node %d returned subscriber correctly", i+1)
 	}
 
 	assertMembershipConsistent(t, ctx, clients)
@@ -175,6 +177,8 @@ func TestIntegrationHAFollowerProxy(t *testing.T) {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
+	beginHATest(t)
+
 	ctx := context.Background()
 
 	dockerClient, err := NewDockerClient()
@@ -184,11 +188,11 @@ func TestIntegrationHAFollowerProxy(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
-	t.Log("bringing up staged HA cluster")
+	HALog(t, "bringing up staged HA cluster")
 
 	clients, err := bringUpHACluster(t, ctx, dockerClient)
 	if err != nil {
@@ -235,7 +239,7 @@ func TestIntegrationHAFollowerProxy(t *testing.T) {
 		t.Fatal("no follower found")
 	}
 
-	t.Logf("sending create-subscriber to follower node %d (will be proxied to leader)", followerIdx)
+	HALogf(t, "sending create-subscriber to follower node %d (will be proxied to leader)", followerIdx)
 
 	// Write via the follower — the proxy middleware forwards to the leader
 	// and waits for the local applied index to catch up before responding.
@@ -250,7 +254,7 @@ func TestIntegrationHAFollowerProxy(t *testing.T) {
 		t.Fatalf("failed to create subscriber via follower proxy: %v", err)
 	}
 
-	t.Log("subscriber created via follower proxy, reading back from the same follower")
+	HALog(t, "subscriber created via follower proxy, reading back from the same follower")
 
 	// Read-your-writes: the proxy waited for the local index to catch up,
 	// so we should be able to read the subscriber back immediately.
@@ -265,7 +269,7 @@ func TestIntegrationHAFollowerProxy(t *testing.T) {
 		t.Fatalf("follower returned subscriber with IMSI %q, expected %q", sub.Imsi, "001019756139936")
 	}
 
-	t.Log("read-your-writes on follower confirmed, verifying on leader")
+	HALog(t, "read-your-writes on follower confirmed, verifying on leader")
 
 	// Confirm the write landed on the leader as well.
 	sub, err = leader.GetSubscriber(ctx, &client.GetSubscriberOptions{
@@ -281,13 +285,15 @@ func TestIntegrationHAFollowerProxy(t *testing.T) {
 
 	assertMembershipConsistent(t, ctx, clients)
 
-	t.Log("leader confirmed subscriber, follower proxy write test passed")
+	HALog(t, "leader confirmed subscriber, follower proxy write test passed")
 }
 
 func TestIntegrationHALeaderFailure(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
+
+	beginHATest(t)
 
 	ctx := context.Background()
 	composeFile := ComposeFile()
@@ -299,11 +305,11 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
-	t.Log("bringing up staged HA cluster")
+	HALog(t, "bringing up staged HA cluster")
 
 	clients, err := bringUpHACluster(t, ctx, dockerClient)
 	if err != nil {
@@ -343,21 +349,21 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 	}
 
 	leaderService := haNodeServices[leaderIdx]
-	t.Logf("stopping leader %s (node %d)", leaderService, stoppedNodeID)
+	HALogf(t, "stopping leader %s (node %d)", leaderService, stoppedNodeID)
 
 	err = dockerClient.ComposeStopWithFile(ctx, haComposeDir, composeFile, leaderService)
 	if err != nil {
 		t.Fatalf("failed to stop leader: %v", err)
 	}
 
-	t.Log("leader stopped, waiting for re-election among survivors")
+	HALog(t, "leader stopped, waiting for re-election among survivors")
 
 	newLeader, err := waitForNewLeader(ctx, survivors)
 	if err != nil {
 		t.Fatalf("re-election failed: %v", err)
 	}
 
-	t.Log("new leader elected, verifying autopilot reports stopped node unhealthy")
+	HALog(t, "new leader elected, verifying autopilot reports stopped node unhealthy")
 
 	apAfterKill, err := waitForAutopilotReportsUnhealthy(ctx, newLeader, stoppedNodeID)
 	if err != nil {
@@ -369,7 +375,7 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 			apAfterKill.FailureTolerance, apAfterKill)
 	}
 
-	t.Log("autopilot reflects the outage; writing subscriber via new leader")
+	HALog(t, "autopilot reflects the outage; writing subscriber via new leader")
 
 	err = newLeader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139937",
@@ -382,7 +388,7 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 		t.Fatalf("failed to create subscriber on new leader: %v", err)
 	}
 
-	t.Log("subscriber created, reading from both surviving nodes")
+	HALog(t, "subscriber created, reading from both surviving nodes")
 
 	idx, err := leaderAppliedIndex(ctx, newLeader)
 	if err != nil {
@@ -406,10 +412,10 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 			t.Fatalf("survivor %d returned IMSI %q, expected %q", i+1, sub.Imsi, "001019756139937")
 		}
 
-		t.Logf("survivor %d returned subscriber correctly", i+1)
+		HALogf(t, "survivor %d returned subscriber correctly", i+1)
 	}
 
-	t.Logf("restarting stopped node %s", leaderService)
+	HALogf(t, "restarting stopped node %s", leaderService)
 
 	err = dockerClient.ComposeStartWithFile(ctx, haComposeDir, composeFile, leaderService)
 	if err != nil {
@@ -418,14 +424,14 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 
 	restartedClient := clients[leaderIdx]
 
-	t.Log("waiting for restarted node to become ready")
+	HALog(t, "waiting for restarted node to become ready")
 
 	err = waitForNodeReady(ctx, restartedClient)
 	if err != nil {
 		t.Fatalf("restarted node did not become ready: %v", err)
 	}
 
-	t.Log("restarted node ready, waiting for it to converge")
+	HALog(t, "restarted node ready, waiting for it to converge")
 
 	err = waitForFollowerConvergence(ctx, []*client.Client{restartedClient}, idx)
 	if err != nil {
@@ -443,14 +449,14 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 		t.Fatalf("restarted node returned IMSI %q, expected %q", sub.Imsi, "001019756139937")
 	}
 
-	t.Log("restarted node returned subscriber correctly; verifying autopilot recovered")
+	HALog(t, "restarted node returned subscriber correctly; verifying autopilot recovered")
 
 	apRecovered, err := waitForAutopilotHealthy(ctx, newLeader, 1, 3)
 	if err != nil {
 		t.Fatalf("autopilot did not recover after node restart: %v", err)
 	}
 
-	t.Logf("autopilot recovered: failureTolerance=%d voters=%v",
+	HALogf(t, "autopilot recovered: failureTolerance=%d voters=%v",
 		apRecovered.FailureTolerance, apRecovered.Voters)
 
 	assertMembershipConsistent(t, ctx, clients)
@@ -461,6 +467,8 @@ func TestIntegrationHADrainLeadership(t *testing.T) {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
+	beginHATest(t)
+
 	ctx := context.Background()
 
 	dockerClient, err := NewDockerClient()
@@ -470,11 +478,11 @@ func TestIntegrationHADrainLeadership(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
-	t.Log("bringing up staged HA cluster")
+	HALog(t, "bringing up staged HA cluster")
 
 	clients, err := bringUpHACluster(t, ctx, dockerClient)
 	if err != nil {
@@ -495,7 +503,7 @@ func TestIntegrationHADrainLeadership(t *testing.T) {
 		t.Fatalf("not all nodes became ready: %v", err)
 	}
 
-	t.Log("draining the current leader")
+	HALog(t, "draining the current leader")
 
 	leaderStatus, err := leader.GetStatus(ctx)
 	if err != nil || leaderStatus.Cluster == nil {
@@ -511,7 +519,7 @@ func TestIntegrationHADrainLeadership(t *testing.T) {
 		t.Fatalf("expected drainState drained, got %q", drainResp.DrainState)
 	}
 
-	t.Log("drain accepted, waiting for new leader")
+	HALog(t, "drain accepted, waiting for new leader")
 
 	// The other two nodes should elect a new leader.
 	newLeader, err := waitForNewLeader(ctx, clients)
@@ -524,7 +532,7 @@ func TestIntegrationHADrainLeadership(t *testing.T) {
 		t.Fatal("new leader is the same client as the drained node")
 	}
 
-	t.Log("new leader confirmed, writing subscriber via new leader")
+	HALog(t, "new leader confirmed, writing subscriber via new leader")
 
 	err = newLeader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139938",
@@ -560,7 +568,7 @@ func TestIntegrationHADrainLeadership(t *testing.T) {
 
 	assertMembershipConsistent(t, ctx, clients)
 
-	t.Log("writes continue on new leader, drain leadership test passed")
+	HALog(t, "writes continue on new leader, drain leadership test passed")
 }
 
 func TestIntegrationHAScaleUpDown(t *testing.T) {
@@ -571,7 +579,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 	const scaleUpComposeDir = "compose/ha-scaleup/"
 
 	ipFamily := DetectIPFamily()
-	t.Logf("Running HA scale-up test in %s mode", ipFamily)
+	HALogf(t, "Running HA scale-up test in %s mode", ipFamily)
 
 	ctx := context.Background()
 
@@ -582,7 +590,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
@@ -593,7 +601,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		dockerClient.ComposeDownWithFile(ctx, scaleUpComposeDir, composeFile)
 	})
 
-	t.Log("bringing up 3-node cluster via scaleup compose")
+	HALog(t, "bringing up 3-node cluster via scaleup compose")
 
 	// Reuse bringUpHACluster's staged startup logic against the
 	// scaleup compose directory. We pass the scaleup-specific service
@@ -620,7 +628,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatalf("not all nodes became ready: %v", err)
 	}
 
-	t.Log("3-node cluster ready, staging + starting 4th node as nonvoter")
+	HALog(t, "3-node cluster ready, staging + starting 4th node as nonvoter")
 
 	fullPeers := []string{
 		ClusterAddressWithPort(1, 7000),
@@ -642,14 +650,14 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 
 	node4Client.SetToken(clients[0].GetToken())
 
-	t.Log("waiting for node 4 to appear as nonvoter")
+	HALog(t, "waiting for node 4 to appear as nonvoter")
 
 	err = waitForMemberSuffrage(ctx, leader, 4, "nonvoter")
 	if err != nil {
 		t.Fatalf("node 4 did not join as nonvoter: %v", err)
 	}
 
-	t.Log("node 4 joined as nonvoter, promoting to voter")
+	HALog(t, "node 4 joined as nonvoter, promoting to voter")
 
 	err = leader.PromoteClusterMember(ctx, 4)
 	if err != nil {
@@ -661,7 +669,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatalf("node 4 did not become voter: %v", err)
 	}
 
-	t.Log("node 4 promoted to voter, writing subscriber on leader")
+	HALog(t, "node 4 promoted to voter, writing subscriber on leader")
 
 	err = leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139939",
@@ -674,7 +682,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatalf("failed to create subscriber on leader: %v", err)
 	}
 
-	t.Log("subscriber created, waiting for node 4 to converge")
+	HALog(t, "subscriber created, waiting for node 4 to converge")
 
 	idx, err := leaderAppliedIndex(ctx, leader)
 	if err != nil {
@@ -697,7 +705,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatalf("node 4 returned IMSI %q, expected %q", sub.Imsi, "001019756139939")
 	}
 
-	t.Log("node 4 returned subscriber correctly, scaling back down to 3 nodes")
+	HALog(t, "node 4 returned subscriber correctly, scaling back down to 3 nodes")
 
 	// --- Scale down: drain and remove node 4 from the cluster (4 → 3) ---
 
@@ -710,7 +718,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatalf("failed to remove node 4 from cluster: %v", err)
 	}
 
-	t.Log("node 4 removed from Raft, verifying cluster members")
+	HALog(t, "node 4 removed from Raft, verifying cluster members")
 
 	members, err := leader.ListClusterMembers(ctx)
 	if err != nil {
@@ -727,7 +735,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatalf("expected 3 cluster members after removal, got %d", len(members))
 	}
 
-	t.Log("cluster members verified (3 members), exercising removed-node fence")
+	HALog(t, "cluster members verified (3 members), exercising removed-node fence")
 
 	// removedNodeFence (cluster_http_mux.go) returns 410 → 502 to the
 	// caller. Cert revocation is a secondary defence; either failure
@@ -750,7 +758,7 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatal("CreateSubscriber via removed node 4 succeeded; fence regression")
 	}
 
-	t.Logf("write via removed node correctly rejected: %v", err)
+	HALogf(t, "write via removed node correctly rejected: %v", err)
 
 	if _, err := node4Client.MintClusterJoinToken(ctx, &client.MintJoinTokenOptions{
 		NodeID:     5,
@@ -765,16 +773,16 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 		t.Fatal("subscriber written via removed node was applied on the leader; fence is broken")
 	}
 
-	t.Log("removed-node fence rejected both write paths and nothing leaked to the leader")
+	HALog(t, "removed-node fence rejected both write paths and nothing leaked to the leader")
 
-	t.Log("stopping removed node container")
+	HALog(t, "stopping removed node container")
 
 	err = dockerClient.ComposeStopWithFile(ctx, scaleUpComposeDir, composeFile, "ella-core-4")
 	if err != nil {
 		t.Fatalf("failed to stop ella-core-4: %v", err)
 	}
 
-	t.Log("writing subscriber on 3-node cluster after scale-down")
+	HALog(t, "writing subscriber on 3-node cluster after scale-down")
 
 	err = leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139942",
@@ -810,13 +818,15 @@ func TestIntegrationHAScaleUpDown(t *testing.T) {
 
 	assertMembershipConsistent(t, ctx, clients)
 
-	t.Log("3-node cluster operational after scale-down, scale up/down test passed")
+	HALog(t, "3-node cluster operational after scale-down, scale up/down test passed")
 }
 
 func TestIntegrationHAQuorumRecovery(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
+
+	beginHATest(t)
 
 	ctx := context.Background()
 	composeFile := ComposeFile()
@@ -828,11 +838,11 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
-	t.Log("bringing up staged HA cluster")
+	HALog(t, "bringing up staged HA cluster")
 
 	clients, err := bringUpHACluster(t, ctx, dockerClient)
 	if err != nil {
@@ -853,7 +863,7 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 		t.Fatalf("not all nodes became ready: %v", err)
 	}
 
-	t.Log("cluster ready, writing subscriber before total shutdown")
+	HALog(t, "cluster ready, writing subscriber before total shutdown")
 
 	err = leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
 		Imsi:           "001019756139940",
@@ -890,7 +900,7 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 	// db.path is "/data/ella.db", so dataDir = "/data" and raftDir = "/data/raft/".
 	const containerRaftDir = "/data/raft"
 
-	t.Log("stopping all 3 nodes (total quorum loss)")
+	HALog(t, "stopping all 3 nodes (total quorum loss)")
 
 	for _, svc := range haNodeServices {
 		if err := dockerClient.ComposeStopWithFile(ctx, haComposeDir, composeFile, svc); err != nil {
@@ -925,7 +935,7 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 	}
 
 	destPath := filepath.Join(containerRaftDir, "peers.json")
-	t.Logf("copying peers.json to %s in containers for nodes 1 and 2", destPath)
+	HALogf(t, "copying peers.json to %s in containers for nodes 1 and 2", destPath)
 
 	err = dockerClient.CopyFileToContainer(ctx, container1, peersPath, destPath)
 	if err != nil {
@@ -937,7 +947,7 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 		t.Fatalf("failed to copy peers.json to node 2: %v", err)
 	}
 
-	t.Log("starting nodes 1 and 2 (node 3 stays down)")
+	HALog(t, "starting nodes 1 and 2 (node 3 stays down)")
 
 	err = dockerClient.ComposeStartWithFile(ctx, haComposeDir, composeFile, "ella-core-1")
 	if err != nil {
@@ -962,7 +972,7 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 		t.Fatalf("no leader in recovered cluster: %v", err)
 	}
 
-	t.Log("recovered cluster has a leader, verifying data survived")
+	HALog(t, "recovered cluster has a leader, verifying data survived")
 
 	sub, err := recoveredLeader.GetSubscriber(ctx, &client.GetSubscriberOptions{
 		ID: "001019756139940",
@@ -977,7 +987,7 @@ func TestIntegrationHAQuorumRecovery(t *testing.T) {
 
 	assertMembershipConsistent(t, ctx, recoveredClients)
 
-	t.Log("data survived quorum-loss recovery, test passed")
+	HALog(t, "data survived quorum-loss recovery, test passed")
 }
 
 // TestIntegrationHADisasterRecovery simulates the worst-case DR
@@ -1000,6 +1010,8 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
+	beginHATest(t)
+
 	ctx := context.Background()
 
 	dockerClient, err := NewDockerClient()
@@ -1009,7 +1021,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
@@ -1019,7 +1031,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		dockerClient.ComposeDownWithFile(ctx, haComposeDir, ComposeFile())
 	})
 
-	t.Log("bringing up staged HA cluster")
+	HALog(t, "bringing up staged HA cluster")
 
 	clients, err := bringUpHACluster(t, ctx, dockerClient)
 	if err != nil {
@@ -1062,7 +1074,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		})
 	}
 
-	t.Log("creating pre-DR subscriber")
+	HALog(t, "creating pre-DR subscriber")
 
 	if err := createSub(leader, imsiPreDR); err != nil {
 		t.Fatalf("create pre-DR subscriber: %v", err)
@@ -1079,7 +1091,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 
 	backupPath := filepath.Join(t.TempDir(), "backup.tar.gz")
 
-	t.Logf("creating backup on leader at %s", backupPath)
+	HALogf(t, "creating backup on leader at %s", backupPath)
 
 	if err := leader.CreateBackup(ctx, &client.CreateBackupParams{Path: backupPath}); err != nil {
 		t.Fatalf("create backup: %v", err)
@@ -1091,7 +1103,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		t.Fatal("backup file is empty")
 	}
 
-	t.Log("tearing down entire cluster (all volumes dropped)")
+	HALog(t, "tearing down entire cluster (all volumes dropped)")
 
 	dockerClient.ComposeDownWithFile(ctx, haComposeDir, ComposeFile())
 
@@ -1107,7 +1119,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		t.Fatalf("write node 1 config: %v", err)
 	}
 
-	t.Log("creating node 1 container (not started) so we can stage restore.bundle")
+	HALog(t, "creating node 1 container (not started) so we can stage restore.bundle")
 
 	if err := dockerClient.ComposeCreateWithFile(ctx, haComposeDir, ComposeFile(), haNodeServices[0]); err != nil {
 		t.Fatalf("compose create node 1: %v", err)
@@ -1118,13 +1130,13 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		t.Fatalf("resolve node 1 container: %v", err)
 	}
 
-	t.Logf("copying backup into %s:/data/restore.bundle", container1)
+	HALogf(t, "copying backup into %s:/data/restore.bundle", container1)
 
 	if err := dockerClient.CopyFileToContainer(ctx, container1, backupPath, "/data/restore.bundle"); err != nil {
 		t.Fatalf("copy restore.bundle to node 1: %v", err)
 	}
 
-	t.Log("starting node 1 — runtime should extract restore.bundle and self-sign a fresh cluster cert")
+	HALog(t, "starting node 1 — runtime should extract restore.bundle and self-sign a fresh cluster cert")
 
 	if err := dockerClient.ComposeStartWithFile(ctx, haComposeDir, ComposeFile(), haNodeServices[0]); err != nil {
 		t.Fatalf("start node 1: %v", err)
@@ -1143,7 +1155,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 	// come back with the rest of the replicated state.
 	restoredNode1.SetToken(adminToken)
 
-	t.Log("verifying pre-DR subscriber survived on the restored node")
+	HALog(t, "verifying pre-DR subscriber survived on the restored node")
 
 	sub, err := restoredNode1.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsiPreDR})
 	if err != nil {
@@ -1154,7 +1166,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		t.Fatalf("restored node returned IMSI %q, want %q", sub.Imsi, imsiPreDR)
 	}
 
-	t.Log("verifying restored node is a functional leader (can mint join tokens)")
+	HALog(t, "verifying restored node is a functional leader (can mint join tokens)")
 
 	status, err := restoredNode1.GetStatus(ctx)
 	if err != nil {
@@ -1165,7 +1177,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		t.Fatalf("restored node role = %v, want Leader", status.Cluster)
 	}
 
-	t.Log("staging fresh joiners for nodes 2 and 3")
+	HALog(t, "staging fresh joiners for nodes 2 and 3")
 
 	for _, i := range []int{2, 3} {
 		if err := stageAndStartJoiner(ctx, dockerClient, restoredNode1, haComposeDir, haNodeServices[i-1], i, peers, ""); err != nil {
@@ -1199,7 +1211,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		t.Fatalf("followers did not converge after DR: %v", err)
 	}
 
-	t.Log("verifying pre-DR subscriber is visible on every node")
+	HALog(t, "verifying pre-DR subscriber is visible on every node")
 
 	for i, c := range clientsAfterDR {
 		got, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsiPreDR})
@@ -1212,7 +1224,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 		}
 	}
 
-	t.Log("verifying writes resume after DR")
+	HALog(t, "verifying writes resume after DR")
 
 	if err := createSub(restoredNode1, imsiPostDR); err != nil {
 		t.Fatalf("post-DR write: %v", err)
@@ -1240,7 +1252,7 @@ func TestIntegrationHADisasterRecovery(t *testing.T) {
 
 	assertMembershipConsistent(t, ctx, clientsAfterDR)
 
-	t.Log("disaster-recovery test passed")
+	HALog(t, "disaster-recovery test passed")
 }
 
 // TestIntegrationHANetworkPartition partitions the current leader from
@@ -1257,6 +1269,8 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 		t.Skip("skipping integration tests, set environment variable INTEGRATION")
 	}
 
+	beginHATest(t)
+
 	ctx := context.Background()
 
 	dockerClient, err := NewDockerClient()
@@ -1266,11 +1280,11 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 
 	defer func() {
 		if err := dockerClient.Close(); err != nil {
-			t.Logf("failed to close docker client: %v", err)
+			HALogf(t, "failed to close docker client: %v", err)
 		}
 	}()
 
-	t.Log("bringing up staged HA cluster")
+	HALog(t, "bringing up staged HA cluster")
 
 	clients, err := bringUpHACluster(t, ctx, dockerClient)
 	if err != nil {
@@ -1311,7 +1325,7 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 		}
 	}
 
-	t.Logf("partitioning %s (node %d) on cluster port 7000", leaderService, isolatedNodeID)
+	HALogf(t, "partitioning %s (node %d) on cluster port 7000", leaderService, isolatedNodeID)
 
 	if err := partitionClusterPort(ctx, dockerClient, leaderContainer); err != nil {
 		t.Fatalf("apply partition: %v", err)
@@ -1325,11 +1339,11 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 		}
 
 		if err := healClusterPort(ctx, dockerClient, leaderContainer); err != nil {
-			t.Logf("cleanup heal failed: %v", err)
+			HALogf(t, "cleanup heal failed: %v", err)
 		}
 	})
 
-	t.Log("partition applied, waiting for survivors to elect a new leader")
+	HALog(t, "partition applied, waiting for survivors to elect a new leader")
 
 	newLeader, err := waitForNewLeader(ctx, survivors)
 	if err != nil {
@@ -1346,7 +1360,7 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 			isolatedNodeID)
 	}
 
-	t.Logf("new leader is node %d", newLeaderStatus.Cluster.NodeID)
+	HALogf(t, "new leader is node %d", newLeaderStatus.Cluster.NodeID)
 
 	const survivorIMSI = "001019756140001"
 
@@ -1369,7 +1383,7 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 		t.Fatalf("survivor follower did not converge: %v", err)
 	}
 
-	t.Log("write to majority side succeeded, attempting write on isolated former leader")
+	HALog(t, "write to majority side succeeded, attempting write on isolated former leader")
 
 	// 503 (propose times out before lease expiry) or 502 (proxy
 	// can't reach a leader after step-down) are both acceptable;
@@ -1391,9 +1405,9 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 		t.Fatal("isolated former leader accepted a write while partitioned; split-brain regression")
 	}
 
-	t.Logf("write on isolated former leader correctly rejected: %v", err)
+	HALogf(t, "write on isolated former leader correctly rejected: %v", err)
 
-	t.Log("healing partition")
+	HALog(t, "healing partition")
 
 	if err := healClusterPort(ctx, dockerClient, leaderContainer); err != nil {
 		t.Fatalf("heal partition: %v", err)
@@ -1401,7 +1415,7 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 
 	healed = true
 
-	t.Log("waiting for formerly isolated node to converge with new leader's state")
+	HALog(t, "waiting for formerly isolated node to converge with new leader's state")
 
 	postHealIdx, err := leaderAppliedIndex(ctx, newLeader)
 	if err != nil {
@@ -1423,7 +1437,7 @@ func TestIntegrationHANetworkPartition(t *testing.T) {
 
 	assertMembershipConsistent(t, ctx, clients)
 
-	t.Log("formerly isolated node converged after heal; partition test passed")
+	HALog(t, "formerly isolated node converged after heal; partition test passed")
 }
 
 // Both --dport and --sport on INPUT and OUTPUT: peer connections are

--- a/integration/n2_handover_test.go
+++ b/integration/n2_handover_test.go
@@ -62,8 +62,10 @@ func TestIntegrationN2Handover(t *testing.T) {
 		for _, svc := range []string{"ella-core", "ella-core-tester"} {
 			logs, logErr := dc.ComposeLogs(cleanupCtx, composeDir, svc)
 			if logErr != nil {
-				t.Logf("=== %s logs: collection failed: %v ===", svc, logErr)
-			} else {
+				if t.Failed() {
+					t.Logf("=== %s logs: collection failed: %v ===", svc, logErr)
+				}
+			} else if t.Failed() {
 				t.Logf("=== %s logs ===\n%s", svc, logs)
 			}
 		}

--- a/integration/network_rules_test.go
+++ b/integration/network_rules_test.go
@@ -224,9 +224,7 @@ func runRuleShape(ctx context.Context, t *testing.T, env *testerEnv, fp ipFamily
 	t.Helper()
 
 	sc, ok := scenarios.Get(shape.scenario)
-	if !ok {
-		t.Fatalf("scenario %q not registered", shape.scenario)
-	}
+	Assert(t, ok, fmt.Sprintf("scenario %q not registered", shape.scenario))
 
 	scenariosEnv := buildScenariosEnv(env)
 

--- a/integration/network_rules_test.go
+++ b/integration/network_rules_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -274,7 +275,12 @@ func runRuleShape(ctx context.Context, t *testing.T, env *testerEnv, fp ipFamily
 	scenarioStart := time.Now()
 
 	for _, p := range shape.protocols {
-		env.RunScenario(ctx, t, shape.scenario, scenarioRunArgs(shape.scenario, spec, pps[p])...)
+		pp := pps[p]
+		scenarioName := fmt.Sprintf("%s/%s", shape.scenario, p)
+		tr := globalReporter.Start(scenarioName)
+		QuietLog(t, tr, "running "+scenarioName)
+		env.RunScenario(ctx, t, shape.scenario, tr, scenarioRunArgs(shape.scenario, spec, pp)...)
+		globalReporter.Pass(tr)
 	}
 
 	scenarioEnd := time.Now()

--- a/integration/network_rules_test.go
+++ b/integration/network_rules_test.go
@@ -276,7 +276,7 @@ func runRuleShape(ctx context.Context, t *testing.T, env *testerEnv, fp ipFamily
 		pp := pps[p]
 		scenarioName := fmt.Sprintf("%s/%s", shape.scenario, p)
 		tr := globalReporter.Start(scenarioName)
-		QuietLog(t, tr, "running "+scenarioName)
+		QuietLogf(t, tr, "running %s", scenarioName)
 		env.RunScenario(ctx, t, shape.scenario, tr, scenarioRunArgs(shape.scenario, spec, pp)...)
 		finishScenarioTest(t, tr)
 	}

--- a/integration/network_rules_test.go
+++ b/integration/network_rules_test.go
@@ -280,7 +280,7 @@ func runRuleShape(ctx context.Context, t *testing.T, env *testerEnv, fp ipFamily
 		tr := globalReporter.Start(scenarioName)
 		QuietLog(t, tr, "running "+scenarioName)
 		env.RunScenario(ctx, t, shape.scenario, tr, scenarioRunArgs(shape.scenario, spec, pp)...)
-		globalReporter.Pass(tr)
+		finishScenarioTest(t, tr)
 	}
 
 	scenarioEnd := time.Now()

--- a/integration/reporter_test.go
+++ b/integration/reporter_test.go
@@ -156,12 +156,7 @@ type summaryBuilder struct {
 }
 
 func (b *summaryBuilder) String() string {
-	var total int
-	if b.fail > 0 {
-		total = b.pass + b.fail + b.skip
-	} else {
-		total = b.pass + b.skip
-	}
+	total := b.pass + b.fail + b.skip
 
 	var result string
 	if b.fail > 0 {
@@ -191,36 +186,10 @@ func (b *summaryBuilder) String() string {
 // globalReporter is the shared test reporter for all integration tests.
 var globalReporter = NewReporter()
 
-// failureReasons stores the t.Fatalf message per test name so that
-// finishScenarioTest can report the exact reason instead of the
-// generic "test failed" placeholder.
-var (
-	failureReasons  = make(map[string]string)
-	failureReasonMu sync.Mutex
-)
-
-// captureFailureReason is a no-op placeholder that signals the test
-// should track failure reasons. The actual reporter update is done by
-// finishScenarioTest which reads the reason set via setFailureReason.
-func captureFailureReason(t *testing.T) {
-	// No-op: finishScenarioTest handles the reporter update.
-}
-
-// setFailureReason records the failure reason for a test name.
+// setFailureReason records the failure reason on the TestResult.
 // Call this from within the test before calling t.Fatalf.
-func setFailureReason(name, reason string) {
-	failureReasonMu.Lock()
-	defer failureReasonMu.Unlock()
-
-	failureReasons[name] = reason
-}
-
-// getFailureReason returns the stored failure reason for a test name.
-func getFailureReason(name string) string {
-	failureReasonMu.Lock()
-	defer failureReasonMu.Unlock()
-
-	return failureReasons[name]
+func setFailureReason(tr *TestResult, reason string) {
+	tr.Reason = reason
 }
 
 // registerScenarioTest creates a reporter entry for a scenario subtest.
@@ -233,7 +202,7 @@ func registerScenarioTest(scenarioName string) *TestResult {
 // Call this after t.Run returns, using t.Failed() to determine pass/fail.
 func finishScenarioTest(t *testing.T, tr *TestResult) {
 	if t.Failed() {
-		reason := getFailureReason(t.Name())
+		reason := tr.Reason
 		if reason == "" {
 			reason = "test failed"
 		}
@@ -376,13 +345,11 @@ func writeFailureReports(t *testing.T, testPrefix string) {
 		// Build filename from scenario name, replacing / with _.
 		safeName := strings.ReplaceAll(name, "/", "_")
 		filename := testPrefix + "_" + safeName + ".txt"
-		path := filepath.Join(logDir, filename)
+		path := filepath.Clean(filepath.Join(logDir, filename))
 
 		if dir := filepath.Dir(path); dir != logDir {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				t.Logf("failed to create report subdir %s: %v", dir, err)
-				return
-			}
+			t.Logf("skipping report for %s: path escapes log directory", name)
+			return
 		}
 
 		f, err := os.Create(path)

--- a/integration/reporter_test.go
+++ b/integration/reporter_test.go
@@ -191,6 +191,38 @@ func (b *summaryBuilder) String() string {
 // globalReporter is the shared test reporter for all integration tests.
 var globalReporter = NewReporter()
 
+// failureReasons stores the t.Fatalf message per test name so that
+// finishScenarioTest can report the exact reason instead of the
+// generic "test failed" placeholder.
+var (
+	failureReasons  = make(map[string]string)
+	failureReasonMu sync.Mutex
+)
+
+// captureFailureReason is a no-op placeholder that signals the test
+// should track failure reasons. The actual reporter update is done by
+// finishScenarioTest which reads the reason set via setFailureReason.
+func captureFailureReason(t *testing.T) {
+	// No-op: finishScenarioTest handles the reporter update.
+}
+
+// setFailureReason records the failure reason for a test name.
+// Call this from within the test before calling t.Fatalf.
+func setFailureReason(name, reason string) {
+	failureReasonMu.Lock()
+	defer failureReasonMu.Unlock()
+
+	failureReasons[name] = reason
+}
+
+// getFailureReason returns the stored failure reason for a test name.
+func getFailureReason(name string) string {
+	failureReasonMu.Lock()
+	defer failureReasonMu.Unlock()
+
+	return failureReasons[name]
+}
+
 // registerScenarioTest creates a reporter entry for a scenario subtest.
 // Call this before t.Run to track the scenario's execution.
 func registerScenarioTest(scenarioName string) *TestResult {
@@ -201,9 +233,12 @@ func registerScenarioTest(scenarioName string) *TestResult {
 // Call this after t.Run returns, using t.Failed() to determine pass/fail.
 func finishScenarioTest(t *testing.T, tr *TestResult) {
 	if t.Failed() {
-		// Go doesn't expose the failure message directly, so we use a
-		// generic message. The detailed logs are captured via QuietLog.
-		globalReporter.Fail(tr, "test failed")
+		reason := getFailureReason(t.Name())
+		if reason == "" {
+			reason = "test failed"
+		}
+
+		globalReporter.Fail(tr, reason)
 	} else {
 		globalReporter.Pass(tr)
 	}

--- a/integration/reporter_test.go
+++ b/integration/reporter_test.go
@@ -1,0 +1,364 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Reporter tracks test execution and produces a summary report.
+type Reporter struct {
+	mu    sync.Mutex
+	tests map[string]*TestResult
+	order []string // preserves insertion order
+}
+
+// TestResult holds the result of a single test or subtest.
+type TestResult struct {
+	Name      string
+	Status    string // "pass", "fail", "skip"
+	Reason    string // failure reason (empty if passed)
+	Duration  time.Duration
+	Logs      []string // captured quiet log lines
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+// NewReporter creates a new test reporter.
+func NewReporter() *Reporter {
+	return &Reporter{
+		tests: make(map[string]*TestResult),
+	}
+}
+
+// Start records the beginning of a test. Returns the TestResult to track.
+func (r *Reporter) Start(name string) *TestResult {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tr := &TestResult{
+		Name:      name,
+		StartTime: time.Now(),
+	}
+	r.tests[name] = tr
+	r.order = append(r.order, name)
+
+	return tr
+}
+
+// Pass records a passing test.
+func (r *Reporter) Pass(tr *TestResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tr.Status = "pass"
+	tr.EndTime = time.Now()
+	tr.Duration = tr.EndTime.Sub(tr.StartTime)
+}
+
+// Fail records a failing test with a reason.
+func (r *Reporter) Fail(tr *TestResult, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tr.Status = "fail"
+	tr.Reason = reason
+	tr.EndTime = time.Now()
+	tr.Duration = tr.EndTime.Sub(tr.StartTime)
+}
+
+// Skip records a skipped test with a reason.
+func (r *Reporter) Skip(tr *TestResult, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tr.Status = "skip"
+	tr.Reason = reason
+	tr.EndTime = time.Now()
+	tr.Duration = tr.EndTime.Sub(tr.StartTime)
+}
+
+// Log records a quiet log line for a test.
+func (r *Reporter) Log(tr *TestResult, msg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tr.Logs = append(tr.Logs, msg)
+}
+
+// FailureCount returns the number of failed tests.
+func (r *Reporter) FailureCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var count int
+
+	for _, tr := range r.tests {
+		if tr.Status == "fail" {
+			count++
+		}
+	}
+
+	return count
+}
+
+// Range calls fn for each tracked test in insertion order.
+// fn receives the test name and a pointer to its TestResult.
+func (r *Reporter) Range(fn func(name string, tr *TestResult)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, name := range r.order {
+		fn(name, r.tests[name])
+	}
+}
+
+// Summary produces a compact summary string of all tracked tests.
+func (r *Reporter) Summary() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var passCount, failCount, skipCount int
+
+	for _, name := range r.order {
+		tr := r.tests[name]
+		switch tr.Status {
+		case "pass":
+			passCount++
+		case "fail":
+			failCount++
+		case "skip":
+			skipCount++
+		}
+	}
+
+	var buf fmt.Stringer = &summaryBuilder{
+		pass:   passCount,
+		fail:   failCount,
+		skip:   skipCount,
+		orders: r.order,
+		tests:  r.tests,
+	}
+
+	return buf.String()
+}
+
+type summaryBuilder struct {
+	pass   int
+	fail   int
+	skip   int
+	orders []string
+	tests  map[string]*TestResult
+}
+
+func (b *summaryBuilder) String() string {
+	var total int
+	if b.fail > 0 {
+		total = b.pass + b.fail + b.skip
+	} else {
+		total = b.pass + b.skip
+	}
+
+	var result string
+	if b.fail > 0 {
+		result = fmt.Sprintf("FAIL: %d total — %d failed, %d passed, %d skipped",
+			total, b.fail, b.pass, b.skip)
+	} else {
+		result = fmt.Sprintf("PASS: %d total — %d passed, %d skipped",
+			total, b.pass, b.skip)
+	}
+
+	// List failures with reasons
+	if b.fail > 0 {
+		result += "\n\nFailed tests:"
+
+		for _, name := range b.orders {
+			tr := b.tests[name]
+			if tr.Status == "fail" {
+				result += fmt.Sprintf("\n  - %s (%.1fs): %s",
+					tr.Name, tr.Duration.Seconds(), tr.Reason)
+			}
+		}
+	}
+
+	return result
+}
+
+// globalReporter is the shared test reporter for all integration tests.
+var globalReporter = NewReporter()
+
+// registerScenarioTest creates a reporter entry for a scenario subtest.
+// Call this before t.Run to track the scenario's execution.
+func registerScenarioTest(scenarioName string) *TestResult {
+	return globalReporter.Start(scenarioName)
+}
+
+// finishScenarioTest records the outcome of a scenario subtest.
+// Call this after t.Run returns, using t.Failed() to determine pass/fail.
+func finishScenarioTest(t *testing.T, tr *TestResult) {
+	if t.Failed() {
+		// Go doesn't expose the failure message directly, so we use a
+		// generic message. The detailed logs are captured via QuietLog.
+		globalReporter.Fail(tr, "test failed")
+	} else {
+		globalReporter.Pass(tr)
+	}
+}
+
+// printTesterSummary prints a compact summary of the core-tester scenarios.
+func printTesterSummary(t *testing.T) {
+	summary := globalReporter.Summary()
+	fmt.Println(summary)
+
+	if globalReporter.FailureCount() > 0 {
+		writeFailureReports(t, "core-tester")
+	}
+}
+
+// isQuiet reports whether quiet reporting is enabled.
+// QUIET_REPORT=false disables quiet mode (shows all logs).
+func isQuiet() bool {
+	return os.Getenv("QUIET_REPORT") != "false"
+}
+
+// QuietLog records a log line for the test without printing it.
+// If quiet mode is disabled (QUIET_REPORT=false), prints immediately.
+func QuietLog(t *testing.T, tr *TestResult, msg string) {
+	if isQuiet() {
+		globalReporter.Log(tr, msg)
+	} else {
+		t.Log(msg)
+	}
+}
+
+// QuietLogf records a formatted log line for the test without printing it.
+// If quiet mode is disabled (QUIET_REPORT=false), prints immediately.
+func QuietLogf(t *testing.T, tr *TestResult, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	QuietLog(t, tr, msg)
+}
+
+// VerboseLog prints a log message immediately regardless of quiet mode.
+// Use for critical messages that should always be visible.
+func VerboseLog(t *testing.T, msg string) {
+	t.Log(msg)
+}
+
+// halogBuffer stores captured log lines for HA tests by test name.
+var (
+	halogBuffer = make(map[string][]string)
+	halogMu     sync.Mutex
+)
+
+// HALog logs a message for an HA test. In quiet mode, the message is
+// captured and only printed if the test fails. In verbose mode (or on
+// failure), it is printed immediately.
+func HALog(t *testing.T, msg string) {
+	name := t.Name()
+
+	if isQuiet() {
+		halogMu.Lock()
+
+		halogBuffer[name] = append(halogBuffer[name], msg)
+		halogMu.Unlock()
+	} else {
+		t.Log(msg)
+	}
+}
+
+// HALogf is the formatted version of HALog.
+func HALogf(t *testing.T, format string, args ...interface{}) {
+	HALog(t, fmt.Sprintf(format, args...))
+}
+
+// printHALogs prints captured HA test logs for failed tests.
+// Should be called from a t.Cleanup after the test completes.
+func printHALogs(t *testing.T) {
+	name := t.Name()
+
+	halogMu.Lock()
+	logs, ok := halogBuffer[name]
+	halogMu.Unlock()
+
+	if !ok || len(logs) == 0 {
+		return
+	}
+
+	// Only print logs for failed tests.
+	if !t.Failed() {
+		return
+	}
+
+	VerboseLog(t, fmt.Sprintf("=== %s: captured logs (%d lines) ===", name, len(logs)))
+	// Print last 30 lines to keep output manageable.
+	start := 0
+	if len(logs) > 30 {
+		start = len(logs) - 30
+	}
+
+	for _, line := range logs[start:] {
+		VerboseLog(t, line)
+	}
+
+	VerboseLog(t, "=== end captured logs ===")
+}
+
+// beginHATest registers a t.Cleanup that prints captured logs for failed HA tests.
+// Call this at the start of each HA test function.
+func beginHATest(t *testing.T) {
+	t.Cleanup(func() {
+		printHALogs(t)
+	})
+}
+
+// writeFailureReports writes detailed failure reports to files.
+func writeFailureReports(t *testing.T, testPrefix string) {
+	logDir := os.Getenv("HA_CLUSTER_LOG_DIR")
+	if logDir == "" {
+		logDir = filepath.Join(os.TempDir(), "integration-failures")
+	}
+
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Logf("failed to create report dir %s: %v", logDir, err)
+		return
+	}
+
+	globalReporter.Range(func(name string, tr *TestResult) {
+		if tr.Status != "fail" {
+			return
+		}
+
+		// Build filename from scenario name, replacing / with _.
+		safeName := strings.ReplaceAll(name, "/", "_")
+		filename := testPrefix + "_" + safeName + ".txt"
+		path := filepath.Join(logDir, filename)
+
+		if dir := filepath.Dir(path); dir != logDir {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Logf("failed to create report subdir %s: %v", dir, err)
+				return
+			}
+		}
+
+		f, err := os.Create(path)
+		if err != nil {
+			t.Logf("failed to create report file %s: %v", path, err)
+			return
+		}
+
+		_, _ = fmt.Fprintf(f, "=== %s ===\n", name)
+		_, _ = fmt.Fprintf(f, "Duration: %.1fs\n", tr.Duration.Seconds())
+		_, _ = fmt.Fprintf(f, "Error: %s\n", tr.Reason)
+		_, _ = fmt.Fprintf(f, "\n--- Captured Logs ---\n")
+
+		for _, line := range tr.Logs {
+			_, _ = fmt.Fprintf(f, "%s\n", line)
+		}
+
+		_ = f.Close()
+	})
+}

--- a/integration/reporter_test.go
+++ b/integration/reporter_test.go
@@ -283,6 +283,12 @@ func VerboseLog(t *testing.T, msg string) {
 	t.Log(msg)
 }
 
+// VerboseLogf prints a formatted log message immediately regardless of quiet mode.
+// Use for critical messages that should always be visible.
+func VerboseLogf(t *testing.T, format string, args ...interface{}) {
+	VerboseLog(t, fmt.Sprintf(format, args...))
+}
+
 // halogBuffer stores captured log lines for HA tests by test name.
 var (
 	halogBuffer = make(map[string][]string)
@@ -328,7 +334,7 @@ func printHALogs(t *testing.T) {
 		return
 	}
 
-	VerboseLog(t, fmt.Sprintf("=== %s: captured logs (%d lines) ===", name, len(logs)))
+	VerboseLogf(t, "=== %s: captured logs (%d lines) ===", name, len(logs))
 	// Print last 30 lines to keep output manageable.
 	start := 0
 	if len(logs) > 30 {

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -71,8 +73,16 @@ func setupTesterEnv(ctx context.Context, t *testing.T) *testerEnv {
 
 	t.Cleanup(func() {
 		logs, err := dc.ComposeLogs(ctx, composeDir, "ella-core")
-		if err == nil && t.Failed() {
-			t.Logf("=== ella-core container logs ===\n%s", logs)
+		if err == nil {
+			logDir := os.Getenv("HA_CLUSTER_LOG_DIR")
+			if logDir != "" && t.Failed() {
+				safeName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+
+				dir := filepath.Join(logDir, safeName)
+				if err := os.MkdirAll(dir, 0o755); err == nil {
+					_ = os.WriteFile(filepath.Join(dir, "ella-core.log"), []byte(logs), 0o644)
+				}
+			}
 		}
 
 		dc.ComposeDownWithFile(ctx, composeDir, composeFile)
@@ -198,6 +208,7 @@ func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario stri
 	QuietLog(t, tr, "running: "+strings.Join(argv, " "))
 
 	if _, err := e.dc.Exec(ctx, e.TesterContainer, argv, false, 5*time.Minute, quietLogWriter{tr}); err != nil {
+		setFailureReason(t.Name(), fmt.Sprintf("scenario %q failed: %v", scenario, err))
 		t.Fatalf("scenario %q failed: %v", scenario, err)
 	}
 }

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -208,7 +208,7 @@ func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario stri
 	QuietLogf(t, tr, "running: %s", strings.Join(argv, " "))
 
 	if _, err := e.dc.Exec(ctx, e.TesterContainer, argv, false, 5*time.Minute, quietLogWriter{tr}); err != nil {
-		setFailureReason(t.Name(), fmt.Sprintf("scenario %q failed: %v", scenario, err))
+		setFailureReason(tr, fmt.Sprintf("scenario %q failed: %v", scenario, err))
 		t.Fatalf("scenario %q failed: %v", scenario, err)
 	}
 }

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -71,7 +71,7 @@ func setupTesterEnv(ctx context.Context, t *testing.T) *testerEnv {
 
 	t.Cleanup(func() {
 		logs, err := dc.ComposeLogs(ctx, composeDir, "ella-core")
-		if err == nil {
+		if err == nil && t.Failed() {
 			t.Logf("=== ella-core container logs ===\n%s", logs)
 		}
 

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -171,8 +171,8 @@ func bootstrapTesterCore(ctx context.Context, cl *client.Client) error {
 // RunScenario invokes `core-tester run <scenario>` in the sidecar,
 // injecting --ella-core-n2-address, --gnb, --ella-api-address, and
 // --ella-api-token from the compose topology. Fails the subtest on
-// non-zero exit. stdout/stderr mirror to the test log.
-func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario string, extraArgs ...string) {
+// non-zero exit. stdout/stderr are captured for failure reporting.
+func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario string, tr *TestResult, extraArgs ...string) {
 	t.Helper()
 
 	argv := []string{"core-tester", "run", scenario}
@@ -195,9 +195,9 @@ func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario stri
 	argv = append(argv, "--verbose")
 	argv = append(argv, extraArgs...)
 
-	t.Logf("running: %s", strings.Join(argv, " "))
+	QuietLog(t, tr, "running: "+strings.Join(argv, " "))
 
-	if _, err := e.dc.Exec(ctx, e.TesterContainer, argv, false, 5*time.Minute, logWriter{t}); err != nil {
+	if _, err := e.dc.Exec(ctx, e.TesterContainer, argv, false, 5*time.Minute, quietLogWriter{tr}); err != nil {
 		t.Fatalf("scenario %q failed: %v", scenario, err)
 	}
 }

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -205,7 +205,7 @@ func (e *testerEnv) RunScenario(ctx context.Context, t *testing.T, scenario stri
 	argv = append(argv, "--verbose")
 	argv = append(argv, extraArgs...)
 
-	QuietLog(t, tr, "running: "+strings.Join(argv, " "))
+	QuietLogf(t, tr, "running: %s", strings.Join(argv, " "))
 
 	if _, err := e.dc.Exec(ctx, e.TesterContainer, argv, false, 5*time.Minute, quietLogWriter{tr}); err != nil {
 		setFailureReason(t.Name(), fmt.Sprintf("scenario %q failed: %v", scenario, err))

--- a/integration/ueransim_test.go
+++ b/integration/ueransim_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -186,11 +187,7 @@ func TestIntegrationUERANSIM(t *testing.T) {
 
 			t.Logf("UERANSIM result: %s", result)
 
-			if !strings.Contains(result, "uesimtun0") {
-				t.Fatalf("expected 'uesimtun0' to be in the result, but it was not found")
-			}
-
-			t.Logf("Verified that 'uesimtun0' is in the result")
+			Assert(t, strings.Contains(result, "uesimtun0"), "'uesimtun0' interface not found in 'ip a' output")
 
 			pingDest := N6RouterIPv4Address()
 			pingCmd := "ping"
@@ -207,15 +204,8 @@ func TestIntegrationUERANSIM(t *testing.T) {
 
 			t.Logf("UERANSIM ping result: %s", result)
 
-			if !strings.Contains(result, "3 packets transmitted, 3 received") {
-				t.Fatalf("expected '3 packets transmitted, 3 received' to be in the result, but it was not found")
-			}
-
-			if !strings.Contains(result, "0% packet loss") {
-				t.Fatalf("expected '0 packet loss' to be in the result, but it was not found")
-			}
-
-			t.Logf("Verified that '3 packets transmitted, 3 received' and '0 packet loss' are in the result")
+			Assert(t, strings.Contains(result, "3 packets transmitted, 3 received"), fmt.Sprintf("expected 3/3 ping packets received, but got: %s", result))
+			Assert(t, strings.Contains(result, "0% packet loss"), fmt.Sprintf("expected 0%% packet loss, but got: %s", result))
 
 			err = dockerClient.CopyFileToContainer(ctx, ueransimContainerName, "network_test.py", "/network_test.py")
 			if err != nil {

--- a/integration/upf_nat_checksum_test.go
+++ b/integration/upf_nat_checksum_test.go
@@ -103,7 +103,7 @@ func TestUPFNATChecksum(t *testing.T) {
 	tr := globalReporter.Start(natChecksumScenario)
 	QuietLog(t, tr, "running nat checksum scenario")
 	env.RunScenario(ctx, t, natChecksumScenario, tr, "--probe-payload-bytes", "16,500,800,1300")
-	globalReporter.Pass(tr)
+	finishScenarioTest(t, tr)
 
 	// Let tcpdump flush the final packets before snapshotting the file.
 	time.Sleep(1 * time.Second)

--- a/integration/upf_nat_checksum_test.go
+++ b/integration/upf_nat_checksum_test.go
@@ -100,7 +100,10 @@ func TestUPFNATChecksum(t *testing.T) {
 	// Let tcpdump open the capture socket before traffic flows.
 	time.Sleep(2 * time.Second)
 
-	env.RunScenario(ctx, t, natChecksumScenario, "--probe-payload-bytes", "16,500,800,1300")
+	tr := globalReporter.Start(natChecksumScenario)
+	QuietLog(t, tr, "running nat checksum scenario")
+	env.RunScenario(ctx, t, natChecksumScenario, tr, "--probe-payload-bytes", "16,500,800,1300")
+	globalReporter.Pass(tr)
 
 	// Let tcpdump flush the final packets before snapshotting the file.
 	time.Sleep(1 * time.Second)

--- a/integration/upf_nat_checksum_test.go
+++ b/integration/upf_nat_checksum_test.go
@@ -74,9 +74,7 @@ func TestUPFNATChecksum(t *testing.T) {
 	})
 
 	sc, ok := scenarios.Get(natChecksumScenario)
-	if !ok {
-		t.Fatalf("scenario %q not registered", natChecksumScenario)
-	}
+	Assert(t, ok, fmt.Sprintf("scenario %q not registered", natChecksumScenario))
 
 	fx := fixture.New(t, ctx, env.Client)
 	fx.Apply(sc.Fixture(buildScenariosEnv(env)))
@@ -183,10 +181,8 @@ func verifyNATChecksumPcap(t *testing.T, path string) {
 			N6RouterIPv4Address(), scenarios.DefaultProbePort)
 	}
 
-	if !natSeen {
-		t.Fatalf("captured %d frames but none sourced from %s; source_nat did not run (NAT disabled?)",
-			total, natChecksumPostNATSrc)
-	}
+	Assert(t, natSeen, fmt.Sprintf("captured %d frames but none sourced from %s; source_nat did not run (NAT disabled?)",
+		total, natChecksumPostNATSrc))
 
 	if largest <= natChecksumL4Threshold {
 		t.Fatalf("captured %d frames but largest L4 datagram was %d bytes (<= %d); no >512 B datagram was exercised",

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -51,6 +51,12 @@ func (w logWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+func Assert(t *testing.T, condition bool, msg string) {
+	if !condition {
+		t.Fatalf("FAIL - %s", msg)
+	}
+}
+
 type quietLogWriter struct{ tr *TestResult }
 
 func (w quietLogWriter) Write(p []byte) (int, error) {

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -51,6 +51,20 @@ func (w logWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+type quietLogWriter struct{ tr *TestResult }
+
+func (w quietLogWriter) Write(p []byte) (int, error) {
+	// Capture output line-by-line for failure reporting.
+	s := string(p)
+
+	sc := bufio.NewScanner(strings.NewReader(s))
+	for sc.Scan() {
+		globalReporter.Log(w.tr, sc.Text())
+	}
+
+	return len(p), nil
+}
+
 func configureEllaCore(ctx context.Context, cl *client.Client, c EllaCoreConfig) error {
 	initializeOpts := &client.InitializeOptions{
 		Email:    "admin@ellanetworks.com",


### PR DESCRIPTION
# Description

The integration tests are very verbose with the logs from the core and the logs from the tests. It creates very large output that hide the failure somewhere in a big wall of text. When there are failures, even Copilot gets confused by the amount of data.

This PR introduces a small framework to capture logs and improve reporting, reducing the output so failures are easier to see and understand.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
