### PR TITLE
feat: select S1AP port via config file

### DIFF
--- a/config/core.yaml
+++ b/config/core.yaml
@@ -1,24 +1,85 @@
+# Ella Core configuration file.
+# Start Ella Core with the `--config` flag to point at this file.
+
+# The logging configuration.
 logging:
+  # The system logging configuration.
   system:
+    # The log level. Options are trace, debug, info, warn, error, and fatal.
     level: "info"
+    # The output for the logs. Options are stdout and file.
     output: "stdout"
+    # The path to the log file. Only used if output is set to file.
+    # path: "/var/log/ella_system.log"
+  # The audit logging configuration.
   audit:
+    # The output for the logs. Options are stdout and file.
     output: "stdout"
+    # The path to the log file. Only used if output is set to file.
+    # path: "/var/log/ella_audit.log"
+
+# The database configuration.
 db:
+  # The path to the directory holding the database file (ella.db).
   path: "ella.db"
+
+# The network interfaces configuration.
 interfaces:
+  # The n2 interface (N2 in 5G, S1-MME in 4G). This is the control-plane
+  # interface to the radios; the same interface serves both 5G gNBs and 4G eNBs.
   n2:
+    # The IP address to listen on. Supports both IPv4 and IPv6 addresses
+    # (optional: either name or address must be provided).
     address: "10.3.0.2"
-    port: 38412
+    # The name of the network interface to listen on (optional: either name or
+    # address must be provided). When set, the server binds to all IP addresses
+    # configured on this interface, excluding link-local addresses.
+    # name: "n2"
+    # The SCTP port for the 5G N2 / NGAP listener. Default 38412.
+    # ngap-port: 38412
+    # The SCTP port for the 4G S1-MME / S1AP listener. Default 36412.
+    # s1ap-port: 36412
+  # The n3 interface (N3 in 5G, S1-U in 4G). This interface should be connected
+  # to the radios.
   n3:
+    # The name of the network interface (optional: either name or address must
+    # be provided).
     name: "n3"
+    # The address to listen on. Supports both IPv4 and IPv6 (optional: either
+    # name or address must be provided).
+    # address: "10.3.0.2"
+  # The n6 interface (N6 in 5G, SGi in 4G). This interface should be connected
+  # to the internet.
   n6:
+    # The name of the network interface.
     name: "eth0"
+  # The api interface, serving the HTTP API and UI.
   api:
+    # The IP address to listen on. Supports both IPv4 and IPv6 addresses
+    # (optional: either name or address must be provided).
     address: "0.0.0.0"
+    # The name of the network interface to listen on (optional: either name or
+    # address must be provided). When set, the server listens on all addresses
+    # but uses SO_BINDTODEVICE to restrict incoming traffic to this interface.
+    # name: "eth0"
+    # The port to listen on.
     port: 5002
+    # The TLS configuration (optional).
+    # tls:
+    #   # The path to the TLS certificate file (optional).
+    #   cert: "/etc/ella/cert.pem"
+    #   # The path to the TLS key file (optional).
+    #   key: "/etc/ella/key.pem"
+
+# The XDP configuration.
 xdp:
+  # The XDP attach mode. Options are native and generic. native is the most
+  # performant option and only works on supported drivers.
   attach-mode: "generic"
+
+# The telemetry configuration.
 telemetry:
+  # Whether telemetry is enabled or not. Default is false.
   enabled: false
+  # The endpoint for the OpenTelemetry Protocol (OTLP) collector.
   otlp-endpoint: "localhost:4317"

--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -21,14 +21,16 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
 - `db` (object): The database configuration.
     - `path` (string): The path to the directory holding the database file (`ella.db`).
 - `interfaces` (object): The network interfaces configuration.
-    - `n2` (object): The configuration for the n2 interface. This interface should be connected to the radios.
+    - `n2` (object): The configuration for the n2 interface (N2 in 5G, S1-MME in 4G). This is the control-plane interface to the radios; the same interface serves both 5G gNBs and 4G eNBs over SCTP.
         - `name` (string): The name of the network interface to listen on (optional: either name or address must be provided). When set, the server binds to all IP addresses configured on this interface. Link-local addresses (IPv6 link-local and IPv4 link-local) are automatically excluded.
         - `address` (string): The IP address to listen on. Supports both IPv4 and IPv6 addresses (optional: either name or address must be provided). When set, the server binds to this specific address.
-        - `port` (int): The port to listen on.
-    - `n3` (object): The configuration for the n3 interface. This interface should be connected to the radios.
+        - `ngap-port` (int, optional): The SCTP port for the 5G N2 / NGAP listener. Default `38412`.
+        - `s1ap-port` (int, optional): The SCTP port for the 4G S1-MME / S1AP listener. Default `36412`.
+        - `port` (int, optional): Deprecated alias for `ngap-port`. Cannot be set together with `ngap-port`.
+    - `n3` (object): The configuration for the n3 interface (N3 in 5G, S1-U in 4G). This interface should be connected to the radios.
         - `name` (string): The name of the network interface (optional: either name or address must be provided).
         - `address` (string): The address to listen on. Supports both IPv4 and IPv6 (optional: either name or address must be provided).
-    - `n6` (object): The configuration for the n6 interface. This interface should be connected to the internet.
+    - `n6` (object): The configuration for the n6 interface (N6 in 5G, SGi in 4G). This interface should be connected to the internet.
         - `name` (string): The name of the network interface.
     - `api` (object): The configuration for the api interface.
         - `name` (string): The name of the network interface to listen on (optional: either name or address must be provided). When set, the server listens on all addresses (`0.0.0.0`) but uses `SO_BINDTODEVICE` to restrict incoming traffic to this interface. Use this when you want to bind to a device without pinning to a specific IP address.
@@ -74,7 +76,6 @@ db:
 interfaces:
   n2:
     address: "22.22.22.2"
-    port: 38412
   n3:
     name: "ens5"
   n6:
@@ -120,7 +121,6 @@ The following example demonstrates using an IPv6 address for those interfaces:
 interfaces:
   n2:
     address: "2001:db8::1"
-    port: 38412
   n3:
     address: "2001:db8::1"
   n6:
@@ -136,7 +136,6 @@ The following example demonstrates using all non link-local addresses for those 
 interfaces:
   n2:
     name: "ens5"
-    port: 38412
   n3:
     address: "ens4"
   n6:

--- a/integration/cfg/node1/core.yaml
+++ b/integration/cfg/node1/core.yaml
@@ -1,7 +1,7 @@
 logging: {system: {level: debug, output: stdout}, audit: {output: stdout}}
 db: {path: /data/ella.db}
 interfaces:
-  n2: {address: "10.100.0.11", port: 38412}
+  n2: {address: "10.100.0.11"}
   n3: {address: "10.100.0.11"}
   n6: {name: eth0}
   api: {address: "10.100.0.11", port: 5002}

--- a/integration/cfg/node2/core.yaml
+++ b/integration/cfg/node2/core.yaml
@@ -1,7 +1,7 @@
 logging: {system: {level: debug, output: stdout}, audit: {output: stdout}}
 db: {path: /data/ella.db}
 interfaces:
-  n2: {address: "10.100.0.12", port: 38412}
+  n2: {address: "10.100.0.12"}
   n3: {address: "10.100.0.12"}
   n6: {name: eth0}
   api: {address: "10.100.0.12", port: 5002}

--- a/integration/cfg/node3/core.yaml
+++ b/integration/cfg/node3/core.yaml
@@ -1,7 +1,7 @@
 logging: {system: {level: debug, output: stdout}, audit: {output: stdout}}
 db: {path: /data/ella.db}
 interfaces:
-  n2: {address: "10.100.0.13", port: 38412}
+  n2: {address: "10.100.0.13"}
   n3: {address: "10.100.0.13"}
   n6: {name: eth0}
   api: {address: "10.100.0.13", port: 5002}

--- a/integration/compose/bgp/compose-ipv6.yaml
+++ b/integration/compose/bgp/compose-ipv6.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "2001:db8:1::10"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/bgp/compose.yaml
+++ b/integration/compose/bgp/compose.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "10.3.0.2"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/core-tester/compose-dualstack.yaml
+++ b/integration/compose/core-tester/compose-dualstack.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           name: "eth0"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/core-tester/compose-ipv6.yaml
+++ b/integration/compose/core-tester/compose-ipv6.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "2001:db8:1::10"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/core-tester/compose.yaml
+++ b/integration/compose/core-tester/compose.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "10.3.0.2"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/ha-3gpp/cfg/node1/core.yaml
+++ b/integration/compose/ha-3gpp/cfg/node1/core.yaml
@@ -9,7 +9,6 @@ db:
 interfaces:
   n2:
     address: "10.100.0.11"
-    port: 38412
   n3:
     address: "10.3.0.11"
   n6:

--- a/integration/compose/ha-3gpp/cfg/node2/core.yaml
+++ b/integration/compose/ha-3gpp/cfg/node2/core.yaml
@@ -9,7 +9,6 @@ db:
 interfaces:
   n2:
     address: "10.100.0.12"
-    port: 38412
   n3:
     address: "10.3.0.12"
   n6:

--- a/integration/compose/ha-3gpp/cfg/node3/core.yaml
+++ b/integration/compose/ha-3gpp/cfg/node3/core.yaml
@@ -9,7 +9,6 @@ db:
 interfaces:
   n2:
     address: "10.100.0.13"
-    port: 38412
   n3:
     address: "10.3.0.13"
   n6:

--- a/integration/compose/ha-5g-multi-gnb/cfg/node1/core.yaml
+++ b/integration/compose/ha-5g-multi-gnb/cfg/node1/core.yaml
@@ -9,7 +9,6 @@ db:
 interfaces:
   n2:
     address: "10.100.0.11"
-    port: 38412
   n3:
     address: "10.3.0.11"
   n6:

--- a/integration/compose/ha-5g-multi-gnb/cfg/node2/core.yaml
+++ b/integration/compose/ha-5g-multi-gnb/cfg/node2/core.yaml
@@ -9,7 +9,6 @@ db:
 interfaces:
   n2:
     address: "10.100.0.12"
-    port: 38412
   n3:
     address: "10.3.0.12"
   n6:

--- a/integration/compose/ha-5g-multi-gnb/cfg/node3/core.yaml
+++ b/integration/compose/ha-5g-multi-gnb/cfg/node3/core.yaml
@@ -9,7 +9,6 @@ db:
 interfaces:
   n2:
     address: "10.100.0.13"
-    port: 38412
   n3:
     address: "10.3.0.13"
   n6:

--- a/integration/compose/n2-handover/compose.yaml
+++ b/integration/compose/n2-handover/compose.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "10.3.0.2"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/srsenb/compose-dualstack.yaml
+++ b/integration/compose/srsenb/compose-dualstack.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "10.3.0.2"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/srsenb/compose.yaml
+++ b/integration/compose/srsenb/compose.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "10.3.0.2"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/ueransim/compose-dualstack.yaml
+++ b/integration/compose/ueransim/compose-dualstack.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           name: "eth0"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/ueransim/compose-ipv6.yaml
+++ b/integration/compose/ueransim/compose-ipv6.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "2001:db8:1::10"
-          port: 38412
         n3:
           address: "2001:db8:3::10"
         n6:

--- a/integration/compose/ueransim/compose.yaml
+++ b/integration/compose/ueransim/compose.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "10.3.0.2"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/integration/compose/x2-handover/compose.yaml
+++ b/integration/compose/x2-handover/compose.yaml
@@ -12,7 +12,6 @@ configs:
       interfaces:
         n2:
           address: "10.3.0.2"
-          port: 38412
         n3:
           name: "n3"
         n6:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ellanetworks/core/internal/logger"
 	"github.com/vishvananda/netlink"
 	"gopkg.in/yaml.v2"
 )
@@ -18,6 +19,13 @@ import (
 const (
 	AttachModeNative  = "native"
 	AttachModeGeneric = "generic"
+)
+
+const (
+	// DefaultNGAPPort is the standard 5G N2 / NGAP SCTP port (3GPP TS 38.412).
+	DefaultNGAPPort = 38412
+	// DefaultS1APPort is the standard 4G S1-MME / S1AP SCTP port (3GPP TS 36.412).
+	DefaultS1APPort = 36412
 )
 
 // AddressFamily specifies which IP address family to return when resolving an interface IP.
@@ -65,9 +73,11 @@ type TLSYaml struct {
 }
 
 type N2InterfaceYaml struct {
-	Name    string `yaml:"name"`
-	Address string `yaml:"address"`
-	Port    int    `yaml:"port"`
+	Name     string `yaml:"name"`
+	Address  string `yaml:"address"`
+	Port     int    `yaml:"port"`
+	NGAPPort int    `yaml:"ngap-port"`
+	S1APPort int    `yaml:"s1ap-port"`
 }
 
 type N3InterfaceYaml struct {
@@ -143,9 +153,10 @@ type ConfigYAML struct {
 }
 
 type N2Interface struct {
-	Name    string
-	Address string
-	Port    int
+	Name     string
+	Address  string
+	Port     int
+	S1APPort int
 }
 
 type N3Interface struct {
@@ -397,7 +408,35 @@ func Validate(filePath string) (Config, error) {
 		config.Interfaces.N2.Address = n2Address
 	}
 
-	config.Interfaces.N2.Port = c.Interfaces.N2.Port
+	ngapPort := c.Interfaces.N2.NGAPPort
+	switch {
+	case c.Interfaces.N2.Port != 0 && ngapPort != 0:
+		return Config{}, errors.New("interfaces.n2.port is deprecated; set only interfaces.n2.ngap-port")
+	case c.Interfaces.N2.Port != 0:
+		logger.EllaLog.Warn("interfaces.n2.port is deprecated, use interfaces.n2.ngap-port")
+
+		ngapPort = c.Interfaces.N2.Port
+	case ngapPort == 0:
+		ngapPort = DefaultNGAPPort
+	}
+
+	s1apPort := c.Interfaces.N2.S1APPort
+	if s1apPort == 0 {
+		s1apPort = DefaultS1APPort
+	}
+
+	for label, p := range map[string]int{"interfaces.n2.ngap-port": ngapPort, "interfaces.n2.s1ap-port": s1apPort} {
+		if p < 1 || p > 65535 {
+			return Config{}, fmt.Errorf("%s must be between 1 and 65535", label)
+		}
+	}
+
+	if ngapPort == s1apPort {
+		return Config{}, errors.New("interfaces.n2.ngap-port and interfaces.n2.s1ap-port must differ")
+	}
+
+	config.Interfaces.N2.Port = ngapPort
+	config.Interfaces.N2.S1APPort = s1apPort
 
 	if c.Interfaces.API.Name != "" {
 		config.Interfaces.API.Name = apiInterfaceName

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,6 +257,79 @@ func TestValidConfigNoTLSSuccess(t *testing.T) {
 	}
 }
 
+func TestN2PortResolution(t *testing.T) {
+	config.CheckInterfaceExistsFunc = func(name string) (bool, error) { return true, nil }
+	config.GetInterfaceNameFunc = func(name string) (string, error) { return InterfaceName, nil }
+	config.GetVLANConfigForInterfaceFunc = func(name string) (*config.VlanConfig, error) { return nil, nil }
+
+	const tmpl = `logging:
+  system:
+    level: "info"
+    output: "stdout"
+  audit:
+    output: "stdout"
+db:
+  path: "test"
+interfaces:
+  n2:
+%s
+  n3:
+    address: "33.33.33.3"
+  n6:
+    name: "enp6s0"
+  api:
+    address: "0.0.0.0"
+    port: 5002
+xdp:
+  attach-mode: "native"
+`
+
+	cases := []struct {
+		name         string
+		n2           string
+		wantNGAP     int
+		wantS1AP     int
+		wantErrParts string
+	}{
+		{"defaults when omitted", "    address: \"0.0.0.0\"", 38412, 36412, ""},
+		{"explicit ngap and s1ap", "    address: \"0.0.0.0\"\n    ngap-port: 1111\n    s1ap-port: 2222", 1111, 2222, ""},
+		{"deprecated port aliases ngap", "    address: \"0.0.0.0\"\n    port: 9999", 9999, 36412, ""},
+		{"port and ngap-port together", "    address: \"0.0.0.0\"\n    port: 9999\n    ngap-port: 8888", 0, 0, "interfaces.n2.port is deprecated"},
+		{"colliding ports", "    address: \"0.0.0.0\"\n    ngap-port: 5000\n    s1ap-port: 5000", 0, 0, "must differ"},
+		{"out of range", "    address: \"0.0.0.0\"\n    ngap-port: 70000", 0, 0, "between 1 and 65535"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := t.TempDir() + "/config.yaml"
+			if err := os.WriteFile(path, []byte(strings.Replace(tmpl, "%s", tc.n2, 1)), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			conf, err := config.Validate(path)
+			if tc.wantErrParts != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrParts) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErrParts, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if conf.Interfaces.N2.Port != tc.wantNGAP {
+				t.Errorf("NGAP port = %d, want %d", conf.Interfaces.N2.Port, tc.wantNGAP)
+			}
+
+			if conf.Interfaces.N2.S1APPort != tc.wantS1AP {
+				t.Errorf("S1AP port = %d, want %d", conf.Interfaces.N2.S1APPort, tc.wantS1AP)
+			}
+		})
+	}
+}
+
 func TestBadConfigFail(t *testing.T) {
 	cases := []struct {
 		Name               string

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -22,9 +22,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-// DefaultS1MMEPort is the standard S1-MME SCTP port (TS 36.412).
-const DefaultS1MMEPort = 36412
-
 // NASHandler is the EMM/ESM NAS layer's entry surface, implemented in
 // internal/mme/nas and injected so the S1AP layer dispatches uplink NAS without
 // the kernel importing its layers (kernel ⊅ nas).

--- a/k8s/core-configmap.yaml
+++ b/k8s/core-configmap.yaml
@@ -15,7 +15,6 @@ data:
     interfaces:
       n2:
         address: "192.168.253.3"
-        port: 38412
       n3:
         name: "n3"
       n6:

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -582,8 +582,7 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 
 	// 4G S1-MME control plane. The composition root owns the SCTP listener and
 	// routes decoded PDUs into the S1AP transport layer (mirrors the AMF/NGAP
-	// wiring above). Bind the RAN-facing interface (same address as N2) on the
-	// standard S1AP port.
+	// wiring above). Bind the RAN-facing interface (same address as N2).
 	mmeServer := amfsctp.NewServer(amfsctp.Config{
 		PPID:   mme.S1apPPID,
 		Name:   "S1-MME",
@@ -597,7 +596,7 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		},
 	})
 
-	if err := mmeServer.ListenAndServe(ctx, cfg.Interfaces.N2.Address, mme.DefaultS1MMEPort, interfaceName); err != nil {
+	if err := mmeServer.ListenAndServe(ctx, cfg.Interfaces.N2.Address, cfg.Interfaces.N2.S1APPort, interfaceName); err != nil {
 		return fmt.Errorf("couldn't start MME: %w", err)
 	}
 

--- a/service/core.yaml
+++ b/service/core.yaml
@@ -1,26 +1,87 @@
+# Ella Core configuration file.
+# When you use the Ella Core snap, this file is located at
+# /var/snap/ella-core/common/config.yaml. After modifying it, restart Ella Core
+# with `sudo snap restart ella-core.cored` for the changes to take effect.
+
+# The logging configuration.
 logging:
+  # The system logging configuration.
   system:
+    # The log level. Options are trace, debug, info, warn, error, and fatal.
     level: "info"
+    # The output for the logs. Options are stdout and file.
     output: "stdout"
+    # The path to the log file. Only used if output is set to file.
+    # path: "/var/snap/ella-core/common/log/ella_system.log"
+  # The audit logging configuration.
   audit:
+    # The output for the logs. Options are stdout and file.
     output: "stdout"
+    # The path to the log file. Only used if output is set to file.
+    # path: "/var/snap/ella-core/common/log/ella_audit.log"
+
+# The database configuration.
 db:
+  # The path to the directory holding the database file (ella.db).
   path: "/var/snap/ella-core/common/data/ella.db"
+
+# The network interfaces configuration.
 interfaces:
+  # The n2 interface (N2 in 5G, S1-MME in 4G). This is the control-plane
+  # interface to the radios; the same interface serves both 5G gNBs and 4G eNBs.
   n2:
+    # The IP address to listen on. Supports both IPv4 and IPv6 addresses
+    # (optional: either name or address must be provided).
     address: "10.3.0.2"
-    port: 38412
+    # The name of the network interface to listen on (optional: either name or
+    # address must be provided). When set, the server binds to all IP addresses
+    # configured on this interface, excluding link-local addresses.
+    # name: "ens5"
+    # The SCTP port for the 5G N2 / NGAP listener. Default 38412.
+    # ngap-port: 38412
+    # The SCTP port for the 4G S1-MME / S1AP listener. Default 36412.
+    # s1ap-port: 36412
+  # The n3 interface (N3 in 5G, S1-U in 4G). This interface should be connected
+  # to the radios.
   n3:
+    # The name of the network interface (optional: either name or address must
+    # be provided).
     name: "ens5"
+    # The address to listen on. Supports both IPv4 and IPv6 (optional: either
+    # name or address must be provided).
+    # address: "10.3.0.2"
+  # The n6 interface (N6 in 5G, SGi in 4G). This interface should be connected
+  # to the internet.
   n6:
+    # The name of the network interface.
     name: "ens3"
+  # The api interface, serving the HTTP API and UI.
   api:
+    # The IP address to listen on. Supports both IPv4 and IPv6 addresses
+    # (optional: either name or address must be provided).
     address: "0.0.0.0"
+    # The name of the network interface to listen on (optional: either name or
+    # address must be provided). When set, the server listens on all addresses
+    # but uses SO_BINDTODEVICE to restrict incoming traffic to this interface.
+    # name: "ens3"
+    # The port to listen on.
     port: 5002
+    # The TLS configuration (optional).
     tls:
+      # The path to the TLS certificate file (optional).
       cert: "/var/snap/ella-core/common/cert.pem"
+      # The path to the TLS key file (optional).
       key: "/var/snap/ella-core/common/key.pem"
+
+# The XDP configuration.
 xdp:
+  # The XDP attach mode. Options are native and generic. native is the most
+  # performant option and only works on supported drivers.
   attach-mode: "native"
+
+# The telemetry configuration.
 telemetry:
+  # Whether telemetry is enabled or not. Default is false.
   enabled: false
+  # The endpoint for the OpenTelemetry Protocol (OTLP) collector.
+  # otlp-endpoint: "localhost:4317"


### PR DESCRIPTION
# Description

Users can configure the S1AP port via the config file. 
- `n2` (object): The configuration for the n2 interface (N2 in 5G, S1-MME in 4G). This is the control-plane interface to the radios; the same interface serves both 5G gNBs and 4G eNBs over SCTP.
  - `name` (string): The name of the network interface to listen on (optional: either name or address must be provided). When set, the server binds to all IP addresses configured on this interface. Link-local addresses (IPv6 link-local and IPv4 link-local) are automatically excluded.
  - `address` (string): The IP address to listen on. Supports both IPv4 and IPv6 addresses (optional: either name or address must be provided). When set, the server binds to this specific address.
  - `ngap-port` (int, optional): The SCTP port for the 5G N2 / NGAP listener. Default `38412`.
  - `s1ap-port` (int, optional): The SCTP port for the 4G S1-MME / S1AP listener. Default `36412`.
  - `port` (int, optional): Deprecated alias for `ngap-port`. Cannot be set together with `ngap-port`.
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
