### PR TITLE
fix: send path switch request failure on duplicate ID

### DIFF
--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -18,11 +18,7 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	// Request Failure.
 	if id, dup := duplicatePDUSessionID(msg.PDUSessionResourceItems); dup {
 		logger.WithTrace(ctx, ran.Log).Error("duplicate PDU Session ID in PathSwitchRequest to-be-switched list", zap.Int64("pduSessionID", id))
-
-		err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, nil, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending path switch request failure", zap.Error(err))
-		}
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngapType.CauseRadioNetworkPresentMultiplePDUSessionIDInstances)
 
 		return
 	}
@@ -30,12 +26,7 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	ranUe := amfInstance.FindRanUeByAmfUeNgapID(msg.SourceAMFUENGAPID)
 	if ranUe == nil {
 		logger.WithTrace(ctx, ran.Log).Error("Cannot find UE from sourceAMfUeNgapID", zap.Int64("sourceAMFUENGAPID", msg.SourceAMFUENGAPID))
-
-		err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, nil, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending path switch request failure", zap.Error(err))
-			return
-		}
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID)
 
 		return
 	}
@@ -46,24 +37,14 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	amfUe := ranUe.AmfUe()
 	if amfUe == nil {
 		logger.WithTrace(ctx, ranUe.Log).Error("AmfUe is nil")
-
-		err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, nil, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ranUe.Log).Error("error sending path switch request failure", zap.Error(err))
-			return
-		}
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngapType.CauseRadioNetworkPresentUnspecified)
 
 		return
 	}
 
 	if !amfUe.SecurityContextIsValid() {
 		logger.WithTrace(ctx, ranUe.Log).Error("No Security Context", logger.SUPI(amfUe.Supi.String()))
-
-		err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, nil, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ranUe.Log).Error("error sending path switch request failure", zap.Error(err))
-			return
-		}
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngapType.CauseRadioNetworkPresentUnspecified)
 
 		return
 	}
@@ -75,9 +56,8 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	ranUe.UpdateLocation(ctx, amfInstance, msg.UserLocationInformation.Raw())
 
 	var (
-		pduSessionResourceSwitchedList       ngapType.PDUSessionResourceSwitchedList
-		pduSessionResourceReleasedListPSAck  ngapType.PDUSessionResourceReleasedListPSAck
-		pduSessionResourceReleasedListPSFail ngapType.PDUSessionResourceReleasedListPSFail
+		pduSessionResourceSwitchedList      ngapType.PDUSessionResourceSwitchedList
+		pduSessionResourceReleasedListPSAck ngapType.PDUSessionResourceReleasedListPSAck
 	)
 
 	for _, item := range msg.PDUSessionResourceItems {
@@ -165,18 +145,10 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 			logger.WithTrace(ctx, ranUe.Log).Error("error sending path switch request acknowledge", zap.Error(err))
 			return
 		}
-	} else if len(pduSessionResourceReleasedListPSFail.List) > 0 {
-		err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, &pduSessionResourceReleasedListPSFail, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ranUe.Log).Error("error sending path switch request failure", zap.Error(err))
-			return
-		}
 	} else {
-		err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, nil, nil)
-		if err != nil {
-			logger.WithTrace(ctx, ranUe.Log).Error("error sending path switch request failure", zap.Error(err))
-			return
-		}
+		// TS 38.413 §8.4.4.3: no PDU session switched, so the whole path switch
+		// fails and every requested session is released.
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngapType.CauseRadioNetworkPresentUnspecified)
 	}
 }
 

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -13,6 +13,20 @@ import (
 
 // TS 23.502 4.9.1
 func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.PathSwitchRequest) {
+	// TS 38.413 §8.4.4.4: a to-be-switched downlink list that repeats a PDU
+	// Session ID is an abnormal condition the AMF rejects with a Path Switch
+	// Request Failure.
+	if id, dup := duplicatePDUSessionID(msg.PDUSessionResourceItems); dup {
+		logger.WithTrace(ctx, ran.Log).Error("duplicate PDU Session ID in PathSwitchRequest to-be-switched list", zap.Int64("pduSessionID", id))
+
+		err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, nil, nil)
+		if err != nil {
+			logger.WithTrace(ctx, ran.Log).Error("error sending path switch request failure", zap.Error(err))
+		}
+
+		return
+	}
+
 	ranUe := amfInstance.FindRanUeByAmfUeNgapID(msg.SourceAMFUENGAPID)
 	if ranUe == nil {
 		logger.WithTrace(ctx, ran.Log).Error("Cannot find UE from sourceAMfUeNgapID", zap.Int64("sourceAMFUENGAPID", msg.SourceAMFUENGAPID))

--- a/internal/amf/ngap/handle_path_switch_request_test.go
+++ b/internal/amf/ngap/handle_path_switch_request_test.go
@@ -351,6 +351,17 @@ func TestPathSwitchRequest_SmContextNotFound(t *testing.T) {
 		t.Fatalf("expected 1 PathSwitchRequestFailure, got %d",
 			len(targetNGAPSender.SentPathSwitchRequestFailures))
 	}
+
+	// TS 38.413 §9.2.3.10: the failure must name the unswitched session in its
+	// mandatory PDU Session Resource Released List.
+	released := targetNGAPSender.SentPathSwitchRequestFailures[0].PduSessionResourceReleasedList
+	if released == nil || len(released.List) != 1 {
+		t.Fatalf("failure must carry a released list naming the unswitched session (TS 38.413 §9.2.3.10); got %v", released)
+	}
+
+	if released.List[0].PDUSessionID.Value != 1 {
+		t.Errorf("released PDU session ID = %d, want 1", released.List[0].PDUSessionID.Value)
+	}
 }
 
 func TestPathSwitchRequest_SmfReturnsError(t *testing.T) {
@@ -611,6 +622,16 @@ func TestPathSwitchRequest_DuplicatePDUSessionIDs(t *testing.T) {
 
 	if failure.RanUeNgapID != targetRanUeNgapID {
 		t.Errorf("expected RanUeNgapID=%d, got %d", targetRanUeNgapID, failure.RanUeNgapID)
+	}
+
+	// The duplicated PDU Session ID appears once in the mandatory released list
+	// (TS 38.413 §9.2.3.10).
+	if failure.PduSessionResourceReleasedList == nil || len(failure.PduSessionResourceReleasedList.List) != 1 {
+		t.Fatalf("failure must carry a deduplicated released list (TS 38.413 §9.2.3.10); got %v", failure.PduSessionResourceReleasedList)
+	}
+
+	if got := failure.PduSessionResourceReleasedList.List[0].PDUSessionID.Value; got != int64(pduSessionID) {
+		t.Errorf("released PDU session ID = %d, want %d", got, pduSessionID)
 	}
 
 	if len(targetNGAPSender.SentPathSwitchRequestAcknowledges) != 0 {

--- a/internal/amf/ngap/handle_path_switch_request_test.go
+++ b/internal/amf/ngap/handle_path_switch_request_test.go
@@ -540,6 +540,88 @@ func TestPathSwitchRequest_HappyPath(t *testing.T) {
 	}
 }
 
+// TestPathSwitchRequest_DuplicatePDUSessionIDs verifies TS 38.413 §8.4.4.4: a
+// to-be-switched downlink list that repeats a PDU Session ID is rejected with a
+// Path Switch Request Failure, even for an otherwise-switchable UE context, and
+// neither the SMF nor an acknowledge is invoked.
+func TestPathSwitchRequest_DuplicatePDUSessionIDs(t *testing.T) {
+	const (
+		pduSessionID      = uint8(1)
+		sourceAmfUeNgapID = int64(10)
+		targetRanUeNgapID = int64(2)
+		kamfHex           = "0000000000000000000000000000000000000000000000000000000000000000"
+	)
+
+	sourceNGAPSender := &FakeNGAPSender{}
+	sourceRan := &amf.Radio{
+		Log:        logger.AmfLog,
+		NGAPSender: sourceNGAPSender,
+		RanUEs:     make(map[int64]*amf.RanUe),
+	}
+
+	amfUe := newValidAmfUe()
+	amfUe.Current().Kamf = kamfHex
+	amfUe.Current().SmContextList[pduSessionID] = &amf.SmContext{
+		Ref:    "imsi-001010000000001-1",
+		Snssai: &models.Snssai{Sst: 1},
+	}
+
+	sourceUe := amf.NewRanUeForTest(sourceRan, 1, sourceAmfUeNgapID, logger.AmfLog)
+	amfUe.AttachRanUe(sourceUe)
+
+	targetNGAPSender := &FakeNGAPSender{}
+	targetRan := &amf.Radio{
+		Log:        logger.AmfLog,
+		NGAPSender: targetNGAPSender,
+		RanUEs:     make(map[int64]*amf.RanUe),
+	}
+
+	fakeSmf := &FakeSmfSbi{PathSwitchResponse: []byte{0xAA, 0xBB, 0xCC}}
+	amfInstance := newTestAMFWithSmf(fakeSmf)
+	amfInstance.Radios[new(sctp.SCTPConn)] = sourceRan
+
+	transfer, err := buildPathSwitchRequestTransfer(5000, []byte{10, 0, 0, 2})
+	if err != nil {
+		t.Fatalf("failed to build transfer: %v", err)
+	}
+
+	// PDU Session ID 1 listed twice.
+	msg := buildPathSwitchRequest(
+		&ngapType.AMFUENGAPID{Value: sourceAmfUeNgapID},
+		&ngapType.RANUENGAPID{Value: targetRanUeNgapID},
+		&ngapType.PDUSessionResourceToBeSwitchedDLList{
+			List: []ngapType.PDUSessionResourceToBeSwitchedDLItem{
+				{PDUSessionID: ngapType.PDUSessionID{Value: int64(pduSessionID)}, PathSwitchRequestTransfer: transfer},
+				{PDUSessionID: ngapType.PDUSessionID{Value: int64(pduSessionID)}, PathSwitchRequestTransfer: transfer},
+			},
+		},
+		nil, nil,
+	)
+
+	ngap.HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, decodePathSwitchRequestOrFatal(t, msg))
+
+	if len(targetNGAPSender.SentPathSwitchRequestFailures) != 1 {
+		t.Fatalf("expected 1 PathSwitchRequestFailure, got %d", len(targetNGAPSender.SentPathSwitchRequestFailures))
+	}
+
+	failure := targetNGAPSender.SentPathSwitchRequestFailures[0]
+	if failure.AmfUeNgapID != sourceAmfUeNgapID {
+		t.Errorf("expected AmfUeNgapID=%d, got %d", sourceAmfUeNgapID, failure.AmfUeNgapID)
+	}
+
+	if failure.RanUeNgapID != targetRanUeNgapID {
+		t.Errorf("expected RanUeNgapID=%d, got %d", targetRanUeNgapID, failure.RanUeNgapID)
+	}
+
+	if len(targetNGAPSender.SentPathSwitchRequestAcknowledges) != 0 {
+		t.Errorf("expected no PathSwitchRequestAcknowledge, got %d", len(targetNGAPSender.SentPathSwitchRequestAcknowledges))
+	}
+
+	if len(fakeSmf.PathSwitchCalls) != 0 {
+		t.Errorf("expected no SMF PathSwitch call, got %d", len(fakeSmf.PathSwitchCalls))
+	}
+}
+
 func TestPathSwitchRequest_MultiplePDUSessions_PartialSuccess(t *testing.T) {
 	sourceNGAPSender := &FakeNGAPSender{}
 	sourceRan := &amf.Radio{

--- a/internal/amf/ngap/path_switch_failure.go
+++ b/internal/amf/ngap/path_switch_failure.go
@@ -1,0 +1,76 @@
+package ngap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/ngap/decode"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapType"
+	"go.uber.org/zap"
+)
+
+// sendPathSwitchRequestFailure rejects a Path Switch Request, naming every
+// distinct requested PDU session in the mandatory PDU Session Resource Released
+// List, each with an AMF-generated Path Switch Request Unsuccessful Transfer
+// carrying causeValue (TS 38.413 §9.2.3.10; the AMF generating the transfer is
+// the §8.4.4.4 note exception).
+func sendPathSwitchRequestFailure(ctx context.Context, ran *amf.Radio, msg decode.PathSwitchRequest, causeValue aper.Enumerated) {
+	released, err := pathSwitchReleasedList(msg.PDUSessionResourceItems, causeValue)
+	if err != nil {
+		logger.WithTrace(ctx, ran.Log).Error("error building path switch released list", zap.Error(err))
+	}
+
+	if err := ran.NGAPSender.SendPathSwitchRequestFailure(ctx, msg.SourceAMFUENGAPID, msg.RANUENGAPID, released, nil); err != nil {
+		logger.WithTrace(ctx, ran.Log).Error("error sending path switch request failure", zap.Error(err))
+	}
+}
+
+// pathSwitchReleasedList builds the PDU Session Resource Released List for a
+// Path Switch Request Failure (TS 38.413 §9.2.3.10): one item per distinct
+// requested PDU session, each carrying an Unsuccessful Transfer with causeValue.
+func pathSwitchReleasedList(items []ngapType.PDUSessionResourceToBeSwitchedDLItem, causeValue aper.Enumerated) (*ngapType.PDUSessionResourceReleasedListPSFail, error) {
+	transfer, err := buildPathSwitchRequestUnsuccessfulTransfer(causeValue)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &ngapType.PDUSessionResourceReleasedListPSFail{}
+	seen := make(map[int64]struct{}, len(items))
+
+	for _, item := range items {
+		id := item.PDUSessionID.Value
+		if _, dup := seen[id]; dup {
+			continue
+		}
+
+		seen[id] = struct{}{}
+
+		list.List = append(list.List, ngapType.PDUSessionResourceReleasedItemPSFail{
+			PDUSessionID:                          ngapType.PDUSessionID{Value: id},
+			PathSwitchRequestUnsuccessfulTransfer: transfer,
+		})
+	}
+
+	return list, nil
+}
+
+// buildPathSwitchRequestUnsuccessfulTransfer encodes a Path Switch Request
+// Unsuccessful Transfer (TS 38.413 §9.3.4.20) carrying a radio-network cause.
+func buildPathSwitchRequestUnsuccessfulTransfer(causeValue aper.Enumerated) ([]byte, error) {
+	transfer := ngapType.PathSwitchRequestUnsuccessfulTransfer{
+		Cause: ngapType.Cause{
+			Present:      ngapType.CausePresentRadioNetwork,
+			RadioNetwork: &ngapType.CauseRadioNetwork{Value: causeValue},
+		},
+	}
+
+	buf, err := aper.MarshalWithParams(transfer, "valueExt")
+	if err != nil {
+		return nil, fmt.Errorf("encode path switch request unsuccessful transfer: %w", err)
+	}
+
+	return buf, nil
+}

--- a/internal/amf/ngap/pdu_session.go
+++ b/internal/amf/ngap/pdu_session.go
@@ -1,9 +1,30 @@
 package ngap
 
+import "github.com/free5gc/ngap/ngapType"
+
 func validPDUSessionID(id int64) (uint8, bool) {
 	if id < 1 || id > 15 {
 		return 0, false
 	}
 
 	return uint8(id), true
+}
+
+// duplicatePDUSessionID returns the first PDU Session ID that appears more than
+// once in the Path Switch Request to-be-switched downlink list. TS 38.413
+// §8.4.4.4 requires the AMF to reject such a message with a Path Switch Request
+// Failure.
+func duplicatePDUSessionID(items []ngapType.PDUSessionResourceToBeSwitchedDLItem) (int64, bool) {
+	seen := make(map[int64]struct{}, len(items))
+
+	for _, item := range items {
+		id := item.PDUSessionID.Value
+		if _, ok := seen[id]; ok {
+			return id, true
+		}
+
+		seen[id] = struct{}{}
+	}
+
+	return 0, false
 }


### PR DESCRIPTION
# Description

Address two minor bugs with XN handover:
- TS 38.413 §8.4.4.4: a Path Switch Request whose to-be-switched downlink list repeats a PDU Session ID must be rejected with PATH SWITCH REQUEST FAILURE. The handler had no such check.
-   Ella Core sent every PATH SWITCH REQUEST FAILURE with PDUSessionResourceReleasedList IE nil.  §9.3.4.20 defines the per-session Unsuccessful Transfer (a mandatory Cause), and §8.4.4.4's NOTE explicitly says "the AMF generates the Path Switch Request Unsuccessful Transfer IE." So the message was structurally incomplete on every failure path.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
