### PR TITLE
fix: retry on transient XDP-induced NIC flap

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ellanetworks/core/internal/kernel"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/netutil"
 	"github.com/ellanetworks/core/internal/smf"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
@@ -129,30 +130,37 @@ func StartDiscovery(ctx context.Context, dbInstance *db.Database, cfg config.Con
 	s.httpServer = srv
 
 	go func() {
-		var serveErr error
+		lc := net.ListenConfig{}
+		if cfg.Interfaces.API.Name != "" {
+			lc.Control = func(network, address string, c syscall.RawConn) error {
+				var setSockOptErr error
 
+				if err := c.Control(func(fd uintptr) {
+					setSockOptErr = syscall.SetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, cfg.Interfaces.API.Name)
+				}); err != nil {
+					return err
+				}
+
+				return setSockOptErr
+			}
+		}
+
+		// A bind can transiently fail while a shared N2/N3 interface flaps; retry.
 		var ln net.Listener
 
-		if cfg.Interfaces.API.Name != "" {
-			lc := net.ListenConfig{
-				Control: func(network, address string, c syscall.RawConn) error {
-					var setSockOptErr error
-
-					if err := c.Control(func(fd uintptr) {
-						setSockOptErr = syscall.SetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, cfg.Interfaces.API.Name)
-					}); err != nil {
-						return err
-					}
-
-					return setSockOptErr
-				},
+		listenErr := netutil.Retry(ctx, netutil.BindTimeout, netutil.BindInterval, netutil.IsAddrNotAvailable, func() error {
+			l, err := lc.Listen(ctx, "tcp", httpAddr)
+			if err != nil {
+				return err
 			}
 
-			ln, serveErr = lc.Listen(ctx, "tcp", httpAddr)
-			if serveErr != nil {
-				logger.APILog.Fatal("couldn't create listener", zap.Error(serveErr))
-				return
-			}
+			ln = l
+
+			return nil
+		})
+		if listenErr != nil {
+			logger.APILog.Fatal("couldn't create listener", zap.Error(listenErr))
+			return
 		}
 
 		logFields := []zap.Field{
@@ -164,6 +172,8 @@ func StartDiscovery(ctx context.Context, dbInstance *db.Database, cfg config.Con
 		}
 
 		logger.APILog.Info("API server started", logFields...)
+
+		var serveErr error
 
 		if scheme == HTTPS {
 			srv.Handler = &s.handler
@@ -185,11 +195,7 @@ func StartDiscovery(ctx context.Context, dbInstance *db.Database, cfg config.Con
 				},
 			}
 
-			if ln != nil {
-				serveErr = srv.ServeTLS(ln, cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key)
-			} else {
-				serveErr = srv.ListenAndServeTLS(cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key)
-			}
+			serveErr = srv.ServeTLS(ln, cfg.Interfaces.API.TLS.Cert, cfg.Interfaces.API.TLS.Key)
 		} else {
 			protocols := new(http.Protocols)
 			protocols.SetHTTP1(true)
@@ -197,11 +203,7 @@ func StartDiscovery(ctx context.Context, dbInstance *db.Database, cfg config.Con
 			srv.Protocols = protocols
 			srv.Handler = &s.handler
 
-			if ln != nil {
-				serveErr = srv.Serve(ln)
-			} else {
-				serveErr = srv.ListenAndServe()
-			}
+			serveErr = srv.Serve(ln)
 		}
 
 		if serveErr != nil && serveErr != http.ErrServerClosed {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,11 @@ const (
 	DefaultS1APPort = 36412
 )
 
+// ErrNoInterfaceIP is returned when an interface exists but currently has no
+// usable IP address of the requested family. The condition is transient during
+// an interface flap, so callers may retry.
+var ErrNoInterfaceIP = errors.New("no valid IP address found")
+
 // AddressFamily specifies which IP address family to return when resolving an interface IP.
 type AddressFamily int
 
@@ -551,7 +556,7 @@ var GetInterfaceIPFunc = func(name string, family AddressFamily) (string, error)
 		return ipv4Fallback, nil
 	}
 
-	return "", errors.New("no valid IP address found")
+	return "", ErrNoInterfaceIP
 }
 
 var GetInterfaceNameFunc = func(address string) (string, error) {

--- a/internal/netutil/retry.go
+++ b/internal/netutil/retry.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package netutil holds small networking helpers used across Ella Core.
+package netutil
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"time"
+)
+
+// BindTimeout and BindInterval bound a bind retry. A native-XDP driver-mode
+// attach on a NIC shared by N2 and N3 flushes its IP addresses for about a
+// second before the kernel restores them; the timeout stays well above that
+// window, while a persistently missing address still fails within it.
+const (
+	BindTimeout  = 15 * time.Second
+	BindInterval = 250 * time.Millisecond
+)
+
+// Retry invokes fn until it succeeds, fails with an error for which isTransient
+// reports false, or timeout elapses. It waits interval between attempts and
+// stops early when ctx is cancelled. On timeout or cancellation it returns fn's
+// last error.
+func Retry(ctx context.Context, timeout, interval time.Duration, isTransient func(error) bool, fn func() error) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		err := fn()
+		if err == nil || !isTransient(err) {
+			return err
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return err
+		case <-timer.C:
+		}
+	}
+}
+
+func IsAddrNotAvailable(err error) bool {
+	return errors.Is(err, syscall.EADDRNOTAVAIL)
+}

--- a/internal/netutil/retry_test.go
+++ b/internal/netutil/retry_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package netutil_test
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/netutil"
+)
+
+var (
+	errTransient = errors.New("transient")
+	errFatal     = errors.New("fatal")
+)
+
+func isTransient(err error) bool { return errors.Is(err, errTransient) }
+
+func TestRetrySucceedsImmediately(t *testing.T) {
+	calls := 0
+
+	err := netutil.Retry(context.Background(), time.Second, time.Millisecond, isTransient, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryTransientThenSuccess(t *testing.T) {
+	calls := 0
+
+	err := netutil.Retry(context.Background(), time.Second, time.Millisecond, isTransient, func() error {
+		calls++
+		if calls < 3 {
+			return errTransient
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryNonTransientReturnsImmediately(t *testing.T) {
+	calls := 0
+
+	err := netutil.Retry(context.Background(), time.Second, time.Millisecond, isTransient, func() error {
+		calls++
+		return errFatal
+	})
+	if !errors.Is(err, errFatal) {
+		t.Fatalf("expected errFatal, got %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("non-transient error must not retry, got %d calls", calls)
+	}
+}
+
+func TestRetryTimeoutReturnsLastError(t *testing.T) {
+	calls := 0
+
+	err := netutil.Retry(context.Background(), 20*time.Millisecond, time.Millisecond, isTransient, func() error {
+		calls++
+		return errTransient
+	})
+	if !errors.Is(err, errTransient) {
+		t.Fatalf("expected errTransient after timeout, got %v", err)
+	}
+
+	if calls < 2 {
+		t.Fatalf("expected multiple attempts before timeout, got %d", calls)
+	}
+}
+
+func TestRetryStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := netutil.Retry(ctx, time.Second, 10*time.Millisecond, isTransient, func() error {
+		return errTransient
+	})
+	if !errors.Is(err, errTransient) {
+		t.Fatalf("expected errTransient after cancel, got %v", err)
+	}
+}
+
+func TestIsAddrNotAvailable(t *testing.T) {
+	if !netutil.IsAddrNotAvailable(syscall.EADDRNOTAVAIL) {
+		t.Fatal("EADDRNOTAVAIL should be reported as address-not-available")
+	}
+
+	if netutil.IsAddrNotAvailable(syscall.EADDRINUSE) {
+		t.Fatal("EADDRINUSE must not be treated as address-not-available")
+	}
+
+	if netutil.IsAddrNotAvailable(nil) {
+		t.Fatal("nil must not be treated as address-not-available")
+	}
+}

--- a/internal/sctp/server.go
+++ b/internal/sctp/server.go
@@ -16,10 +16,13 @@ import (
 	"net"
 	"sync"
 
+	"github.com/ellanetworks/core/internal/netutil"
 	"go.uber.org/zap"
 )
 
 const readBufSize uint32 = 131072
+
+var errNoInterfaceAddrs = errors.New("no IP addresses found")
 
 var serverSocketConfig = SocketConfig{
 	InitMsg:   InitMsg{NumOstreams: 2, MaxInstreams: 5, MaxAttempts: 2, MaxInitTimeout: 2},
@@ -72,56 +75,81 @@ func (s *Server) ListenAndServe(ctx context.Context, address string, port int, i
 		addrStr string
 	)
 
-	if interfaceName != "" {
-		iface, err := net.InterfaceByName(interfaceName)
-		if err != nil {
-			return fmt.Errorf("failed to get interface %s: %w", interfaceName, err)
-		}
-
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return fmt.Errorf("failed to get interface addresses: %w", err)
-		}
-
-		var ipAddrs []net.IPAddr
-
-		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
-				continue
+	// A bind can transiently fail while a shared N2/N3 interface flaps; retry
+	// resolve and listen together.
+	bind := func() error {
+		if interfaceName != "" {
+			iface, err := net.InterfaceByName(interfaceName)
+			if err != nil {
+				return fmt.Errorf("failed to get interface %s: %w", interfaceName, err)
 			}
 
-			ip := ipNet.IP
-			if ip.IsLoopback() {
-				continue
+			addrs, err := iface.Addrs()
+			if err != nil {
+				return fmt.Errorf("failed to get interface addresses: %w", err)
 			}
 
-			if ip.IsLinkLocalUnicast() {
-				continue
+			var ipAddrs []net.IPAddr
+
+			for _, addr := range addrs {
+				ipNet, ok := addr.(*net.IPNet)
+				if !ok {
+					continue
+				}
+
+				ip := ipNet.IP
+				if ip.IsLoopback() {
+					continue
+				}
+
+				if ip.IsLinkLocalUnicast() {
+					continue
+				}
+
+				ipAddrs = append(ipAddrs, net.IPAddr{IP: ip})
 			}
 
-			ipAddrs = append(ipAddrs, net.IPAddr{IP: ip})
+			if len(ipAddrs) == 0 {
+				return fmt.Errorf("%w on interface %s", errNoInterfaceAddrs, interfaceName)
+			}
+
+			laddr = &SCTPAddr{IPAddrs: ipAddrs, Port: port}
+			addrStr = laddr.String()
+		} else {
+			netAddr, err := net.ResolveIPAddr("ip", address)
+			if err != nil {
+				return fmt.Errorf("error resolving address %q: %w", address, err)
+			}
+
+			laddr = &SCTPAddr{IPAddrs: []net.IPAddr{*netAddr}, Port: port}
+			addrStr = laddr.String()
 		}
 
-		if len(ipAddrs) == 0 {
-			return fmt.Errorf("no IP addresses found on interface %s", interfaceName)
-		}
-
-		laddr = &SCTPAddr{IPAddrs: ipAddrs, Port: port}
-		addrStr = laddr.String()
-	} else {
-		netAddr, err := net.ResolveIPAddr("ip", address)
-		if err != nil {
-			return fmt.Errorf("error resolving address %q: %w", address, err)
-		}
-
-		laddr = &SCTPAddr{IPAddrs: []net.IPAddr{*netAddr}, Port: port}
-		addrStr = laddr.String()
+		return nil
 	}
 
-	listener, err := serverSocketConfig.Listen("sctp", laddr)
+	isTransient := func(err error) bool {
+		return errors.Is(err, errNoInterfaceAddrs) || netutil.IsAddrNotAvailable(err)
+	}
+
+	var listener *SCTPListener
+
+	err := netutil.Retry(ctx, netutil.BindTimeout, netutil.BindInterval, isTransient, func() error {
+		if err := bind(); err != nil {
+			return err
+		}
+
+		l, err := serverSocketConfig.Listen("sctp", laddr)
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s: %w", addrStr, err)
+		}
+
+		listener = l
+
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("failed to listen on %s: %w", addrStr, err)
+		return err
 	}
 
 	s.listener = listener

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -35,6 +36,7 @@ import (
 	"github.com/ellanetworks/core/internal/mme"
 	mmenas "github.com/ellanetworks/core/internal/mme/nas"
 	mmes1ap "github.com/ellanetworks/core/internal/mme/s1ap"
+	"github.com/ellanetworks/core/internal/netutil"
 	ellaraft "github.com/ellanetworks/core/internal/raft"
 	amfsctp "github.com/ellanetworks/core/internal/sctp"
 	"github.com/ellanetworks/core/internal/sessions"
@@ -60,7 +62,20 @@ type RuntimeConfig struct {
 }
 
 func Start(ctx context.Context, rc RuntimeConfig) error {
-	cfg, err := config.Validate(rc.ConfigPath)
+	// A native-XDP attach on a NIC shared by N2 and N3 briefly flushes the RAN
+	// interface's address, which can be absent at startup. Retry validation
+	// across that window; any non-address error fails fast.
+	var cfg config.Config
+
+	err := netutil.Retry(ctx, netutil.BindTimeout, netutil.BindInterval,
+		func(e error) bool { return errors.Is(e, config.ErrNoInterfaceIP) },
+		func() error {
+			var vErr error
+
+			cfg, vErr = config.Validate(rc.ConfigPath)
+
+			return vErr
+		})
 	if err != nil {
 		return fmt.Errorf("couldn't validate config: %w", err)
 	}


### PR DESCRIPTION
# Description

Whenever the XDP attaches, it can flap the interface, making the IP unavailable for a few seconds. This is a problem whenever the same interface is also used for NGAP/API.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
