### PR TITLE
fix: separate transient per-connection state from persistent 4G UE context

### DIFF
--- a/internal/mme/auth_failure.go
+++ b/internal/mme/auth_failure.go
@@ -27,12 +27,12 @@ func (m *MME) onAuthenticationFailure(ctx context.Context, ue *UeContext, plain 
 	}
 
 	logger.MmeLog.Info("Authentication Failure",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.Uint8("emm-cause", resp.Cause))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.Uint8("emm-cause", resp.Cause))
 
 	if resp.Cause == emmCauseSynchFailure && len(resp.AUTS) > 0 && !ue.resyncTried && ue.authVector != nil {
 		ue.resyncTried = true
 
-		logger.MmeLog.Info("re-synchronising SQN, re-authenticating", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+		logger.MmeLog.Info("re-synchronising SQN, re-authenticating", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 
 		// The credential authority resyncs from AUTS and issues a fresh vector.
 		if err := m.sendAuthRequest(ctx, ue, hex.EncodeToString(resp.AUTS), hex.EncodeToString(ue.authVector.RAND[:])); err != nil {
@@ -54,7 +54,7 @@ func (m *MME) rejectAuthentication(ctx context.Context, ue *UeContext) {
 	metrics.RegistrationAttempt(metrics.RAT4G, attachTypeName(ue), metrics.ResultReject)
 
 	logger.MmeLog.Info("authentication rejected",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 	m.sendDownlinkMessage(ctx, ue, &eps.AuthenticationReject{})
 	m.releaseUEContext(ctx, ue, causeNASUnspecified)
 }

--- a/internal/mme/bearer.go
+++ b/internal/mme/bearer.go
@@ -436,7 +436,7 @@ func (m *MME) sendInitialContextSetup(ctx context.Context, ue *UeContext, qos *e
 
 	p := m.defaultPDN(ue)
 	if p == nil {
-		logger.MmeLog.Error("Initial Context Setup with no active PDN", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+		logger.MmeLog.Error("Initial Context Setup with no active PDN", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 		return
 	}
 
@@ -449,8 +449,8 @@ func (m *MME) sendInitialContextSetup(ctx context.Context, ue *UeContext, qos *e
 	}
 
 	ics := &s1ap.InitialContextSetupRequest{
-		MMEUES1APID:               ue.MMEUES1APID,
-		ENBUES1APID:               ue.ENBUES1APID,
+		MMEUES1APID:               ue.s1.MMEUES1APID,
+		ENBUES1APID:               ue.s1.ENBUES1APID,
 		UEAggregateMaximumBitRate: s1ap.UEAggregateMaximumBitRate{DL: s1ap.BitRate(qos.AMBRDL), UL: s1ap.BitRate(qos.AMBRUL)},
 		ERABToBeSetup: []s1ap.ERABToBeSetupItemCtxtSUReq{{
 			ERABID: s1ap.ERABID(p.ebi),
@@ -483,8 +483,8 @@ func (m *MME) sendInitialContextSetup(ctx context.Context, ue *UeContext, qos *e
 	// the eNB releases the UE (TS 33.401). Record the inputs so such a
 	// failure can be told apart from a radio-side release.
 	logger.MmeLog.Info("Initial Context Setup Request",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
-		zap.Uint32("enb-ue-id", uint32(ue.ENBUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
+		zap.Uint32("enb-ue-id", uint32(ue.s1.ENBUES1APID)),
 		zap.String("ue-ip", p.ueIP.String()),
 		zap.Uint32("kenb-ul-count", kenbCount),
 		zap.Uint8("eea", ue.eea),
@@ -581,7 +581,7 @@ func (m *MME) onAttachComplete(ctx context.Context, ue *UeContext, plain []byte)
 	metrics.RegistrationAttempt(metrics.RAT4G, attachTypeName(ue), metrics.ResultAccept)
 
 	logger.MmeLog.Info("UE attached (EMM-REGISTERED)",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.String("imsi", ue.imsi),
 	)
 

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -64,6 +64,24 @@ func (f *fakeSessionManager) ModifyEPSSession(_ context.Context, _ string, _ uin
 	return nil
 }
 
+// hookSessionManager runs onModify on the first ModifyEPSSession, so a test can
+// simulate a concurrent release (freeing ue.s1) during the unlocked user-plane
+// switch of a Path Switch or Handover Notify.
+type hookSessionManager struct {
+	*fakeSessionManager
+	onModify func()
+	fired    bool
+}
+
+func (h *hookSessionManager) ModifyEPSSession(ctx context.Context, imsi string, ebi uint8, enb models.FTEID) error {
+	if !h.fired && h.onModify != nil {
+		h.fired = true
+		h.onModify()
+	}
+
+	return h.fakeSessionManager.ModifyEPSSession(ctx, imsi, ebi, enb)
+}
+
 func (f *fakeSessionManager) UpdateEPSSessionAMBR(_ context.Context, _ string, _ uint8, ambrUplink, ambrDownlink string) error {
 	if f.ambrErr != nil {
 		return f.ambrErr

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -27,10 +27,27 @@ func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 		return
 	}
 
+	ue.emmState.store(EMMDeregistered)
+
+	// An idle UE (ECM-IDLE) holds no S1 connection to carry the DETACH REQUEST, so
+	// release its sessions and context locally. The deleted subscriber is denied at
+	// its next contact, as it can no longer authenticate.
+	m.mu.RLock()
+
+	connected := ue.s1 != nil
+
+	m.mu.RUnlock()
+
+	if !connected {
+		logger.MmeLog.Info("releasing idle UE on subscriber deletion", zap.String("imsi", imsi))
+		m.releaseAllSessions(ue)
+		m.removeUe(ue)
+
+		return
+	}
+
 	logger.MmeLog.Info("network-initiated detach (subscriber deleted)",
 		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", imsi))
-
-	ue.emmState.store(EMMDeregistered)
 
 	naspdu, err := m.protectDownlink(ue, &eps.DetachRequestNetwork{TypeOfDetach: detachTypeReattachNotRequired})
 	if err != nil {

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -28,7 +28,7 @@ func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 	}
 
 	logger.MmeLog.Info("network-initiated detach (subscriber deleted)",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", imsi))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", imsi))
 
 	ue.emmState.store(EMMDeregistered)
 
@@ -47,7 +47,7 @@ func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 // EMM-DEREGISTERED).
 func (m *MME) onDetachAccept(ctx context.Context, ue *UeContext) {
 	m.stopNASGuard(ue)
-	logger.MmeLog.Info("Detach Accept", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+	logger.MmeLog.Info("Detach Accept", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 	m.releaseUEContext(ctx, ue, causeNASDetach)
 }
 
@@ -75,7 +75,7 @@ func (m *MME) onDetachRequest(ctx context.Context, ue *UeContext, plain []byte) 
 	}
 
 	logger.MmeLog.Info("Detach Request",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.Bool("switch-off", req.SwitchOff),
 		zap.String("imsi", ue.imsi),
 	)

--- a/internal/mme/detach_test.go
+++ b/internal/mme/detach_test.go
@@ -440,3 +440,23 @@ func TestUEContextReleaseRequestFromForeignENB(t *testing.T) {
 		t.Fatalf("expected cause unknown-mme-ue-s1ap-id, got %v", ind.Cause)
 	}
 }
+
+// TestDetachSubscriberIdleReleasesLocally checks that deleting a subscriber whose
+// UE is in ECM-IDLE releases its sessions and removes the context locally, without
+// dereferencing the freed S1 connection.
+func TestDetachSubscriberIdleReleasesLocally(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+	testPDN(ue).apn = "internet"
+	m.freeS1Conn(ue) // ECM-IDLE: no S1 connection
+
+	m.DetachSubscriber(context.Background(), ue.imsi)
+
+	if _, ok := m.lookupUeByIMSI(ue.imsi); ok {
+		t.Fatal("idle UE context not removed on subscriber deletion")
+	}
+
+	if !m.session.(*fakeSessionManager).released {
+		t.Fatal("EPS session not released on subscriber deletion")
+	}
+}

--- a/internal/mme/detach_test.go
+++ b/internal/mme/detach_test.go
@@ -460,3 +460,13 @@ func TestDetachSubscriberIdleReleasesLocally(t *testing.T) {
 		t.Fatal("EPS session not released on subscriber deletion")
 	}
 }
+
+// TestReleaseUEContextIdleNoPanic checks releaseUEContext on a UE whose connection
+// was freed in the gap before it took the lock returns without dereferencing nil.
+func TestReleaseUEContextIdleNoPanic(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+	m.freeS1Conn(ue)
+
+	m.releaseUEContext(context.Background(), ue, causeNASNormalRelease)
+}

--- a/internal/mme/detach_test.go
+++ b/internal/mme/detach_test.go
@@ -218,10 +218,9 @@ func TestDetachSwitchOff(t *testing.T) {
 	}
 }
 
-// TestDetachSwitchOffNullSecurity covers srsUE's behaviour: a switch-off Detach
-// Request sent with a null MAC and an unciphered payload, which the MME must
-// accept despite the failed integrity check (TS 24.301 §5.5.2.2.2).
-func TestDetachSwitchOffNullSecurity(t *testing.T) {
+// A switch-off DETACH REQUEST that fails the integrity check is ignored once a
+// security context exists (TS 24.301 §4.4.4.3).
+func TestDetachSwitchOffUnverifiableIgnoredForSecuredUE(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
@@ -233,8 +232,39 @@ func TestDetachSwitchOffNullSecurity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wrap as security-protected (SHT integrity+ciphered) but with null
-	// algorithms: zero MAC and unciphered payload, as srsUE does.
+	// Null algorithms: zero MAC, unciphered payload — unverifiable without the keys.
+	wire, err := eps.Protect(plain, eps.SHTIntegrityProtectedCiphered, 0, nascommon.DirectionUplink,
+		[16]byte{}, [16]byte{}, nascommon.NullIntegrity{}, nascommon.NullCipher{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.handleNAS(context.Background(), ue, wire)
+
+	if len(cc.sent) != 0 {
+		t.Fatalf("S1AP messages sent = %d, want 0", len(cc.sent))
+	}
+
+	if _, ok := m.lookupUe(ue.MMEUES1APID); !ok || ue.emmState.load() != EMMRegistered || !ue.secured {
+		t.Fatal("secured UE state changed by an unverifiable switch-off detach")
+	}
+}
+
+// Before a security context exists, an unverifiable switch-off detach is honoured
+// (TS 24.301 §4.4.4.3).
+func TestDetachSwitchOffUnsecuredAccepted(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+	ue.secured = false
+
+	plain, err := (&eps.DetachRequestUE{
+		SwitchOff: true, TypeOfDetach: eps.DetachTypeEPS,
+		EPSMobileIdentity: eps.EPSMobileIdentity{Type: eps.IdentityGUTI, MCC: "001", MNC: "01", MMEGroupID: 1, MMECode: 1, MTMSI: 1},
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	wire, err := eps.Protect(plain, eps.SHTIntegrityProtectedCiphered, 0, nascommon.DirectionUplink,
 		[16]byte{}, [16]byte{}, nascommon.NullIntegrity{}, nascommon.NullCipher{})
 	if err != nil {

--- a/internal/mme/detach_test.go
+++ b/internal/mme/detach_test.go
@@ -44,14 +44,14 @@ func TestDetachSubscriberNetworkInitiated(t *testing.T) {
 	m.onDetachAccept(context.Background(), ue)
 	parseUEContextReleaseCommand(t, cc.sent[1])
 
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: 7}
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: 7}
 
 	b, _ := complete.Marshal()
 	pdu, _ := s1ap.Unmarshal(b)
 
 	m.handleUEContextReleaseComplete(cc, pdu.(*s1ap.SuccessfulOutcome).Value)
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); ok {
+	if _, ok := m.lookupUeByIMSI(ue.imsi); ok {
 		t.Fatal("UE context not deleted after network-initiated detach")
 	}
 }
@@ -73,7 +73,7 @@ func TestDetachSubscriberUnansweredReleases(t *testing.T) {
 		return cc.count() >= 4
 	})
 
-	if !ue.releasing {
+	if !ue.s1.releasing {
 		t.Fatal("UE not released after an unanswered network-initiated detach")
 	}
 }
@@ -111,7 +111,7 @@ func TestForgedMessageIgnoredForSecuredUE(t *testing.T) {
 		t.Fatalf("forged DETACH against a secured UE was acted on: %d downlink(s) sent", cc.count())
 	}
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); !ok || ue.emmState.load() != EMMRegistered || !ue.secured {
+	if _, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok || ue.emmState.load() != EMMRegistered || !ue.secured {
 		t.Fatal("secured UE was disrupted by a forged, unverifiable DETACH")
 	}
 }
@@ -143,9 +143,22 @@ func securedUE(t *testing.T, m *MME) (*UeContext, *captureConn) {
 
 	ue.secured = true
 	ue.emmState.store(EMMRegistered)
-	ue.imsi = testSubscriber.IMSI
+	registerTestUE(m, ue, testSubscriber.IMSI)
 
 	return ue, cc
+}
+
+// registerTestUE sets a UE's IMSI and indexes it in the persistent registry, as a
+// completed attach would. Re-registering a UE under a new IMSI moves its index.
+func registerTestUE(m *MME, ue *UeContext, imsi string) {
+	m.mu.Lock()
+	if ue.imsi != "" && m.ues[ue.imsi] == ue {
+		delete(m.ues, ue.imsi)
+	}
+
+	ue.imsi = imsi
+	m.ues[imsi] = ue
+	m.mu.Unlock()
 }
 
 func parseUEContextReleaseCommand(t *testing.T, pdu []byte) *s1ap.UEContextReleaseCommand {
@@ -201,19 +214,19 @@ func TestDetachSwitchOff(t *testing.T) {
 	}
 
 	cmd := parseUEContextReleaseCommand(t, cc.sent[0])
-	if !cmd.UES1APIDs.Pair || cmd.UES1APIDs.MMEUES1APID != ue.MMEUES1APID || cmd.UES1APIDs.ENBUES1APID != 7 {
+	if !cmd.UES1APIDs.Pair || cmd.UES1APIDs.MMEUES1APID != ue.s1.MMEUES1APID || cmd.UES1APIDs.ENBUES1APID != 7 {
 		t.Fatalf("unexpected release command IDs: %+v", cmd.UES1APIDs)
 	}
 
 	// eNB confirms release → context deleted.
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: 7}
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: 7}
 
 	b, _ := complete.Marshal()
 	pdu, _ := s1ap.Unmarshal(b)
 
 	m.handleUEContextReleaseComplete(cc, pdu.(*s1ap.SuccessfulOutcome).Value)
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); ok {
+	if _, ok := m.lookupUeByIMSI(ue.imsi); ok {
 		t.Fatal("UE context not deleted after release complete")
 	}
 }
@@ -245,7 +258,7 @@ func TestDetachSwitchOffUnverifiableIgnoredForSecuredUE(t *testing.T) {
 		t.Fatalf("S1AP messages sent = %d, want 0", len(cc.sent))
 	}
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); !ok || ue.emmState.load() != EMMRegistered || !ue.secured {
+	if _, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok || ue.emmState.load() != EMMRegistered || !ue.secured {
 		t.Fatal("secured UE state changed by an unverifiable switch-off detach")
 	}
 }
@@ -314,13 +327,13 @@ func TestECMIdleBuffersSession(t *testing.T) {
 	ue, cc := securedUE(t, m)
 	testPDN(ue).apn = "internet"
 
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: 7}
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: 7}
 	b, _ := complete.Marshal()
 	cpdu, _ := s1ap.Unmarshal(b)
 
 	m.handleUEContextReleaseComplete(cc, cpdu.(*s1ap.SuccessfulOutcome).Value)
 
-	if ue.ecmState.load() != ECMIdle {
+	if ue.connected() {
 		t.Fatal("UE not ECM-IDLE after release complete")
 	}
 
@@ -334,7 +347,7 @@ func TestUEContextReleaseRequestFromENB(t *testing.T) {
 	ue, cc := securedUE(t, m)
 
 	req := &s1ap.UEContextReleaseRequest{
-		MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: 7,
+		MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: 7,
 		Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 0},
 	}
 
@@ -358,19 +371,19 @@ func TestUEContextReleaseRequestFromENB(t *testing.T) {
 
 	// Completing an eNB-initiated release moves the UE to ECM-IDLE; the EMM
 	// context is retained, not deleted.
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: 7}
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: 7}
 
 	b, _ = complete.Marshal()
 	cpdu, _ := s1ap.Unmarshal(b)
 
 	m.handleUEContextReleaseComplete(cc, cpdu.(*s1ap.SuccessfulOutcome).Value)
 
-	got, ok := m.lookupUe(ue.MMEUES1APID)
+	got, ok := m.lookupUeByIMSI(ue.imsi)
 	if !ok {
 		t.Fatal("EMM context deleted on an inactivity release; expected ECM-IDLE retention")
 	}
 
-	if got.ecmState.load() != ECMIdle {
+	if got.connected() {
 		t.Fatal("UE not marked ECM-IDLE after eNB release")
 	}
 
@@ -400,7 +413,7 @@ func TestUEContextReleaseRequestFromForeignENB(t *testing.T) {
 	ue, cc := securedUE(t, m)
 
 	req := &s1ap.UEContextReleaseRequest{
-		MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID,
 		Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 0},
 	}
 
@@ -414,7 +427,7 @@ func TestUEContextReleaseRequestFromForeignENB(t *testing.T) {
 		t.Fatalf("foreign eNB released a UE on another association: %d S1AP messages on the owning association", len(cc.sent))
 	}
 
-	if ue.releasing {
+	if ue.s1.releasing {
 		t.Fatal("UE marked releasing by a message from a foreign association")
 	}
 

--- a/internal/mme/emm.go
+++ b/internal/mme/emm.go
@@ -27,6 +27,7 @@ const (
 	emmCauseESMFailure            uint8 = 19
 	emmCauseMACFailure            uint8 = 20
 	emmCauseSynchFailure          uint8 = 21
+	emmCauseUESecCapsMismatch     uint8 = 23
 )
 
 // epsAttachTypeCombined is the "combined EPS/IMSI attach" EPS attach type value
@@ -51,6 +52,7 @@ func (m *MME) handleNAS(ctx context.Context, ue *UeContext, nas []byte) {
 	}
 
 	plain := nas
+	integrityVerified := false
 
 	if nas[0]>>4 != uint8(eps.SHTPlain) {
 		if len(nas) < 6 {
@@ -78,10 +80,10 @@ func (m *MME) handleNAS(ctx context.Context, ue *UeContext, nas []byte) {
 		if err != nil {
 			body := nas[6:]
 
-			// A switch-off DETACH REQUEST may be sent without valid integrity
-			// protection (TS 24.301) — srsUE sends it with a null MAC
-			// and an unciphered payload. Accept it from the plaintext body.
-			if isSwitchOffDetach(body) {
+			// A switch-off DETACH REQUEST is honoured without integrity protection
+			// only before the secure exchange of NAS messages is established
+			// (TS 24.301 §4.4.4.3).
+			if !ue.secured && isSwitchOffDetach(body) {
 				m.onDetachRequest(ctx, ue, body)
 				return
 			}
@@ -123,13 +125,46 @@ func (m *MME) handleNAS(ctx context.Context, ue *UeContext, nas []byte) {
 		}
 
 		plain = p
+		integrityVerified = true
 		// Advance the expected count past the accepted message, so a replay
 		// estimates to a stale count whose MAC fails to verify.
 		ue.ulCount = count + 1
 	}
 
-	// An ESM (session management) NAS message rides on its own protocol
-	// discriminator; route it separately from EMM mobility messages.
+	m.dispatchEMM(ctx, ue, plain, integrityVerified)
+}
+
+// unprotectUplink verifies and deciphers a protected uplink NAS message against
+// ue's security context, returning the plain message and its NAS COUNT. It does
+// not mutate ue, so a caller resolving a UE by S-TMSI can authenticate the
+// message before binding the context to the requesting association.
+func (m *MME) unprotectUplink(ue *UeContext, nas []byte) (plain []byte, count uint32, ok bool) {
+	if len(nas) < 6 {
+		return nil, 0, false
+	}
+
+	recvSeq := nas[5]
+
+	overflow := uint16(ue.ulCount >> 8)
+	if recvSeq < uint8(ue.ulCount) {
+		overflow++
+	}
+
+	count = nascommon.NASCount(overflow, recvSeq)
+
+	p, err := eps.Unprotect(nas, count, nascommon.DirectionUplink,
+		ue.knasInt, ue.knasEnc, integrityAlg(ue.eia), cipherAlg(ue.eea))
+	if err != nil {
+		return nil, 0, false
+	}
+
+	return p, count, true
+}
+
+// dispatchEMM routes a plain NAS message to its procedure handler, splitting ESM
+// session-management messages from EMM mobility messages by protocol
+// discriminator.
+func (m *MME) dispatchEMM(ctx context.Context, ue *UeContext, plain []byte, integrityVerified bool) {
 	if len(plain) > 0 && plain[0]&0x0F == eps.PDESM {
 		m.handleESM(ctx, ue, plain)
 		return
@@ -147,7 +182,7 @@ func (m *MME) handleNAS(ctx context.Context, ue *UeContext, nas []byte) {
 
 	switch mt {
 	case eps.MsgAttachRequest:
-		m.onAttachRequest(ctx, ue, plain)
+		m.onAttachRequest(ctx, ue, plain, integrityVerified)
 	case eps.MsgIdentityResponse:
 		m.onIdentityResponse(ctx, ue, plain)
 	case eps.MsgAuthenticationResponse:
@@ -188,7 +223,7 @@ func (m *MME) processWithoutIntegrity(ctx context.Context, ue *UeContext, mt eps
 		// A native GUTI the MME still holds lets it reuse the
 		// security context and skip authentication (TS 23.401).
 		if !m.reuseContextForGUTIAttach(ctx, ue, nas, body) {
-			m.onAttachRequest(ctx, ue, body)
+			m.onAttachRequest(ctx, ue, body, false)
 		}
 	case eps.MsgIdentityResponse:
 		// The IMSI is carried in cleartext; identification continues to
@@ -232,11 +267,19 @@ func (m *MME) onSecurityModeReject(ctx context.Context, ue *UeContext, plain []b
 	m.releaseUEContext(ctx, ue, causeNASUnspecified)
 }
 
-func (m *MME) onAttachRequest(ctx context.Context, ue *UeContext, plain []byte) {
+func (m *MME) onAttachRequest(ctx context.Context, ue *UeContext, plain []byte, integrityVerified bool) {
 	req, err := eps.ParseAttachRequest(plain)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Attach Request", zap.Error(err))
 		return
+	}
+
+	// An Attach without verified integrity is replayed to the UE as a HashMME in
+	// the SECURITY MODE COMMAND, so the UE can detect tampering (TS 24.301 §5.4.3.2).
+	if integrityVerified {
+		ue.hashmmeInput = nil
+	} else {
+		ue.hashmmeInput = plain
 	}
 
 	m.ingestAttachRequest(ue, req)
@@ -316,14 +359,24 @@ func (m *MME) reuseContextForGUTIAttach(ctx context.Context, ue *UeContext, nas,
 		return false
 	}
 
-	// Only a UE that actually holds the resolved context can produce a valid MAC
-	// over the Attach Request; verify it before trusting the GUTI (TS 24.301).
-	// A mismatch (e.g. a stale or spoofed GUTI) falls back to
-	// authentication.
-	if _, err := eps.Unprotect(nas, nascommon.NASCount(0, nas[5]), nascommon.DirectionUplink,
+	// Verify the Attach MAC against the held context's expected uplink NAS COUNT
+	// (TS 24.301): a replayed or stale Attach fails the check, so only the genuine
+	// holder of the context reuses it.
+	recvSeq := nas[5]
+
+	overflow := uint16(existing.ulCount >> 8)
+	if recvSeq < uint8(existing.ulCount) {
+		overflow++
+	}
+
+	count := nascommon.NASCount(overflow, recvSeq)
+
+	if _, err := eps.Unprotect(nas, count, nascommon.DirectionUplink,
 		existing.knasInt, existing.knasEnc, integrityAlg(existing.eia), cipherAlg(existing.eea)); err != nil {
 		return false
 	}
+
+	existing.ulCount = count + 1
 
 	// Authentic returning UE: carry over the EPS security context and identity,
 	// drop the superseded registration, and run the security mode procedure with
@@ -439,13 +492,35 @@ func (m *MME) onAuthenticationResponse(ctx context.Context, ue *UeContext, plain
 }
 
 func (m *MME) startSecurityMode(ctx context.Context, ue *UeContext) {
-	var ciphering, integrity []string
-	if op, err := m.bearer.GetOperator(ctx); err == nil {
-		ciphering, _ = op.GetCiphering()
-		integrity, _ = op.GetIntegrity()
+	// A security policy the MME cannot read must not yield a default (null)
+	// context; abort and let the UE retry once the policy is available.
+	op, err := m.bearer.GetOperator(ctx)
+	if err != nil {
+		logger.MmeLog.Error("failed to resolve operator security policy", zap.Error(err))
+		return
 	}
 
-	eea, eia := selectAlgorithms(ue.ueNetCap, ciphering, integrity)
+	ciphering, err := op.GetCiphering()
+	if err != nil {
+		logger.MmeLog.Error("failed to read ciphering policy", zap.Error(err))
+		return
+	}
+
+	integrity, err := op.GetIntegrity()
+	if err != nil {
+		logger.MmeLog.Error("failed to read integrity policy", zap.Error(err))
+		return
+	}
+
+	eea, eia, ok := selectAlgorithms(ue.ueNetCap, ciphering, integrity)
+	if !ok {
+		logger.MmeLog.Warn("no NAS security algorithm common to UE and operator policy",
+			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+			zap.String("ue-network-capability", fmt.Sprintf("%x", ue.ueNetCap)))
+		m.rejectAttach(ctx, ue, emmCauseUESecCapsMismatch)
+
+		return
+	}
 
 	knasEnc, err := deriveKNASEnc(ue.kasme, eea)
 	if err != nil {
@@ -469,6 +544,7 @@ func (m *MME) startSecurityMode(ctx context.Context, ue *UeContext) {
 		NASKeySetIdentifier:            0,
 		ReplayedUESecurityCapabilities: replayed,
 		IMEISVRequested:                true,
+		HASHMME:                        hashMME(ue.hashmmeInput),
 	}
 
 	plain, err := smc.Marshal()

--- a/internal/mme/emm.go
+++ b/internal/mme/emm.go
@@ -261,7 +261,7 @@ func (m *MME) onSecurityModeReject(ctx context.Context, ue *UeContext, plain []b
 	}
 
 	logger.MmeLog.Warn("Security Mode Reject",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.Uint8("emm-cause", cause))
 
 	m.releaseUEContext(ctx, ue, causeNASUnspecified)
@@ -385,10 +385,10 @@ func (m *MME) reuseContextForGUTIAttach(ctx context.Context, ue *UeContext, nas,
 	ue.imei = existing.imei
 	ue.kasme = existing.kasme
 
-	m.removeUe(existing.MMEUES1APID)
+	m.removeUe(existing)
 
 	logger.MmeLog.Info("Attach with valid native GUTI: reusing security context, skipping authentication",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 
 	m.ingestAttachRequest(ue, req)
 	m.startSecurityMode(ctx, ue)
@@ -437,7 +437,7 @@ func attachTypeName(ue *UeContext) string {
 func (m *MME) startAuthentication(ctx context.Context, ue *UeContext) {
 	if err := m.sendAuthRequest(ctx, ue, "", ""); err != nil {
 		logger.MmeLog.Info("attach rejected: cannot authenticate subscriber",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.Error(err))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.Error(err))
 		m.rejectAttach(ctx, ue, emmCauseIMSIUnknownInHSS)
 	}
 }
@@ -463,7 +463,7 @@ func (m *MME) sendAuthRequest(ctx context.Context, ue *UeContext, resyncAuts, re
 
 	ue.authVector = vec
 
-	logger.MmeLog.Info("Authentication Request", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+	logger.MmeLog.Info("Authentication Request", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 	m.sendGuardedMessage(ctx, ue, "Authentication Request", &eps.AuthenticationRequest{NASKeySetIdentifier: 0, RAND: vec.RAND, AUTN: vec.AUTN[:]})
 
 	return nil
@@ -479,7 +479,7 @@ func (m *MME) onAuthenticationResponse(ctx context.Context, ue *UeContext, plain
 	}
 
 	if ue.authVector == nil || subtle.ConstantTimeCompare(resp.RES, ue.authVector.XRES) != 1 {
-		logger.MmeLog.Warn("authentication failed: RES mismatch", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+		logger.MmeLog.Warn("authentication failed: RES mismatch", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 		m.rejectAuthentication(ctx, ue)
 
 		return
@@ -487,7 +487,7 @@ func (m *MME) onAuthenticationResponse(ctx context.Context, ue *UeContext, plain
 
 	ue.kasme = ue.authVector.KASME
 
-	logger.MmeLog.Info("authentication succeeded", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+	logger.MmeLog.Info("authentication succeeded", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 	m.startSecurityMode(ctx, ue)
 }
 
@@ -515,7 +515,7 @@ func (m *MME) startSecurityMode(ctx context.Context, ue *UeContext) {
 	eea, eia, ok := selectAlgorithms(ue.ueNetCap, ciphering, integrity)
 	if !ok {
 		logger.MmeLog.Warn("no NAS security algorithm common to UE and operator policy",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 			zap.String("ue-network-capability", fmt.Sprintf("%x", ue.ueNetCap)))
 		m.rejectAttach(ctx, ue, emmCauseUESecCapsMismatch)
 
@@ -561,7 +561,7 @@ func (m *MME) startSecurityMode(ctx context.Context, ue *UeContext) {
 		return
 	}
 
-	logger.MmeLog.Info("Security Mode Command", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+	logger.MmeLog.Info("Security Mode Command", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.Uint8("eea", eea), zap.Uint8("eia", eia),
 		zap.String("ue-network-capability", fmt.Sprintf("%x", ue.ueNetCap)),
 		zap.String("ms-network-capability", fmt.Sprintf("%x", ue.msNetCap)),
@@ -593,7 +593,7 @@ func (m *MME) onSecurityModeComplete(ctx context.Context, ue *UeContext, plain [
 	ue.markSecured(imei)
 
 	logger.MmeLog.Info("NAS security context established",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.String("imsi", ue.imsi),
 	)
 

--- a/internal/mme/emm.go
+++ b/internal/mme/emm.go
@@ -4,8 +4,8 @@
 package mme
 
 import (
-	"bytes"
 	"context"
+	"crypto/subtle"
 	"fmt"
 
 	"github.com/ellanetworks/core/etsi"
@@ -478,7 +478,7 @@ func (m *MME) onAuthenticationResponse(ctx context.Context, ue *UeContext, plain
 		return
 	}
 
-	if ue.authVector == nil || !bytes.Equal(resp.RES, ue.authVector.XRES) {
+	if ue.authVector == nil || subtle.ConstantTimeCompare(resp.RES, ue.authVector.XRES) != 1 {
 		logger.MmeLog.Warn("authentication failed: RES mismatch", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
 		m.rejectAuthentication(ctx, ue)
 

--- a/internal/mme/emm.go
+++ b/internal/mme/emm.go
@@ -358,36 +358,25 @@ func (m *MME) reuseContextForGUTIAttach(ctx context.Context, ue *UeContext, nas,
 	// Verify the Attach MAC against the held context's expected uplink NAS COUNT
 	// (TS 24.301): a replayed or stale Attach fails the check, so only the genuine
 	// holder of the context reuses it.
-	recvSeq := nas[5]
-
-	overflow := uint16(existing.ulCount >> 8)
-	if recvSeq < uint8(existing.ulCount) {
-		overflow++
-	}
-
-	count := nascommon.NASCount(overflow, recvSeq)
-
-	if _, err := eps.Unprotect(nas, count, nascommon.DirectionUplink,
-		existing.knasInt, existing.knasEnc, integrityAlg(existing.eia), cipherAlg(existing.eea)); err != nil {
+	_, count, ok := m.unprotectUplink(existing, nas)
+	if !ok {
 		return false
 	}
 
+	// Authentic returning UE: reuse the held EPS security context in place. The
+	// connection is rebound onto it and its NAS COUNTs continue (a native context is
+	// reused, not re-derived, so the counts are never reset — TS 24.301 §4.4.3,
+	// §5.4.3.3). Authentication and the security mode procedure are skipped; the
+	// Attach Accept rides the reused context at the continued counts, mirroring the
+	// 5G AMF and the EPS spec's native-context reuse.
+	m.adoptConn(existing, ue)
 	existing.ulCount = count + 1
 
-	// Authentic returning UE: carry over the EPS security context and identity,
-	// drop the superseded registration, and run the security mode procedure with
-	// the reused K_ASME — skipping the authentication round-trip and HSS vector.
-	m.setIMSI(ue, existing.imsi)
-	ue.imei = existing.imei
-	ue.kasme = existing.kasme
-
-	m.removeUe(existing)
-
 	logger.MmeLog.Info("Attach with valid native GUTI: reusing security context, skipping authentication",
-		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
+		zap.Uint32("mme-ue-id", uint32(existing.s1.MMEUES1APID)), zap.String("imsi", existing.imsi))
 
-	m.ingestAttachRequest(ue, req)
-	m.startSecurityMode(ctx, ue)
+	m.ingestAttachRequest(existing, req)
+	m.activateDefaultBearer(ctx, existing)
 
 	return true
 }

--- a/internal/mme/emm.go
+++ b/internal/mme/emm.go
@@ -237,10 +237,6 @@ func (m *MME) processWithoutIntegrity(ctx context.Context, ue *UeContext, mt eps
 		m.onSecurityModeReject(ctx, ue, body)
 	case eps.MsgDetachRequest:
 		m.onDetachRequest(ctx, ue, body)
-	case eps.MsgTrackingAreaUpdateRequest:
-		// The update cannot be trusted without a verifiable MAC; reject it so the
-		// UE re-attaches and rebuilds the context (TS 24.301).
-		m.rejectTrackingAreaUpdate(ctx, ue)
 	default:
 		return false
 	}

--- a/internal/mme/emm_test.go
+++ b/internal/mme/emm_test.go
@@ -201,7 +201,7 @@ func nativeGUTIAttach(t *testing.T, m *MME, ue *UeContext) []byte {
 func TestAttachReusesContextForNativeGUTI(t *testing.T) {
 	m := newTestMME(t)
 	existing, _ := securedUE(t, m)
-	oldID := existing.s1.MMEUES1APID
+	existing.dlCount = 7 // a live downlink chain that reuse must continue, not reset
 
 	wire := nativeGUTIAttach(t, m, existing)
 
@@ -209,21 +209,43 @@ func TestAttachReusesContextForNativeGUTI(t *testing.T) {
 	fresh := m.newUe(cc, 9)
 	m.handleNAS(context.Background(), fresh, wire)
 
-	if fresh.authVector != nil {
+	// The held context is reused in place — the connection is rebound onto it and
+	// the transient context the Initial UE Message created is discarded.
+	if got, ok := m.lookupUeByIMSI(existing.imsi); !ok || got != existing {
+		t.Fatal("held context not reused in place")
+	}
+
+	if fresh.s1 != nil {
+		t.Fatal("transient context not discarded after context reuse")
+	}
+
+	if existing.s1 == nil || existing.s1.conn != cc {
+		t.Fatal("held context not rebound to the returning UE's connection")
+	}
+
+	// Authentication is skipped on a valid native GUTI.
+	if existing.authVector != nil {
 		t.Fatal("authentication was not skipped on a valid native GUTI")
 	}
 
-	if fresh.imsi != existing.imsi || len(fresh.kasme) == 0 {
-		t.Fatalf("security context not reused: imsi=%q kasme=%d bytes", fresh.imsi, len(fresh.kasme))
+	// NAS COUNTs continue (TS 24.301 §4.4.3, §5.4.3.3): a native context is reused,
+	// not re-derived, so the counts are never reset to zero — reusing them with the
+	// same keys would be a keystream reuse.
+	if existing.ulCount != 1 {
+		t.Fatalf("uplink NAS COUNT = %d, want 1 (continued past the Attach)", existing.ulCount)
 	}
 
-	if _, ok := m.lookupUe(oldID); ok {
-		t.Fatal("superseded registration was not removed")
+	if existing.dlCount < 7 {
+		t.Fatalf("downlink NAS COUNT reset to %d on context reuse (keystream reuse)", existing.dlCount)
 	}
 
+	// The security mode procedure is skipped: the only downlink is the Initial
+	// Context Setup carrying the Attach Accept, not a Security Mode Command.
 	if cc.count() != 1 {
-		t.Fatalf("expected one downlink (Security Mode Command), got %d", cc.count())
+		t.Fatalf("expected one downlink (Initial Context Setup), got %d", cc.count())
 	}
+
+	parseInitialContextSetup(t, cc.sent[0])
 }
 
 // TestAttachNativeGUTIBadMACFallsBackToAuth checks that when the Attach does not

--- a/internal/mme/emm_test.go
+++ b/internal/mme/emm_test.go
@@ -4,7 +4,9 @@
 package mme
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"sync"
 	"testing"
 
@@ -248,6 +250,26 @@ func TestAttachNativeGUTIBadMACFallsBackToAuth(t *testing.T) {
 	}
 }
 
+// A replayed native-GUTI Attach with a stale uplink NAS COUNT must not remove the
+// live context (TS 24.301).
+func TestAttachNativeGUTIReplayDoesNotRemoveContext(t *testing.T) {
+	m := newTestMME(t)
+	existing, _ := securedUE(t, m)
+	oldID := existing.MMEUES1APID
+
+	wire := nativeGUTIAttach(t, m, existing) // protected at NASCount(0, 0)
+
+	existing.ulCount = 50
+
+	cc := &captureConn{}
+	attacker := m.newUe(cc, 9)
+	m.handleNAS(context.Background(), attacker, wire)
+
+	if _, ok := m.lookupUe(oldID); !ok {
+		t.Fatal("live context removed by a replayed stale-count Attach")
+	}
+}
+
 func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
@@ -333,6 +355,12 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 
 	if smc.CipheringAlgorithm != 2 || smc.IntegrityAlgorithm != 2 {
 		t.Fatalf("SMC algorithms eea=%d eia=%d, want 2/2", smc.CipheringAlgorithm, smc.IntegrityAlgorithm)
+	}
+
+	// The unprotected Attach is hashed into the SMC HashMME (TS 24.301 §5.4.3.2).
+	wantHash := sha256.Sum256(attachBytes)
+	if !bytes.Equal(smc.HASHMME, wantHash[:8]) {
+		t.Fatalf("SMC HashMME = %x, want %x", smc.HASHMME, wantHash[:8])
 	}
 
 	// 3. UE → Security Mode Complete (integrity protected + ciphered), returning

--- a/internal/mme/emm_test.go
+++ b/internal/mme/emm_test.go
@@ -201,7 +201,7 @@ func nativeGUTIAttach(t *testing.T, m *MME, ue *UeContext) []byte {
 func TestAttachReusesContextForNativeGUTI(t *testing.T) {
 	m := newTestMME(t)
 	existing, _ := securedUE(t, m)
-	oldID := existing.MMEUES1APID
+	oldID := existing.s1.MMEUES1APID
 
 	wire := nativeGUTIAttach(t, m, existing)
 
@@ -232,7 +232,7 @@ func TestAttachReusesContextForNativeGUTI(t *testing.T) {
 func TestAttachNativeGUTIBadMACFallsBackToAuth(t *testing.T) {
 	m := newTestMME(t)
 	existing, _ := securedUE(t, m)
-	oldID := existing.MMEUES1APID
+	oldID := existing.s1.MMEUES1APID
 
 	wire := nativeGUTIAttach(t, m, existing)
 	wire[1] ^= 0xff // corrupt the MAC
@@ -255,7 +255,7 @@ func TestAttachNativeGUTIBadMACFallsBackToAuth(t *testing.T) {
 func TestAttachNativeGUTIReplayDoesNotRemoveContext(t *testing.T) {
 	m := newTestMME(t)
 	existing, _ := securedUE(t, m)
-	oldID := existing.MMEUES1APID
+	oldID := existing.s1.MMEUES1APID
 
 	wire := nativeGUTIAttach(t, m, existing) // protected at NASCount(0, 0)
 
@@ -402,7 +402,7 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 
 	ics := parseInitialContextSetup(t, cc.sent[2])
 
-	if ics.MMEUES1APID != ue.MMEUES1APID || ics.ENBUES1APID != 7 || len(ics.ERABToBeSetup) != 1 {
+	if ics.MMEUES1APID != ue.s1.MMEUES1APID || ics.ENBUES1APID != 7 || len(ics.ERABToBeSetup) != 1 {
 		t.Fatalf("unexpected Initial Context Setup Request: %+v", ics)
 	}
 
@@ -503,7 +503,7 @@ func TestSecurityModeRejectReleasesUE(t *testing.T) {
 
 	m.handleNAS(context.Background(), ue, plain)
 
-	if !ue.releasing {
+	if !ue.s1.releasing {
 		t.Fatal("UE not released after Security Mode Reject")
 	}
 

--- a/internal/mme/enb_disconnect_test.go
+++ b/internal/mme/enb_disconnect_test.go
@@ -14,13 +14,13 @@ func TestENBDisconnectRetainsRegisteredUE(t *testing.T) {
 
 	m.reclaimUEsOnConnLoss(cc)
 
-	got, ok := m.lookupUe(ue.MMEUES1APID)
-	if !ok {
+	got, ok := m.lookupUeByIMSI(ue.imsi)
+	if !ok || got != ue {
 		t.Fatal("registered UE deleted on eNB disconnect; expected ECM-IDLE retention")
 	}
 
-	if got.ecmState.load() != ECMIdle {
-		t.Fatalf("ecmState = %v, want ECMIdle after eNB disconnect", got.ecmState.load())
+	if got.connected() {
+		t.Fatal("UE not in ECM-IDLE after eNB disconnect")
 	}
 
 	if got.mobileReachableTimer == nil {
@@ -31,7 +31,7 @@ func TestENBDisconnectRetainsRegisteredUE(t *testing.T) {
 		t.Fatal("EPS session not deactivated for paging after eNB disconnect")
 	}
 
-	m.removeUe(ue.MMEUES1APID) // stop the default-duration timer
+	m.removeUe(ue) // stop the default-duration timer
 }
 
 // TestENBDisconnectDropsMidAttachUE confirms a UE that had not completed
@@ -44,7 +44,7 @@ func TestENBDisconnectDropsMidAttachUE(t *testing.T) {
 
 	m.reclaimUEsOnConnLoss(cc)
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); ok {
+	if _, ok := m.lookupUeByIMSI(ue.imsi); ok {
 		t.Fatal("incomplete-registration UE retained on eNB disconnect; expected drop")
 	}
 
@@ -53,22 +53,18 @@ func TestENBDisconnectDropsMidAttachUE(t *testing.T) {
 	}
 }
 
-// TestENBDisconnectLeavesIdleUE confirms an already-idle UE keeps its own
-// supervision and is not disturbed by its eNB's disconnect.
+// TestENBDisconnectLeavesIdleUE confirms an already-idle UE on no association is
+// not disturbed by an eNB's disconnect.
 func TestENBDisconnectLeavesIdleUE(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
-	ue.ecmState.store(ECMIdle) // already idle, own mobile reachable supervision
+	m.freeS1Conn(ue) // already idle
 
 	m.reclaimUEsOnConnLoss(cc)
 
-	got, ok := m.lookupUe(ue.MMEUES1APID)
-	if !ok {
-		t.Fatal("idle UE removed on eNB disconnect")
-	}
-
-	if got.ecmState.load() != ECMIdle {
-		t.Fatalf("idle UE ecmState changed to %v on eNB disconnect", got.ecmState.load())
+	got, ok := m.lookupUeByIMSI(ue.imsi)
+	if !ok || got != ue || got.connected() {
+		t.Fatal("idle UE disturbed by an unrelated eNB disconnect")
 	}
 
 	if m.session.(*fakeSessionManager).deactivated {

--- a/internal/mme/erab_release.go
+++ b/internal/mme/erab_release.go
@@ -67,8 +67,8 @@ func (m *MME) disconnectBearer(ctx context.Context, ue *UeContext, p *pdnConnect
 // both releases the radio bearer and delivers the NAS (TS 36.413 §8.2.3).
 func (m *MME) sendERABRelease(ctx context.Context, ue *UeContext, p *pdnConnection, naspdu []byte) {
 	cmd := &s1ap.ERABReleaseCommand{
-		MMEUES1APID: ue.MMEUES1APID,
-		ENBUES1APID: ue.ENBUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
+		ENBUES1APID: ue.s1.ENBUES1APID,
 		ERABToBeReleased: []s1ap.ERABItem{{
 			ERABID: s1ap.ERABID(p.ebi),
 			Cause:  causeNASNormalRelease,
@@ -102,7 +102,7 @@ func (m *MME) handleERABReleaseResponse(conn nasWriter, value []byte) {
 
 	for _, erab := range msg.ERABReleased {
 		logger.MmeLog.Info("E-RAB released at eNB",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi),
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi),
 			zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 	}
 }

--- a/internal/mme/error_indication.go
+++ b/internal/mme/error_indication.go
@@ -45,7 +45,7 @@ func (m *MME) resolveUE(conn nasWriter, mmeID s1ap.MMEUES1APID, enbID s1ap.ENBUE
 		return nil, false
 	}
 
-	if ue.conn != conn {
+	if ue.s1.conn != conn {
 		logger.MmeLog.Warn("UE-associated S1AP message for an MME-UE-S1AP-ID on a different S1 association",
 			zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint32("enb-ue-id", uint32(enbID)))
 		m.sendErrorIndication(conn, &mmeID, &enbID, causeUnknownMMEUES1APID)
@@ -53,7 +53,7 @@ func (m *MME) resolveUE(conn nasWriter, mmeID s1ap.MMEUES1APID, enbID s1ap.ENBUE
 		return nil, false
 	}
 
-	if ue.ecmState.load() != ECMConnected {
+	if !ue.connected() {
 		logger.MmeLog.Warn("UE-associated S1AP message for an MME-UE-S1AP-ID with no active S1 connection",
 			zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint32("enb-ue-id", uint32(enbID)))
 		m.sendErrorIndication(conn, &mmeID, &enbID, causeUnknownMMEUES1APID)
@@ -61,10 +61,10 @@ func (m *MME) resolveUE(conn nasWriter, mmeID s1ap.MMEUES1APID, enbID s1ap.ENBUE
 		return nil, false
 	}
 
-	if ue.ENBUES1APID != enbID {
+	if ue.s1.ENBUES1APID != enbID {
 		logger.MmeLog.Warn("UE-associated S1AP message with an inconsistent eNB-UE-S1AP-ID",
 			zap.Uint32("mme-ue-id", uint32(mmeID)),
-			zap.Uint32("stored-enb-ue-id", uint32(ue.ENBUES1APID)),
+			zap.Uint32("stored-enb-ue-id", uint32(ue.s1.ENBUES1APID)),
 			zap.Uint32("received-enb-ue-id", uint32(enbID)))
 		m.sendErrorIndication(conn, &mmeID, &enbID, causeUnknownPairUES1APID)
 

--- a/internal/mme/error_indication_test.go
+++ b/internal/mme/error_indication_test.go
@@ -14,7 +14,7 @@ func TestErrorIndicationReleasesReferencedUE(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	id := ue.MMEUES1APID
+	id := ue.s1.MMEUES1APID
 	cause := s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 0}
 
 	b, err := (&s1ap.ErrorIndication{MMEUES1APID: &id, Cause: &cause}).Marshal()

--- a/internal/mme/guti_test.go
+++ b/internal/mme/guti_test.go
@@ -38,7 +38,7 @@ func TestAssignGUTI(t *testing.T) {
 	}
 
 	// Releasing the UE clears the index.
-	m.removeUe(ue.MMEUES1APID)
+	m.removeUe(ue)
 
 	if _, ok := m.lookupUeByMTMSI(guti.MTMSI); ok {
 		t.Fatal("M-TMSI index not cleared on UE removal")

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -412,6 +412,17 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 	m.ensureDefaultPDN(ue, admitted)
 
 	m.mu.Lock()
+	if ue.handover != ho || ue.s1 == nil {
+		// A concurrent release (e.g. the source association dropping) tore the UE
+		// down during the unlocked user-plane switch above and cleared the handover;
+		// it is moot, so leave the UE released.
+		m.mu.Unlock()
+		logger.MmeLog.Warn("Handover Notify: UE released during the user-plane switch",
+			zap.Uint32("target-mme-ue-id", uint32(notify.MMEUES1APID)))
+
+		return
+	}
+
 	source := ho.source
 	ue.nh = ho.newNH
 	ue.ncc = ho.newNCC

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -655,7 +655,12 @@ func (m *MME) abortHandoversOnConnLoss(conn nasWriter) {
 		}
 	}
 
-	for _, ue := range m.ues {
+	for _, c := range m.conns {
+		ue := c.ue
+		if ue == nil {
+			continue
+		}
+
 		if ho := ue.handover; ho != nil && (ho.sourceConn == conn || ho.target == conn) {
 			m.clearHandoverLocked(ue)
 		}

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -614,6 +614,11 @@ func (m *MME) clearHandover(ue *UeContext) {
 func (m *MME) onHandoverGuardExpiry(ue *UeContext, gen uint64) {
 	m.mu.Lock()
 
+	if ue.s1 == nil {
+		m.mu.Unlock()
+		return
+	}
+
 	ho := ue.s1.handover
 	if ho == nil || ue.s1.handoverGen != gen || ho.state == hoCommitting {
 		m.mu.Unlock()
@@ -633,16 +638,6 @@ func (m *MME) onHandoverGuardExpiry(ue *UeContext, gen uint64) {
 	if prepared && target != nil {
 		m.releaseHandoverTarget(context.Background(), target, mmeUEID, targetENBUEID)
 	}
-}
-
-// handoverInProgress reports whether the UE has an in-flight S1 handover, so the
-// data-network reconciler defers E-RAB management during the handover window
-// (TS 36.413 §8.4.1.2).
-func (m *MME) handoverInProgress(ue *UeContext) bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return ue.s1.handover != nil
 }
 
 // abortHandoversOnConnLoss clears any in-flight handover that referenced a dropped

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -42,36 +42,20 @@ type admittedERAB struct {
 }
 
 // handoverContext is the MME's state for one in-flight inter-eNB S1 handover
-// (TS 36.413 §8.4). The MME-UE-S1AP-ID is stable across the handover; the target
-// eNB allocates targetENBUEID, learned from the HANDOVER REQUEST ACKNOWLEDGE.
-// Guarded by MME.mu.
+// (TS 36.413 §8.4). source and target are distinct UE-associated S1-connections,
+// each with its own MME-UE-S1AP-ID; the UE's active connection (ue.s1) stays the
+// source until HANDOVER NOTIFY switches it to the target. Guarded by MME.mu.
 type handoverContext struct {
-	state         hoState
-	sourceConn    nasWriter
-	sourceENBUEID s1ap.ENBUES1APID
-	target        nasWriter
-	targetENBUEID s1ap.ENBUES1APID
-	admitted      []admittedERAB
-	releaseEBIs   []uint8 // bearers the target rejected, released at notify (TS 23.401 §5.5.1.2.2 step 15)
+	state       hoState
+	source      *s1Conn // the UE's source association (ue.s1 during preparation)
+	target      *s1Conn // the target association; its ENBUES1APID is learned from the acknowledge
+	admitted    []admittedERAB
+	releaseEBIs []uint8 // bearers the target rejected, released at notify (TS 23.401 §5.5.1.2.2 step 15)
 	// {NH, NCC} for the target, advanced at preparation, committed at notify (TS 33.401 §7.2.8).
 	newNH  [32]byte
 	newNCC uint8
 	// guardTimer abandons the handover if the target never completes it (TS 36.413 §8.4).
 	guardTimer *time.Timer
-}
-
-// srcReleaseKey identifies a handover UE Context Release Command, so its Release
-// Complete is consumed without disturbing the UE active on the target.
-//
-// Intra-MME handover keeps one UeContext under a single MME-UE-S1AP-ID across both
-// associations, so the source's Release Complete is indistinguishable by id from
-// the moved UE's. This {conn, eNB-UE-S1AP-ID} set disambiguates them; entries clear
-// on the Release Complete, and abortHandoversOnConnLoss sweeps any orphaned by a
-// dropped association. A source/target RAN-context split (as in the AMF) is
-// unnecessary for Ella Core's single-node topology.
-type srcReleaseKey struct {
-	conn    nasWriter
-	enbUEID s1ap.ENBUES1APID
 }
 
 // handleHandoverRequired starts an S1 handover preparation toward the target eNB,
@@ -127,9 +111,10 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 		return
 	}
 
-	// Only one handover preparation may be ongoing for a UE (TS 36.413 §8.4.1.1).
-	// The {NH, NCC} chain is read and advanced under the lock so it cannot race the
-	// commit at notify; it is committed to the UE only at notify (TS 33.401 §7.2.8).
+	// One handover at a time per UE, and the key chain must not be advanced
+	// concurrently by a Path Switch (TS 33.401 §7.2.8). The target connection gets a
+	// fresh MME-UE-S1AP-ID so it is a distinct UE-associated logical connection from
+	// the source (TS 36.413); the {NH, NCC} is advanced here and committed at notify.
 	m.mu.Lock()
 	if ue.keyChainBusy {
 		m.mu.Unlock()
@@ -151,23 +136,27 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 
 	newNCC := (ue.ncc + 1) & 0x07
 
-	gen := ue.s1.handoverGen
+	tid := m.nextMMEUEID
+	m.nextMMEUEID++
+	targetConn := &s1Conn{MMEUES1APID: s1ap.MMEUES1APID(tid), conn: target, ue: ue}
+	m.conns[tid] = targetConn
+
+	gen := ue.handoverGen
 	ho := &handoverContext{
-		state:         hoPreparing,
-		sourceConn:    conn,
-		sourceENBUEID: req.ENBUES1APID,
-		target:        target,
-		newNH:         newNH,
-		newNCC:        newNCC,
+		state:  hoPreparing,
+		source: ue.s1,
+		target: targetConn,
+		newNH:  newNH,
+		newNCC: newNCC,
 	}
 	ho.guardTimer = time.AfterFunc(m.handoverGuardTimeout, func() { m.onHandoverGuardExpiry(ue, gen) })
-	ue.s1.handover = ho
+	ue.handover = ho
 	ue.keyChainBusy = true
-	mmeUEID := ue.s1.MMEUES1APID
+	targetMMEID := targetConn.MMEUES1APID
 	m.mu.Unlock()
 
 	hoReq := &s1ap.HandoverRequest{
-		MMEUES1APID:            mmeUEID,
+		MMEUES1APID:            targetMMEID,
 		HandoverType:           s1ap.HandoverTypeIntraLTE,
 		Cause:                  req.Cause,
 		UEAMBR:                 m.handoverUEAMBR(ue),
@@ -187,7 +176,7 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 	}
 
 	logger.MmeLog.Info("Handover Request",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)),
+		zap.Uint32("target-mme-ue-id", uint32(targetMMEID)),
 		zap.String("target-enb", enbID(req.TargetID.TargeteNBID.GlobalENBID)),
 		zap.Int("e-rabs", len(bearers)))
 	m.sendS1APConn(ctx, target, S1APProcedureHandoverRequest, b)
@@ -195,7 +184,8 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 
 // handleHandoverRequestAcknowledge records the target's downlink endpoints and
 // sends a HANDOVER COMMAND to the source, or fails the handover when no usable
-// bearer was admitted (TS 36.413 §8.4.2). conn is the target.
+// bearer was admitted (TS 36.413 §8.4.2). conn is the target; the acknowledge
+// carries the target's MME-UE-S1AP-ID.
 func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWriter, value []byte) {
 	ack, err := s1ap.ParseHandoverRequestAcknowledge(value)
 	if err != nil {
@@ -205,24 +195,24 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 
 	ue, ok := m.lookupUe(ack.MMEUES1APID)
 	if !ok {
-		// No UE for this id; release the target context the ack just created.
-		m.releaseHandoverTarget(ctx, conn, ack.MMEUES1APID, ack.ENBUES1APID)
+		// No UE for this target id; release the context the ack just created.
+		m.sendUEContextRelease(ctx, conn, ack.MMEUES1APID, ack.ENBUES1APID)
 		return
 	}
 
 	m.mu.Lock()
-	ho := ue.s1.handover
+	ho := ue.handover
 
-	if ho == nil || ho.state != hoPreparing || ho.target != conn {
+	if ho == nil || ho.state != hoPreparing || ho.target.MMEUES1APID != ack.MMEUES1APID || ho.target.conn != conn {
 		m.mu.Unlock()
 		logger.MmeLog.Warn("Handover Request Acknowledge with no matching preparation",
-			zap.Uint32("mme-ue-id", uint32(ack.MMEUES1APID)))
-		m.releaseHandoverTarget(ctx, conn, ack.MMEUES1APID, ack.ENBUES1APID)
+			zap.Uint32("target-mme-ue-id", uint32(ack.MMEUES1APID)))
+		m.sendUEContextRelease(ctx, conn, ack.MMEUES1APID, ack.ENBUES1APID)
 
 		return
 	}
 
-	ho.targetENBUEID = ack.ENBUES1APID
+	ho.target.ENBUES1APID = ack.ENBUES1APID
 	m.mu.Unlock()
 
 	admitted := make([]admittedERAB, 0, len(ack.ERABAdmitted))
@@ -231,7 +221,7 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 		addr, ok := enbTransportAddress(it.TransportLayerAddress)
 		if !ok {
 			logger.MmeLog.Warn("Handover Request Acknowledge E-RAB has an invalid target address; treating as failed",
-				zap.Uint32("mme-ue-id", uint32(ack.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(it.ERABID)))
+				zap.Uint32("target-mme-ue-id", uint32(ack.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(it.ERABID)))
 
 			continue
 		}
@@ -246,15 +236,15 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 	if len(admitted) == 0 {
 		// No default bearer admitted: the handover is rejected (TS 23.401 §5.5.1.2.3).
 		logger.MmeLog.Warn("Handover Request Acknowledge admitted no E-RAB; rejecting handover",
-			zap.Uint32("mme-ue-id", uint32(ack.MMEUES1APID)))
-		m.releaseHandoverTarget(ctx, conn, ack.MMEUES1APID, ack.ENBUES1APID)
+			zap.Uint32("target-mme-ue-id", uint32(ack.MMEUES1APID)))
+		m.sendUEContextRelease(ctx, conn, ack.MMEUES1APID, ack.ENBUES1APID)
 		m.failHandoverToSource(ctx, ue, causeHOFailureInTarget)
 
 		return
 	}
 
 	m.mu.Lock()
-	if ue.s1.handover != ho || ho.state != hoPreparing {
+	if ue.handover != ho || ho.state != hoPreparing {
 		m.mu.Unlock()
 		return
 	}
@@ -262,13 +252,14 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 	ho.admitted = admitted
 	ho.releaseEBIs = releaseEBIs
 	ho.state = hoPrepared
-	sourceConn, sourceENBUEID := ho.sourceConn, ho.sourceENBUEID
-	mmeUEID := ue.s1.MMEUES1APID
+	sourceConn := ho.source.conn
+	sourceMMEID := ho.source.MMEUES1APID
+	sourceENBID := ho.source.ENBUES1APID
 	m.mu.Unlock()
 
 	cmd := &s1ap.HandoverCommand{
-		MMEUES1APID:    mmeUEID,
-		ENBUES1APID:    sourceENBUEID,
+		MMEUES1APID:    sourceMMEID,
+		ENBUES1APID:    sourceENBID,
 		HandoverType:   s1ap.HandoverTypeIntraLTE,
 		ERABToRelease:  releaseItems(releaseEBIs),
 		TargetToSource: ack.TargetToSource,
@@ -281,7 +272,7 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 	}
 
 	logger.MmeLog.Info("Handover Command",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)),
+		zap.Uint32("mme-ue-id", uint32(sourceMMEID)),
 		zap.Int("admitted", len(admitted)),
 		zap.Int("released", len(releaseEBIs)))
 	m.sendS1APConn(ctx, sourceConn, S1APProcedureHandoverCommand, b)
@@ -289,6 +280,7 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 
 // handleHandoverFailure fails the preparation toward the source when the target
 // could not admit the handover, leaving the UE on the source (TS 36.413 §8.4.2.3).
+// conn is the target; the failure carries the target's MME-UE-S1AP-ID.
 func (m *MME) handleHandoverFailure(ctx context.Context, conn nasWriter, value []byte) {
 	fail, err := s1ap.ParseHandoverFailure(value)
 	if err != nil {
@@ -302,21 +294,21 @@ func (m *MME) handleHandoverFailure(ctx context.Context, conn nasWriter, value [
 	}
 
 	m.mu.Lock()
-	ho := ue.s1.handover
+	ho := ue.handover
 
-	if ho == nil || ho.target != conn {
+	if ho == nil || ho.target.MMEUES1APID != fail.MMEUES1APID || ho.target.conn != conn {
 		m.mu.Unlock()
 		return
 	}
 	m.mu.Unlock()
 
-	logger.MmeLog.Info("Handover Failure", zap.Uint32("mme-ue-id", uint32(fail.MMEUES1APID)))
+	logger.MmeLog.Info("Handover Failure", zap.Uint32("target-mme-ue-id", uint32(fail.MMEUES1APID)))
 	m.failHandoverToSource(ctx, ue, causeHOFailureInTarget)
 }
 
 // handleENBStatusTransfer relays the source's status container to the target as an
 // MME STATUS TRANSFER (TS 36.413 §8.4.6/§8.4.7). Optional: the source may omit it,
-// so it never gates completion.
+// so it never gates completion. conn is the source.
 func (m *MME) handleENBStatusTransfer(ctx context.Context, conn nasWriter, value []byte) {
 	st, err := s1ap.ParseENBStatusTransfer(value)
 	if err != nil {
@@ -330,20 +322,21 @@ func (m *MME) handleENBStatusTransfer(ctx context.Context, conn nasWriter, value
 	}
 
 	m.mu.Lock()
-	ho := ue.s1.handover
+	ho := ue.handover
 
-	if ho == nil || ho.target == nil {
+	if ho == nil {
 		m.mu.Unlock()
 		logger.MmeLog.Warn("eNB Status Transfer with no handover in progress", zap.Uint32("mme-ue-id", uint32(st.MMEUES1APID)))
 
 		return
 	}
 
-	target, targetENBUEID := ho.target, ho.targetENBUEID
-	mmeUEID := ue.s1.MMEUES1APID
+	targetConn := ho.target.conn
+	targetMMEID := ho.target.MMEUES1APID
+	targetENBID := ho.target.ENBUES1APID
 	m.mu.Unlock()
 
-	mst := &s1ap.MMEStatusTransfer{MMEUES1APID: mmeUEID, ENBUES1APID: targetENBUEID, Container: st.Container}
+	mst := &s1ap.MMEStatusTransfer{MMEUES1APID: targetMMEID, ENBUES1APID: targetENBID, Container: st.Container}
 
 	b, err := mst.Marshal()
 	if err != nil {
@@ -351,12 +344,13 @@ func (m *MME) handleENBStatusTransfer(ctx context.Context, conn nasWriter, value
 		return
 	}
 
-	m.sendS1APConn(ctx, target, S1APProcedureMMEStatusTransfer, b)
+	m.sendS1APConn(ctx, targetConn, S1APProcedureMMEStatusTransfer, b)
 }
 
 // handleHandoverNotify completes the handover once the UE reaches the target: it
-// switches the user plane, commits the {NH, NCC} chain, moves the S1 association,
-// and releases the source (TS 36.413 §8.4.3, TS 23.401 §5.5.1.2.2 steps 13-19).
+// switches the user plane, commits the {NH, NCC} chain, moves the active S1
+// connection to the target, and releases the source by its own MME-UE-S1AP-ID
+// (TS 36.413 §8.4.3, TS 23.401 §5.5.1.2.2 steps 13-19). conn is the target.
 func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []byte) {
 	notify, err := s1ap.ParseHandoverNotify(value)
 	if err != nil {
@@ -370,11 +364,11 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 	}
 
 	m.mu.Lock()
-	ho := ue.s1.handover
+	ho := ue.handover
 
-	if ho == nil || ho.state != hoPrepared || ho.target != conn || ho.targetENBUEID != notify.ENBUES1APID {
+	if ho == nil || ho.state != hoPrepared || ho.target.conn != conn || ho.target.ENBUES1APID != notify.ENBUES1APID {
 		m.mu.Unlock()
-		logger.MmeLog.Warn("Handover Notify with no matching prepared handover", zap.Uint32("mme-ue-id", uint32(notify.MMEUES1APID)))
+		logger.MmeLog.Warn("Handover Notify with no matching prepared handover", zap.Uint32("target-mme-ue-id", uint32(notify.MMEUES1APID)))
 
 		return
 	}
@@ -382,10 +376,12 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 	// Committing locks out a concurrent CANCEL or the guard timer while the
 	// user-plane switch I/O runs outside the lock.
 	ho.state = hoCommitting
+	admitted := ho.admitted
+	releaseEBIs := ho.releaseEBIs
 	m.mu.Unlock()
 
 	// Switch the downlink only at notify (TS 23.401 §5.5.1.2.2 step 15).
-	for _, a := range ho.admitted {
+	for _, a := range admitted {
 		p := m.lookupPDN(ue, a.ebi)
 		if p == nil {
 			continue
@@ -404,7 +400,7 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 	}
 
 	// Release the PDN connections whose default bearer the target rejected.
-	for _, ebi := range ho.releaseEBIs {
+	for _, ebi := range releaseEBIs {
 		if err := m.session.ReleaseEPSSession(ctx, ue.imsi, ebi); err != nil {
 			logger.MmeLog.Error("failed to release a rejected PDN connection after handover",
 				zap.String("imsi", ue.imsi), zap.Uint8("e-rab-id", ebi), zap.Error(err))
@@ -413,17 +409,16 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 		m.dropPDN(ue, ebi)
 	}
 
-	m.ensureDefaultPDN(ue, ho.admitted)
+	m.ensureDefaultPDN(ue, admitted)
 
 	m.mu.Lock()
-	source := srcReleaseKey{conn: ho.sourceConn, enbUEID: ho.sourceENBUEID}
+	source := ho.source
 	ue.nh = ho.newNH
 	ue.ncc = ho.newNCC
-	ue.s1.conn = conn
-	ue.s1.ENBUES1APID = notify.ENBUES1APID
+	ue.s1 = ho.target // the target becomes the UE's active connection
+	source.ue = nil   // detach the source; its Release Complete removes the connection
 	m.clearHandoverLocked(ue)
-	m.handoverSrcReleases[source] = struct{}{}
-	mmeUEID := ue.s1.MMEUES1APID
+	targetMMEID := ue.s1.MMEUES1APID
 	m.mu.Unlock()
 
 	if notify.TAI.TAC != 0 {
@@ -431,10 +426,10 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 	}
 
 	logger.MmeLog.Info("Handover Notify",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)),
+		zap.Uint32("target-mme-ue-id", uint32(targetMMEID)),
 		zap.Uint32("target-enb-ue-id", uint32(notify.ENBUES1APID)))
 
-	m.sendSourceRelease(ctx, source, mmeUEID)
+	m.sendUEContextRelease(ctx, source.conn, source.MMEUES1APID, source.ENBUES1APID)
 }
 
 // handleHandoverCancel releases any prepared target resources and acknowledges,
@@ -453,13 +448,9 @@ func (m *MME) handleHandoverCancel(ctx context.Context, conn nasWriter, value []
 
 	m.mu.Lock()
 
-	var (
-		target        nasWriter
-		targetENBUEID s1ap.ENBUES1APID
-		hadTarget     bool
-	)
+	var releaseTarget *s1Conn
 
-	ho := ue.s1.handover
+	ho := ue.handover
 	switch {
 	case ho == nil:
 		// Nothing to cancel; still acknowledge below (TS 36.413 §8.4.5.4).
@@ -467,15 +458,15 @@ func (m *MME) handleHandoverCancel(ctx context.Context, conn nasWriter, value []
 		// Too late to cancel: acknowledge but let the in-flight move finish.
 	default:
 		if ho.state == hoPrepared {
-			target, targetENBUEID, hadTarget = ho.target, ho.targetENBUEID, true
+			releaseTarget = ho.target
 		}
 
 		m.clearHandoverLocked(ue)
 	}
 	m.mu.Unlock()
 
-	if hadTarget {
-		m.releaseHandoverTarget(ctx, target, cancel.MMEUES1APID, targetENBUEID)
+	if releaseTarget != nil {
+		m.sendUEContextRelease(ctx, releaseTarget.conn, releaseTarget.MMEUES1APID, releaseTarget.ENBUES1APID)
 	}
 
 	ack := &s1ap.HandoverCancelAcknowledge{MMEUES1APID: cancel.MMEUES1APID, ENBUES1APID: cancel.ENBUES1APID}
@@ -491,22 +482,25 @@ func (m *MME) handleHandoverCancel(ctx context.Context, conn nasWriter, value []
 }
 
 // failHandoverToSource clears the handover and sends a HANDOVER PREPARATION
-// FAILURE to the source eNB, leaving the UE on the source association.
+// FAILURE to the source eNB, leaving the UE on the source association. The target
+// connection allocated for the preparation is dropped by clearHandoverLocked.
 func (m *MME) failHandoverToSource(ctx context.Context, ue *UeContext, cause s1ap.Cause) {
 	m.mu.Lock()
-	ho := ue.s1.handover
+	ho := ue.handover
 
 	if ho == nil {
 		m.mu.Unlock()
 		return
 	}
 
-	sourceConn, sourceENBUEID := ho.sourceConn, ho.sourceENBUEID
-	mmeUEID := ue.s1.MMEUES1APID
+	sourceConn := ho.source.conn
+	sourceMMEID := ho.source.MMEUES1APID
+	sourceENBID := ho.source.ENBUES1APID
+
 	m.clearHandoverLocked(ue)
 	m.mu.Unlock()
 
-	m.sendHandoverPreparationFailure(ctx, sourceConn, mmeUEID, sourceENBUEID, cause)
+	m.sendHandoverPreparationFailure(ctx, sourceConn, sourceMMEID, sourceENBID, cause)
 }
 
 // sendHandoverPreparationFailure sends a HANDOVER PREPARATION FAILURE on the
@@ -523,16 +517,11 @@ func (m *MME) sendHandoverPreparationFailure(ctx context.Context, conn nasWriter
 	m.sendS1APConn(ctx, conn, S1APProcedureHandoverPreparationFailure, b)
 }
 
-// releaseHandoverTarget releases a target eNB's half-prepared UE context with a
-// UE Context Release Command (TS 36.413), tracking the release so its Complete is
-// consumed cleanly.
-func (m *MME) releaseHandoverTarget(ctx context.Context, conn nasWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) {
-	key := srcReleaseKey{conn: conn, enbUEID: enbUEID}
-
-	m.mu.Lock()
-	m.handoverSrcReleases[key] = struct{}{}
-	m.mu.Unlock()
-
+// sendUEContextRelease sends a UE Context Release Command for a handover
+// association by its own MME-UE-S1AP-ID (TS 36.413 §8.4): the source after notify,
+// or a rejected/superseded target. The connection is removed when its Release
+// Complete arrives (releaseDetachedConn) or when its association drops.
+func (m *MME) sendUEContextRelease(ctx context.Context, conn nasWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) {
 	cmd := &s1ap.UEContextReleaseCommand{
 		UES1APIDs: s1ap.UES1APIDs{MMEUES1APID: mmeUEID, ENBUES1APID: enbUEID, Pair: true},
 		Cause:     causeSuccessfulHandover,
@@ -540,62 +529,54 @@ func (m *MME) releaseHandoverTarget(ctx context.Context, conn nasWriter, mmeUEID
 
 	b, err := cmd.Marshal()
 	if err != nil {
-		logger.MmeLog.Error("failed to marshal target UE Context Release Command", zap.Error(err))
+		logger.MmeLog.Error("failed to marshal handover UE Context Release Command", zap.Error(err))
 		return
 	}
 
+	logger.MmeLog.Info("UE Context Release Command (handover)", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
 	m.sendS1APConn(ctx, conn, S1APProcedureUEContextReleaseCommand, b)
 }
 
-// sendSourceRelease sends the source eNB its UE Context Release Command after a
-// completed handover (TS 23.401 §5.5.1.2.2 step 19).
-func (m *MME) sendSourceRelease(ctx context.Context, key srcReleaseKey, mmeUEID s1ap.MMEUES1APID) {
-	cmd := &s1ap.UEContextReleaseCommand{
-		UES1APIDs: s1ap.UES1APIDs{MMEUES1APID: mmeUEID, ENBUES1APID: key.enbUEID, Pair: true},
-		Cause:     causeSuccessfulHandover,
-	}
-
-	b, err := cmd.Marshal()
-	if err != nil {
-		logger.MmeLog.Error("failed to marshal source UE Context Release Command", zap.Error(err))
-		return
-	}
-
-	logger.MmeLog.Info("UE Context Release Command (handover source)", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
-	m.sendS1APConn(ctx, key.conn, S1APProcedureUEContextReleaseCommand, b)
-}
-
-// consumeHandoverRelease reports whether a UE Context Release Complete on conn for
-// enbUEID acknowledges a handover-related release the MME initiated; if so it
-// removes the tracking entry so the complete is not applied to the moved UE.
-func (m *MME) consumeHandoverRelease(conn nasWriter, enbUEID s1ap.ENBUES1APID) bool {
-	key := srcReleaseKey{conn: conn, enbUEID: enbUEID}
-
+// releaseDetachedConn removes a UE-associated connection that holds no UE context —
+// a handover source detached at HANDOVER NOTIFY, or a released target — when its UE
+// Context Release Complete arrives, identified by its own MME-UE-S1AP-ID (TS 36.413
+// §8.4). It reports whether it handled one.
+func (m *MME) releaseDetachedConn(conn nasWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.handoverSrcReleases[key]; ok {
-		delete(m.handoverSrcReleases, key)
-		return true
+	c, ok := m.conns[uint32(mmeUEID)]
+	if !ok || c.ue != nil || c.conn != conn || c.ENBUES1APID != enbUEID {
+		return false
 	}
 
-	return false
+	delete(m.conns, uint32(mmeUEID))
+
+	return true
 }
 
 // clearHandoverLocked drops the UE's in-flight handover context, stops its guard
-// timer, and bumps handoverGen so a guard callback that fired concurrently is
-// recognised as stale. The caller holds MME.mu.
+// timer, and removes the target connection it allocated — unless the handover
+// completed and the UE moved onto the target (ue.s1). It bumps handoverGen so a
+// guard callback that fired concurrently is recognised as stale. The caller holds
+// MME.mu.
 func (m *MME) clearHandoverLocked(ue *UeContext) {
-	if ue.s1.handover == nil {
+	ho := ue.handover
+	if ho == nil {
 		return
 	}
 
-	if ue.s1.handover.guardTimer != nil {
-		ue.s1.handover.guardTimer.Stop()
+	if ho.guardTimer != nil {
+		ho.guardTimer.Stop()
 	}
 
-	ue.s1.handover = nil
-	ue.s1.handoverGen++
+	if ho.target != nil && ho.target != ue.s1 {
+		ho.target.ue = nil
+		delete(m.conns, uint32(ho.target.MMEUES1APID))
+	}
+
+	ue.handover = nil
+	ue.handoverGen++
 	ue.keyChainBusy = false
 }
 
@@ -607,61 +588,34 @@ func (m *MME) clearHandover(ue *UeContext) {
 }
 
 // onHandoverGuardExpiry abandons a handover whose target never completed it
-// (TS 36.413 §8.4): the UE stays on the source eNB and any prepared target
-// resources are released. gen guards against a callback that fired just as the
-// handover was cleared or replaced. A handover already committing (the UE has
-// reached the target) is left to finish.
+// (TS 36.413 §8.4): the UE stays on the source eNB and a prepared target's resources
+// are released. gen guards against a callback that fired just as the handover was
+// cleared or replaced. A handover already committing (the UE has reached the
+// target) is left to finish.
 func (m *MME) onHandoverGuardExpiry(ue *UeContext, gen uint64) {
 	m.mu.Lock()
 
-	if ue.s1 == nil {
+	ho := ue.handover
+	if ho == nil || ue.handoverGen != gen || ho.state == hoCommitting {
 		m.mu.Unlock()
 		return
 	}
 
-	ho := ue.s1.handover
-	if ho == nil || ue.s1.handoverGen != gen || ho.state == hoCommitting {
-		m.mu.Unlock()
-		return
+	var releaseTarget *s1Conn
+	if ho.state == hoPrepared {
+		releaseTarget = ho.target
 	}
 
-	target, targetENBUEID, prepared := ho.target, ho.targetENBUEID, ho.state == hoPrepared
-	mmeUEID := ue.s1.MMEUES1APID
+	sourceMMEID := ho.source.MMEUES1APID
+
 	m.clearHandoverLocked(ue)
 	m.mu.Unlock()
 
 	logger.MmeLog.Warn("S1 handover abandoned: target did not complete it in time",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)))
+		zap.Uint32("mme-ue-id", uint32(sourceMMEID)))
 
-	// A still-preparing target's later acknowledge self-releases on finding no
-	// matching preparation; only a prepared target needs an explicit release.
-	if prepared && target != nil {
-		m.releaseHandoverTarget(context.Background(), target, mmeUEID, targetENBUEID)
-	}
-}
-
-// abortHandoversOnConnLoss clears any in-flight handover that referenced a dropped
-// eNB association, so the context does not leak when an SCTP association closes
-// mid-handover.
-func (m *MME) abortHandoversOnConnLoss(conn nasWriter) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for k := range m.handoverSrcReleases {
-		if k.conn == conn {
-			delete(m.handoverSrcReleases, k)
-		}
-	}
-
-	for _, c := range m.conns {
-		ue := c.ue
-		if ue == nil {
-			continue
-		}
-
-		if ho := ue.s1.handover; ho != nil && (ho.sourceConn == conn || ho.target == conn) {
-			m.clearHandoverLocked(ue)
-		}
+	if releaseTarget != nil {
+		m.sendUEContextRelease(context.Background(), releaseTarget.conn, releaseTarget.MMEUES1APID, releaseTarget.ENBUES1APID)
 	}
 }
 

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -131,9 +131,9 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 	// The {NH, NCC} chain is read and advanced under the lock so it cannot race the
 	// commit at notify; it is committed to the UE only at notify (TS 33.401 §7.2.8).
 	m.mu.Lock()
-	if ue.s1.handover != nil {
+	if ue.keyChainBusy {
 		m.mu.Unlock()
-		logger.MmeLog.Warn("Handover Required while a handover is already in progress",
+		logger.MmeLog.Warn("Handover Required while the key chain is being advanced",
 			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)))
 		m.sendHandoverPreparationFailure(ctx, conn, req.MMEUES1APID, req.ENBUES1APID, causeHandoverPrepUnspecific)
 
@@ -162,6 +162,7 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 	}
 	ho.guardTimer = time.AfterFunc(m.handoverGuardTimeout, func() { m.onHandoverGuardExpiry(ue, gen) })
 	ue.s1.handover = ho
+	ue.keyChainBusy = true
 	mmeUEID := ue.s1.MMEUES1APID
 	m.mu.Unlock()
 
@@ -595,6 +596,7 @@ func (m *MME) clearHandoverLocked(ue *UeContext) {
 
 	ue.s1.handover = nil
 	ue.s1.handoverGen++
+	ue.keyChainBusy = false
 }
 
 // clearHandover drops the UE's in-flight handover context under MME.mu.

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -131,7 +131,7 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 	// The {NH, NCC} chain is read and advanced under the lock so it cannot race the
 	// commit at notify; it is committed to the UE only at notify (TS 33.401 §7.2.8).
 	m.mu.Lock()
-	if ue.handover != nil {
+	if ue.s1.handover != nil {
 		m.mu.Unlock()
 		logger.MmeLog.Warn("Handover Required while a handover is already in progress",
 			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)))
@@ -151,7 +151,7 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 
 	newNCC := (ue.ncc + 1) & 0x07
 
-	gen := ue.handoverGen
+	gen := ue.s1.handoverGen
 	ho := &handoverContext{
 		state:         hoPreparing,
 		sourceConn:    conn,
@@ -161,8 +161,8 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 		newNCC:        newNCC,
 	}
 	ho.guardTimer = time.AfterFunc(m.handoverGuardTimeout, func() { m.onHandoverGuardExpiry(ue, gen) })
-	ue.handover = ho
-	mmeUEID := ue.MMEUES1APID
+	ue.s1.handover = ho
+	mmeUEID := ue.s1.MMEUES1APID
 	m.mu.Unlock()
 
 	hoReq := &s1ap.HandoverRequest{
@@ -210,7 +210,7 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 	}
 
 	m.mu.Lock()
-	ho := ue.handover
+	ho := ue.s1.handover
 
 	if ho == nil || ho.state != hoPreparing || ho.target != conn {
 		m.mu.Unlock()
@@ -253,7 +253,7 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 	}
 
 	m.mu.Lock()
-	if ue.handover != ho || ho.state != hoPreparing {
+	if ue.s1.handover != ho || ho.state != hoPreparing {
 		m.mu.Unlock()
 		return
 	}
@@ -262,7 +262,7 @@ func (m *MME) handleHandoverRequestAcknowledge(ctx context.Context, conn nasWrit
 	ho.releaseEBIs = releaseEBIs
 	ho.state = hoPrepared
 	sourceConn, sourceENBUEID := ho.sourceConn, ho.sourceENBUEID
-	mmeUEID := ue.MMEUES1APID
+	mmeUEID := ue.s1.MMEUES1APID
 	m.mu.Unlock()
 
 	cmd := &s1ap.HandoverCommand{
@@ -301,7 +301,7 @@ func (m *MME) handleHandoverFailure(ctx context.Context, conn nasWriter, value [
 	}
 
 	m.mu.Lock()
-	ho := ue.handover
+	ho := ue.s1.handover
 
 	if ho == nil || ho.target != conn {
 		m.mu.Unlock()
@@ -329,7 +329,7 @@ func (m *MME) handleENBStatusTransfer(ctx context.Context, conn nasWriter, value
 	}
 
 	m.mu.Lock()
-	ho := ue.handover
+	ho := ue.s1.handover
 
 	if ho == nil || ho.target == nil {
 		m.mu.Unlock()
@@ -339,7 +339,7 @@ func (m *MME) handleENBStatusTransfer(ctx context.Context, conn nasWriter, value
 	}
 
 	target, targetENBUEID := ho.target, ho.targetENBUEID
-	mmeUEID := ue.MMEUES1APID
+	mmeUEID := ue.s1.MMEUES1APID
 	m.mu.Unlock()
 
 	mst := &s1ap.MMEStatusTransfer{MMEUES1APID: mmeUEID, ENBUES1APID: targetENBUEID, Container: st.Container}
@@ -369,7 +369,7 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 	}
 
 	m.mu.Lock()
-	ho := ue.handover
+	ho := ue.s1.handover
 
 	if ho == nil || ho.state != hoPrepared || ho.target != conn || ho.targetENBUEID != notify.ENBUES1APID {
 		m.mu.Unlock()
@@ -418,11 +418,11 @@ func (m *MME) handleHandoverNotify(ctx context.Context, conn nasWriter, value []
 	source := srcReleaseKey{conn: ho.sourceConn, enbUEID: ho.sourceENBUEID}
 	ue.nh = ho.newNH
 	ue.ncc = ho.newNCC
-	ue.conn = conn
-	ue.ENBUES1APID = notify.ENBUES1APID
+	ue.s1.conn = conn
+	ue.s1.ENBUES1APID = notify.ENBUES1APID
 	m.clearHandoverLocked(ue)
 	m.handoverSrcReleases[source] = struct{}{}
-	mmeUEID := ue.MMEUES1APID
+	mmeUEID := ue.s1.MMEUES1APID
 	m.mu.Unlock()
 
 	if notify.TAI.TAC != 0 {
@@ -458,7 +458,7 @@ func (m *MME) handleHandoverCancel(ctx context.Context, conn nasWriter, value []
 		hadTarget     bool
 	)
 
-	ho := ue.handover
+	ho := ue.s1.handover
 	switch {
 	case ho == nil:
 		// Nothing to cancel; still acknowledge below (TS 36.413 §8.4.5.4).
@@ -493,7 +493,7 @@ func (m *MME) handleHandoverCancel(ctx context.Context, conn nasWriter, value []
 // FAILURE to the source eNB, leaving the UE on the source association.
 func (m *MME) failHandoverToSource(ctx context.Context, ue *UeContext, cause s1ap.Cause) {
 	m.mu.Lock()
-	ho := ue.handover
+	ho := ue.s1.handover
 
 	if ho == nil {
 		m.mu.Unlock()
@@ -501,7 +501,7 @@ func (m *MME) failHandoverToSource(ctx context.Context, ue *UeContext, cause s1a
 	}
 
 	sourceConn, sourceENBUEID := ho.sourceConn, ho.sourceENBUEID
-	mmeUEID := ue.MMEUES1APID
+	mmeUEID := ue.s1.MMEUES1APID
 	m.clearHandoverLocked(ue)
 	m.mu.Unlock()
 
@@ -585,16 +585,16 @@ func (m *MME) consumeHandoverRelease(conn nasWriter, enbUEID s1ap.ENBUES1APID) b
 // timer, and bumps handoverGen so a guard callback that fired concurrently is
 // recognised as stale. The caller holds MME.mu.
 func (m *MME) clearHandoverLocked(ue *UeContext) {
-	if ue.handover == nil {
+	if ue.s1.handover == nil {
 		return
 	}
 
-	if ue.handover.guardTimer != nil {
-		ue.handover.guardTimer.Stop()
+	if ue.s1.handover.guardTimer != nil {
+		ue.s1.handover.guardTimer.Stop()
 	}
 
-	ue.handover = nil
-	ue.handoverGen++
+	ue.s1.handover = nil
+	ue.s1.handoverGen++
 }
 
 // clearHandover drops the UE's in-flight handover context under MME.mu.
@@ -612,14 +612,14 @@ func (m *MME) clearHandover(ue *UeContext) {
 func (m *MME) onHandoverGuardExpiry(ue *UeContext, gen uint64) {
 	m.mu.Lock()
 
-	ho := ue.handover
-	if ho == nil || ue.handoverGen != gen || ho.state == hoCommitting {
+	ho := ue.s1.handover
+	if ho == nil || ue.s1.handoverGen != gen || ho.state == hoCommitting {
 		m.mu.Unlock()
 		return
 	}
 
 	target, targetENBUEID, prepared := ho.target, ho.targetENBUEID, ho.state == hoPrepared
-	mmeUEID := ue.MMEUES1APID
+	mmeUEID := ue.s1.MMEUES1APID
 	m.clearHandoverLocked(ue)
 	m.mu.Unlock()
 
@@ -640,7 +640,7 @@ func (m *MME) handoverInProgress(ue *UeContext) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return ue.handover != nil
+	return ue.s1.handover != nil
 }
 
 // abortHandoversOnConnLoss clears any in-flight handover that referenced a dropped
@@ -662,7 +662,7 @@ func (m *MME) abortHandoversOnConnLoss(conn nasWriter) {
 			continue
 		}
 
-		if ho := ue.handover; ho != nil && (ho.sourceConn == conn || ho.target == conn) {
+		if ho := ue.s1.handover; ho != nil && (ho.sourceConn == conn || ho.target == conn) {
 			m.clearHandoverLocked(ue)
 		}
 	}

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -127,19 +127,9 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 		return
 	}
 
-	// Advance the {NH, NCC} for the target before any commitment; the chain is
-	// committed only at notify (TS 33.401 §7.2.8).
-	newNH, err := deriveNH(ue.kasme, ue.nh[:])
-	if err != nil {
-		logger.MmeLog.Error("failed to advance NH for handover", zap.Error(err))
-		m.sendHandoverPreparationFailure(ctx, conn, req.MMEUES1APID, req.ENBUES1APID, causeHandoverPrepUnspecific)
-
-		return
-	}
-
-	newNCC := (ue.ncc + 1) & 0x07
-
 	// Only one handover preparation may be ongoing for a UE (TS 36.413 §8.4.1.1).
+	// The {NH, NCC} chain is read and advanced under the lock so it cannot race the
+	// commit at notify; it is committed to the UE only at notify (TS 33.401 §7.2.8).
 	m.mu.Lock()
 	if ue.handover != nil {
 		m.mu.Unlock()
@@ -149,6 +139,17 @@ func (m *MME) handleHandoverRequired(ctx context.Context, conn nasWriter, value 
 
 		return
 	}
+
+	newNH, err := deriveNH(ue.kasme, ue.nh[:])
+	if err != nil {
+		m.mu.Unlock()
+		logger.MmeLog.Error("failed to advance NH for handover", zap.Error(err))
+		m.sendHandoverPreparationFailure(ctx, conn, req.MMEUES1APID, req.ENBUES1APID, causeHandoverPrepUnspecific)
+
+		return
+	}
+
+	newNCC := (ue.ncc + 1) & 0x07
 
 	gen := ue.handoverGen
 	ho := &handoverContext{

--- a/internal/mme/handover_test.go
+++ b/internal/mme/handover_test.go
@@ -119,9 +119,29 @@ func lastPDU(t *testing.T, cc *captureConn) s1ap.PDU {
 	return pdu
 }
 
+// targetMMEUEID reads the MME-UE-S1AP-ID the MME assigned to the target connection
+// from the HANDOVER REQUEST it sent — the target's own id, distinct from the
+// source's (TS 36.413).
+func targetMMEUEID(t *testing.T, target *captureConn) s1ap.MMEUES1APID {
+	t.Helper()
+
+	req, ok := lastPDU(t, target).(*s1ap.InitiatingMessage)
+	if !ok || req.ProcedureCode != s1ap.ProcHandoverResourceAllocation {
+		t.Fatalf("expected HANDOVER REQUEST to target, got %T", lastPDU(t, target))
+	}
+
+	hoReq, err := s1ap.ParseHandoverRequest(req.Value)
+	if err != nil {
+		t.Fatalf("parse HANDOVER REQUEST: %v", err)
+	}
+
+	return hoReq.MMEUES1APID
+}
+
 // driveToPrepared runs HANDOVER REQUIRED then HANDOVER REQUEST ACKNOWLEDGE so the
-// handover reaches the prepared state, returning the target eNB-UE-S1AP-ID used.
-func driveToPrepared(t *testing.T, m *MME, ue *UeContext, source, target *captureConn) s1ap.ENBUES1APID {
+// handover reaches the prepared state, returning the target's MME-UE-S1AP-ID and
+// eNB-UE-S1AP-ID.
+func driveToPrepared(t *testing.T, m *MME, ue *UeContext, source, target *captureConn) (s1ap.MMEUES1APID, s1ap.ENBUES1APID) {
 	t.Helper()
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
@@ -130,10 +150,12 @@ func driveToPrepared(t *testing.T, m *MME, ue *UeContext, source, target *captur
 		t.Fatalf("expected one HANDOVER REQUEST to the target, got %d", target.count())
 	}
 
+	targetMME := targetMMEUEID(t, target)
+
 	const targetENBUEID s1ap.ENBUES1APID = 55
 
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.s1.MMEUES1APID,
+		MMEUES1APID: targetMME,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                s1ap.ERABID(defaultERABID),
@@ -145,7 +167,7 @@ func driveToPrepared(t *testing.T, m *MME, ue *UeContext, source, target *captur
 
 	m.handleHandoverRequestAcknowledge(context.Background(), target, successfulValue(t, mustMarshal(t, ack.Marshal)))
 
-	return targetENBUEID
+	return targetMME, targetENBUEID
 }
 
 // TestHandoverHappyPath drives the full S1 handover: REQUIRED → REQUEST →
@@ -156,12 +178,16 @@ func TestHandoverHappyPath(t *testing.T) {
 	m := newTestMME(t)
 	ue, source, target := handoverUE(t, m)
 
+	sourceMME := ue.s1.MMEUES1APID
+	sourceENB := ue.s1.ENBUES1APID
+
 	wantNH, err := deriveNH(ue.kasme, ue.nh[:])
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// HANDOVER REQUIRED → HANDOVER REQUEST to the target.
+	// HANDOVER REQUIRED → HANDOVER REQUEST to the target, carrying the target's own
+	// fresh MME-UE-S1AP-ID.
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
 	req, ok := lastPDU(t, target).(*s1ap.InitiatingMessage)
@@ -174,9 +200,11 @@ func TestHandoverHappyPath(t *testing.T) {
 		t.Fatalf("parse HANDOVER REQUEST: %v", err)
 	}
 
-	if hoReq.MMEUES1APID != ue.s1.MMEUES1APID || len(hoReq.ERABToBeSetup) != 1 ||
+	targetMME := hoReq.MMEUES1APID
+
+	if targetMME == sourceMME || len(hoReq.ERABToBeSetup) != 1 ||
 		hoReq.ERABToBeSetup[0].GTPTEID != 0x1111 || hoReq.SecurityContext.NextHopChainingCount != 2 {
-		t.Fatalf("HANDOVER REQUEST = %+v", hoReq)
+		t.Fatalf("HANDOVER REQUEST = %+v (source-mme-id %d)", hoReq, sourceMME)
 	}
 
 	if s1ap.SecurityKey(wantNH) != hoReq.SecurityContext.NextHopParameter {
@@ -188,11 +216,11 @@ func TestHandoverHappyPath(t *testing.T) {
 		t.Fatalf("user plane switched during preparation: %+v", fsm.modifiedENB)
 	}
 
-	// HANDOVER REQUEST ACKNOWLEDGE → HANDOVER COMMAND to the source.
+	// HANDOVER REQUEST ACKNOWLEDGE (target id) → HANDOVER COMMAND to the source.
 	const targetENBUEID s1ap.ENBUES1APID = 55
 
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.s1.MMEUES1APID,
+		MMEUES1APID: targetMME,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                s1ap.ERABID(defaultERABID),
@@ -209,13 +237,17 @@ func TestHandoverHappyPath(t *testing.T) {
 		t.Fatalf("expected HANDOVER COMMAND to source, got %T", lastPDU(t, source))
 	}
 
+	if hoCmd, err := s1ap.ParseHandoverCommand(cmd.Value); err != nil || hoCmd.MMEUES1APID != sourceMME || hoCmd.ENBUES1APID != sourceENB {
+		t.Fatalf("HANDOVER COMMAND addressed wrong source: %+v err %v", hoCmd, err)
+	}
+
 	// Still no user-plane switch before notify.
 	if fsm := m.session.(*fakeSessionManager); fsm.modifiedENB != (models.FTEID{}) {
 		t.Fatalf("user plane switched before notify: %+v", fsm.modifiedENB)
 	}
 
-	// eNB STATUS TRANSFER → MME STATUS TRANSFER to the target.
-	st := &s1ap.ENBStatusTransfer{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID, Container: s1ap.StatusTransferContainer{0xde, 0xad}}
+	// eNB STATUS TRANSFER (source id) → MME STATUS TRANSFER (target id) to the target.
+	st := &s1ap.ENBStatusTransfer{MMEUES1APID: sourceMME, ENBUES1APID: sourceENB, Container: s1ap.StatusTransferContainer{0xde, 0xad}}
 	m.handleENBStatusTransfer(context.Background(), source, initiatingValue(t, mustMarshal(t, st.Marshal)))
 
 	mst, ok := lastPDU(t, target).(*s1ap.InitiatingMessage)
@@ -224,13 +256,13 @@ func TestHandoverHappyPath(t *testing.T) {
 	}
 
 	parsedMST, err := s1ap.ParseMMEStatusTransfer(mst.Value)
-	if err != nil || parsedMST.ENBUES1APID != targetENBUEID {
+	if err != nil || parsedMST.MMEUES1APID != targetMME || parsedMST.ENBUES1APID != targetENBUEID {
 		t.Fatalf("MME STATUS TRANSFER = %+v, err %v", parsedMST, err)
 	}
 
-	// HANDOVER NOTIFY → user-plane switch, association move, source release.
+	// HANDOVER NOTIFY (target id) → user-plane switch, association move, source release.
 	notify := &s1ap.HandoverNotify{
-		MMEUES1APID: ue.s1.MMEUES1APID,
+		MMEUES1APID: targetMME,
 		ENBUES1APID: targetENBUEID,
 		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
 		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
@@ -242,30 +274,41 @@ func TestHandoverHappyPath(t *testing.T) {
 		t.Fatalf("ModifyEPSSession eNB F-TEID = %+v, want %+v", fsm.modifiedENB, wantFTEID)
 	}
 
-	if ue.s1.conn != target || ue.s1.ENBUES1APID != targetENBUEID || testPDN(ue).enbFTEID != wantFTEID {
-		t.Fatalf("association not moved: conn=%v enb-id=%d", ue.s1.conn == target, ue.s1.ENBUES1APID)
+	// The UE's active connection is now the target connection (its own id).
+	if ue.s1.conn != target || ue.s1.MMEUES1APID != targetMME || ue.s1.ENBUES1APID != targetENBUEID || testPDN(ue).enbFTEID != wantFTEID {
+		t.Fatalf("association not moved to the target connection: conn=%v mme-id=%d enb-id=%d", ue.s1.conn == target, ue.s1.MMEUES1APID, ue.s1.ENBUES1APID)
 	}
 
 	if ue.ncc != 2 || ue.nh != wantNH {
 		t.Fatalf("key chain not committed: ncc=%d nh-match=%v", ue.ncc, ue.nh == wantNH)
 	}
 
-	if ue.s1.handover != nil {
+	if ue.handover != nil {
 		t.Fatal("handover context not cleared after notify")
 	}
 
-	// The source eNB received a UE Context Release Command.
+	// The source eNB received a UE Context Release Command addressed by the source's
+	// own id.
 	rel, ok := lastPDU(t, source).(*s1ap.InitiatingMessage)
 	if !ok || rel.ProcedureCode != s1ap.ProcUEContextRelease {
 		t.Fatalf("expected UE Context Release Command to source, got %T", lastPDU(t, source))
 	}
 
-	// Its Release Complete is consumed without disturbing the moved UE.
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID}
+	if relCmd, err := s1ap.ParseUEContextReleaseCommand(rel.Value); err != nil || relCmd.UES1APIDs.MMEUES1APID != sourceMME {
+		t.Fatalf("source release addressed wrong id: %+v err %v", relCmd, err)
+	}
+
+	// The source Release Complete (source id) removes the source connection without
+	// disturbing the moved UE, which is found under the target id.
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: sourceMME, ENBUES1APID: sourceENB}
 	m.handleUEContextReleaseComplete(source, successfulValue(t, mustMarshal(t, complete.Marshal)))
 
-	if _, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok {
-		t.Fatal("UE removed by the source Release Complete")
+	if _, ok := m.lookupUe(sourceMME); ok {
+		t.Fatal("source connection not removed by its Release Complete")
+	}
+
+	if got, ok := m.lookupUe(targetMME); !ok || got != ue {
+		t.Fatal("UE not found under the target id after the source release")
 	}
 
 	if ue.s1.conn != target {
@@ -296,7 +339,7 @@ func TestHandoverRequiredNoSecurityFails(t *testing.T) {
 		t.Fatalf("cause = %+v, want authentication-failure", fail.Cause)
 	}
 
-	if ue.s1.handover != nil {
+	if ue.handover != nil {
 		t.Fatal("handover context left set on failure")
 	}
 }
@@ -331,15 +374,15 @@ func TestHandoverConcurrentRefused(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	if ue.s1.handover == nil {
+	if ue.handover == nil {
 		t.Fatal("first handover did not start")
 	}
 
-	first := ue.s1.handover
+	first := ue.handover
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	if ue.s1.handover != first {
+	if ue.handover != first {
 		t.Fatal("second handover disturbed the in-flight one")
 	}
 
@@ -357,7 +400,7 @@ func TestPathSwitchRefusedDuringHandover(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	if ue.s1.handover == nil {
+	if ue.handover == nil {
 		t.Fatal("handover did not start")
 	}
 
@@ -389,7 +432,7 @@ func TestHandoverRefusedWhileKeyChainBusy(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	if ue.s1.handover != nil {
+	if ue.handover != nil {
 		t.Fatal("handover started while the key chain was busy")
 	}
 
@@ -412,11 +455,11 @@ func TestHandoverGuardSurvivesContextRelease(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	if ue.s1.handover == nil {
+	if ue.handover == nil {
 		t.Fatal("handover did not start")
 	}
 
-	gen := ue.s1.handoverGen
+	gen := ue.handoverGen
 
 	m.freeS1Conn(ue)
 
@@ -436,10 +479,10 @@ func TestHandoverFailureFailsToSource(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	fail := &s1ap.HandoverFailure{MMEUES1APID: ue.s1.MMEUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 12}}
+	fail := &s1ap.HandoverFailure{MMEUES1APID: targetMMEUEID(t, target), Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 12}}
 	m.handleHandoverFailure(context.Background(), target, unsuccessfulValue(t, mustMarshal(t, fail.Marshal)))
 
-	if ue.s1.handover != nil {
+	if ue.handover != nil {
 		t.Fatal("handover not cleared after failure")
 	}
 
@@ -459,12 +502,12 @@ func TestHandoverCancelReleasesTarget(t *testing.T) {
 	m := newTestMME(t)
 	ue, source, target := handoverUE(t, m)
 
-	targetENBUEID := driveToPrepared(t, m, ue, source, target)
+	targetMME, targetENBUEID := driveToPrepared(t, m, ue, source, target)
 
 	cancel := &s1ap.HandoverCancel{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 5}}
 	m.handleHandoverCancel(context.Background(), source, initiatingValue(t, mustMarshal(t, cancel.Marshal)))
 
-	if ue.s1.handover != nil {
+	if ue.handover != nil {
 		t.Fatal("handover not cleared after cancel")
 	}
 
@@ -484,8 +527,9 @@ func TestHandoverCancelReleasesTarget(t *testing.T) {
 		t.Fatal("UE association moved on a cancelled handover")
 	}
 
-	// The target's Release Complete is consumed.
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: targetENBUEID}
+	// The target's Release Complete (target id) does not disturb the UE, which stays
+	// on the source.
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: targetMME, ENBUES1APID: targetENBUEID}
 	m.handleUEContextReleaseComplete(target, successfulValue(t, mustMarshal(t, complete.Marshal)))
 
 	if _, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok {
@@ -513,11 +557,13 @@ func TestHandoverPartialAdmissionReleasesFailedPDN(t *testing.T) {
 		t.Fatalf("expected 2 E-RABs in HANDOVER REQUEST, got %d", len(req.ERABToBeSetup))
 	}
 
+	targetMME := req.MMEUES1APID
+
 	const targetENBUEID s1ap.ENBUES1APID = 55
 
 	// Target admits the default bearer (EBI 5), rejects EBI 6.
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.s1.MMEUES1APID,
+		MMEUES1APID: targetMME,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                s1ap.ERABID(defaultERABID),
@@ -536,7 +582,7 @@ func TestHandoverPartialAdmissionReleasesFailedPDN(t *testing.T) {
 	}
 
 	notify := &s1ap.HandoverNotify{
-		MMEUES1APID: ue.s1.MMEUES1APID,
+		MMEUES1APID: targetMME,
 		ENBUES1APID: targetENBUEID,
 		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
 		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
@@ -568,7 +614,7 @@ func TestHandoverCancelDuringCommitIgnored(t *testing.T) {
 
 	// Simulate the in-flight user-plane switch of HANDOVER NOTIFY.
 	m.mu.Lock()
-	ue.s1.handover.state = hoCommitting
+	ue.handover.state = hoCommitting
 	m.mu.Unlock()
 
 	targetBefore := target.count()
@@ -576,7 +622,7 @@ func TestHandoverCancelDuringCommitIgnored(t *testing.T) {
 	cancel := &s1ap.HandoverCancel{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 5}}
 	m.handleHandoverCancel(context.Background(), source, initiatingValue(t, mustMarshal(t, cancel.Marshal)))
 
-	if ue.s1.handover == nil {
+	if ue.handover == nil {
 		t.Fatal("a committing handover was torn down by a late cancel")
 	}
 
@@ -614,7 +660,7 @@ func TestHandoverGuardTimerAbandons(t *testing.T) {
 
 	m.mu.RLock()
 
-	cleared := ue.s1.handover == nil
+	cleared := ue.handover == nil
 	conn := ue.s1.conn
 
 	m.mu.RUnlock()
@@ -647,11 +693,13 @@ func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
+	targetMME := targetMMEUEID(t, target)
+
 	const targetENBUEID s1ap.ENBUES1APID = 55
 
 	// Target admits the secondary (EBI 6), rejects the attach default (EBI 5).
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.s1.MMEUES1APID,
+		MMEUES1APID: targetMME,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                6,
@@ -664,7 +712,7 @@ func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
 	m.handleHandoverRequestAcknowledge(context.Background(), target, successfulValue(t, mustMarshal(t, ack.Marshal)))
 
 	notify := &s1ap.HandoverNotify{
-		MMEUES1APID: ue.s1.MMEUES1APID,
+		MMEUES1APID: targetMME,
 		ENBUES1APID: targetENBUEID,
 		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
 		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
@@ -682,4 +730,59 @@ func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
 	if defaultEBI != 6 {
 		t.Fatalf("default EBI = %d, want 6 (promoted survivor)", defaultEBI)
 	}
+}
+
+// TestHandoverTargetConnLossAborts checks that losing the target eNB association
+// mid-handover aborts the handover and removes the target connection by its own
+// id, leaving the UE on its source.
+func TestHandoverTargetConnLossAborts(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	targetMME, _ := driveToPrepared(t, m, ue, source, target)
+
+	if _, ok := m.lookupUe(targetMME); !ok {
+		t.Fatal("target connection not registered during preparation")
+	}
+
+	m.reclaimUEsOnConnLoss(target)
+
+	if ue.handover != nil {
+		t.Fatal("handover not aborted when the target association dropped")
+	}
+
+	if _, ok := m.lookupUe(targetMME); ok {
+		t.Fatal("target connection not removed when its association dropped")
+	}
+
+	if ue.s1 == nil || ue.s1.conn != source {
+		t.Fatal("UE not left on its source after the target association dropped")
+	}
+}
+
+// TestHandoverSourceConnLossReclaims checks that losing the source eNB association
+// mid-handover reclaims the UE to ECM-IDLE and drops the prepared target
+// connection.
+func TestHandoverSourceConnLossReclaims(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	targetMME, _ := driveToPrepared(t, m, ue, source, target)
+
+	m.reclaimUEsOnConnLoss(source)
+
+	if _, ok := m.lookupUe(targetMME); ok {
+		t.Fatal("target connection not dropped when the source association dropped")
+	}
+
+	got, ok := m.lookupUeByIMSI(ue.imsi)
+	if !ok || got != ue || got.connected() {
+		t.Fatal("UE not reclaimed to ECM-IDLE on source association loss")
+	}
+
+	if got.handover != nil {
+		t.Fatal("handover not cleared on source association loss")
+	}
+
+	m.removeUe(ue) // stop the default-duration mobile reachable timer
 }

--- a/internal/mme/handover_test.go
+++ b/internal/mme/handover_test.go
@@ -786,3 +786,28 @@ func TestHandoverSourceConnLossReclaims(t *testing.T) {
 
 	m.removeUe(ue) // stop the default-duration mobile reachable timer
 }
+
+// TestHandoverTargetResetAborts checks that an S1 Reset on the target eNB
+// mid-handover aborts the handover (the UE stays on its source) rather than
+// reclaiming the UE active on the source.
+func TestHandoverTargetResetAborts(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	targetMME, _ := driveToPrepared(t, m, ue, source, target)
+
+	cause := s1ap.Cause{Group: s1ap.CauseGroupMisc, Value: 0}
+	m.handleReset(target, resetValue(t, &s1ap.Reset{Cause: cause, ResetType: s1ap.ResetType{All: true}}))
+
+	if ue.handover != nil {
+		t.Fatal("handover not aborted by a reset on the target eNB")
+	}
+
+	if _, ok := m.lookupUe(targetMME); ok {
+		t.Fatal("target connection not removed by the target reset")
+	}
+
+	if ue.s1 == nil || ue.s1.conn != source {
+		t.Fatal("UE not left on its source after a reset on the target eNB")
+	}
+}

--- a/internal/mme/handover_test.go
+++ b/internal/mme/handover_test.go
@@ -348,6 +348,61 @@ func TestHandoverConcurrentRefused(t *testing.T) {
 	}
 }
 
+// TestPathSwitchRefusedDuringHandover checks a Path Switch is refused while an S1
+// handover is advancing the key chain, so the two cannot derive a fresh NH from
+// the same base for different targets (TS 33.401 §7.2.8).
+func TestPathSwitchRefusedDuringHandover(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, _ := handoverUE(t, m)
+
+	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
+
+	if ue.s1.handover == nil {
+		t.Fatal("handover did not start")
+	}
+
+	ncc, nh, conn := ue.ncc, ue.nh, ue.s1.conn
+
+	target := &captureConn{}
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, samplePathSwitchRequest(ue)))
+
+	if target.count() != 1 {
+		t.Fatalf("expected one downlink (Path Switch Failure), got %d", target.count())
+	}
+
+	parsePathSwitchFailure(t, target.sent[0])
+
+	if ue.ncc != ncc || ue.nh != nh || ue.s1.conn != conn {
+		t.Fatal("Path Switch advanced the key chain or moved the association during a handover")
+	}
+}
+
+// TestHandoverRefusedWhileKeyChainBusy checks an S1 handover is refused while a
+// Path Switch holds the key chain — the symmetric guard of the shared marker.
+func TestHandoverRefusedWhileKeyChainBusy(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	m.mu.Lock()
+	ue.keyChainBusy = true // a Path Switch is mid-advance
+	m.mu.Unlock()
+
+	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
+
+	if ue.s1.handover != nil {
+		t.Fatal("handover started while the key chain was busy")
+	}
+
+	if target.count() != 0 {
+		t.Fatalf("handover sent a HANDOVER REQUEST while the key chain was busy: %d", target.count())
+	}
+
+	uo, ok := lastPDU(t, source).(*s1ap.UnsuccessfulOutcome)
+	if !ok || uo.ProcedureCode != s1ap.ProcHandoverPreparation {
+		t.Fatalf("expected HANDOVER PREPARATION FAILURE to source, got %T", lastPDU(t, source))
+	}
+}
+
 // TestHandoverFailureFailsToSource checks a HANDOVER FAILURE from the target ends
 // the handover with a HANDOVER PREPARATION FAILURE to the source, the UE intact.
 func TestHandoverFailureFailsToSource(t *testing.T) {

--- a/internal/mme/handover_test.go
+++ b/internal/mme/handover_test.go
@@ -811,3 +811,56 @@ func TestHandoverTargetResetAborts(t *testing.T) {
 		t.Fatal("UE not left on its source after a reset on the target eNB")
 	}
 }
+
+// TestHandoverSourceConnLossReleasesTarget checks that aborting a prepared handover
+// by source-connection loss explicitly releases the target eNB, like the guard
+// timer, rather than leaving it to its own timeout.
+func TestHandoverSourceConnLossReleasesTarget(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	driveToPrepared(t, m, ue, source, target)
+	before := target.count()
+
+	m.reclaimUEsOnConnLoss(source)
+
+	if target.count() != before+1 {
+		t.Fatalf("target not released on source loss: count %d -> %d", before, target.count())
+	}
+
+	rel, ok := lastPDU(t, target).(*s1ap.InitiatingMessage)
+	if !ok || rel.ProcedureCode != s1ap.ProcUEContextRelease {
+		t.Fatalf("expected UE Context Release Command to target, got %T", lastPDU(t, target))
+	}
+
+	m.removeUe(ue) // stop the default-duration mobile reachable timer
+}
+
+// TestHandoverNotifyUEReleasedDuringSwitch checks the notify commit is guarded
+// against a concurrent release during the unlocked user-plane switch: the UE is
+// not resurrected onto the target.
+func TestHandoverNotifyUEReleasedDuringSwitch(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	targetMME, targetENB := driveToPrepared(t, m, ue, source, target)
+
+	base := m.session.(*fakeSessionManager)
+	m.session = &hookSessionManager{fakeSessionManager: base, onModify: func() { m.freeS1Conn(ue) }}
+
+	notify := &s1ap.HandoverNotify{
+		MMEUES1APID: targetMME,
+		ENBUES1APID: targetENB,
+		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
+		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
+	}
+	m.handleHandoverNotify(context.Background(), target, initiatingValue(t, mustMarshal(t, notify.Marshal)))
+
+	if ue.s1 != nil {
+		t.Fatal("released UE resurrected onto the target by Handover Notify")
+	}
+
+	if ue.handover != nil {
+		t.Fatal("handover not cleared after the UE was released mid-switch")
+	}
+}

--- a/internal/mme/handover_test.go
+++ b/internal/mme/handover_test.go
@@ -403,6 +403,31 @@ func TestHandoverRefusedWhileKeyChainBusy(t *testing.T) {
 	}
 }
 
+// TestHandoverGuardSurvivesContextRelease checks that freeing a UE's connection
+// mid-handover (e.g. a re-attach or detach) stops the handover guard timer, so its
+// later expiry does not dereference the freed connection.
+func TestHandoverGuardSurvivesContextRelease(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, _ := handoverUE(t, m)
+
+	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
+
+	if ue.s1.handover == nil {
+		t.Fatal("handover did not start")
+	}
+
+	gen := ue.s1.handoverGen
+
+	m.freeS1Conn(ue)
+
+	if ue.s1 != nil {
+		t.Fatal("UE not idle after release")
+	}
+
+	// The orphaned guard timer firing must not panic on the freed connection.
+	m.onHandoverGuardExpiry(ue, gen)
+}
+
 // TestHandoverFailureFailsToSource checks a HANDOVER FAILURE from the target ends
 // the handover with a HANDOVER PREPARATION FAILURE to the source, the UE intact.
 func TestHandoverFailureFailsToSource(t *testing.T) {

--- a/internal/mme/handover_test.go
+++ b/internal/mme/handover_test.go
@@ -51,8 +51,8 @@ func handoverUE(t *testing.T, m *MME) (*UeContext, *captureConn, *captureConn) {
 
 func sampleHandoverRequired(ue *UeContext) *s1ap.HandoverRequired {
 	return &s1ap.HandoverRequired{
-		MMEUES1APID:    ue.MMEUES1APID,
-		ENBUES1APID:    ue.ENBUES1APID,
+		MMEUES1APID:    ue.s1.MMEUES1APID,
+		ENBUES1APID:    ue.s1.ENBUES1APID,
 		HandoverType:   s1ap.HandoverTypeIntraLTE,
 		Cause:          s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 16},
 		TargetID:       s1ap.TargetID{TargeteNBID: s1ap.TargeteNBID{GlobalENBID: targetGlobalENBID, SelectedTAI: s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1}}},
@@ -133,7 +133,7 @@ func driveToPrepared(t *testing.T, m *MME, ue *UeContext, source, target *captur
 	const targetENBUEID s1ap.ENBUES1APID = 55
 
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                s1ap.ERABID(defaultERABID),
@@ -174,7 +174,7 @@ func TestHandoverHappyPath(t *testing.T) {
 		t.Fatalf("parse HANDOVER REQUEST: %v", err)
 	}
 
-	if hoReq.MMEUES1APID != ue.MMEUES1APID || len(hoReq.ERABToBeSetup) != 1 ||
+	if hoReq.MMEUES1APID != ue.s1.MMEUES1APID || len(hoReq.ERABToBeSetup) != 1 ||
 		hoReq.ERABToBeSetup[0].GTPTEID != 0x1111 || hoReq.SecurityContext.NextHopChainingCount != 2 {
 		t.Fatalf("HANDOVER REQUEST = %+v", hoReq)
 	}
@@ -192,7 +192,7 @@ func TestHandoverHappyPath(t *testing.T) {
 	const targetENBUEID s1ap.ENBUES1APID = 55
 
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                s1ap.ERABID(defaultERABID),
@@ -215,7 +215,7 @@ func TestHandoverHappyPath(t *testing.T) {
 	}
 
 	// eNB STATUS TRANSFER → MME STATUS TRANSFER to the target.
-	st := &s1ap.ENBStatusTransfer{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID, Container: s1ap.StatusTransferContainer{0xde, 0xad}}
+	st := &s1ap.ENBStatusTransfer{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID, Container: s1ap.StatusTransferContainer{0xde, 0xad}}
 	m.handleENBStatusTransfer(context.Background(), source, initiatingValue(t, mustMarshal(t, st.Marshal)))
 
 	mst, ok := lastPDU(t, target).(*s1ap.InitiatingMessage)
@@ -230,7 +230,7 @@ func TestHandoverHappyPath(t *testing.T) {
 
 	// HANDOVER NOTIFY → user-plane switch, association move, source release.
 	notify := &s1ap.HandoverNotify{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: targetENBUEID,
 		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
 		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
@@ -242,15 +242,15 @@ func TestHandoverHappyPath(t *testing.T) {
 		t.Fatalf("ModifyEPSSession eNB F-TEID = %+v, want %+v", fsm.modifiedENB, wantFTEID)
 	}
 
-	if ue.conn != target || ue.ENBUES1APID != targetENBUEID || testPDN(ue).enbFTEID != wantFTEID {
-		t.Fatalf("association not moved: conn=%v enb-id=%d", ue.conn == target, ue.ENBUES1APID)
+	if ue.s1.conn != target || ue.s1.ENBUES1APID != targetENBUEID || testPDN(ue).enbFTEID != wantFTEID {
+		t.Fatalf("association not moved: conn=%v enb-id=%d", ue.s1.conn == target, ue.s1.ENBUES1APID)
 	}
 
 	if ue.ncc != 2 || ue.nh != wantNH {
 		t.Fatalf("key chain not committed: ncc=%d nh-match=%v", ue.ncc, ue.nh == wantNH)
 	}
 
-	if ue.handover != nil {
+	if ue.s1.handover != nil {
 		t.Fatal("handover context not cleared after notify")
 	}
 
@@ -261,14 +261,14 @@ func TestHandoverHappyPath(t *testing.T) {
 	}
 
 	// Its Release Complete is consumed without disturbing the moved UE.
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID}
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID}
 	m.handleUEContextReleaseComplete(source, successfulValue(t, mustMarshal(t, complete.Marshal)))
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); !ok {
+	if _, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok {
 		t.Fatal("UE removed by the source Release Complete")
 	}
 
-	if ue.conn != target {
+	if ue.s1.conn != target {
 		t.Fatal("UE association disturbed by the source Release Complete")
 	}
 }
@@ -296,7 +296,7 @@ func TestHandoverRequiredNoSecurityFails(t *testing.T) {
 		t.Fatalf("cause = %+v, want authentication-failure", fail.Cause)
 	}
 
-	if ue.handover != nil {
+	if ue.s1.handover != nil {
 		t.Fatal("handover context left set on failure")
 	}
 }
@@ -331,15 +331,15 @@ func TestHandoverConcurrentRefused(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	if ue.handover == nil {
+	if ue.s1.handover == nil {
 		t.Fatal("first handover did not start")
 	}
 
-	first := ue.handover
+	first := ue.s1.handover
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	if ue.handover != first {
+	if ue.s1.handover != first {
 		t.Fatal("second handover disturbed the in-flight one")
 	}
 
@@ -356,10 +356,10 @@ func TestHandoverFailureFailsToSource(t *testing.T) {
 
 	m.handleHandoverRequired(context.Background(), source, initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
 
-	fail := &s1ap.HandoverFailure{MMEUES1APID: ue.MMEUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 12}}
+	fail := &s1ap.HandoverFailure{MMEUES1APID: ue.s1.MMEUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 12}}
 	m.handleHandoverFailure(context.Background(), target, unsuccessfulValue(t, mustMarshal(t, fail.Marshal)))
 
-	if ue.handover != nil {
+	if ue.s1.handover != nil {
 		t.Fatal("handover not cleared after failure")
 	}
 
@@ -368,7 +368,7 @@ func TestHandoverFailureFailsToSource(t *testing.T) {
 		t.Fatalf("expected HANDOVER PREPARATION FAILURE to source, got %T", lastPDU(t, source))
 	}
 
-	if ue.conn != source {
+	if ue.s1.conn != source {
 		t.Fatal("UE association moved on a failed handover")
 	}
 }
@@ -381,10 +381,10 @@ func TestHandoverCancelReleasesTarget(t *testing.T) {
 
 	targetENBUEID := driveToPrepared(t, m, ue, source, target)
 
-	cancel := &s1ap.HandoverCancel{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 5}}
+	cancel := &s1ap.HandoverCancel{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 5}}
 	m.handleHandoverCancel(context.Background(), source, initiatingValue(t, mustMarshal(t, cancel.Marshal)))
 
-	if ue.handover != nil {
+	if ue.s1.handover != nil {
 		t.Fatal("handover not cleared after cancel")
 	}
 
@@ -400,15 +400,15 @@ func TestHandoverCancelReleasesTarget(t *testing.T) {
 		t.Fatalf("expected HANDOVER CANCEL ACKNOWLEDGE to source, got %T", lastPDU(t, source))
 	}
 
-	if ue.conn != source {
+	if ue.s1.conn != source {
 		t.Fatal("UE association moved on a cancelled handover")
 	}
 
 	// The target's Release Complete is consumed.
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: targetENBUEID}
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: targetENBUEID}
 	m.handleUEContextReleaseComplete(target, successfulValue(t, mustMarshal(t, complete.Marshal)))
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); !ok {
+	if _, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok {
 		t.Fatal("UE removed by the target Release Complete")
 	}
 }
@@ -437,7 +437,7 @@ func TestHandoverPartialAdmissionReleasesFailedPDN(t *testing.T) {
 
 	// Target admits the default bearer (EBI 5), rejects EBI 6.
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                s1ap.ERABID(defaultERABID),
@@ -456,7 +456,7 @@ func TestHandoverPartialAdmissionReleasesFailedPDN(t *testing.T) {
 	}
 
 	notify := &s1ap.HandoverNotify{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: targetENBUEID,
 		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
 		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
@@ -488,15 +488,15 @@ func TestHandoverCancelDuringCommitIgnored(t *testing.T) {
 
 	// Simulate the in-flight user-plane switch of HANDOVER NOTIFY.
 	m.mu.Lock()
-	ue.handover.state = hoCommitting
+	ue.s1.handover.state = hoCommitting
 	m.mu.Unlock()
 
 	targetBefore := target.count()
 
-	cancel := &s1ap.HandoverCancel{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 5}}
+	cancel := &s1ap.HandoverCancel{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 5}}
 	m.handleHandoverCancel(context.Background(), source, initiatingValue(t, mustMarshal(t, cancel.Marshal)))
 
-	if ue.handover == nil {
+	if ue.s1.handover == nil {
 		t.Fatal("a committing handover was torn down by a late cancel")
 	}
 
@@ -534,8 +534,8 @@ func TestHandoverGuardTimerAbandons(t *testing.T) {
 
 	m.mu.RLock()
 
-	cleared := ue.handover == nil
-	conn := ue.conn
+	cleared := ue.s1.handover == nil
+	conn := ue.s1.conn
 
 	m.mu.RUnlock()
 
@@ -571,7 +571,7 @@ func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
 
 	// Target admits the secondary (EBI 6), rejects the attach default (EBI 5).
 	ack := &s1ap.HandoverRequestAcknowledge{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: targetENBUEID,
 		ERABAdmitted: []s1ap.ERABAdmittedItem{{
 			ERABID:                6,
@@ -584,7 +584,7 @@ func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
 	m.handleHandoverRequestAcknowledge(context.Background(), target, successfulValue(t, mustMarshal(t, ack.Marshal)))
 
 	notify := &s1ap.HandoverNotify{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: targetENBUEID,
 		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
 		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -94,10 +94,6 @@ type MME struct {
 	ues         map[string]*UeContext // persistent UE contexts keyed by IMSI; survives the connection across ECM-IDLE
 	byMTMSI     map[uint32]*UeContext // keyed by M-TMSI, for S-TMSI lookup
 	nextMMEUEID uint32
-	// handoverSrcReleases tracks the source-eNB UE Context Release Commands the MME
-	// sends on S1-handover completion, so the matching Release Complete is consumed
-	// without disturbing the UE now active on the target (TS 36.413 §8.4).
-	handoverSrcReleases map[srcReleaseKey]struct{}
 	// mtmsi allocates an unpredictable M-TMSI (TS 23.401 privacy): random MSBs
 	// with allocate/free.
 	mtmsi *etsi.TmsiAllocator
@@ -161,17 +157,16 @@ const defaultHandoverGuardTimeout = 10 * time.Second
 // that allocates the UE IP. The MME never holds subscriber keys or the SQN.
 func New(cred *udm.Service, bearer bearerStore, session epsSessionManager) *MME {
 	return &MME{
-		cred:                cred,
-		bearer:              bearer,
-		session:             session,
-		enbs:                make(map[*sctp.SCTPConn]*enbState),
-		enbByID:             make(map[string]nasWriter),
-		conns:               make(map[uint32]*s1Conn),
-		ues:                 make(map[string]*UeContext),
-		byMTMSI:             make(map[uint32]*UeContext),
-		nextMMEUEID:         1,
-		mtmsi:               etsi.NewTMSIAllocator(),
-		handoverSrcReleases: make(map[srcReleaseKey]struct{}),
+		cred:        cred,
+		bearer:      bearer,
+		session:     session,
+		enbs:        make(map[*sctp.SCTPConn]*enbState),
+		enbByID:     make(map[string]nasWriter),
+		conns:       make(map[uint32]*s1Conn),
+		ues:         make(map[string]*UeContext),
+		byMTMSI:     make(map[uint32]*UeContext),
+		nextMMEUEID: 1,
+		mtmsi:       etsi.NewTMSIAllocator(),
 
 		mobileReachableTime: defaultMobileReachableTime,
 		implicitDetachTime:  defaultImplicitDetachTime,

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -90,7 +90,7 @@ type MME struct {
 	mu          sync.RWMutex
 	enbs        map[*sctp.SCTPConn]*enbState
 	enbByID     map[string]nasWriter  // S1-setup-complete eNBs keyed by Global eNB ID, for S1-handover target resolution
-	ues         map[uint32]*UeContext // keyed by MME-UE-S1AP-ID
+	conns       map[uint32]*s1Conn    // UE-associated S1-connections keyed by MME-UE-S1AP-ID; conn.ue is nil until a UE context is bound
 	byMTMSI     map[uint32]*UeContext // keyed by M-TMSI, for S-TMSI lookup
 	nextMMEUEID uint32
 	// handoverSrcReleases tracks the source-eNB UE Context Release Commands the MME
@@ -165,7 +165,7 @@ func New(cred *udm.Service, bearer bearerStore, session epsSessionManager) *MME 
 		session:             session,
 		enbs:                make(map[*sctp.SCTPConn]*enbState),
 		enbByID:             make(map[string]nasWriter),
-		ues:                 make(map[uint32]*UeContext),
+		conns:               make(map[uint32]*s1Conn),
 		byMTMSI:             make(map[uint32]*UeContext),
 		nextMMEUEID:         1,
 		mtmsi:               etsi.NewTMSIAllocator(),

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -70,8 +70,8 @@ type epsSessionManager interface {
 //     is reached only through chokepoint methods (downlinkSecCtx, nextDownlinkCount,
 //     setEPSSecurityContext, markSecured, securitySnapshot) so the COUNT invariant
 //     is auditable in one place.
-//   - UeContext.emmState/ecmState are atomic — independent enums read on the hot
-//     path, kept lock-free.
+//   - UeContext.emmState is atomic — an enum read on the hot path, kept lock-free.
+//     The ECM state is derived from whether the UE holds an S1-connection (ue.s1).
 //
 // Lock ordering (acquire in this order, never reverse):
 //
@@ -91,6 +91,7 @@ type MME struct {
 	enbs        map[*sctp.SCTPConn]*enbState
 	enbByID     map[string]nasWriter  // S1-setup-complete eNBs keyed by Global eNB ID, for S1-handover target resolution
 	conns       map[uint32]*s1Conn    // UE-associated S1-connections keyed by MME-UE-S1AP-ID; conn.ue is nil until a UE context is bound
+	ues         map[string]*UeContext // persistent UE contexts keyed by IMSI; survives the connection across ECM-IDLE
 	byMTMSI     map[uint32]*UeContext // keyed by M-TMSI, for S-TMSI lookup
 	nextMMEUEID uint32
 	// handoverSrcReleases tracks the source-eNB UE Context Release Commands the MME
@@ -166,6 +167,7 @@ func New(cred *udm.Service, bearer bearerStore, session epsSessionManager) *MME 
 		enbs:                make(map[*sctp.SCTPConn]*enbState),
 		enbByID:             make(map[string]nasWriter),
 		conns:               make(map[uint32]*s1Conn),
+		ues:                 make(map[string]*UeContext),
 		byMTMSI:             make(map[uint32]*UeContext),
 		nextMMEUEID:         1,
 		mtmsi:               etsi.NewTMSIAllocator(),

--- a/internal/mme/mme_enb.go
+++ b/internal/mme/mme_enb.go
@@ -216,7 +216,12 @@ func (m *MME) reclaimUEsOnConnLoss(conn nasWriter) {
 
 	var orphaned []*UeContext
 
-	for _, ue := range m.ues {
+	for _, c := range m.conns {
+		ue := c.ue
+		if ue == nil {
+			continue
+		}
+
 		if ue.conn == conn && ue.ecmState.load() == ECMConnected {
 			orphaned = append(orphaned, ue)
 		}

--- a/internal/mme/mme_enb.go
+++ b/internal/mme/mme_enb.go
@@ -208,28 +208,28 @@ func (m *MME) removeENB(conn *sctp.SCTPConn) {
 
 // reclaimUEsOnConnLoss handles the connections of an eNB whose SCTP association
 // dropped without a graceful S1 release, so no UE Context Release Complete will
-// arrive for them. A UE whose active connection dropped is reclaimed (ECM-IDLE or,
-// if mid-attach, dropped); a handover target connection that dropped aborts the
-// handover, leaving the UE on its surviving source; a detached or bare connection
-// is removed. Idle UEs are left alone — they run conn-independent supervision.
+// arrive for them. Idle UEs are left alone — they run conn-independent supervision.
 func (m *MME) reclaimUEsOnConnLoss(conn nasWriter) {
+	m.reclaimConns(m.connsOnConn(conn), "eNB disconnect")
+}
+
+// reclaimConns reclaims a set of UE-associated connections an eNB no longer holds
+// (an SCTP drop or an S1 Reset). A UE's active connection moves the UE to ECM-IDLE
+// (or, mid-attach, drops it); a handover target connection aborts the handover,
+// leaving the UE on its surviving source; a detached or bare connection is removed.
+// trigger names the cause for the event log.
+func (m *MME) reclaimConns(conns []*s1Conn, trigger string) {
 	m.mu.Lock()
 
 	var (
-		orphaned    []*UeContext
-		abortTarget []*UeContext
-		dropConns   []uint32
-		seen        = map[*UeContext]struct{}{}
+		orphaned []*UeContext
+		seen     = map[*UeContext]struct{}{}
 	)
 
-	for id, c := range m.conns {
-		if c.conn != conn {
-			continue
-		}
-
+	for _, c := range conns {
 		ue := c.ue
 		if ue == nil {
-			dropConns = append(dropConns, id)
+			delete(m.conns, uint32(c.MMEUES1APID))
 			continue
 		}
 
@@ -239,25 +239,21 @@ func (m *MME) reclaimUEsOnConnLoss(conn nasWriter) {
 
 		seen[ue] = struct{}{}
 
-		if c == ue.s1 {
+		switch {
+		case c == ue.s1:
 			orphaned = append(orphaned, ue)
-		} else {
-			abortTarget = append(abortTarget, ue)
+		case ue.handover != nil && ue.handover.target == c:
+			m.clearHandoverLocked(ue) // a handover target: abort, leaving the UE on its source
+		default:
+			c.ue = nil
+			delete(m.conns, uint32(c.MMEUES1APID))
 		}
-	}
-
-	for _, id := range dropConns {
-		delete(m.conns, id)
-	}
-
-	for _, ue := range abortTarget {
-		m.clearHandoverLocked(ue) // drops the target connection, leaving the UE on its source
 	}
 
 	m.mu.Unlock()
 
 	for _, ue := range orphaned {
-		m.releaseUEContextLocally(ue, "eNB disconnect")
+		m.releaseUEContextLocally(ue, trigger)
 	}
 }
 

--- a/internal/mme/mme_enb.go
+++ b/internal/mme/mme_enb.go
@@ -4,6 +4,7 @@
 package mme
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -222,8 +223,9 @@ func (m *MME) reclaimConns(conns []*s1Conn, trigger string) {
 	m.mu.Lock()
 
 	var (
-		orphaned []*UeContext
-		seen     = map[*UeContext]struct{}{}
+		orphaned       []*UeContext
+		releaseTargets []s1Release
+		seen           = map[*UeContext]struct{}{}
 	)
 
 	for _, c := range conns {
@@ -241,6 +243,13 @@ func (m *MME) reclaimConns(conns []*s1Conn, trigger string) {
 
 		switch {
 		case c == ue.s1:
+			// The UE's active connection is gone. A handover prepared on a (still
+			// live) target eNB is released explicitly, like the guard-timer abort, so
+			// the target does not hold the context until its own TS1RELOCoverall.
+			if ho := ue.handover; ho != nil && ho.state == hoPrepared {
+				releaseTargets = append(releaseTargets, s1Release{ho.target.conn, ho.target.MMEUES1APID, ho.target.ENBUES1APID})
+			}
+
 			orphaned = append(orphaned, ue)
 		case ue.handover != nil && ue.handover.target == c:
 			m.clearHandoverLocked(ue) // a handover target: abort, leaving the UE on its source
@@ -252,9 +261,21 @@ func (m *MME) reclaimConns(conns []*s1Conn, trigger string) {
 
 	m.mu.Unlock()
 
+	for _, r := range releaseTargets {
+		m.sendUEContextRelease(context.Background(), r.conn, r.mmeID, r.enbID)
+	}
+
 	for _, ue := range orphaned {
 		m.releaseUEContextLocally(ue, trigger)
 	}
+}
+
+// s1Release names a UE-associated connection to send a UE Context Release Command
+// to, captured under the lock for a send after it is released.
+type s1Release struct {
+	conn  nasWriter
+	mmeID s1ap.MMEUES1APID
+	enbID s1ap.ENBUES1APID
 }
 
 // CountENBs returns the number of eNBs currently associated with the MME.

--- a/internal/mme/mme_enb.go
+++ b/internal/mme/mme_enb.go
@@ -222,7 +222,7 @@ func (m *MME) reclaimUEsOnConnLoss(conn nasWriter) {
 			continue
 		}
 
-		if ue.conn == conn && ue.ecmState.load() == ECMConnected {
+		if ue.s1.conn == conn && ue.connected() {
 			orphaned = append(orphaned, ue)
 		}
 	}

--- a/internal/mme/mme_enb.go
+++ b/internal/mme/mme_enb.go
@@ -203,28 +203,55 @@ func (m *MME) removeENB(conn *sctp.SCTPConn) {
 	delete(m.enbs, conn)
 	m.mu.Unlock()
 
-	m.abortHandoversOnConnLoss(conn)
 	m.reclaimUEsOnConnLoss(conn)
 }
 
-// reclaimUEsOnConnLoss handles the UEs of an eNB whose SCTP association dropped
-// without a graceful S1 release, so no UE Context Release Complete will arrive
-// for them. Idle UEs are left alone — they already run their own
-// conn-independent mobile reachable supervision.
+// reclaimUEsOnConnLoss handles the connections of an eNB whose SCTP association
+// dropped without a graceful S1 release, so no UE Context Release Complete will
+// arrive for them. A UE whose active connection dropped is reclaimed (ECM-IDLE or,
+// if mid-attach, dropped); a handover target connection that dropped aborts the
+// handover, leaving the UE on its surviving source; a detached or bare connection
+// is removed. Idle UEs are left alone — they run conn-independent supervision.
 func (m *MME) reclaimUEsOnConnLoss(conn nasWriter) {
 	m.mu.Lock()
 
-	var orphaned []*UeContext
+	var (
+		orphaned    []*UeContext
+		abortTarget []*UeContext
+		dropConns   []uint32
+		seen        = map[*UeContext]struct{}{}
+	)
 
-	for _, c := range m.conns {
-		ue := c.ue
-		if ue == nil {
+	for id, c := range m.conns {
+		if c.conn != conn {
 			continue
 		}
 
-		if ue.s1.conn == conn && ue.connected() {
-			orphaned = append(orphaned, ue)
+		ue := c.ue
+		if ue == nil {
+			dropConns = append(dropConns, id)
+			continue
 		}
+
+		if _, ok := seen[ue]; ok {
+			continue
+		}
+
+		seen[ue] = struct{}{}
+
+		if c == ue.s1 {
+			orphaned = append(orphaned, ue)
+		} else {
+			abortTarget = append(abortTarget, ue)
+		}
+	}
+
+	for _, id := range dropConns {
+		delete(m.conns, id)
+	}
+
+	for _, ue := range abortTarget {
+		m.clearHandoverLocked(ue) // drops the target connection, leaving the UE on its source
 	}
 
 	m.mu.Unlock()

--- a/internal/mme/mme_enb_test.go
+++ b/internal/mme/mme_enb_test.go
@@ -89,7 +89,7 @@ func TestDispatchGatesUEMessageBeforeS1Setup(t *testing.T) {
 	// must be dropped before any UE context is created.
 	m.dispatch(context.Background(), nil, raw)
 
-	if len(m.ues) != 0 {
-		t.Fatalf("UE context created from an Initial UE Message before S1 Setup: %d", len(m.ues))
+	if len(m.conns) != 0 {
+		t.Fatalf("UE context created from an Initial UE Message before S1 Setup: %d", len(m.conns))
 	}
 }

--- a/internal/mme/mme_nas.go
+++ b/internal/mme/mme_nas.go
@@ -36,20 +36,31 @@ func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, v
 	}
 
 	// A security-protected NAS message from a UE that presents its S-TMSI is a
-	// resume in an existing security context (e.g. a TAU from idle). Bind the
-	// persistent context to a fresh S1 connection (TS 36.413) and dispatch
-	// with that context. A UE without a resolvable context (e.g. after an MME
+	// resume in an existing security context (e.g. a TAU from idle). The message
+	// is authenticated against the resolved context before the context is bound to
+	// the requesting association (TS 24.301 §4.4.4.3), so an unverified message
+	// cannot move the UE. A UE without a resolvable context (e.g. after an MME
 	// restart) falls through to a fresh context below.
 	if len(nas) > 0 && nas[0]>>4 != uint8(eps.SHTPlain) && msg.STMSI != nil {
 		if ue, ok := m.lookupUeByMTMSI(msg.STMSI.MTMSI); ok && ue.emmState.load() == EMMRegistered && ue.secured {
+			plain, count, valid := m.unprotectUplink(ue, nas)
+			if !valid {
+				logger.MmeLog.Warn("Initial UE Message (resume) failed integrity check",
+					zap.Uint32("m-tmsi", msg.STMSI.MTMSI))
+
+				return
+			}
+
+			ue.touchLastSeen()
 			m.establishS1Connection(ue, conn, msg.ENBUES1APID)
+			ue.ulCount = count + 1
 
 			logger.MmeLog.Info("Initial UE Message (resume)",
 				zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),
 				zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
 			)
 
-			m.handleNAS(ctx, ue, nas)
+			m.dispatchEMM(ctx, ue, plain, true)
 
 			return
 		}

--- a/internal/mme/mme_nas.go
+++ b/internal/mme/mme_nas.go
@@ -66,6 +66,16 @@ func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, v
 		}
 	}
 
+	// A fresh connection's first NAS message allocates a UE context only when it is
+	// an ATTACH REQUEST; any other (or malformed) initial message is dropped without
+	// allocating one, so an unauthenticated peer cannot exhaust UE contexts.
+	if !isInitialAttach(nas) {
+		logger.MmeLog.Debug("dropping non-Attach Initial UE Message",
+			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+
+		return
+	}
+
 	m.dropStaleUe(conn, msg.ENBUES1APID)
 	ue := m.newUe(conn, msg.ENBUES1APID)
 
@@ -75,6 +85,36 @@ func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, v
 	)
 
 	m.handleNAS(ctx, ue, nas)
+}
+
+// isInitialAttach reports whether a fresh connection's first NAS message is an
+// ATTACH REQUEST — the only message warranting a new UE context (TS 24.301):
+// plain for an IMSI or foreign-GUTI attach, or integrity-only for a native-GUTI
+// re-attach whose body is readable without a security context. A ciphered or
+// non-EMM message cannot be an initial attach the network can act on.
+func isInitialAttach(nas []byte) bool {
+	pd, err := eps.ProtocolDiscriminator(nas)
+	if err != nil || pd != eps.PDEMM {
+		return false
+	}
+
+	body := nas
+
+	switch nas[0] >> 4 {
+	case uint8(eps.SHTPlain):
+	case uint8(eps.SHTIntegrityProtected), uint8(eps.SHTIntegrityProtectedNewContext):
+		if len(nas) < 6 {
+			return false
+		}
+
+		body = nas[6:]
+	default:
+		return false
+	}
+
+	mt, err := eps.PeekMessageType(body)
+
+	return err == nil && mt == eps.MsgAttachRequest
 }
 
 // handleUplinkNASTransport routes an uplink NAS message to its UE context

--- a/internal/mme/mme_nas.go
+++ b/internal/mme/mme_nas.go
@@ -66,18 +66,23 @@ func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, v
 		}
 	}
 
-	// A fresh connection's first NAS message allocates a UE context only when it is
-	// an ATTACH REQUEST; any other (or malformed) initial message is dropped without
-	// allocating one, so an unauthenticated peer cannot exhaust UE contexts.
+	// A fresh connection is tracked by a bare UE-associated S1-connection. A
+	// persistent UE context is bound to it only when its first NAS message is an
+	// ATTACH REQUEST; any other (or malformed) initial message releases the bare
+	// connection without binding one, so an unauthenticated peer cannot exhaust UE
+	// contexts.
+	c := m.newConn(conn, msg.ENBUES1APID)
+
 	if !isInitialAttach(nas) {
 		logger.MmeLog.Debug("dropping non-Attach Initial UE Message",
 			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+		m.releaseBareConn(c)
 
 		return
 	}
 
 	m.dropStaleUe(conn, msg.ENBUES1APID)
-	ue := m.newUe(conn, msg.ENBUES1APID)
+	ue := m.bindConn(c)
 
 	logger.MmeLog.Info("Initial UE Message",
 		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),

--- a/internal/mme/mme_nas.go
+++ b/internal/mme/mme_nas.go
@@ -57,7 +57,7 @@ func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, v
 
 			logger.MmeLog.Info("Initial UE Message (resume)",
 				zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),
-				zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+				zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 			)
 
 			m.dispatchEMM(ctx, ue, plain, true)
@@ -81,7 +81,7 @@ func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, v
 
 	logger.MmeLog.Info("Initial UE Message",
 		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 	)
 
 	m.handleNAS(ctx, ue, nas)
@@ -197,6 +197,10 @@ func (m *MME) handleInitialContextSetupResponse(ctx context.Context, conn nasWri
 	}
 
 	p.enbFTEID = models.FTEID{TEID: uint32(erab.GTPTEID), Addr: enbAddr}
+
+	if ue.s1 != nil {
+		ue.s1.bearersUp = true
+	}
 
 	if err := m.session.ModifyEPSSession(ctx, ue.imsi, p.ebi, p.enbFTEID); err != nil {
 		logger.MmeLog.Error("failed to set the eNB F-TEID on the EPS session",

--- a/internal/mme/mme_nas.go
+++ b/internal/mme/mme_nas.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/metrics"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/sctp"
 	"github.com/ellanetworks/core/nas/eps"
@@ -22,7 +23,7 @@ import (
 // (TS 36.413). A SERVICE REQUEST re-establishes an existing EMM-IDLE
 // context (resolved by S-TMSI); anything else (an Attach Request) starts a new
 // one.
-func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, value []byte) {
+func (m *MME) handleInitialUEMessage(ctx context.Context, conn nasWriter, value []byte) {
 	msg, err := s1ap.ParseInitialUEMessage(value)
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Initial UE Message", zap.Error(err))
@@ -74,8 +75,20 @@ func (m *MME) handleInitialUEMessage(ctx context.Context, conn *sctp.SCTPConn, v
 	c := m.newConn(conn, msg.ENBUES1APID)
 
 	if !isInitialAttach(nas) {
-		logger.MmeLog.Debug("dropping non-Attach Initial UE Message",
-			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+		// A protected TRACKING AREA UPDATE the MME cannot resolve (e.g. a periodic
+		// update after an MME restart) is rejected with EMM cause #9 over the bare
+		// connection, so the UE re-attaches at once instead of waiting out T3430
+		// (TS 24.301 §5.5.3.2.5).
+		if isProtectedTrackingAreaUpdate(nas) {
+			metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
+			logger.MmeLog.Info("Tracking Area Update rejected; UE will re-attach",
+				zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+			m.sendOverConn(ctx, c, &eps.TrackingAreaUpdateReject{Cause: emmCauseUEIdentityUnderivable})
+		} else {
+			logger.MmeLog.Debug("dropping non-Attach Initial UE Message",
+				zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+		}
+
 		m.releaseBareConn(c)
 
 		return
@@ -120,6 +133,32 @@ func isInitialAttach(nas []byte) bool {
 	mt, err := eps.PeekMessageType(body)
 
 	return err == nil && mt == eps.MsgAttachRequest
+}
+
+// isProtectedTrackingAreaUpdate reports whether nas is an integrity-protected
+// (peekable) TRACKING AREA UPDATE REQUEST. An idle UE sends this from a security
+// context the MME may have lost (e.g. after a restart); when the context is
+// unresolvable the MME rejects it so the UE re-attaches (TS 24.301 §5.5.3.2.5). A
+// ciphered body cannot be peeked, so it is not matched.
+func isProtectedTrackingAreaUpdate(nas []byte) bool {
+	if len(nas) < 6 {
+		return false
+	}
+
+	pd, err := eps.ProtocolDiscriminator(nas)
+	if err != nil || pd != eps.PDEMM {
+		return false
+	}
+
+	switch nas[0] >> 4 {
+	case uint8(eps.SHTIntegrityProtected), uint8(eps.SHTIntegrityProtectedNewContext):
+	default:
+		return false
+	}
+
+	mt, err := eps.PeekMessageType(nas[6:])
+
+	return err == nil && mt == eps.MsgTrackingAreaUpdateRequest
 }
 
 // handleUplinkNASTransport routes an uplink NAS message to its UE context
@@ -241,6 +280,30 @@ func downlinkNASTransportBytes(mmeID s1ap.MMEUES1APID, enbID s1ap.ENBUES1APID, n
 // nasMessage is any EPS NAS message that can serialize itself.
 type nasMessage interface {
 	Marshal() ([]byte, error)
+}
+
+// sendOverConn wraps a plain NAS message in a Downlink NAS Transport and sends it
+// over a connection that carries no bound UE context — a reject to an
+// unidentified peer (an Initial UE Message the MME cannot act on).
+func (m *MME) sendOverConn(ctx context.Context, c *s1Conn, msg nasMessage) {
+	b, err := msg.Marshal()
+	if err != nil {
+		logger.MmeLog.Error("failed to marshal NAS message", zap.Error(err))
+		return
+	}
+
+	pdu, err := downlinkNASTransportBytes(c.MMEUES1APID, c.ENBUES1APID, b)
+	if err != nil {
+		logger.MmeLog.Error("failed to build Downlink NAS Transport", zap.Error(err))
+		return
+	}
+
+	if _, err := c.conn.WriteMsg(pdu, &sctp.SndRcvInfo{PPID: s1apWirePPID, Stream: s1apStreamUE}); err != nil {
+		logger.MmeLog.Error("failed to send Downlink NAS Transport", zap.Error(err))
+		return
+	}
+
+	m.logOutboundS1AP(ctx, c.conn, S1APProcedureDownlinkNASTransport, pdu)
 }
 
 // sendDownlinkMessage serializes a plain NAS message and sends it to the UE.

--- a/internal/mme/mme_nas_test.go
+++ b/internal/mme/mme_nas_test.go
@@ -23,7 +23,7 @@ func TestInitialContextSetupResponseRelaysENBFTEID(t *testing.T) {
 	testPDN(ue).apn = "internet"
 
 	resp := &s1ap.InitialContextSetupResponse{
-		MMEUES1APID: ue.MMEUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
 		ENBUES1APID: 7,
 		ERABSetup: []s1ap.ERABSetupItemCtxtSURes{{
 			ERABID:                s1ap.ERABID(defaultERABID),
@@ -86,7 +86,7 @@ func TestInitialContextSetupResponseENBTransportFamily(t *testing.T) {
 			testPDN(ue).apn = "internet"
 
 			resp := &s1ap.InitialContextSetupResponse{
-				MMEUES1APID: ue.MMEUES1APID,
+				MMEUES1APID: ue.s1.MMEUES1APID,
 				ENBUES1APID: 7,
 				ERABSetup: []s1ap.ERABSetupItemCtxtSURes{{
 					ERABID:                s1ap.ERABID(defaultERABID),

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -184,6 +184,12 @@ type UeContext struct {
 	nh  [32]byte
 	ncc uint8
 
+	// keyChainBusy is set while a Path Switch or S1 handover is advancing the
+	// {NH, NCC} chain. Both procedures refuse to start while it is set, so they
+	// cannot derive a fresh NH from the same base for two targets (TS 33.401
+	// §7.2.8). Guarded by MME.mu.
+	keyChainBusy bool
+
 	// emmState is the EPS Mobility Management state (TS 23.401), independent of the
 	// ECM state on s1Conn: an S1 release moves the UE to ECM-IDLE while leaving the
 	// EMM state untouched, so the release-complete handler deletes the context only

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -418,9 +418,10 @@ func (m *MME) dropPDN(ue *UeContext, ebi uint8) {
 	}
 }
 
-// newUe allocates an MME-UE-S1AP-ID and registers a UE context for the eNB
-// association.
-func (m *MME) newUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
+// newConn allocates an MME-UE-S1AP-ID and registers a bare UE-associated
+// S1-connection — one carrying an Initial UE Message not yet bound to a UE
+// context (TS 36.413). An unidentified peer holds at most a bare connection.
+func (m *MME) newConn(conn nasWriter, enbUEID s1ap.ENBUES1APID) *s1Conn {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -428,12 +429,38 @@ func (m *MME) newUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
 	m.nextMMEUEID++
 
 	c := &s1Conn{ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id), conn: conn}
+	m.conns[id] = c
+
+	return c
+}
+
+// bindConn attaches a fresh persistent UE context to a bare connection, once the
+// connection's first NAS message warrants one (an Attach Request).
+func (m *MME) bindConn(c *s1Conn) *UeContext {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	ue := &UeContext{s1: c}
 	c.ue = ue
 
-	m.conns[id] = c
-
 	return ue
+}
+
+// releaseBareConn drops a connection that never bound a UE context.
+func (m *MME) releaseBareConn(c *s1Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if c.ue != nil {
+		return
+	}
+
+	delete(m.conns, uint32(c.MMEUES1APID))
+}
+
+// newUe registers a bare connection and immediately binds a UE context to it.
+func (m *MME) newUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
+	return m.bindConn(m.newConn(conn, enbUEID))
 }
 
 // establishS1Connection binds a UE returning from ECM-IDLE to a fresh

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -65,13 +65,73 @@ type pdnConnection struct {
 	pendingARP           uint8
 }
 
-// UeContext is the MME's per-UE state for an S1AP UE-associated connection: the
-// S1AP identities, the owning eNB association, and (during attach) the EMM/NAS
-// security context.
-type UeContext struct {
+// s1Conn is a UE's transient state for one UE-associated logical S1-connection
+// (TS 36.413): the S1AP identities, the eNB association, the connection and
+// idle-mode supervision timers, and any in-flight handover. A fresh one is bound
+// on each idle→active transition; the persistent UeContext it belongs to survives
+// across them. Fields are guarded by MME.mu unless noted.
+type s1Conn struct {
 	ENBUES1APID s1ap.ENBUES1APID
 	MMEUES1APID s1ap.MMEUES1APID
 	conn        nasWriter
+
+	// EPS Connection Management state (TS 23.401): ECM-CONNECTED on an active S1
+	// connection, ECM-IDLE between them.
+	ecmState ecmStateAtomic
+
+	// tauReleaseOnComplete defers the S1 release of a no-active TAU until the
+	// GUTI reallocation it carried is acknowledged.
+	tauReleaseOnComplete bool
+	// releasing gates the registry op during a UE Context Release.
+	releasing bool
+
+	// handover is the in-flight S1 handover for this UE (nil when none); the UE is
+	// reachable on both the source and target associations until HANDOVER NOTIFY
+	// moves conn/ENBUES1APID to the target (TS 36.413 §8.4). handoverGen invalidates
+	// a guard-timer callback that fired just as the handover was cleared or
+	// replaced.
+	handover    *handoverContext
+	handoverGen uint64
+
+	// Idle-mode reachability supervision (TS 24.301), armed in ECM-IDLE
+	// and cancelled on reconnect. idleGen invalidates a timer callback that fired
+	// just as a reconnect or re-arm ran.
+	mobileReachableTimer *time.Timer
+	implicitDetachTimer  *time.Timer
+	idleGen              uint64
+
+	// Paging supervision (T3413, TS 24.301 §5.6.2): armed when the MME pages an
+	// idle UE for buffered downlink data, retransmitted a bounded number of times,
+	// and cancelled when the UE reconnects. pagingPDU is the S1AP Paging message
+	// retransmitted on expiry; pagingGen invalidates a stale callback.
+	pagingTimer *time.Timer
+	pagingPDU   []byte
+	pagingTries int
+	pagingGen   uint64
+
+	// NAS common-procedure guard (TS 24.301: T3450/T3460/T3470). At most
+	// one common procedure is outstanding at a time, so a single guard suffices;
+	// nasGuardPDU is the downlink message retransmitted on expiry. nasGuardGen
+	// invalidates a stale callback.
+	nasGuardTimer *time.Timer
+	nasGuardPDU   []byte
+	nasGuardName  string
+	nasGuardTries int
+	nasGuardGen   uint64
+	// nasGuardOnAbort, when non-nil, makes the guard abort-only: on exhausting
+	// its retransmissions it runs this finalizer and leaves the UE connected,
+	// rather than releasing the context. Used for non-critical procedures whose
+	// failure must not drop the UE — a bearer modification (TS 24.301 §6.4.2.5:
+	// on T3486 expiry the bearer stays active) or a single-PDN deactivation
+	// (§6.4.4.5: on T3495 expiry the bearer is deactivated locally).
+	nasGuardOnAbort func()
+}
+
+// UeContext is the MME's persistent per-UE EMM context: subscriber identity, the
+// EPS NAS security context, and the bearer state. The embedded *s1Conn carries
+// the transient state of its current UE-associated S1-connection.
+type UeContext struct {
+	*s1Conn
 
 	imsi            string
 	imei            string // 15-digit IMEI from the UE's IMEISV (TS 24.301)
@@ -81,6 +141,10 @@ type UeContext struct {
 	esmContainer    []byte // PDN Connectivity Request, kept for default-bearer activation
 	authVector      *udm.EPSAV
 	combinedAttach  bool // UE requested combined EPS/IMSI attach (TS 24.301)
+	// hashmmeInput is the plain Attach Request to hash into the SECURITY MODE
+	// COMMAND HashMME IE, set when the Attach arrived without integrity protection;
+	// nil when the Attach verified (TS 24.301 §5.4.3.2).
+	hashmmeInput []byte
 
 	// lastSeen is the Unix-nanosecond time of the UE's most recent uplink NAS
 	// activity, updated on the hot path and read concurrently by the status API.
@@ -104,9 +168,6 @@ type UeContext struct {
 	// (0 = none): both stay resolvable, and the UE is paged with the old one,
 	// until TRACKING AREA UPDATE COMPLETE commits the new GUTI (TS 24.301).
 	oldMTMSI uint32
-	// tauReleaseOnComplete defers the S1 release of a no-active TAU until the
-	// GUTI reallocation it carried is acknowledged.
-	tauReleaseOnComplete bool
 
 	// mu is the per-UE lock guarding this UE's data state — the EPS NAS security
 	// context below (dlCount, knasEnc, knasInt, eea, eia, imei, secured), the PDN
@@ -124,7 +185,6 @@ type UeContext struct {
 	ulCount     uint32
 	dlCount     uint32
 	secured     bool
-	releasing   bool
 	resyncTried bool
 
 	// X2-handover key chain (TS 33.401): nh is the Next Hop the next path
@@ -133,54 +193,11 @@ type UeContext struct {
 	nh  [32]byte
 	ncc uint8
 
-	// handover is the in-flight S1 handover for this UE (nil when none); the UE is
-	// reachable on both the source and target associations until HANDOVER NOTIFY
-	// moves conn/ENBUES1APID to the target (TS 36.413 §8.4). handoverGen invalidates
-	// a guard-timer callback that fired just as the handover was cleared or
-	// replaced. Both guarded by MME.mu.
-	handover    *handoverContext
-	handoverGen uint64
-
-	// EMM/ECM state machines (TS 23.401) — independent: an S1 release moves
-	// the UE to ECM-IDLE while leaving the EMM state untouched, so the
-	// release-complete handler deletes the context only if the UE is also
-	// EMM-DEREGISTERED (detach), otherwise it is retained in ECM-IDLE.
+	// emmState is the EPS Mobility Management state (TS 23.401), independent of the
+	// ECM state on s1Conn: an S1 release moves the UE to ECM-IDLE while leaving the
+	// EMM state untouched, so the release-complete handler deletes the context only
+	// if the UE is also EMM-DEREGISTERED (detach), else it is retained in ECM-IDLE.
 	emmState emmStateAtomic
-	ecmState ecmStateAtomic
-
-	// Idle-mode reachability supervision (TS 24.301), armed in ECM-IDLE
-	// and cancelled on reconnect. idleGen invalidates a timer callback that fired
-	// just as a reconnect or re-arm ran; all three are guarded by MME.mu.
-	mobileReachableTimer *time.Timer
-	implicitDetachTimer  *time.Timer
-	idleGen              uint64
-
-	// Paging supervision (T3413, TS 24.301 §5.6.2): armed when the MME pages an
-	// idle UE for buffered downlink data, retransmitted a bounded number of times,
-	// and cancelled when the UE reconnects. pagingPDU is the S1AP Paging message
-	// retransmitted on expiry; pagingGen invalidates a stale callback. All guarded
-	// by MME.mu.
-	pagingTimer *time.Timer
-	pagingPDU   []byte
-	pagingTries int
-	pagingGen   uint64
-
-	// NAS common-procedure guard (TS 24.301: T3450/T3460/T3470). At most
-	// one common procedure is outstanding at a time, so a single guard suffices;
-	// nasGuardPDU is the downlink message retransmitted on expiry. nasGuardGen
-	// invalidates a stale callback. All guarded by MME.mu.
-	nasGuardTimer *time.Timer
-	nasGuardPDU   []byte
-	nasGuardName  string
-	nasGuardTries int
-	nasGuardGen   uint64
-	// nasGuardOnAbort, when non-nil, makes the guard abort-only: on exhausting
-	// its retransmissions it runs this finalizer and leaves the UE connected,
-	// rather than releasing the context. Used for non-critical procedures whose
-	// failure must not drop the UE — a bearer modification (TS 24.301 §6.4.2.5:
-	// on T3486 expiry the bearer stays active) or a single-PDN deactivation
-	// (§6.4.4.5: on T3495 expiry the bearer is deactivated locally).
-	nasGuardOnAbort func()
 }
 
 // touchLastSeen records the current time as the UE's most recent uplink NAS
@@ -385,7 +402,7 @@ func (m *MME) newUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
 	id := m.nextMMEUEID
 	m.nextMMEUEID++
 
-	ue := &UeContext{ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id), conn: conn}
+	ue := &UeContext{s1Conn: &s1Conn{ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id), conn: conn}}
 	ue.ecmState.store(ECMConnected)
 	m.ues[id] = ue
 
@@ -404,19 +421,20 @@ func (m *MME) establishS1Connection(ue *UeContext, conn nasWriter, enbUEID s1ap.
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// A NAS signalling connection is being established for the UE, so the idle
-	// reachability timers and any paging supervision are stopped (TS 24.301).
+	// A NAS signalling connection is being established for the UE, so the prior
+	// connection's idle, paging, and NAS-guard supervision are stopped before its
+	// s1Conn is replaced, leaving no timer that could fire against the new one
+	// (TS 24.301).
 	m.stopIdleTimersLocked(ue)
 	m.stopPagingLocked(ue)
+	m.stopNASGuardLocked(ue)
 
 	delete(m.ues, uint32(ue.MMEUES1APID))
 
 	id := m.nextMMEUEID
 	m.nextMMEUEID++
 
-	ue.MMEUES1APID = s1ap.MMEUES1APID(id)
-	ue.ENBUES1APID = enbUEID
-	ue.conn = conn
+	ue.s1Conn = &s1Conn{MMEUES1APID: s1ap.MMEUES1APID(id), ENBUES1APID: enbUEID, conn: conn}
 	m.ues[id] = ue
 }
 

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -92,14 +92,6 @@ type s1Conn struct {
 	// releasing gates the registry op during a UE Context Release.
 	releasing bool
 
-	// handover is the in-flight S1 handover for this UE (nil when none); the UE is
-	// reachable on both the source and target associations until HANDOVER NOTIFY
-	// moves conn/ENBUES1APID to the target (TS 36.413 §8.4). handoverGen invalidates
-	// a guard-timer callback that fired just as the handover was cleared or
-	// replaced.
-	handover    *handoverContext
-	handoverGen uint64
-
 	// NAS common-procedure guard (TS 24.301: T3450/T3460/T3470). At most
 	// one common procedure is outstanding at a time, so a single guard suffices;
 	// nasGuardPDU is the downlink message retransmitted on expiry. nasGuardGen
@@ -189,6 +181,14 @@ type UeContext struct {
 	// cannot derive a fresh NH from the same base for two targets (TS 33.401
 	// §7.2.8). Guarded by MME.mu.
 	keyChainBusy bool
+
+	// handover is the in-flight S1 handover (nil when none). It holds the source
+	// and target connections, each a distinct s1Conn with its own MME-UE-S1AP-ID;
+	// s1 stays the source until HANDOVER NOTIFY switches it to the target (TS 36.413
+	// §8.4). handoverGen invalidates a guard-timer callback that fired just as the
+	// handover was cleared or replaced. Guarded by MME.mu.
+	handover    *handoverContext
+	handoverGen uint64
 
 	// emmState is the EPS Mobility Management state (TS 23.401), independent of the
 	// ECM state on s1Conn: an S1 release moves the UE to ECM-IDLE while leaving the

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -569,7 +569,7 @@ func (m *MME) dropStaleUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) {
 	var stale []*UeContext
 
 	for _, c := range m.conns {
-		if c.ue != nil && c.conn == conn && c.ENBUES1APID == enbUEID {
+		if c.ue != nil && c.ue.s1 == c && c.conn == conn && c.ENBUES1APID == enbUEID {
 			stale = append(stale, c.ue)
 		}
 	}

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -75,6 +75,11 @@ type s1Conn struct {
 	MMEUES1APID s1ap.MMEUES1APID
 	conn        nasWriter
 
+	// ue is the persistent UE context bound to this connection, nil until a UE
+	// is identified (a bare connection carries an Initial UE Message not yet
+	// attached to a context). Guarded by MME.mu.
+	ue *UeContext
+
 	// EPS Connection Management state (TS 23.401): ECM-CONNECTED on an active S1
 	// connection, ECM-IDLE between them.
 	ecmState ecmStateAtomic
@@ -402,9 +407,12 @@ func (m *MME) newUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
 	id := m.nextMMEUEID
 	m.nextMMEUEID++
 
-	ue := &UeContext{s1Conn: &s1Conn{ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id), conn: conn}}
+	c := &s1Conn{ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id), conn: conn}
+	ue := &UeContext{s1Conn: c}
+	c.ue = ue
 	ue.ecmState.store(ECMConnected)
-	m.ues[id] = ue
+
+	m.conns[id] = c
 
 	return ue
 }
@@ -429,13 +437,14 @@ func (m *MME) establishS1Connection(ue *UeContext, conn nasWriter, enbUEID s1ap.
 	m.stopPagingLocked(ue)
 	m.stopNASGuardLocked(ue)
 
-	delete(m.ues, uint32(ue.MMEUES1APID))
+	delete(m.conns, uint32(ue.MMEUES1APID))
 
 	id := m.nextMMEUEID
 	m.nextMMEUEID++
 
-	ue.s1Conn = &s1Conn{MMEUES1APID: s1ap.MMEUES1APID(id), ENBUES1APID: enbUEID, conn: conn}
-	m.ues[id] = ue
+	c := &s1Conn{MMEUES1APID: s1ap.MMEUES1APID(id), ENBUES1APID: enbUEID, conn: conn, ue: ue}
+	ue.s1Conn = c
+	m.conns[id] = c
 }
 
 // removeUe deletes a UE context. It is idempotent (deleting an absent context
@@ -444,14 +453,14 @@ func (m *MME) removeUe(mmeUEID s1ap.MMEUES1APID) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if ue, ok := m.ues[uint32(mmeUEID)]; ok {
-		m.stopIdleTimersLocked(ue)
-		m.stopNASGuardLocked(ue)
-		m.stopPagingLocked(ue)
-		m.releaseMTMSIsLocked(ue)
+	if c, ok := m.conns[uint32(mmeUEID)]; ok && c.ue != nil {
+		m.stopIdleTimersLocked(c.ue)
+		m.stopNASGuardLocked(c.ue)
+		m.stopPagingLocked(c.ue)
+		m.releaseMTMSIsLocked(c.ue)
 	}
 
-	delete(m.ues, uint32(mmeUEID))
+	delete(m.conns, uint32(mmeUEID))
 }
 
 // dropStaleUe removes any context bound to the same eNB association and
@@ -461,14 +470,16 @@ func (m *MME) dropStaleUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for id, ue := range m.ues {
-		if ue.conn == conn && ue.ENBUES1APID == enbUEID {
-			m.stopIdleTimersLocked(ue)
-			m.stopNASGuardLocked(ue)
-			m.stopPagingLocked(ue)
-			m.releaseMTMSIsLocked(ue)
+	for id, c := range m.conns {
+		if c.conn == conn && c.ENBUES1APID == enbUEID {
+			if c.ue != nil {
+				m.stopIdleTimersLocked(c.ue)
+				m.stopNASGuardLocked(c.ue)
+				m.stopPagingLocked(c.ue)
+				m.releaseMTMSIsLocked(c.ue)
+			}
 
-			delete(m.ues, id)
+			delete(m.conns, id)
 		}
 	}
 }
@@ -484,14 +495,18 @@ func (m *MME) s1Identity(ue *UeContext) (nasWriter, s1ap.MMEUES1APID, s1ap.ENBUE
 	return ue.conn, ue.MMEUES1APID, ue.ENBUES1APID
 }
 
-// lookupUe finds a UE context by its MME-UE-S1AP-ID.
+// lookupUe finds the UE context bound to a connection by its MME-UE-S1AP-ID. A
+// bare connection (no UE context yet) reports not found.
 func (m *MME) lookupUe(mmeUEID s1ap.MMEUES1APID) (*UeContext, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	ue, ok := m.ues[uint32(mmeUEID)]
+	c, ok := m.conns[uint32(mmeUEID)]
+	if !ok || c.ue == nil {
+		return nil, false
+	}
 
-	return ue, ok
+	return c.ue, true
 }
 
 // lookupUeByMTMSI finds a UE context by the M-TMSI of its assigned GUTI, used to
@@ -511,13 +526,17 @@ func (m *MME) lookupUeByIMSI(imsi string) (*UeContext, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for _, ue := range m.ues {
-		ue.mu.Lock()
-		match := ue.imsi == imsi
-		ue.mu.Unlock()
+	for _, c := range m.conns {
+		if c.ue == nil {
+			continue
+		}
+
+		c.ue.mu.Lock()
+		match := c.ue.imsi == imsi
+		c.ue.mu.Unlock()
 
 		if match {
-			return ue, true
+			return c.ue, true
 		}
 	}
 

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -66,8 +66,8 @@ type pdnConnection struct {
 }
 
 // s1Conn is a UE's transient state for one UE-associated logical S1-connection
-// (TS 36.413): the S1AP identities, the eNB association, the connection and
-// idle-mode supervision timers, and any in-flight handover. A fresh one is bound
+// (TS 36.413): the S1AP identities, the eNB association, the connection-scoped
+// NAS-guard supervision, and any in-flight handover. A fresh one is bound
 // on each idle→active transition; the persistent UeContext it belongs to survives
 // across them. Fields are guarded by MME.mu unless noted.
 type s1Conn struct {
@@ -80,9 +80,11 @@ type s1Conn struct {
 	// attached to a context). Guarded by MME.mu.
 	ue *UeContext
 
-	// EPS Connection Management state (TS 23.401): ECM-CONNECTED on an active S1
-	// connection, ECM-IDLE between them.
-	ecmState ecmStateAtomic
+	// bearersUp is set once the eNB confirms the radio bearers (Initial Context
+	// Setup Response): it distinguishes a fully-established connection from one a
+	// UE is still resuming on (e.g. a TAU resume that has not re-established
+	// bearers).
+	bearersUp bool
 
 	// tauReleaseOnComplete defers the S1 release of a no-active TAU until the
 	// GUTI reallocation it carried is acknowledged.
@@ -97,22 +99,6 @@ type s1Conn struct {
 	// replaced.
 	handover    *handoverContext
 	handoverGen uint64
-
-	// Idle-mode reachability supervision (TS 24.301), armed in ECM-IDLE
-	// and cancelled on reconnect. idleGen invalidates a timer callback that fired
-	// just as a reconnect or re-arm ran.
-	mobileReachableTimer *time.Timer
-	implicitDetachTimer  *time.Timer
-	idleGen              uint64
-
-	// Paging supervision (T3413, TS 24.301 §5.6.2): armed when the MME pages an
-	// idle UE for buffered downlink data, retransmitted a bounded number of times,
-	// and cancelled when the UE reconnects. pagingPDU is the S1AP Paging message
-	// retransmitted on expiry; pagingGen invalidates a stale callback.
-	pagingTimer *time.Timer
-	pagingPDU   []byte
-	pagingTries int
-	pagingGen   uint64
 
 	// NAS common-procedure guard (TS 24.301: T3450/T3460/T3470). At most
 	// one common procedure is outstanding at a time, so a single guard suffices;
@@ -133,10 +119,10 @@ type s1Conn struct {
 }
 
 // UeContext is the MME's persistent per-UE EMM context: subscriber identity, the
-// EPS NAS security context, and the bearer state. The embedded *s1Conn carries
-// the transient state of its current UE-associated S1-connection.
+// EPS NAS security context, and the bearer state. s1 is the UE's current
+// UE-associated S1-connection, nil while the UE is in ECM-IDLE.
 type UeContext struct {
-	*s1Conn
+	s1 *s1Conn
 
 	imsi            string
 	imei            string // 15-digit IMEI from the UE's IMEISV (TS 24.301)
@@ -203,6 +189,23 @@ type UeContext struct {
 	// EMM state untouched, so the release-complete handler deletes the context only
 	// if the UE is also EMM-DEREGISTERED (detach), else it is retained in ECM-IDLE.
 	emmState emmStateAtomic
+
+	// Idle-mode supervision lives on the persistent context because it runs while
+	// the UE has no S1-connection (TS 24.301), armed in ECM-IDLE and cancelled on
+	// reconnect. idleGen invalidates a timer callback that fired just as a reconnect
+	// or re-arm ran.
+	mobileReachableTimer *time.Timer
+	implicitDetachTimer  *time.Timer
+	idleGen              uint64
+
+	// Paging supervision (T3413, TS 24.301 §5.6.2): armed when the MME pages an
+	// idle UE for buffered downlink data, retransmitted a bounded number of times,
+	// and cancelled when the UE reconnects. pagingPDU is the S1AP Paging message
+	// retransmitted on expiry; pagingGen invalidates a stale callback.
+	pagingTimer *time.Timer
+	pagingPDU   []byte
+	pagingTries int
+	pagingGen   uint64
 }
 
 // touchLastSeen records the current time as the UE's most recent uplink NAS
@@ -227,6 +230,23 @@ func (m *MME) setIMSI(ue *UeContext, imsi string) {
 	ue.mu.Lock()
 	ue.imsi = imsi
 	ue.mu.Unlock()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// A new context for a subscriber supersedes any prior one (a re-attach), so a
+	// subscriber maps to exactly one UE context.
+	if old, ok := m.ues[imsi]; ok && old != ue {
+		m.removeContextLocked(old)
+	}
+
+	m.ues[imsi] = ue
+}
+
+// connected reports whether the UE has an active UE-associated S1-connection
+// (ECM-CONNECTED); an idle UE has none (TS 23.401).
+func (ue *UeContext) connected() bool {
+	return ue.s1 != nil
 }
 
 // downlinkSecCtx reserves the next downlink NAS COUNT and returns the security context to protect with (TS 24.301).
@@ -408,59 +428,77 @@ func (m *MME) newUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
 	m.nextMMEUEID++
 
 	c := &s1Conn{ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id), conn: conn}
-	ue := &UeContext{s1Conn: c}
+	ue := &UeContext{s1: c}
 	c.ue = ue
-	ue.ecmState.store(ECMConnected)
 
 	m.conns[id] = c
 
 	return ue
 }
 
-// establishS1Connection binds an existing UE context to a new UE-associated
-// logical S1-connection: it allocates a fresh MME-UE-S1AP-ID (the one from the
-// released connection must not be reused, TS 36.413), re-keys the
-// active-connection index, and records the new eNB association, for a UE
-// returning from ECM-IDLE (Service Request, paging response, tracking area
-// update with the active flag). ECM-CONNECTED is set by
-// the caller once the procedure succeeds, so a rejected request leaves the UE in
-// ECM-IDLE.
+// establishS1Connection binds a UE returning from ECM-IDLE to a fresh
+// UE-associated logical S1-connection, allocating a new MME-UE-S1AP-ID (the
+// released one must not be reused, TS 36.413). Any prior connection and its
+// idle/paging supervision are released first.
 func (m *MME) establishS1Connection(ue *UeContext, conn nasWriter, enbUEID s1ap.ENBUES1APID) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// A NAS signalling connection is being established for the UE, so the prior
-	// connection's idle, paging, and NAS-guard supervision are stopped before its
-	// s1Conn is replaced, leaving no timer that could fire against the new one
-	// (TS 24.301).
 	m.stopIdleTimersLocked(ue)
 	m.stopPagingLocked(ue)
-	m.stopNASGuardLocked(ue)
-
-	delete(m.conns, uint32(ue.MMEUES1APID))
+	m.freeS1ConnLocked(ue)
 
 	id := m.nextMMEUEID
 	m.nextMMEUEID++
 
 	c := &s1Conn{MMEUES1APID: s1ap.MMEUES1APID(id), ENBUES1APID: enbUEID, conn: conn, ue: ue}
-	ue.s1Conn = c
+	ue.s1 = c
 	m.conns[id] = c
 }
 
-// removeUe deletes a UE context. It is idempotent (deleting an absent context
-// is a no-op), which absorbs the detach/RLF release race.
-func (m *MME) removeUe(mmeUEID s1ap.MMEUES1APID) {
+// freeS1ConnLocked releases the UE's current S1-connection (moving it to
+// ECM-IDLE) and stops the connection-scoped NAS-guard supervision. The
+// persistent context, its idle timers, and its registry indexes are left intact.
+// The caller holds m.mu.
+func (m *MME) freeS1ConnLocked(ue *UeContext) {
+	if ue.s1 == nil {
+		return
+	}
+
+	m.stopNASGuardLocked(ue)
+	delete(m.conns, uint32(ue.s1.MMEUES1APID))
+	ue.s1 = nil
+}
+
+// freeS1Conn releases the UE's S1-connection under m.mu, moving it to ECM-IDLE.
+func (m *MME) freeS1Conn(ue *UeContext) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if c, ok := m.conns[uint32(mmeUEID)]; ok && c.ue != nil {
-		m.stopIdleTimersLocked(c.ue)
-		m.stopNASGuardLocked(c.ue)
-		m.stopPagingLocked(c.ue)
-		m.releaseMTMSIsLocked(c.ue)
-	}
+	m.freeS1ConnLocked(ue)
+}
 
-	delete(m.conns, uint32(mmeUEID))
+// removeUe deletes a UE context entirely: its S1-connection, idle/paging
+// supervision, and all registry indexes. Idempotent, absorbing the detach/RLF
+// release race.
+func (m *MME) removeUe(ue *UeContext) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.removeContextLocked(ue)
+}
+
+// removeContextLocked deletes the UE from every registry index and stops all its
+// supervision. The caller holds m.mu.
+func (m *MME) removeContextLocked(ue *UeContext) {
+	m.stopIdleTimersLocked(ue)
+	m.stopPagingLocked(ue)
+	m.releaseMTMSIsLocked(ue)
+	m.freeS1ConnLocked(ue)
+
+	if ue.imsi != "" && m.ues[ue.imsi] == ue {
+		delete(m.ues, ue.imsi)
+	}
 }
 
 // dropStaleUe removes any context bound to the same eNB association and
@@ -470,29 +508,34 @@ func (m *MME) dropStaleUe(conn nasWriter, enbUEID s1ap.ENBUES1APID) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for id, c := range m.conns {
-		if c.conn == conn && c.ENBUES1APID == enbUEID {
-			if c.ue != nil {
-				m.stopIdleTimersLocked(c.ue)
-				m.stopNASGuardLocked(c.ue)
-				m.stopPagingLocked(c.ue)
-				m.releaseMTMSIsLocked(c.ue)
-			}
+	var stale []*UeContext
 
-			delete(m.conns, id)
+	for _, c := range m.conns {
+		if c.ue != nil && c.conn == conn && c.ENBUES1APID == enbUEID {
+			stale = append(stale, c.ue)
 		}
+	}
+
+	for _, ue := range stale {
+		m.removeContextLocked(ue)
 	}
 }
 
 // s1Identity snapshots the UE's S1 association — the eNB connection and the
 // MME/ENB-UE-S1AP-IDs — under m.mu, so an off-dispatch send reads a consistent
 // identity even while the UE rebinds it on an ECM-IDLE resume or a path switch
-// (TS 36.413). The caller then does I/O with the snapshot, never under the lock.
+// (TS 36.413). It returns a nil writer for an idle UE (no connection), which the
+// caller treats as undeliverable. The caller does I/O with the snapshot, never
+// under the lock.
 func (m *MME) s1Identity(ue *UeContext) (nasWriter, s1ap.MMEUES1APID, s1ap.ENBUES1APID) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return ue.conn, ue.MMEUES1APID, ue.ENBUES1APID
+	if ue.s1 == nil {
+		return nil, 0, 0
+	}
+
+	return ue.s1.conn, ue.s1.MMEUES1APID, ue.s1.ENBUES1APID
 }
 
 // lookupUe finds the UE context bound to a connection by its MME-UE-S1AP-ID. A
@@ -520,25 +563,14 @@ func (m *MME) lookupUeByMTMSI(mtmsi uint32) (*UeContext, bool) {
 	return ue, ok
 }
 
-// lookupUeByIMSI finds the attached UE context for imsi by scanning the
-// registry, used by the detach and paging paths that key on the subscriber.
+// lookupUeByIMSI finds the persistent UE context for imsi, used by the detach
+// and paging paths that key on the subscriber. It resolves a UE in ECM-IDLE as
+// well as a connected one.
 func (m *MME) lookupUeByIMSI(imsi string) (*UeContext, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for _, c := range m.conns {
-		if c.ue == nil {
-			continue
-		}
+	ue, ok := m.ues[imsi]
 
-		c.ue.mu.Lock()
-		match := c.ue.imsi == imsi
-		c.ue.mu.Unlock()
-
-		if match {
-			return c.ue, true
-		}
-	}
-
-	return nil, false
+	return ue, ok
 }

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -489,6 +489,28 @@ func (m *MME) establishS1Connection(ue *UeContext, conn nasWriter, enbUEID s1ap.
 	m.conns[id] = c
 }
 
+// adoptConn moves the connection an Initial UE Message created onto a held
+// persistent context, superseding the transient context that first received it.
+// A returning UE whose native GUTI resolves to a held EPS security context reuses
+// that context whole — keys, algorithms, and NAS COUNTs continue in place — so its
+// connection, not its security state, is what is rebound (TS 24.301 §4.4.3,
+// §5.4.3.3). Any prior connection and idle supervision of the held context are
+// released first.
+func (m *MME) adoptConn(existing, transient *UeContext) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c := transient.s1
+	transient.s1 = nil
+
+	m.stopIdleTimersLocked(existing)
+	m.stopPagingLocked(existing)
+	m.freeS1ConnLocked(existing)
+
+	existing.s1 = c
+	c.ue = existing
+}
+
 // freeS1ConnLocked releases the UE's current S1-connection (moving it to
 // ECM-IDLE) and stops the connection-scoped NAS-guard supervision. The
 // persistent context, its idle timers, and its registry indexes are left intact.
@@ -498,6 +520,9 @@ func (m *MME) freeS1ConnLocked(ue *UeContext) {
 		return
 	}
 
+	// Abort any in-flight handover so its guard timer does not outlive ue.s1 and
+	// fire on a freed connection.
+	m.clearHandoverLocked(ue)
 	m.stopNASGuardLocked(ue)
 	delete(m.conns, uint32(ue.s1.MMEUES1APID))
 	ue.s1 = nil

--- a/internal/mme/nas_guard.go
+++ b/internal/mme/nas_guard.go
@@ -51,15 +51,21 @@ func (m *MME) armNASGuardMode(ue *UeContext, name string, nas []byte, onAbort fu
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// The NAS guard is connection-scoped; a UE with no S1-connection (ECM-IDLE)
+	// has no common procedure to guard.
+	if ue.s1 == nil {
+		return
+	}
+
 	m.stopNASGuardLocked(ue)
-	gen := ue.nasGuardGen
+	gen := ue.s1.nasGuardGen
 
-	ue.nasGuardName = name
-	ue.nasGuardPDU = nas
-	ue.nasGuardTries = 0
-	ue.nasGuardOnAbort = onAbort
+	ue.s1.nasGuardName = name
+	ue.s1.nasGuardPDU = nas
+	ue.s1.nasGuardTries = 0
+	ue.s1.nasGuardOnAbort = onAbort
 
-	ue.nasGuardTimer = time.AfterFunc(m.nasGuardTimeout, func() {
+	ue.s1.nasGuardTimer = time.AfterFunc(m.nasGuardTimeout, func() {
 		m.onNASGuardExpiry(ue, gen)
 	})
 }
@@ -75,15 +81,19 @@ func (m *MME) stopNASGuard(ue *UeContext) {
 // stopNASGuardLocked cancels the guard and invalidates any in-flight callback.
 // The caller holds m.mu.
 func (m *MME) stopNASGuardLocked(ue *UeContext) {
-	ue.nasGuardGen++
-
-	if ue.nasGuardTimer != nil {
-		ue.nasGuardTimer.Stop()
-		ue.nasGuardTimer = nil
+	if ue.s1 == nil {
+		return
 	}
 
-	ue.nasGuardPDU = nil
-	ue.nasGuardOnAbort = nil
+	ue.s1.nasGuardGen++
+
+	if ue.s1.nasGuardTimer != nil {
+		ue.s1.nasGuardTimer.Stop()
+		ue.s1.nasGuardTimer = nil
+	}
+
+	ue.s1.nasGuardPDU = nil
+	ue.s1.nasGuardOnAbort = nil
 }
 
 // onNASGuardExpiry retransmits the outstanding downlink message, or releases the
@@ -92,21 +102,23 @@ func (m *MME) stopNASGuardLocked(ue *UeContext) {
 func (m *MME) onNASGuardExpiry(ue *UeContext, gen uint64) {
 	m.mu.Lock()
 
-	if ue.nasGuardGen != gen {
+	// The connection may have been released (ECM-IDLE) after the timer fired but
+	// before it took the lock; the guard goes with it.
+	if ue.s1 == nil || ue.s1.nasGuardGen != gen {
 		m.mu.Unlock()
 		return
 	}
 
-	ue.nasGuardTries++
-	name := ue.nasGuardName
+	ue.s1.nasGuardTries++
+	name := ue.s1.nasGuardName
 
-	if ue.nasGuardTries > m.nasGuardMaxRetransmit {
-		ue.nasGuardTimer = nil
-		ue.nasGuardPDU = nil
-		ue.nasGuardGen++
-		mmeUEID := ue.MMEUES1APID
-		onAbort := ue.nasGuardOnAbort
-		ue.nasGuardOnAbort = nil
+	if ue.s1.nasGuardTries > m.nasGuardMaxRetransmit {
+		ue.s1.nasGuardTimer = nil
+		ue.s1.nasGuardPDU = nil
+		ue.s1.nasGuardGen++
+		mmeUEID := ue.s1.MMEUES1APID
+		onAbort := ue.s1.nasGuardOnAbort
+		ue.s1.nasGuardOnAbort = nil
 
 		m.mu.Unlock()
 
@@ -127,17 +139,17 @@ func (m *MME) onNASGuardExpiry(ue *UeContext, gen uint64) {
 		return
 	}
 
-	pdu := ue.nasGuardPDU
-	tries := ue.nasGuardTries
+	pdu := ue.s1.nasGuardPDU
+	tries := ue.s1.nasGuardTries
 
-	ue.nasGuardTimer = time.AfterFunc(m.nasGuardTimeout, func() {
+	ue.s1.nasGuardTimer = time.AfterFunc(m.nasGuardTimeout, func() {
 		m.onNASGuardExpiry(ue, gen)
 	})
 
 	m.mu.Unlock()
 
 	logger.MmeLog.Info("retransmitting NAS message",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("procedure", name), zap.Int("attempt", tries))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("procedure", name), zap.Int("attempt", tries))
 	// Retransmission is timer-driven, outside the original request; start a fresh root.
 	m.sendDownlink(context.Background(), ue, pdu)
 }

--- a/internal/mme/nas_guard_test.go
+++ b/internal/mme/nas_guard_test.go
@@ -50,7 +50,7 @@ func TestNASGuardAbortOnlyRunsFinalizer(t *testing.T) {
 		t.Fatal("abort-only finalizer not run after retransmissions exhausted")
 	}
 
-	if ue.releasing {
+	if ue.s1.releasing {
 		t.Fatal("abort-only guard released the UE; expected it to stay connected")
 	}
 
@@ -75,11 +75,11 @@ func TestNASGuardStoppedByResponse(t *testing.T) {
 	// The guard is cancelled, so after the timeout window nothing mutates the UE.
 	time.Sleep(50 * time.Millisecond)
 
-	if ue.releasing {
+	if ue.s1.releasing {
 		t.Fatal("UE released despite the guarded response arriving")
 	}
 
-	if ue.nasGuardTimer != nil {
+	if ue.s1.nasGuardTimer != nil {
 		t.Fatal("NAS guard still armed after the response")
 	}
 

--- a/internal/mme/nas_security.go
+++ b/internal/mme/nas_security.go
@@ -4,21 +4,41 @@
 package mme
 
 import (
+	"crypto/sha256"
+
 	nascommon "github.com/ellanetworks/core/nas/common"
 	"github.com/ellanetworks/core/nas/eps"
 )
 
+// hashMME returns the 8-octet HashMME for the SECURITY MODE COMMAND — the 64 most
+// significant bits of the SHA-256 of the triggering plain Attach/TAU — or nil when
+// there is nothing to hash (TS 24.301 §5.4.3.2, TS 33.401 §6.4.2.1).
+func hashMME(input []byte) []byte {
+	if len(input) == 0 {
+		return nil
+	}
+
+	sum := sha256.Sum256(input)
+
+	return sum[:8]
+}
+
 // selectAlgorithms picks the EPS NAS algorithms allowed by both the UE network
 // capability and the operator policy (TS 33.401), in the operator's order of
 // preference. The operator's list uses the RAT-neutral algorithm identities
-// (NULL ≡ EEA0/EIA0, SNOW3G ≡ 128-EEA1/128-EIA1, AES ≡ 128-EEA2/128-EIA2).
-func selectAlgorithms(ueNetCap []byte, ciphering, integrity []string) (eea, eia byte) {
+// (NULL ≡ EEA0/EIA0, SNOW3G ≡ 128-EEA1/128-EIA1, AES ≡ 128-EEA2/128-EIA2). It
+// reports false when the UE and operator share no algorithm, so the caller
+// rejects the attach without falling back to the null algorithm.
+func selectAlgorithms(ueNetCap []byte, ciphering, integrity []string) (eea, eia byte, ok bool) {
 	uecap, err := eps.ParseUENetworkCapability(ueNetCap)
 	if err != nil {
-		return 0, 0
+		return 0, 0, false
 	}
 
-	return selectEPSAlgorithm(ciphering, uecap.SupportsEEA), selectEPSAlgorithm(integrity, uecap.SupportsEIA)
+	eea, eok := selectEPSAlgorithm(ciphering, uecap.SupportsEEA)
+	eia, iok := selectEPSAlgorithm(integrity, uecap.SupportsEIA)
+
+	return eea, eia, eok && iok
 }
 
 // epsAlgorithmValue maps an operator algorithm identity to its EPS algorithm
@@ -37,21 +57,22 @@ func epsAlgorithmValue(name string) (byte, bool) {
 }
 
 // selectEPSAlgorithm returns the first operator-preferred algorithm the UE
-// supports. The null algorithm (0) is supported by every UE and is the fallback
-// when no configured algorithm is common (TS 24.301).
-func selectEPSAlgorithm(preference []string, supported func(uint8) bool) byte {
+// advertises support for, reporting false when none is common. The null
+// algorithm is selected only when the operator lists it and the UE advertises it
+// (TS 33.401 §5: EIA0 is not an implicit fallback for a non-emergency UE).
+func selectEPSAlgorithm(preference []string, supported func(uint8) bool) (byte, bool) {
 	for _, name := range preference {
 		v, ok := epsAlgorithmValue(name)
 		if !ok {
 			continue
 		}
 
-		if v == 0 || supported(v) {
-			return v
+		if supported(v) {
+			return v, true
 		}
 	}
 
-	return 0
+	return 0, false
 }
 
 // geaOctet maps the GERAN ciphering algorithms from the UE's MS network

--- a/internal/mme/nas_security_test.go
+++ b/internal/mme/nas_security_test.go
@@ -5,9 +5,11 @@ package mme
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	nascommon "github.com/ellanetworks/core/nas/common"
+	"github.com/ellanetworks/core/nas/eps"
 )
 
 // TestReplayedUESecCapClearsUCS2 reproduces the iPhone Security Mode Reject
@@ -78,31 +80,61 @@ func TestReplayedUESecCapNoGERAN(t *testing.T) {
 }
 
 func TestSelectEPSAlgorithm(t *testing.T) {
-	// A UE that supports SNOW3G and AES for both ciphering and integrity.
 	supportsAll := func(uint8) bool { return true }
-	// A UE that supports only AES (value 2).
 	supportsAESOnly := func(n uint8) bool { return n == 2 }
+	supportsNullOnly := func(n uint8) bool { return n == 0 }
 
 	tests := []struct {
 		name       string
 		preference []string
 		supported  func(uint8) bool
 		want       byte
+		wantOK     bool
 	}{
-		{"AES preferred", []string{"AES", "SNOW3G"}, supportsAll, 2},
-		{"SNOW3G preferred", []string{"SNOW3G", "AES"}, supportsAll, 1},
-		{"SNOW3G preferred but UE lacks it", []string{"SNOW3G", "AES"}, supportsAESOnly, 2},
-		{"only SNOW3G, UE lacks it falls to null", []string{"SNOW3G"}, supportsAESOnly, 0},
-		{"explicit NULL", []string{"NULL", "AES"}, supportsAll, 0},
-		{"empty falls to null", nil, supportsAll, 0},
+		{"AES preferred", []string{"AES", "SNOW3G"}, supportsAll, 2, true},
+		{"SNOW3G preferred", []string{"SNOW3G", "AES"}, supportsAll, 1, true},
+		{"SNOW3G preferred but UE lacks it", []string{"SNOW3G", "AES"}, supportsAESOnly, 2, true},
+		{"no common algorithm", []string{"SNOW3G"}, supportsAESOnly, 0, false},
+		{"NULL configured and UE advertises it", []string{"AES", "NULL"}, supportsNullOnly, 0, true},
+		{"NULL configured but UE does not advertise it", []string{"AES", "NULL"}, supportsAESOnly, 2, true},
+		{"NULL configured, UE supports nothing", []string{"NULL"}, supportsAESOnly, 0, false},
+		{"empty preference", nil, supportsAll, 0, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := selectEPSAlgorithm(tt.preference, tt.supported); got != tt.want {
-				t.Fatalf("selectEPSAlgorithm = %d, want %d", got, tt.want)
+			got, ok := selectEPSAlgorithm(tt.preference, tt.supported)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("selectEPSAlgorithm = (%d, %v), want (%d, %v)", got, ok, tt.want, tt.wantOK)
 			}
 		})
+	}
+}
+
+// A UE that advertises no integrity algorithm common with the operator policy is
+// rejected (EMM cause #23), not silently downgraded to the null algorithm
+// (TS 33.401 §5).
+func TestStartSecurityModeRejectsNoCommonIntegrity(t *testing.T) {
+	m := newTestMME(t)
+	cc := &captureConn{}
+	ue := m.newUe(cc, 7)
+	ue.imsi = testSubscriber.IMSI
+	ue.kasme = make([]byte, 32)
+	ue.ueNetCap = eps.UENetworkCapability{EEA: 0xff, EIA: 0x00}.Marshal()
+
+	m.startSecurityMode(context.Background(), ue)
+
+	if ue.secured {
+		t.Fatal("UE secured despite no common integrity algorithm")
+	}
+
+	reject, err := eps.ParseAttachReject(decodeDownlinkNAS(t, cc.sent[0]))
+	if err != nil {
+		t.Fatalf("expected Attach Reject, got: %v", err)
+	}
+
+	if reject.Cause != emmCauseUESecCapsMismatch {
+		t.Fatalf("Attach Reject cause = %d, want %d", reject.Cause, emmCauseUESecCapsMismatch)
 	}
 }
 

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -36,7 +36,7 @@ func (m *MME) Page(ctx context.Context, imsi string) error {
 
 	m.mu.RLock()
 
-	skip := ue.ecmState.load() == ECMConnected || ue.pagingTimer != nil
+	skip := ue.connected() || ue.pagingTimer != nil
 
 	m.mu.RUnlock()
 
@@ -108,7 +108,7 @@ func (m *MME) onPagingExpiry(ue *UeContext, gen uint64) {
 		return
 	}
 
-	if ue.ecmState.load() == ECMConnected {
+	if ue.connected() {
 		m.stopPagingLocked(ue)
 		m.mu.Unlock()
 
@@ -116,12 +116,11 @@ func (m *MME) onPagingExpiry(ue *UeContext, gen uint64) {
 	}
 
 	if ue.pagingTries >= m.pagingMaxRetransmit {
-		mmeUEID, imsi := ue.MMEUES1APID, ue.imsi
+		imsi := ue.imsi
 		m.stopPagingLocked(ue)
 		m.mu.Unlock()
 
-		logger.MmeLog.Info("paging unanswered, abandoning procedure",
-			zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("imsi", imsi))
+		logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
 
 		return
 	}
@@ -137,7 +136,7 @@ func (m *MME) onPagingExpiry(ue *UeContext, gen uint64) {
 	m.mu.Unlock()
 
 	logger.MmeLog.Info("paging unanswered, retransmitting",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.Int("attempt", tries))
+		zap.String("imsi", ue.imsi), zap.Int("attempt", tries))
 	m.broadcastPaging(context.Background(), pdu)
 }
 

--- a/internal/mme/paging_test.go
+++ b/internal/mme/paging_test.go
@@ -124,7 +124,6 @@ func TestPagingStoppedOnReconnect(t *testing.T) {
 	m.pagingTimeout = time.Hour // long enough not to fire during the test
 
 	ue, _ := idleRegisteredUE(t, m)
-	conn := ue.conn
 
 	if err := m.Page(context.Background(), ue.imsi); err != nil {
 		t.Fatalf("Page: %v", err)
@@ -134,7 +133,7 @@ func TestPagingStoppedOnReconnect(t *testing.T) {
 		t.Fatal("paging not supervised after Page")
 	}
 
-	m.establishS1Connection(ue, conn, 9)
+	m.establishS1Connection(ue, &captureConn{}, 9)
 
 	if m.pagingActive(ue) {
 		t.Fatal("paging supervision not stopped when the UE reconnected")

--- a/internal/mme/path_switch.go
+++ b/internal/mme/path_switch.go
@@ -56,7 +56,7 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 
 	if !ue.secured || len(ue.kasme) == 0 {
 		logger.MmeLog.Warn("Path Switch Request for a UE without a security context",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 		m.sendPathSwitchFailure(conn, req, causePathSwitchNoSecurity)
 
 		return
@@ -65,10 +65,10 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	// Snapshot the {NH, NCC} chain base under the lock — refusing if an S1 handover
 	// is concurrently advancing it, which would derive the same NH for two targets.
 	m.mu.Lock()
-	if ue.handover != nil {
+	if ue.s1.handover != nil {
 		m.mu.Unlock()
 		logger.MmeLog.Warn("Path Switch Request while a handover is in progress",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 		m.sendPathSwitchFailure(conn, req, causePathSwitchUPFailure)
 
 		return
@@ -93,7 +93,7 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	if switched == 0 {
 		// TS 36.413: the UP path was switched for no E-RAB.
 		logger.MmeLog.Warn("Path Switch Request switched no E-RAB",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 		m.sendPathSwitchFailure(conn, req, causePathSwitchUPFailure)
 
 		return
@@ -104,15 +104,15 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	// UP switch succeeded: move the S1 association to the target eNB and commit the
 	// advanced {NH, NCC}. NCC is a 3-bit chaining counter (TS 33.401).
 	m.mu.Lock()
-	ue.conn = conn
-	ue.ENBUES1APID = req.ENBUES1APID
+	ue.s1.conn = conn
+	ue.s1.ENBUES1APID = req.ENBUES1APID
 	ue.nh = newNH
 	ue.ncc = (curNCC + 1) & 0x07
 	ncc := ue.ncc
 	m.mu.Unlock()
 
 	ack := &s1ap.PathSwitchRequestAcknowledge{
-		MMEUES1APID:            ue.MMEUES1APID,
+		MMEUES1APID:            ue.s1.MMEUES1APID,
 		ENBUES1APID:            req.ENBUES1APID,
 		SecurityContext:        s1ap.SecurityContext{NextHopChainingCount: ncc, NextHopParameter: s1ap.SecurityKey(newNH)},
 		UESecurityCapabilities: replayCaps,
@@ -125,7 +125,7 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	}
 
 	logger.MmeLog.Info("Path Switch Request",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.Uint32("enb-ue-id", uint32(req.ENBUES1APID)),
 		zap.Int("e-rabs-switched", switched),
 		zap.Uint8("ncc", ncc))
@@ -146,7 +146,7 @@ func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, items []s1ap
 		p := m.lookupPDN(ue, uint8(erab.ERABID))
 		if p == nil {
 			logger.MmeLog.Warn("Path Switch Request lists an unknown E-RAB; not switched",
-				zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			continue
 		}
@@ -154,7 +154,7 @@ func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, items []s1ap
 		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
 		if !ok {
 			logger.MmeLog.Warn("Path Switch Request E-RAB has an invalid eNB transport address; not switched",
-				zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			continue
 		}
@@ -172,7 +172,7 @@ func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, items []s1ap
 		switched++
 
 		logger.MmeLog.Debug("Path Switch: E-RAB downlink switched",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 			zap.Uint8("e-rab-id", uint8(erab.ERABID)),
 			zap.String("enb-s1u", addr.String()))
 	}
@@ -223,7 +223,7 @@ func (m *MME) pathSwitchSecurityCapabilities(ue *UeContext, received s1ap.UESecu
 	}
 
 	logger.MmeLog.Warn("UE security capabilities reported by target eNB differ from stored; replaying stored values",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.Uint16("received-eea", received.EncryptionAlgorithms),
 		zap.Uint16("received-eia", received.IntegrityProtectionAlgorithms),
 		zap.Uint16("stored-eea", stored.EncryptionAlgorithms),

--- a/internal/mme/path_switch.go
+++ b/internal/mme/path_switch.go
@@ -62,20 +62,29 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 		return
 	}
 
-	// Snapshot the {NH, NCC} chain base under the lock — refusing if an S1 handover
-	// is concurrently advancing it, which would derive the same NH for two targets.
+	// Claim the {NH, NCC} chain under the lock — refusing if a Path Switch or S1
+	// handover is concurrently advancing it, which would derive the same NH for two
+	// targets. The claim is held until commit so a handover cannot start in the
+	// unlocked derive/switch window below.
 	m.mu.Lock()
-	if ue.s1.handover != nil {
+	if ue.keyChainBusy {
 		m.mu.Unlock()
-		logger.MmeLog.Warn("Path Switch Request while a handover is in progress",
+		logger.MmeLog.Warn("Path Switch Request while the key chain is being advanced",
 			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 		m.sendPathSwitchFailure(conn, req, causePathSwitchUPFailure)
 
 		return
 	}
 
+	ue.keyChainBusy = true
 	curNH, curNCC := ue.nh, ue.ncc
 	m.mu.Unlock()
+
+	defer func() {
+		m.mu.Lock()
+		ue.keyChainBusy = false
+		m.mu.Unlock()
+	}()
 
 	// Compute the next NH before any user-plane change so a derivation error leaves
 	// the UE on the source eNB cleanly; the chain is committed only after at least

--- a/internal/mme/path_switch.go
+++ b/internal/mme/path_switch.go
@@ -78,6 +78,7 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 
 	ue.keyChainBusy = true
 	curNH, curNCC := ue.nh, ue.ncc
+	mmeID := ue.s1.MMEUES1APID // a release in the unlocked window below may nil ue.s1
 	m.mu.Unlock()
 
 	defer func() {
@@ -98,11 +99,11 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	}
 
 	// Switch the downlink of every E-RAB in the list to the endpoint it carries.
-	switched := m.switchPathBearers(ctx, ue, req.ERABToBeSwitchedDL)
+	switched := m.switchPathBearers(ctx, ue, mmeID, req.ERABToBeSwitchedDL)
 	if switched == 0 {
 		// TS 36.413: the UP path was switched for no E-RAB.
 		logger.MmeLog.Warn("Path Switch Request switched no E-RAB",
-			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
+			zap.Uint32("mme-ue-id", uint32(mmeID)))
 		m.sendPathSwitchFailure(conn, req, causePathSwitchUPFailure)
 
 		return
@@ -111,8 +112,19 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	replayCaps := m.pathSwitchSecurityCapabilities(ue, req.UESecurityCapabilities)
 
 	// UP switch succeeded: move the S1 association to the target eNB and commit the
-	// advanced {NH, NCC}. NCC is a 3-bit chaining counter (TS 33.401).
+	// advanced {NH, NCC}. NCC is a 3-bit chaining counter (TS 33.401). The UE may
+	// have been released during the unlocked switch above (its source association
+	// dropping), so the commit is gated on the connection still being present.
 	m.mu.Lock()
+	if ue.s1 == nil {
+		m.mu.Unlock()
+		logger.MmeLog.Warn("Path Switch Request: UE released during the user-plane switch",
+			zap.Uint32("mme-ue-id", uint32(mmeID)))
+		m.sendPathSwitchFailure(conn, req, causePathSwitchUPFailure)
+
+		return
+	}
+
 	ue.s1.conn = conn
 	ue.s1.ENBUES1APID = req.ENBUES1APID
 	ue.nh = newNH
@@ -121,7 +133,7 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	m.mu.Unlock()
 
 	ack := &s1ap.PathSwitchRequestAcknowledge{
-		MMEUES1APID:            ue.s1.MMEUES1APID,
+		MMEUES1APID:            mmeID,
 		ENBUES1APID:            req.ENBUES1APID,
 		SecurityContext:        s1ap.SecurityContext{NextHopChainingCount: ncc, NextHopParameter: s1ap.SecurityKey(newNH)},
 		UESecurityCapabilities: replayCaps,
@@ -134,7 +146,7 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	}
 
 	logger.MmeLog.Info("Path Switch Request",
-		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(mmeID)),
 		zap.Uint32("enb-ue-id", uint32(req.ENBUES1APID)),
 		zap.Int("e-rabs-switched", switched),
 		zap.Uint8("ncc", ncc))
@@ -148,14 +160,14 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 // to a PDN connection, or whose endpoint is malformed or fails to switch, is
 // logged and skipped — not silently dropped — and counts as not switched
 // (TS 36.413).
-func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, items []s1ap.ERABToBeSwitchedDLItem) int {
+func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, mmeID s1ap.MMEUES1APID, items []s1ap.ERABToBeSwitchedDLItem) int {
 	switched := 0
 
 	for _, erab := range items {
 		p := m.lookupPDN(ue, uint8(erab.ERABID))
 		if p == nil {
 			logger.MmeLog.Warn("Path Switch Request lists an unknown E-RAB; not switched",
-				zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			continue
 		}
@@ -163,7 +175,7 @@ func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, items []s1ap
 		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
 		if !ok {
 			logger.MmeLog.Warn("Path Switch Request E-RAB has an invalid eNB transport address; not switched",
-				zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			continue
 		}
@@ -181,7 +193,7 @@ func (m *MME) switchPathBearers(ctx context.Context, ue *UeContext, items []s1ap
 		switched++
 
 		logger.MmeLog.Debug("Path Switch: E-RAB downlink switched",
-			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
+			zap.Uint32("mme-ue-id", uint32(mmeID)),
 			zap.Uint8("e-rab-id", uint8(erab.ERABID)),
 			zap.String("enb-s1u", addr.String()))
 	}

--- a/internal/mme/path_switch.go
+++ b/internal/mme/path_switch.go
@@ -62,10 +62,25 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 		return
 	}
 
+	// Snapshot the {NH, NCC} chain base under the lock — refusing if an S1 handover
+	// is concurrently advancing it, which would derive the same NH for two targets.
+	m.mu.Lock()
+	if ue.handover != nil {
+		m.mu.Unlock()
+		logger.MmeLog.Warn("Path Switch Request while a handover is in progress",
+			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+		m.sendPathSwitchFailure(conn, req, causePathSwitchUPFailure)
+
+		return
+	}
+
+	curNH, curNCC := ue.nh, ue.ncc
+	m.mu.Unlock()
+
 	// Compute the next NH before any user-plane change so a derivation error leaves
 	// the UE on the source eNB cleanly; the chain is committed only after at least
 	// one E-RAB is switched (TS 33.401 — no rollback once advanced).
-	newNH, err := deriveNH(ue.kasme, ue.nh[:])
+	newNH, err := deriveNH(ue.kasme, curNH[:])
 	if err != nil {
 		logger.MmeLog.Error("failed to advance NH for Path Switch", zap.Error(err))
 		m.sendPathSwitchFailure(conn, req, causePathSwitchUPFailure)
@@ -92,7 +107,7 @@ func (m *MME) handlePathSwitchRequest(ctx context.Context, conn nasWriter, value
 	ue.conn = conn
 	ue.ENBUES1APID = req.ENBUES1APID
 	ue.nh = newNH
-	ue.ncc = (ue.ncc + 1) & 0x07
+	ue.ncc = (curNCC + 1) & 0x07
 	ncc := ue.ncc
 	m.mu.Unlock()
 

--- a/internal/mme/path_switch_test.go
+++ b/internal/mme/path_switch_test.go
@@ -103,7 +103,7 @@ func samplePathSwitchRequest(ue *UeContext) *s1ap.PathSwitchRequest {
 	return &s1ap.PathSwitchRequest{
 		ENBUES1APID:        42,
 		ERABToBeSwitchedDL: []s1ap.ERABToBeSwitchedDLItem{switchedDLItem()},
-		SourceMMEUES1APID:  ue.MMEUES1APID,
+		SourceMMEUES1APID:  ue.s1.MMEUES1APID,
 		EUTRANCGI:          s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
 		TAI:                s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
 		// Matches the stored capabilities (EEA/EIA 0xe0, EEA0/EIA0 bit dropped).
@@ -133,8 +133,8 @@ func TestPathSwitchSwitchesDownlinkAndAcks(t *testing.T) {
 	}
 
 	// S1 association moved to the target eNB.
-	if ue.conn != target || ue.ENBUES1APID != 42 || testPDN(ue).enbFTEID != wantFTEID {
-		t.Fatalf("association not switched: conn=%v enb-id=%d fteid=%+v", ue.conn == target, ue.ENBUES1APID, testPDN(ue).enbFTEID)
+	if ue.s1.conn != target || ue.s1.ENBUES1APID != 42 || testPDN(ue).enbFTEID != wantFTEID {
+		t.Fatalf("association not switched: conn=%v enb-id=%d fteid=%+v", ue.s1.conn == target, ue.s1.ENBUES1APID, testPDN(ue).enbFTEID)
 	}
 
 	// Key chain advanced: NCC 1 -> 2 and NH = KDF(KASME, previous NH).
@@ -148,7 +148,7 @@ func TestPathSwitchSwitchesDownlinkAndAcks(t *testing.T) {
 
 	ack := parsePathSwitchAck(t, target.sent[0])
 
-	if ack.MMEUES1APID != ue.MMEUES1APID || ack.ENBUES1APID != 42 {
+	if ack.MMEUES1APID != ue.s1.MMEUES1APID || ack.ENBUES1APID != 42 {
 		t.Fatalf("ack UE IDs: mme=%#x enb=%d", ack.MMEUES1APID, ack.ENBUES1APID)
 	}
 
@@ -253,8 +253,8 @@ func TestPathSwitchUnknownERABFails(t *testing.T) {
 		t.Fatal("downlink switched for an unresolved E-RAB")
 	}
 
-	if ue.ncc != 1 || ue.conn == target {
-		t.Fatalf("UE moved on a failed path switch: ncc=%d moved=%v", ue.ncc, ue.conn == target)
+	if ue.ncc != 1 || ue.s1.conn == target {
+		t.Fatalf("UE moved on a failed path switch: ncc=%d moved=%v", ue.ncc, ue.s1.conn == target)
 	}
 }
 

--- a/internal/mme/path_switch_test.go
+++ b/internal/mme/path_switch_test.go
@@ -278,3 +278,27 @@ func TestPathSwitchCapabilityMismatchReplaysStored(t *testing.T) {
 		t.Fatalf("replayed capabilities = %+v, want %+v", ack.UESecurityCapabilities, want)
 	}
 }
+
+// TestPathSwitchUEReleasedDuringSwitch checks the commit is guarded against a
+// concurrent release that frees ue.s1 during the unlocked user-plane switch: the
+// path switch fails gracefully rather than dereferencing a nil connection.
+func TestPathSwitchUEReleasedDuringSwitch(t *testing.T) {
+	m := newTestMME(t)
+	ue := pathSwitchUE(t, m)
+
+	base := m.session.(*fakeSessionManager)
+	m.session = &hookSessionManager{fakeSessionManager: base, onModify: func() { m.freeS1Conn(ue) }}
+
+	target := &captureConn{}
+	m.handlePathSwitchRequest(context.Background(), target, pathSwitchValue(t, samplePathSwitchRequest(ue)))
+
+	if ue.s1 != nil {
+		t.Fatal("UE unexpectedly reconnected after being released mid-switch")
+	}
+
+	if target.count() != 1 {
+		t.Fatalf("expected one downlink (Path Switch Failure), got %d", target.count())
+	}
+
+	parsePathSwitchFailure(t, target.sent[0])
+}

--- a/internal/mme/pdn_connectivity.go
+++ b/internal/mme/pdn_connectivity.go
@@ -70,7 +70,7 @@ func (m *MME) onPDNConnectivityRequest(ctx context.Context, ue *UeContext, plain
 		return
 	}
 
-	if ue.emmState.load() != EMMRegistered || ue.ecmState.load() != ECMConnected {
+	if ue.emmState.load() != EMMRegistered || !ue.connected() {
 		m.rejectPDNConnectivity(ctx, ue, pti, esmCauseRequestRejectedUnspecified)
 		return
 	}
@@ -196,8 +196,8 @@ func (m *MME) sendERABSetup(ctx context.Context, ue *UeContext, p *pdnConnection
 	ambr := s1ap.UEAggregateMaximumBitRate{DL: s1ap.BitRate(qos.AMBRDL), UL: s1ap.BitRate(qos.AMBRUL)}
 
 	reqMsg := &s1ap.ERABSetupRequest{
-		MMEUES1APID:               ue.MMEUES1APID,
-		ENBUES1APID:               ue.ENBUES1APID,
+		MMEUES1APID:               ue.s1.MMEUES1APID,
+		ENBUES1APID:               ue.s1.ENBUES1APID,
 		UEAggregateMaximumBitRate: &ambr,
 		ERABToBeSetup: []s1ap.ERABToBeSetupItemBearerSUReq{{
 			ERABID: s1ap.ERABID(p.ebi),
@@ -245,7 +245,7 @@ func (m *MME) handleERABSetupResponse(conn nasWriter, value []byte) {
 		p := m.lookupPDN(ue, uint8(erab.ERABID))
 		if p == nil {
 			logger.MmeLog.Warn("E-RAB Setup Response for an unknown E-RAB",
-				zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			continue
 		}
@@ -253,7 +253,7 @@ func (m *MME) handleERABSetupResponse(conn nasWriter, value []byte) {
 		enbAddr, ok := enbTransportAddress(erab.TransportLayerAddress)
 		if !ok {
 			logger.MmeLog.Warn("E-RAB Setup Response with an invalid eNB transport address",
-				zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			continue
 		}

--- a/internal/mme/pdn_connectivity_test.go
+++ b/internal/mme/pdn_connectivity_test.go
@@ -138,7 +138,7 @@ func TestAdditionalPDNConnectionLifecycle(t *testing.T) {
 	}
 
 	resp := &s1ap.ERABSetupResponse{
-		MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID,
 		ERABSetup: []s1ap.ERABSetupItemBearerSURes{{
 			ERABID: 6, TransportLayerAddress: s1ap.TransportLayerAddress(tla), GTPTEID: 0x1234,
 		}},
@@ -194,7 +194,7 @@ func TestAdditionalPDNConnectionLifecycle(t *testing.T) {
 
 	// The eNB confirms the release; then the UE accepts the deactivation.
 	relResp := &s1ap.ERABReleaseResponse{
-		MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID,
 		ERABReleased: []s1ap.ERABReleaseItemBearerRelComp{{ERABID: 6}},
 	}
 
@@ -221,7 +221,7 @@ func TestAdditionalPDNConnectionLifecycle(t *testing.T) {
 		t.Fatal("second PDN not released after disconnect accept")
 	}
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); !ok {
+	if _, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok {
 		t.Fatal("UE removed by a single-PDN disconnect; expected it to stay registered")
 	}
 

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -45,7 +45,7 @@ func (m *MME) ReconcileDataNetwork(ctx context.Context) {
 // is signalled; an idle UE is signalled when it returns to ECM-CONNECTED
 // (reconcileBearer on the ICS Response) or by the next backstop sweep.
 func (m *MME) reconcileUE(ctx context.Context, ue *UeContext) {
-	if ue.emmState.load() != EMMRegistered || ue.ecmState.load() != ECMConnected {
+	if ue.emmState.load() != EMMRegistered || !ue.connected() {
 		return
 	}
 
@@ -131,14 +131,14 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, p *pdnConnecti
 	// re-establishes (the new bearer also picks up the new QoS/Session-AMBR).
 	if dnChanged && !dnsOnlyChange(curDNConfig, newFingerprint) {
 		logger.MmeLog.Info("data-network configuration changed; reactivating EPS bearer",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
 		m.reactivateBearer(ctx, ue, p)
 
 		return
 	}
 
 	logger.MmeLog.Info("policy/data-network changed; modifying EPS bearer in place",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn),
 		zap.Bool("dns", dnChanged), zap.Bool("session-ambr", ambrChanged), zap.Bool("qos", qosChanged))
 	m.modifyBearer(ctx, ue, p, qos, dnChanged, ambrChanged, qosChanged)
 }
@@ -264,8 +264,8 @@ func (m *MME) modifyBearer(ctx context.Context, ue *UeContext, p *pdnConnection,
 // Response, so this does not block on it.
 func (m *MME) sendERABModify(ctx context.Context, ue *UeContext, p *pdnConnection, qos *epsQoS, naspdu []byte) {
 	req := &s1ap.ERABModifyRequest{
-		MMEUES1APID: ue.MMEUES1APID,
-		ENBUES1APID: ue.ENBUES1APID,
+		MMEUES1APID: ue.s1.MMEUES1APID,
+		ENBUES1APID: ue.s1.ENBUES1APID,
 		ERABToBeModified: []s1ap.ERABToBeModifiedItemBearerModReq{{
 			ERABID: s1ap.ERABID(p.ebi),
 			QoS: s1ap.ERABLevelQoSParameters{
@@ -378,7 +378,7 @@ func (m *MME) onModifyBearerAccept(ue *UeContext, plain []byte) {
 	ue.mu.Unlock()
 
 	logger.MmeLog.Info("EPS bearer modified in place",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
 }
 
 // onModifyBearerReject abandons the modification when the UE rejects it
@@ -400,7 +400,7 @@ func (m *MME) onModifyBearerReject(ue *UeContext, plain []byte) {
 	}
 
 	logger.MmeLog.Warn("UE rejected EPS bearer modification",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 }
 
 // onDeactivateBearerAccept finalises an EPS bearer deactivation. A deactivation
@@ -434,7 +434,7 @@ func (m *MME) onDeactivateBearerAccept(ctx context.Context, ue *UeContext, plain
 
 	if releaseOnly {
 		logger.MmeLog.Info("PDN connection released",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi), zap.String("apn", p.apn))
 		m.releasePDN(ue, p)
 
 		return
@@ -448,6 +448,6 @@ func (m *MME) onDeactivateBearerAccept(ctx context.Context, ue *UeContext, plain
 	m.releaseAllSessions(ue)
 
 	logger.MmeLog.Info("EPS bearer deactivated for reactivation; UE will re-attach",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 	m.releaseUEContext(ctx, ue, causeNASNormalRelease)
 }

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -51,7 +51,7 @@ func (m *MME) reconcileUE(ctx context.Context, ue *UeContext) {
 	// bearer signalling (TS 36.413 §8.4.1.2); the next sweep re-converges the UE.
 	m.mu.RLock()
 
-	ready := ue.emmState.load() == EMMRegistered && ue.s1 != nil && ue.s1.handover == nil
+	ready := ue.emmState.load() == EMMRegistered && ue.s1 != nil && ue.handover == nil
 
 	m.mu.RUnlock()
 

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -45,14 +45,17 @@ func (m *MME) ReconcileDataNetwork(ctx context.Context) {
 // is signalled; an idle UE is signalled when it returns to ECM-CONNECTED
 // (reconcileBearer on the ICS Response) or by the next backstop sweep.
 func (m *MME) reconcileUE(ctx context.Context, ue *UeContext) {
-	if ue.emmState.load() != EMMRegistered || !ue.connected() {
-		return
-	}
+	// Read the connection state under the lock: ue.s1 is freed concurrently by a
+	// release goroutine. Reconciliation is deferred while an S1 handover is in
+	// flight, as an E-RAB Modify or Release would collide with the handover's
+	// bearer signalling (TS 36.413 §8.4.1.2); the next sweep re-converges the UE.
+	m.mu.RLock()
 
-	// Defer reconciliation while an S1 handover is in flight: an E-RAB Modify or
-	// Release would collide with the handover's bearer signalling (TS 36.413
-	// §8.4.1.2). The next sweep re-converges the UE once the handover clears.
-	if m.handoverInProgress(ue) {
+	ready := ue.emmState.load() == EMMRegistered && ue.s1 != nil && ue.s1.handover == nil
+
+	m.mu.RUnlock()
+
+	if !ready {
 		return
 	}
 

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -26,9 +26,11 @@ import (
 func (m *MME) ReconcileDataNetwork(ctx context.Context) {
 	m.mu.Lock()
 
-	ues := make([]*UeContext, 0, len(m.ues))
-	for _, ue := range m.ues {
-		ues = append(ues, ue)
+	ues := make([]*UeContext, 0, len(m.conns))
+	for _, c := range m.conns {
+		if c.ue != nil {
+			ues = append(ues, c.ue)
+		}
 	}
 
 	m.mu.Unlock()

--- a/internal/mme/reconcile_test.go
+++ b/internal/mme/reconcile_test.go
@@ -511,3 +511,14 @@ func TestModifyBearerAcceptCommitsConfig(t *testing.T) {
 		t.Fatalf("modification accept must not trigger downlink S1AP, got %d", len(cc.sent))
 	}
 }
+
+// TestReconcileUEIdleNoPanic checks reconciling a UE that has moved to ECM-IDLE
+// returns without dereferencing the freed S1 connection.
+func TestReconcileUEIdleNoPanic(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+	testPDN(ue).apn = "internet"
+	m.freeS1Conn(ue)
+
+	m.reconcileUE(context.Background(), ue)
+}

--- a/internal/mme/reconcile_test.go
+++ b/internal/mme/reconcile_test.go
@@ -23,8 +23,6 @@ func connectedBearerUE(t *testing.T, m *MME) (*UeContext, *captureConn) {
 	p := testPDN(ue)
 	p.apn = "internet"
 
-	ue.ecmState.store(ECMConnected)
-
 	// Record the QoS a real activation would, so a reconcile against an unchanged
 	// policy is a no-op.
 	if qos, err := m.resolveQoSByAPN(context.Background(), ue.imsi, p.apn); err == nil {
@@ -100,7 +98,7 @@ func TestReconcileDataNetworkSkipsUnchanged(t *testing.T) {
 func TestReconcileDataNetworkSkipsIdleUE(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := connectedBearerUE(t, m)
-	ue.ecmState.store(ECMIdle) // an idle UE picks up the change on its next attach
+	m.freeS1Conn(ue) // an idle UE picks up the change on its next attach
 	testPDN(ue).dnConfig = "stale|config|0.0.0.0|0"
 
 	m.ReconcileDataNetwork(context.Background())

--- a/internal/mme/reset.go
+++ b/internal/mme/reset.go
@@ -62,9 +62,9 @@ func (m *MME) uesOnConn(conn nasWriter) []*UeContext {
 
 	var out []*UeContext
 
-	for _, ue := range m.ues {
-		if ue.conn == conn {
-			out = append(out, ue)
+	for _, c := range m.conns {
+		if c.ue != nil && c.conn == conn {
+			out = append(out, c.ue)
 		}
 	}
 
@@ -84,13 +84,13 @@ func (m *MME) uesForConnectionList(conn nasWriter, items []s1ap.UEAssociatedLogi
 	for _, it := range items {
 		switch {
 		case it.MMEUES1APID != nil:
-			if ue, ok := m.ues[uint32(*it.MMEUES1APID)]; ok && ue.conn == conn {
-				out = append(out, ue)
+			if c, ok := m.conns[uint32(*it.MMEUES1APID)]; ok && c.ue != nil && c.conn == conn {
+				out = append(out, c.ue)
 			}
 		case it.ENBUES1APID != nil:
-			for _, ue := range m.ues {
-				if ue.conn == conn && ue.ENBUES1APID == *it.ENBUES1APID {
-					out = append(out, ue)
+			for _, c := range m.conns {
+				if c.ue != nil && c.conn == conn && c.ENBUES1APID == *it.ENBUES1APID {
+					out = append(out, c.ue)
 					break
 				}
 			}

--- a/internal/mme/reset.go
+++ b/internal/mme/reset.go
@@ -31,66 +31,62 @@ func (m *MME) handleReset(conn nasWriter, value []byte) {
 	}
 
 	if req.ResetType.All {
-		affected := m.uesOnConn(conn)
-		for _, ue := range affected {
-			m.releaseUEContextLocally(ue, "S1 reset")
-		}
+		affected := m.connsOnConn(conn)
+		m.reclaimConns(affected, "S1 reset")
 
-		logger.MmeLog.Info("S1 Reset (whole interface)", zap.Int("released", len(affected)))
+		logger.MmeLog.Info("S1 Reset (whole interface)", zap.Int("connections", len(affected)))
 		m.sendResetAcknowledge(conn, nil)
 
 		return
 	}
 
-	affected := m.uesForConnectionList(conn, req.ResetType.Part)
-	for _, ue := range affected {
-		m.releaseUEContextLocally(ue, "S1 reset")
-	}
+	affected := m.connsForConnectionList(conn, req.ResetType.Part)
+	m.reclaimConns(affected, "S1 reset")
 
 	logger.MmeLog.Info("S1 Reset (part of interface)",
-		zap.Int("requested", len(req.ResetType.Part)), zap.Int("released", len(affected)))
+		zap.Int("requested", len(req.ResetType.Part)), zap.Int("connections", len(affected)))
 
 	// TS 36.413 §8.7.1.2.1: the acknowledge echoes the UE-associated logical
 	// S1-connections that were reset.
 	m.sendResetAcknowledge(conn, req.ResetType.Part)
 }
 
-// uesOnConn returns every UE context bound to the given eNB association.
-func (m *MME) uesOnConn(conn nasWriter) []*UeContext {
+// connsOnConn returns every UE-associated connection on the given eNB association.
+func (m *MME) connsOnConn(conn nasWriter) []*s1Conn {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	var out []*UeContext
+	var out []*s1Conn
 
 	for _, c := range m.conns {
-		if c.ue != nil && c.conn == conn {
-			out = append(out, c.ue)
+		if c.conn == conn {
+			out = append(out, c)
 		}
 	}
 
 	return out
 }
 
-// uesForConnectionList resolves the UE contexts named by a part-of-interface
-// reset list, scoped to the association the reset arrived on. Each item is
-// matched by its MME-UE-S1AP-ID, else by its eNB-UE-S1AP-ID; an item naming no
-// known UE is skipped (it is still echoed in the acknowledge).
-func (m *MME) uesForConnectionList(conn nasWriter, items []s1ap.UEAssociatedLogicalS1ConnectionItem) []*UeContext {
+// connsForConnectionList resolves the UE-associated connections named by a
+// part-of-interface reset list, scoped to the association the reset arrived on.
+// Each item is matched by its MME-UE-S1AP-ID, else by its eNB-UE-S1AP-ID; an item
+// naming no known connection is skipped (it is still echoed in the acknowledge).
+func (m *MME) connsForConnectionList(conn nasWriter, items []s1ap.UEAssociatedLogicalS1ConnectionItem) []*s1Conn {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	var out []*UeContext
+	var out []*s1Conn
 
 	for _, it := range items {
 		switch {
 		case it.MMEUES1APID != nil:
-			if c, ok := m.conns[uint32(*it.MMEUES1APID)]; ok && c.ue != nil && c.conn == conn {
-				out = append(out, c.ue)
+			if c, ok := m.conns[uint32(*it.MMEUES1APID)]; ok && c.conn == conn {
+				out = append(out, c)
 			}
 		case it.ENBUES1APID != nil:
 			for _, c := range m.conns {
-				if c.ue != nil && c.conn == conn && c.ENBUES1APID == *it.ENBUES1APID {
-					out = append(out, c.ue)
+				if c.conn == conn && c.ENBUES1APID == *it.ENBUES1APID {
+					out = append(out, c)
 					break
 				}
 			}

--- a/internal/mme/reset_test.go
+++ b/internal/mme/reset_test.go
@@ -56,32 +56,35 @@ func TestS1ResetWholeInterface(t *testing.T) {
 	m := newTestMME(t)
 
 	ue1, cc := securedUE(t, m)
+	registerTestUE(m, ue1, "001010000000010")
 	testPDN(ue1).apn = "internet"
 
 	ue2 := m.newUe(cc, 8)
 	ue2.emmState.store(EMMRegistered)
+	registerTestUE(m, ue2, "001010000000011")
 	testPDN(ue2).apn = "internet"
 
 	other, _ := securedUE(t, m)
+	registerTestUE(m, other, "001010000000012")
 	testPDN(other).apn = "internet"
 
 	cause := s1ap.Cause{Group: s1ap.CauseGroupMisc, Value: 0}
 	m.handleReset(cc, resetValue(t, &s1ap.Reset{Cause: cause, ResetType: s1ap.ResetType{All: true}}))
 
 	for _, ue := range []*UeContext{ue1, ue2} {
-		got, ok := m.lookupUe(ue.MMEUES1APID)
-		if !ok {
-			t.Fatalf("registered UE %d deleted by S1 reset; expected ECM-IDLE retention", ue.MMEUES1APID)
+		got, ok := m.lookupUeByIMSI(ue.imsi)
+		if !ok || got != ue {
+			t.Fatalf("registered UE %q deleted by S1 reset; expected ECM-IDLE retention", ue.imsi)
 		}
 
-		if got.ecmState.load() != ECMIdle {
-			t.Fatalf("UE %d ecmState = %v, want ECMIdle after S1 reset", ue.MMEUES1APID, got.ecmState.load())
+		if got.connected() {
+			t.Fatalf("UE %q not in ECM-IDLE after S1 reset", ue.imsi)
 		}
 
-		m.removeUe(ue.MMEUES1APID) // stop the default-duration timer
+		m.removeUe(ue) // stop the default-duration timer
 	}
 
-	if got, ok := m.lookupUe(other.MMEUES1APID); !ok || got.ecmState.load() != ECMConnected {
+	if got, ok := m.lookupUeByIMSI(other.imsi); !ok || !got.connected() {
 		t.Fatal("UE on another association disturbed by S1 reset")
 	}
 
@@ -100,14 +103,16 @@ func TestS1ResetPartOfInterface(t *testing.T) {
 	m := newTestMME(t)
 
 	ue1, cc := securedUE(t, m)
+	registerTestUE(m, ue1, "001010000000010")
 	testPDN(ue1).apn = "internet"
 
 	ue2 := m.newUe(cc, 8)
 	ue2.emmState.store(EMMRegistered)
+	registerTestUE(m, ue2, "001010000000011")
 	testPDN(ue2).apn = "internet"
 
-	mmeID := ue1.MMEUES1APID
-	enbID := ue1.ENBUES1APID
+	mmeID := ue1.s1.MMEUES1APID
+	enbID := ue1.s1.ENBUES1APID
 	cause := s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 0}
 
 	m.handleReset(cc, resetValue(t, &s1ap.Reset{
@@ -117,14 +122,14 @@ func TestS1ResetPartOfInterface(t *testing.T) {
 		}},
 	}))
 
-	got1, ok := m.lookupUe(mmeID)
-	if !ok || got1.ecmState.load() != ECMIdle {
-		t.Fatalf("listed UE not released to ECM-IDLE: ok=%v state=%v", ok, got1.ecmState.load())
+	got1, ok := m.lookupUeByIMSI(ue1.imsi)
+	if !ok || got1 != ue1 || got1.connected() {
+		t.Fatalf("listed UE not released to ECM-IDLE: ok=%v connected=%v", ok, got1.connected())
 	}
 
-	m.removeUe(mmeID)
+	m.removeUe(ue1)
 
-	if got2, ok := m.lookupUe(ue2.MMEUES1APID); !ok || got2.ecmState.load() != ECMConnected {
+	if got2, ok := m.lookupUeByIMSI(ue2.imsi); !ok || !got2.connected() {
 		t.Fatal("unlisted UE disturbed by part-of-interface reset")
 	}
 
@@ -151,7 +156,7 @@ func TestS1ResetDropsMidAttachUE(t *testing.T) {
 	cause := s1ap.Cause{Group: s1ap.CauseGroupMisc, Value: 0}
 	m.handleReset(cc, resetValue(t, &s1ap.Reset{Cause: cause, ResetType: s1ap.ResetType{All: true}}))
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); ok {
+	if _, ok := m.lookupUeByIMSI(ue.imsi); ok {
 		t.Fatal("incomplete-registration UE retained after S1 reset; expected drop")
 	}
 

--- a/internal/mme/resolve_ue_test.go
+++ b/internal/mme/resolve_ue_test.go
@@ -62,7 +62,7 @@ func TestResolveUEInconsistentENBUES1APIDSendsErrorIndication(t *testing.T) {
 	m := newTestMME(t)
 	ue, conn := securedUE(t, m) // ENBUES1APID == 7
 
-	if got, ok := m.resolveUE(conn, ue.MMEUES1APID, 99); ok || got != nil {
+	if got, ok := m.resolveUE(conn, ue.s1.MMEUES1APID, 99); ok || got != nil {
 		t.Fatalf("expected resolution to fail for a mismatched eNB-UE-S1AP-ID")
 	}
 
@@ -72,8 +72,8 @@ func TestResolveUEInconsistentENBUES1APIDSendsErrorIndication(t *testing.T) {
 
 	ind := parseOutboundErrorIndication(t, conn.sent[0])
 
-	if ind.MMEUES1APID == nil || *ind.MMEUES1APID != ue.MMEUES1APID {
-		t.Fatalf("expected MME-UE-S1AP-ID %d, got %v", ue.MMEUES1APID, ind.MMEUES1APID)
+	if ind.MMEUES1APID == nil || *ind.MMEUES1APID != ue.s1.MMEUES1APID {
+		t.Fatalf("expected MME-UE-S1AP-ID %d, got %v", ue.s1.MMEUES1APID, ind.MMEUES1APID)
 	}
 
 	if ind.ENBUES1APID == nil || *ind.ENBUES1APID != 99 {
@@ -89,7 +89,7 @@ func TestResolveUEValidPairResolves(t *testing.T) {
 	m := newTestMME(t)
 	ue, conn := securedUE(t, m) // ENBUES1APID == 7
 
-	got, ok := m.resolveUE(conn, ue.MMEUES1APID, ue.ENBUES1APID)
+	got, ok := m.resolveUE(conn, ue.s1.MMEUES1APID, ue.s1.ENBUES1APID)
 	if !ok || got != ue {
 		t.Fatalf("expected the valid AP-ID pair to resolve to the UE")
 	}

--- a/internal/mme/robustness_test.go
+++ b/internal/mme/robustness_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 )
 
@@ -29,14 +30,14 @@ func TestDispatchSurvivesGarbage(t *testing.T) {
 	}
 }
 
-func initialUEMessagePDU(t *testing.T, enbID s1ap.ENBUES1APID) []byte {
+func initialUEMessagePDU(t *testing.T, enbID s1ap.ENBUES1APID, nas []byte) []byte {
 	t.Helper()
 
 	plmn := s1ap.PLMNIdentity{0x00, 0xf1, 0x10}
 
 	b, err := (&s1ap.InitialUEMessage{
 		ENBUES1APID:           enbID,
-		NASPDU:                s1ap.NASPDU{0x00}, // routed-but-ignored (non-EMM PD)
+		NASPDU:                s1ap.NASPDU(nas),
 		TAI:                   s1ap.TAI{PLMNIdentity: plmn, TAC: 1},
 		EUTRANCGI:             s1ap.EUTRANCGI{PLMNIdentity: plmn, CellID: 1},
 		RRCEstablishmentCause: s1ap.RRCCauseEmergency,
@@ -48,16 +49,82 @@ func initialUEMessagePDU(t *testing.T, enbID s1ap.ENBUES1APID) []byte {
 	return b
 }
 
-// TestDuplicateInitialUEMessage checks a second Initial UE Message for the same
-// eNB UE id on the same association replaces the prior context rather than
-// leaking it.
-func TestDuplicateInitialUEMessage(t *testing.T) {
+func TestIsInitialAttach(t *testing.T) {
+	attach := plainAttachNAS(t)
+
+	tests := []struct {
+		name string
+		nas  []byte
+		want bool
+	}{
+		{"plain attach", attach, true},
+		{"integrity-only attach", append([]byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x00}, attach...), true},
+		{"ciphered (unpeekable)", append([]byte{0x27, 0x00, 0x00, 0x00, 0x00, 0x00}, attach...), false},
+		{"plain EMM STATUS", []byte{0x07, 0x60, 0x00}, false},
+		{"non-EMM PD", []byte{0x02, 0x41}, false},
+		{"empty", nil, false},
+		{"short protected", []byte{0x17, 0x00}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInitialAttach(tt.nas); got != tt.want {
+				t.Fatalf("isInitialAttach = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func plainAttachNAS(t *testing.T) []byte {
+	t.Helper()
+
+	esm, err := (&eps.PDNConnectivityRequest{ProcedureTransactionIdentity: 1, RequestType: 1, PDNType: eps.PDNTypeIPv4}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nas, err := (&eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		NASKeySetIdentifier: 7,
+		EPSMobileIdentity:   eps.EPSMobileIdentity{Type: eps.IdentityIMSI, Digits: testSubscriber.IMSI},
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}.Marshal(),
+		ESMMessageContainer: esm,
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return nas
+}
+
+// TestDropStaleUe checks a re-attach reusing the same eNB UE id on the same
+// association drops the prior context rather than leaking it (TS 36.413).
+func TestDropStaleUe(t *testing.T) {
 	m := newTestMME(t)
 
-	m.handleInitialUEMessage(context.Background(), nil, initiatingValue(t, initialUEMessagePDU(t, 7)))
-	m.handleInitialUEMessage(context.Background(), nil, initiatingValue(t, initialUEMessagePDU(t, 7)))
+	cc := &captureConn{}
+	m.newUe(cc, 7)
 
-	if got := len(m.ues); got != 1 {
-		t.Fatalf("duplicate Initial UE Message left %d contexts, want 1", got)
+	m.dropStaleUe(cc, 7)
+
+	if got := len(m.conns); got != 0 {
+		t.Fatalf("dropStaleUe left %d connections, want 0", got)
+	}
+}
+
+// TestNonAttachInitialUEMessageCreatesNoContext checks that an Initial UE Message
+// whose NAS is not an Attach Request allocates no UE context, so an
+// unauthenticated peer cannot exhaust contexts (TS 24.301).
+func TestNonAttachInitialUEMessageCreatesNoContext(t *testing.T) {
+	m := newTestMME(t)
+
+	// A plain EMM STATUS — a valid EMM message that is not an Attach Request.
+	emmStatus := []byte{0x07, 0x60, 0x00}
+	for i := 0; i < 100; i++ {
+		m.handleInitialUEMessage(context.Background(), nil, initiatingValue(t, initialUEMessagePDU(t, s1ap.ENBUES1APID(1000+i), emmStatus)))
+	}
+
+	if got := len(m.conns); got != 0 {
+		t.Fatalf("non-Attach Initial UE Messages allocated %d contexts, want 0", got)
 	}
 }

--- a/internal/mme/robustness_test.go
+++ b/internal/mme/robustness_test.go
@@ -98,7 +98,7 @@ func plainAttachNAS(t *testing.T) []byte {
 }
 
 // TestDropStaleUe checks a re-attach reusing the same eNB UE id on the same
-// association drops the prior context rather than leaking it (TS 36.413).
+// association drops the prior context, so it is not leaked (TS 36.413).
 func TestDropStaleUe(t *testing.T) {
 	m := newTestMME(t)
 

--- a/internal/mme/robustness_test.go
+++ b/internal/mme/robustness_test.go
@@ -113,8 +113,9 @@ func TestDropStaleUe(t *testing.T) {
 }
 
 // TestNonAttachInitialUEMessageCreatesNoContext checks that an Initial UE Message
-// whose NAS is not an Attach Request allocates no UE context, so an
-// unauthenticated peer cannot exhaust contexts (TS 24.301).
+// whose NAS is not an Attach Request binds no UE context and leaves no connection
+// behind (its bare connection is released), so an unauthenticated peer cannot
+// exhaust contexts (TS 24.301).
 func TestNonAttachInitialUEMessageCreatesNoContext(t *testing.T) {
 	m := newTestMME(t)
 
@@ -125,6 +126,33 @@ func TestNonAttachInitialUEMessageCreatesNoContext(t *testing.T) {
 	}
 
 	if got := len(m.conns); got != 0 {
-		t.Fatalf("non-Attach Initial UE Messages allocated %d contexts, want 0", got)
+		t.Fatalf("non-Attach Initial UE Messages left %d connections, want 0", got)
+	}
+}
+
+// TestBareConnectionIgnoredByLookups checks that a connection with no bound UE
+// context (an Initial UE Message not yet attached) is invisible to UE lookups and
+// subscriber counts, and is removed by release.
+func TestBareConnectionIgnoredByLookups(t *testing.T) {
+	m := newTestMME(t)
+
+	c := m.newConn(&captureConn{}, 7)
+
+	if c.ue != nil {
+		t.Fatal("new connection is not bare")
+	}
+
+	if _, ok := m.lookupUe(c.MMEUES1APID); ok {
+		t.Fatal("bare connection resolved as a UE")
+	}
+
+	if got := m.CountRegisteredSubscribers(); got != 0 {
+		t.Fatalf("bare connection counted as a registered subscriber: got %d", got)
+	}
+
+	m.releaseBareConn(c)
+
+	if got := len(m.conns); got != 0 {
+		t.Fatalf("bare connection not removed by release: %d remain", got)
 	}
 }

--- a/internal/mme/service_request.go
+++ b/internal/mme/service_request.go
@@ -65,11 +65,10 @@ func (m *MME) onServiceRequest(ctx context.Context, conn nasWriter, msg *s1ap.In
 	m.establishS1Connection(ue, conn, msg.ENBUES1APID)
 
 	ue.ulCount++
-	ue.ecmState.store(ECMConnected)
 
 	logger.MmeLog.Info("Service Request accepted",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
-		zap.Uint32("enb-ue-id", uint32(ue.ENBUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
+		zap.Uint32("enb-ue-id", uint32(ue.s1.ENBUES1APID)),
 		zap.String("imsi", ue.imsi))
 
 	qos, err := m.resolveQoS(ctx, ue.imsi)
@@ -85,7 +84,7 @@ func (m *MME) onServiceRequest(ctx context.Context, conn nasWriter, msg *s1ap.In
 // over a transient context, so a rejected request never touches a resolved UE.
 func (m *MME) sendServiceReject(ctx context.Context, conn nasWriter, enbUEID s1ap.ENBUES1APID) {
 	ue := m.newUe(conn, enbUEID)
-	defer m.removeUe(ue.MMEUES1APID)
+	defer m.removeUe(ue)
 
 	m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
 }

--- a/internal/mme/service_request.go
+++ b/internal/mme/service_request.go
@@ -81,10 +81,10 @@ func (m *MME) onServiceRequest(ctx context.Context, conn nasWriter, msg *s1ap.In
 }
 
 // sendServiceReject sends a SERVICE REJECT with cause #9 (TS 24.301 §5.6.1.5)
-// over a transient context, so a rejected request never touches a resolved UE.
+// over a bare connection, so a rejected request never touches a resolved UE.
 func (m *MME) sendServiceReject(ctx context.Context, conn nasWriter, enbUEID s1ap.ENBUES1APID) {
-	ue := m.newUe(conn, enbUEID)
-	defer m.removeUe(ue)
+	c := m.newConn(conn, enbUEID)
+	defer m.releaseBareConn(c)
 
-	m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
+	m.sendOverConn(ctx, c, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
 }

--- a/internal/mme/service_request.go
+++ b/internal/mme/service_request.go
@@ -22,7 +22,7 @@ import (
 func (m *MME) onServiceRequest(ctx context.Context, conn nasWriter, msg *s1ap.InitialUEMessage) {
 	if msg.STMSI == nil {
 		logger.MmeLog.Warn("Service Request without an S-TMSI")
-		m.sendServiceReject(ctx, conn, msg.ENBUES1APID, emmCauseUEIdentityUnderivable)
+		m.sendServiceReject(ctx, conn, msg.ENBUES1APID)
 
 		return
 	}
@@ -31,41 +31,38 @@ func (m *MME) onServiceRequest(ctx context.Context, conn nasWriter, msg *s1ap.In
 	if !ok || ue.emmState.load() != EMMRegistered {
 		logger.MmeLog.Info("Service Request for an unknown or deregistered UE",
 			zap.Uint32("m-tmsi", msg.STMSI.MTMSI))
-		m.sendServiceReject(ctx, conn, msg.ENBUES1APID, emmCauseUEIdentityUnderivable)
+		m.sendServiceReject(ctx, conn, msg.ENBUES1APID)
 
 		return
 	}
-
-	// The UE returns from ECM-IDLE on a new UE-associated logical S1-connection;
-	// allocate a fresh MME-UE-S1AP-ID for it (TS 36.413). Every downlink
-	// below — reject or Initial Context Setup — is then deliverable on it.
-	m.establishS1Connection(ue, conn, msg.ENBUES1APID)
 
 	sr, err := eps.ParseServiceRequest([]byte(msg.NASPDU))
 	if err != nil {
 		logger.MmeLog.Warn("failed to decode Service Request", zap.Error(err))
-		m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
+		m.sendServiceReject(ctx, conn, msg.ENBUES1APID)
 
 		return
 	}
 
-	// Verify the short MAC over the 2-octet header at the expected uplink NAS
-	// COUNT; the truncated sequence must also match (TS 24.301).
+	// An unverified Service Request must not move the UE's S1 connection
+	// (TS 24.301 §5.6.1).
 	want, err := eps.ServiceRequestShortMAC([]byte(msg.NASPDU)[:2], ue.knasInt, ue.ulCount,
 		nascommon.DirectionUplink, integrityAlg(ue.eia))
 	if err != nil || want != sr.ShortMAC || uint8(ue.ulCount)&0x1f != sr.SeqShort {
 		logger.MmeLog.Warn("Service Request short-MAC verification failed",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+			zap.Uint32("m-tmsi", msg.STMSI.MTMSI),
 			zap.String("expected-short-mac", fmt.Sprintf("%x", want)),
 			zap.String("received-short-mac", fmt.Sprintf("%x", sr.ShortMAC)),
 			zap.Uint8("expected-sequence", uint8(ue.ulCount)&0x1f),
 			zap.Uint8("received-sequence", sr.SeqShort),
 			zap.Uint32("stored-ul-count", ue.ulCount))
 
-		m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
+		m.sendServiceReject(ctx, conn, msg.ENBUES1APID)
 
 		return
 	}
+
+	m.establishS1Connection(ue, conn, msg.ENBUES1APID)
 
 	ue.ulCount++
 	ue.ecmState.store(ECMConnected)
@@ -84,11 +81,11 @@ func (m *MME) onServiceRequest(ctx context.Context, conn nasWriter, msg *s1ap.In
 	m.sendInitialContextSetup(ctx, ue, qos, nil)
 }
 
-// sendServiceReject sends a SERVICE REJECT (TS 24.301) on the given
-// association via a transient context, prompting the UE to re-attach.
-func (m *MME) sendServiceReject(ctx context.Context, conn nasWriter, enbUEID s1ap.ENBUES1APID, cause uint8) {
+// sendServiceReject sends a SERVICE REJECT with cause #9 (TS 24.301 §5.6.1.5)
+// over a transient context, so a rejected request never touches a resolved UE.
+func (m *MME) sendServiceReject(ctx context.Context, conn nasWriter, enbUEID s1ap.ENBUES1APID) {
 	ue := m.newUe(conn, enbUEID)
 	defer m.removeUe(ue.MMEUES1APID)
 
-	m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: cause})
+	m.sendDownlinkMessage(ctx, ue, &eps.ServiceReject{Cause: emmCauseUEIdentityUnderivable})
 }

--- a/internal/mme/service_request_test.go
+++ b/internal/mme/service_request_test.go
@@ -24,7 +24,7 @@ func idleRegisteredUE(t *testing.T, m *MME) (*UeContext, eps.EPSMobileIdentity) 
 	ue.ueNetCap = eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}.Marshal()
 	testPDN(ue).sgwFTEID = testSGWFTEID // S-GW S1-U persists across idle, as after a real attach
 	guti := m.assignGUTI(ue, models.PlmnID{Mcc: "001", Mnc: "01"}, 1, 1)
-	ue.ecmState.store(ECMIdle)
+	m.freeS1Conn(ue)
 
 	return ue, guti
 }
@@ -62,12 +62,12 @@ func TestServiceRequestReestablishes(t *testing.T) {
 
 	m.onServiceRequest(context.Background(), cc, msg)
 
-	if ue.ecmState.load() != ECMConnected {
+	if !ue.connected() {
 		t.Fatal("UE not ECM-CONNECTED after Service Request")
 	}
 
-	if ue.ENBUES1APID != 9 {
-		t.Fatalf("UE not bound to the new eNB UE id, got %d", ue.ENBUES1APID)
+	if ue.s1.ENBUES1APID != 9 {
+		t.Fatalf("UE not bound to the new eNB UE id, got %d", ue.s1.ENBUES1APID)
 	}
 
 	if len(cc.sent) != 1 {
@@ -130,15 +130,15 @@ func TestServiceRequestS1UTransportFamily(t *testing.T) {
 }
 
 // TestServiceRequestAllocatesFreshMMEUES1APID checks that a UE returning from
-// ECM-IDLE is rebound to a fresh MME-UE-S1AP-ID (TS 36.413 §3.1): the released
-// identity is dropped from the active-connection index and the UE is reindexed
-// under the new one. Reusing the old identity is what the eNB rejects with
-// unknown-mme-ue-s1ap-id.
+// ECM-IDLE is bound to a fresh MME-UE-S1AP-ID and indexed under it (TS 36.413
+// §3.1); an idle UE holds no connection identity until it returns.
 func TestServiceRequestAllocatesFreshMMEUES1APID(t *testing.T) {
 	m := newTestMME(t)
 	ue, guti := idleRegisteredUE(t, m)
 
-	oldID := ue.MMEUES1APID
+	if ue.connected() {
+		t.Fatal("a UE in ECM-IDLE must hold no S1-connection")
+	}
 
 	cc := &captureConn{}
 	msg := &s1ap.InitialUEMessage{
@@ -149,15 +149,11 @@ func TestServiceRequestAllocatesFreshMMEUES1APID(t *testing.T) {
 
 	m.onServiceRequest(context.Background(), cc, msg)
 
-	if ue.MMEUES1APID == oldID {
-		t.Fatalf("MME-UE-S1AP-ID was reused (%d); a returning UE must get a fresh one", oldID)
+	if !ue.connected() {
+		t.Fatal("UE not bound to a connection after Service Request")
 	}
 
-	if _, ok := m.lookupUe(oldID); ok {
-		t.Fatal("released MME-UE-S1AP-ID still indexed after re-establishment")
-	}
-
-	if got, ok := m.lookupUe(ue.MMEUES1APID); !ok || got != ue {
+	if got, ok := m.lookupUe(ue.s1.MMEUES1APID); !ok || got != ue {
 		t.Fatal("UE not indexed under its fresh MME-UE-S1AP-ID")
 	}
 }
@@ -204,7 +200,7 @@ func TestServiceRequestBadMACRejected(t *testing.T) {
 
 	m.onServiceRequest(context.Background(), cc, msg)
 
-	if ue.ecmState.load() == ECMConnected {
+	if ue.connected() {
 		t.Fatal("UE reconnected despite a bad short MAC")
 	}
 
@@ -218,9 +214,6 @@ func TestServiceRequestBadMACRejected(t *testing.T) {
 func TestResumeBadMACDoesNotRebindVictim(t *testing.T) {
 	m := newTestMME(t)
 	ue, guti := idleRegisteredUE(t, m)
-
-	victimConn := ue.conn
-	victimID := ue.MMEUES1APID
 
 	nas := protectedUplink(t, ue, nascommon.NASCount(0, 0))
 	nas[2] ^= 0xff // corrupt the MAC
@@ -241,8 +234,8 @@ func TestResumeBadMACDoesNotRebindVictim(t *testing.T) {
 
 	m.handleInitialUEMessage(context.Background(), nil, initiatingValue(t, b))
 
-	if ue.conn != victimConn || ue.MMEUES1APID != victimID {
-		t.Fatalf("victim binding changed on a forged resume: id %d -> %d", victimID, ue.MMEUES1APID)
+	if ue.connected() {
+		t.Fatal("a forged resume connected the idle victim")
 	}
 }
 
@@ -251,9 +244,6 @@ func TestResumeBadMACDoesNotRebindVictim(t *testing.T) {
 func TestServiceRequestBadMACDoesNotRebindVictim(t *testing.T) {
 	m := newTestMME(t)
 	ue, guti := idleRegisteredUE(t, m)
-
-	victimConn := ue.conn
-	victimID := ue.MMEUES1APID
 
 	nas := serviceRequestNAS(t, ue)
 	nas[3] ^= 0xff
@@ -265,7 +255,7 @@ func TestServiceRequestBadMACDoesNotRebindVictim(t *testing.T) {
 		STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
 	})
 
-	if ue.conn != victimConn || ue.MMEUES1APID != victimID {
-		t.Fatalf("UE binding changed: conn moved=%v, id %d -> %d", ue.conn == nasWriter(attacker), victimID, ue.MMEUES1APID)
+	if ue.connected() {
+		t.Fatal("a forged Service Request connected the idle victim to the attacker")
 	}
 }

--- a/internal/mme/service_request_test.go
+++ b/internal/mme/service_request_test.go
@@ -212,3 +212,60 @@ func TestServiceRequestBadMACRejected(t *testing.T) {
 		t.Fatalf("expected Service Reject, got %d S1AP messages", len(cc.sent))
 	}
 }
+
+// A resume (protected Initial UE Message) with an invalid MAC, carrying a
+// victim's S-TMSI, must not move the victim's S1 binding (TS 24.301 §4.4.4.3).
+func TestResumeBadMACDoesNotRebindVictim(t *testing.T) {
+	m := newTestMME(t)
+	ue, guti := idleRegisteredUE(t, m)
+
+	victimConn := ue.conn
+	victimID := ue.MMEUES1APID
+
+	nas := protectedUplink(t, ue, nascommon.NASCount(0, 0))
+	nas[2] ^= 0xff // corrupt the MAC
+
+	plmn := s1ap.PLMNIdentity{0x00, 0xf1, 0x10}
+
+	b, err := (&s1ap.InitialUEMessage{
+		ENBUES1APID:           9,
+		NASPDU:                s1ap.NASPDU(nas),
+		STMSI:                 &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
+		TAI:                   s1ap.TAI{PLMNIdentity: plmn, TAC: 1},
+		EUTRANCGI:             s1ap.EUTRANCGI{PLMNIdentity: plmn, CellID: 1},
+		RRCEstablishmentCause: s1ap.RRCCauseMOSignalling,
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.handleInitialUEMessage(context.Background(), nil, initiatingValue(t, b))
+
+	if ue.conn != victimConn || ue.MMEUES1APID != victimID {
+		t.Fatalf("victim binding changed on a forged resume: id %d -> %d", victimID, ue.MMEUES1APID)
+	}
+}
+
+// A Service Request with an invalid short MAC, on a different association, must
+// not move the resolved UE's S1 binding (TS 24.301 §5.6.1).
+func TestServiceRequestBadMACDoesNotRebindVictim(t *testing.T) {
+	m := newTestMME(t)
+	ue, guti := idleRegisteredUE(t, m)
+
+	victimConn := ue.conn
+	victimID := ue.MMEUES1APID
+
+	nas := serviceRequestNAS(t, ue)
+	nas[3] ^= 0xff
+
+	attacker := &captureConn{}
+	m.onServiceRequest(context.Background(), attacker, &s1ap.InitialUEMessage{
+		ENBUES1APID: 9,
+		NASPDU:      s1ap.NASPDU(nas),
+		STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
+	})
+
+	if ue.conn != victimConn || ue.MMEUES1APID != victimID {
+		t.Fatalf("UE binding changed: conn moved=%v, id %d -> %d", ue.conn == nasWriter(attacker), victimID, ue.MMEUES1APID)
+	}
+}

--- a/internal/mme/states.go
+++ b/internal/mme/states.go
@@ -5,8 +5,8 @@ package mme
 
 import "sync/atomic"
 
-// EMMState is the EPS Mobility Management state of a UE (TS 24.301,
-// TS 23.401). It is orthogonal to ECMState (TS 23.401).
+// EMMState is the EPS Mobility Management state of a UE (TS 24.301, TS 23.401).
+// The ECM state is derived from whether the UE holds an S1-connection (ue.s1).
 type EMMState uint8
 
 const (
@@ -14,24 +14,8 @@ const (
 	EMMRegistered
 )
 
-// ECMState is the EPS Connection Management state of a UE (TS 23.401).
-// ECM-IDLE/ECM-CONNECTED correspond to the EMM-IDLE/EMM-CONNECTED modes of
-// TS 24.301.
-type ECMState uint8
-
-const (
-	ECMIdle ECMState = iota
-	ECMConnected
-)
-
 // emmStateAtomic holds a UE's EMMState; see the MME concurrency model.
 type emmStateAtomic struct{ v atomic.Uint32 }
 
 func (a *emmStateAtomic) load() EMMState   { return EMMState(a.v.Load()) }
 func (a *emmStateAtomic) store(s EMMState) { a.v.Store(uint32(s)) }
-
-// ecmStateAtomic holds a UE's ECMState; see the MME concurrency model.
-type ecmStateAtomic struct{ v atomic.Uint32 }
-
-func (a *ecmStateAtomic) load() ECMState   { return ECMState(a.v.Load()) }
-func (a *ecmStateAtomic) store(s ECMState) { a.v.Store(uint32(s)) }

--- a/internal/mme/status.go
+++ b/internal/mme/status.go
@@ -40,9 +40,11 @@ type SubscriberSession struct {
 func (m *MME) connectedSubscriber(ue *UeContext) ConnectedSubscriber {
 	radioName := ""
 
-	if conn, ok := ue.s1.conn.(*sctp.SCTPConn); ok {
-		if s := m.enbs[conn]; s != nil {
-			radioName = s.name
+	if ue.s1 != nil {
+		if conn, ok := ue.s1.conn.(*sctp.SCTPConn); ok {
+			if s := m.enbs[conn]; s != nil {
+				radioName = s.name
+			}
 		}
 	}
 
@@ -91,13 +93,12 @@ func (m *MME) ConnectedSubscribers() map[string]ConnectedSubscriber {
 
 	out := make(map[string]ConnectedSubscriber)
 
-	for _, c := range m.conns {
-		ue := c.ue
-		if ue == nil || ue.emmState.load() != EMMRegistered || ue.imsi == "" {
+	for imsi, ue := range m.ues {
+		if ue.emmState.load() != EMMRegistered || ue.imsi == "" {
 			continue
 		}
 
-		out[ue.imsi] = m.connectedSubscriber(ue)
+		out[imsi] = m.connectedSubscriber(ue)
 	}
 
 	return out
@@ -108,14 +109,12 @@ func (m *MME) LookupSubscriber(imsi string) (ConnectedSubscriber, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for _, c := range m.conns {
-		ue := c.ue
-		if ue != nil && ue.emmState.load() == EMMRegistered && ue.imsi == imsi {
-			return m.connectedSubscriber(ue), true
-		}
+	ue, ok := m.ues[imsi]
+	if !ok || ue.emmState.load() != EMMRegistered {
+		return ConnectedSubscriber{}, false
 	}
 
-	return ConnectedSubscriber{}, false
+	return m.connectedSubscriber(ue), true
 }
 
 // CountRegisteredSubscribers returns the number of EMM-registered UEs.
@@ -125,9 +124,8 @@ func (m *MME) CountRegisteredSubscribers() int {
 
 	count := 0
 
-	for _, c := range m.conns {
-		ue := c.ue
-		if ue != nil && ue.emmState.load() == EMMRegistered && ue.imsi != "" {
+	for _, ue := range m.ues {
+		if ue.emmState.load() == EMMRegistered && ue.imsi != "" {
 			count++
 		}
 	}

--- a/internal/mme/status.go
+++ b/internal/mme/status.go
@@ -91,8 +91,9 @@ func (m *MME) ConnectedSubscribers() map[string]ConnectedSubscriber {
 
 	out := make(map[string]ConnectedSubscriber)
 
-	for _, ue := range m.ues {
-		if ue.emmState.load() != EMMRegistered || ue.imsi == "" {
+	for _, c := range m.conns {
+		ue := c.ue
+		if ue == nil || ue.emmState.load() != EMMRegistered || ue.imsi == "" {
 			continue
 		}
 
@@ -107,8 +108,9 @@ func (m *MME) LookupSubscriber(imsi string) (ConnectedSubscriber, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for _, ue := range m.ues {
-		if ue.emmState.load() == EMMRegistered && ue.imsi == imsi {
+	for _, c := range m.conns {
+		ue := c.ue
+		if ue != nil && ue.emmState.load() == EMMRegistered && ue.imsi == imsi {
 			return m.connectedSubscriber(ue), true
 		}
 	}
@@ -123,8 +125,9 @@ func (m *MME) CountRegisteredSubscribers() int {
 
 	count := 0
 
-	for _, ue := range m.ues {
-		if ue.emmState.load() == EMMRegistered && ue.imsi != "" {
+	for _, c := range m.conns {
+		ue := c.ue
+		if ue != nil && ue.emmState.load() == EMMRegistered && ue.imsi != "" {
 			count++
 		}
 	}

--- a/internal/mme/status.go
+++ b/internal/mme/status.go
@@ -40,7 +40,7 @@ type SubscriberSession struct {
 func (m *MME) connectedSubscriber(ue *UeContext) ConnectedSubscriber {
 	radioName := ""
 
-	if conn, ok := ue.conn.(*sctp.SCTPConn); ok {
+	if conn, ok := ue.s1.conn.(*sctp.SCTPConn); ok {
 		if s := m.enbs[conn]; s != nil {
 			radioName = s.name
 		}

--- a/internal/mme/status_test.go
+++ b/internal/mme/status_test.go
@@ -17,7 +17,7 @@ func TestConnectedSubscribers(t *testing.T) {
 	m.trackENB(conn, ENBInfo{Name: "enb-a", ID: "00f110-1"})
 
 	registered := m.newUe(conn, 7)
-	registered.imsi = "001010000000001"
+	registerTestUE(m, registered, "001010000000001")
 	registered.emmState.store(EMMRegistered)
 	registered.eea = 2
 	registered.eia = 2
@@ -29,9 +29,11 @@ func TestConnectedSubscribers(t *testing.T) {
 	registered.touchLastSeen()
 
 	deregistered := m.newUe(conn, 8)
-	deregistered.imsi = "001010000000002"
+	registerTestUE(m, deregistered, "001010000000002")
 	deregistered.emmState.store(EMMDeregistered)
 
+	// A registered context with no IMSI is never indexed by subscriber identity,
+	// so it is excluded from the status surface.
 	noIMSI := m.newUe(conn, 9)
 	noIMSI.emmState.store(EMMRegistered)
 
@@ -80,6 +82,43 @@ func TestConnectedSubscribers(t *testing.T) {
 	}
 }
 
+// TestStatusIncludesIdleSubscriber confirms a registered UE that has moved to
+// ECM-IDLE (no S1 connection) is still reported by the status surface, with no
+// radio name.
+func TestStatusIncludesIdleSubscriber(t *testing.T) {
+	m := newTestMME(t)
+
+	ue, _ := securedUE(t, m)
+	registerTestUE(m, ue, "001010000000001")
+	ue.emmState.store(EMMRegistered)
+	testPDN(ue).apn = "internet"
+
+	m.freeS1Conn(ue)
+
+	if ue.connected() {
+		t.Fatal("UE still connected after freeS1Conn")
+	}
+
+	if got := m.CountRegisteredSubscribers(); got != 1 {
+		t.Fatalf("idle registered subscriber not counted: got %d", got)
+	}
+
+	cs, ok := m.LookupSubscriber("001010000000001")
+	if !ok {
+		t.Fatal("idle registered subscriber not found by LookupSubscriber")
+	}
+
+	if cs.RadioName != "" {
+		t.Fatalf("idle subscriber RadioName = %q, want empty", cs.RadioName)
+	}
+
+	if _, ok := m.ConnectedSubscribers()["001010000000001"]; !ok {
+		t.Fatal("idle registered subscriber missing from ConnectedSubscribers")
+	}
+
+	m.removeUe(ue) // stop the default-duration timer
+}
+
 func TestMobileIdentityDigitsIMEISV(t *testing.T) {
 	// IMEISV mobile identity (TS 24.008 §10.5.1.4): octet 0 carries the type and
 	// the first digit; the rest is packed BCD with a trailing 0xF filler.
@@ -98,7 +137,7 @@ func TestLookupSubscriber(t *testing.T) {
 	m.trackENB(conn, ENBInfo{Name: "enb-a", ID: "00f110-1"})
 
 	ue := m.newUe(conn, 7)
-	ue.imsi = "001010000000001"
+	registerTestUE(m, ue, "001010000000001")
 	ue.emmState.store(EMMRegistered)
 
 	if _, ok := m.LookupSubscriber("001010000000099"); ok {
@@ -120,11 +159,11 @@ func TestCountRegisteredSubscribers(t *testing.T) {
 	conn := new(sctp.SCTPConn)
 
 	a := m.newUe(conn, 7)
-	a.imsi = "001010000000001"
+	registerTestUE(m, a, "001010000000001")
 	a.emmState.store(EMMRegistered)
 
 	b := m.newUe(conn, 8)
-	b.imsi = "001010000000002"
+	registerTestUE(m, b, "001010000000002")
 	b.emmState.store(EMMDeregistered)
 
 	if got := m.CountRegisteredSubscribers(); got != 1 {

--- a/internal/mme/tau.go
+++ b/internal/mme/tau.go
@@ -247,18 +247,3 @@ func (m *MME) protectDownlinkBytes(ue *UeContext, plain []byte) ([]byte, error) 
 
 	return wire, nil
 }
-
-// rejectTrackingAreaUpdate rejects a TRACKING AREA UPDATE REQUEST the MME cannot
-// verify (no security context, e.g. after an MME restart, TS 24.301) with EMM
-// cause #9 "UE identity cannot be derived by the network". The UE accepts the
-// reject without integrity protection and re-attaches. The reject is sent on the
-// transient context, which is then discarded.
-func (m *MME) rejectTrackingAreaUpdate(ctx context.Context, ue *UeContext) {
-	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
-
-	logger.MmeLog.Info("Tracking Area Update rejected; UE will re-attach",
-		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
-
-	m.sendDownlinkMessage(ctx, ue, &eps.TrackingAreaUpdateReject{Cause: emmCauseUEIdentityUnderivable})
-	m.removeUe(ue)
-}

--- a/internal/mme/tau.go
+++ b/internal/mme/tau.go
@@ -28,7 +28,7 @@ func (m *MME) onTrackingAreaUpdate(ctx context.Context, ue *UeContext, plain []b
 
 	logger.MmeLog.Info("Tracking Area Update Request",
 		zap.String("imsi", ue.imsi),
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.String("update-type", epsUpdateTypeName(req.EPSUpdateType)),
 		zap.Bool("active-flag", req.ActiveFlag))
 
@@ -59,9 +59,11 @@ func (m *MME) onTrackingAreaUpdate(ctx context.Context, ue *UeContext, plain []b
 
 	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultAccept)
 
-	if ue.ecmState.load() == ECMConnected {
+	// A UE already fully connected (bearers up) keeps its connection; only a UE
+	// resuming for this TAU needs re-establishment or a deferred release below.
+	if ue.s1.bearersUp {
 		logger.MmeLog.Info("Tracking Area Update accepted",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 		m.sendDownlink(ctx, ue, naspdu)
 		m.armNASGuard(ue, "Tracking Area Update Accept", naspdu)
 
@@ -75,10 +77,8 @@ func (m *MME) onTrackingAreaUpdate(ctx context.Context, ue *UeContext, plain []b
 			return
 		}
 
-		ue.ecmState.store(ECMConnected)
-
 		logger.MmeLog.Info("Tracking Area Update accepted (bearer re-established)",
-			zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+			zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 		m.sendInitialContextSetup(ctx, ue, qos, naspdu)
 		m.armNASGuard(ue, "Tracking Area Update Accept", naspdu)
 
@@ -91,11 +91,10 @@ func (m *MME) onTrackingAreaUpdate(ctx context.Context, ue *UeContext, plain []b
 	// connection for this exchange, so it is ECM-CONNECTED until the deferred
 	// release; without this the TAU Complete would be rejected as having no active
 	// connection (TS 36.413 §10.6 handling).
-	ue.ecmState.store(ECMConnected)
-	ue.tauReleaseOnComplete = true
+	ue.s1.tauReleaseOnComplete = true
 
 	logger.MmeLog.Info("Tracking Area Update accepted (returning to idle)",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 	m.sendDownlink(ctx, ue, naspdu)
 	m.armNASGuard(ue, "Tracking Area Update Accept", naspdu)
 }
@@ -108,10 +107,10 @@ func (m *MME) onTrackingAreaUpdateComplete(ctx context.Context, ue *UeContext) {
 	m.commitGUTIRealloc(ue)
 
 	logger.MmeLog.Info("Tracking Area Update Complete",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)), zap.String("imsi", ue.imsi))
 
-	if ue.tauReleaseOnComplete {
-		ue.tauReleaseOnComplete = false
+	if ue.s1.tauReleaseOnComplete {
+		ue.s1.tauReleaseOnComplete = false
 		m.releaseUEContext(ctx, ue, causeNASNormalRelease)
 	}
 }
@@ -258,8 +257,8 @@ func (m *MME) rejectTrackingAreaUpdate(ctx context.Context, ue *UeContext) {
 	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
 
 	logger.MmeLog.Info("Tracking Area Update rejected; UE will re-attach",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 
 	m.sendDownlinkMessage(ctx, ue, &eps.TrackingAreaUpdateReject{Cause: emmCauseUEIdentityUnderivable})
-	m.removeUe(ue.MMEUES1APID)
+	m.removeUe(ue)
 }

--- a/internal/mme/tau_test.go
+++ b/internal/mme/tau_test.go
@@ -75,7 +75,7 @@ func TestTrackingAreaUpdateConnectedAccepted(t *testing.T) {
 		t.Fatalf("EPS-only TAU Accept carries EMM cause #%d, want none", *parsed.EMMCause)
 	}
 
-	if ue.emmState.load() != EMMRegistered || ue.ecmState.load() != ECMConnected {
+	if ue.emmState.load() != EMMRegistered || !ue.connected() {
 		t.Fatal("UE should remain registered and connected after a periodic TAU")
 	}
 }
@@ -231,7 +231,6 @@ func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 	ue.mtmsi = 1 // a GUTI to reallocate
-	ue.ecmState.store(ECMIdle)
 
 	m.onTrackingAreaUpdate(context.Background(), ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x00})
 
@@ -243,7 +242,7 @@ func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 	// The UE is ECM-CONNECTED for the exchange so its TAU Complete resolves on the
 	// re-established connection (would be dropped as "no active connection"
 	// otherwise, TS 36.413 §10.6).
-	if ue.ecmState.load() != ECMConnected {
+	if !ue.connected() {
 		t.Fatal("UE not ECM-CONNECTED for the TAU exchange; TAU Complete would be rejected")
 	}
 
@@ -275,11 +274,12 @@ func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 func TestTrackingAreaUpdateIdleActiveFlagReestablishes(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := idleRegisteredUE(t, m)
-	cc := ue.conn.(*captureConn)
+	cc := &captureConn{}
+	m.establishS1Connection(ue, cc, 9) // the resume re-binds the connection
 
 	m.onTrackingAreaUpdate(context.Background(), ue, []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x08})
 
-	if ue.ecmState.load() != ECMConnected {
+	if !ue.connected() {
 		t.Fatal("UE not ECM-CONNECTED after an active-flag TAU")
 	}
 
@@ -318,7 +318,7 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 		t.Fatalf("TAU Reject cause = %d, want %d", rej.Cause, emmCauseUEIdentityUnderivable)
 	}
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); ok {
+	if _, ok := m.lookupUeByIMSI(ue.imsi); ok {
 		t.Fatal("transient UE context was not discarded after the TAU Reject")
 	}
 }

--- a/internal/mme/tau_test.go
+++ b/internal/mme/tau_test.go
@@ -290,20 +290,20 @@ func TestTrackingAreaUpdateIdleActiveFlagReestablishes(t *testing.T) {
 	parseInitialContextSetup(t, cc.sent[0])
 }
 
-// TestTrackingAreaUpdateRecovery checks that an integrity-protected TRACKING
-// AREA UPDATE REQUEST the MME cannot verify (no security context, e.g. after an
-// MME restart, TS 24.301 §4.4.4.3) is answered with TAU REJECT #9 rather than
-// dropped, and that the transient UE context is discarded so the UE re-attaches.
+// TestTrackingAreaUpdateRecovery checks that an integrity-protected TRACKING AREA
+// UPDATE REQUEST arriving as an Initial UE Message that the MME cannot resolve (no
+// security context, e.g. after an MME restart, TS 24.301 §5.5.3.2.5) is answered
+// with TAU REJECT #9 over the bare connection rather than dropped, and that no UE
+// context or connection is left behind, so the UE re-attaches at once.
 func TestTrackingAreaUpdateRecovery(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.newUe(cc, 7)
 
 	// Security-protected NAS: SHT=integrity-protected | PD=EMM, a MAC the MME
 	// cannot reproduce (no context), sequence 1, and an inner plain TAU REQUEST.
 	nas := []byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x07, byte(eps.MsgTrackingAreaUpdateRequest)}
 
-	m.handleNAS(context.Background(), ue, nas)
+	m.handleInitialUEMessage(context.Background(), cc, initiatingValue(t, initialUEMessagePDU(t, 7, nas)))
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one downlink (TAU Reject), got %d", len(cc.sent))
@@ -318,7 +318,7 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 		t.Fatalf("TAU Reject cause = %d, want %d", rej.Cause, emmCauseUEIdentityUnderivable)
 	}
 
-	if _, ok := m.lookupUeByIMSI(ue.imsi); ok {
-		t.Fatal("transient UE context was not discarded after the TAU Reject")
+	if len(m.conns) != 0 {
+		t.Fatalf("bare connection not released after the TAU Reject: %d remain", len(m.conns))
 	}
 }

--- a/internal/mme/ue_capability.go
+++ b/internal/mme/ue_capability.go
@@ -27,6 +27,6 @@ func (m *MME) handleUECapabilityInfoIndication(conn nasWriter, value []byte) {
 
 	ue.radioCapability = msg.UERadioCapability
 	logger.MmeLog.Info("stored UE Radio Capability",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.Int("bytes", len(msg.UERadioCapability)))
 }

--- a/internal/mme/ue_capability_test.go
+++ b/internal/mme/ue_capability_test.go
@@ -17,8 +17,8 @@ func TestUECapabilityInfoIndicationStoresRadioCapability(t *testing.T) {
 
 	radioCap := []byte{0x01, 0x02, 0x03, 0x04}
 	ind := &s1ap.UECapabilityInfoIndication{
-		MMEUES1APID:       ue.MMEUES1APID,
-		ENBUES1APID:       ue.ENBUES1APID,
+		MMEUES1APID:       ue.s1.MMEUES1APID,
+		ENBUES1APID:       ue.s1.ENBUES1APID,
 		UERadioCapability: radioCap,
 	}
 

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -18,9 +18,11 @@ import (
 // state, since the two state machines are independent.
 func (m *MME) releaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Cause) {
 	// The idempotency check is atomic: a NAS guard timeout and an eNB-initiated
-	// release request can race to release the same UE from different goroutines.
+	// release request can race to release the same UE from different goroutines. A
+	// Release Complete in the gap before the lock may already have freed the
+	// connection, which is itself a completed release.
 	m.mu.Lock()
-	if ue.s1.releasing {
+	if ue.s1 == nil || ue.s1.releasing {
 		m.mu.Unlock()
 		return
 	}

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -96,12 +96,12 @@ func (m *MME) handleUEContextReleaseComplete(conn nasWriter, value []byte) {
 		return
 	}
 
-	// A Release Complete from a source (or rejected target) eNB during an S1
-	// handover acknowledges a release the MME initiated; consume it without
-	// touching the UE, which is now active on the target association (TS 36.413
-	// §8.4).
-	if m.consumeHandoverRelease(conn, msg.ENBUES1APID) {
-		logger.MmeLog.Info("UE Context Release Complete (handover source)", zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+	// A Release Complete for a detached handover association — the source after
+	// notify, or a rejected/superseded target — is identified by its own
+	// MME-UE-S1AP-ID and just removes the connection, without touching the UE now
+	// active on the other association (TS 36.413 §8.4).
+	if m.releaseDetachedConn(conn, msg.MMEUES1APID, msg.ENBUES1APID) {
+		logger.MmeLog.Info("UE Context Release Complete (handover association)", zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)))
 		return
 	}
 

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -20,16 +20,16 @@ func (m *MME) releaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Ca
 	// The idempotency check is atomic: a NAS guard timeout and an eNB-initiated
 	// release request can race to release the same UE from different goroutines.
 	m.mu.Lock()
-	if ue.releasing {
+	if ue.s1.releasing {
 		m.mu.Unlock()
 		return
 	}
 
-	ue.releasing = true
+	ue.s1.releasing = true
 	m.mu.Unlock()
 
 	cmd := &s1ap.UEContextReleaseCommand{
-		UES1APIDs: s1ap.UES1APIDs{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: ue.ENBUES1APID, Pair: true},
+		UES1APIDs: s1ap.UES1APIDs{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: ue.s1.ENBUES1APID, Pair: true},
 		Cause:     cause,
 	}
 
@@ -39,7 +39,7 @@ func (m *MME) releaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Ca
 		return
 	}
 
-	logger.MmeLog.Info("UE Context Release Command", zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)))
+	logger.MmeLog.Info("UE Context Release Command", zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)))
 	m.sendS1AP(ctx, ue, S1APProcedureUEContextReleaseCommand, b)
 }
 
@@ -61,7 +61,7 @@ func (m *MME) handleUEContextReleaseRequest(ctx context.Context, conn nasWriter,
 	// context is retained. The cause distinguishes a normal inactivity release
 	// from a radio-link failure.
 	fields := []zap.Field{
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)),
+		zap.Uint32("mme-ue-id", uint32(ue.s1.MMEUES1APID)),
 		zap.String("imsi", ue.imsi),
 		zap.String("cause", s1apCauseName(&msg.Cause)),
 	}
@@ -114,14 +114,13 @@ func (m *MME) handleUEContextReleaseComplete(conn nasWriter, value []byte) {
 	// still-registered UE is retained in ECM-IDLE.
 	if ue.emmState.load() == EMMDeregistered {
 		m.releaseAllSessions(ue)
-		m.removeUe(msg.MMEUES1APID)
+		m.removeUe(ue)
 		logger.MmeLog.Info("UE context released", zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)))
 
 		return
 	}
 
-	ue.ecmState.store(ECMIdle)
-	ue.releasing = false
+	m.freeS1Conn(ue)
 
 	// Buffer the downlink bearers so data for the idle UE triggers paging
 	// (TS 23.401).
@@ -145,18 +144,23 @@ func (m *MME) handleUEContextReleaseComplete(conn nasWriter, value []byte) {
 func (m *MME) releaseUEContextLocally(ue *UeContext, trigger string) {
 	m.mu.Lock()
 	registered := ue.emmState.load() == EMMRegistered
-	imsi, mmeUEID := ue.imsi, ue.MMEUES1APID
+	imsi := ue.imsi
+
+	var mmeUEID s1ap.MMEUES1APID
+	if ue.s1 != nil {
+		mmeUEID = ue.s1.MMEUES1APID
+	}
 
 	if registered {
-		ue.ecmState.store(ECMIdle)
-		ue.releasing = false
+		m.freeS1ConnLocked(ue)
+	} else {
+		m.removeContextLocked(ue)
 	}
 
 	m.mu.Unlock()
 
 	if !registered {
 		m.releaseAllSessions(ue)
-		m.removeUe(mmeUEID)
 		logger.MmeLog.Info("aborted incomplete UE registration",
 			zap.String("trigger", trigger), zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("imsi", imsi))
 

--- a/internal/mme/ue_state_race_test.go
+++ b/internal/mme/ue_state_race_test.go
@@ -68,7 +68,6 @@ func TestUEStateConcurrentAccess(t *testing.T) {
 
 		for i := 0; i < iters; i++ {
 			ue.emmState.store(EMMRegistered)
-			ue.ecmState.store(ECMConnected)
 		}
 	}()
 

--- a/internal/mme/ue_timers.go
+++ b/internal/mme/ue_timers.go
@@ -56,8 +56,7 @@ func (m *MME) onMobileReachableExpiry(ue *UeContext, gen uint64) {
 
 	ue.mobileReachableTimer = nil
 
-	logger.MmeLog.Debug("mobile reachable timer expired",
-		zap.Uint32("mme-ue-id", uint32(ue.MMEUES1APID)), zap.String("imsi", ue.imsi))
+	logger.MmeLog.Debug("mobile reachable timer expired", zap.String("imsi", ue.imsi))
 
 	ue.implicitDetachTimer = time.AfterFunc(m.implicitDetachTime, func() {
 		m.onImplicitDetachExpiry(ue, gen)
@@ -78,13 +77,13 @@ func (m *MME) onImplicitDetachExpiry(ue *UeContext, gen uint64) {
 
 	ue.implicitDetachTimer = nil
 	ue.emmState.store(EMMDeregistered)
-	imsi, mmeUEID := ue.imsi, ue.MMEUES1APID
+	imsi := ue.imsi
 
 	m.mu.Unlock()
 
 	logger.MmeLog.Info("implicit detach: UE unreachable, releasing context",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("imsi", imsi))
+		zap.String("imsi", imsi))
 
 	m.releaseAllSessions(ue)
-	m.removeUe(mmeUEID)
+	m.removeUe(ue)
 }

--- a/internal/mme/ue_timers_test.go
+++ b/internal/mme/ue_timers_test.go
@@ -39,7 +39,7 @@ func TestMobileReachableEscalatesToImplicitDetach(t *testing.T) {
 	m.startMobileReachable(ue)
 
 	eventually(t, time.Second, func() bool {
-		_, ok := m.lookupUe(ue.MMEUES1APID)
+		_, ok := m.lookupUeByIMSI(ue.imsi)
 		return !ok
 	})
 
@@ -67,7 +67,7 @@ func TestReconnectStopsIdleTimers(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	if _, ok := m.lookupUe(ue.MMEUES1APID); !ok {
+	if _, ok := m.lookupUeByIMSI(ue.imsi); !ok {
 		t.Fatal("UE implicitly detached despite reconnecting")
 	}
 
@@ -81,10 +81,9 @@ func TestReconnectStopsIdleTimers(t *testing.T) {
 func TestUEContextReleaseCompleteArmsMobileReachable(t *testing.T) {
 	m := newTestMME(t)
 
-	ue, _ := idleRegisteredUE(t, m)
-	ue.ecmState.store(ECMConnected)
+	ue, cc := securedUE(t, m) // connected; the release moves it to ECM-IDLE
 
-	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.MMEUES1APID, ENBUES1APID: 7}
+	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.s1.MMEUES1APID, ENBUES1APID: 7}
 
 	b, err := complete.Marshal()
 	if err != nil {
@@ -96,11 +95,15 @@ func TestUEContextReleaseCompleteArmsMobileReachable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.handleUEContextReleaseComplete(ue.conn, cpdu.(*s1ap.SuccessfulOutcome).Value)
+	m.handleUEContextReleaseComplete(cc, cpdu.(*s1ap.SuccessfulOutcome).Value)
+
+	if ue.connected() {
+		t.Fatal("UE still connected after S1 release")
+	}
 
 	if ue.mobileReachableTimer == nil {
 		t.Fatal("mobile reachable timer not armed when UE moved to ECM-IDLE")
 	}
 
-	m.removeUe(ue.MMEUES1APID) // stop the default-duration timer
+	m.removeUe(ue) // stop the default-duration timer
 }

--- a/internal/tester/scenarios/s1enb/s1_handover.go
+++ b/internal/tester/scenarios/s1enb/s1_handover.go
@@ -121,9 +121,14 @@ func runS1ENBHandover(ctx context.Context, env scenarios.Env, _ any) error {
 		return fmt.Errorf("handover request carried %d E-RABs, want 1", len(hoReq.ERABToBeSetup))
 	}
 
+	// The MME assigns the target its own MME-UE-S1AP-ID (TS 36.413 §9.1.5.6),
+	// distinct from the source's; the target eNB echoes that one — not the source's
+	// — on the acknowledge and notify.
+	targetMMEUEID := int64(hoReq.MMEUES1APID)
+
 	targetENBUEID := target.AllocateENBUEID()
 
-	dlTEID, err := target.SendHandoverRequestAcknowledge(targetENBUEID, res.MMEUES1APID, res.ERABID)
+	dlTEID, err := target.SendHandoverRequestAcknowledge(targetENBUEID, targetMMEUEID, res.ERABID)
 	if err != nil {
 		return fmt.Errorf("send Handover Request Acknowledge: %w", err)
 	}
@@ -145,7 +150,7 @@ func runS1ENBHandover(ctx context.Context, env scenarios.Env, _ any) error {
 		return fmt.Errorf("ping during handover preparation via source eNB (UPF switched too early?): %w", err)
 	}
 
-	if err := target.SendHandoverNotify(targetENBUEID, res.MMEUES1APID); err != nil {
+	if err := target.SendHandoverNotify(targetENBUEID, targetMMEUEID); err != nil {
 		return fmt.Errorf("send Handover Notify: %w", err)
 	}
 

--- a/nas/eps/emm_negotiation_test.go
+++ b/nas/eps/emm_negotiation_test.go
@@ -14,6 +14,7 @@ func TestSecurityModeRoundTrips(t *testing.T) {
 			CipheringAlgorithm: 2, IntegrityAlgorithm: 2, NASKeySetIdentifier: 0x07,
 			ReplayedUESecurityCapabilities: []byte{0xf0, 0xf0, 0xc0, 0xc0},
 			IMEISVRequested:                true,
+			HASHMME:                        []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
 		}
 
 		b, err := in.Marshal()
@@ -28,7 +29,7 @@ func TestSecurityModeRoundTrips(t *testing.T) {
 
 		if out.CipheringAlgorithm != 2 || out.IntegrityAlgorithm != 2 || out.NASKeySetIdentifier != 7 ||
 			!bytes.Equal(out.ReplayedUESecurityCapabilities, in.ReplayedUESecurityCapabilities) ||
-			!out.IMEISVRequested {
+			!out.IMEISVRequested || !bytes.Equal(out.HASHMME, in.HASHMME) {
 			t.Fatalf("mismatch:\n in  %+v\n out %+v", in, out)
 		}
 	})

--- a/nas/eps/emm_security_mode.go
+++ b/nas/eps/emm_security_mode.go
@@ -13,6 +13,7 @@ const (
 	imeisvRequestIEI uint8 = 0xC
 	imeisvRequested  uint8 = 0x1
 	imeisvIEI        uint8 = 0x23
+	hashMMEIEI       uint8 = 0x4F
 )
 
 // SecurityModeCommand is the SECURITY MODE COMMAND message (TS 24.301 §8.2.20),
@@ -23,7 +24,8 @@ type SecurityModeCommand struct {
 	IntegrityAlgorithm             uint8
 	NASKeySetIdentifier            uint8
 	ReplayedUESecurityCapabilities []byte
-	IMEISVRequested                bool // request the UE's IMEISV in SECURITY MODE COMPLETE
+	IMEISVRequested                bool   // request the UE's IMEISV in SECURITY MODE COMPLETE
+	HASHMME                        []byte // 8-octet hash of the triggering plain Attach/TAU (TS 24.301 §9.9.3.50), nil when absent
 }
 
 // Marshal encodes the plain SECURITY MODE COMMAND message.
@@ -40,6 +42,14 @@ func (m *SecurityModeCommand) Marshal() ([]byte, error) {
 
 	if m.IMEISVRequested {
 		w.U8(imeisvRequestIEI<<4 | imeisvRequested)
+	}
+
+	if len(m.HASHMME) > 0 {
+		w.U8(hashMMEIEI)
+
+		if err := w.LV(m.HASHMME); err != nil {
+			return nil, err
+		}
 	}
 
 	return w.Bytes(), nil
@@ -73,12 +83,14 @@ func ParseSecurityModeCommand(b []byte) (*SecurityModeCommand, error) {
 		return nil, err
 	}
 
-	// The only optional IE Ella Core consumes is the IMEISV request, a type-1 IE
-	// the walker delimits inherently (IEI >= 0x80 after the half-octet shift), so
-	// no per-IEI table entry is needed.
-	if _, err := common.WalkOptionalIEs(r, nil, func(iei uint8, value []byte) error {
-		if iei == imeisvRequestIEI<<4 && len(value) == 1 {
+	// The IMEISV request is a type-1 IE the walker delimits inherently (IEI >= 0x80
+	// after the half-octet shift); HashMME is a type-4 TLV and needs a table entry.
+	if _, err := common.WalkOptionalIEs(r, securityModeCommandIEs, func(iei uint8, value []byte) error {
+		switch {
+		case iei == imeisvRequestIEI<<4 && len(value) == 1:
 			m.IMEISVRequested = value[0] == imeisvRequested
+		case iei == hashMMEIEI:
+			m.HASHMME = value
 		}
 
 		return nil
@@ -87,6 +99,12 @@ func ParseSecurityModeCommand(b []byte) (*SecurityModeCommand, error) {
 	}
 
 	return m, nil
+}
+
+// securityModeCommandIEs are the optional type-4 IEs Ella Core round-trips in a
+// SECURITY MODE COMMAND (TS 24.301 §8.2.20): the HashMME.
+var securityModeCommandIEs = []common.OptionalIE{
+	{IEI: hashMMEIEI, Format: common.IETLV},
 }
 
 // SecurityModeComplete is the SECURITY MODE COMPLETE message (TS 24.301

--- a/nas/eps/security.go
+++ b/nas/eps/security.go
@@ -4,6 +4,7 @@
 package eps
 
 import (
+	"crypto/subtle"
 	"errors"
 
 	"github.com/ellanetworks/core/nas/common"
@@ -77,7 +78,7 @@ func Unprotect(
 		return nil, err
 	}
 
-	if want != m.MAC {
+	if subtle.ConstantTimeCompare(want[:], m.MAC[:]) != 1 {
 		return nil, ErrMACMismatch
 	}
 


### PR DESCRIPTION
# Description

Separate transient per-connection state from persistent UE context and other security-related improvements in 4G code.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
