### PR TITLE
feat: add OTel tracing support to 4G

### DIFF
--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -77,7 +77,7 @@ Ella Core supports distributed tracing using [OpenTelemetry](https://opentelemet
 
 Traces are collected for the following components:
 
- - **NGAP**: Traces for NGAP message handling between gNodeBs and Ella Core.
+ - **NGAP/S1AP**: Traces for NGAP (5G) and S1AP (4G) message handling between radios and Ella Core.
  - **API**: Traces for HTTP requests to the REST API.
 
 For more information on configuring tracing in Ella Core, refer to the [Configuration File](config_file.md) documentation.

--- a/internal/mme/attach_reject_test.go
+++ b/internal/mme/attach_reject_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ellanetworks/core/nas/eps"
@@ -35,7 +36,7 @@ func TestAttachUnknownIMSI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, b)
+	m.handleNAS(context.Background(), ue, b)
 
 	// Expect Attach Reject (downlink NAS) followed by the UE Context Release Command.
 	if len(cc.sent) != 2 {

--- a/internal/mme/auth_failure.go
+++ b/internal/mme/auth_failure.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"encoding/hex"
 
 	"github.com/ellanetworks/core/internal/logger"
@@ -15,7 +16,7 @@ import (
 // A first synch failure (#21) with a valid AUTS triggers SQN
 // re-synchronisation and a new AUTHENTICATION REQUEST; every other case — MAC
 // failure (#20), a repeated synch failure, or an invalid AUTS — is rejected.
-func (m *MME) onAuthenticationFailure(ue *UeContext, plain []byte) {
+func (m *MME) onAuthenticationFailure(ctx context.Context, ue *UeContext, plain []byte) {
 	m.stopNASGuard(ue)
 
 	resp, err := eps.ParseAuthenticationFailure(plain)
@@ -33,9 +34,9 @@ func (m *MME) onAuthenticationFailure(ue *UeContext, plain []byte) {
 		logger.MmeLog.Info("re-synchronising SQN, re-authenticating", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
 
 		// The credential authority resyncs from AUTS and issues a fresh vector.
-		if err := m.sendAuthRequest(ue, hex.EncodeToString(resp.AUTS), hex.EncodeToString(ue.authVector.RAND[:])); err != nil {
+		if err := m.sendAuthRequest(ctx, ue, hex.EncodeToString(resp.AUTS), hex.EncodeToString(ue.authVector.RAND[:])); err != nil {
 			logger.MmeLog.Warn("SQN re-synchronisation failed", zap.Error(err))
-			m.rejectAuthentication(ue)
+			m.rejectAuthentication(ctx, ue)
 		}
 
 		return
@@ -43,14 +44,14 @@ func (m *MME) onAuthenticationFailure(ue *UeContext, plain []byte) {
 
 	// MAC failure, a repeated synch failure, or a bad AUTS: the UE attaches with
 	// its IMSI, so per TS 24.301 the network aborts with a reject.
-	m.rejectAuthentication(ue)
+	m.rejectAuthentication(ctx, ue)
 }
 
 // rejectAuthentication sends AUTHENTICATION REJECT (TS 24.301) and
 // releases the UE's S1 context.
-func (m *MME) rejectAuthentication(ue *UeContext) {
+func (m *MME) rejectAuthentication(ctx context.Context, ue *UeContext) {
 	logger.MmeLog.Info("authentication rejected",
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
-	m.sendDownlinkMessage(ue, &eps.AuthenticationReject{})
-	m.releaseUEContext(ue, causeNASUnspecified)
+	m.sendDownlinkMessage(ctx, ue, &eps.AuthenticationReject{})
+	m.releaseUEContext(ctx, ue, causeNASUnspecified)
 }

--- a/internal/mme/auth_failure_test.go
+++ b/internal/mme/auth_failure_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/udm"
@@ -78,7 +79,7 @@ func TestAuthenticationResponseWrongRESRejects(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, resp)
+	m.handleNAS(context.Background(), ue, resp)
 
 	// Authentication Reject (downlink NAS) followed by UE Context Release Command.
 	if cc.count() != 2 {
@@ -100,7 +101,7 @@ func TestAuthFailureMACFailureRejects(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := authChallengedUE(t, m)
 
-	m.handleNAS(ue, authFailure(t, emmCauseMACFailure, nil))
+	m.handleNAS(context.Background(), ue, authFailure(t, emmCauseMACFailure, nil))
 
 	// Authentication Reject (downlink NAS) followed by UE Context Release Command.
 	if len(cc.sent) != 2 {
@@ -120,7 +121,7 @@ func TestAuthFailureSynchResyncsAndReauthenticates(t *testing.T) {
 
 	auts := autsFor(t, ue, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x21})
 
-	m.handleNAS(ue, authFailure(t, emmCauseSynchFailure, auts))
+	m.handleNAS(context.Background(), ue, authFailure(t, emmCauseSynchFailure, auts))
 
 	// A fresh Authentication Request, not a reject.
 	if len(cc.sent) != 1 {
@@ -136,7 +137,7 @@ func TestAuthFailureSynchResyncsAndReauthenticates(t *testing.T) {
 	}
 
 	// A second synch failure must not resync again — it rejects.
-	m.handleNAS(ue, authFailure(t, emmCauseSynchFailure, auts))
+	m.handleNAS(context.Background(), ue, authFailure(t, emmCauseSynchFailure, auts))
 
 	if _, err := eps.ParseAuthenticationReject(decodeDownlinkNAS(t, cc.sent[1])); err != nil {
 		t.Fatalf("second synch failure not rejected: %v", err)
@@ -150,7 +151,7 @@ func TestAuthFailureBadAUTSRejects(t *testing.T) {
 	auts := autsFor(t, ue, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x21})
 	auts[len(auts)-1] ^= 0xff // corrupt MAC-S
 
-	m.handleNAS(ue, authFailure(t, emmCauseSynchFailure, auts))
+	m.handleNAS(context.Background(), ue, authFailure(t, emmCauseSynchFailure, auts))
 
 	if _, err := eps.ParseAuthenticationReject(decodeDownlinkNAS(t, cc.sent[0])); err != nil {
 		t.Fatalf("bad AUTS not rejected: %v", err)

--- a/internal/mme/bearer.go
+++ b/internal/mme/bearer.go
@@ -234,8 +234,8 @@ func bitRateToBps(s string) uint64 {
 // activateDefaultBearer builds the Attach Accept (carrying the default-bearer
 // activation and the UE IP) and sends it to the eNB inside an Initial Context
 // Setup Request, with K_eNB and the UE security capabilities for AS security.
-func (m *MME) activateDefaultBearer(ue *UeContext) {
-	qos, err := m.resolveQoS(context.Background(), ue.imsi)
+func (m *MME) activateDefaultBearer(ctx context.Context, ue *UeContext) {
+	qos, err := m.resolveQoS(ctx, ue.imsi)
 	if err != nil {
 		logger.MmeLog.Error("failed to resolve subscriber QoS", zap.String("imsi", ue.imsi), zap.Error(err))
 		return
@@ -247,7 +247,7 @@ func (m *MME) activateDefaultBearer(ue *UeContext) {
 	if !qos.Allow4G {
 		logger.MmeLog.Info("attach rejected: 4G not allowed for subscriber",
 			zap.String("imsi", ue.imsi))
-		m.rejectAttach(ue, emmCauseEPSServicesNotAllowed)
+		m.rejectAttach(ctx, ue, emmCauseEPSServicesNotAllowed)
 
 		return
 	}
@@ -255,7 +255,7 @@ func (m *MME) activateDefaultBearer(ue *UeContext) {
 	// Delegate the default-bearer session to the SMF+PGW-C anchor: it negotiates
 	// the PDN type, allocates the UE address(es), programs the user plane, and
 	// returns the S-GW S1-U F-TEID.
-	bearer, err := m.session.CreateEPSSession(context.Background(), models.EPSBearerRequest{
+	bearer, err := m.session.CreateEPSSession(ctx, models.EPSBearerRequest{
 		IMSI:              ue.imsi,
 		EPSBearerIdentity: defaultERABID,
 		PolicyID:          qos.PolicyID,
@@ -274,7 +274,7 @@ func (m *MME) activateDefaultBearer(ue *UeContext) {
 		// the attach with EMM cause #19 "ESM failure" (TS 24.301).
 		logger.MmeLog.Info("attach rejected: default bearer setup failed",
 			zap.String("imsi", ue.imsi), zap.Error(err))
-		m.rejectAttach(ue, emmCauseESMFailure)
+		m.rejectAttach(ctx, ue, emmCauseESMFailure)
 
 		return
 	}
@@ -301,7 +301,7 @@ func (m *MME) activateDefaultBearer(ue *UeContext) {
 		zap.Uint8("esm-cause", p.esmCause),
 	)
 
-	naspdu, err := m.buildProtectedAttachAccept(ue, qos)
+	naspdu, err := m.buildProtectedAttachAccept(ctx, ue, qos)
 	if err != nil {
 		logger.MmeLog.Error("failed to build Attach Accept", zap.Error(err))
 		return
@@ -311,7 +311,7 @@ func (m *MME) activateDefaultBearer(ue *UeContext) {
 	// the Initial Context Setup, so the eNB re-fetches it from the UE (TS 23.401).
 	ue.radioCapability = nil
 
-	m.sendInitialContextSetup(ue, qos, naspdu)
+	m.sendInitialContextSetup(ctx, ue, qos, naspdu)
 
 	// Guard the Attach Accept: if the UE does not send Attach Complete, the MME
 	// retransmits it and ultimately releases the UE (T3450, TS 24.301).
@@ -323,7 +323,7 @@ func (m *MME) activateDefaultBearer(ue *UeContext) {
 // security. naspdu carries the Attach Accept on attach; it is nil on a Service
 // Request, where the EPS bearer context already exists and only the radio and S1
 // bearers are re-established.
-func (m *MME) sendInitialContextSetup(ue *UeContext, qos *epsQoS, naspdu []byte) {
+func (m *MME) sendInitialContextSetup(ctx context.Context, ue *UeContext, qos *epsQoS, naspdu []byte) {
 	// K_eNB is derived from the uplink NAS COUNT of the most recently received
 	// uplink NAS message (the Security Mode Complete on attach, the Service
 	// Request on reconnect), i.e. one less than the next-expected count
@@ -417,12 +417,12 @@ func (m *MME) sendInitialContextSetup(ue *UeContext, qos *epsQoS, naspdu []byte)
 		zap.Uint8("eea", ue.eea),
 		zap.Uint8("eia", ue.eia),
 	)
-	m.sendS1AP(ue, S1APProcedureInitialContextSetupRequest, b)
+	m.sendS1AP(ctx, ue, S1APProcedureInitialContextSetupRequest, b)
 }
 
 // buildProtectedAttachAccept assembles the Attach Accept (with the embedded
 // Activate Default EPS Bearer Context Request) and protects it for the UE.
-func (m *MME) buildProtectedAttachAccept(ue *UeContext, qos *epsQoS) ([]byte, error) {
+func (m *MME) buildProtectedAttachAccept(ctx context.Context, ue *UeContext, qos *epsQoS) ([]byte, error) {
 	p := ue.defaultPDN()
 	if p == nil {
 		return nil, fmt.Errorf("attach accept with no active PDN")
@@ -438,12 +438,12 @@ func (m *MME) buildProtectedAttachAccept(ue *UeContext, qos *epsQoS) ([]byte, er
 		return nil, err
 	}
 
-	plmn, err := m.operatorPLMN(context.Background())
+	plmn, err := m.operatorPLMN(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	tac, err := m.operatorTAC(context.Background())
+	tac, err := m.operatorTAC(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +495,7 @@ func (m *MME) buildProtectedAttachAccept(ue *UeContext, qos *epsQoS) ([]byte, er
 
 // onAttachComplete finalises the attach: the UE is EMM-REGISTERED with an active
 // default bearer.
-func (m *MME) onAttachComplete(ue *UeContext, plain []byte) {
+func (m *MME) onAttachComplete(ctx context.Context, ue *UeContext, plain []byte) {
 	m.stopNASGuard(ue)
 
 	if _, err := eps.ParseAttachComplete(plain); err != nil {
@@ -510,15 +510,15 @@ func (m *MME) onAttachComplete(ue *UeContext, plain []byte) {
 		zap.String("imsi", ue.imsi),
 	)
 
-	m.sendNetworkName(ue)
+	m.sendNetworkName(ctx, ue)
 }
 
 // sendNetworkName provides the operator's network name to the UE in an EMM
 // INFORMATION message (TS 24.301), the 4G counterpart of the AMF's
 // Configuration Update Command. The procedure is optional, so it is skipped when
 // no service provider name is configured.
-func (m *MME) sendNetworkName(ue *UeContext) {
-	op, err := m.bearer.GetOperator(context.Background())
+func (m *MME) sendNetworkName(ctx context.Context, ue *UeContext) {
+	op, err := m.bearer.GetOperator(ctx)
 	if err != nil {
 		logger.MmeLog.Warn("failed to get operator for network name", zap.String("imsi", ue.imsi), zap.Error(err))
 		return
@@ -528,7 +528,7 @@ func (m *MME) sendNetworkName(ue *UeContext) {
 		return
 	}
 
-	m.sendDownlinkProtected(ue, &eps.EMMInformation{
+	m.sendDownlinkProtected(ctx, ue, &eps.EMMInformation{
 		FullNetworkName:  op.SpnFullName,
 		ShortNetworkName: op.SpnShortName,
 	})
@@ -601,7 +601,7 @@ func buildActivateDefaultESM(p *pdnConnection, qos *epsQoS, pti uint8) ([]byte, 
 }
 
 // sendS1AP writes a complete S1AP PDU to the UE's eNB association.
-func (m *MME) sendS1AP(ue *UeContext, messageType S1APProcedure, b []byte) {
+func (m *MME) sendS1AP(ctx context.Context, ue *UeContext, messageType S1APProcedure, b []byte) {
 	if ue.conn == nil {
 		return
 	}
@@ -611,5 +611,5 @@ func (m *MME) sendS1AP(ue *UeContext, messageType S1APProcedure, b []byte) {
 		return
 	}
 
-	m.logOutboundS1AP(ue.conn, messageType, b)
+	m.logOutboundS1AP(ctx, ue.conn, messageType, b)
 }

--- a/internal/mme/bearer.go
+++ b/internal/mme/bearer.go
@@ -16,6 +16,9 @@ import (
 	nascommon "github.com/ellanetworks/core/nas/common"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -602,12 +605,26 @@ func buildActivateDefaultESM(p *pdnConnection, qos *epsQoS, pti uint8) ([]byte, 
 
 // sendS1AP writes a complete S1AP PDU to the UE's eNB association.
 func (m *MME) sendS1AP(ctx context.Context, ue *UeContext, messageType S1APProcedure, b []byte) {
+	ctx, span := tracer.Start(ctx, "s1ap/send",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("s1ap.message_type", string(messageType)),
+			attribute.Int("s1ap.message_size", len(b)),
+			attribute.String("network.protocol.name", "s1ap"),
+			attribute.String("network.transport", "sctp"),
+		),
+	)
+	defer span.End()
+
 	if ue.conn == nil {
 		return
 	}
 
 	if _, err := ue.conn.WriteMsg(b, &sctp.SndRcvInfo{PPID: s1apPPID, Stream: 0}); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to send S1AP message")
 		logger.MmeLog.Error("failed to send S1AP message", zap.Error(err))
+
 		return
 	}
 

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -35,7 +35,7 @@ func (m *MME) lookupUeByIMSI(imsi string) *UeContext {
 // to the attached UE for imsi, if any. It is the 4G counterpart of the AMF's
 // network-initiated deregistration, invoked when a subscriber is deleted. The UE
 // replies with Detach Accept, on which the S1 context is released and removed.
-func (m *MME) DetachSubscriber(_ context.Context, imsi string) {
+func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 	ue := m.lookupUeByIMSI(imsi)
 	if ue == nil {
 		return
@@ -45,14 +45,14 @@ func (m *MME) DetachSubscriber(_ context.Context, imsi string) {
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", imsi))
 
 	ue.emmState = EMMDeregistered
-	m.sendDownlinkProtected(ue, &eps.DetachRequestNetwork{TypeOfDetach: detachTypeReattachNotRequired})
+	m.sendDownlinkProtected(ctx, ue, &eps.DetachRequestNetwork{TypeOfDetach: detachTypeReattachNotRequired})
 }
 
 // onDetachAccept completes a network-initiated detach: the UE has acknowledged,
 // so release and delete its context (the UE is already EMM-DEREGISTERED).
-func (m *MME) onDetachAccept(ue *UeContext) {
+func (m *MME) onDetachAccept(ctx context.Context, ue *UeContext) {
 	logger.MmeLog.Info("Detach Accept", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
-	m.releaseUEContext(ue, causeNASDetach)
+	m.releaseUEContext(ctx, ue, causeNASDetach)
 }
 
 // S1AP causes (TS 36.413) the MME uses when releasing a UE context:
@@ -79,7 +79,7 @@ func isSwitchOffDetach(body []byte) bool {
 // onDetachRequest handles a UE-originating DETACH REQUEST (TS 24.301):
 // for a non-switch-off detach it replies with Detach Accept, then releases the
 // UE's S1 context.
-func (m *MME) onDetachRequest(ue *UeContext, plain []byte) {
+func (m *MME) onDetachRequest(ctx context.Context, ue *UeContext, plain []byte) {
 	req, err := eps.ParseDetachRequestUE(plain)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Detach Request", zap.Error(err))
@@ -95,10 +95,10 @@ func (m *MME) onDetachRequest(ue *UeContext, plain []byte) {
 	ue.emmState = EMMDeregistered
 
 	if !req.SwitchOff {
-		m.sendDownlinkProtected(ue, &eps.DetachAccept{})
+		m.sendDownlinkProtected(ctx, ue, &eps.DetachAccept{})
 	}
 
-	m.releaseUEContext(ue, causeNASDetach)
+	m.releaseUEContext(ctx, ue, causeNASDetach)
 }
 
 // releaseUEContext starts the S1 UE Context Release procedure for a UE
@@ -106,7 +106,7 @@ func (m *MME) onDetachRequest(ue *UeContext, plain []byte) {
 // eNB-initiated release request cannot both emit a command. Whether the context
 // is deleted or retained in ECM-IDLE is decided at release-complete from the EMM
 // state, since the two state machines are independent.
-func (m *MME) releaseUEContext(ue *UeContext, cause s1ap.Cause) {
+func (m *MME) releaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Cause) {
 	// The idempotency check is atomic: a NAS guard timeout and an eNB-initiated
 	// release request can race to release the same UE from different goroutines.
 	m.mu.Lock()
@@ -130,12 +130,12 @@ func (m *MME) releaseUEContext(ue *UeContext, cause s1ap.Cause) {
 	}
 
 	logger.MmeLog.Info("UE Context Release Command", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
-	m.sendS1AP(ue, S1APProcedureUEContextReleaseCommand, b)
+	m.sendS1AP(ctx, ue, S1APProcedureUEContextReleaseCommand, b)
 }
 
 // handleUEContextReleaseRequest handles an eNB-initiated release (TS 36.413,
 // e.g. radio-link failure or inactivity) by issuing a release command.
-func (m *MME) handleUEContextReleaseRequest(conn nasWriter, value []byte) {
+func (m *MME) handleUEContextReleaseRequest(ctx context.Context, conn nasWriter, value []byte) {
 	msg, err := s1ap.ParseUEContextReleaseRequest(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode UE Context Release Request", zap.Error(err))
@@ -174,7 +174,7 @@ func (m *MME) handleUEContextReleaseRequest(conn nasWriter, value []byte) {
 		logger.MmeLog.Info("UE Context Release Request", fields...)
 	}
 
-	m.releaseUEContext(ue, msg.Cause)
+	m.releaseUEContext(ctx, ue, msg.Cause)
 }
 
 // handleUEContextReleaseComplete completes the release (TS 36.413):

--- a/internal/mme/detach_test.go
+++ b/internal/mme/detach_test.go
@@ -40,7 +40,7 @@ func TestDetachSubscriberNetworkInitiated(t *testing.T) {
 	}
 
 	// UE acknowledges → release + delete.
-	m.onDetachAccept(ue)
+	m.onDetachAccept(context.Background(), ue)
 	parseUEContextReleaseCommand(t, cc.sent[1])
 
 	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: 7}
@@ -82,7 +82,7 @@ func TestForgedMessageIgnoredForSecuredUE(t *testing.T) {
 	// Integrity-protected envelope (SHT=1) with a MAC the MME cannot reproduce.
 	forged := append([]byte{0x17, 0xde, 0xad, 0xbe, 0xef, byte(ue.ulCount)}, plain...)
 
-	m.handleNAS(ue, forged)
+	m.handleNAS(context.Background(), ue, forged)
 
 	if cc.count() != 0 {
 		t.Fatalf("forged DETACH against a secured UE was acted on: %d downlink(s) sent", cc.count())
@@ -170,7 +170,7 @@ func TestDetachSwitchOff(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	m.handleNAS(ue, detachRequest(t, ue, true))
+	m.handleNAS(context.Background(), ue, detachRequest(t, ue, true))
 
 	// Switch-off: no Detach Accept, just the UE Context Release Command.
 	if len(cc.sent) != 1 {
@@ -218,7 +218,7 @@ func TestDetachSwitchOffNullSecurity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, wire)
+	m.handleNAS(context.Background(), ue, wire)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected UE Context Release Command, got %d S1AP messages", len(cc.sent))
@@ -231,7 +231,7 @@ func TestDetachNotSwitchOff(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	m.handleNAS(ue, detachRequest(t, ue, false))
+	m.handleNAS(context.Background(), ue, detachRequest(t, ue, false))
 
 	// Not switch-off: Detach Accept (downlink NAS), then UE Context Release Command.
 	if len(cc.sent) != 2 {
@@ -288,7 +288,7 @@ func TestUEContextReleaseRequestFromENB(t *testing.T) {
 	b, _ := req.Marshal()
 	pdu, _ := s1ap.Unmarshal(b)
 
-	m.handleUEContextReleaseRequest(cc, pdu.(*s1ap.InitiatingMessage).Value)
+	m.handleUEContextReleaseRequest(context.Background(), cc, pdu.(*s1ap.InitiatingMessage).Value)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected 1 UE Context Release Command, got %d", len(cc.sent))
@@ -297,7 +297,7 @@ func TestUEContextReleaseRequestFromENB(t *testing.T) {
 	parseUEContextReleaseCommand(t, cc.sent[0])
 
 	// A second release attempt must not emit another command (idempotent).
-	m.releaseUEContext(ue, causeNASDetach)
+	m.releaseUEContext(context.Background(), ue, causeNASDetach)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("release not idempotent: %d commands sent", len(cc.sent))
@@ -325,7 +325,7 @@ func TestUEContextReleaseRequestFromENB(t *testing.T) {
 	// A repeat UE Context Release Request on the same association is answered
 	// with an Error Indication, not re-actioned with another release command
 	// (TS 36.413).
-	m.handleUEContextReleaseRequest(cc, pdu.(*s1ap.InitiatingMessage).Value)
+	m.handleUEContextReleaseRequest(context.Background(), cc, pdu.(*s1ap.InitiatingMessage).Value)
 
 	if len(cc.sent) != 2 {
 		t.Fatalf("expected an Error Indication for the released AP ID, got %d S1AP messages", len(cc.sent))
@@ -355,7 +355,7 @@ func TestUEContextReleaseRequestFromForeignENB(t *testing.T) {
 	pdu, _ := s1ap.Unmarshal(b)
 
 	foreign := &captureConn{}
-	m.handleUEContextReleaseRequest(foreign, pdu.(*s1ap.InitiatingMessage).Value)
+	m.handleUEContextReleaseRequest(context.Background(), foreign, pdu.(*s1ap.InitiatingMessage).Value)
 
 	if len(cc.sent) != 0 {
 		t.Fatalf("foreign eNB released a UE on another association: %d S1AP messages on the owning association", len(cc.sent))

--- a/internal/mme/emm.go
+++ b/internal/mme/emm.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 	nascommon "github.com/ellanetworks/core/nas/common"
 	"github.com/ellanetworks/core/nas/eps"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -137,6 +139,10 @@ func (m *MME) handleNAS(ctx context.Context, ue *UeContext, nas []byte) {
 		logger.MmeLog.Warn("failed to read EMM message type", zap.Error(err))
 		return
 	}
+
+	ctx, span := tracer.Start(ctx, "mme/emm",
+		trace.WithAttributes(attribute.String("nas.message_type", emmMessageTypeName(mt))))
+	defer span.End()
 
 	switch mt {
 	case eps.MsgAttachRequest:

--- a/internal/mme/emm.go
+++ b/internal/mme/emm.go
@@ -33,7 +33,7 @@ const epsAttachTypeCombined uint8 = 2
 // handleNAS is the MME's EMM entry point for an inbound NAS message on a UE
 // context. It unwraps NAS security when the message is protected, then routes
 // the plain message to its procedure handler.
-func (m *MME) handleNAS(ue *UeContext, nas []byte) {
+func (m *MME) handleNAS(ctx context.Context, ue *UeContext, nas []byte) {
 	ue.touchLastSeen()
 
 	pd, err := eps.ProtocolDiscriminator(nas)
@@ -79,7 +79,7 @@ func (m *MME) handleNAS(ue *UeContext, nas []byte) {
 			// protection (TS 24.301) — srsUE sends it with a null MAC
 			// and an unciphered payload. Accept it from the plaintext body.
 			if isSwitchOffDetach(body) {
-				m.onDetachRequest(ue, body)
+				m.onDetachRequest(ctx, ue, body)
 				return
 			}
 
@@ -100,7 +100,7 @@ func (m *MME) handleNAS(ue *UeContext, nas []byte) {
 					// restart). Once the UE is secured, a message failing the integrity
 					// check is discarded, so a forged or replayed NAS message cannot
 					// disrupt an authenticated UE.
-					if !ue.secured && m.processWithoutIntegrity(ue, mt, nas, body) {
+					if !ue.secured && m.processWithoutIntegrity(ctx, ue, mt, nas, body) {
 						return
 					}
 				}
@@ -128,7 +128,7 @@ func (m *MME) handleNAS(ue *UeContext, nas []byte) {
 	// An ESM (session management) NAS message rides on its own protocol
 	// discriminator; route it separately from EMM mobility messages.
 	if len(plain) > 0 && plain[0]&0x0F == eps.PDESM {
-		m.handleESM(ue, plain)
+		m.handleESM(ctx, ue, plain)
 		return
 	}
 
@@ -140,27 +140,27 @@ func (m *MME) handleNAS(ue *UeContext, nas []byte) {
 
 	switch mt {
 	case eps.MsgAttachRequest:
-		m.onAttachRequest(ue, plain)
+		m.onAttachRequest(ctx, ue, plain)
 	case eps.MsgIdentityResponse:
-		m.onIdentityResponse(ue, plain)
+		m.onIdentityResponse(ctx, ue, plain)
 	case eps.MsgAuthenticationResponse:
-		m.onAuthenticationResponse(ue, plain)
+		m.onAuthenticationResponse(ctx, ue, plain)
 	case eps.MsgAuthenticationFailure:
-		m.onAuthenticationFailure(ue, plain)
+		m.onAuthenticationFailure(ctx, ue, plain)
 	case eps.MsgSecurityModeComplete:
-		m.onSecurityModeComplete(ue, plain)
+		m.onSecurityModeComplete(ctx, ue, plain)
 	case eps.MsgSecurityModeReject:
-		m.onSecurityModeReject(ue, plain)
+		m.onSecurityModeReject(ctx, ue, plain)
 	case eps.MsgAttachComplete:
-		m.onAttachComplete(ue, plain)
+		m.onAttachComplete(ctx, ue, plain)
 	case eps.MsgDetachRequest:
-		m.onDetachRequest(ue, plain)
+		m.onDetachRequest(ctx, ue, plain)
 	case eps.MsgDetachAccept:
-		m.onDetachAccept(ue)
+		m.onDetachAccept(ctx, ue)
 	case eps.MsgTrackingAreaUpdateRequest:
-		m.onTrackingAreaUpdate(ue, plain)
+		m.onTrackingAreaUpdate(ctx, ue, plain)
 	case eps.MsgTrackingAreaUpdateComplete:
-		m.onTrackingAreaUpdateComplete(ue)
+		m.onTrackingAreaUpdateComplete(ctx, ue)
 	default:
 		logger.MmeLog.Warn("unhandled EMM message",
 			zap.String("message-type", emmMessageTypeName(mt)),
@@ -174,31 +174,31 @@ func (m *MME) handleNAS(ue *UeContext, nas []byte) {
 // list (or otherwise unrecoverable), which the caller then drops. nas is the
 // full protected message (needed to reuse a held context on a GUTI attach);
 // body is its plaintext.
-func (m *MME) processWithoutIntegrity(ue *UeContext, mt eps.MessageType, nas, body []byte) bool {
+func (m *MME) processWithoutIntegrity(ctx context.Context, ue *UeContext, mt eps.MessageType, nas, body []byte) bool {
 	switch mt {
 	case eps.MsgAttachRequest:
 		// Authenticate before processing the attach further (TS 24.301).
 		// A native GUTI the MME still holds lets it reuse the
 		// security context and skip authentication (TS 23.401).
-		if !m.reuseContextForGUTIAttach(ue, nas, body) {
-			m.onAttachRequest(ue, body)
+		if !m.reuseContextForGUTIAttach(ctx, ue, nas, body) {
+			m.onAttachRequest(ctx, ue, body)
 		}
 	case eps.MsgIdentityResponse:
 		// The IMSI is carried in cleartext; identification continues to
 		// authentication, which rebuilds the security context.
-		m.onIdentityResponse(ue, body)
+		m.onIdentityResponse(ctx, ue, body)
 	case eps.MsgAuthenticationResponse:
-		m.onAuthenticationResponse(ue, body)
+		m.onAuthenticationResponse(ctx, ue, body)
 	case eps.MsgAuthenticationFailure:
-		m.onAuthenticationFailure(ue, body)
+		m.onAuthenticationFailure(ctx, ue, body)
 	case eps.MsgSecurityModeReject:
-		m.onSecurityModeReject(ue, body)
+		m.onSecurityModeReject(ctx, ue, body)
 	case eps.MsgDetachRequest:
-		m.onDetachRequest(ue, body)
+		m.onDetachRequest(ctx, ue, body)
 	case eps.MsgTrackingAreaUpdateRequest:
 		// The update cannot be trusted without a verifiable MAC; reject it so the
 		// UE re-attaches and rebuilds the context (TS 24.301).
-		m.rejectTrackingAreaUpdate(ue)
+		m.rejectTrackingAreaUpdate(ctx, ue)
 	default:
 		return false
 	}
@@ -210,7 +210,7 @@ func (m *MME) processWithoutIntegrity(ue *UeContext, mt eps.MessageType, nas, bo
 // UE rejected the selected NAS security algorithms, so the security mode control
 // procedure — and the attach/service procedure that triggered it — is aborted
 // and the UE's S1 context released.
-func (m *MME) onSecurityModeReject(ue *UeContext, plain []byte) {
+func (m *MME) onSecurityModeReject(ctx context.Context, ue *UeContext, plain []byte) {
 	m.stopNASGuard(ue)
 
 	var cause uint8
@@ -222,10 +222,10 @@ func (m *MME) onSecurityModeReject(ue *UeContext, plain []byte) {
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
 		zap.Uint8("emm-cause", cause))
 
-	m.releaseUEContext(ue, causeNASUnspecified)
+	m.releaseUEContext(ctx, ue, causeNASUnspecified)
 }
 
-func (m *MME) onAttachRequest(ue *UeContext, plain []byte) {
+func (m *MME) onAttachRequest(ctx context.Context, ue *UeContext, plain []byte) {
 	req, err := eps.ParseAttachRequest(plain)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Attach Request", zap.Error(err))
@@ -236,14 +236,14 @@ func (m *MME) onAttachRequest(ue *UeContext, plain []byte) {
 
 	if req.EPSMobileIdentity.Type == eps.IdentityIMSI {
 		ue.imsi = req.EPSMobileIdentity.Digits
-		m.authenticateOrReject(ue)
+		m.authenticateOrReject(ctx, ue)
 
 		return
 	}
 
 	// A foreign or unknown GUTI cannot be resolved locally, so ask the UE for its
 	// IMSI. (A native GUTI the MME still holds is resolved in handleNAS.)
-	m.sendGuardedMessage(ue, "Identity Request", &eps.IdentityRequest{IdentityType: 1})
+	m.sendGuardedMessage(ctx, ue, "Identity Request", &eps.IdentityRequest{IdentityType: 1})
 }
 
 // ingestAttachRequest records the attach parameters the rest of the procedure
@@ -266,8 +266,8 @@ func (m *MME) ingestAttachRequest(ue *UeContext, req *eps.AttachRequest) {
 // and GUMMEI), so its M-TMSI can be resolved against the local context index
 // (TS 23.401). A foreign GUTI would require S10, which Ella Core (a
 // single MME) does not implement.
-func (m *MME) isNativeGUTI(id eps.EPSMobileIdentity) bool {
-	plmn, err := m.operatorPLMN(context.Background())
+func (m *MME) isNativeGUTI(ctx context.Context, id eps.EPSMobileIdentity) bool {
+	plmn, err := m.operatorPLMN(ctx)
 	if err != nil {
 		return false
 	}
@@ -283,13 +283,13 @@ func (m *MME) isNativeGUTI(id eps.EPSMobileIdentity) bool {
 // context, the MME reuses it and skips authentication; otherwise it returns
 // false so the caller falls back to a normal re-identify + authenticate attach.
 // nas is the full integrity-protected message; body is its plaintext.
-func (m *MME) reuseContextForGUTIAttach(ue *UeContext, nas, body []byte) bool {
+func (m *MME) reuseContextForGUTIAttach(ctx context.Context, ue *UeContext, nas, body []byte) bool {
 	req, err := eps.ParseAttachRequest(body)
 	if err != nil || req.EPSMobileIdentity.Type != eps.IdentityGUTI {
 		return false
 	}
 
-	if !m.isNativeGUTI(req.EPSMobileIdentity) {
+	if !m.isNativeGUTI(ctx, req.EPSMobileIdentity) {
 		return false
 	}
 
@@ -320,12 +320,12 @@ func (m *MME) reuseContextForGUTIAttach(ue *UeContext, nas, body []byte) bool {
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
 
 	m.ingestAttachRequest(ue, req)
-	m.startSecurityMode(ue)
+	m.startSecurityMode(ctx, ue)
 
 	return true
 }
 
-func (m *MME) onIdentityResponse(ue *UeContext, plain []byte) {
+func (m *MME) onIdentityResponse(ctx context.Context, ue *UeContext, plain []byte) {
 	m.stopNASGuard(ue)
 
 	resp, err := eps.ParseIdentityResponse(plain)
@@ -335,37 +335,37 @@ func (m *MME) onIdentityResponse(ue *UeContext, plain []byte) {
 	}
 
 	ue.imsi = mobileIdentityDigits(resp.MobileIdentity)
-	m.authenticateOrReject(ue)
+	m.authenticateOrReject(ctx, ue)
 }
 
-func (m *MME) authenticateOrReject(ue *UeContext) {
-	m.startAuthentication(ue)
+func (m *MME) authenticateOrReject(ctx context.Context, ue *UeContext) {
+	m.startAuthentication(ctx, ue)
 }
 
 // rejectAttach sends ATTACH REJECT (TS 24.301) with the given EMM
 // cause, then releases the UE's S1 context.
-func (m *MME) rejectAttach(ue *UeContext, cause uint8) {
+func (m *MME) rejectAttach(ctx context.Context, ue *UeContext, cause uint8) {
 	m.stopNASGuard(ue)
-	m.sendDownlinkMessage(ue, &eps.AttachReject{Cause: cause})
-	m.releaseUEContext(ue, causeNASUnspecified)
+	m.sendDownlinkMessage(ctx, ue, &eps.AttachReject{Cause: cause})
+	m.releaseUEContext(ctx, ue, causeNASUnspecified)
 }
 
 // startAuthentication requests an EPS-AKA vector from the credential authority
 // and challenges the UE. A subscriber the authority cannot serve (e.g. an
 // unknown IMSI) is rejected with ATTACH REJECT #2.
-func (m *MME) startAuthentication(ue *UeContext) {
-	if err := m.sendAuthRequest(ue, "", ""); err != nil {
+func (m *MME) startAuthentication(ctx context.Context, ue *UeContext) {
+	if err := m.sendAuthRequest(ctx, ue, "", ""); err != nil {
 		logger.MmeLog.Info("attach rejected: cannot authenticate subscriber",
 			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.Error(err))
-		m.rejectAttach(ue, emmCauseIMSIUnknownInHSS)
+		m.rejectAttach(ctx, ue, emmCauseIMSIUnknownInHSS)
 	}
 }
 
 // sendAuthRequest obtains an EPS-AKA vector from the credential authority (the
 // resync params drive an AUTS re-synchronisation when set) and sends an
 // AUTHENTICATION REQUEST. It returns an error if no vector could be produced.
-func (m *MME) sendAuthRequest(ue *UeContext, resyncAuts, resyncRand string) error {
-	op, err := m.operatorPLMN(context.Background())
+func (m *MME) sendAuthRequest(ctx context.Context, ue *UeContext, resyncAuts, resyncRand string) error {
+	op, err := m.operatorPLMN(ctx)
 	if err != nil {
 		return err
 	}
@@ -375,7 +375,7 @@ func (m *MME) sendAuthRequest(ue *UeContext, resyncAuts, resyncRand string) erro
 		return fmt.Errorf("encode serving PLMN: %w", err)
 	}
 
-	vec, err := m.cred.GenerateEPSVector(context.Background(), ue.imsi, plmn[:], resyncAuts, resyncRand)
+	vec, err := m.cred.GenerateEPSVector(ctx, ue.imsi, plmn[:], resyncAuts, resyncRand)
 	if err != nil {
 		return err
 	}
@@ -383,12 +383,12 @@ func (m *MME) sendAuthRequest(ue *UeContext, resyncAuts, resyncRand string) erro
 	ue.authVector = vec
 
 	logger.MmeLog.Info("Authentication Request", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
-	m.sendGuardedMessage(ue, "Authentication Request", &eps.AuthenticationRequest{NASKeySetIdentifier: 0, RAND: vec.RAND, AUTN: vec.AUTN[:]})
+	m.sendGuardedMessage(ctx, ue, "Authentication Request", &eps.AuthenticationRequest{NASKeySetIdentifier: 0, RAND: vec.RAND, AUTN: vec.AUTN[:]})
 
 	return nil
 }
 
-func (m *MME) onAuthenticationResponse(ue *UeContext, plain []byte) {
+func (m *MME) onAuthenticationResponse(ctx context.Context, ue *UeContext, plain []byte) {
 	m.stopNASGuard(ue)
 
 	resp, err := eps.ParseAuthenticationResponse(plain)
@@ -399,7 +399,7 @@ func (m *MME) onAuthenticationResponse(ue *UeContext, plain []byte) {
 
 	if ue.authVector == nil || !bytes.Equal(resp.RES, ue.authVector.XRES) {
 		logger.MmeLog.Warn("authentication failed: RES mismatch", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
-		m.rejectAuthentication(ue)
+		m.rejectAuthentication(ctx, ue)
 
 		return
 	}
@@ -407,12 +407,12 @@ func (m *MME) onAuthenticationResponse(ue *UeContext, plain []byte) {
 	ue.kasme = ue.authVector.KASME
 
 	logger.MmeLog.Info("authentication succeeded", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
-	m.startSecurityMode(ue)
+	m.startSecurityMode(ctx, ue)
 }
 
-func (m *MME) startSecurityMode(ue *UeContext) {
+func (m *MME) startSecurityMode(ctx context.Context, ue *UeContext) {
 	var ciphering, integrity []string
-	if op, err := m.bearer.GetOperator(context.Background()); err == nil {
+	if op, err := m.bearer.GetOperator(ctx); err == nil {
 		ciphering, _ = op.GetCiphering()
 		integrity, _ = op.GetIntegrity()
 	}
@@ -461,10 +461,10 @@ func (m *MME) startSecurityMode(ue *UeContext) {
 		zap.String("ue-network-capability", fmt.Sprintf("%x", ue.ueNetCap)),
 		zap.String("ms-network-capability", fmt.Sprintf("%x", ue.msNetCap)),
 		zap.String("replayed-ue-security-capability", fmt.Sprintf("%x", replayed)))
-	m.sendGuardedDownlink(ue, "Security Mode Command", wire)
+	m.sendGuardedDownlink(ctx, ue, "Security Mode Command", wire)
 }
 
-func (m *MME) onSecurityModeComplete(ue *UeContext, plain []byte) {
+func (m *MME) onSecurityModeComplete(ctx context.Context, ue *UeContext, plain []byte) {
 	m.stopNASGuard(ue)
 
 	smc, err := eps.ParseSecurityModeComplete(plain)
@@ -490,12 +490,12 @@ func (m *MME) onSecurityModeComplete(ue *UeContext, plain []byte) {
 		zap.String("imsi", ue.imsi),
 	)
 
-	m.activateDefaultBearer(ue)
+	m.activateDefaultBearer(ctx, ue)
 }
 
 // sendDownlinkProtected encodes a plain NAS message, integrity-protects and
 // ciphers it with the UE's security context, and sends it downlink.
-func (m *MME) sendDownlinkProtected(ue *UeContext, msg nasMessage) {
+func (m *MME) sendDownlinkProtected(ctx context.Context, ue *UeContext, msg nasMessage) {
 	plain, err := msg.Marshal()
 	if err != nil {
 		logger.MmeLog.Error("failed to marshal NAS message", zap.Error(err))
@@ -511,7 +511,7 @@ func (m *MME) sendDownlinkProtected(ue *UeContext, msg nasMessage) {
 
 	ue.dlCount++
 
-	m.sendDownlink(ue, wire)
+	m.sendDownlink(ctx, ue, wire)
 }
 
 // mobileIdentityDigits extracts the identity digits from a TS 24.008 Mobile

--- a/internal/mme/emm_test.go
+++ b/internal/mme/emm_test.go
@@ -98,7 +98,7 @@ func TestAttachRecoveryAfterMMERestart(t *testing.T) {
 	// context: SHT|PD, 4-octet MAC, sequence, then the inner Attach Request.
 	nas := append([]byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x04}, attachBytes...)
 
-	m.handleNAS(ue, nas)
+	m.handleNAS(context.Background(), ue, nas)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one downlink (Identity Request), got %d", len(cc.sent))
@@ -136,7 +136,7 @@ func TestIdentityResponseRecoveryAfterMMERestart(t *testing.T) {
 	// Integrity-protected envelope (SHT=1) with a MAC the MME cannot reproduce.
 	nas := append([]byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x21}, idResp...)
 
-	m.handleNAS(ue, nas)
+	m.handleNAS(context.Background(), ue, nas)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one downlink (Authentication Request), got %d", len(cc.sent))
@@ -205,7 +205,7 @@ func TestAttachReusesContextForNativeGUTI(t *testing.T) {
 
 	cc := &captureConn{}
 	fresh := m.newUe(cc, 9)
-	m.handleNAS(fresh, wire)
+	m.handleNAS(context.Background(), fresh, wire)
 
 	if fresh.authVector != nil {
 		t.Fatal("authentication was not skipped on a valid native GUTI")
@@ -237,7 +237,7 @@ func TestAttachNativeGUTIBadMACFallsBackToAuth(t *testing.T) {
 
 	cc := &captureConn{}
 	fresh := m.newUe(cc, 9)
-	m.handleNAS(fresh, wire)
+	m.handleNAS(context.Background(), fresh, wire)
 
 	if _, ok := m.lookupUe(oldID); !ok {
 		t.Fatal("context was removed despite a MAC mismatch")
@@ -273,7 +273,7 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, attachBytes)
+	m.handleNAS(context.Background(), ue, attachBytes)
 
 	// MME → Authentication Request.
 	if len(cc.sent) != 1 {
@@ -301,7 +301,7 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, authResp)
+	m.handleNAS(context.Background(), ue, authResp)
 
 	// MME → Security Mode Command (integrity protected with the new context).
 	if len(cc.sent) != 2 {
@@ -350,7 +350,7 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, smCompleteWire)
+	m.handleNAS(context.Background(), ue, smCompleteWire)
 
 	if !ue.secured {
 		t.Fatal("NAS security context not established after Security Mode Complete")
@@ -451,7 +451,7 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, completeWire)
+	m.handleNAS(context.Background(), ue, completeWire)
 
 	if ue.emmState != EMMRegistered {
 		t.Fatal("UE not EMM-REGISTERED after Attach Complete")
@@ -473,7 +473,7 @@ func TestSecurityModeRejectReleasesUE(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, plain)
+	m.handleNAS(context.Background(), ue, plain)
 
 	if !ue.releasing {
 		t.Fatal("UE not released after Security Mode Reject")

--- a/internal/mme/erab_release.go
+++ b/internal/mme/erab_release.go
@@ -4,6 +4,8 @@
 package mme
 
 import (
+	"context"
+
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
@@ -21,7 +23,7 @@ import (
 // (first) bearer with reactivation requested, the UE re-attaches and the full UE
 // Context Release that follows tears down the radio bearers, so the NAS is sent
 // on a Downlink NAS Transport and guarded like other common procedures.
-func (m *MME) deactivateBearer(ue *UeContext, p *pdnConnection, esmCause, pti uint8, disconnecting bool) {
+func (m *MME) deactivateBearer(ctx context.Context, ue *UeContext, p *pdnConnection, esmCause, pti uint8, disconnecting bool) {
 	naspdu, err := m.protectDownlink(ue, &eps.DeactivateEPSBearerContextRequest{
 		EPSBearerIdentity:            p.ebi,
 		ProcedureTransactionIdentity: pti,
@@ -36,18 +38,18 @@ func (m *MME) deactivateBearer(ue *UeContext, p *pdnConnection, esmCause, pti ui
 	p.disconnecting = disconnecting
 
 	if disconnecting || p.ebi != ue.defaultEBI {
-		m.sendERABRelease(ue, p, naspdu)
+		m.sendERABRelease(ctx, ue, p, naspdu)
 		return
 	}
 
-	m.sendDownlink(ue, naspdu)
+	m.sendDownlink(ctx, ue, naspdu)
 	m.armNASGuard(ue, "Deactivate EPS Bearer Context Request", naspdu)
 }
 
 // sendERABRelease releases a UE's E-RAB at the eNB while the UE stays connected,
 // carrying the DEACTIVATE EPS BEARER CONTEXT REQUEST in the NAS-PDU so the eNB
 // both releases the radio bearer and delivers the NAS (TS 36.413 §8.2.3).
-func (m *MME) sendERABRelease(ue *UeContext, p *pdnConnection, naspdu []byte) {
+func (m *MME) sendERABRelease(ctx context.Context, ue *UeContext, p *pdnConnection, naspdu []byte) {
 	cmd := &s1ap.ERABReleaseCommand{
 		MMEUES1APID: ue.MMEUES1APID,
 		ENBUES1APID: ue.ENBUES1APID,
@@ -64,7 +66,7 @@ func (m *MME) sendERABRelease(ue *UeContext, p *pdnConnection, naspdu []byte) {
 		return
 	}
 
-	m.sendS1AP(ue, S1APProcedureERABReleaseCommand, b)
+	m.sendS1AP(ctx, ue, S1APProcedureERABReleaseCommand, b)
 }
 
 // handleERABReleaseResponse logs the eNB's confirmation that the radio bearer was

--- a/internal/mme/error_indication.go
+++ b/internal/mme/error_indication.go
@@ -4,6 +4,8 @@
 package mme
 
 import (
+	"context"
+
 	"github.com/ellanetworks/core/internal/amf/sctp"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/s1ap"
@@ -90,14 +92,16 @@ func (m *MME) sendErrorIndication(conn nasWriter, mmeID *s1ap.MMEUES1APID, enbID
 		return
 	}
 
-	m.logOutboundS1AP(conn, S1APProcedureErrorIndication, b)
+	// Error Indications are sent from resolution failures across many handlers,
+	// some outside a request span; use a fresh root.
+	m.logOutboundS1AP(context.Background(), conn, S1APProcedureErrorIndication, b)
 }
 
 // handleErrorIndication processes an ERROR INDICATION from the eNB (TS 36.413).
 // A protocol error on a UE-associated S1 connection leaves it in an
 // inconsistent state, so if the indication names a known UE the MME releases it
 // to ECM-IDLE; the UE re-establishes on its next Service Request.
-func (m *MME) handleErrorIndication(_ *sctp.SCTPConn, value []byte) {
+func (m *MME) handleErrorIndication(ctx context.Context, _ *sctp.SCTPConn, value []byte) {
 	msg, err := s1ap.ParseErrorIndication(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Error Indication", zap.Error(err))
@@ -124,6 +128,6 @@ func (m *MME) handleErrorIndication(_ *sctp.SCTPConn, value []byte) {
 	}
 
 	if ue, ok := m.lookupUe(*msg.MMEUES1APID); ok {
-		m.releaseUEContext(ue, causeNASUnspecified)
+		m.releaseUEContext(ctx, ue, causeNASUnspecified)
 	}
 }

--- a/internal/mme/error_indication_test.go
+++ b/internal/mme/error_indication_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ellanetworks/core/s1ap"
@@ -21,7 +22,7 @@ func TestErrorIndicationReleasesReferencedUE(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleErrorIndication(nil, initiatingValue(t, b))
+	m.handleErrorIndication(context.Background(), nil, initiatingValue(t, b))
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected the referenced UE to be released, got %d S1AP messages", len(cc.sent))
@@ -39,5 +40,5 @@ func TestErrorIndicationWithoutUEIsNoop(t *testing.T) {
 	}
 
 	// No UE referenced: log only, no release, no panic.
-	m.handleErrorIndication(nil, initiatingValue(t, b))
+	m.handleErrorIndication(context.Background(), nil, initiatingValue(t, b))
 }

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -22,6 +22,10 @@ import (
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/s1ap"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -147,13 +151,42 @@ func (m *MME) Shutdown(ctx context.Context) {
 	}
 }
 
+// tracer instruments the MME's S1AP/EMM control plane, the 4G counterpart of the
+// AMF's ngap tracer.
+var tracer = otel.Tracer("ella-core/mme")
+
 // dispatch decodes an S1AP PDU and routes it to the matching procedure handler.
 func (m *MME) dispatch(ctx context.Context, conn *sctp.SCTPConn, msg []byte) {
+	// Inbound S1AP carries no propagated trace context, so this is a fresh root
+	// span, mirroring the AMF's ngap/receive.
+	ctx, span := tracer.Start(ctx, "s1ap/receive",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.Int("s1ap.message_size", len(msg)),
+			attribute.String("network.protocol.name", "s1ap"),
+			attribute.String("network.transport", "sctp"),
+		),
+	)
+	defer span.End()
+
+	if conn != nil {
+		span.SetAttributes(
+			attribute.String("network.peer.address", addrString(conn.RemoteAddr())),
+			attribute.String("network.local.address", addrString(conn.LocalAddr())),
+		)
+	}
+
 	pdu, err := s1ap.Unmarshal(msg)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to decode S1AP PDU")
 		logger.MmeLog.Warn("failed to decode S1AP PDU", zap.Error(err))
+
 		return
 	}
+
+	messageType := s1apMessageType(pdu)
+	span.SetAttributes(attribute.String("s1ap.message_type", string(messageType)))
 
 	// Track the eNB from an S1 Setup Request before logging, so the inbound
 	// event is attributed to the radio ahead of the outbound S1 Setup Response,
@@ -166,7 +199,7 @@ func (m *MME) dispatch(ctx context.Context, conn *sctp.SCTPConn, msg []byte) {
 	}
 
 	m.touchENB(conn)
-	m.logNetworkEvent(ctx, conn, s1apMessageType(pdu), logger.DirectionInbound, msg)
+	m.logNetworkEvent(ctx, conn, messageType, logger.DirectionInbound, msg)
 
 	// TS 36.413: S1 Setup is the first S1AP procedure on a TNL
 	// association. Until it completes, drop every other message — including UE
@@ -174,7 +207,7 @@ func (m *MME) dispatch(ctx context.Context, conn *sctp.SCTPConn, msg []byte) {
 	// NG Setup gate (TS 38.413).
 	if !isSetup && !m.enbSetupComplete(conn) {
 		logger.MmeLog.Warn("S1AP message before S1 Setup, dropping",
-			zap.String("message-type", string(s1apMessageType(pdu))))
+			zap.String("message-type", string(messageType)))
 
 		return
 	}

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -183,30 +183,30 @@ func (m *MME) dispatch(ctx context.Context, conn *sctp.SCTPConn, msg []byte) {
 	case *s1ap.InitiatingMessage:
 		switch p.ProcedureCode {
 		case s1ap.ProcS1Setup:
-			m.handleS1Setup(conn, p.Value)
+			m.handleS1Setup(ctx, conn, p.Value)
 		case s1ap.ProcInitialUEMessage:
-			m.handleInitialUEMessage(conn, p.Value)
+			m.handleInitialUEMessage(ctx, conn, p.Value)
 		case s1ap.ProcUplinkNASTransport:
-			m.handleUplinkNASTransport(conn, p.Value)
+			m.handleUplinkNASTransport(ctx, conn, p.Value)
 		case s1ap.ProcUEContextReleaseRequest:
-			m.handleUEContextReleaseRequest(conn, p.Value)
+			m.handleUEContextReleaseRequest(ctx, conn, p.Value)
 		case s1ap.ProcUECapabilityInfoIndication:
 			m.handleUECapabilityInfoIndication(conn, p.Value)
 		case s1ap.ProcPathSwitchRequest:
-			m.handlePathSwitchRequest(conn, p.Value)
+			m.handlePathSwitchRequest(ctx, conn, p.Value)
 		case s1ap.ProcErrorIndication:
-			m.handleErrorIndication(conn, p.Value)
+			m.handleErrorIndication(ctx, conn, p.Value)
 		case s1ap.ProcReset:
 			m.handleReset(conn, p.Value)
 		case s1ap.ProcENBConfigurationUpdate:
-			m.handleENBConfigurationUpdate(conn, p.Value)
+			m.handleENBConfigurationUpdate(ctx, conn, p.Value)
 		default:
 			logger.MmeLog.Debug("ignoring S1AP initiating message", zap.Int("procedure-code", int(p.ProcedureCode)))
 		}
 	case *s1ap.SuccessfulOutcome:
 		switch p.ProcedureCode {
 		case s1ap.ProcInitialContextSetup:
-			m.handleInitialContextSetupResponse(conn, p.Value)
+			m.handleInitialContextSetupResponse(ctx, conn, p.Value)
 		case s1ap.ProcUEContextRelease:
 			m.handleUEContextReleaseComplete(conn, p.Value)
 		case s1ap.ProcERABSetup:
@@ -229,8 +229,8 @@ var causeUnknownPLMN = s1ap.Cause{Group: s1ap.CauseGroupMisc, Value: 5}
 // handleS1Setup answers an eNB's S1 Setup Request: an S1 Setup Response when the
 // eNB broadcasts a PLMN this MME serves, otherwise an S1 Setup Failure with
 // cause "Unknown PLMN" (TS 36.413).
-func (m *MME) handleS1Setup(conn *sctp.SCTPConn, value []byte) {
-	plmn, err := m.operatorPLMN(context.Background())
+func (m *MME) handleS1Setup(ctx context.Context, conn *sctp.SCTPConn, value []byte) {
+	plmn, err := m.operatorPLMN(ctx)
 	if err != nil {
 		logger.MmeLog.Error("failed to get operator PLMN for S1 Setup", zap.Error(err))
 		return
@@ -255,7 +255,7 @@ func (m *MME) handleS1Setup(conn *sctp.SCTPConn, value []byte) {
 			return
 		}
 
-		m.logNetworkEvent(context.Background(), conn, S1APProcedureS1SetupFailure, logger.DirectionOutbound, outBytes)
+		m.logNetworkEvent(ctx, conn, S1APProcedureS1SetupFailure, logger.DirectionOutbound, outBytes)
 
 		logger.MmeLog.Warn("S1 Setup rejected: eNB broadcasts no PLMN served by this MME (Unknown PLMN)",
 			zap.String("enb-name", req.ENBName),
@@ -267,7 +267,7 @@ func (m *MME) handleS1Setup(conn *sctp.SCTPConn, value []byte) {
 	// A UE re-registers (tracking area updating) whenever the cell's broadcast TAC
 	// is absent from its registered TAI list (TS 24.301). Surfacing an
 	// eNB/operator TAC mismatch here explains otherwise-unexpected TAU churn.
-	if opTAC, err := m.operatorTAC(context.Background()); err == nil {
+	if opTAC, err := m.operatorTAC(ctx); err == nil {
 		for _, ta := range req.SupportedTAs {
 			if uint16(ta.TAC) != opTAC {
 				logger.MmeLog.Warn("eNB TAC differs from operator TAC",
@@ -282,7 +282,7 @@ func (m *MME) handleS1Setup(conn *sctp.SCTPConn, value []byte) {
 		return
 	}
 
-	m.logNetworkEvent(context.Background(), conn, S1APProcedureS1SetupResponse, logger.DirectionOutbound, outBytes)
+	m.logNetworkEvent(ctx, conn, S1APProcedureS1SetupResponse, logger.DirectionOutbound, outBytes)
 
 	// S1 Setup has completed: allow the eNB's UE-associated signalling through the
 	// dispatcher's setup-first gate (TS 36.413).
@@ -296,14 +296,14 @@ func (m *MME) handleS1Setup(conn *sctp.SCTPConn, value []byte) {
 // (otherwise an ENB CONFIGURATION UPDATE FAILURE with cause "Unknown PLMN"),
 // stores an updated eNB name, and acknowledges (TS 36.413 §8.7.4). The eNB blocks
 // on this response, so an unhandled update would stall its reconfiguration.
-func (m *MME) handleENBConfigurationUpdate(conn *sctp.SCTPConn, value []byte) {
+func (m *MME) handleENBConfigurationUpdate(ctx context.Context, conn *sctp.SCTPConn, value []byte) {
 	req, err := s1ap.ParseENBConfigurationUpdate(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode ENB Configuration Update", zap.Error(err))
 		return
 	}
 
-	plmn, err := m.operatorPLMN(context.Background())
+	plmn, err := m.operatorPLMN(ctx)
 	if err != nil {
 		logger.MmeLog.Error("failed to get operator PLMN for ENB Configuration Update", zap.Error(err))
 		return
@@ -325,7 +325,7 @@ func (m *MME) handleENBConfigurationUpdate(conn *sctp.SCTPConn, value []byte) {
 		return
 	}
 
-	m.logNetworkEvent(context.Background(), conn, msgType, logger.DirectionOutbound, out)
+	m.logNetworkEvent(ctx, conn, msgType, logger.DirectionOutbound, out)
 
 	if !accepted {
 		logger.MmeLog.Warn("ENB Configuration Update rejected: eNB broadcasts no served PLMN (Unknown PLMN)")

--- a/internal/mme/mme_nas.go
+++ b/internal/mme/mme_nas.go
@@ -19,7 +19,7 @@ import (
 // (TS 36.413). A SERVICE REQUEST re-establishes an existing EMM-IDLE
 // context (resolved by S-TMSI); anything else (an Attach Request) starts a new
 // one.
-func (m *MME) handleInitialUEMessage(conn *sctp.SCTPConn, value []byte) {
+func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, value []byte) {
 	msg, err := s1ap.ParseInitialUEMessage(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Initial UE Message", zap.Error(err))
@@ -28,7 +28,7 @@ func (m *MME) handleInitialUEMessage(conn *sctp.SCTPConn, value []byte) {
 
 	nas := []byte(msg.NASPDU)
 	if len(nas) > 0 && nas[0]>>4 == uint8(eps.SHTServiceRequest) {
-		m.onServiceRequest(conn, msg)
+		m.onServiceRequest(ctx, conn, msg)
 		return
 	}
 
@@ -46,7 +46,7 @@ func (m *MME) handleInitialUEMessage(conn *sctp.SCTPConn, value []byte) {
 				zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
 			)
 
-			m.handleNAS(ue, nas)
+			m.handleNAS(ctx, ue, nas)
 
 			return
 		}
@@ -60,12 +60,12 @@ func (m *MME) handleInitialUEMessage(conn *sctp.SCTPConn, value []byte) {
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
 	)
 
-	m.handleNAS(ue, nas)
+	m.handleNAS(ctx, ue, nas)
 }
 
 // handleUplinkNASTransport routes an uplink NAS message to its UE context
 // (TS 36.413).
-func (m *MME) handleUplinkNASTransport(conn nasWriter, value []byte) {
+func (m *MME) handleUplinkNASTransport(ctx context.Context, conn nasWriter, value []byte) {
 	msg, err := s1ap.ParseUplinkNASTransport(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Uplink NAS Transport", zap.Error(err))
@@ -77,7 +77,7 @@ func (m *MME) handleUplinkNASTransport(conn nasWriter, value []byte) {
 		return
 	}
 
-	m.handleNAS(ue, []byte(msg.NASPDU))
+	m.handleNAS(ctx, ue, []byte(msg.NASPDU))
 }
 
 // enbTransportAddress resolves the eNB S1-U endpoint from an E-RAB Transport
@@ -103,7 +103,7 @@ func enbTransportAddress(tla s1ap.TransportLayerAddress) (netip.Addr, bool) {
 // handleInitialContextSetupResponse records the eNB's bearer-setup result
 // (TS 36.413): the eNB S1-U F-TEID it returns is handed to the anchor
 // as the session's downlink endpoint.
-func (m *MME) handleInitialContextSetupResponse(conn nasWriter, value []byte) {
+func (m *MME) handleInitialContextSetupResponse(ctx context.Context, conn nasWriter, value []byte) {
 	msg, err := s1ap.ParseInitialContextSetupResponse(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Initial Context Setup Response", zap.Error(err))
@@ -144,7 +144,7 @@ func (m *MME) handleInitialContextSetupResponse(conn nasWriter, value []byte) {
 
 	p.enbFTEID = models.FTEID{TEID: uint32(erab.GTPTEID), Addr: enbAddr}
 
-	if err := m.session.ModifyEPSSession(context.Background(), ue.imsi, p.ebi, p.enbFTEID); err != nil {
+	if err := m.session.ModifyEPSSession(ctx, ue.imsi, p.ebi, p.enbFTEID); err != nil {
 		logger.MmeLog.Error("failed to set the eNB F-TEID on the EPS session",
 			zap.String("imsi", ue.imsi), zap.Error(err))
 
@@ -160,7 +160,7 @@ func (m *MME) handleInitialContextSetupResponse(conn nasWriter, value []byte) {
 	// its bearer from ECM-IDLE (Service Request): the radio bearer is now up, so
 	// a modify/reactivate is deliverable. During attach this is a no-op — the UE
 	// is not yet EMM-REGISTERED — so reconcileUE returns early.
-	m.reconcileUE(context.Background(), ue)
+	m.reconcileUE(ctx, ue)
 }
 
 // downlinkNASTransportBytes builds a Downlink NAS Transport PDU carrying nas for
@@ -181,19 +181,19 @@ type nasMessage interface {
 }
 
 // sendDownlinkMessage serializes a plain NAS message and sends it to the UE.
-func (m *MME) sendDownlinkMessage(ue *UeContext, msg nasMessage) {
+func (m *MME) sendDownlinkMessage(ctx context.Context, ue *UeContext, msg nasMessage) {
 	b, err := msg.Marshal()
 	if err != nil {
 		logger.MmeLog.Error("failed to marshal NAS message", zap.Error(err))
 		return
 	}
 
-	m.sendDownlink(ue, b)
+	m.sendDownlink(ctx, ue, b)
 }
 
 // sendDownlink wraps NAS bytes (plain or security-protected) in a Downlink NAS
 // Transport and sends them to the UE's eNB.
-func (m *MME) sendDownlink(ue *UeContext, nas []byte) {
+func (m *MME) sendDownlink(ctx context.Context, ue *UeContext, nas []byte) {
 	b, err := downlinkNASTransportBytes(ue, nas)
 	if err != nil {
 		logger.MmeLog.Error("failed to build Downlink NAS Transport", zap.Error(err))
@@ -209,5 +209,5 @@ func (m *MME) sendDownlink(ue *UeContext, nas []byte) {
 		return
 	}
 
-	m.logOutboundS1AP(ue.conn, S1APProcedureDownlinkNASTransport, b)
+	m.logOutboundS1AP(ctx, ue.conn, S1APProcedureDownlinkNASTransport, b)
 }

--- a/internal/mme/mme_nas.go
+++ b/internal/mme/mme_nas.go
@@ -12,6 +12,9 @@ import (
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -194,9 +197,23 @@ func (m *MME) sendDownlinkMessage(ctx context.Context, ue *UeContext, msg nasMes
 // sendDownlink wraps NAS bytes (plain or security-protected) in a Downlink NAS
 // Transport and sends them to the UE's eNB.
 func (m *MME) sendDownlink(ctx context.Context, ue *UeContext, nas []byte) {
+	ctx, span := tracer.Start(ctx, "s1ap/send",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("s1ap.message_type", string(S1APProcedureDownlinkNASTransport)),
+			attribute.Int("s1ap.message_size", len(nas)),
+			attribute.String("network.protocol.name", "s1ap"),
+			attribute.String("network.transport", "sctp"),
+		),
+	)
+	defer span.End()
+
 	b, err := downlinkNASTransportBytes(ue, nas)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to build Downlink NAS Transport")
 		logger.MmeLog.Error("failed to build Downlink NAS Transport", zap.Error(err))
+
 		return
 	}
 
@@ -205,7 +222,10 @@ func (m *MME) sendDownlink(ctx context.Context, ue *UeContext, nas []byte) {
 	}
 
 	if _, err := ue.conn.WriteMsg(b, &sctp.SndRcvInfo{PPID: s1apPPID, Stream: 0}); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to send Downlink NAS Transport")
 		logger.MmeLog.Error("failed to send Downlink NAS Transport", zap.Error(err))
+
 		return
 	}
 

--- a/internal/mme/mme_nas_test.go
+++ b/internal/mme/mme_nas_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"net/netip"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestInitialContextSetupResponseRelaysENBFTEID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleInitialContextSetupResponse(cc, pdu.(*s1ap.SuccessfulOutcome).Value)
+	m.handleInitialContextSetupResponse(context.Background(), cc, pdu.(*s1ap.SuccessfulOutcome).Value)
 
 	want := models.FTEID{TEID: 0x55, Addr: netip.AddrFrom4([4]byte{10, 3, 0, 3})}
 
@@ -104,7 +105,7 @@ func TestInitialContextSetupResponseENBTransportFamily(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.handleInitialContextSetupResponse(cc, pdu.(*s1ap.SuccessfulOutcome).Value)
+			m.handleInitialContextSetupResponse(context.Background(), cc, pdu.(*s1ap.SuccessfulOutcome).Value)
 
 			if testPDN(ue).enbFTEID.Addr != tc.want {
 				t.Fatalf("eNB F-TEID address = %v, want %v", testPDN(ue).enbFTEID.Addr, tc.want)

--- a/internal/mme/mme_ue_test.go
+++ b/internal/mme/mme_ue_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ellanetworks/core/s1ap"
@@ -44,7 +45,7 @@ func TestUplinkNASTransportUnknownUE(t *testing.T) {
 	// An unknown MME-UE-S1AP-ID is answered with an Error Indication, not
 	// silently dropped, and no context is created (TS 36.413).
 	conn := &captureConn{}
-	m.handleUplinkNASTransport(conn, initiatingValue(t, b))
+	m.handleUplinkNASTransport(context.Background(), conn, initiatingValue(t, b))
 
 	if _, ok := m.lookupUe(999); ok {
 		t.Fatal("unexpected UE context for unknown MME-UE-S1AP-ID")

--- a/internal/mme/nas_guard.go
+++ b/internal/mme/nas_guard.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"time"
 
 	"github.com/ellanetworks/core/internal/logger"
@@ -13,20 +14,20 @@ import (
 // sendGuardedMessage serializes a NAS message, sends it to the UE, and arms the
 // NAS common-procedure guard timer so the message is retransmitted if the UE
 // does not respond (TS 24.301: T3450/T3460/T3470).
-func (m *MME) sendGuardedMessage(ue *UeContext, name string, msg nasMessage) {
+func (m *MME) sendGuardedMessage(ctx context.Context, ue *UeContext, name string, msg nasMessage) {
 	b, err := msg.Marshal()
 	if err != nil {
 		logger.MmeLog.Error("failed to marshal NAS message", zap.Error(err))
 		return
 	}
 
-	m.sendGuardedDownlink(ue, name, b)
+	m.sendGuardedDownlink(ctx, ue, name, b)
 }
 
 // sendGuardedDownlink sends already-serialized NAS bytes and arms the guard.
-func (m *MME) sendGuardedDownlink(ue *UeContext, name string, nas []byte) {
+func (m *MME) sendGuardedDownlink(ctx context.Context, ue *UeContext, name string, nas []byte) {
 	m.armNASGuard(ue, name, nas)
-	m.sendDownlink(ue, nas)
+	m.sendDownlink(ctx, ue, nas)
 }
 
 // armNASGuard records the outstanding downlink message and starts its guard
@@ -124,7 +125,8 @@ func (m *MME) onNASGuardExpiry(ue *UeContext, gen uint64) {
 
 		logger.MmeLog.Info("NAS procedure timed out, releasing UE",
 			zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("procedure", name))
-		m.releaseUEContext(ue, causeNASUnspecified)
+		// The guard fires from a timer outside any request; start a fresh root.
+		m.releaseUEContext(context.Background(), ue, causeNASUnspecified)
 
 		return
 	}
@@ -140,5 +142,6 @@ func (m *MME) onNASGuardExpiry(ue *UeContext, gen uint64) {
 
 	logger.MmeLog.Info("retransmitting NAS message",
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("procedure", name), zap.Int("attempt", tries))
-	m.sendDownlink(ue, pdu)
+	// Retransmission is timer-driven, outside the original request; start a fresh root.
+	m.sendDownlink(context.Background(), ue, pdu)
 }

--- a/internal/mme/nas_replay_test.go
+++ b/internal/mme/nas_replay_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"testing"
 
 	nascommon "github.com/ellanetworks/core/nas/common"
@@ -37,7 +38,7 @@ func TestNASUplinkReplayRejected(t *testing.T) {
 
 	msg := protectedUplink(t, ue, nascommon.NASCount(0, 0))
 
-	m.handleNAS(ue, msg)
+	m.handleNAS(context.Background(), ue, msg)
 
 	if ue.ulCount != 1 {
 		t.Fatalf("valid message not accepted: ulCount = %d, want 1", ue.ulCount)
@@ -45,7 +46,7 @@ func TestNASUplinkReplayRejected(t *testing.T) {
 
 	// Replaying the identical bytes must not advance the expected count: the
 	// message now estimates to a stale NAS COUNT and fails the integrity check.
-	m.handleNAS(ue, msg)
+	m.handleNAS(context.Background(), ue, msg)
 
 	if ue.ulCount != 1 {
 		t.Fatalf("replay accepted: ulCount advanced to %d", ue.ulCount)
@@ -60,14 +61,14 @@ func TestNASUplinkCountWrap(t *testing.T) {
 	ue, _ := securedUE(t, m)
 	ue.ulCount = 255
 
-	m.handleNAS(ue, protectedUplink(t, ue, nascommon.NASCount(0, 255)))
+	m.handleNAS(context.Background(), ue, protectedUplink(t, ue, nascommon.NASCount(0, 255)))
 
 	if ue.ulCount != 256 {
 		t.Fatalf("sequence 255 not accepted: ulCount = %d, want 256", ue.ulCount)
 	}
 
 	// The UE's sequence wraps 255->0 and its overflow becomes 1.
-	m.handleNAS(ue, protectedUplink(t, ue, nascommon.NASCount(1, 0)))
+	m.handleNAS(context.Background(), ue, protectedUplink(t, ue, nascommon.NASCount(1, 0)))
 
 	if ue.ulCount != 257 {
 		t.Fatalf("wrapped message not accepted: ulCount = %d, want 257", ue.ulCount)

--- a/internal/mme/network_event.go
+++ b/internal/mme/network_event.go
@@ -51,11 +51,11 @@ func (m *MME) logNetworkEvent(ctx context.Context, conn *sctp.SCTPConn, messageT
 
 // logOutboundS1AP records an outbound S1AP message. The UE-facing writer is the
 // SCTP association; events from non-SCTP writers (tests) are skipped.
-func (m *MME) logOutboundS1AP(conn nasWriter, messageType S1APProcedure, raw []byte) {
+func (m *MME) logOutboundS1AP(ctx context.Context, conn nasWriter, messageType S1APProcedure, raw []byte) {
 	sctpConn, ok := conn.(*sctp.SCTPConn)
 	if !ok {
 		return
 	}
 
-	m.logNetworkEvent(context.Background(), sctpConn, messageType, logger.DirectionOutbound, raw)
+	m.logNetworkEvent(ctx, sctpConn, messageType, logger.DirectionOutbound, raw)
 }

--- a/internal/mme/network_name_test.go
+++ b/internal/mme/network_name_test.go
@@ -31,7 +31,7 @@ func TestSendNetworkName(t *testing.T) {
 	m := New(udm.New(newFakeCredStore(), noopKeyResolver), spnBearerStore{}, &fakeSessionManager{})
 	ue, cc := securedUE(t, m)
 
-	m.sendNetworkName(ue)
+	m.sendNetworkName(context.Background(), ue)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one EMM INFORMATION downlink, got %d", len(cc.sent))
@@ -56,7 +56,7 @@ func TestSendNetworkNameNoSPN(t *testing.T) {
 	m := newTestMME(t) // fakeBearerStore has no SPN configured
 	ue, cc := securedUE(t, m)
 
-	m.sendNetworkName(ue)
+	m.sendNetworkName(context.Background(), ue)
 
 	if len(cc.sent) != 0 {
 		t.Fatalf("expected no downlink without an SPN, got %d", len(cc.sent))

--- a/internal/mme/path_switch.go
+++ b/internal/mme/path_switch.go
@@ -28,7 +28,7 @@ var (
 // with PATH SWITCH REQUEST ACKNOWLEDGE — or a FAILURE when the path cannot be
 // switched. value is the initiatingMessage open-type payload; conn is the target
 // eNB's association the request arrived on.
-func (m *MME) handlePathSwitchRequest(conn nasWriter, value []byte) {
+func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value []byte) {
 	req, err := s1ap.ParsePathSwitchRequest(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Path Switch Request", zap.Error(err))
@@ -74,7 +74,7 @@ func (m *MME) handlePathSwitchRequest(conn nasWriter, value []byte) {
 	}
 
 	// Switch the downlink of every E-RAB in the list to the endpoint it carries.
-	switched := m.switchPathBearers(ue, req.ERABToBeSwitchedDL)
+	switched := m.switchPathBearers(ctx, ue, req.ERABToBeSwitchedDL)
 	if switched == 0 {
 		// TS 36.413: the UP path was switched for no E-RAB.
 		logger.MmeLog.Warn("Path Switch Request switched no E-RAB",
@@ -114,7 +114,7 @@ func (m *MME) handlePathSwitchRequest(conn nasWriter, value []byte) {
 		zap.Uint32("enb-ue-id", uint32(req.ENBUES1APID)),
 		zap.Int("e-rabs-switched", switched),
 		zap.Uint8("ncc", ncc))
-	m.sendS1AP(ue, S1APProcedurePathSwitchRequestAck, b)
+	m.sendS1AP(ctx, ue, S1APProcedurePathSwitchRequestAck, b)
 }
 
 // switchPathBearers points the downlink of each E-RAB in the to-be-switched list
@@ -124,7 +124,7 @@ func (m *MME) handlePathSwitchRequest(conn nasWriter, value []byte) {
 // to a PDN connection, or whose endpoint is malformed or fails to switch, is
 // logged and skipped — not silently dropped — and counts as not switched
 // (TS 36.413).
-func (m *MME) switchPathBearers(ue *UeContext, items []s1ap.ERABToBeSwitchedDLItem) int {
+func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, items []s1ap.ERABToBeSwitchedDLItem) int {
 	switched := 0
 
 	for _, erab := range items {
@@ -146,7 +146,7 @@ func (m *MME) switchPathBearers(ue *UeContext, items []s1ap.ERABToBeSwitchedDLIt
 
 		fteid := models.FTEID{TEID: uint32(erab.GTPTEID), Addr: addr}
 
-		if err := m.session.ModifyEPSSession(context.Background(), ue.imsi, p.ebi, fteid); err != nil {
+		if err := m.session.ModifyEPSSession(ctx, ue.imsi, p.ebi, fteid); err != nil {
 			logger.MmeLog.Error("failed to switch an EPS session downlink to the target eNB",
 				zap.String("imsi", ue.imsi), zap.Uint8("e-rab-id", uint8(erab.ERABID)), zap.Error(err))
 
@@ -185,7 +185,8 @@ func (m *MME) sendPathSwitchFailure(conn nasWriter, req *s1ap.PathSwitchRequest,
 		return
 	}
 
-	m.logOutboundS1AP(conn, S1APProcedurePathSwitchRequestFailure, b)
+	// A Path Switch Failure can be sent before the UE is resolved; use a fresh root.
+	m.logOutboundS1AP(context.Background(), conn, S1APProcedurePathSwitchRequestFailure, b)
 }
 
 // pathSwitchSecurityCapabilities compares the UE security capabilities the target

--- a/internal/mme/path_switch_test.go
+++ b/internal/mme/path_switch_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"net/netip"
 	"testing"
 
@@ -123,7 +124,7 @@ func TestPathSwitchSwitchesDownlinkAndAcks(t *testing.T) {
 	}
 
 	target := &captureConn{}
-	m.handlePathSwitchRequest(target, pathSwitchValue(t, samplePathSwitchRequest(ue)))
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, samplePathSwitchRequest(ue)))
 
 	// Downlink switched to the new eNB S1-U endpoint.
 	wantFTEID := models.FTEID{TEID: 0x99, Addr: netip.AddrFrom4([4]byte{10, 4, 0, 2})}
@@ -175,7 +176,7 @@ func TestPathSwitchUnknownUEFails(t *testing.T) {
 	}
 
 	target := &captureConn{}
-	m.handlePathSwitchRequest(target, pathSwitchValue(t, req))
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, req))
 
 	if target.count() != 1 {
 		t.Fatalf("expected one downlink (Failure), got %d", target.count())
@@ -193,7 +194,7 @@ func TestPathSwitchNoSecurityContextFails(t *testing.T) {
 	ue := m.newUe(&captureConn{}, 7) // not secured
 
 	target := &captureConn{}
-	m.handlePathSwitchRequest(target, pathSwitchValue(t, samplePathSwitchRequest(ue)))
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, samplePathSwitchRequest(ue)))
 
 	if target.count() != 1 {
 		t.Fatalf("expected one downlink (Failure), got %d", target.count())
@@ -220,7 +221,7 @@ func TestPathSwitchDuplicateERABFails(t *testing.T) {
 	req.ERABToBeSwitchedDL = append(req.ERABToBeSwitchedDL, switchedDLItem())
 
 	target := &captureConn{}
-	m.handlePathSwitchRequest(target, pathSwitchValue(t, req))
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, req))
 
 	if fail := parsePathSwitchFailure(t, target.sent[0]); fail.Cause != causeMultipleERABInstances {
 		t.Fatalf("cause = %+v, want multiple-E-RAB-ID-instances", fail.Cause)
@@ -242,7 +243,7 @@ func TestPathSwitchUnknownERABFails(t *testing.T) {
 	req.ERABToBeSwitchedDL[0].ERABID = s1ap.ERABID(defaultERABID + 1) // not the default bearer
 
 	target := &captureConn{}
-	m.handlePathSwitchRequest(target, pathSwitchValue(t, req))
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, req))
 
 	if fail := parsePathSwitchFailure(t, target.sent[0]); fail.Cause != causePathSwitchUPFailure {
 		t.Fatalf("cause = %+v, want transport-resource-unavailable", fail.Cause)
@@ -268,7 +269,7 @@ func TestPathSwitchCapabilityMismatchReplaysStored(t *testing.T) {
 	req.UESecurityCapabilities = s1ap.UESecurityCapabilities{EncryptionAlgorithms: 0x8000, IntegrityProtectionAlgorithms: 0x8000}
 
 	target := &captureConn{}
-	m.handlePathSwitchRequest(target, pathSwitchValue(t, req))
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, req))
 
 	ack := parsePathSwitchAck(t, target.sent[0])
 

--- a/internal/mme/pdn_address_test.go
+++ b/internal/mme/pdn_address_test.go
@@ -5,6 +5,7 @@ package mme
 
 import (
 	"bytes"
+	"context"
 	"net/netip"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 func activateFromAccept(t *testing.T, m *MME, ue *UeContext) *eps.ActivateDefaultEPSBearerContextRequest {
 	t.Helper()
 
-	wire, err := m.buildProtectedAttachAccept(ue, &epsQoS{APN: "internet", QCI: 9, MTU: 1400})
+	wire, err := m.buildProtectedAttachAccept(context.Background(), ue, &epsQoS{APN: "internet", QCI: 9, MTU: 1400})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +52,7 @@ func TestAttachAcceptIMSVoPS(t *testing.T) {
 	testPDN(ue).pdnType = eps.PDNTypeIPv4
 	testPDN(ue).ueIP = testUEIP
 
-	wire, err := m.buildProtectedAttachAccept(ue, &epsQoS{APN: "internet", QCI: 9, MTU: 1400})
+	wire, err := m.buildProtectedAttachAccept(context.Background(), ue, &epsQoS{APN: "internet", QCI: 9, MTU: 1400})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +133,7 @@ func TestActivateDefaultBearerRejectsWhen4GNotAllowed(t *testing.T) {
 	m := New(udm.New(newFakeCredStore(), noopKeyResolver), barredBearerStore{}, &fakeSessionManager{})
 	ue, cc := securedUE(t, m)
 
-	m.activateDefaultBearer(ue)
+	m.activateDefaultBearer(context.Background(), ue)
 
 	if len(cc.sent) != 2 {
 		t.Fatalf("expected Attach Reject + UE Context Release Command, got %d", len(cc.sent))
@@ -157,7 +158,7 @@ func TestActivateDefaultBearerRejectsOnSessionFailure(t *testing.T) {
 	m := New(udm.New(newFakeCredStore(), noopKeyResolver), fakeBearerStore{}, &erroringSessionManager{})
 	ue, cc := securedUE(t, m)
 
-	m.activateDefaultBearer(ue)
+	m.activateDefaultBearer(context.Background(), ue)
 
 	if len(cc.sent) != 2 {
 		t.Fatalf("expected Attach Reject + UE Context Release Command, got %d", len(cc.sent))
@@ -198,7 +199,7 @@ func TestAttachAcceptPDNAddress(t *testing.T) {
 			testPDN(ue).ueIP = testUEIP
 			testPDN(ue).ueIPv6IID = testUEIPv6IID
 
-			wire, err := m.buildProtectedAttachAccept(ue, &epsQoS{APN: "internet", QCI: 9})
+			wire, err := m.buildProtectedAttachAccept(context.Background(), ue, &epsQoS{APN: "internet", QCI: 9})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/mme/pdn_connectivity.go
+++ b/internal/mme/pdn_connectivity.go
@@ -52,7 +52,7 @@ func esmRequestHeaderCause(pti, headerEBI uint8) uint8 {
 // EPS bearer identity, asks the anchor for a session, and sets up the radio leg
 // with an E-RAB SETUP REQUEST carrying the ACTIVATE DEFAULT EPS BEARER CONTEXT
 // REQUEST.
-func (m *MME) onPDNConnectivityRequest(ue *UeContext, plain []byte) {
+func (m *MME) onPDNConnectivityRequest(ctx context.Context, ue *UeContext, plain []byte) {
 	req, err := eps.ParsePDNConnectivityRequest(plain)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode PDN Connectivity Request", zap.Error(err))
@@ -65,13 +65,13 @@ func (m *MME) onPDNConnectivityRequest(ue *UeContext, plain []byte) {
 		logger.MmeLog.Info("PDN connectivity rejected: invalid ESM header",
 			zap.String("imsi", ue.imsi), zap.Uint8("pti", pti),
 			zap.Uint8("header-ebi", req.EPSBearerIdentity), zap.Uint8("esm-cause", cause))
-		m.rejectPDNConnectivity(ue, pti, cause)
+		m.rejectPDNConnectivity(ctx, ue, pti, cause)
 
 		return
 	}
 
 	if ue.emmState != EMMRegistered || ue.ecmState != ECMConnected {
-		m.rejectPDNConnectivity(ue, pti, esmCauseRequestRejectedUnspecified)
+		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseRequestRejectedUnspecified)
 		return
 	}
 
@@ -79,37 +79,37 @@ func (m *MME) onPDNConnectivityRequest(ue *UeContext, plain []byte) {
 	if len(req.AccessPointName) > 0 {
 		if apn, err = eps.DecodeAPN(req.AccessPointName); err != nil {
 			logger.MmeLog.Warn("failed to decode APN in PDN Connectivity Request", zap.Error(err))
-			m.rejectPDNConnectivity(ue, pti, esmCauseUnknownAPN)
+			m.rejectPDNConnectivity(ctx, ue, pti, esmCauseUnknownAPN)
 
 			return
 		}
 	}
 
 	if apn == "" {
-		m.rejectPDNConnectivity(ue, pti, esmCauseUnknownAPN)
+		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseUnknownAPN)
 		return
 	}
 
 	if m.findPDNByAPN(ue, apn) != nil {
 		logger.MmeLog.Info("PDN connectivity rejected: APN already connected",
 			zap.String("imsi", ue.imsi), zap.String("apn", apn))
-		m.rejectPDNConnectivity(ue, pti, esmCauseMultiplePDNForAPNNotAllowed)
+		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseMultiplePDNForAPNNotAllowed)
 
 		return
 	}
 
-	qos, err := m.resolveQoSByAPN(context.Background(), ue.imsi, apn)
+	qos, err := m.resolveQoSByAPN(ctx, ue.imsi, apn)
 	if errors.Is(err, ErrUnknownAPN) {
 		logger.MmeLog.Info("PDN connectivity rejected: APN not in subscriber profile",
 			zap.String("imsi", ue.imsi), zap.String("apn", apn))
-		m.rejectPDNConnectivity(ue, pti, esmCauseUnknownAPN)
+		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseUnknownAPN)
 
 		return
 	}
 
 	if err != nil {
 		logger.MmeLog.Warn("failed to resolve QoS for additional PDN", zap.String("apn", apn), zap.Error(err))
-		m.rejectPDNConnectivity(ue, pti, esmCauseRequestRejectedUnspecified)
+		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseRequestRejectedUnspecified)
 
 		return
 	}
@@ -118,12 +118,12 @@ func (m *MME) onPDNConnectivityRequest(ue *UeContext, plain []byte) {
 	if p == nil {
 		logger.MmeLog.Info("PDN connectivity rejected: no free EPS bearer identity",
 			zap.String("imsi", ue.imsi))
-		m.rejectPDNConnectivity(ue, pti, esmCauseMaxEPSBearersReached)
+		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseMaxEPSBearersReached)
 
 		return
 	}
 
-	bearer, err := m.session.CreateEPSSession(context.Background(), models.EPSBearerRequest{
+	bearer, err := m.session.CreateEPSSession(ctx, models.EPSBearerRequest{
 		IMSI:              ue.imsi,
 		EPSBearerIdentity: p.ebi,
 		PolicyID:          qos.PolicyID,
@@ -140,7 +140,7 @@ func (m *MME) onPDNConnectivityRequest(ue *UeContext, plain []byte) {
 		logger.MmeLog.Info("PDN connectivity rejected: session setup failed",
 			zap.String("imsi", ue.imsi), zap.String("apn", apn), zap.Error(err))
 		m.dropPDN(ue, p.ebi)
-		m.rejectPDNConnectivity(ue, pti, esmCauseRequestRejectedUnspecified)
+		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseRequestRejectedUnspecified)
 
 		return
 	}
@@ -174,13 +174,13 @@ func (m *MME) onPDNConnectivityRequest(ue *UeContext, plain []byte) {
 
 	logger.MmeLog.Info("opening additional PDN connection",
 		zap.String("imsi", ue.imsi), zap.String("apn", apn), zap.Uint8("ebi", p.ebi))
-	m.sendERABSetup(ue, p, qos, naspdu)
+	m.sendERABSetup(ctx, ue, p, qos, naspdu)
 }
 
 // sendERABSetup asks the eNB to set up the radio leg of a new PDN connection,
 // carrying the ACTIVATE DEFAULT EPS BEARER CONTEXT REQUEST to the UE (TS 36.413
 // §8.2.1).
-func (m *MME) sendERABSetup(ue *UeContext, p *pdnConnection, qos *epsQoS, naspdu []byte) {
+func (m *MME) sendERABSetup(ctx context.Context, ue *UeContext, p *pdnConnection, qos *epsQoS, naspdu []byte) {
 	sgwTLA, err := models.EncodeTransportLayerAddress(p.sgwFTEID.Addr, p.sgwN3IPv6)
 	if err != nil {
 		logger.MmeLog.Error("failed to encode S-GW transport layer address", zap.Error(err))
@@ -219,7 +219,7 @@ func (m *MME) sendERABSetup(ue *UeContext, p *pdnConnection, qos *epsQoS, naspdu
 		return
 	}
 
-	m.sendS1AP(ue, S1APProcedureERABSetupRequest, b)
+	m.sendS1AP(ctx, ue, S1APProcedureERABSetupRequest, b)
 }
 
 // handleERABSetupResponse processes the eNB's answer to an E-RAB SETUP REQUEST
@@ -283,7 +283,7 @@ func (m *MME) handleERABSetupResponse(conn nasWriter, value []byte) {
 // disconnected this way — the UE detaches instead (ESM cause #49). The bearer is
 // torn down with a DEACTIVATE EPS BEARER CONTEXT REQUEST; the session is released
 // when the UE accepts.
-func (m *MME) onPDNDisconnectRequest(ue *UeContext, plain []byte) {
+func (m *MME) onPDNDisconnectRequest(ctx context.Context, ue *UeContext, plain []byte) {
 	req, err := eps.ParsePDNDisconnectRequest(plain)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode PDN Disconnect Request", zap.Error(err))
@@ -296,7 +296,7 @@ func (m *MME) onPDNDisconnectRequest(ue *UeContext, plain []byte) {
 		logger.MmeLog.Info("PDN disconnect rejected: invalid ESM header",
 			zap.String("imsi", ue.imsi), zap.Uint8("pti", pti),
 			zap.Uint8("header-ebi", req.EPSBearerIdentity), zap.Uint8("esm-cause", cause))
-		m.rejectPDNDisconnect(ue, pti, cause)
+		m.rejectPDNDisconnect(ctx, ue, pti, cause)
 
 		return
 	}
@@ -305,7 +305,7 @@ func (m *MME) onPDNDisconnectRequest(ue *UeContext, plain []byte) {
 	if p == nil {
 		logger.MmeLog.Info("PDN disconnect rejected: unknown linked EPS bearer",
 			zap.String("imsi", ue.imsi), zap.Uint8("linked-ebi", req.LinkedEPSBearerIdentity))
-		m.rejectPDNDisconnect(ue, pti, esmCauseRequestRejectedUnspecified)
+		m.rejectPDNDisconnect(ctx, ue, pti, esmCauseRequestRejectedUnspecified)
 
 		return
 	}
@@ -313,20 +313,20 @@ func (m *MME) onPDNDisconnectRequest(ue *UeContext, plain []byte) {
 	if len(ue.pdns) <= 1 {
 		logger.MmeLog.Info("PDN disconnect rejected: last PDN connection",
 			zap.String("imsi", ue.imsi), zap.Uint8("linked-ebi", req.LinkedEPSBearerIdentity))
-		m.rejectPDNDisconnect(ue, pti, esmCauseLastPDNDisconnectNotAllowed)
+		m.rejectPDNDisconnect(ctx, ue, pti, esmCauseLastPDNDisconnectNotAllowed)
 
 		return
 	}
 
 	logger.MmeLog.Info("disconnecting PDN connection",
 		zap.String("imsi", ue.imsi), zap.String("apn", p.apn), zap.Uint8("ebi", p.ebi))
-	m.deactivateBearer(ue, p, esmCauseRegularDeactivation, pti, true)
+	m.deactivateBearer(ctx, ue, p, esmCauseRegularDeactivation, pti, true)
 }
 
 // rejectPDNDisconnect refuses a PDN DISCONNECT REQUEST with an ESM cause
 // (TS 24.301 §6.5.2.4).
-func (m *MME) rejectPDNDisconnect(ue *UeContext, pti, cause uint8) {
-	m.sendDownlinkProtected(ue, &eps.PDNDisconnectReject{
+func (m *MME) rejectPDNDisconnect(ctx context.Context, ue *UeContext, pti, cause uint8) {
+	m.sendDownlinkProtected(ctx, ue, &eps.PDNDisconnectReject{
 		ProcedureTransactionIdentity: pti,
 		ESMCause:                     cause,
 	})
@@ -372,8 +372,8 @@ func (m *MME) onActivateDefaultBearerReject(ue *UeContext, plain []byte) {
 
 // rejectPDNConnectivity refuses a PDN CONNECTIVITY REQUEST with an ESM cause
 // (TS 24.301 §6.5.1.4).
-func (m *MME) rejectPDNConnectivity(ue *UeContext, pti, cause uint8) {
-	m.sendDownlinkProtected(ue, &eps.PDNConnectivityReject{
+func (m *MME) rejectPDNConnectivity(ctx context.Context, ue *UeContext, pti, cause uint8) {
+	m.sendDownlinkProtected(ctx, ue, &eps.PDNConnectivityReject{
 		ProcedureTransactionIdentity: pti,
 		ESMCause:                     cause,
 	})

--- a/internal/mme/pdn_connectivity_test.go
+++ b/internal/mme/pdn_connectivity_test.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"net/netip"
 	"testing"
 
@@ -114,7 +115,7 @@ func TestAdditionalPDNConnectionLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.onPDNConnectivityRequest(ue, connReq)
+	m.onPDNConnectivityRequest(context.Background(), ue, connReq)
 
 	p := ue.pdnForAPN("ims")
 	if p == nil {
@@ -177,7 +178,7 @@ func TestAdditionalPDNConnectionLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.onPDNDisconnectRequest(ue, dis)
+	m.onPDNDisconnectRequest(context.Background(), ue, dis)
 
 	if !ue.pdns[6].deactivating || !ue.pdns[6].disconnecting {
 		t.Fatalf("deactivation not in flight for the disconnected PDN: %+v", ue.pdns[6])
@@ -214,7 +215,7 @@ func TestAdditionalPDNConnectionLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.onDeactivateBearerAccept(ue, da)
+	m.onDeactivateBearerAccept(context.Background(), ue, da)
 
 	if _, ok := ue.pdns[6]; ok {
 		t.Fatal("second PDN not released after disconnect accept")
@@ -285,7 +286,7 @@ func TestAdditionalPDNRejectedUnknownAPN(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.onPDNConnectivityRequest(ue, connReq)
+	m.onPDNConnectivityRequest(context.Background(), ue, connReq)
 
 	if ue.pdnForAPN("enterprise") != nil {
 		t.Fatal("PDN created for an APN not in the profile")
@@ -331,7 +332,7 @@ func TestPDNConnectivityRejectedInvalidHeader(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.onPDNConnectivityRequest(ue, plain)
+			m.onPDNConnectivityRequest(context.Background(), ue, plain)
 
 			if ue.pdnForAPN("ims") != nil {
 				t.Fatal("PDN created despite an invalid ESM header")
@@ -372,7 +373,7 @@ func TestPDNDisconnectRejectedInvalidHeader(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.onPDNDisconnectRequest(ue, plain)
+			m.onPDNDisconnectRequest(context.Background(), ue, plain)
 
 			reject, err := eps.ParsePDNDisconnectReject(lastDownlinkESM(t, ue, cc))
 			if err != nil {
@@ -400,7 +401,7 @@ func TestLastPDNDisconnectRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.onPDNDisconnectRequest(ue, dis)
+	m.onPDNDisconnectRequest(context.Background(), ue, dis)
 
 	if ue.defaultPDN() == nil {
 		t.Fatal("the only PDN was disconnected; expected it to be retained")

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/nas/eps"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -176,6 +178,10 @@ func (m *MME) handleESM(ctx context.Context, ue *UeContext, plain []byte) {
 		logger.MmeLog.Warn("failed to read ESM message type", zap.Error(err))
 		return
 	}
+
+	ctx, span := tracer.Start(ctx, "mme/esm",
+		trace.WithAttributes(attribute.Int("esm.message_type", int(mt))))
+	defer span.End()
 
 	switch mt {
 	case eps.MsgPDNConnectivityRequest:

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -89,14 +89,14 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, p *pdnConnecti
 	if dnsOnlyChange(p.dnConfig, newFingerprint) {
 		logger.MmeLog.Info("data-network DNS changed; modifying EPS bearer in place",
 			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
-		m.modifyBearerDNS(ue, p, qos)
+		m.modifyBearerDNS(ctx, ue, p, qos)
 
 		return
 	}
 
 	logger.MmeLog.Info("data-network configuration changed; reactivating EPS bearer",
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
-	m.reactivateBearer(ue, p)
+	m.reactivateBearer(ctx, ue, p)
 }
 
 // dnsOnlyChange reports whether the data-network fingerprint changed in the DNS
@@ -121,7 +121,7 @@ func dnsOnlyChange(oldFingerprint, newFingerprint string) bool {
 // fingerprint is committed to dnConfig only when the UE accepts, so an aborted
 // modification leaves it stale for the backstop to retry. The IPv4 link MTU is
 // replayed unchanged for IPv4-capable bearers, matching the attach PCO.
-func (m *MME) modifyBearerDNS(ue *UeContext, p *pdnConnection, qos *epsQoS) {
+func (m *MME) modifyBearerDNS(ctx context.Context, ue *UeContext, p *pdnConnection, qos *epsQoS) {
 	var dnsServers [][]byte
 
 	dns, parseErr := netip.ParseAddr(qos.DNS)
@@ -157,7 +157,7 @@ func (m *MME) modifyBearerDNS(ue *UeContext, p *pdnConnection, qos *epsQoS) {
 		p.dns = dns
 	}
 
-	m.sendDownlink(ue, naspdu)
+	m.sendDownlink(ctx, ue, naspdu)
 	m.armNASGuardAbortOnly(ue, "Modify EPS Bearer Context Request", naspdu)
 }
 
@@ -165,12 +165,12 @@ func (m *MME) modifyBearerDNS(ue *UeContext, p *pdnConnection, qos *epsQoS) {
 // the default bearer with ESM cause #39 "reactivation requested" (TS 24.301
 // §6.4.4.2). The request is guarded and retransmitted until the UE answers with
 // DEACTIVATE EPS BEARER CONTEXT ACCEPT.
-func (m *MME) reactivateBearer(ue *UeContext, p *pdnConnection) {
-	m.deactivateBearer(ue, p, eps.ESMCauseReactivationRequested, 0, false)
+func (m *MME) reactivateBearer(ctx context.Context, ue *UeContext, p *pdnConnection) {
+	m.deactivateBearer(ctx, ue, p, eps.ESMCauseReactivationRequested, 0, false)
 }
 
 // handleESM dispatches an uplink ESM (session management) NAS message.
-func (m *MME) handleESM(ue *UeContext, plain []byte) {
+func (m *MME) handleESM(ctx context.Context, ue *UeContext, plain []byte) {
 	mt, err := eps.PeekESMMessageType(plain)
 	if err != nil {
 		logger.MmeLog.Warn("failed to read ESM message type", zap.Error(err))
@@ -179,15 +179,15 @@ func (m *MME) handleESM(ue *UeContext, plain []byte) {
 
 	switch mt {
 	case eps.MsgPDNConnectivityRequest:
-		m.onPDNConnectivityRequest(ue, plain)
+		m.onPDNConnectivityRequest(ctx, ue, plain)
 	case eps.MsgPDNDisconnectRequest:
-		m.onPDNDisconnectRequest(ue, plain)
+		m.onPDNDisconnectRequest(ctx, ue, plain)
 	case eps.MsgActivateDefaultEPSBearerContextAccept:
 		m.onActivateDefaultBearerAccept(ue, plain)
 	case eps.MsgActivateDefaultEPSBearerContextReject:
 		m.onActivateDefaultBearerReject(ue, plain)
 	case eps.MsgDeactivateEPSBearerContextAccept:
-		m.onDeactivateBearerAccept(ue, plain)
+		m.onDeactivateBearerAccept(ctx, ue, plain)
 	case eps.MsgModifyEPSBearerContextAccept:
 		m.onModifyBearerAccept(ue)
 	case eps.MsgModifyEPSBearerContextReject:
@@ -237,7 +237,7 @@ func (m *MME) onModifyBearerReject(ue *UeContext) {
 // the UE connected (TS 24.301 §6.5.2). A deactivation with reactivation requested
 // for the default bearer instead releases the S1 context so the UE re-attaches
 // and picks up the new data-network configuration (TS 24.301 §6.4.4.2).
-func (m *MME) onDeactivateBearerAccept(ue *UeContext, plain []byte) {
+func (m *MME) onDeactivateBearerAccept(ctx context.Context, ue *UeContext, plain []byte) {
 	m.stopNASGuard(ue)
 
 	p := ue.defaultPDN()
@@ -269,5 +269,5 @@ func (m *MME) onDeactivateBearerAccept(ue *UeContext, plain []byte) {
 
 	logger.MmeLog.Info("EPS bearer deactivated for reactivation; UE will re-attach",
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
-	m.releaseUEContext(ue, causeNASNormalRelease)
+	m.releaseUEContext(ctx, ue, causeNASNormalRelease)
 }

--- a/internal/mme/reconcile_test.go
+++ b/internal/mme/reconcile_test.go
@@ -117,7 +117,7 @@ func TestDeactivateBearerAcceptReleases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, wire)
+	m.handleNAS(context.Background(), ue, wire)
 
 	if !m.session.(*fakeSessionManager).released {
 		t.Fatal("EPS session not released after Deactivate Accept")
@@ -209,7 +209,7 @@ func TestModifyBearerAcceptCommitsConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleNAS(ue, wire)
+	m.handleNAS(context.Background(), ue, wire)
 
 	if testPDN(ue).modifying {
 		t.Fatal("UE still marked modifying after Modify Accept")

--- a/internal/mme/reset.go
+++ b/internal/mme/reset.go
@@ -4,6 +4,8 @@
 package mme
 
 import (
+	"context"
+
 	"github.com/ellanetworks/core/internal/amf/sctp"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/s1ap"
@@ -114,5 +116,6 @@ func (m *MME) sendResetAcknowledge(conn nasWriter, connectionList []s1ap.UEAssoc
 		return
 	}
 
-	m.logOutboundS1AP(conn, S1APProcedureResetAcknowledge, b)
+	// Reset handling is not tied to a single UE request span; use a fresh root.
+	m.logOutboundS1AP(context.Background(), conn, S1APProcedureResetAcknowledge, b)
 }

--- a/internal/mme/robustness_test.go
+++ b/internal/mme/robustness_test.go
@@ -54,8 +54,8 @@ func initialUEMessagePDU(t *testing.T, enbID s1ap.ENBUES1APID) []byte {
 func TestDuplicateInitialUEMessage(t *testing.T) {
 	m := newTestMME(t)
 
-	m.handleInitialUEMessage(nil, initiatingValue(t, initialUEMessagePDU(t, 7)))
-	m.handleInitialUEMessage(nil, initiatingValue(t, initialUEMessagePDU(t, 7)))
+	m.handleInitialUEMessage(context.Background(), nil, initiatingValue(t, initialUEMessagePDU(t, 7)))
+	m.handleInitialUEMessage(context.Background(), nil, initiatingValue(t, initialUEMessagePDU(t, 7)))
 
 	if got := len(m.ues); got != 1 {
 		t.Fatalf("duplicate Initial UE Message left %d contexts, want 1", got)

--- a/internal/mme/service_request.go
+++ b/internal/mme/service_request.go
@@ -19,10 +19,10 @@ import (
 // UE by the S-TMSI, verifies the short MAC against the stored NAS context, binds
 // the UE to the new S1 association, and re-establishes the S1 context and
 // default bearer (ECM-IDLE → ECM-CONNECTED).
-func (m *MME) onServiceRequest(conn nasWriter, msg *s1ap.InitialUEMessage) {
+func (m *MME) onServiceRequest(ctx context.Context, conn nasWriter, msg *s1ap.InitialUEMessage) {
 	if msg.STMSI == nil {
 		logger.MmeLog.Warn("Service Request without an S-TMSI")
-		m.sendServiceReject(conn, msg.ENBUES1APID, emmCauseUEIdentityUnderivable)
+		m.sendServiceReject(ctx, conn, msg.ENBUES1APID, emmCauseUEIdentityUnderivable)
 
 		return
 	}
@@ -31,7 +31,7 @@ func (m *MME) onServiceRequest(conn nasWriter, msg *s1ap.InitialUEMessage) {
 	if !ok || ue.emmState != EMMRegistered {
 		logger.MmeLog.Info("Service Request for an unknown or deregistered UE",
 			zap.Uint32("m-tmsi", msg.STMSI.MTMSI))
-		m.sendServiceReject(conn, msg.ENBUES1APID, emmCauseUEIdentityUnderivable)
+		m.sendServiceReject(ctx, conn, msg.ENBUES1APID, emmCauseUEIdentityUnderivable)
 
 		return
 	}
@@ -44,7 +44,7 @@ func (m *MME) onServiceRequest(conn nasWriter, msg *s1ap.InitialUEMessage) {
 	sr, err := eps.ParseServiceRequest([]byte(msg.NASPDU))
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Service Request", zap.Error(err))
-		m.sendDownlinkMessage(ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
+		m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
 
 		return
 	}
@@ -62,7 +62,7 @@ func (m *MME) onServiceRequest(conn nasWriter, msg *s1ap.InitialUEMessage) {
 			zap.Uint8("received-sequence", sr.SeqShort),
 			zap.Uint32("stored-ul-count", ue.ulCount))
 
-		m.sendDownlinkMessage(ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
+		m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
 
 		return
 	}
@@ -75,20 +75,20 @@ func (m *MME) onServiceRequest(conn nasWriter, msg *s1ap.InitialUEMessage) {
 		zap.Uint32("enb-ue-id", uint32(ue.ENBUES1APID)),
 		zap.String("imsi", ue.imsi))
 
-	qos, err := m.resolveQoS(context.Background(), ue.imsi)
+	qos, err := m.resolveQoS(ctx, ue.imsi)
 	if err != nil {
 		logger.MmeLog.Error("failed to resolve subscriber QoS", zap.String("imsi", ue.imsi), zap.Error(err))
 		return
 	}
 
-	m.sendInitialContextSetup(ue, qos, nil)
+	m.sendInitialContextSetup(ctx, ue, qos, nil)
 }
 
 // sendServiceReject sends a SERVICE REJECT (TS 24.301) on the given
 // association via a transient context, prompting the UE to re-attach.
-func (m *MME) sendServiceReject(conn nasWriter, enbUEID s1ap.ENBUES1APID, cause uint8) {
+func (m *MME) sendServiceReject(ctx context.Context, conn nasWriter, enbUEID s1ap.ENBUES1APID, cause uint8) {
 	ue := m.newUe(conn, enbUEID)
 	defer m.removeUe(ue.MMEUES1APID)
 
-	m.sendDownlinkMessage(ue, &eps.ServiceReject{Cause: cause})
+	m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: cause})
 }

--- a/internal/mme/service_request_test.go
+++ b/internal/mme/service_request_test.go
@@ -5,6 +5,7 @@ package mme
 
 import (
 	"bytes"
+	"context"
 	"net/netip"
 	"testing"
 
@@ -59,7 +60,7 @@ func TestServiceRequestReestablishes(t *testing.T) {
 		STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
 	}
 
-	m.onServiceRequest(cc, msg)
+	m.onServiceRequest(context.Background(), cc, msg)
 
 	if ue.ecmState != ECMConnected {
 		t.Fatal("UE not ECM-CONNECTED after Service Request")
@@ -108,7 +109,7 @@ func TestServiceRequestS1UTransportFamily(t *testing.T) {
 			testPDN(ue).sgwN3IPv6 = tc.sgwV6
 
 			cc := &captureConn{}
-			m.onServiceRequest(cc, &s1ap.InitialUEMessage{
+			m.onServiceRequest(context.Background(), cc, &s1ap.InitialUEMessage{
 				ENBUES1APID: 9,
 				NASPDU:      s1ap.NASPDU(serviceRequestNAS(t, ue)),
 				STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
@@ -146,7 +147,7 @@ func TestServiceRequestAllocatesFreshMMEUES1APID(t *testing.T) {
 		STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
 	}
 
-	m.onServiceRequest(cc, msg)
+	m.onServiceRequest(context.Background(), cc, msg)
 
 	if ue.MMEUES1APID == oldID {
 		t.Fatalf("MME-UE-S1AP-ID was reused (%d); a returning UE must get a fresh one", oldID)
@@ -171,7 +172,7 @@ func TestServiceRequestUnknownSTMSIRejected(t *testing.T) {
 		STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: 0xDEADBEEF},
 	}
 
-	m.onServiceRequest(cc, msg)
+	m.onServiceRequest(context.Background(), cc, msg)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected Service Reject, got %d S1AP messages", len(cc.sent))
@@ -201,7 +202,7 @@ func TestServiceRequestBadMACRejected(t *testing.T) {
 		STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
 	}
 
-	m.onServiceRequest(cc, msg)
+	m.onServiceRequest(context.Background(), cc, msg)
 
 	if ue.ecmState == ECMConnected {
 		t.Fatal("UE reconnected despite a bad short MAC")

--- a/internal/mme/tau.go
+++ b/internal/mme/tau.go
@@ -18,7 +18,7 @@ import (
 // A UE returning from ECM-IDLE is accepted over the Initial Context Setup when it
 // requests bearers (active flag), otherwise over Downlink NAS Transport followed
 // by an S1 release back to ECM-IDLE.
-func (m *MME) onTrackingAreaUpdate(ue *UeContext, plain []byte) {
+func (m *MME) onTrackingAreaUpdate(ctx context.Context, ue *UeContext, plain []byte) {
 	req, err := eps.ParseTrackingAreaUpdateRequest(plain)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Tracking Area Update Request", zap.Error(err))
@@ -38,7 +38,7 @@ func (m *MME) onTrackingAreaUpdate(ue *UeContext, plain []byte) {
 		m.reconcileBearerContextStatus(ue, *req.EPSBearerContextStatus)
 	}
 
-	accept, err := m.trackingAreaUpdateAccept(context.Background(), ue, isCombinedUpdate(req.EPSUpdateType), req.EPSBearerContextStatus != nil)
+	accept, err := m.trackingAreaUpdateAccept(ctx, ue, isCombinedUpdate(req.EPSUpdateType), req.EPSBearerContextStatus != nil)
 	if err != nil {
 		logger.MmeLog.Error("failed to build Tracking Area Update Accept", zap.String("imsi", ue.imsi), zap.Error(err))
 		return
@@ -56,14 +56,14 @@ func (m *MME) onTrackingAreaUpdate(ue *UeContext, plain []byte) {
 	if ue.ecmState == ECMConnected {
 		logger.MmeLog.Info("Tracking Area Update accepted",
 			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
-		m.sendDownlink(ue, naspdu)
+		m.sendDownlink(ctx, ue, naspdu)
 		m.armNASGuard(ue, "Tracking Area Update Accept", naspdu)
 
 		return
 	}
 
 	if req.ActiveFlag {
-		qos, err := m.resolveQoS(context.Background(), ue.imsi)
+		qos, err := m.resolveQoS(ctx, ue.imsi)
 		if err != nil {
 			logger.MmeLog.Error("failed to resolve subscriber QoS", zap.String("imsi", ue.imsi), zap.Error(err))
 			return
@@ -73,7 +73,7 @@ func (m *MME) onTrackingAreaUpdate(ue *UeContext, plain []byte) {
 
 		logger.MmeLog.Info("Tracking Area Update accepted (bearer re-established)",
 			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
-		m.sendInitialContextSetup(ue, qos, naspdu)
+		m.sendInitialContextSetup(ctx, ue, qos, naspdu)
 		m.armNASGuard(ue, "Tracking Area Update Accept", naspdu)
 
 		return
@@ -90,14 +90,14 @@ func (m *MME) onTrackingAreaUpdate(ue *UeContext, plain []byte) {
 
 	logger.MmeLog.Info("Tracking Area Update accepted (returning to idle)",
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
-	m.sendDownlink(ue, naspdu)
+	m.sendDownlink(ctx, ue, naspdu)
 	m.armNASGuard(ue, "Tracking Area Update Accept", naspdu)
 }
 
 // onTrackingAreaUpdateComplete finalises a GUTI reallocation: it stops the T3450
 // guard, commits the new GUTI (freeing the old M-TMSI), and — for a no-active
 // TAU — releases the UE back to ECM-IDLE (TS 24.301).
-func (m *MME) onTrackingAreaUpdateComplete(ue *UeContext) {
+func (m *MME) onTrackingAreaUpdateComplete(ctx context.Context, ue *UeContext) {
 	m.stopNASGuard(ue)
 	m.commitGUTIRealloc(ue)
 
@@ -106,7 +106,7 @@ func (m *MME) onTrackingAreaUpdateComplete(ue *UeContext) {
 
 	if ue.tauReleaseOnComplete {
 		ue.tauReleaseOnComplete = false
-		m.releaseUEContext(ue, causeNASNormalRelease)
+		m.releaseUEContext(ctx, ue, causeNASNormalRelease)
 	}
 }
 
@@ -240,10 +240,10 @@ func (m *MME) protectDownlinkBytes(ue *UeContext, plain []byte) ([]byte, error) 
 // cause #9 "UE identity cannot be derived by the network". The UE accepts the
 // reject without integrity protection and re-attaches. The reject is sent on the
 // transient context, which is then discarded.
-func (m *MME) rejectTrackingAreaUpdate(ue *UeContext) {
+func (m *MME) rejectTrackingAreaUpdate(ctx context.Context, ue *UeContext) {
 	logger.MmeLog.Info("Tracking Area Update rejected; UE will re-attach",
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
 
-	m.sendDownlinkMessage(ue, &eps.TrackingAreaUpdateReject{Cause: emmCauseUEIdentityUnderivable})
+	m.sendDownlinkMessage(ctx, ue, &eps.TrackingAreaUpdateReject{Cause: emmCauseUEIdentityUnderivable})
 	m.removeUe(ue.MMEUES1APID)
 }

--- a/internal/mme/tau_test.go
+++ b/internal/mme/tau_test.go
@@ -44,7 +44,7 @@ func TestTrackingAreaUpdateConnectedAccepted(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m) // ECM-CONNECTED, secured, EMM-REGISTERED
 
-	m.handleNAS(ue, trackingAreaUpdateNAS(t, ue, false, nil))
+	m.handleNAS(context.Background(), ue, trackingAreaUpdateNAS(t, ue, false, nil))
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one downlink (TAU Accept), got %d", len(cc.sent))
@@ -93,7 +93,7 @@ func TestTrackingAreaUpdateReconcilesBearerContextStatus(t *testing.T) {
 	ue.ensurePDN(6)     // an additional PDN connection
 
 	status := uint16(1 << 5) // the UE reports only EBI 5 active
-	m.handleNAS(ue, trackingAreaUpdateNAS(t, ue, false, &status))
+	m.handleNAS(context.Background(), ue, trackingAreaUpdateNAS(t, ue, false, &status))
 
 	if _, ok := ue.pdns[6]; ok {
 		t.Fatal("EBI 6 should be released locally after the UE reports it inactive")
@@ -134,7 +134,7 @@ func TestTrackingAreaUpdateCombinedSignalsCSDomainUnavailable(t *testing.T) {
 	ue, cc := securedUE(t, m) // ECM-CONNECTED, secured, EMM-REGISTERED
 
 	// EPS update type 2 = combined TA/LA updating with IMSI attach.
-	m.onTrackingAreaUpdate(ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x02})
+	m.onTrackingAreaUpdate(context.Background(), ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x02})
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one downlink (TAU Accept), got %d", len(cc.sent))
@@ -175,7 +175,7 @@ func TestTrackingAreaUpdateReallocatesGUTI(t *testing.T) {
 	m.assignGUTI(ue, plmn, group, code)
 	oldMTMSI := ue.mtmsi
 
-	m.onTrackingAreaUpdate(ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x03}) // periodic
+	m.onTrackingAreaUpdate(context.Background(), ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x03}) // periodic
 
 	if ue.oldMTMSI != oldMTMSI || ue.mtmsi == oldMTMSI {
 		t.Fatalf("GUTI not reallocated: mtmsi=%d oldMTMSI=%d (was %d)", ue.mtmsi, ue.oldMTMSI, oldMTMSI)
@@ -208,7 +208,7 @@ func TestTrackingAreaUpdateReallocatesGUTI(t *testing.T) {
 	}
 
 	// TAU Complete commits the new GUTI and frees the old M-TMSI.
-	m.onTrackingAreaUpdateComplete(ue)
+	m.onTrackingAreaUpdateComplete(context.Background(), ue)
 
 	if ue.oldMTMSI != 0 {
 		t.Fatal("reallocation not committed after TAU Complete")
@@ -233,7 +233,7 @@ func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 	ue.mtmsi = 1 // a GUTI to reallocate
 	ue.ecmState = ECMIdle
 
-	m.onTrackingAreaUpdate(ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x00})
+	m.onTrackingAreaUpdate(context.Background(), ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x00})
 
 	// Only the TAU Accept goes out; the release waits for TAU Complete.
 	if len(cc.sent) != 1 {
@@ -252,7 +252,7 @@ func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 	}
 
 	// UE Completes: the new GUTI commits and the UE is released to ECM-IDLE.
-	m.onTrackingAreaUpdateComplete(ue)
+	m.onTrackingAreaUpdateComplete(context.Background(), ue)
 
 	if ue.oldMTMSI != 0 {
 		t.Fatal("old M-TMSI not freed after TAU Complete")
@@ -277,7 +277,7 @@ func TestTrackingAreaUpdateIdleActiveFlagReestablishes(t *testing.T) {
 	ue, _ := idleRegisteredUE(t, m)
 	cc := ue.conn.(*captureConn)
 
-	m.onTrackingAreaUpdate(ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x08})
+	m.onTrackingAreaUpdate(context.Background(), ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x08})
 
 	if ue.ecmState != ECMConnected {
 		t.Fatal("UE not ECM-CONNECTED after an active-flag TAU")
@@ -303,7 +303,7 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 	// cannot reproduce (no context), sequence 1, and an inner plain TAU REQUEST.
 	nas := []byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x07, byte(eps.MsgTrackingAreaUpdateRequest)}
 
-	m.handleNAS(ue, nas)
+	m.handleNAS(context.Background(), ue, nas)
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one downlink (TAU Reject), got %d", len(cc.sent))

--- a/internal/mme/tracing_test.go
+++ b/internal/mme/tracing_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/s1ap"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestDispatchRecordsReceiveSpan verifies the MME emits an s1ap/receive span for
+// every inbound S1AP message — the 4G counterpart of the AMF's ngap/receive — so
+// 4G control-plane traffic is traceable.
+func TestDispatchRecordsReceiveSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+
+	prev := otel.GetTracerProvider()
+
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	m := newTestMME(t)
+
+	raw, err := (&s1ap.InitialUEMessage{
+		ENBUES1APID:           1,
+		NASPDU:                s1ap.NASPDU{0x07, 0x41},
+		TAI:                   s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
+		EUTRANCGI:             s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
+		RRCEstablishmentCause: s1ap.RRCCauseMOSignalling,
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A nil conn gates the message, but the receive span is created and ended
+	// before the gate, so it is recorded regardless.
+	m.dispatch(context.Background(), nil, raw)
+
+	var receive sdktrace.ReadOnlySpan
+
+	for _, s := range sr.Ended() {
+		if s.Name() == "s1ap/receive" {
+			receive = s
+			break
+		}
+	}
+
+	if receive == nil {
+		t.Fatalf("no s1ap/receive span recorded; got %d spans", len(sr.Ended()))
+	}
+
+	var sawMessageType bool
+
+	for _, attr := range receive.Attributes() {
+		if attr.Key == "s1ap.message_type" {
+			sawMessageType = true
+		}
+	}
+
+	if !sawMessageType {
+		t.Fatal("s1ap/receive span missing s1ap.message_type attribute")
+	}
+}

--- a/internal/smf/eps.go
+++ b/internal/smf/eps.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/free5gc/nas/nasMessage"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -31,6 +33,15 @@ import (
 // type, the allocated addresses, and the S-GW S1-U F-TEID the eNB sends uplink
 // traffic to; the eNB downlink endpoint is supplied later via ModifyEPSSession.
 func (s *SMF) CreateEPSSession(ctx context.Context, req models.EPSBearerRequest) (models.EPSBearer, error) {
+	ctx, span := tracer.Start(ctx, "smf/create_eps_session",
+		trace.WithAttributes(
+			attribute.String("ue.imsi", req.IMSI),
+			attribute.Int("eps.bearer_id", int(req.EPSBearerIdentity)),
+			attribute.String("eps.apn", req.APN),
+		),
+	)
+	defer span.End()
+
 	supi, err := etsi.NewSUPIFromIMSI(req.IMSI)
 	if err != nil {
 		return models.EPSBearer{}, fmt.Errorf("invalid imsi %q: %w", req.IMSI, err)
@@ -142,6 +153,14 @@ func (s *SMF) CreateEPSSession(ctx context.Context, req models.EPSBearerRequest)
 // UPF encapsulates downlink traffic toward the eNB (plain, PSC-less GTP-U on
 // S1-U). It mirrors the 5G handling of the gNB F-TEID from the N2 setup response.
 func (s *SMF) ModifyEPSSession(ctx context.Context, imsi string, ebi uint8, enb models.FTEID) error {
+	ctx, span := tracer.Start(ctx, "smf/modify_eps_session",
+		trace.WithAttributes(
+			attribute.String("ue.imsi", imsi),
+			attribute.Int("eps.bearer_id", int(ebi)),
+		),
+	)
+	defer span.End()
+
 	supi, err := etsi.NewSUPIFromIMSI(imsi)
 	if err != nil {
 		return fmt.Errorf("invalid imsi %q: %w", imsi, err)


### PR DESCRIPTION
# Description

Add OTel tracing to the 4G control plane. Each incoming `s1ap` message creates a span, just like we do for 5G and `ngap` messages.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
