### PR TITLE
fix(ui): use app_sessions_total metric in Active Sessions card

### DIFF
--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -107,8 +107,16 @@ const parseMetrics = (raw: string): ParsedMetrics => {
 
   const g = (k: string) => map.get(k) ?? null;
 
+  const sumByPrefix = (prefix: string) => {
+    let total: number | null = null;
+    for (const [key, val] of map) {
+      if (key.startsWith(prefix)) total = (total ?? 0) + val;
+    }
+    return total;
+  };
+
   return {
-    pduSessions: g("app_pdu_sessions_total "),
+    pduSessions: sumByPrefix("app_sessions_total{"),
     heapMemoryBytes: g("go_memstats_heap_inuse_bytes "),
     totalMemoryBytes: g("process_resident_memory_bytes "),
     databaseSizeBytes: g("app_database_storage_bytes "),


### PR DESCRIPTION
# Description

We recently changed some metric names and the UI uses one of those metrics to represent the number of active sessions.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
