### PR TITLE
chore(ui): clearly differentiate 4G and 5G radios

### DIFF
--- a/client/radios.go
+++ b/client/radios.go
@@ -39,7 +39,7 @@ type Radio struct {
 	Name        string `json:"name"`
 	ID          string `json:"id"`
 	Address     string `json:"address"`
-	RanNodeType string `json:"ran_node_type"`
+	RanNodeType string `json:"type"`
 	// Deprecated: Use GetRadio (GET /api/v1/ran/radios/{name}) for supported TAIs.
 	SupportedTAIs []SupportedTAI `json:"supported_tais"`
 }
@@ -50,7 +50,7 @@ type RadioDetail struct {
 	Address       string         `json:"address"`
 	ConnectedAt   string         `json:"connected_at"`
 	LastSeenAt    string         `json:"last_seen_at"`
-	RanNodeType   string         `json:"ran_node_type"`
+	RanNodeType   string         `json:"type"`
 	SupportedTAIs []SupportedTAI `json:"supported_tais"`
 }
 

--- a/client/radios_test.go
+++ b/client/radios_test.go
@@ -18,7 +18,7 @@ func TestGetRadio_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"name": "my-radio", "id": "000102", "address": "10.0.0.1:9487", "connected_at": "2025-08-12T16:58:00Z", "last_seen_at": "2025-08-12T17:02:30Z", "ran_node_type": "gNB", "supported_tais": []}`),
+			Result:     []byte(`{"name": "my-radio", "id": "000102", "address": "10.0.0.1:9487", "connected_at": "2025-08-12T16:58:00Z", "last_seen_at": "2025-08-12T17:02:30Z", "type": "gNB", "supported_tais": []}`),
 		},
 		err: nil,
 	}
@@ -55,7 +55,7 @@ func TestGetRadio_Success(t *testing.T) {
 	}
 
 	if radio.RanNodeType != "gNB" {
-		t.Fatalf("expected ran_node_type gNB, got %v", radio.RanNodeType)
+		t.Fatalf("expected type gNB, got %v", radio.RanNodeType)
 	}
 }
 

--- a/docs/reference/api/radios.md
+++ b/docs/reference/api/radios.md
@@ -77,7 +77,7 @@ This path returns the details of a specific radio, including connection timestam
         "address": "10.1.107.203/192.168.251.5:9487",
         "connected_at": "2025-08-12T16:58:00Z",
         "last_seen_at": "2025-08-12T17:02:30Z",
-        "ran_node_type": "gNB",
+        "type": "gNB",
         "supported_tais": [
             {
                 "tai": {

--- a/integration/s1setup_4g_test.go
+++ b/integration/s1setup_4g_test.go
@@ -15,7 +15,7 @@ import (
 // TestIntegration4GS1Setup brings up Ella Core and a real srsRAN eNB
 // (gradiant/srsran-4g) and verifies the eNB completes S1 Setup against the MME.
 //
-// The eNB appears in the radios API with ran_node_type "eNB" only after the MME
+// The eNB appears in the radios API with type "eNB" only after the MME
 // has accepted its S1 Setup Request and sent an S1 Setup Response, so its
 // presence is positive proof of the request/response exchange.
 func TestIntegration4GS1Setup(t *testing.T) {

--- a/internal/api/server/api_radios.go
+++ b/internal/api/server/api_radios.go
@@ -37,7 +37,7 @@ type Radio struct {
 	Name        string `json:"name"`
 	ID          string `json:"id"`
 	Address     string `json:"address"`
-	RanNodeType string `json:"ran_node_type"`
+	RanNodeType string `json:"type"`
 	// Deprecated: Use the GET /api/v1/ran/radios/{name} detail endpoint instead.
 	SupportedTAIs []SupportedTAI `json:"supported_tais"`
 }
@@ -55,7 +55,7 @@ type RadioDetail struct {
 	Address       string         `json:"address"`
 	ConnectedAt   string         `json:"connected_at"`
 	LastSeenAt    string         `json:"last_seen_at"`
-	RanNodeType   string         `json:"ran_node_type"`
+	RanNodeType   string         `json:"type"`
 	SupportedTAIs []SupportedTAI `json:"supported_tais"`
 }
 
@@ -156,7 +156,7 @@ func ListRadios(amfInstance *amf.AMF, mmeInstance *mme.MME) http.HandlerFunc {
 		}
 
 		// 4G eNBs connected to the MME appear in the same radio list,
-		// distinguished by ran_node_type.
+		// distinguished by type.
 		if mmeInstance != nil {
 			for _, enb := range mmeInstance.ListENBs() {
 				items = append(items, Radio{
@@ -224,7 +224,7 @@ func GetRadio(amfInstance *amf.AMF, mmeInstance *mme.MME) http.HandlerFunc {
 		}
 
 		// 4G eNBs connected to the MME share the radio namespace, distinguished
-		// by ran_node_type.
+		// by type.
 		if mmeInstance != nil {
 			for _, enb := range mmeInstance.ListENBs() {
 				if enb.Name != radioName {

--- a/internal/api/server/api_radios_test.go
+++ b/internal/api/server/api_radios_test.go
@@ -44,7 +44,7 @@ type Radio struct {
 	Name          string         `json:"name"`
 	ID            string         `json:"id"`
 	Address       string         `json:"address"`
-	RanNodeType   string         `json:"ran_node_type"`
+	RanNodeType   string         `json:"type"`
 	SupportedTAIs []SupportedTAI `json:"supported_tais"`
 }
 

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -4745,9 +4745,9 @@ components:
           type: string
         address:
           type: string
-        ran_node_type:
+        type:
           type: string
-          enum: [gNB, ng-eNB, N3IWF, Unknown]
+          enum: [gNB, ng-eNB, eNB, N3IWF, Unknown]
           description: Type of the RAN node.
         supported_tais:
           type: array
@@ -4755,7 +4755,7 @@ components:
           description: "Deprecated: use GET /api/v1/ran/radios/{name} for full radio details including supported TAIs."
           items:
             $ref: "#/components/schemas/SupportedTAI"
-      required: [name, id, address, ran_node_type, supported_tais]
+      required: [name, id, address, type, supported_tais]
 
     RadioDetail:
       type: object
@@ -4777,15 +4777,15 @@ components:
           type: string
           format: date-time
           description: Timestamp of the last NGAP message received from the radio (RFC 3339).
-        ran_node_type:
+        type:
           type: string
-          enum: [gNB, ng-eNB, N3IWF, Unknown]
+          enum: [gNB, ng-eNB, eNB, N3IWF, Unknown]
           description: Type of the RAN node.
         supported_tais:
           type: array
           items:
             $ref: "#/components/schemas/SupportedTAI"
-      required: [name, id, address, connected_at, last_seen_at, ran_node_type, supported_tais]
+      required: [name, id, address, connected_at, last_seen_at, type, supported_tais]
 
     RadioResponseEnvelope:
       type: object

--- a/ui/src/components/ProtocolChip.tsx
+++ b/ui/src/components/ProtocolChip.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Ella Networks Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-import { Chip, Tooltip } from "@mui/material";
+import { Chip } from "@mui/material";
 
 // The control-plane protocol maps to a radio generation: NGAP is 5G, S1AP is 4G.
 const PROTOCOL_GENERATION: Record<string, string> = {
@@ -10,23 +10,18 @@ const PROTOCOL_GENERATION: Record<string, string> = {
 };
 
 /**
- * ProtocolChip renders a neutral control-plane protocol tag ("NGAP" / "S1AP").
- * A protocol isn't a success/error state, so the chip is colour-neutral, and the
- * radio generation it belongs to is shown as a tooltip. Used in the network
- * events table, drawer header, and drawer metadata so the styling stays
- * consistent.
+ * ProtocolChip renders a neutral control-plane protocol tag with its radio
+ * generation ("NGAP (5G)" / "S1AP (4G)"). A protocol isn't a success/error
+ * state, so the chip is colour-neutral. Used in the network events table,
+ * drawer header, and drawer metadata so the styling stays consistent.
  */
 const ProtocolChip: React.FC<{ protocol?: string | null }> = ({ protocol }) => {
   if (!protocol) return null;
 
   const generation = PROTOCOL_GENERATION[protocol];
-  const chip = (
-    <Chip size="small" label={protocol} color="default" variant="filled" />
-  );
+  const label = generation ? `${protocol} (${generation})` : protocol;
 
-  if (!generation) return chip;
-
-  return <Tooltip title={generation}>{chip}</Tooltip>;
+  return <Chip size="small" label={label} color="default" variant="filled" />;
 };
 
 export default ProtocolChip;

--- a/ui/src/pages/RadioDetail.tsx
+++ b/ui/src/pages/RadioDetail.tsx
@@ -58,7 +58,8 @@ const ranNodeTypeChip = (t: string) => {
         : t === "N3IWF"
           ? "warning"
           : "default";
-  return <Chip size="small" label={t} color={color} variant="outlined" />;
+  const label = t === "gNB" ? "gNB (5g)" : t === "eNB" ? "eNB (4g)" : t;
+  return <Chip size="small" label={label} color={color} variant="outlined" />;
 };
 
 const RadioDetail: React.FC = () => {

--- a/ui/src/pages/RadioDetail.tsx
+++ b/ui/src/pages/RadioDetail.tsx
@@ -58,7 +58,7 @@ const ranNodeTypeChip = (t: string) => {
         : t === "N3IWF"
           ? "warning"
           : "default";
-  const label = t === "gNB" ? "gNB (5g)" : t === "eNB" ? "eNB (4g)" : t;
+  const label = t === "gNB" ? "gNB (5G)" : t === "eNB" ? "eNB (4G)" : t;
   return <Chip size="small" label={label} color={color} variant="outlined" />;
 };
 
@@ -401,9 +401,9 @@ const RadioDetail: React.FC = () => {
                   <TableCell sx={valueCellSx}>{radio.address || "—"}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell sx={labelCellSx}>RAN Node Type</TableCell>
+                  <TableCell sx={labelCellSx}>Type</TableCell>
                   <TableCell sx={valueCellSx}>
-                    {ranNodeTypeChip(radio.ran_node_type)}
+                    {ranNodeTypeChip(radio.type)}
                   </TableCell>
                 </TableRow>
                 <TableRow>

--- a/ui/src/pages/radios/RadiosListTab.tsx
+++ b/ui/src/pages/radios/RadiosListTab.tsx
@@ -105,8 +105,9 @@ export default function RadiosListTab() {
                 : t === "N3IWF"
                   ? "warning"
                   : "default";
+          const label = t === "gNB" ? "gNB (5g)" : t === "eNB" ? "eNB (4g)" : t;
           return (
-            <Chip size="small" label={t} color={color} variant="outlined" />
+            <Chip size="small" label={label} color={color} variant="outlined" />
           );
         },
       },

--- a/ui/src/pages/radios/RadiosListTab.tsx
+++ b/ui/src/pages/radios/RadiosListTab.tsx
@@ -91,12 +91,12 @@ export default function RadiosListTab() {
       },
       { field: "id", headerName: "ID", flex: 0.6, minWidth: 100 },
       {
-        field: "ran_node_type",
+        field: "type",
         headerName: "Type",
         flex: 0.4,
         minWidth: 80,
         renderCell: (params) => {
-          const t = params.row.ran_node_type;
+          const t = params.row.type;
           const color =
             t === "gNB"
               ? "primary"
@@ -105,7 +105,7 @@ export default function RadiosListTab() {
                 : t === "N3IWF"
                   ? "warning"
                   : "default";
-          const label = t === "gNB" ? "gNB (5g)" : t === "eNB" ? "eNB (4g)" : t;
+          const label = t === "gNB" ? "gNB (5G)" : t === "eNB" ? "eNB (4G)" : t;
           return (
             <Chip size="small" label={label} color={color} variant="outlined" />
           );

--- a/ui/src/queries/radios.tsx
+++ b/ui/src/queries/radios.tsx
@@ -27,7 +27,7 @@ export type APIRadio = {
   name: string;
   id: string;
   address: string;
-  ran_node_type: string;
+  type: string;
   supported_tais: SupportedTAI[];
 };
 
@@ -55,7 +55,7 @@ export type APIRadioDetail = {
   address: string;
   connected_at: string;
   last_seen_at: string;
-  ran_node_type: string;
+  type: string;
   supported_tais: SupportedTAI[];
 };
 


### PR DESCRIPTION
# Description

Make it clear in the UI that an "enb" is a 4G radio and a "gnb" is a 5G radio.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
