### PR TITLE
fix: T3422 timer

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -197,6 +197,20 @@ func (amf *AMF) DeregisterSubscriber(ctx context.Context, supi etsi.SUPI) {
 		return
 	}
 
+	// A connected UE with a security context is told to deregister over the air,
+	// guarded by T3522; the accept — or T3522 exhaustion — then removes the
+	// context. An idle or unsecured UE cannot be signalled, so it is removed
+	// locally.
+	if ue.RanUe() != nil && ue.Current().SecurityContextAvailable {
+		if err := amf.sendNetworkInitiatedDeregistration(ctx, ue); err != nil {
+			logger.AmfLog.Warn("failed to send network-initiated deregistration; removing UE context locally",
+				zap.Error(err), logger.SUPI(supi.String()))
+			amf.DeregisterAndRemoveAMFUE(ctx, ue)
+		}
+
+		return
+	}
+
 	amf.DeregisterAndRemoveAMFUE(ctx, ue)
 	logger.AmfLog.Info("removed ue context", logger.SUPI(supi.String()))
 }

--- a/internal/amf/deregistration.go
+++ b/internal/amf/deregistration.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+	"go.uber.org/zap"
+)
+
+// buildDeregistrationRequest assembles a network-initiated (UE-terminated)
+// DEREGISTRATION REQUEST (TS 24.501 §8.2.14) over 3GPP access, integrity
+// protected and ciphered with the UE's security context. Re-registration is not
+// requested: the subscriber was removed, so the UE stays deregistered.
+func buildDeregistrationRequest(ue *AmfUe) ([]byte, error) {
+	m := nas.NewMessage()
+	m.GmmMessage = nas.NewGmmMessage()
+	m.GmmHeader.SetMessageType(nas.MsgTypeDeregistrationRequestUETerminatedDeregistration)
+
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+
+	req := nasMessage.NewDeregistrationRequestUETerminatedDeregistration(0)
+	req.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	req.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	req.SetSpareHalfOctet(0)
+	req.SetMessageType(nas.MsgTypeDeregistrationRequestUETerminatedDeregistration)
+	req.SetAccessType(nasMessage.AccessType3GPP)
+	req.SetReRegistrationRequired(0)
+	req.SetSwitchOff(0)
+
+	m.DeregistrationRequestUETerminatedDeregistration = req
+
+	return ue.EncodeNASMessage(m)
+}
+
+// sendNetworkInitiatedDeregistration sends a UE-terminated DEREGISTRATION
+// REQUEST to a connected UE and arms T3522 (TS 24.501 §5.5.2.3): if the UE does
+// not answer with DEREGISTRATION ACCEPT the request is retransmitted, and on
+// exhaustion the UE context is removed regardless, so a silent UE cannot leak
+// the context. On a normal accept the context is removed by the
+// nw-initiated-deregistration UE context release.
+func (amf *AMF) sendNetworkInitiatedDeregistration(ctx context.Context, ue *AmfUe) error {
+	ranUe := ue.RanUe()
+	if ranUe == nil {
+		return fmt.Errorf("ranUe is nil")
+	}
+
+	nasMsg, err := buildDeregistrationRequest(ue)
+	if err != nil {
+		return fmt.Errorf("build deregistration request: %w", err)
+	}
+
+	if err := ranUe.SendDownlinkNasTransport(ctx, nasMsg, nil); err != nil {
+		return fmt.Errorf("send downlink nas transport: %w", err)
+	}
+
+	ue.Log.Info("sent network-initiated Deregistration Request")
+
+	conn := ue.NasConn()
+	if !amf.T3522Cfg.Enable || conn == nil {
+		return nil
+	}
+
+	cfg := amf.T3522Cfg
+	conn.T3522 = NewTimer(cfg.ExpireTime, cfg.MaxRetryTimes, func(expireTimes int32) {
+		retryRanUe := ue.RanUe()
+		if retryRanUe == nil {
+			ue.Log.Warn("UE context released, abort retransmission of Deregistration Request")
+
+			conn.T3522 = nil
+
+			return
+		}
+
+		ue.Log.Warn("T3522 expired, retransmit Deregistration Request", zap.Int32("retry", expireTimes))
+
+		if err := retryRanUe.SendDownlinkNasTransport(context.Background(), nasMsg, nil); err != nil {
+			ue.Log.Error("could not retransmit Deregistration Request", zap.Error(err))
+		}
+	}, func() {
+		ue.Log.Warn("T3522 expired, abort network-initiated deregistration and remove UE context")
+
+		conn.T3522 = nil
+
+		amf.DeregisterAndRemoveAMFUE(context.Background(), ue)
+	})
+
+	return nil
+}

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -17,8 +17,10 @@ import (
 const detachTypeReattachNotRequired uint8 = 2
 
 // DetachSubscriber sends a network-initiated DETACH REQUEST (TS 24.301)
-// to the attached UE for imsi, if any, when a subscriber is deleted. The UE
-// replies with Detach Accept, on which the S1 context is released and removed.
+// to the attached UE for imsi, if any, when a subscriber is deleted. The
+// request is guarded by T3422: if the UE does not reply with Detach Accept it
+// is retransmitted, and on exhaustion the UE context is released regardless, so
+// a silent UE cannot leak the context.
 func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 	ue, ok := m.lookupUeByIMSI(imsi)
 	if !ok {
@@ -29,12 +31,22 @@ func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", imsi))
 
 	ue.emmState.store(EMMDeregistered)
-	m.sendDownlinkProtected(ctx, ue, &eps.DetachRequestNetwork{TypeOfDetach: detachTypeReattachNotRequired})
+
+	naspdu, err := m.protectDownlink(ue, &eps.DetachRequestNetwork{TypeOfDetach: detachTypeReattachNotRequired})
+	if err != nil {
+		logger.MmeLog.Error("failed to protect Detach Request", zap.Error(err))
+		return
+	}
+
+	m.sendDownlink(ctx, ue, naspdu)
+	m.armNASGuard(ue, "Detach Request", naspdu)
 }
 
 // onDetachAccept completes a network-initiated detach: the UE has acknowledged,
-// so release and delete its context (the UE is already EMM-DEREGISTERED).
+// so stop the guard and release and delete its context (the UE is already
+// EMM-DEREGISTERED).
 func (m *MME) onDetachAccept(ctx context.Context, ue *UeContext) {
+	m.stopNASGuard(ue)
 	logger.MmeLog.Info("Detach Accept", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
 	m.releaseUEContext(ctx, ue, causeNASDetach)
 }

--- a/internal/mme/detach_test.go
+++ b/internal/mme/detach_test.go
@@ -6,6 +6,7 @@ package mme
 import (
 	"context"
 	"testing"
+	"time"
 
 	nascommon "github.com/ellanetworks/core/nas/common"
 	"github.com/ellanetworks/core/nas/eps"
@@ -52,6 +53,28 @@ func TestDetachSubscriberNetworkInitiated(t *testing.T) {
 
 	if _, ok := m.lookupUe(ue.MMEUES1APID); ok {
 		t.Fatal("UE context not deleted after network-initiated detach")
+	}
+}
+
+// TestDetachSubscriberUnansweredReleases confirms a network-initiated detach
+// whose Detach Accept never arrives is retransmitted and then releases the UE
+// context, so a silent UE cannot leak it (TS 24.301: T3422).
+func TestDetachSubscriberUnansweredReleases(t *testing.T) {
+	m := newTestMME(t)
+	m.nasGuardTimeout = 5 * time.Millisecond
+	m.nasGuardMaxRetransmit = 2
+
+	ue, cc := securedUE(t, m)
+
+	m.DetachSubscriber(context.Background(), testSubscriber.IMSI)
+
+	// Initial Detach Request + 2 retransmissions + the UE Context Release Command.
+	eventually(t, time.Second, func() bool {
+		return cc.count() >= 4
+	})
+
+	if !ue.releasing {
+		t.Fatal("UE not released after an unanswered network-initiated detach")
 	}
 }
 

--- a/internal/mme/erab_release.go
+++ b/internal/mme/erab_release.go
@@ -41,6 +41,14 @@ func (m *MME) deactivateBearer(ctx context.Context, ue *UeContext, p *pdnConnect
 
 	if disconnecting || p.ebi != ue.defaultEBI {
 		m.sendERABRelease(ctx, ue, p, naspdu)
+		// The eNB releases the radio bearer, but the NAS DEACTIVATE EPS BEARER
+		// CONTEXT REQUEST still needs an answer: guard it with T3495 so it is
+		// retransmitted, and on exhaustion release just this PDN connection
+		// locally rather than dropping the UE (TS 24.301 §6.4.4.5).
+		m.armNASGuardAbortOnly(ue, "Deactivate EPS Bearer Context Request", naspdu, func() {
+			m.releasePDN(ue, p)
+		})
+
 		return
 	}
 

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -166,11 +166,13 @@ type UeContext struct {
 	nasGuardName  string
 	nasGuardTries int
 	nasGuardGen   uint64
-	// nasGuardAbortOnly leaves the UE connected when the guarded procedure
-	// exhausts its retransmissions, rather than releasing the context. Used for
-	// non-critical procedures (a bearer modification) whose failure must not drop
-	// the UE (TS 24.301 §6.4.2.5: on T3486 expiry the bearer stays active).
-	nasGuardAbortOnly bool
+	// nasGuardOnAbort, when non-nil, makes the guard abort-only: on exhausting
+	// its retransmissions it runs this finalizer and leaves the UE connected,
+	// rather than releasing the context. Used for non-critical procedures whose
+	// failure must not drop the UE — a bearer modification (TS 24.301 §6.4.2.5:
+	// on T3486 expiry the bearer stays active) or a single-PDN deactivation
+	// (§6.4.4.5: on T3495 expiry the bearer is deactivated locally).
+	nasGuardOnAbort func()
 }
 
 // touchLastSeen records the current time as the UE's most recent uplink NAS

--- a/internal/mme/nas_guard.go
+++ b/internal/mme/nas_guard.go
@@ -36,17 +36,18 @@ func (m *MME) sendGuardedDownlink(ctx context.Context, ue *UeContext, name strin
 // Exhausting the retransmissions releases the UE (the UE stopped answering a
 // procedure the network requires).
 func (m *MME) armNASGuard(ue *UeContext, name string, nas []byte) {
-	m.armNASGuardMode(ue, name, nas, false)
+	m.armNASGuardMode(ue, name, nas, nil)
 }
 
 // armNASGuardAbortOnly arms the guard for a non-critical procedure: exhausting
-// the retransmissions aborts the procedure without releasing the UE (TS 24.301
-// §6.4.2.5).
-func (m *MME) armNASGuardAbortOnly(ue *UeContext, name string, nas []byte) {
-	m.armNASGuardMode(ue, name, nas, true)
+// the retransmissions runs onAbort and leaves the UE connected rather than
+// releasing it (TS 24.301 §6.4.2.5, §6.4.4.5). onAbort finalizes the procedure
+// locally (e.g. clearing a pending modification or releasing a single PDN).
+func (m *MME) armNASGuardAbortOnly(ue *UeContext, name string, nas []byte, onAbort func()) {
+	m.armNASGuardMode(ue, name, nas, onAbort)
 }
 
-func (m *MME) armNASGuardMode(ue *UeContext, name string, nas []byte, abortOnly bool) {
+func (m *MME) armNASGuardMode(ue *UeContext, name string, nas []byte, onAbort func()) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -56,7 +57,7 @@ func (m *MME) armNASGuardMode(ue *UeContext, name string, nas []byte, abortOnly 
 	ue.nasGuardName = name
 	ue.nasGuardPDU = nas
 	ue.nasGuardTries = 0
-	ue.nasGuardAbortOnly = abortOnly
+	ue.nasGuardOnAbort = onAbort
 
 	ue.nasGuardTimer = time.AfterFunc(m.nasGuardTimeout, func() {
 		m.onNASGuardExpiry(ue, gen)
@@ -82,6 +83,7 @@ func (m *MME) stopNASGuardLocked(ue *UeContext) {
 	}
 
 	ue.nasGuardPDU = nil
+	ue.nasGuardOnAbort = nil
 }
 
 // onNASGuardExpiry retransmits the outstanding downlink message, or releases the
@@ -103,21 +105,16 @@ func (m *MME) onNASGuardExpiry(ue *UeContext, gen uint64) {
 		ue.nasGuardPDU = nil
 		ue.nasGuardGen++
 		mmeUEID := ue.MMEUES1APID
-		abortOnly := ue.nasGuardAbortOnly
+		onAbort := ue.nasGuardOnAbort
+		ue.nasGuardOnAbort = nil
 
 		m.mu.Unlock()
 
-		if abortOnly {
-			// An aborted modification leaves the UE connected and its data-network
-			// fingerprint stale, so the backstop reconcile retries it later.
-			ue.mu.Lock()
-			if p := ue.defaultPDNLocked(); p != nil {
-				clearPendingModifyLocked(p)
-			}
-			ue.mu.Unlock()
-
+		if onAbort != nil {
 			logger.MmeLog.Info("NAS procedure timed out, aborting (UE stays connected)",
 				zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("procedure", name))
+
+			onAbort()
 
 			return
 		}

--- a/internal/mme/nas_guard_test.go
+++ b/internal/mme/nas_guard_test.go
@@ -28,6 +28,38 @@ func TestNASGuardRetransmitsThenReleases(t *testing.T) {
 	})
 }
 
+// TestNASGuardAbortOnlyRunsFinalizer confirms an abort-only guard, on exhausting
+// its retransmissions, runs its finalizer and leaves the UE connected rather
+// than releasing the context (TS 24.301 §6.4.2.5, §6.4.4.5).
+func TestNASGuardAbortOnlyRunsFinalizer(t *testing.T) {
+	m := newTestMME(t)
+	m.nasGuardTimeout = 5 * time.Millisecond
+	m.nasGuardMaxRetransmit = 2
+
+	ue, cc := securedUE(t, m)
+
+	finalized := make(chan struct{}, 1)
+
+	m.armNASGuardAbortOnly(ue, "Deactivate EPS Bearer Context Request", []byte{0x07, 0xc9}, func() {
+		finalized <- struct{}{}
+	})
+
+	select {
+	case <-finalized:
+	case <-time.After(time.Second):
+		t.Fatal("abort-only finalizer not run after retransmissions exhausted")
+	}
+
+	if ue.releasing {
+		t.Fatal("abort-only guard released the UE; expected it to stay connected")
+	}
+
+	// Two retransmissions, and no UE Context Release Command.
+	if got := cc.count(); got != 2 {
+		t.Fatalf("sent %d messages, want 2 retransmissions and no release", got)
+	}
+}
+
 // TestNASGuardStoppedByResponse confirms a UE response cancels the guard before
 // it can retransmit or release.
 func TestNASGuardStoppedByResponse(t *testing.T) {

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -237,7 +237,15 @@ func (m *MME) modifyBearer(ctx context.Context, ue *UeContext, p *pdnConnection,
 		m.sendDownlink(ctx, ue, naspdu)
 	}
 
-	m.armNASGuardAbortOnly(ue, "Modify EPS Bearer Context Request", naspdu)
+	m.armNASGuardAbortOnly(ue, "Modify EPS Bearer Context Request", naspdu, func() {
+		// An aborted modification leaves the UE connected and its data-network
+		// fingerprint stale, so the backstop reconcile retries it later.
+		ue.mu.Lock()
+		if p := ue.defaultPDNLocked(); p != nil {
+			clearPendingModifyLocked(p)
+		}
+		ue.mu.Unlock()
+	})
 }
 
 // sendERABModify reconfigures the UE's default-bearer radio QoS with an S1AP


### PR DESCRIPTION
# Description

The 4G network-initiated detach (DetachSubscriber) sent the DETACH REQUEST fire-and-forget with no T3422 guard, so a UE that never replied with Detach Accept leaked its context forever.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
