### PR TITLE
fix: Sequence number resynchronization

### DIFF
--- a/internal/amf/nas/handle_authentication_failure.go
+++ b/internal/amf/nas/handle_authentication_failure.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/free5gc/nas/nasMessage"
+	"go.uber.org/zap"
 )
 
 func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nasMessage.AuthenticationFailure) error {
@@ -63,14 +64,16 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		ue.Log.Warn("amf.Authentication Failure 5GMM Cause: Synch Failure")
 
 		conn.AuthFailureCauseSynchFailureTimes++
-		if conn.AuthFailureCauseSynchFailureTimes >= 2 {
-			ue.Log.Warn("2 consecutive Synch Failure, terminate authentication procedure")
+		if conn.AuthFailureCauseSynchFailureTimes >= 10 {
+			ue.Log.Warn("10 consecutive Synch Failure, terminate authentication procedure")
 			ue.Deregister(ctx)
 
 			amf.SendAuthenticationReject(ctx, ranUe)
 
 			return nil
 		}
+
+		ue.Log.Info("Resynchronizing SQN from AUTS", zap.Int("attempt", conn.AuthFailureCauseSynchFailureTimes))
 
 		if msg.AuthenticationFailureParameter == nil {
 			return fmt.Errorf("missing AuthenticationFailureParameter IE for SynchFailure")

--- a/internal/amf/nas/handle_authentication_failure_test.go
+++ b/internal/amf/nas/handle_authentication_failure_test.go
@@ -334,14 +334,14 @@ func TestHandleAuthenticationFailure_SynchFailure_FirstTime_AusfError(t *testing
 	}
 }
 
-func TestHandleAuthenticationFailure_SynchFailure_SecondTime_DeregistersAndSendsReject(t *testing.T) {
+func TestHandleAuthenticationFailure_SynchFailure_MaxAttempts_DeregistersAndSendsReject(t *testing.T) {
 	ue, ngapSender, err := buildUeAndRadio()
 	if err != nil {
 		t.Fatalf("could not build UE and radio: %v", err)
 	}
 
 	ue.ForceState(amf.Authentication)
-	ue.NasConn().AuthFailureCauseSynchFailureTimes = 1
+	ue.NasConn().AuthFailureCauseSynchFailureTimes = 9
 
 	msg := buildTestAuthenticationFailureMessage(nasMessage.Cause5GMMSynchFailure, nil)
 

--- a/internal/ausf/ausf_test.go
+++ b/internal/ausf/ausf_test.go
@@ -516,13 +516,13 @@ func TestWithClock(t *testing.T) {
 	}
 }
 
-func TestAuthenticate_SQNWrapsAt43BitBoundary(t *testing.T) {
+func TestAuthenticate_SQNWrapsAt48BitBoundary(t *testing.T) {
 	store := newFakeStore()
-	// Set SQN just below the 43-bit max so the next +32 wraps.
+	// Set SQN just below the 48-bit max (TS 33.102 §6.3.1) so the next +32 wraps.
 	store.Add(testIMSI, &ausf.Subscriber{
 		PermanentKey:   testK,
 		Opc:            testOPc,
-		SequenceNumber: "07ffffffffe0", // sqnMax - 31
+		SequenceNumber: "ffffffffffe0", // sqnMax - 31
 	})
 
 	a := newTestAUSF(store)
@@ -537,7 +537,7 @@ func TestAuthenticate_SQNWrapsAt43BitBoundary(t *testing.T) {
 	sqn := store.subs[testIMSI].SequenceNumber
 	store.mu.Unlock()
 
-	// 0x07ffffffffe0 + 32 = 0x0800000000000, masked to 43 bits = 0x000000000000
+	// 0xffffffffffe0 + 32 = 0x1000000000000, masked to 48 bits = 0x000000000000
 	if sqn != "000000000000" {
 		t.Fatalf("expected SQN to wrap to 000000000000, got %s", sqn)
 	}

--- a/internal/udm/sqn.go
+++ b/internal/udm/sqn.go
@@ -44,7 +44,12 @@ func aucSQN(opc, k, auts, rand []byte) ([]byte, []byte, error) {
 	return SQNms, macS, nil
 }
 
-const sqnMax uint64 = 0x7FFFFFFFFFF // 2^43 - 1; bitwise AND mask
+// sqnMax is the wrap-around mask for SQN. Per TS 33.102 §6.3.1, SQN is 48 bits
+// (SQN = SEQ‖IND, where SEQ is 43 bits and IND is 5 bits). The mask must cover
+// the full 48-bit SQN — masking to 43 bits would truncate the high bits of SEQ
+// and corrupt the SQN recovered from a UE's AUTS whose SQN >= 2^43 (e.g. a
+// previously-provisioned USIM using a time-based SQN), breaking re-sync.
+const sqnMax uint64 = 0xFFFFFFFFFFFF // 2^48 - 1; bitwise AND mask
 
 // IndStep is 2^IND_LEN (IND_LEN = 5 per TS 33.102 Annex C) — the number
 // of IND slots. Incrementing SQN by this value advances SEQ by 1 while
@@ -52,7 +57,7 @@ const sqnMax uint64 = 0x7FFFFFFFFFF // 2^43 - 1; bitwise AND mask
 // sequence-number management.
 const IndStep uint64 = 32
 
-// AdvanceSQN adds delta to sqn, masked to 43 bits, and returns the
+// AdvanceSQN adds delta to sqn, masked to 48 bits, and returns the
 // new value as a zero-padded 12-character hex string.
 func AdvanceSQN(sqnHex string, delta uint64) (string, error) {
 	n, err := strconv.ParseUint(sqnHex, 16, 64)

--- a/internal/udm/sqn_test.go
+++ b/internal/udm/sqn_test.go
@@ -54,15 +54,21 @@ func TestAdvanceSQN(t *testing.T) {
 		},
 		{
 			name:  "wraps at sqnMax minus IndStep",
-			input: "07ffffffffdf",
+			input: "ffffffffffdf",
 			delta: 32,
-			want:  "07ffffffffff",
+			want:  "ffffffffffff",
 		},
 		{
 			name:  "wraps past sqnMax",
-			input: "07ffffffffff",
+			input: "ffffffffffff",
 			delta: 32,
 			want:  "00000000001f",
+		},
+		{
+			name:  "SQN above 2^43 is preserved (not truncated to 43 bits)",
+			input: "080000000000",
+			delta: 32,
+			want:  "080000000020",
 		},
 		{
 			name:  "delta of 1",
@@ -281,13 +287,13 @@ func TestAdvanceSQN_BoundaryValues(t *testing.T) {
 	}{
 		{
 			name:  "sqnMax wraps to itself minus 1",
-			input: "07fffffffffe",
+			input: "fffffffffffe",
 			delta: 1,
-			want:  "07ffffffffff",
+			want:  "ffffffffffff",
 		},
 		{
 			name:  "sqnMax plus 1 wraps to zero",
-			input: "07ffffffffff",
+			input: "ffffffffffff",
 			delta: 1,
 			want:  "000000000000",
 		},
@@ -299,7 +305,7 @@ func TestAdvanceSQN_BoundaryValues(t *testing.T) {
 		},
 		{
 			name:  "resync step from sqnMax wraps correctly",
-			input: "07ffffffffff",
+			input: "ffffffffffff",
 			delta: 33,
 			want:  "000000000020",
 		},


### PR DESCRIPTION
# Description

I observed issues with connecting a UE while developing where I had to clear the database and reprovision UEs manually. Because I did not have the right sequence number, the UE was not able to reconnect.

This fixes the mask we were using from 43 bits to 48 bits, following the specs (TS 33.102 §6.3.1). We also increase the number of allowed resynchronization attempts; this is not specified in the specs, but it makes the network a bit more resilient in case of large de-synchronizations.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
