### PR TITLE
chore: converge AMF/MME procedure parity

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -643,8 +643,8 @@ func (amf *AMF) pageRadios(ctx context.Context, ue *UeContext, ngapBuf []byte) {
 	for _, ran := range amf.ConnectedRadios() {
 		for _, item := range ran.SupportedTAIList() {
 			if InTaiList(item.Tai, taiList) {
-				if err := amf.SendToRan(ctx, ran.Conn, send.NGAPProcedurePaging, ngapBuf); err != nil {
-					logger.From(ctx, logger.AmfLog).Error("failed to send paging", zap.Error(err))
+				if err := amf.SendToRadio(ctx, ran.Conn, send.NGAPProcedurePaging, ngapBuf); err != nil {
+					// The send failure is logged at the chokepoint.
 					continue
 				}
 

--- a/internal/amf/handover.go
+++ b/internal/amf/handover.go
@@ -127,9 +127,11 @@ func handoverGuardExpiry(a *AMF, sourceUe, targetUe *UeConn) func(context.Contex
 
 		targetUe.ReleaseAction = UeContextReleaseHandover
 
-		return targetUe.SendUEContextReleaseCommand(cctx,
+		targetUe.SendUEContextReleaseCommand(cctx,
 			ngapType.CausePresentRadioNetwork,
 			ngapType.CauseRadioNetworkPresentTngrelocoverallExpiry)
+
+		return nil
 	}
 }
 

--- a/internal/amf/n1n2message.go
+++ b/internal/amf/n1n2message.go
@@ -84,7 +84,7 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 
 	send.AppendPDUSessionResourceSetupListCxtReq(&list, req.PduSessionID, req.SNssai, nasPdu, req.BinaryDataN2Information)
 
-	err = ueConn.SendInitialContextSetupRequest(
+	err = ueConn.SendInitialContextSetup(
 		ctx,
 		ue.Ambr.Uplink,
 		ue.Ambr.Downlink,
@@ -349,7 +349,7 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 	list := ngapType.PDUSessionResourceSetupListCxtReq{}
 	send.AppendPDUSessionResourceSetupListCxtReq(&list, req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 
-	err = ueConn.SendInitialContextSetupRequest(
+	err = ueConn.SendInitialContextSetup(
 		ctx,
 		ue.Ambr.Uplink,
 		ue.Ambr.Downlink,

--- a/internal/amf/nas/handle_deregistration_accept.go
+++ b/internal/amf/nas/handle_deregistration_accept.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/free5gc/ngap/ngapType"
-	"go.uber.org/zap"
 )
 
 // TS 23.502
@@ -29,11 +28,7 @@ func handleDeregistrationAccept(ctx context.Context, ue *amf.UeContext) nasreply
 
 	ueConn.ReleaseAction = amf.UeContextReleaseDueToNwInitiatedDeregistraion
 
-	err := ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
-	if err != nil {
-		logger.From(ctx, logger.AmfLog).Warn("error sending ue context release command", zap.Error(err))
-		return nasreply.Handled()
-	}
+	ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
 
 	return nasreply.Handled()
 }

--- a/internal/amf/nas/handle_deregistration_request.go
+++ b/internal/amf/nas/handle_deregistration_request.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/ngap/ngapType"
-	"go.uber.org/zap"
 )
 
 // TS 23.502
@@ -50,11 +49,7 @@ func handleDeregistrationRequestUEOriginatingDeregistration(ctx context.Context,
 
 	ueConn.ReleaseAction = amf.UeContextReleaseUeContext
 
-	err := ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
-	if err != nil {
-		logger.From(ctx, logger.AmfLog).Warn("error sending ue context release command", zap.Error(err))
-		return nasreply.Handled()
-	}
+	ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentDeregister)
 
 	return nasreply.Handled()
 }

--- a/internal/amf/nas/handle_registration_complete.go
+++ b/internal/amf/nas/handle_registration_complete.go
@@ -53,11 +53,7 @@ func handleRegistrationComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 
 		ueConn.ReleaseAction = amf.UeContextN2NormalRelease
 
-		err := ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
-		if err != nil {
-			logger.From(ctx, logger.AmfLog).Warn("error sending ue context release command", zap.Error(err))
-			return nasreply.Handled()
-		}
+		ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 	}
 
 	ue.ClearRegistrationRequestData()

--- a/internal/amf/nas/handle_security_mode_reject.go
+++ b/internal/amf/nas/handle_security_mode_reject.go
@@ -40,11 +40,7 @@ func handleSecurityModeReject(ctx context.Context, ue *amf.UeContext, msg *nasMe
 
 	ueConn.ReleaseAction = amf.UeContextReleaseUeContext
 
-	err := ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
-	if err != nil {
-		logger.From(ctx, logger.AmfLog).Warn("error sending ue context release command", zap.Error(err))
-		return nasreply.Handled()
-	}
+	ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 
 	return nasreply.Handled()
 }

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -369,7 +369,5 @@ func rejectService(ctx context.Context, ueConn *amf.UeConn, cause uint8) {
 	amf.SendServiceReject(ctx, ueConn, cause)
 
 	ueConn.ReleaseAction = amf.UeContextN2NormalRelease
-	if err := ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease); err != nil {
-		logger.From(ctx, logger.AmfLog).Warn("error sending ue context release command", zap.Error(err))
-	}
+	ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 }

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -65,7 +65,7 @@ func sendServiceAccept(
 
 		ueConn.MarkICSPending()
 
-		err = ueConn.SendInitialContextSetupRequest(
+		err = ueConn.SendInitialContextSetup(
 			ctx,
 			ue.Ambr.Uplink,
 			ue.Ambr.Downlink,

--- a/internal/amf/nas/reg_initial.go
+++ b/internal/amf/nas/reg_initial.go
@@ -37,10 +37,8 @@ func abortRegistration(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeCont
 func releaseAbortedRegistration(ctx context.Context, ueConn *amf.UeConn) {
 	ueConn.ReleaseAction = amf.UeContextReleaseAbortRegistration
 
-	if err := ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentUnspecified); err != nil {
-		// SendUEContextReleaseCommand already released locally on a send failure; log only.
-		logger.From(ctx, logger.AmfLog).Warn("failed to send UE Context Release Command for aborted registration", zap.Error(err))
-	}
+	// SendUEContextReleaseCommand releases locally on a send failure and logs it.
+	ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentNas, ngapType.CauseNasPresentUnspecified)
 }
 
 func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) {

--- a/internal/amf/ngap/decode_dispatch.go
+++ b/internal/amf/ngap/decode_dispatch.go
@@ -29,8 +29,8 @@ func handleDecodeReport(ctx context.Context, ran *amf.Radio, report *decode.Repo
 
 			if pkt, err := send.BuildErrorIndication(nil, nil, nil, &cd); err != nil {
 				logger.WithTrace(ctx, ran.Log).Error("error building error indication", zap.Error(err))
-			} else if err := ran.SendToRan(ctx, send.NGAPProcedureErrorIndication, pkt); err != nil {
-				logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
+			} else {
+				_ = ran.SendToRadio(ctx, send.NGAPProcedureErrorIndication, pkt)
 			}
 		}
 

--- a/internal/amf/ngap/decode_dispatch.go
+++ b/internal/amf/ngap/decode_dispatch.go
@@ -30,7 +30,7 @@ func handleDecodeReport(ctx context.Context, ran *amf.Radio, report *decode.Repo
 			if pkt, err := send.BuildErrorIndication(nil, nil, nil, &cd); err != nil {
 				logger.WithTrace(ctx, ran.Log).Error("error building error indication", zap.Error(err))
 			} else {
-				_ = ran.SendToRadio(ctx, send.NGAPProcedureErrorIndication, pkt)
+				ran.SendToRadio(ctx, send.NGAPProcedureErrorIndication, pkt)
 			}
 		}
 

--- a/internal/amf/ngap/handle_error_indication.go
+++ b/internal/amf/ngap/handle_error_indication.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/free5gc/ngap/ngapType"
-	"go.uber.org/zap"
 )
 
 func HandleErrorIndication(ctx gocontext.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.ErrorIndication) {
@@ -38,7 +37,5 @@ func HandleErrorIndication(ctx gocontext.Context, amfInstance *amf.AMF, ran *amf
 
 	ueConn.ReleaseAction = amf.UeContextN2NormalRelease
 
-	if err := ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentUnspecified); err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("failed to release UE on Error Indication", zap.Error(err))
-	}
+	ueConn.SendUEContextReleaseCommand(ctx, ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentUnspecified)
 }

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -46,14 +46,10 @@ func HandleHandoverCancel(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	if aborted && target != nil {
 		target.ReleaseAction = amf.UeContextReleaseHandover
 
-		if err := target.SendUEContextReleaseCommand(ctx, causePresent, causeValue); err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending UE Context Release Command to target UE", zap.Error(err))
-		}
+		target.SendUEContextReleaseCommand(ctx, causePresent, causeValue)
 	}
 
 	// The acknowledge is mandatory, so it is sent regardless of the target-release
 	// outcome (TS 38.413 §8.4.5).
-	if err := sourceUe.SendHandoverCancelAcknowledge(ctx); err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover cancel acknowledge to source UE", zap.Error(err))
-	}
+	sourceUe.SendHandoverCancelAcknowledge(ctx)
 }

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -61,11 +61,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 		if sourceUe.Radio() == nil {
 			logger.WithTrace(ctx, targetUe.Log).Error("source UE radio is nil, cannot send handover preparation failure")
 		} else {
-			err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, msg.CriticalityDiagnostics)
-			if err != nil {
-				logger.WithTrace(ctx, targetUe.Log).Error("error sending handover preparation failure", zap.Error(err))
-				return
-			}
+			sourceUe.SendHandoverPreparationFailure(ctx, failureCause, msg.CriticalityDiagnostics)
 		}
 	}
 

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -84,9 +84,5 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	sourceUe.ReleaseAction = amf.UeContextReleaseHandover
 
-	err := sourceUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentSuccessfulHandover)
-	if err != nil {
-		logger.WithTrace(ctx, targetUe.Log).Error("error sending ue context release command", zap.Error(err))
-		return
-	}
+	sourceUe.SendUEContextReleaseCommand(ctx, ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentSuccessfulHandover)
 }

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -149,17 +149,15 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 
 		if sourceUe.Radio() == nil {
 			logger.WithTrace(ctx, targetUe.Log).Error("source UE radio is nil, cannot send handover preparation failure")
-		} else if err := sourceUe.SendHandoverPreparationFailure(ctx, cause, nil); err != nil {
-			logger.WithTrace(ctx, targetUe.Log).Error("error sending handover preparation failure", zap.Error(err))
+		} else {
+			sourceUe.SendHandoverPreparationFailure(ctx, cause, nil)
 		}
 
 		// The target acknowledged and so holds a reserved UE context, but no session
 		// survived core-side preparation. Its resources are reclaimed only by a
 		// CN-initiated UE Context Release (TS 38.413 §8.4.2).
 		targetUe.ReleaseAction = amf.UeContextReleaseHandover
-		if err := targetUe.SendUEContextReleaseCommand(ctx, cause.Present, cause.RadioNetwork.Value); err != nil {
-			logger.WithTrace(ctx, targetUe.Log).Error("error sending UE Context Release Command to target UE", zap.Error(err))
-		}
+		targetUe.SendUEContextReleaseCommand(ctx, cause.Present, cause.RadioNetwork.Value)
 
 		return
 	}
@@ -175,7 +173,5 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	if err := sourceUe.SendNGAP(ctx, send.NGAPProcedureHandoverCommand, pkt); err != nil {
-		logger.WithTrace(ctx, targetUe.Log).Error("error sending handover command to source UE", zap.Error(err))
-	}
+	sourceUe.SendNGAP(ctx, send.NGAPProcedureHandoverCommand, pkt)
 }

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -41,9 +41,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		if err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil); err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(err))
-		}
+		sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 
 		return
 	}
@@ -64,11 +62,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(err))
-			return
-		}
+		sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 
 		return
 	}
@@ -88,9 +82,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		if err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil); err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(err))
-		}
+		sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 
 		return
 	}
@@ -107,9 +99,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		if err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil); err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(err))
-		}
+		sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 
 		return
 	}
@@ -146,11 +136,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
-		if err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(err))
-			return
-		}
+		sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 
 		return
 	}
@@ -176,9 +162,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		if err := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil); err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(err))
-		}
+		sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 
 		return
 	}
@@ -217,9 +201,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 			},
 		}
 
-		if ferr := sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil); ferr != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover preparation failure", zap.Error(ferr))
-		}
+		sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil)
 
 		return
 	}

--- a/internal/amf/ngap/handle_location_report.go
+++ b/internal/amf/ngap/handle_location_report.go
@@ -77,8 +77,8 @@ func HandleLocationReport(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		pkt, err := send.BuildLocationReportingControl(int64(ueConn.AmfUeNgapID), int64(ueConn.RanUeNgapID), msg.LocationReportingRequestType.EventType)
 		if err != nil {
 			logger.WithTrace(ctx, ueConn.Log).Error("error building location reporting control", zap.Error(err))
-		} else if err := ueConn.SendNGAP(ctx, send.NGAPProcedureLocationReportingControl, pkt); err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("error sending location reporting control", zap.Error(err))
+		} else {
+			ueConn.SendNGAP(ctx, send.NGAPProcedureLocationReportingControl, pkt)
 		}
 	case ngapType.EventTypePresentStopUePresenceInAreaOfInterest:
 		if msg.LocationReportingRequestType.LocationReportingReferenceIDToBeCancelled == nil {

--- a/internal/amf/ngap/handle_ng_reset.go
+++ b/internal/amf/ngap/handle_ng_reset.go
@@ -37,10 +37,7 @@ func HandleNGReset(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, ms
 			return
 		}
 
-		if err := ran.SendToRan(ctx, send.NGAPProcedureNGResetAcknowledge, pkt); err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending NG Reset Acknowledge", zap.Error(err))
-			return
-		}
+		_ = ran.SendToRadio(ctx, send.NGAPProcedureNGResetAcknowledge, pkt)
 	case ngapType.ResetTypePresentPartOfNGInterface:
 		logger.WithTrace(ctx, ran.Log).Debug("ResetType Present: Part of NG Interface")
 
@@ -87,10 +84,7 @@ func HandleNGReset(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, ms
 			return
 		}
 
-		if err := ran.SendToRan(ctx, send.NGAPProcedureNGResetAcknowledge, pkt); err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending NG Reset Acknowledge", zap.Error(err))
-			return
-		}
+		_ = ran.SendToRadio(ctx, send.NGAPProcedureNGResetAcknowledge, pkt)
 	default:
 		logger.WithTrace(ctx, ran.Log).Warn("Invalid ResetType", zap.Any("ResetType", msg.ResetType.Present))
 	}

--- a/internal/amf/ngap/handle_ng_reset.go
+++ b/internal/amf/ngap/handle_ng_reset.go
@@ -37,7 +37,7 @@ func HandleNGReset(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, ms
 			return
 		}
 
-		_ = ran.SendToRadio(ctx, send.NGAPProcedureNGResetAcknowledge, pkt)
+		ran.SendToRadio(ctx, send.NGAPProcedureNGResetAcknowledge, pkt)
 	case ngapType.ResetTypePresentPartOfNGInterface:
 		logger.WithTrace(ctx, ran.Log).Debug("ResetType Present: Part of NG Interface")
 
@@ -84,7 +84,7 @@ func HandleNGReset(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, ms
 			return
 		}
 
-		_ = ran.SendToRadio(ctx, send.NGAPProcedureNGResetAcknowledge, pkt)
+		ran.SendToRadio(ctx, send.NGAPProcedureNGResetAcknowledge, pkt)
 	default:
 		logger.WithTrace(ctx, ran.Log).Warn("Invalid ResetType", zap.Any("ResetType", msg.ResetType.Present))
 	}

--- a/internal/amf/ngap/handle_ng_setup_request.go
+++ b/internal/amf/ngap/handle_ng_setup_request.go
@@ -27,9 +27,7 @@ func sendNGSetupFailure(ctx context.Context, ran *amf.Radio, cause *ngapType.Cau
 		return
 	}
 
-	if err := ran.SendToRan(ctx, send.NGAPProcedureNGSetupFailure, pkt); err != nil {
-		logger.WithTrace(ctx, ran.Log).Error("error sending NG Setup Failure", zap.Error(err))
-	}
+	_ = ran.SendToRadio(ctx, send.NGAPProcedureNGSetupFailure, pkt)
 }
 
 func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.NGSetupRequest) {
@@ -181,10 +179,7 @@ func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	if err := ran.SendToRan(ctx, send.NGAPProcedureNGSetupResponse, pkt); err != nil {
-		logger.WithTrace(ctx, ran.Log).Error("error sending NG Setup Response", zap.Error(err))
-		return
-	}
+	_ = ran.SendToRadio(ctx, send.NGAPProcedureNGSetupResponse, pkt)
 
 	logger.WithTrace(ctx, ran.Log).Info("Radio completed NG Setup", zap.String("name", name))
 }

--- a/internal/amf/ngap/handle_ng_setup_request.go
+++ b/internal/amf/ngap/handle_ng_setup_request.go
@@ -27,7 +27,7 @@ func sendNGSetupFailure(ctx context.Context, ran *amf.Radio, cause *ngapType.Cau
 		return
 	}
 
-	_ = ran.SendToRadio(ctx, send.NGAPProcedureNGSetupFailure, pkt)
+	ran.SendToRadio(ctx, send.NGAPProcedureNGSetupFailure, pkt)
 }
 
 func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg decode.NGSetupRequest) {
@@ -179,7 +179,7 @@ func HandleNGSetupRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	_ = ran.SendToRadio(ctx, send.NGAPProcedureNGSetupResponse, pkt)
+	ran.SendToRadio(ctx, send.NGAPProcedureNGSetupResponse, pkt)
 
 	logger.WithTrace(ctx, ran.Log).Info("Radio completed NG Setup", zap.String("name", name))
 }

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -196,10 +196,7 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 			return
 		}
 
-		if err := ueConn.SendNGAP(ctx, send.NGAPProcedurePathSwitchRequestAcknowledge, pkt); err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("error sending path switch request acknowledge", zap.Error(err))
-			return
-		}
+		ueConn.SendNGAP(ctx, send.NGAPProcedurePathSwitchRequestAcknowledge, pkt)
 	} else {
 		// TS 38.413: no session switched, so the path switch fails and every requested
 		// session is released.

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
@@ -73,9 +73,7 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 		return
 	}
 
-	if err := ran.SendToRan(ctx, send.NGAPProcedurePDUSessionResourceModifyConfirm, pkt); err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("error sending pdu session resource modify confirm", zap.Error(err))
-	}
+	_ = ran.SendToRadio(ctx, send.NGAPProcedurePDUSessionResourceModifyConfirm, pkt)
 }
 
 func appendFailedToModify(ctx context.Context, ueConn *amf.UeConn, list *ngapType.PDUSessionResourceFailedToModifyListModCfm, pduSessionID ngapType.PDUSessionID, causeValue aper.Enumerated) {

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
@@ -73,7 +73,7 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 		return
 	}
 
-	_ = ran.SendToRadio(ctx, send.NGAPProcedurePDUSessionResourceModifyConfirm, pkt)
+	ran.SendToRadio(ctx, send.NGAPProcedurePDUSessionResourceModifyConfirm, pkt)
 }
 
 func appendFailedToModify(ctx context.Context, ueConn *amf.UeConn, list *ngapType.PDUSessionResourceFailedToModifyListModCfm, pduSessionID ngapType.PDUSessionID, causeValue aper.Enumerated) {

--- a/internal/amf/ngap/handle_ran_configuration_update.go
+++ b/internal/amf/ngap/handle_ran_configuration_update.go
@@ -45,7 +45,7 @@ func HandleRanConfigurationUpdate(ctx context.Context, amfInstance *amf.AMF, ran
 			return
 		}
 
-		_ = ran.SendToRadio(ctx, send.NGAPProcedureRanConfigurationUpdateAcknowledge, pkt)
+		ran.SendToRadio(ctx, send.NGAPProcedureRanConfigurationUpdateAcknowledge, pkt)
 	} else {
 		pkt, err := send.BuildRanConfigurationUpdateFailure(cause, nil)
 		if err != nil {
@@ -53,7 +53,7 @@ func HandleRanConfigurationUpdate(ctx context.Context, amfInstance *amf.AMF, ran
 			return
 		}
 
-		_ = ran.SendToRadio(ctx, send.NGAPProcedureRanConfigurationUpdateFailure, pkt)
+		ran.SendToRadio(ctx, send.NGAPProcedureRanConfigurationUpdateFailure, pkt)
 	}
 }
 

--- a/internal/amf/ngap/handle_ran_configuration_update.go
+++ b/internal/amf/ngap/handle_ran_configuration_update.go
@@ -45,9 +45,7 @@ func HandleRanConfigurationUpdate(ctx context.Context, amfInstance *amf.AMF, ran
 			return
 		}
 
-		if err := ran.SendToRan(ctx, send.NGAPProcedureRanConfigurationUpdateAcknowledge, pkt); err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending ran configuration update acknowledge", zap.Error(err))
-		}
+		_ = ran.SendToRadio(ctx, send.NGAPProcedureRanConfigurationUpdateAcknowledge, pkt)
 	} else {
 		pkt, err := send.BuildRanConfigurationUpdateFailure(cause, nil)
 		if err != nil {
@@ -55,9 +53,7 @@ func HandleRanConfigurationUpdate(ctx context.Context, amfInstance *amf.AMF, ran
 			return
 		}
 
-		if err := ran.SendToRan(ctx, send.NGAPProcedureRanConfigurationUpdateFailure, pkt); err != nil {
-			logger.WithTrace(ctx, ran.Log).Error("error sending ran configuration update failure", zap.Error(err))
-		}
+		_ = ran.SendToRadio(ctx, send.NGAPProcedureRanConfigurationUpdateFailure, pkt)
 	}
 }
 

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -84,11 +84,7 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 			logger.WithTrace(ctx, ueConn.Log).Info("Ue Context in Non GMM-Registered")
 			ueConn.ReleaseAction = amf.UeContextReleaseUeContext
 
-			err := ueConn.SendUEContextReleaseCommand(ctx, causeGroup, causeValue)
-			if err != nil {
-				logger.WithTrace(ctx, ueConn.Log).Error("error sending ue context release command", zap.Error(err))
-				return
-			}
+			ueConn.SendUEContextReleaseCommand(ctx, causeGroup, causeValue)
 
 			for _, sr := range amfUe.SmContextRefs() {
 				err := amfInstance.Session.ReleaseSmContext(ctx, sr.Ref)
@@ -103,9 +99,5 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 	ueConn.ReleaseAction = amf.UeContextN2NormalRelease
 
-	err = ueConn.SendUEContextReleaseCommand(ctx, causeGroup, causeValue)
-	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("error sending ue context release command", zap.Error(err))
-		return
-	}
+	ueConn.SendUEContextReleaseCommand(ctx, causeGroup, causeValue)
 }

--- a/internal/amf/ngap/handle_ue_context_release_request_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_request_test.go
@@ -92,13 +92,8 @@ func TestSendUEContextReleaseCommand_Idempotent(t *testing.T) {
 	sender := ran.Conn.(*fakeNGAPSender)
 	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
 
-	if err := ueConn.SendUEContextReleaseCommand(context.Background(), ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease); err != nil {
-		t.Fatalf("first release: %v", err)
-	}
-
-	if err := ueConn.SendUEContextReleaseCommand(context.Background(), ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease); err != nil {
-		t.Fatalf("second release: %v", err)
-	}
+	ueConn.SendUEContextReleaseCommand(context.Background(), ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
+	ueConn.SendUEContextReleaseCommand(context.Background(), ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 
 	if len(sender.SentUEContextReleaseCommands) != 1 {
 		t.Fatalf("expected a single UE Context Release Command, got %d", len(sender.SentUEContextReleaseCommands))

--- a/internal/amf/ngap/handle_uplink_ran_configuration_transfer.go
+++ b/internal/amf/ngap/handle_uplink_ran_configuration_transfer.go
@@ -38,5 +38,5 @@ func HandleUplinkRanConfigurationTransfer(ctx context.Context, amfInstance *amf.
 		return
 	}
 
-	_ = targetRan.SendToRadio(ctx, send.NGAPProcedureDownlinkRanConfigurationTransfer, pkt)
+	targetRan.SendToRadio(ctx, send.NGAPProcedureDownlinkRanConfigurationTransfer, pkt)
 }

--- a/internal/amf/ngap/handle_uplink_ran_configuration_transfer.go
+++ b/internal/amf/ngap/handle_uplink_ran_configuration_transfer.go
@@ -38,8 +38,5 @@ func HandleUplinkRanConfigurationTransfer(ctx context.Context, amfInstance *amf.
 		return
 	}
 
-	if err := targetRan.SendToRan(ctx, send.NGAPProcedureDownlinkRanConfigurationTransfer, pkt); err != nil {
-		logger.WithTrace(ctx, ran.Log).Error("error sending downlink ran configuration transfer", zap.Error(err))
-		return
-	}
+	_ = targetRan.SendToRadio(ctx, send.NGAPProcedureDownlinkRanConfigurationTransfer, pkt)
 }

--- a/internal/amf/ngap/handle_uplink_ran_status_transfer.go
+++ b/internal/amf/ngap/handle_uplink_ran_status_transfer.go
@@ -37,7 +37,5 @@ func HandleUplinkRanStatusTransfer(ctx context.Context, amfInstance *amf.AMF, ra
 		return
 	}
 
-	if err := target.SendNGAP(ctx, send.NGAPProcedureDownlinkRanStatusTransfer, pkt); err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("failed to send Downlink RAN Status Transfer", zap.Error(err))
-	}
+	target.SendNGAP(ctx, send.NGAPProcedureDownlinkRanStatusTransfer, pkt)
 }

--- a/internal/amf/ngap/path_switch_failure.go
+++ b/internal/amf/ngap/path_switch_failure.go
@@ -31,7 +31,7 @@ func sendPathSwitchRequestFailure(ctx context.Context, ran *amf.Radio, msg decod
 		return
 	}
 
-	_ = ran.SendToRadio(ctx, send.NGAPProcedurePathSwitchRequestFailure, pkt)
+	ran.SendToRadio(ctx, send.NGAPProcedurePathSwitchRequestFailure, pkt)
 }
 
 // pathSwitchReleasedList builds the released list with one item per distinct

--- a/internal/amf/ngap/path_switch_failure.go
+++ b/internal/amf/ngap/path_switch_failure.go
@@ -31,9 +31,7 @@ func sendPathSwitchRequestFailure(ctx context.Context, ran *amf.Radio, msg decod
 		return
 	}
 
-	if err := ran.SendToRan(ctx, send.NGAPProcedurePathSwitchRequestFailure, pkt); err != nil {
-		logger.WithTrace(ctx, ran.Log).Error("error sending path switch request failure", zap.Error(err))
-	}
+	_ = ran.SendToRadio(ctx, send.NGAPProcedurePathSwitchRequestFailure, pkt)
 }
 
 // pathSwitchReleasedList builds the released list with one item per distinct

--- a/internal/amf/ngap/resolve_ue.go
+++ b/internal/amf/ngap/resolve_ue.go
@@ -94,7 +94,5 @@ func sendErrorIndication(ctx context.Context, ran *amf.Radio, amfID, ranID *int6
 		return
 	}
 
-	if err := ran.SendToRan(ctx, send.NGAPProcedureErrorIndication, pkt); err != nil {
-		logger.WithTrace(ctx, ran.Log).Error("error sending error indication", zap.Error(err))
-	}
+	_ = ran.SendToRadio(ctx, send.NGAPProcedureErrorIndication, pkt)
 }

--- a/internal/amf/ngap/resolve_ue.go
+++ b/internal/amf/ngap/resolve_ue.go
@@ -94,5 +94,5 @@ func sendErrorIndication(ctx context.Context, ran *amf.Radio, amfID, ranID *int6
 		return
 	}
 
-	_ = ran.SendToRadio(ctx, send.NGAPProcedureErrorIndication, pkt)
+	ran.SendToRadio(ctx, send.NGAPProcedureErrorIndication, pkt)
 }

--- a/internal/amf/ngap_transport.go
+++ b/internal/amf/ngap_transport.go
@@ -25,25 +25,34 @@ type NGAPWriter interface {
 	WriteMsg(b []byte, info *sctp.SndRcvInfo) (int, error)
 }
 
-// SendToRadio writes a complete NGAP PDU to this radio's gNB association.
-func (r *Radio) SendToRadio(ctx context.Context, msgType send.NGAPProcedure, packet []byte) error {
+// SendToRadio writes a complete NGAP PDU to this radio's gNB association. This is the
+// node-level, fire-and-forget path: a send failure is logged at the chokepoint and not
+// returned. Callers that must act on the send outcome (session/ICS setup) use
+// (*AMF).SendToRadio directly.
+func (r *Radio) SendToRadio(ctx context.Context, msgType send.NGAPProcedure, packet []byte) {
+	if r == nil || r.amf == nil {
+		logger.From(ctx, logger.AmfLog).Error("cannot send NGAP message: radio is not bound to an amf", zap.String("message_type", string(msgType)))
+		return
+	}
+
+	// The send failure, if any, is logged at the chokepoint.
+	_ = r.amf.SendToRadio(ctx, r.Conn, msgType, packet)
+}
+
+// SendDownlinkNRPPaTransport builds a DOWNLINK UE-ASSOCIATED NRPPa TRANSPORT carrying
+// the LMF's NRPPa PDU and sends it to this radio's gNB (TS 38.413 §8.14.2). It returns
+// the send outcome so the LMF positioning client can report a delivery failure.
+func (r *Radio) SendDownlinkNRPPaTransport(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, routingID int64, nrppaPdu []byte) error {
 	if r == nil || r.amf == nil {
 		return fmt.Errorf("radio is not bound to an amf")
 	}
 
-	return r.amf.SendToRadio(ctx, r.Conn, msgType, packet)
-}
-
-// SendDownlinkNRPPaTransport builds a DOWNLINK UE-ASSOCIATED NRPPa TRANSPORT carrying
-// the LMF's NRPPa PDU and sends it to this radio's gNB (TS 38.413 §8.14.2). The LMF
-// positioning client uses this to reach the RAN through the AMF's NGAP association.
-func (r *Radio) SendDownlinkNRPPaTransport(ctx context.Context, amfUeNgapID int64, ranUeNgapID int64, routingID int64, nrppaPdu []byte) error {
 	pkt, err := send.BuildDownlinkUEAssociatedNRPPaTransport(amfUeNgapID, ranUeNgapID, routingID, nrppaPdu)
 	if err != nil {
 		return fmt.Errorf("build downlink NRPPa transport: %w", err)
 	}
 
-	return r.SendToRadio(ctx, send.NGAPProcedureDownlinkNRPPaTransport, pkt)
+	return r.amf.SendToRadio(ctx, r.Conn, send.NGAPProcedureDownlinkNRPPaTransport, pkt)
 }
 
 // SendToRadio writes a complete NGAP PDU to a gNB association, selecting the SCTP

--- a/internal/amf/ngap_transport.go
+++ b/internal/amf/ngap_transport.go
@@ -8,10 +8,13 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/internal/amf/ngap/send"
+	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/sctp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 )
 
 var ngapSendTracer = otel.Tracer("ella-core/amf/ngap/send")
@@ -22,13 +25,13 @@ type NGAPWriter interface {
 	WriteMsg(b []byte, info *sctp.SndRcvInfo) (int, error)
 }
 
-// SendToRan writes a complete NGAP PDU to this radio's gNB association.
-func (r *Radio) SendToRan(ctx context.Context, msgType send.NGAPProcedure, packet []byte) error {
+// SendToRadio writes a complete NGAP PDU to this radio's gNB association.
+func (r *Radio) SendToRadio(ctx context.Context, msgType send.NGAPProcedure, packet []byte) error {
 	if r == nil || r.amf == nil {
 		return fmt.Errorf("radio is not bound to an amf")
 	}
 
-	return r.amf.SendToRan(ctx, r.Conn, msgType, packet)
+	return r.amf.SendToRadio(ctx, r.Conn, msgType, packet)
 }
 
 // SendDownlinkNRPPaTransport builds a DOWNLINK UE-ASSOCIATED NRPPa TRANSPORT carrying
@@ -40,13 +43,13 @@ func (r *Radio) SendDownlinkNRPPaTransport(ctx context.Context, amfUeNgapID int6
 		return fmt.Errorf("build downlink NRPPa transport: %w", err)
 	}
 
-	return r.SendToRan(ctx, send.NGAPProcedureDownlinkNRPPaTransport, pkt)
+	return r.SendToRadio(ctx, send.NGAPProcedureDownlinkNRPPaTransport, pkt)
 }
 
-// SendToRan writes a complete NGAP PDU to a gNB association, selecting the SCTP
+// SendToRadio writes a complete NGAP PDU to a gNB association, selecting the SCTP
 // stream from the procedure (TS 38.412). It takes the connection (the send target)
 // directly — a UE sends through ueConn.conn.
-func (a *AMF) SendToRan(ctx context.Context, conn NGAPWriter, msgType send.NGAPProcedure, packet []byte) error {
+func (a *AMF) SendToRadio(ctx context.Context, conn NGAPWriter, msgType send.NGAPProcedure, packet []byte) error {
 	ctx, span := ngapSendTracer.Start(ctx, "ngap/send",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -76,6 +79,10 @@ func (a *AMF) SendToRan(ctx context.Context, conn NGAPWriter, msgType send.NGAPP
 		PPID:   sctp.PPIDWireOrder(send.NGAPPPID),
 	}
 	if _, err := conn.WriteMsg(packet, &info); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to send NGAP message")
+		logger.From(ctx, logger.AmfLog).Error("failed to send NGAP message", zap.String("message_type", string(msgType)), zap.Error(err))
+
 		return fmt.Errorf("send write to sctp connection: %w", err)
 	}
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -470,11 +470,9 @@ func (ueConn *UeConn) abortHandoverOnRemoval(ctx context.Context) {
 		if target != nil {
 			target.ReleaseAction = UeContextReleaseHandover
 
-			if err := target.SendUEContextReleaseCommand(ctx,
+			target.SendUEContextReleaseCommand(ctx,
 				ngapType.CausePresentRadioNetwork,
-				ngapType.CauseRadioNetworkPresentRadioConnectionWithUeLost); err != nil {
-				logger.WithTrace(ctx, ueConn.Log).Error("error releasing prepared handover target after source association loss", zap.Error(err))
-			}
+				ngapType.CauseRadioNetworkPresentRadioConnectionWithUeLost)
 		}
 
 		logger.WithTrace(ctx, ueConn.Log).Info("released prepared N2 handover target: source association removed")

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -296,7 +296,7 @@ func SendRegistrationAccept(
 	if ueConn.UeContextRequest {
 		ueConn.MarkICSPending()
 
-		if err := ueConn.SendInitialContextSetupRequest(
+		if err := ueConn.SendInitialContextSetup(
 			ctx,
 			ue.Ambr.Uplink,
 			ue.Ambr.Downlink,
@@ -330,7 +330,7 @@ func SendRegistrationAccept(
 				logger.From(ctx, logger.AmfLog).Warn("[NAS] UE Context released, abort retransmission of Registration Accept")
 			} else {
 				if retryUeConn.UeContextRequest && retryUeConn.ICS() != ICSCompleted {
-					err = retryUeConn.SendInitialContextSetupRequest(
+					err = retryUeConn.SendInitialContextSetup(
 						context.Background(),
 						ue.Ambr.Uplink,
 						ue.Ambr.Downlink,
@@ -525,9 +525,8 @@ func (ueConn *UeConn) SendNGAP(ctx context.Context, msgType send.NGAPProcedure, 
 		return
 	}
 
-	if err := amfInstance.SendToRan(ctx, conn, msgType, pkt); err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to send NGAP message", zap.String("procedure", string(msgType)), zap.Error(err))
-	}
+	// The send failure, if any, is logged at the chokepoint.
+	_ = amfInstance.SendToRadio(ctx, conn, msgType, pkt)
 }
 
 func (ueConn *UeConn) SendDownlinkNASTransport(ctx context.Context, nasPdu []byte) error {
@@ -541,7 +540,7 @@ func (ueConn *UeConn) SendDownlinkNASTransport(ctx context.Context, nasPdu []byt
 		return err
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedureDownlinkNasTransport, pkt)
+	return amfInstance.SendToRadio(ctx, conn, send.NGAPProcedureDownlinkNasTransport, pkt)
 }
 
 func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, causePresent int, cause aper.Enumerated) {
@@ -569,8 +568,8 @@ func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, causePres
 		return
 	}
 
-	if err := amfInstance.SendToRan(ctx, conn, send.NGAPProcedureUEContextReleaseCommand, pkt); err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to send UE Context Release Command", zap.Error(err))
+	if err := amfInstance.SendToRadio(ctx, conn, send.NGAPProcedureUEContextReleaseCommand, pkt); err != nil {
+		// The chokepoint logs the send failure; release locally so the UeConn cannot leak.
 		amfInstance.ReleaseUeConn(ctx, ueConn)
 
 		return
@@ -595,7 +594,7 @@ func (ueConn *UeConn) SendPDUSessionResourceSetupRequest(ctx context.Context, am
 		return err
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedurePDUSessionResourceSetupRequest, pkt)
+	return amfInstance.SendToRadio(ctx, conn, send.NGAPProcedurePDUSessionResourceSetupRequest, pkt)
 }
 
 func (ueConn *UeConn) SendPDUSessionResourceReleaseCommand(ctx context.Context, nasPdu []byte, list ngapType.PDUSessionResourceToReleaseListRelCmd) error {
@@ -609,10 +608,10 @@ func (ueConn *UeConn) SendPDUSessionResourceReleaseCommand(ctx context.Context, 
 		return err
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedurePDUSessionResourceReleaseCommand, pkt)
+	return amfInstance.SendToRadio(ctx, conn, send.NGAPProcedurePDUSessionResourceReleaseCommand, pkt)
 }
 
-func (ueConn *UeConn) SendInitialContextSetupRequest(
+func (ueConn *UeConn) SendInitialContextSetup(
 	ctx context.Context,
 	ambrUp string,
 	ambrDown string,
@@ -648,7 +647,7 @@ func (ueConn *UeConn) SendInitialContextSetupRequest(
 		return err
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedureInitialContextSetupRequest, pkt)
+	return amfInstance.SendToRadio(ctx, conn, send.NGAPProcedureInitialContextSetupRequest, pkt)
 }
 
 func (ueConn *UeConn) SendPDUSessionResourceModifyConfirm(
@@ -671,7 +670,7 @@ func (ueConn *UeConn) SendPDUSessionResourceModifyConfirm(
 		return err
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedurePDUSessionResourceModifyConfirm, pkt)
+	return amfInstance.SendToRadio(ctx, conn, send.NGAPProcedurePDUSessionResourceModifyConfirm, pkt)
 }
 
 func (ueConn *UeConn) SendPDUSessionResourceModifyRequest(
@@ -692,7 +691,7 @@ func (ueConn *UeConn) SendPDUSessionResourceModifyRequest(
 		return err
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedurePDUSessionResourceModifyRequest, pkt)
+	return amfInstance.SendToRadio(ctx, conn, send.NGAPProcedurePDUSessionResourceModifyRequest, pkt)
 }
 
 func (ueConn *UeConn) SendHandoverPreparationFailure(ctx context.Context, cause ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) {
@@ -752,5 +751,5 @@ func (ueConn *UeConn) SendHandoverRequest(
 		return err
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedureHandoverRequest, pkt)
+	return amfInstance.SendToRadio(ctx, conn, send.NGAPProcedureHandoverRequest, pkt)
 }

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -518,13 +518,16 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 }
 
 // SendNGAP writes a complete NGAP PDU to this UE's gNB association (via its conn).
-func (ueConn *UeConn) SendNGAP(ctx context.Context, msgType send.NGAPProcedure, pkt []byte) error {
+func (ueConn *UeConn) SendNGAP(ctx context.Context, msgType send.NGAPProcedure, pkt []byte) {
 	amfInstance, conn, err := ueConn.sendTarget()
 	if err != nil {
-		return err
+		logger.From(ctx, ueConn.Log).Error("failed to resolve NGAP send target", zap.String("procedure", string(msgType)), zap.Error(err))
+		return
 	}
 
-	return amfInstance.SendToRan(ctx, conn, msgType, pkt)
+	if err := amfInstance.SendToRan(ctx, conn, msgType, pkt); err != nil {
+		logger.From(ctx, ueConn.Log).Error("failed to send NGAP message", zap.String("procedure", string(msgType)), zap.Error(err))
+	}
 }
 
 func (ueConn *UeConn) SendDownlinkNASTransport(ctx context.Context, nasPdu []byte) error {
@@ -541,10 +544,11 @@ func (ueConn *UeConn) SendDownlinkNASTransport(ctx context.Context, nasPdu []byt
 	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedureDownlinkNasTransport, pkt)
 }
 
-func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, causePresent int, cause aper.Enumerated) error {
+func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, causePresent int, cause aper.Enumerated) {
 	amfInstance, conn, err := ueConn.sendTarget()
 	if err != nil {
-		return err
+		logger.From(ctx, ueConn.Log).Error("failed to resolve send target for UE Context Release Command", zap.Error(err))
+		return
 	}
 
 	// Idempotent: a release already in flight for this RAN UE (an eNB-initiated release
@@ -552,20 +556,24 @@ func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, causePres
 	// UE Context Release Command.
 	if !amfInstance.claimRelease(ueConn) {
 		logger.WithTrace(ctx, ueConn.Log).Debug("UE Context Release already in progress; suppressing duplicate")
-		return nil
+		return
 	}
 
 	pkt, err := send.BuildUEContextReleaseCommand(int64(ueConn.AmfUeNgapID), int64(ueConn.RanUeNgapID), causePresent, cause)
 	if err != nil {
 		// The command cannot be sent, so no Release Complete will arrive; release
 		// locally now to avoid leaking the UeConn and its claim.
+		logger.From(ctx, ueConn.Log).Error("failed to build UE Context Release Command", zap.Error(err))
 		amfInstance.ReleaseUeConn(ctx, ueConn)
-		return err
+
+		return
 	}
 
 	if err := amfInstance.SendToRan(ctx, conn, send.NGAPProcedureUEContextReleaseCommand, pkt); err != nil {
+		logger.From(ctx, ueConn.Log).Error("failed to send UE Context Release Command", zap.Error(err))
 		amfInstance.ReleaseUeConn(ctx, ueConn)
-		return err
+
+		return
 	}
 
 	// Supervise the Release Complete: if it is lost, fire once and run the same
@@ -574,8 +582,6 @@ func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, causePres
 	ueConn.releaseGuard.Arm(releaseGuardTimeout, 0, nil, func() {
 		amfInstance.ReleaseUeConn(context.Background(), ueConn)
 	})
-
-	return nil
 }
 
 func (ueConn *UeConn) SendPDUSessionResourceSetupRequest(ctx context.Context, ambrUp string, ambrDown string, nasPdu []byte, list ngapType.PDUSessionResourceSetupListSUReq) error {
@@ -689,32 +695,24 @@ func (ueConn *UeConn) SendPDUSessionResourceModifyRequest(
 	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedurePDUSessionResourceModifyRequest, pkt)
 }
 
-func (ueConn *UeConn) SendHandoverPreparationFailure(ctx context.Context, cause ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) error {
-	amfInstance, conn, err := ueConn.sendTarget()
-	if err != nil {
-		return err
-	}
-
+func (ueConn *UeConn) SendHandoverPreparationFailure(ctx context.Context, cause ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics) {
 	pkt, err := send.BuildHandoverPreparationFailure(int64(ueConn.AmfUeNgapID), int64(ueConn.RanUeNgapID), cause, criticalityDiagnostics)
 	if err != nil {
-		return err
+		logger.From(ctx, ueConn.Log).Error("failed to build Handover Preparation Failure", zap.Error(err))
+		return
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedureHandoverPreparationFailure, pkt)
+	ueConn.SendNGAP(ctx, send.NGAPProcedureHandoverPreparationFailure, pkt)
 }
 
-func (ueConn *UeConn) SendHandoverCancelAcknowledge(ctx context.Context) error {
-	amfInstance, conn, err := ueConn.sendTarget()
-	if err != nil {
-		return err
-	}
-
+func (ueConn *UeConn) SendHandoverCancelAcknowledge(ctx context.Context) {
 	pkt, err := send.BuildHandoverCancelAcknowledge(int64(ueConn.AmfUeNgapID), int64(ueConn.RanUeNgapID))
 	if err != nil {
-		return err
+		logger.From(ctx, ueConn.Log).Error("failed to build Handover Cancel Acknowledge", zap.Error(err))
+		return
 	}
 
-	return amfInstance.SendToRan(ctx, conn, send.NGAPProcedureHandoverCancelAcknowledge, pkt)
+	ueConn.SendNGAP(ctx, send.NGAPProcedureHandoverCancelAcknowledge, pkt)
 }
 
 func (ueConn *UeConn) SendHandoverRequest(

--- a/internal/api/server/api_drain.go
+++ b/internal/api/server/api_drain.go
@@ -424,7 +424,7 @@ func notifyRANsUnavailable(ctx context.Context, amfInstance *amf.AMF, timeout ti
 	}
 
 	for _, ran := range amfInstance.ConnectedRadios() {
-		if err := ran.SendToRan(sendCtx, send.NGAPProcedureAMFStatusIndication, pkt); err != nil {
+		if err := ran.SendToRadio(sendCtx, send.NGAPProcedureAMFStatusIndication, pkt); err != nil {
 			logger.APILog.Warn("failed to send AMF Status Indication to RAN during drain", zap.Error(err))
 			continue
 		}

--- a/internal/api/server/api_drain.go
+++ b/internal/api/server/api_drain.go
@@ -424,7 +424,7 @@ func notifyRANsUnavailable(ctx context.Context, amfInstance *amf.AMF, timeout ti
 	}
 
 	for _, ran := range amfInstance.ConnectedRadios() {
-		if err := ran.SendToRadio(sendCtx, send.NGAPProcedureAMFStatusIndication, pkt); err != nil {
+		if err := amfInstance.SendToRadio(sendCtx, ran.Conn, send.NGAPProcedureAMFStatusIndication, pkt); err != nil {
 			logger.APILog.Warn("failed to send AMF Status Indication to RAN during drain", zap.Error(err))
 			continue
 		}

--- a/internal/mme/bearer_support.go
+++ b/internal/mme/bearer_support.go
@@ -5,11 +5,29 @@ package mme
 
 import (
 	"context"
+	"slices"
 
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 )
+
+// ActiveEBIs returns the EPS bearer identities of the UE's established PDN
+// connections, sorted. Used to detect an E-RAB Modification Indication that omits
+// an E-RAB already in the UE context (TS 36.413 §8.2.4.4).
+func (ue *UeContext) ActiveEBIs() []uint8 {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	out := make([]uint8, 0, len(ue.Pdns))
+	for ebi := range ue.Pdns {
+		out = append(out, ebi)
+	}
+
+	slices.Sort(out)
+
+	return out
+}
 
 // DefaultERABID is the EPS bearer identity of the default bearer (TS 24.301).
 const DefaultERABID byte = 5

--- a/internal/mme/bearer_support.go
+++ b/internal/mme/bearer_support.go
@@ -13,8 +13,7 @@ import (
 )
 
 // ActiveEBIs returns the EPS bearer identities of the UE's established PDN
-// connections, sorted. Used to detect an E-RAB Modification Indication that omits
-// an E-RAB already in the UE context (TS 36.413 §8.2.4.4).
+// connections, sorted.
 func (ue *UeContext) ActiveEBIs() []uint8 {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/mme/cause.go
+++ b/internal/mme/cause.go
@@ -43,6 +43,7 @@ const (
 	EmmCauseIMSIUnknownInHSS       uint8 = 2
 	EmmCauseEPSServicesNotAllowed  uint8 = 7
 	EmmCauseUEIdentityUnderivable  uint8 = 9
+	EmmCauseTrackingAreaNotAllowed uint8 = 12
 	EmmCauseCSDomainNotAvailable   uint8 = 18
 	EmmCauseESMFailure             uint8 = 19
 	EmmCauseMACFailure             uint8 = 20

--- a/internal/mme/guti.go
+++ b/internal/mme/guti.go
@@ -8,9 +8,42 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/eps"
+	"go.uber.org/zap"
 )
+
+// SendGUTIReallocationCommand reassigns the UE's GUTI with the standalone GUTI
+// reallocation procedure: it stages a new GUTI, sends a protected GUTI REALLOCATION
+// COMMAND, and arms T3450 so the command is retransmitted until the UE acknowledges
+// with GUTI REALLOCATION COMPLETE (TS 24.301 §5.4.1). It mirrors the AMF's
+// post-Service-Request CONFIGURATION UPDATE, giving a fresh temporary identity when
+// the UE returns from idle with no accept message to carry one. The UE keeps using
+// the old GUTI until it acknowledges (§5.4.1.4).
+func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
+	plmn, err := m.OperatorPLMN(ctx)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("GUTI reallocation: get operator PLMN", zap.Error(err))
+		return
+	}
+
+	mmeGroupID, mmeCode := m.MmeIdentity()
+
+	guti, err := m.ReallocateGUTI(ctx, ue, plmn, mmeGroupID, mmeCode)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("GUTI reallocation: allocate GUTI", zap.Error(err))
+		return
+	}
+
+	wire, err := ue.ProtectDownlinkMessage(&eps.GUTIReallocationCommand{GUTI: guti})
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("GUTI reallocation: protect command", zap.Error(err))
+		return
+	}
+
+	ue.Conn().SendGuardedDownlink(ctx, "GUTI Reallocation Command", wire)
+}
 
 // releaseMTMSIsLocked unindexes and frees both the UE's current M-TMSI and any
 // pending old one from an in-flight GUTI reallocation. The caller holds m.mu.

--- a/internal/mme/guti.go
+++ b/internal/mme/guti.go
@@ -14,13 +14,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// SendGUTIReallocationCommand reassigns the UE's GUTI with the standalone GUTI
-// reallocation procedure: it stages a new GUTI, sends a protected GUTI REALLOCATION
-// COMMAND, and arms T3450 so the command is retransmitted until the UE acknowledges
-// with GUTI REALLOCATION COMPLETE (TS 24.301 §5.4.1). It mirrors the AMF's
-// post-Service-Request CONFIGURATION UPDATE, giving a fresh temporary identity when
-// the UE returns from idle with no accept message to carry one. The UE keeps using
-// the old GUTI until it acknowledges (§5.4.1.4).
+// SendGUTIReallocationCommand runs the standalone GUTI reallocation procedure, arming
+// T3450 to retransmit the GUTI REALLOCATION COMMAND until the UE acknowledges; the UE
+// keeps the old GUTI until then (TS 24.301 §5.4.1, §5.4.1.4).
 func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
 	plmn, err := m.OperatorPLMN(ctx)
 	if err != nil {
@@ -42,10 +38,9 @@ func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
 		return
 	}
 
-	// On T3450 exhaustion the reallocation is aborted, leaving the UE connected with
-	// both the old and new GUTI valid (TS 24.301 §5.4.1.6 a) — a later Service Request
-	// re-initiates with the staged M-TMSI. Abort-only, not a release: it mirrors the
-	// AMF's CONFIGURATION UPDATE (T3555), which keeps the UE on exhaustion.
+	// On T3450 exhaustion the reallocation is abort-only, not a UE release: the UE stays
+	// connected with both old and new GUTI valid, and a later Service Request re-initiates
+	// with the staged M-TMSI (TS 24.301 §5.4.1.6 a).
 	ue.Conn().ArmNASGuardAbortOnly("GUTI Reallocation Command", wire, func() {
 		logger.From(ctx, logger.MmeLog).Warn("GUTI reallocation aborted: no GUTI Reallocation Complete after T3450 retransmissions",
 			zap.String("imsi", ue.IMSI()))

--- a/internal/mme/guti.go
+++ b/internal/mme/guti.go
@@ -42,7 +42,15 @@ func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
 		return
 	}
 
-	ue.Conn().SendGuardedDownlink(ctx, "GUTI Reallocation Command", wire)
+	// On T3450 exhaustion the reallocation is aborted, leaving the UE connected with
+	// both the old and new GUTI valid (TS 24.301 §5.4.1.6 a) — a later Service Request
+	// re-initiates with the staged M-TMSI. Abort-only, not a release: it mirrors the
+	// AMF's CONFIGURATION UPDATE (T3555), which keeps the UE on exhaustion.
+	ue.Conn().ArmNASGuardAbortOnly("GUTI Reallocation Command", wire, func() {
+		logger.From(ctx, logger.MmeLog).Warn("GUTI reallocation aborted: no GUTI Reallocation Complete after T3450 retransmissions",
+			zap.String("imsi", ue.IMSI()))
+	})
+	ue.Conn().SendDownlinkNASTransport(ctx, wire)
 }
 
 // releaseMTMSIsLocked unindexes and frees both the UE's current M-TMSI and any

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -427,7 +427,7 @@ func SendHandoverPreparationFailure(ctx context.Context, m *MME, conn S1APWriter
 		return
 	}
 
-	m.SendS1APConn(ctx, conn, S1APProcedureHandoverPreparationFailure, b)
+	m.SendToRadio(ctx, conn, S1APProcedureHandoverPreparationFailure, b)
 }
 
 // SendUEContextRelease sends a UE Context Release Command over conn. pair selects the
@@ -447,7 +447,7 @@ func SendUEContextRelease(ctx context.Context, m *MME, conn S1APWriter, mmeUEID 
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("UE Context Release Command (handover)", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
-	m.SendS1APConn(ctx, conn, S1APProcedureUEContextReleaseCommand, b)
+	m.SendToRadio(ctx, conn, S1APProcedureUEContextReleaseCommand, b)
 }
 
 // S1AP Cause Radio Network values used when releasing an eNB's UE context during a

--- a/internal/mme/nas/attach_reject_test.go
+++ b/internal/mme/nas/attach_reject_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// TestAttachTrackingAreaNotAllowed checks that an Attach from a serving cell outside
-// the operator's served area is rejected with ATTACH REJECT #12 ("Tracking area not
-// allowed") and the S1 context is released, without authenticating. The eNB broadcasts
-// a served TAC (S1 Setup accepted it), but the UE camps on its unserved TAC — the case
-// only the per-UE gate catches (TS 24.301 §5.5.1.2.5).
+// TestAttachTrackingAreaNotAllowed checks an Attach from a serving cell outside the
+// served area is rejected with ATTACH REJECT #12 and the S1 context released, without
+// authenticating (TS 24.301 §5.5.1.2.5).
 func TestAttachTrackingAreaNotAllowed(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}

--- a/internal/mme/nas/attach_reject_test.go
+++ b/internal/mme/nas/attach_reject_test.go
@@ -9,7 +9,57 @@ import (
 
 	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/s1ap"
 )
+
+// TestAttachTrackingAreaNotAllowed checks that an Attach from a serving cell outside
+// the operator's served area is rejected with ATTACH REJECT #12 ("Tracking area not
+// allowed") and the S1 context is released, without authenticating. The eNB broadcasts
+// a served TAC (S1 Setup accepted it), but the UE camps on its unserved TAC — the case
+// only the per-UE gate catches (TS 24.301 §5.5.1.2.5).
+func TestAttachTrackingAreaNotAllowed(t *testing.T) {
+	m := newTestMME(t)
+	cc := &captureConn{}
+	ue := newAttachUe(m, cc, 7)
+
+	// Served PLMN 001/01 but TAC 2, which the operator does not serve (it serves TAC 1).
+	ue.Conn().ServingTAI = s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 2}
+
+	esm, err := (&eps.PDNConnectivityRequest{ProcedureTransactionIdentity: 1, RequestType: 1, PDNType: 1}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attach := &eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		NASKeySetIdentifier: 7,
+		EPSMobileIdentity:   eps.EPSMobileIdentity{Type: eps.IdentityIMSI, Digits: testSubscriber.IMSI},
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}.Marshal(),
+		ESMMessageContainer: esm,
+	}
+
+	b, err := attach.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	HandleNAS(context.Background(), m, ue.Conn(), b)
+
+	if len(cc.sent) != 2 {
+		t.Fatalf("expected Attach Reject + Release Command, got %d S1AP messages", len(cc.sent))
+	}
+
+	rej, err := eps.ParseAttachReject(decodeDownlinkNAS(t, cc.sent[0]))
+	if err != nil {
+		t.Fatalf("not an Attach Reject: %v", err)
+	}
+
+	if rej.Cause != mme.EmmCauseTrackingAreaNotAllowed {
+		t.Fatalf("Attach Reject cause = %d, want %d", rej.Cause, mme.EmmCauseTrackingAreaNotAllowed)
+	}
+
+	parseUEContextReleaseCommand(t, cc.sent[1])
+}
 
 // TestAttachUnknownIMSI checks that an Attach Request from an unprovisioned IMSI
 // is rejected with ATTACH REJECT #2 ("IMSI unknown in HSS") and the S1 context
@@ -17,7 +67,7 @@ import (
 func TestAttachUnknownIMSI(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	esm, err := (&eps.PDNConnectivityRequest{ProcedureTransactionIdentity: 1, RequestType: 1, PDNType: 1}).Marshal()
 	if err != nil {

--- a/internal/mme/nas/emm.go
+++ b/internal/mme/nas/emm.go
@@ -107,6 +107,8 @@ func HandleEmmMessage(ctx context.Context, m *mme.MME, ue *mme.UeContext, plain 
 		return handleSecurityModeReject(ctx, m, ue, plain)
 	case eps.MsgAttachComplete:
 		return handleAttachComplete(ctx, m, ue, plain)
+	case eps.MsgGUTIReallocationComplete:
+		return handleGUTIReallocationComplete(ctx, m, ue, plain)
 	case eps.MsgDetachRequest:
 		return handleDetachRequest(ctx, m, ue, plain, integrityVerified)
 	case eps.MsgDetachAccept:

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -75,7 +75,7 @@ func decodeDownlinkNAS(t *testing.T, pdu []byte) []byte {
 func TestAttachRecoveryAfterMMERestart(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	esm, err := (&eps.PDNConnectivityRequest{ProcedureTransactionIdentity: 1, RequestType: 1, PDNType: 1}).Marshal()
 	if err != nil {
@@ -122,7 +122,7 @@ func TestAttachRecoveryAfterMMERestart(t *testing.T) {
 func TestIdentityResponseRecoveryAfterMMERestart(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 8)
+	ue := newAttachUe(m, cc, 8)
 	ue.TransitionTo(mme.EMMRegistrationInitiated) // attach in progress: authentication sub-phase
 
 	// Mobile identity for testSubscriber.IMSI (TS 24.008 §10.5.1.4): first digit in
@@ -213,7 +213,7 @@ func TestAttachReusesContextForNativeGUTI(t *testing.T) {
 	wire := nativeGUTIAttach(t, m, existing)
 
 	cc := &captureConn{}
-	fresh := m.NewUe(cc, 9)
+	fresh := newAttachUe(m, cc, 9)
 	HandleNAS(context.Background(), m, fresh.Conn(), wire)
 
 	// The held context is reused in place — the connection is rebound onto it and
@@ -272,7 +272,7 @@ func TestAttachReusesContextForNativeGUTI_ReleasesOldBearers(t *testing.T) {
 	wire := nativeGUTIAttach(t, m, existing)
 
 	cc := &captureConn{}
-	fresh := m.NewUe(cc, 9)
+	fresh := newAttachUe(m, cc, 9)
 	HandleNAS(context.Background(), m, fresh.Conn(), wire)
 
 	if !m.Session.(*fakeSessionManager).released {
@@ -293,7 +293,7 @@ func TestAttachKeepsOldGUTIResolvableUntilComplete(t *testing.T) {
 	presented := existing.TmsiForTest()
 
 	cc := &captureConn{}
-	fresh := m.NewUe(cc, 9)
+	fresh := newAttachUe(m, cc, 9)
 	HandleNAS(context.Background(), m, fresh.Conn(), wire)
 
 	// The Attach Accept has been sent but not yet acknowledged. The M-TMSI the UE
@@ -344,7 +344,7 @@ func TestAttachNativeGUTIBadMACFallsBackToAuth(t *testing.T) {
 	wire[1] ^= 0xff // corrupt the MAC
 
 	cc := &captureConn{}
-	fresh := m.NewUe(cc, 9)
+	fresh := newAttachUe(m, cc, 9)
 	HandleNAS(context.Background(), m, fresh.Conn(), wire)
 
 	if _, ok := m.LookupUe(oldID); !ok {
@@ -368,7 +368,7 @@ func TestAttachNativeGUTIReplayDoesNotRemoveContext(t *testing.T) {
 	existing.SetULCountForTest(50)
 
 	cc := &captureConn{}
-	attacker := m.NewUe(cc, 9)
+	attacker := newAttachUe(m, cc, 9)
 	HandleNAS(context.Background(), m, attacker.Conn(), wire)
 
 	if _, ok := m.LookupUe(oldID); !ok {
@@ -379,7 +379,7 @@ func TestAttachNativeGUTIReplayDoesNotRemoveContext(t *testing.T) {
 func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	// 1. UE → Attach Request (IMSI), EEA2/EIA2 capable, with a PDN Connectivity
 	// Request in the ESM container.
@@ -623,7 +623,7 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 func TestSecurityModeRejectReleasesUE(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	// A security mode exchange is in flight (the command was sent).
 	if !m.TryClaimKeyChain(ue) {
@@ -658,7 +658,7 @@ func TestSecurityModeRejectReleasesUE(t *testing.T) {
 func TestIdentityResponseIgnoredAfterAuthStarted(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 	ue.SetIMSIForTest(testSubscriber.IMSI)
 	ue.Conn().AuthVector = &udm.EPSAV{} // authentication already in progress
 
@@ -682,7 +682,7 @@ func TestIdentityResponseIgnoredAfterAuthStarted(t *testing.T) {
 func TestSecurityModeRejectIgnoredOutsideExchange(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	// No security mode exchange is claimed.
 	plain, err := (&eps.SecurityModeReject{Cause: 23}).Marshal()
@@ -782,7 +782,7 @@ func parseInitialContextSetup(t *testing.T, pdu []byte) *s1ap.InitialContextSetu
 func TestDispatchEMM_UnhandledMessageReturnsEMMStatus(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	// A plain EMM message (SHT=plain, PD=EMM) carrying a type the MME does not handle.
 	plain := []byte{0x07, 0x55}
@@ -800,7 +800,7 @@ func TestDispatchEMM_UnhandledMessageReturnsEMMStatus(t *testing.T) {
 func TestDispatchESM_UnhandledMessageReturnsESMStatus(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	// A plain NAS message with the ESM protocol discriminator and an ESM type the MME does
 	// not handle (bearer 0/PTI in octet 1, unhandled message type in octet 3).
@@ -820,7 +820,7 @@ func TestDispatchESM_UnhandledMessageReturnsESMStatus(t *testing.T) {
 func TestDispatchEMM_EMMStatusHandledNoReply(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	plain, err := (&eps.EMMStatus{EMMCause: mme.EmmCauseProtocolErrorUnspec}).Marshal()
 	if err != nil {
@@ -925,7 +925,7 @@ func TestAttachDuplicateDifferingIEsProgresses(t *testing.T) {
 func TestAttachIgnoredDuringNetworkInitiatedDetach(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 	ue.ForceStateForTest(mme.EMMDeregistrationInitiated)
 
 	attach := &eps.AttachRequest{

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -322,6 +322,7 @@ func parseUEContextReleaseCommand(t *testing.T, pdu []byte) *s1ap.UEContextRelea
 // connection, the resume primitives HandleServiceRequest uses.
 func establishResumeForTest(m *mme.MME, ue *mme.UeContext, conn mme.S1APWriter, enbUEID s1ap.ENBUES1APID) {
 	c := m.NewUeConn(conn, enbUEID)
+	c.ServingTAI = servedAttachTAI // set from the resume's INITIAL UE MESSAGE in production
 	m.AttachUeConn(ue, c)
 	c.MarkSecureExchangeEstablished()
 }

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -252,12 +252,11 @@ func (h *nasHandler) HandleServiceRequest(ctx context.Context, conn mme.S1APWrit
 }
 
 // servedAttachTAI is a TAI in the test operator's served area (PLMN 001/01, TAC 1),
-// mirroring the serving TAI an INITIAL UE MESSAGE reports for an admitted attach.
+// as an INITIAL UE MESSAGE reports for an admitted attach.
 var servedAttachTAI = s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1}
 
-// newAttachUe registers a test UE whose connection reports a served serving TAI, as
-// HandleInitialUEMessage does in production, so the attach clears the serving-area
-// gate (EMM #12, TS 24.301 §5.5.1.2.5).
+// newAttachUe registers a test UE with a served serving TAI (as HandleInitialUEMessage
+// sets in production) so the attach clears the serving-area gate (TS 24.301 §5.5.1.2.5).
 func newAttachUe(m *mme.MME, conn mme.S1APWriter, enbUEID s1ap.ENBUES1APID) *mme.UeContext {
 	ue := m.NewUe(conn, enbUEID)
 	if ue != nil {

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -251,12 +251,28 @@ func (h *nasHandler) HandleServiceRequest(ctx context.Context, conn mme.S1APWrit
 	HandleServiceRequest(ctx, h.m, conn, msg)
 }
 
+// servedAttachTAI is a TAI in the test operator's served area (PLMN 001/01, TAC 1),
+// mirroring the serving TAI an INITIAL UE MESSAGE reports for an admitted attach.
+var servedAttachTAI = s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1}
+
+// newAttachUe registers a test UE whose connection reports a served serving TAI, as
+// HandleInitialUEMessage does in production, so the attach clears the serving-area
+// gate (EMM #12, TS 24.301 §5.5.1.2.5).
+func newAttachUe(m *mme.MME, conn mme.S1APWriter, enbUEID s1ap.ENBUES1APID) *mme.UeContext {
+	ue := m.NewUe(conn, enbUEID)
+	if ue != nil {
+		ue.Conn().ServingTAI = servedAttachTAI
+	}
+
+	return ue
+}
+
 // securedUE returns a registered UE with a valid EPS NAS security context.
 func securedUE(t *testing.T, m *mme.MME) (*mme.UeContext, *captureConn) {
 	t.Helper()
 
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	kasme := make([]byte, 32)
 	for i := range kasme {

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -50,6 +50,20 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, pla
 		return nasreply.Handled()
 	}
 
+	// The UE's serving cell must be in this MME's served area. The S1 Setup gate
+	// accepts an eNB broadcasting any served TAI, so a UE camped on an unserved TAC
+	// of an otherwise-served eNB is caught only here (TS 24.301 §5.5.1.2.5, EMM #12).
+	if served, err := m.ServesTAI(ctx, ue.Conn().ServingTAI); err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to evaluate serving TAI for attach", zap.Error(err))
+		return nasreply.Handled()
+	} else if !served {
+		logger.From(ctx, logger.MmeLog).Info("Attach rejected [Tracking area not allowed]",
+			zap.Uint32("mme-ue-id", uint32(ue.Conn().MMEUES1APID)))
+		rejectAttach(ctx, m, ue, mme.EmmCauseTrackingAreaNotAllowed)
+
+		return nasreply.Handled()
+	}
+
 	// An Attach without verified integrity is replayed to the UE as a HashMME in
 	// the SECURITY MODE COMMAND, so the UE can detect tampering (TS 24.301 §5.4.3.2).
 	if integrityVerified {

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -50,9 +50,8 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, pla
 		return nasreply.Handled()
 	}
 
-	// The UE's serving cell must be in this MME's served area. The S1 Setup gate
-	// accepts an eNB broadcasting any served TAI, so a UE camped on an unserved TAC
-	// of an otherwise-served eNB is caught only here (TS 24.301 §5.5.1.2.5, EMM #12).
+	// The UE's serving cell must be in this MME's served area, or ATTACH REJECT #12
+	// (ServesTAI, TS 24.301 §5.5.1.2.5).
 	if served, err := m.ServesTAI(ctx, ue.Conn().ServingTAI); err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to evaluate serving TAI for attach", zap.Error(err))
 		return nasreply.Handled()

--- a/internal/mme/nas/handle_authentication_failure_test.go
+++ b/internal/mme/nas/handle_authentication_failure_test.go
@@ -19,7 +19,7 @@ import (
 func TestAuthenticationFailureIgnoredWithNoAuthInProgress(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 
 	// No AuthVector: no authentication is in progress.
 	plain, err := (&eps.AuthenticationFailure{Cause: mme.EmmCauseMACFailure}).Marshal()
@@ -88,7 +88,7 @@ func authChallengedUE(t *testing.T, m *mme.MME) (*mme.UeContext, *captureConn) {
 	t.Helper()
 
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 	ue.SetIMSIForTest(testSubscriber.IMSI)
 	ue.ForceRegStepForTest(mme.RegStepAuthenticating)
 

--- a/internal/mme/nas/handle_guti_reallocation.go
+++ b/internal/mme/nas/handle_guti_reallocation.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/nasreply"
+	"github.com/ellanetworks/core/nas/eps"
+	"go.uber.org/zap"
+)
+
+// handleGUTIReallocationComplete finalises a standalone GUTI reallocation: it stops
+// T3450 and commits the new GUTI, freeing the old one (TS 24.301 §5.4.1.4).
+func handleGUTIReallocationComplete(ctx context.Context, m *mme.MME, ue *mme.UeContext, plain []byte) nasreply.Disposition {
+	if ue.EMMState() != mme.EMMRegistered {
+		logger.From(ctx, logger.MmeLog).Warn("ignoring GUTI Reallocation Complete outside EMM-REGISTERED")
+		return nasreply.Silent(nasreply.ReasonOutOfState)
+	}
+
+	if _, err := eps.ParseGUTIReallocationComplete(plain); err != nil {
+		logger.From(ctx, logger.MmeLog).Warn("failed to decode GUTI Reallocation Complete", zap.Error(err))
+		return nasreply.Handled()
+	}
+
+	ue.Conn().StopNASGuard()
+	m.CommitGUTIRealloc(ue)
+
+	return nasreply.Handled()
+}

--- a/internal/mme/nas/handle_guti_reallocation_test.go
+++ b/internal/mme/nas/handle_guti_reallocation_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// TestGUTIReallocationCommitsOnComplete drives the standalone GUTI reallocation
-// procedure: the command stages a new GUTI while keeping the old M-TMSI resolvable,
-// and GUTI REALLOCATION COMPLETE commits it, freeing the old one (TS 24.301 §5.4.1).
+// TestGUTIReallocationCommitsOnComplete verifies the old M-TMSI stays resolvable until
+// GUTI REALLOCATION COMPLETE commits the new GUTI and frees the old one (TS 24.301 §5.4.1).
 func TestGUTIReallocationCommitsOnComplete(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
@@ -32,8 +31,6 @@ func TestGUTIReallocationCommitsOnComplete(t *testing.T) {
 
 	m.CommitGUTIRealloc(ue)
 
-	// Standalone reallocation sends a protected GUTI REALLOCATION COMMAND and stages
-	// a new GUTI; the old M-TMSI stays resolvable until the UE acknowledges.
 	before := len(cc.sent)
 
 	m.SendGUTIReallocationCommand(context.Background(), ue)
@@ -46,7 +43,6 @@ func TestGUTIReallocationCommitsOnComplete(t *testing.T) {
 		t.Fatal("old M-TMSI must stay resolvable until the UE acknowledges")
 	}
 
-	// GUTI REALLOCATION COMPLETE commits the reallocation.
 	complete, err := (&eps.GUTIReallocationComplete{}).Marshal()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/mme/nas/handle_guti_reallocation_test.go
+++ b/internal/mme/nas/handle_guti_reallocation_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// TestGUTIReallocationCommitsOnComplete drives the standalone GUTI reallocation
+// procedure: the command stages a new GUTI while keeping the old M-TMSI resolvable,
+// and GUTI REALLOCATION COMPLETE commits it, freeing the old one (TS 24.301 §5.4.1).
+func TestGUTIReallocationCommitsOnComplete(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	// Give the UE an initial committed GUTI so the reallocation has an old M-TMSI.
+	plmn, err := m.OperatorPLMN(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gid, code := m.MmeIdentity()
+
+	first, err := m.ReallocateGUTI(context.Background(), ue, plmn, gid, code)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.CommitGUTIRealloc(ue)
+
+	// Standalone reallocation sends a protected GUTI REALLOCATION COMMAND and stages
+	// a new GUTI; the old M-TMSI stays resolvable until the UE acknowledges.
+	before := len(cc.sent)
+
+	m.SendGUTIReallocationCommand(context.Background(), ue)
+
+	if len(cc.sent) != before+1 {
+		t.Fatalf("expected one GUTI Reallocation Command downlink, got %d", len(cc.sent)-before)
+	}
+
+	if _, ok := m.LookupUeByMTMSI(first.MTMSI); !ok {
+		t.Fatal("old M-TMSI must stay resolvable until the UE acknowledges")
+	}
+
+	// GUTI REALLOCATION COMPLETE commits the reallocation.
+	complete, err := (&eps.GUTIReallocationComplete{}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handleGUTIReallocationComplete(context.Background(), m, ue, complete)
+
+	if _, ok := m.LookupUeByMTMSI(first.MTMSI); ok {
+		t.Fatal("old M-TMSI still resolvable after GUTI Reallocation Complete")
+	}
+}

--- a/internal/mme/nas/handle_service_request.go
+++ b/internal/mme/nas/handle_service_request.go
@@ -86,10 +86,9 @@ func HandleServiceRequest(ctx context.Context, m *mme.MME, conn mme.S1APWriter, 
 
 	sendInitialContextSetup(ctx, m, ue, qos, nil)
 
-	// The SERVICE REQUEST carries no accept message to convey a fresh GUTI, so
-	// reassign one with the standalone GUTI reallocation procedure — identity
-	// confidentiality on return from idle, parity with the AMF's post-Service-Request
-	// CONFIGURATION UPDATE (TS 24.301 §5.4.1).
+	// The SERVICE REQUEST carries no accept message to convey a fresh GUTI, so reassign
+	// one with the standalone reallocation procedure — identity confidentiality on return
+	// from idle (TS 24.301 §5.4.1).
 	m.SendGUTIReallocationCommand(ctx, ue)
 }
 

--- a/internal/mme/nas/handle_service_request.go
+++ b/internal/mme/nas/handle_service_request.go
@@ -85,6 +85,12 @@ func HandleServiceRequest(ctx context.Context, m *mme.MME, conn mme.S1APWriter, 
 	}
 
 	sendInitialContextSetup(ctx, m, ue, qos, nil)
+
+	// The SERVICE REQUEST carries no accept message to convey a fresh GUTI, so
+	// reassign one with the standalone GUTI reallocation procedure — identity
+	// confidentiality on return from idle, parity with the AMF's post-Service-Request
+	// CONFIGURATION UPDATE (TS 24.301 §5.4.1).
+	m.SendGUTIReallocationCommand(ctx, ue)
 }
 
 // sendServiceReject sends a SERVICE REJECT with the given EMM cause over a bare connection,

--- a/internal/mme/nas/handle_service_request_test.go
+++ b/internal/mme/nas/handle_service_request_test.go
@@ -77,8 +77,8 @@ func TestServiceRequestReestablishes(t *testing.T) {
 		t.Fatalf("UE not bound to the new eNB UE id, got %d", ue.Conn().ENBUES1APID)
 	}
 
-	if len(cc.sent) != 1 {
-		t.Fatalf("expected Initial Context Setup Request, got %d S1AP messages", len(cc.sent))
+	if len(cc.sent) != 2 {
+		t.Fatalf("expected Initial Context Setup Request + GUTI Reallocation Command, got %d S1AP messages", len(cc.sent))
 	}
 
 	ics := parseInitialContextSetup(t, cc.sent[0])
@@ -113,8 +113,8 @@ func TestServiceRequestReactivatesAllBearers(t *testing.T) {
 		STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
 	})
 
-	if len(cc.sent) != 1 {
-		t.Fatalf("expected Initial Context Setup Request, got %d S1AP messages", len(cc.sent))
+	if len(cc.sent) != 2 {
+		t.Fatalf("expected Initial Context Setup Request + GUTI Reallocation Command, got %d S1AP messages", len(cc.sent))
 	}
 
 	ics := parseInitialContextSetup(t, cc.sent[0])
@@ -180,8 +180,8 @@ func TestServiceRequestS1UTransportFamily(t *testing.T) {
 				STMSI:       &s1ap.STMSI{MMEC: 1, MTMSI: guti.MTMSI},
 			})
 
-			if len(cc.sent) != 1 {
-				t.Fatalf("expected Initial Context Setup Request, got %d S1AP messages", len(cc.sent))
+			if len(cc.sent) != 2 {
+				t.Fatalf("expected Initial Context Setup Request + GUTI Reallocation Command, got %d S1AP messages", len(cc.sent))
 			}
 
 			ics := parseInitialContextSetup(t, cc.sent[0])

--- a/internal/mme/nas/nas_security_nas_test.go
+++ b/internal/mme/nas/nas_security_nas_test.go
@@ -14,7 +14,7 @@ import (
 func TestStartSecurityModeRejectsNoCommonIntegrity(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 	ue.SetIMSIForTest(testSubscriber.IMSI)
 	ue.SetKASMEForTest(make([]byte, 32))
 	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xff, EIA: 0x00}.Marshal(), nil, mme.MintAuthProofForAttachRequest())
@@ -42,7 +42,7 @@ func TestStartSecurityModeRejectsNoCommonIntegrity(t *testing.T) {
 func TestStartSecurityModeClaimsKeyChain(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
-	ue := m.NewUe(cc, 7)
+	ue := newAttachUe(m, cc, 7)
 	ue.SetIMSIForTest(testSubscriber.IMSI)
 	ue.SetKASMEForTest(make([]byte, 32))
 	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xff, EIA: 0xff}.Marshal(), nil, mme.MintAuthProofForAttachRequest())

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -30,9 +30,8 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		zap.String("update-type", epsUpdateTypeName(req.EPSUpdateType)),
 		zap.Bool("active-flag", req.ActiveFlag))
 
-	// The UE's serving cell must be in this MME's served area, as at attach — a TAU
-	// onto an unserved TAC is rejected with EMM #12 (TS 24.301 §5.5.3.2.5). Mirrors
-	// the AMF's serving-TAI check on mobility registration.
+	// The UE's serving cell must be in this MME's served area, as at attach, or TAU
+	// REJECT #12 (TS 24.301 §5.5.3.2.5).
 	if served, err := m.ServesTAI(ctx, ue.Conn().ServingTAI); err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to evaluate serving TAI for Tracking Area Update", zap.Error(err))
 		return nasreply.Handled()
@@ -106,8 +105,8 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	return nasreply.Handled()
 }
 
-// rejectTrackingAreaUpdate sends a TRACKING AREA UPDATE REJECT with the given EMM
-// cause and releases the UE's S1 context, mirroring rejectAttach (TS 24.301 §5.5.3.2.5).
+// rejectTrackingAreaUpdate sends a TAU REJECT and releases the UE's S1 context
+// (TS 24.301 §5.5.3.2.5).
 func rejectTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause uint8) {
 	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
 	ue.Conn().StopNASGuard()

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -30,6 +30,19 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		zap.String("update-type", epsUpdateTypeName(req.EPSUpdateType)),
 		zap.Bool("active-flag", req.ActiveFlag))
 
+	// The UE's serving cell must be in this MME's served area, as at attach — a TAU
+	// onto an unserved TAC is rejected with EMM #12 (TS 24.301 §5.5.3.2.5). Mirrors
+	// the AMF's serving-TAI check on mobility registration.
+	if served, err := m.ServesTAI(ctx, ue.Conn().ServingTAI); err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to evaluate serving TAI for Tracking Area Update", zap.Error(err))
+		return nasreply.Handled()
+	} else if !served {
+		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update rejected [Tracking area not allowed]", zap.String("imsi", ue.IMSI()))
+		rejectTrackingAreaUpdate(ctx, m, ue, mme.EmmCauseTrackingAreaNotAllowed)
+
+		return nasreply.Handled()
+	}
+
 	// When the UE reports its EPS bearer context status, the MME deactivates the
 	// bearers it holds but the UE considers inactive, then reflects the resulting
 	// active set in the accept (TS 24.301 §5.5.3.2.4).
@@ -91,6 +104,15 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	ue.Conn().ArmNASGuard("Tracking Area Update Accept", naspdu)
 
 	return nasreply.Handled()
+}
+
+// rejectTrackingAreaUpdate sends a TRACKING AREA UPDATE REJECT with the given EMM
+// cause and releases the UE's S1 context, mirroring rejectAttach (TS 24.301 §5.5.3.2.5).
+func rejectTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause uint8) {
+	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
+	ue.Conn().StopNASGuard()
+	ue.Conn().SendDownlinkMessage(ctx, &eps.TrackingAreaUpdateReject{Cause: cause})
+	m.ReleaseUEContext(ctx, ue, mme.CauseNASUnspecified)
 }
 
 // handleTrackingAreaUpdateComplete finalises a GUTI reallocation; for a no-active

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -14,10 +14,8 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// TestTrackingAreaUpdateTrackingAreaNotAllowed checks that a TAU from a serving cell
-// outside the operator's served area is rejected with TRACKING AREA UPDATE REJECT #12
-// ("Tracking area not allowed"), matching the AMF's serving-TAI check on mobility
-// registration (TS 24.301 §5.5.3.2.5).
+// TestTrackingAreaUpdateTrackingAreaNotAllowed checks a TAU from a serving cell outside
+// the served area is rejected with TAU REJECT #12 (TS 24.301 §5.5.3.2.5).
 func TestTrackingAreaUpdateTrackingAreaNotAllowed(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -11,7 +11,35 @@ import (
 	mmes1ap "github.com/ellanetworks/core/internal/mme/s1ap"
 	nascommon "github.com/ellanetworks/core/nas/common"
 	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/s1ap"
 )
+
+// TestTrackingAreaUpdateTrackingAreaNotAllowed checks that a TAU from a serving cell
+// outside the operator's served area is rejected with TRACKING AREA UPDATE REJECT #12
+// ("Tracking area not allowed"), matching the AMF's serving-TAI check on mobility
+// registration (TS 24.301 §5.5.3.2.5).
+func TestTrackingAreaUpdateTrackingAreaNotAllowed(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	// Served PLMN 001/01 but TAC 2, which the operator does not serve (it serves TAC 1).
+	ue.Conn().ServingTAI = s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 2}
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, false, nil))
+
+	if len(cc.sent) == 0 {
+		t.Fatal("expected a TAU Reject, got no downlink")
+	}
+
+	rej, err := eps.ParseTrackingAreaUpdateReject(decodeDownlinkNAS(t, cc.sent[0]))
+	if err != nil {
+		t.Fatalf("not a TAU Reject: %v", err)
+	}
+
+	if rej.Cause != mme.EmmCauseTrackingAreaNotAllowed {
+		t.Fatalf("TAU Reject cause = %d, want %d", rej.Cause, mme.EmmCauseTrackingAreaNotAllowed)
+	}
+}
 
 // trackingAreaUpdateNAS builds a protected TRACKING AREA UPDATE REQUEST at the
 // UE's current uplink NAS COUNT, optionally carrying an EPS bearer context status

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -164,7 +164,7 @@ func (m *MME) pageRadios(ctx context.Context, ue *UeContext, b []byte) {
 	m.mu.RUnlock()
 
 	for _, conn := range conns {
-		m.SendS1APConn(ctx, conn, S1APProcedurePaging, b)
+		m.SendToRadio(ctx, conn, S1APProcedurePaging, b)
 	}
 }
 

--- a/internal/mme/plmn.go
+++ b/internal/mme/plmn.go
@@ -13,11 +13,10 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// ServesTAI reports whether tai — a UE's serving-cell TAI — is one this MME serves:
-// its PLMN is the operator PLMN and its TAC is an operator E-UTRAN TAC. It is the
-// per-UE serving-area gate behind EMM cause #12 (TS 24.301 §5.5.1.2.5), finer than
-// the node-level S1 Setup gate, which accepts an eNB that broadcasts any served TAI
-// even when it also broadcasts an unserved one.
+// ServesTAI reports whether tai — a UE's serving-cell TAI — is served: operator PLMN
+// and an operator E-UTRAN TAC. This per-UE gate (EMM cause #12, TS 24.301 §5.5.1.2.5)
+// is finer than the node-level S1 Setup gate, which admits an eNB broadcasting any
+// served TAI even when it also broadcasts an unserved one.
 func (m *MME) ServesTAI(ctx context.Context, tai s1ap.TAI) (bool, error) {
 	plmn, err := m.OperatorPLMN(ctx)
 	if err != nil {

--- a/internal/mme/plmn.go
+++ b/internal/mme/plmn.go
@@ -4,12 +4,42 @@
 package mme
 
 import (
+	"context"
 	"fmt"
+	"slices"
 
 	"github.com/ellanetworks/core/internal/models"
 	nascommon "github.com/ellanetworks/core/nas/common"
 	"github.com/ellanetworks/core/s1ap"
 )
+
+// ServesTAI reports whether tai — a UE's serving-cell TAI — is one this MME serves:
+// its PLMN is the operator PLMN and its TAC is an operator E-UTRAN TAC. It is the
+// per-UE serving-area gate behind EMM cause #12 (TS 24.301 §5.5.1.2.5), finer than
+// the node-level S1 Setup gate, which accepts an eNB that broadcasts any served TAI
+// even when it also broadcasts an unserved one.
+func (m *MME) ServesTAI(ctx context.Context, tai s1ap.TAI) (bool, error) {
+	plmn, err := m.OperatorPLMN(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	served, err := EncodePLMN(plmn)
+	if err != nil {
+		return false, err
+	}
+
+	if tai.PLMNIdentity != served {
+		return false, nil
+	}
+
+	tacs, err := m.OperatorTACs(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return slices.Contains(tacs, uint16(tai.TAC)), nil
+}
 
 // EncodePLMN encodes an MCC/MNC pair into the 3-octet TBCD PLMN identity
 // (TS 23.003).

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -42,9 +42,10 @@ type UeConn struct {
 	// attached to a context). Guarded by MME.mu.
 	ue *UeContext
 
-	// ServingTAI is the UE's serving-cell TAI from its INITIAL UE MESSAGE (the eNB's
-	// User Location, TS 36.413), gating attach against the operator's served area
-	// (EMM cause #12). Dispatch-confined, set once when the connection is created.
+	// ServingTAI is the UE's current serving-cell TAI, from the User Location of its
+	// INITIAL UE MESSAGE and refreshed on each UPLINK NAS TRANSPORT (TS 36.413). It
+	// gates attach/TAU against the operator's served area (EMM cause #12).
+	// Dispatch-confined.
 	ServingTAI s1ap.TAI
 
 	m *MME

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -42,6 +42,11 @@ type UeConn struct {
 	// attached to a context). Guarded by MME.mu.
 	ue *UeContext
 
+	// ServingTAI is the UE's serving-cell TAI from its INITIAL UE MESSAGE (the eNB's
+	// User Location, TS 36.413), gating attach against the operator's served area
+	// (EMM cause #12). Dispatch-confined, set once when the connection is created.
+	ServingTAI s1ap.TAI
+
 	m *MME
 
 	// ICS is the S1AP Initial Context Setup progress: it distinguishes a

--- a/internal/mme/s1ap/handle_enb_configuration_transfer.go
+++ b/internal/mme/s1ap/handle_enb_configuration_transfer.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/s1ap"
+	"go.uber.org/zap"
+)
+
+// handleENBConfigurationTransfer relays a SON Configuration Transfer IE between
+// eNBs (TS 36.413 §8.15/§8.16). Per §8.15.2 the MME "shall transparently transfer
+// the SON Configuration Transfer IE towards the eNB indicated in the Target eNB-ID
+// IE"; the IE is copied verbatim into an MME CONFIGURATION TRANSFER. Non-UE,
+// fire-and-forget: an absent IE or an unconnected target eNB is dropped.
+func handleENBConfigurationTransfer(m *mme.MME, ctx context.Context, radio *mme.Radio, value []byte) {
+	msg, err := s1ap.ParseENBConfigurationTransfer(value)
+	if err != nil {
+		handleParseError(m, radio.Conn, s1ap.ProcENBConfigurationTransfer, err)
+		return
+	}
+
+	if msg.SONConfigurationTransfer == nil {
+		return
+	}
+
+	target, err := msg.SONConfigurationTransfer.TargetENBID()
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Warn("could not decode Target eNB-ID from SON Configuration Transfer", zap.Error(err))
+		return
+	}
+
+	targetRadio, ok := m.FindRadioByGlobalENBID(target.GlobalENBID)
+	if !ok {
+		logger.From(ctx, logger.MmeLog).Warn("SON Configuration Transfer target eNB not connected", zap.String("target-enb", mme.ENBID(target.GlobalENBID)))
+		return
+	}
+
+	mct := &s1ap.MMEConfigurationTransfer{SONConfigurationTransfer: msg.SONConfigurationTransfer}
+
+	b, err := mct.Marshal()
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to marshal MME Configuration Transfer", zap.Error(err))
+		return
+	}
+
+	m.SendS1APConn(ctx, targetRadio.Conn, mme.S1APProcedureMMEConfigurationTransfer, b)
+}

--- a/internal/mme/s1ap/handle_enb_configuration_transfer.go
+++ b/internal/mme/s1ap/handle_enb_configuration_transfer.go
@@ -12,11 +12,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// handleENBConfigurationTransfer relays a SON Configuration Transfer IE between
-// eNBs (TS 36.413 §8.15/§8.16). Per §8.15.2 the MME "shall transparently transfer
-// the SON Configuration Transfer IE towards the eNB indicated in the Target eNB-ID
-// IE"; the IE is copied verbatim into an MME CONFIGURATION TRANSFER. Non-UE,
-// fire-and-forget: an absent IE or an unconnected target eNB is dropped.
+// handleENBConfigurationTransfer relays a SON Configuration Transfer IE verbatim
+// from ENB CONFIGURATION TRANSFER into an MME CONFIGURATION TRANSFER toward the eNB
+// named in its Target eNB-ID (TS 36.413 §8.15.2/§8.16.2). Non-UE, fire-and-forget:
+// an absent IE or an unconnected target is dropped.
 func handleENBConfigurationTransfer(m *mme.MME, ctx context.Context, radio *mme.Radio, value []byte) {
 	msg, err := s1ap.ParseENBConfigurationTransfer(value)
 	if err != nil {

--- a/internal/mme/s1ap/handle_enb_configuration_transfer.go
+++ b/internal/mme/s1ap/handle_enb_configuration_transfer.go
@@ -48,5 +48,5 @@ func handleENBConfigurationTransfer(m *mme.MME, ctx context.Context, radio *mme.
 		return
 	}
 
-	m.SendS1APConn(ctx, targetRadio.Conn, mme.S1APProcedureMMEConfigurationTransfer, b)
+	m.SendToRadio(ctx, targetRadio.Conn, mme.S1APProcedureMMEConfigurationTransfer, b)
 }

--- a/internal/mme/s1ap/handle_enb_configuration_transfer_test.go
+++ b/internal/mme/s1ap/handle_enb_configuration_transfer_test.go
@@ -69,7 +69,6 @@ func TestHandleENBConfigurationTransfer_TargetNotConnected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// No target eNB is registered: the transfer is dropped, nothing is sent.
 	handleENBConfigurationTransfer(m, context.Background(), mme.NewRadioForTest(sourceConn), value)
 
 	if sourceConn.count() != 0 {

--- a/internal/mme/s1ap/handle_enb_configuration_transfer_test.go
+++ b/internal/mme/s1ap/handle_enb_configuration_transfer_test.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// goldenENBConfigTransfer is an ENB CONFIGURATION TRANSFER initiatingMessage value
+// (TS 36.413 §8.15) whose SON Configuration Transfer IE targets eNB 0x00abc
+// (PLMN 001/01, TAC 7), followed by opaque SON payload bytes.
+const goldenENBConfigTransfer = "000001008140110000f1100000abc000f1100007deadbeef"
+
+func targetENBID() s1ap.GlobalENBID {
+	return s1ap.GlobalENBID{
+		PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10},
+		ENBID:        s1ap.ENBID{Kind: s1ap.ENBIDMacro, Value: 0x00abc},
+	}
+}
+
+func TestHandleENBConfigurationTransfer_RelaysToTarget(t *testing.T) {
+	m := newTestMME(t)
+
+	// Target eNB, resolvable by its Global eNB ID.
+	targetConn := &captureConn{}
+	m.ClaimENBID(mme.NewRadioForTest(targetConn), targetENBID())
+
+	// A distinct source eNB initiates the transfer toward the target.
+	sourceConn := &captureConn{}
+
+	value, err := hex.DecodeString(goldenENBConfigTransfer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handleENBConfigurationTransfer(m, context.Background(), mme.NewRadioForTest(sourceConn), value)
+
+	if targetConn.count() != 1 {
+		t.Fatalf("expected 1 relayed message to the target eNB, got %d", targetConn.count())
+	}
+
+	if sourceConn.count() != 0 {
+		t.Fatalf("source eNB must not receive the relay, got %d", sourceConn.count())
+	}
+
+	pdu, err := s1ap.Unmarshal(targetConn.sent[0])
+	if err != nil {
+		t.Fatalf("Unmarshal relayed PDU: %v", err)
+	}
+
+	im, ok := pdu.(*s1ap.InitiatingMessage)
+	if !ok || im.ProcedureCode != s1ap.ProcMMEConfigurationTransfer {
+		t.Fatalf("expected MME CONFIGURATION TRANSFER (proc %d), got %T", s1ap.ProcMMEConfigurationTransfer, pdu)
+	}
+}
+
+func TestHandleENBConfigurationTransfer_TargetNotConnected(t *testing.T) {
+	m := newTestMME(t)
+	sourceConn := &captureConn{}
+
+	value, err := hex.DecodeString(goldenENBConfigTransfer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No target eNB is registered: the transfer is dropped, nothing is sent.
+	handleENBConfigurationTransfer(m, context.Background(), mme.NewRadioForTest(sourceConn), value)
+
+	if sourceConn.count() != 0 {
+		t.Fatalf("no relay expected when the target eNB is not connected, got %d", sourceConn.count())
+	}
+}

--- a/internal/mme/s1ap/handle_enb_configuration_update.go
+++ b/internal/mme/s1ap/handle_enb_configuration_update.go
@@ -46,7 +46,7 @@ func handleENBConfigurationUpdate(m *mme.MME, ctx context.Context, radio *mme.Ra
 		msgType = mme.S1APProcedureENBConfigUpdateFailure
 	}
 
-	m.SendS1APConn(ctx, radio.Conn, msgType, out)
+	m.SendToRadio(ctx, radio.Conn, msgType, out)
 
 	if !accepted {
 		logger.From(ctx, radio.Log).Warn("ENB Configuration Update rejected: eNB broadcasts no TAI (PLMN + TAC) served by this MME")

--- a/internal/mme/s1ap/handle_enb_status_transfer.go
+++ b/internal/mme/s1ap/handle_enb_status_transfer.go
@@ -44,5 +44,5 @@ func handleENBStatusTransfer(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 		return
 	}
 
-	m.SendS1APConn(ctx, targetConn, mme.S1APProcedureMMEStatusTransfer, b)
+	m.SendToRadio(ctx, targetConn, mme.S1APProcedureMMEStatusTransfer, b)
 }

--- a/internal/mme/s1ap/handle_erab_modification_indication.go
+++ b/internal/mme/s1ap/handle_erab_modification_indication.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/s1ap"
+	"go.uber.org/zap"
+)
+
+// causeERABModOmittedERAB is the UE Context Release cause when an E-RAB
+// Modification Indication omits an established E-RAB (TS 36.413 §8.2.4.4): no
+// specific radio-network cause applies, so "unspecified".
+var causeERABModOmittedERAB = s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkUnspecified}
+
+// handleERABModificationIndication relocates the downlink S1-U endpoint of the
+// UE's established E-RABs to the addresses the eNB reports (the DC / secondary-node
+// bearer-relocation case) and confirms them (TS 36.413 §8.2.4). Per §8.2.4.4, an
+// indication that repeats an E-RAB ID or omits an E-RAB already in the UE context
+// is abnormal and triggers a UE Context Release rather than a modification.
+func handleERABModificationIndication(m *mme.MME, ctx context.Context, radio *mme.Radio, value []byte) {
+	msg, err := s1ap.ParseERABModificationIndication(value)
+	if err != nil {
+		handleParseError(m, radio.Conn, s1ap.ProcERABModificationIndication, err)
+		return
+	}
+
+	ue, ok := m.LookupUe(msg.MMEUES1APID)
+	if !ok {
+		// The procedure has no failure message; an unresolvable UE is dropped.
+		logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication for unknown UE",
+			zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)))
+
+		return
+	}
+
+	ue.TouchLastSeen()
+
+	if id, dup := duplicateModifiedERABID(msg); dup {
+		logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication repeats an E-RAB ID; releasing UE context",
+			zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(id)))
+		m.ReleaseUEContext(ctx, ue, causeMultipleERABInstances)
+
+		return
+	}
+
+	if ebi, omitted := omittedEstablishedERAB(ue, msg); omitted {
+		logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication omits an established E-RAB; releasing UE context",
+			zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)), zap.Uint8("e-rab-id", ebi))
+		m.ReleaseUEContext(ctx, ue, causeERABModOmittedERAB)
+
+		return
+	}
+
+	modified := modifyBearerDownlinks(m, ctx, ue, msg.ToBeModified)
+
+	confirm := &s1ap.ERABModificationConfirm{
+		MMEUES1APID:   msg.MMEUES1APID,
+		ENBUES1APID:   msg.ENBUES1APID,
+		ModifiedERABs: modified,
+	}
+
+	b, err := confirm.Marshal()
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to marshal E-RAB Modification Confirm", zap.Error(err))
+		return
+	}
+
+	logger.From(ctx, logger.MmeLog).Info("E-RAB Modification Indication",
+		zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)),
+		zap.Int("e-rabs-modified", len(modified)))
+
+	m.SendS1APConn(ctx, radio.Conn, mme.S1APProcedureERABModificationConfirm, b)
+}
+
+// modifyBearerDownlinks relocates each listed E-RAB's downlink to the eNB S1-U
+// endpoint it names, returning the E-RABs successfully relocated. Reuses the same
+// user-plane path as a Path Switch (TS 36.413 §8.2.4.2).
+func modifyBearerDownlinks(m *mme.MME, ctx context.Context, ue *mme.UeContext, items []s1ap.ERABToBeModifiedItemBearerModInd) []s1ap.ERABID {
+	var modified []s1ap.ERABID
+
+	for _, erab := range items {
+		p := m.LookupPDN(ue, uint8(erab.ERABID))
+		if p == nil {
+			logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication lists an unknown E-RAB; skipped",
+				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+
+			continue
+		}
+
+		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
+		if !ok {
+			logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication has an invalid eNB transport address; skipped",
+				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+
+			continue
+		}
+
+		fteid := models.FTEID{TEID: uint32(erab.DLGTPTEID), Addr: addr}
+
+		if err := m.Session.ModifyEPSSession(ctx, ue.IMSI(), p.Ebi, fteid); err != nil {
+			logger.From(ctx, logger.MmeLog).Error("failed to relocate an E-RAB downlink",
+				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)), zap.Error(err))
+
+			continue
+		}
+
+		p.EnbFTEID = fteid
+
+		modified = append(modified, erab.ERABID)
+
+		logger.From(ctx, logger.MmeLog).Debug("E-RAB downlink relocated",
+			zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)), zap.String("enb-s1u", addr.String()))
+	}
+
+	return modified
+}
+
+// duplicateModifiedERABID reports the first E-RAB ID appearing more than once
+// across the indication's to-be-modified and not-to-be-modified lists (TS 36.413 §8.2.4.4).
+func duplicateModifiedERABID(msg *s1ap.ERABModificationIndication) (s1ap.ERABID, bool) {
+	seen := make(map[s1ap.ERABID]struct{})
+
+	for _, it := range msg.ToBeModified {
+		if _, dup := seen[it.ERABID]; dup {
+			return it.ERABID, true
+		}
+
+		seen[it.ERABID] = struct{}{}
+	}
+
+	for _, it := range msg.NotToBeModified {
+		if _, dup := seen[it.ERABID]; dup {
+			return it.ERABID, true
+		}
+
+		seen[it.ERABID] = struct{}{}
+	}
+
+	return 0, false
+}
+
+// omittedEstablishedERAB reports an E-RAB in the UE context that the indication
+// lists in neither its to-be-modified nor its not-to-be-modified list (TS 36.413 §8.2.4.4).
+func omittedEstablishedERAB(ue *mme.UeContext, msg *s1ap.ERABModificationIndication) (uint8, bool) {
+	present := make(map[uint8]struct{})
+
+	for _, it := range msg.ToBeModified {
+		present[uint8(it.ERABID)] = struct{}{}
+	}
+
+	for _, it := range msg.NotToBeModified {
+		present[uint8(it.ERABID)] = struct{}{}
+	}
+
+	for _, ebi := range ue.ActiveEBIs() {
+		if _, ok := present[ebi]; !ok {
+			return ebi, true
+		}
+	}
+
+	return 0, false
+}

--- a/internal/mme/s1ap/handle_erab_modification_indication.go
+++ b/internal/mme/s1ap/handle_erab_modification_indication.go
@@ -75,7 +75,7 @@ func handleERABModificationIndication(m *mme.MME, ctx context.Context, radio *mm
 		zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)),
 		zap.Int("e-rabs-modified", len(modified)))
 
-	m.SendS1APConn(ctx, radio.Conn, mme.S1APProcedureERABModificationConfirm, b)
+	m.SendToRadio(ctx, radio.Conn, mme.S1APProcedureERABModificationConfirm, b)
 }
 
 // modifyBearerDownlinks relocates each listed E-RAB's downlink to the eNB S1-U

--- a/internal/mme/s1ap/handle_erab_modification_indication.go
+++ b/internal/mme/s1ap/handle_erab_modification_indication.go
@@ -22,7 +22,7 @@ var causeERABModOmittedERAB = s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Val
 // UE's established E-RABs to the addresses the eNB reports (the DC / secondary-node
 // bearer-relocation case) and confirms them (TS 36.413 §8.2.4). Per §8.2.4.4, an
 // indication that repeats an E-RAB ID or omits an E-RAB already in the UE context
-// is abnormal and triggers a UE Context Release rather than a modification.
+// is abnormal and triggers a UE Context Release, not a modification.
 func handleERABModificationIndication(m *mme.MME, ctx context.Context, radio *mme.Radio, value []byte) {
 	msg, err := s1ap.ParseERABModificationIndication(value)
 	if err != nil {

--- a/internal/mme/s1ap/handle_erab_modification_indication_test.go
+++ b/internal/mme/s1ap/handle_erab_modification_indication_test.go
@@ -52,7 +52,6 @@ func TestERABModificationIndication_RelocatesAndConfirms(t *testing.T) {
 
 	handleERABModificationIndication(m, context.Background(), mme.NewRadioForTest(cc), erabModValue(t, req))
 
-	// Downlink relocated to the reported eNB S1-U endpoint.
 	wantFTEID := models.FTEID{TEID: 0x1234, Addr: netip.AddrFrom4([4]byte{10, 5, 0, 2})}
 	if fsm := m.Session.(*fakeSessionManager); fsm.modifiedENB != wantFTEID {
 		t.Fatalf("ModifyEPSSession eNB F-TEID = %+v, want %+v", fsm.modifiedENB, wantFTEID)
@@ -62,7 +61,6 @@ func TestERABModificationIndication_RelocatesAndConfirms(t *testing.T) {
 		t.Fatalf("stored eNB F-TEID = %+v, want %+v", testPDN(ue).EnbFTEID, wantFTEID)
 	}
 
-	// A single E-RAB MODIFICATION CONFIRM was sent.
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected 1 E-RAB Modification Confirm, got %d S1AP messages", len(cc.sent))
 	}
@@ -95,12 +93,10 @@ func TestERABModificationIndication_OmittedERABReleases(t *testing.T) {
 
 	handleERABModificationIndication(m, context.Background(), mme.NewRadioForTest(cc), erabModValue(t, req))
 
-	// No downlink was modified — the abnormal condition took over.
 	if fsm := m.Session.(*fakeSessionManager); fsm.modifiedENB != (models.FTEID{}) {
 		t.Fatalf("expected no E-RAB modification, got F-TEID %+v", fsm.modifiedENB)
 	}
 
-	// The sole message is a UE Context Release Command, not a Confirm.
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected 1 UE Context Release Command, got %d S1AP messages", len(cc.sent))
 	}

--- a/internal/mme/s1ap/handle_erab_modification_indication_test.go
+++ b/internal/mme/s1ap/handle_erab_modification_indication_test.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// erabModValue marshals an E-RAB MODIFICATION INDICATION and returns the
+// initiatingMessage open-type payload the handler consumes.
+func erabModValue(t *testing.T, req *s1ap.ERABModificationIndication) []byte {
+	t.Helper()
+
+	b, err := req.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pdu, err := s1ap.Unmarshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pdu.(*s1ap.InitiatingMessage).Value
+}
+
+func modifiedItem(addr [4]byte, teid uint32) s1ap.ERABToBeModifiedItemBearerModInd {
+	return s1ap.ERABToBeModifiedItemBearerModInd{
+		ERABID:                s1ap.ERABID(mme.DefaultERABID),
+		TransportLayerAddress: s1ap.TransportLayerAddress(addr[:]),
+		DLGTPTEID:             s1ap.GTPTEID(teid),
+	}
+}
+
+func TestERABModificationIndication_RelocatesAndConfirms(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+	testPDN(ue) // default bearer, EBI 5
+
+	req := &s1ap.ERABModificationIndication{
+		MMEUES1APID:  ue.Conn().MMEUES1APID,
+		ENBUES1APID:  ue.Conn().ENBUES1APID,
+		ToBeModified: []s1ap.ERABToBeModifiedItemBearerModInd{modifiedItem([4]byte{10, 5, 0, 2}, 0x1234)},
+	}
+
+	handleERABModificationIndication(m, context.Background(), mme.NewRadioForTest(cc), erabModValue(t, req))
+
+	// Downlink relocated to the reported eNB S1-U endpoint.
+	wantFTEID := models.FTEID{TEID: 0x1234, Addr: netip.AddrFrom4([4]byte{10, 5, 0, 2})}
+	if fsm := m.Session.(*fakeSessionManager); fsm.modifiedENB != wantFTEID {
+		t.Fatalf("ModifyEPSSession eNB F-TEID = %+v, want %+v", fsm.modifiedENB, wantFTEID)
+	}
+
+	if testPDN(ue).EnbFTEID != wantFTEID {
+		t.Fatalf("stored eNB F-TEID = %+v, want %+v", testPDN(ue).EnbFTEID, wantFTEID)
+	}
+
+	// A single E-RAB MODIFICATION CONFIRM was sent.
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected 1 E-RAB Modification Confirm, got %d S1AP messages", len(cc.sent))
+	}
+
+	pdu, err := s1ap.Unmarshal(cc.sent[0])
+	if err != nil {
+		t.Fatalf("unmarshal confirm: %v", err)
+	}
+
+	so, ok := pdu.(*s1ap.SuccessfulOutcome)
+	if !ok || so.ProcedureCode != s1ap.ProcERABModificationIndication {
+		t.Fatalf("expected E-RAB Modification Confirm, got %T", pdu)
+	}
+}
+
+// TestERABModificationIndication_OmittedERABReleases covers TS 36.413 §8.2.4.4:
+// an indication that omits an established E-RAB triggers a UE Context Release, not
+// a modification.
+func TestERABModificationIndication_OmittedERABReleases(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+	testPDN(ue)     // default bearer, EBI 5
+	ue.EnsurePDN(6) // a second bearer the indication will omit
+
+	req := &s1ap.ERABModificationIndication{
+		MMEUES1APID:  ue.Conn().MMEUES1APID,
+		ENBUES1APID:  ue.Conn().ENBUES1APID,
+		ToBeModified: []s1ap.ERABToBeModifiedItemBearerModInd{modifiedItem([4]byte{10, 5, 0, 2}, 0x1234)},
+	}
+
+	handleERABModificationIndication(m, context.Background(), mme.NewRadioForTest(cc), erabModValue(t, req))
+
+	// No downlink was modified — the abnormal condition took over.
+	if fsm := m.Session.(*fakeSessionManager); fsm.modifiedENB != (models.FTEID{}) {
+		t.Fatalf("expected no E-RAB modification, got F-TEID %+v", fsm.modifiedENB)
+	}
+
+	// The sole message is a UE Context Release Command, not a Confirm.
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected 1 UE Context Release Command, got %d S1AP messages", len(cc.sent))
+	}
+
+	pdu, err := s1ap.Unmarshal(cc.sent[0])
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	im, ok := pdu.(*s1ap.InitiatingMessage)
+	if !ok {
+		t.Fatalf("expected UE Context Release Command (InitiatingMessage), got %T", pdu)
+	}
+
+	if im.ProcedureCode != s1ap.ProcUEContextRelease {
+		t.Fatalf("expected UE Context Release Command, got proc %d", im.ProcedureCode)
+	}
+}
+
+// TestERABModificationIndication_DuplicateERABReleases covers TS 36.413 §8.2.4.4:
+// a repeated E-RAB ID triggers a UE Context Release.
+func TestERABModificationIndication_DuplicateERABReleases(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+	testPDN(ue)
+
+	req := &s1ap.ERABModificationIndication{
+		MMEUES1APID: ue.Conn().MMEUES1APID,
+		ENBUES1APID: ue.Conn().ENBUES1APID,
+		ToBeModified: []s1ap.ERABToBeModifiedItemBearerModInd{
+			modifiedItem([4]byte{10, 5, 0, 2}, 0x1234),
+			modifiedItem([4]byte{10, 5, 0, 3}, 0x5678),
+		},
+	}
+
+	handleERABModificationIndication(m, context.Background(), mme.NewRadioForTest(cc), erabModValue(t, req))
+
+	if fsm := m.Session.(*fakeSessionManager); fsm.modifiedENB != (models.FTEID{}) {
+		t.Fatalf("expected no E-RAB modification on duplicate, got F-TEID %+v", fsm.modifiedENB)
+	}
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected 1 UE Context Release Command, got %d", len(cc.sent))
+	}
+
+	pdu, err := s1ap.Unmarshal(cc.sent[0])
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if im, ok := pdu.(*s1ap.InitiatingMessage); !ok || im.ProcedureCode != s1ap.ProcUEContextRelease {
+		t.Fatalf("expected UE Context Release Command, got %T", pdu)
+	}
+}

--- a/internal/mme/s1ap/handle_error_indication.go
+++ b/internal/mme/s1ap/handle_error_indication.go
@@ -99,7 +99,7 @@ func emitErrorIndication(m *mme.MME, conn mme.S1APWriter, ind *s1ap.ErrorIndicat
 
 	// Resolution failures fire from many handlers, some outside a request span;
 	// fresh root.
-	m.SendS1APConn(context.Background(), conn, mme.S1APProcedureErrorIndication, b)
+	m.SendToRadio(context.Background(), conn, mme.S1APProcedureErrorIndication, b)
 }
 
 // handleErrorIndication processes an ERROR INDICATION from the eNB (TS 36.413). A

--- a/internal/mme/s1ap/handle_handover_cancel.go
+++ b/internal/mme/s1ap/handle_handover_cancel.go
@@ -43,5 +43,5 @@ func handleHandoverCancel(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Handover Cancel", zap.Uint32("mme-ue-id", uint32(cancel.MMEUES1APID)))
-	m.SendS1APConn(ctx, radio.Conn, mme.S1APProcedureHandoverCancelAcknowledge, b)
+	m.SendToRadio(ctx, radio.Conn, mme.S1APProcedureHandoverCancelAcknowledge, b)
 }

--- a/internal/mme/s1ap/handle_handover_request_acknowledge.go
+++ b/internal/mme/s1ap/handle_handover_request_acknowledge.go
@@ -97,7 +97,7 @@ func handleHandoverRequestAcknowledge(m *mme.MME, ctx context.Context, radio *mm
 		zap.Uint32("mme-ue-id", uint32(sourceMMEID)),
 		zap.Int("admitted", len(admitted)),
 		zap.Int("released", len(releaseEBIs)))
-	m.SendS1APConn(ctx, sourceConn, mme.S1APProcedureHandoverCommand, b)
+	m.SendToRadio(ctx, sourceConn, mme.S1APProcedureHandoverCommand, b)
 }
 
 // failedHandoverEBIs returns the EPS bearer identities the target eNB reported

--- a/internal/mme/s1ap/handle_handover_required.go
+++ b/internal/mme/s1ap/handle_handover_required.go
@@ -98,7 +98,7 @@ func handleHandoverRequired(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 		zap.Uint32("target-mme-ue-id", uint32(targetMMEID)),
 		zap.String("target-enb", mme.ENBID(req.TargetID.TargeteNBID.GlobalENBID)),
 		zap.Int("e-rabs", len(bearers)))
-	m.SendS1APConn(ctx, target.Conn, mme.S1APProcedureHandoverRequest, b)
+	m.SendToRadio(ctx, target.Conn, mme.S1APProcedureHandoverRequest, b)
 
 	// Arm the guard after the HANDOVER REQUEST is sent, so the timer cannot race the
 	// outbound request (TS 36.413 §8.4).

--- a/internal/mme/s1ap/handle_initial_ue_message.go
+++ b/internal/mme/s1ap/handle_initial_ue_message.go
@@ -39,6 +39,8 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 		return
 	}
 
+	c.ServingTAI = msg.TAI
+
 	logger.From(ctx, c.Log).Info("Initial UE Message",
 		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),
 	)

--- a/internal/mme/s1ap/handle_path_switch_request.go
+++ b/internal/mme/s1ap/handle_path_switch_request.go
@@ -197,7 +197,7 @@ func sendPathSwitchFailure(m *mme.MME, conn mme.S1APWriter, req *s1ap.PathSwitch
 	}
 
 	// A Path Switch Failure can be sent before the UE is resolved; use a fresh root.
-	m.SendS1APConn(context.Background(), conn, mme.S1APProcedurePathSwitchRequestFailure, b)
+	m.SendToRadio(context.Background(), conn, mme.S1APProcedurePathSwitchRequestFailure, b)
 }
 
 // pathSwitchSecurityCapabilities compares the UE security capabilities the target

--- a/internal/mme/s1ap/handle_reset.go
+++ b/internal/mme/s1ap/handle_reset.go
@@ -55,5 +55,5 @@ func sendResetAcknowledge(m *mme.MME, conn mme.S1APWriter, connectionList []s1ap
 	}
 
 	// Reset handling is not tied to a single UE request span; use a fresh root.
-	m.SendS1APConn(context.Background(), conn, mme.S1APProcedureResetAcknowledge, b)
+	m.SendToRadio(context.Background(), conn, mme.S1APProcedureResetAcknowledge, b)
 }

--- a/internal/mme/s1ap/handle_s1_setup.go
+++ b/internal/mme/s1ap/handle_s1_setup.go
@@ -56,7 +56,7 @@ func handleS1Setup(m *mme.MME, ctx context.Context, conn *sctp.SCTPConn, value [
 	)
 
 	if !accepted {
-		m.SendS1APConn(ctx, conn, mme.S1APProcedureS1SetupFailure, outBytes)
+		m.SendToRadio(ctx, conn, mme.S1APProcedureS1SetupFailure, outBytes)
 
 		logger.From(ctx, m.RadioLog(conn)).Warn("S1 Setup rejected",
 			zap.String("enb-name", req.ENBName),
@@ -66,7 +66,7 @@ func handleS1Setup(m *mme.MME, ctx context.Context, conn *sctp.SCTPConn, value [
 		return
 	}
 
-	m.SendS1APConn(ctx, conn, mme.S1APProcedureS1SetupResponse, outBytes)
+	m.SendToRadio(ctx, conn, mme.S1APProcedureS1SetupResponse, outBytes)
 
 	// Claim the eNB's identity and broadcast TAIs only on accept; until then the
 	// dispatcher's setup-first gate drops the association's UE signalling (TS 36.413).

--- a/internal/mme/s1ap/handle_ue_context_release_complete.go
+++ b/internal/mme/s1ap/handle_ue_context_release_complete.go
@@ -51,10 +51,6 @@ func HandleUEContextReleaseComplete(m *mme.MME, ctx context.Context, radio *mme.
 
 	m.FreeUeConn(ue)
 
-	// Buffer the downlink bearers so data for the idle UE triggers paging
-	// (TS 23.401).
-	m.DeactivateAllSessions(ctx, ue)
-
 	// Supervise the UE's reachability while idle: the mobile reachable timer is
 	// (re)started when the MME releases the NAS signalling connection (TS 24.301).
 	m.StartMobileReachable(ue)

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -51,12 +51,9 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 		logger.From(ctx, ue.Conn().Log).Info("UE Context Release Request", fields...)
 	}
 
-	// TS 23.401 §5.3.5: buffer the downlink (Release Access Bearers, step 2) BEFORE the
-	// S1 UE Context Release Command (step 4), so a downlink arriving during the release
-	// is buffered for paging rather than forwarded to the eNB bearer being torn down.
-	// Only a registered UE goes to ECM-IDLE; an aborted attach or detach is fully
-	// released at release-complete. Mirrors the 5G AN-release order (deactivate on the
-	// release request, not on completion).
+	// Deactivate before the S1 UE Context Release Command so a concurrent downlink is
+	// buffered for paging (TS 23.401 §5.3.5: Release Access Bearers precedes the release
+	// command). Only a registered UE transitions to ECM-IDLE.
 	if ue.EMMState() == mme.EMMRegistered {
 		m.DeactivateAllSessions(ctx, ue)
 	}

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -51,5 +51,15 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 		logger.From(ctx, ue.Conn().Log).Info("UE Context Release Request", fields...)
 	}
 
+	// TS 23.401 §5.3.5: buffer the downlink (Release Access Bearers, step 2) BEFORE the
+	// S1 UE Context Release Command (step 4), so a downlink arriving during the release
+	// is buffered for paging rather than forwarded to the eNB bearer being torn down.
+	// Only a registered UE goes to ECM-IDLE; an aborted attach or detach is fully
+	// released at release-complete. Mirrors the 5G AN-release order (deactivate on the
+	// release request, not on completion).
+	if ue.EMMState() == mme.EMMRegistered {
+		m.DeactivateAllSessions(ctx, ue)
+	}
+
 	m.ReleaseUEContext(ctx, ue, msg.Cause)
 }

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -51,12 +51,5 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 		logger.From(ctx, ue.Conn().Log).Info("UE Context Release Request", fields...)
 	}
 
-	// Deactivate before the S1 UE Context Release Command so a concurrent downlink is
-	// buffered for paging (TS 23.401 §5.3.5: Release Access Bearers precedes the release
-	// command). Only a registered UE transitions to ECM-IDLE.
-	if ue.EMMState() == mme.EMMRegistered {
-		m.DeactivateAllSessions(ctx, ue)
-	}
-
 	m.ReleaseUEContext(ctx, ue, msg.Cause)
 }

--- a/internal/mme/s1ap/handle_uplink_nas_transport.go
+++ b/internal/mme/s1ap/handle_uplink_nas_transport.go
@@ -26,6 +26,11 @@ func handleUplinkNASTransport(m *mme.MME, ctx context.Context, radio *mme.Radio,
 
 	ue.TouchLastSeen()
 
+	// Track the UE's current serving-cell TAI so a mobility procedure (TAU) is gated
+	// on where the UE now is, not where it first attached (TS 36.413: UPLINK NAS
+	// TRANSPORT carries the current TAI).
+	ue.Conn().ServingTAI = msg.TAI
+
 	// resolveUE guarantees the UE is connected on this association, so ue.Conn() is
 	// the connection the message arrived on.
 	m.NAS.HandleNAS(ctx, ue.Conn(), []byte(msg.NASPDU))

--- a/internal/mme/s1ap/handle_uplink_nas_transport.go
+++ b/internal/mme/s1ap/handle_uplink_nas_transport.go
@@ -26,9 +26,8 @@ func handleUplinkNASTransport(m *mme.MME, ctx context.Context, radio *mme.Radio,
 
 	ue.TouchLastSeen()
 
-	// Track the UE's current serving-cell TAI so a mobility procedure (TAU) is gated
-	// on where the UE now is, not where it first attached (TS 36.413: UPLINK NAS
-	// TRANSPORT carries the current TAI).
+	// Track the UE's current serving-cell TAI so a later TAU is gated on where the UE
+	// now is (TS 36.413: UPLINK NAS TRANSPORT carries the current TAI).
 	ue.Conn().ServingTAI = msg.TAI
 
 	// resolveUE guarantees the UE is connected on this association, so ue.Conn() is

--- a/internal/mme/s1ap/release_test.go
+++ b/internal/mme/s1ap/release_test.go
@@ -16,6 +16,10 @@ func TestECMIdleBuffersSession(t *testing.T) {
 	ue, cc := securedUE(t, m)
 	testPDN(ue).Apn = "internet"
 
+	// The release buffers the session and sends the Release Command (TS 23.401 §5.3.5),
+	// then the eNB acknowledges with Release Complete.
+	m.ReleaseUEContext(context.Background(), ue, mme.CauseNASNormalRelease)
+
 	complete := &s1ap.UEContextReleaseComplete{MMEUES1APID: ue.Conn().MMEUES1APID, ENBUES1APID: 7}
 	b, _ := complete.Marshal()
 	cpdu, _ := s1ap.Unmarshal(b)

--- a/internal/mme/s1ap/route.go
+++ b/internal/mme/s1ap/route.go
@@ -46,6 +46,8 @@ func Route(m *mme.MME, ctx context.Context, radio *mme.Radio, pdu any) {
 			handleENBConfigurationUpdate(m, ctx, radio, p.Value)
 		case s1ap.ProcENBConfigurationTransfer:
 			handleENBConfigurationTransfer(m, ctx, radio, p.Value)
+		case s1ap.ProcERABModificationIndication:
+			handleERABModificationIndication(m, ctx, radio, p.Value)
 		default:
 			logger.From(ctx, radio.Log).Warn("ignoring unsupported procedure", zap.String("kind", "initiating"), zap.Int64("procedureCode", int64(p.ProcedureCode)))
 		}

--- a/internal/mme/s1ap/route.go
+++ b/internal/mme/s1ap/route.go
@@ -44,6 +44,8 @@ func Route(m *mme.MME, ctx context.Context, radio *mme.Radio, pdu any) {
 			handleReset(m, radio, p.Value)
 		case s1ap.ProcENBConfigurationUpdate:
 			handleENBConfigurationUpdate(m, ctx, radio, p.Value)
+		case s1ap.ProcENBConfigurationTransfer:
+			handleENBConfigurationTransfer(m, ctx, radio, p.Value)
 		default:
 			logger.From(ctx, radio.Log).Warn("ignoring unsupported procedure", zap.String("kind", "initiating"), zap.Int64("procedureCode", int64(p.ProcedureCode)))
 		}

--- a/internal/mme/s1ap_procedures.go
+++ b/internal/mme/s1ap_procedures.go
@@ -51,6 +51,8 @@ const (
 	S1APProcedureHandoverCancelAcknowledge   S1APProcedure = "HandoverCancelAcknowledge"
 	S1APProcedureENBStatusTransfer           S1APProcedure = "ENBStatusTransfer"
 	S1APProcedureMMEStatusTransfer           S1APProcedure = "MMEStatusTransfer"
+	S1APProcedureENBConfigurationTransfer    S1APProcedure = "ENBConfigurationTransfer"
+	S1APProcedureMMEConfigurationTransfer    S1APProcedure = "MMEConfigurationTransfer"
 	S1APProcedureUnknown                     S1APProcedure = "UnknownMessage"
 )
 
@@ -116,6 +118,10 @@ func s1apInitiatingMessageType(code s1ap.ProcedureCode) S1APProcedure {
 		return S1APProcedureENBStatusTransfer
 	case s1ap.ProcMMEStatusTransfer:
 		return S1APProcedureMMEStatusTransfer
+	case s1ap.ProcENBConfigurationTransfer:
+		return S1APProcedureENBConfigurationTransfer
+	case s1ap.ProcMMEConfigurationTransfer:
+		return S1APProcedureMMEConfigurationTransfer
 	default:
 		return S1APProcedureUnknown
 	}

--- a/internal/mme/s1ap_procedures.go
+++ b/internal/mme/s1ap_procedures.go
@@ -53,6 +53,8 @@ const (
 	S1APProcedureMMEStatusTransfer           S1APProcedure = "MMEStatusTransfer"
 	S1APProcedureENBConfigurationTransfer    S1APProcedure = "ENBConfigurationTransfer"
 	S1APProcedureMMEConfigurationTransfer    S1APProcedure = "MMEConfigurationTransfer"
+	S1APProcedureERABModificationIndication  S1APProcedure = "E-RABModificationIndication"
+	S1APProcedureERABModificationConfirm     S1APProcedure = "E-RABModificationConfirm"
 	S1APProcedureUnknown                     S1APProcedure = "UnknownMessage"
 )
 
@@ -120,6 +122,8 @@ func s1apInitiatingMessageType(code s1ap.ProcedureCode) S1APProcedure {
 		return S1APProcedureMMEStatusTransfer
 	case s1ap.ProcENBConfigurationTransfer:
 		return S1APProcedureENBConfigurationTransfer
+	case s1ap.ProcERABModificationIndication:
+		return S1APProcedureERABModificationIndication
 	case s1ap.ProcMMEConfigurationTransfer:
 		return S1APProcedureMMEConfigurationTransfer
 	default:
@@ -143,6 +147,8 @@ func s1apSuccessfulOutcomeType(code s1ap.ProcedureCode) S1APProcedure {
 		return S1APProcedureERABSetupResponse
 	case s1ap.ProcERABModify:
 		return S1APProcedureERABModifyResponse
+	case s1ap.ProcERABModificationIndication:
+		return S1APProcedureERABModificationConfirm
 	case s1ap.ProcERABRelease:
 		return S1APProcedureERABReleaseResponse
 	case s1ap.ProcPathSwitchRequest:

--- a/internal/mme/s1ap_transport.go
+++ b/internal/mme/s1ap_transport.go
@@ -42,7 +42,7 @@ func (c *UeConn) SendS1AP(ctx context.Context, messageType S1APProcedure, b []by
 		return
 	}
 
-	c.m.SendS1APConn(ctx, c.conn, messageType, b)
+	c.m.SendToRadio(ctx, c.conn, messageType, b)
 }
 
 // s1apStreamForProcedure returns the SCTP stream for an S1AP procedure: the reserved
@@ -60,9 +60,9 @@ func s1apStreamForProcedure(p S1APProcedure) uint16 {
 	}
 }
 
-// SendS1APConn writes a complete S1AP PDU to a specific eNB association — the single
+// SendToRadio writes a complete S1AP PDU to a specific eNB association — the single
 // traced+logged send chokepoint. The SCTP stream is derived from the procedure.
-func (m *MME) SendS1APConn(ctx context.Context, conn S1APWriter, messageType S1APProcedure, b []byte) {
+func (m *MME) SendToRadio(ctx context.Context, conn S1APWriter, messageType S1APProcedure, b []byte) {
 	ctx, span := Tracer.Start(ctx, "s1ap/send",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -73,6 +73,11 @@ func (m *MME) SendS1APConn(ctx context.Context, conn S1APWriter, messageType S1A
 		),
 	)
 	defer span.End()
+
+	if conn == nil {
+		logger.From(ctx, logger.MmeLog).Error("cannot send S1AP message: eNB connection is nil", zap.String("message-type", string(messageType)))
+		return
+	}
 
 	if _, err := conn.WriteMsg(b, &sctp.SndRcvInfo{PPID: S1apWirePPID, Stream: s1apStreamForProcedure(messageType)}); err != nil {
 		span.RecordError(err)

--- a/internal/mme/send.go
+++ b/internal/mme/send.go
@@ -111,7 +111,7 @@ func downlinkNASTransportBytes(mmeID s1ap.MMEUES1APID, enbID s1ap.ENBUES1APID, n
 // association — so no handler re-derives the IDs by hand. Each returns a marshal
 // error; send errors are logged by
 // SendS1AP. Commands targeting a *different* association (in-flight handover) keep
-// using SendS1APConn.
+// using SendToRadio.
 
 // SendInitialContextSetup stamps the UE identities and sends the Initial Context
 // Setup Request on the UE's eNB association (TS 36.413 §8.3).

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -55,6 +55,13 @@ func (m *MME) ReleaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Ca
 		return
 	}
 
+	// Deactivate before the S1 UE Context Release Command so a concurrent downlink is
+	// buffered for paging (TS 23.401 §5.3.5: Release Access Bearers precedes the release
+	// command). Only a registered UE transitions to ECM-IDLE.
+	if ue.EMMState() == EMMRegistered {
+		m.DeactivateAllSessions(ctx, ue)
+	}
+
 	conn.SendUEContextReleaseCommand(ctx, cause)
 
 	// Supervise the Release Complete: a lost Complete (or a command that could not be

--- a/internal/upf/engine/delete_session.go
+++ b/internal/upf/engine/delete_session.go
@@ -39,11 +39,9 @@ func (conn *SessionEngine) DeleteSession(ctx context.Context, req *models.Delete
 	bpfObjects := conn.BpfObjects
 	pdrContext := NewPDRCreationContext(session, conn.FteIDResourceManager)
 
-	// Delete every PDR best-effort. A PDR whose BPF map entry is already gone —
-	// e.g. a duplicate PDR sharing a downlink UE-IP key that an earlier iteration
-	// removed — is a benign no-op: the session must still be fully removed,
-	// otherwise the engine keeps reporting usage for a torn-down session and its
-	// stale forwarding state leaks into a later session that reuses the UE IP.
+	// An already-removed PDR map key is a benign no-op; the session must still be fully
+	// removed so a torn-down session is not orphaned in the engine (reporting usage and
+	// leaking forwarding state to a later session that reuses the UE IP).
 	var pdrErr error
 
 	for _, pdrInfo := range session.ListPDRs() {

--- a/nas/eps/emm_attach_accept.go
+++ b/nas/eps/emm_attach_accept.go
@@ -192,14 +192,14 @@ func ParseAttachComplete(b []byte) (*AttachComplete, error) {
 // REJECT.
 type AttachReject struct {
 	Cause uint8
-	// T3402 is the encoded one-octet GPRS timer value (§9.9.3.16); 0 omits the IE.
+	// T3402 is the encoded one-octet GPRS timer value (§9.9.3.16A); 0 omits the IE.
 	T3402 uint8
 }
 
 // attachRejectIEs are the optional IEs Ella Core emits in an ATTACH REJECT: the
-// T3402 value, a type-2 (TV) IE with a one-octet value.
+// T3402 value, a type-4 (TLV) "GPRS timer 2" IE with a one-octet value (§8.2.3.4).
 var attachRejectIEs = []common.OptionalIE{
-	{IEI: t3402ValueIEI, Format: common.IETV3, Len: 1},
+	{IEI: t3402ValueIEI, Format: common.IETLV},
 }
 
 // Marshal encodes the plain ATTACH REJECT message.
@@ -211,7 +211,10 @@ func (m *AttachReject) Marshal() ([]byte, error) {
 
 	if m.T3402 != 0 {
 		w.U8(t3402ValueIEI)
-		w.U8(m.T3402)
+
+		if err := w.LV([]byte{m.T3402}); err != nil {
+			return nil, err
+		}
 	}
 
 	return w.Bytes(), nil

--- a/nas/eps/emm_guti_realloc.go
+++ b/nas/eps/emm_guti_realloc.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package eps
+
+import "github.com/ellanetworks/core/nas/common"
+
+// GUTIReallocationCommand is the GUTI REALLOCATION COMMAND message
+// (TS 24.301 §8.2.16). The assigned GUTI is the only mandatory information
+// element (an LV); the optional TAI list and other IEs are not emitted, as a
+// standalone reallocation leaves the registration area unchanged.
+type GUTIReallocationCommand struct {
+	GUTI EPSMobileIdentity
+}
+
+// Marshal encodes the plain GUTI REALLOCATION COMMAND message.
+func (m *GUTIReallocationCommand) Marshal() ([]byte, error) {
+	var w common.Writer
+
+	writeEMMHeader(&w, MsgGUTIReallocationCommand)
+
+	v, err := m.GUTI.encode()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := w.LV(v); err != nil {
+		return nil, err
+	}
+
+	return w.Bytes(), nil
+}
+
+// ParseGUTIReallocationCommand decodes a plain GUTI REALLOCATION COMMAND message.
+func ParseGUTIReallocationCommand(b []byte) (*GUTIReallocationCommand, error) {
+	r := common.NewReader(b)
+
+	if err := readEMMHeader(r, MsgGUTIReallocationCommand); err != nil {
+		return nil, err
+	}
+
+	v, err := r.LV()
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := decodeEPSMobileIdentity(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GUTIReallocationCommand{GUTI: id}, nil
+}
+
+// GUTIReallocationComplete is the GUTI REALLOCATION COMPLETE message
+// (TS 24.301 §8.2.17), which carries no information elements.
+type GUTIReallocationComplete struct{}
+
+// Marshal encodes the plain GUTI REALLOCATION COMPLETE message.
+func (m *GUTIReallocationComplete) Marshal() ([]byte, error) {
+	var w common.Writer
+
+	writeEMMHeader(&w, MsgGUTIReallocationComplete)
+
+	return w.Bytes(), nil
+}
+
+// ParseGUTIReallocationComplete decodes a plain GUTI REALLOCATION COMPLETE message.
+func ParseGUTIReallocationComplete(b []byte) (*GUTIReallocationComplete, error) {
+	r := common.NewReader(b)
+
+	if err := readEMMHeader(r, MsgGUTIReallocationComplete); err != nil {
+		return nil, err
+	}
+
+	return &GUTIReallocationComplete{}, nil
+}

--- a/nas/eps/emm_guti_realloc.go
+++ b/nas/eps/emm_guti_realloc.go
@@ -5,10 +5,9 @@ package eps
 
 import "github.com/ellanetworks/core/nas/common"
 
-// GUTIReallocationCommand is the GUTI REALLOCATION COMMAND message
-// (TS 24.301 §8.2.16). The assigned GUTI is the only mandatory information
-// element (an LV); the optional TAI list and other IEs are not emitted, as a
-// standalone reallocation leaves the registration area unchanged.
+// GUTIReallocationCommand is the GUTI REALLOCATION COMMAND message (TS 24.301 §8.2.16).
+// The assigned GUTI is the only mandatory IE (an LV); the optional TAI list is omitted,
+// as a standalone reallocation leaves the registration area unchanged.
 type GUTIReallocationCommand struct {
 	GUTI EPSMobileIdentity
 }

--- a/nas/eps/emm_guti_realloc_test.go
+++ b/nas/eps/emm_guti_realloc_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package eps
+
+import "testing"
+
+func TestGUTIReallocationCommandRoundTrip(t *testing.T) {
+	guti := EPSMobileIdentity{Type: IdentityGUTI, MCC: "001", MNC: "01", MMEGroupID: 1, MMECode: 1, MTMSI: 0x01020304}
+
+	b, err := (&GUTIReallocationCommand{GUTI: guti}).Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if MessageType(b[1]) != MsgGUTIReallocationCommand {
+		t.Fatalf("message type = %#x, want %#x", b[1], MsgGUTIReallocationCommand)
+	}
+
+	got, err := ParseGUTIReallocationCommand(b)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if got.GUTI != guti {
+		t.Fatalf("GUTI = %+v, want %+v", got.GUTI, guti)
+	}
+}
+
+func TestGUTIReallocationCompleteRoundTrip(t *testing.T) {
+	b, err := (&GUTIReallocationComplete{}).Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if MessageType(b[1]) != MsgGUTIReallocationComplete {
+		t.Fatalf("message type = %#x, want %#x", b[1], MsgGUTIReallocationComplete)
+	}
+
+	if _, err := ParseGUTIReallocationComplete(b); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+}

--- a/nas/eps/emm_negotiation_test.go
+++ b/nas/eps/emm_negotiation_test.go
@@ -148,8 +148,7 @@ func TestAttachNetworkRoundTrips(t *testing.T) {
 		}
 
 		// The ATTACH REJECT T3402 is IEI 0x16 "GPRS timer 2", TLV (TS 24.301
-		// §8.2.3.1) — not the ATTACH ACCEPT's IEI 0x17 TV. Header (2) + cause (1),
-		// then 0x16, length 1, value.
+		// §8.2.3.1) — not the ATTACH ACCEPT's IEI 0x17 TV.
 		want := []byte{b[0], b[1], 11, 0x16, 0x01, t3402}
 		if !bytes.Equal(b, want) {
 			t.Fatalf("ATTACH REJECT T3402 encoding = % x, want % x", b, want)

--- a/nas/eps/emm_negotiation_test.go
+++ b/nas/eps/emm_negotiation_test.go
@@ -146,6 +146,14 @@ func TestAttachNetworkRoundTrips(t *testing.T) {
 		if err != nil || out.Cause != 11 || out.T3402 != t3402 {
 			t.Fatalf("T3402 round-trip: got %+v (want cause 11, T3402 %#x), err %v", out, t3402, err)
 		}
+
+		// The ATTACH REJECT T3402 is IEI 0x16 "GPRS timer 2", TLV (TS 24.301
+		// §8.2.3.1) — not the ATTACH ACCEPT's IEI 0x17 TV. Header (2) + cause (1),
+		// then 0x16, length 1, value.
+		want := []byte{b[0], b[1], 11, 0x16, 0x01, t3402}
+		if !bytes.Equal(b, want) {
+			t.Fatalf("ATTACH REJECT T3402 encoding = % x, want % x", b, want)
+		}
 	})
 }
 

--- a/nas/eps/iei.go
+++ b/nas/eps/iei.go
@@ -17,6 +17,7 @@ const (
 	// carried in ATTACH ACCEPT and TRACKING AREA UPDATE ACCEPT.
 	epsNetworkFeatureSupportIEI = 0x64
 	// t3402ValueIEI is the T3402 value IE in ATTACH REJECT (TS 24.301 §8.2.3.4): a
-	// type-2 (TV) IE carrying a one-octet GPRS timer value (§9.9.3.16).
-	t3402ValueIEI = 0x17
+	// type-4 (TLV) "GPRS timer 2" IE carrying a one-octet timer value (§9.9.3.16A).
+	// Distinct from the ATTACH ACCEPT T3402 (IEI 0x17, type-2 TV, §9.9.3.16).
+	t3402ValueIEI = 0x16
 )

--- a/nas/eps/message.go
+++ b/nas/eps/message.go
@@ -14,22 +14,24 @@ import (
 type MessageType uint8
 
 const (
-	MsgAttachRequest          MessageType = 0x41
-	MsgAttachAccept           MessageType = 0x42
-	MsgAttachComplete         MessageType = 0x43
-	MsgAttachReject           MessageType = 0x44
-	MsgDetachRequest          MessageType = 0x45
-	MsgDetachAccept           MessageType = 0x46
-	MsgAuthenticationRequest  MessageType = 0x52
-	MsgAuthenticationResponse MessageType = 0x53
-	MsgAuthenticationReject   MessageType = 0x54
-	MsgIdentityRequest        MessageType = 0x55
-	MsgIdentityResponse       MessageType = 0x56
-	MsgAuthenticationFailure  MessageType = 0x5c
-	MsgSecurityModeCommand    MessageType = 0x5d
-	MsgSecurityModeComplete   MessageType = 0x5e
-	MsgSecurityModeReject     MessageType = 0x5f
-	MsgEMMStatus              MessageType = 0x60
+	MsgAttachRequest            MessageType = 0x41
+	MsgAttachAccept             MessageType = 0x42
+	MsgAttachComplete           MessageType = 0x43
+	MsgAttachReject             MessageType = 0x44
+	MsgDetachRequest            MessageType = 0x45
+	MsgDetachAccept             MessageType = 0x46
+	MsgGUTIReallocationCommand  MessageType = 0x50
+	MsgGUTIReallocationComplete MessageType = 0x51
+	MsgAuthenticationRequest    MessageType = 0x52
+	MsgAuthenticationResponse   MessageType = 0x53
+	MsgAuthenticationReject     MessageType = 0x54
+	MsgIdentityRequest          MessageType = 0x55
+	MsgIdentityResponse         MessageType = 0x56
+	MsgAuthenticationFailure    MessageType = 0x5c
+	MsgSecurityModeCommand      MessageType = 0x5d
+	MsgSecurityModeComplete     MessageType = 0x5e
+	MsgSecurityModeReject       MessageType = 0x5f
+	MsgEMMStatus                MessageType = 0x60
 )
 
 // ErrNotPlain reports a non-zero security-header type where a plain message was

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -757,9 +757,7 @@ func closeAMF(ctx context.Context, amfInstance *amf.AMF, srv *amfsctp.Server) {
 			logger.AmfLog.Error("failed to build AMF Status Indication", zap.Error(buildErr))
 		} else {
 			for _, ran := range amfInstance.ConnectedRadios() {
-				if err := ran.SendToRadio(ctx, send.NGAPProcedureAMFStatusIndication, pkt); err != nil {
-					logger.AmfLog.Error("failed to send AMF Status Indication to RAN", zap.Error(err))
-				}
+				ran.SendToRadio(ctx, send.NGAPProcedureAMFStatusIndication, pkt)
 			}
 		}
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -757,7 +757,7 @@ func closeAMF(ctx context.Context, amfInstance *amf.AMF, srv *amfsctp.Server) {
 			logger.AmfLog.Error("failed to build AMF Status Indication", zap.Error(buildErr))
 		} else {
 			for _, ran := range amfInstance.ConnectedRadios() {
-				if err := ran.SendToRan(ctx, send.NGAPProcedureAMFStatusIndication, pkt); err != nil {
+				if err := ran.SendToRadio(ctx, send.NGAPProcedureAMFStatusIndication, pkt); err != nil {
 					logger.AmfLog.Error("failed to send AMF Status Indication to RAN", zap.Error(err))
 				}
 			}

--- a/s1ap/cause.go
+++ b/s1ap/cause.go
@@ -36,6 +36,7 @@ var causeGroupRootCount = [causeRootGroups]int{
 // Ella Core emits. Each value is its group's enumeration index, so the same
 // number means different things in different groups — the group prefix names it.
 const (
+	CauseRadioNetworkUnspecified             = 0  // unspecified
 	CauseRadioNetworkUnknownMMEUES1APID      = 13 // unknown-mme-ue-s1ap-id
 	CauseRadioNetworkUnknownPairUES1APID     = 15 // unknown-pair-ue-s1ap-id
 	CauseRadioNetworkMultipleERABIDInstances = 31 // multiple-E-RAB-ID-instances

--- a/s1ap/config_transfer.go
+++ b/s1ap/config_transfer.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/s1ap/aper"
+)
+
+// SONConfigurationTransfer holds the SON Configuration Transfer IE
+// (TS 36.413 §9.2.3.26) as its raw open-type value bytes. The MME does not
+// interpret the SON Information it carries; per §8.15.2/§8.16.2 it relays the IE
+// verbatim from ENB CONFIGURATION TRANSFER into MME CONFIGURATION TRANSFER,
+// decoding only the leading Target eNB-ID to route it.
+type SONConfigurationTransfer []byte
+
+func (c SONConfigurationTransfer) field(id ProtocolIEID) ieField {
+	return ieField{id: id, crit: CriticalityIgnore, enc: func(w *aper.Writer) error {
+		w.WriteOctets(c)
+		return nil
+	}}
+}
+
+// TargetENBID decodes the leading Target eNB-ID, which names the eNB the IE is
+// destined for (TS 36.413 §9.2.3.26: SONConfigurationTransfer ::= SEQUENCE {
+// targeteNB-ID, sourceeNB-ID, sONInformation, iE-Extensions OPTIONAL, ... }).
+// Only the first field is decoded; the rest are relayed as opaque bytes.
+func (c SONConfigurationTransfer) TargetENBID() (TargeteNBID, error) {
+	r := aper.NewReader(c)
+
+	if _, _, err := r.ReadSequencePreamble(true, 1); err != nil {
+		return TargeteNBID{}, fmt.Errorf("s1ap: SONConfigurationTransfer preamble: %w", err)
+	}
+
+	return decodeTargeteNBID(r)
+}
+
+// ENBConfigurationTransfer is the ENB CONFIGURATION TRANSFER message
+// (TS 36.413 §8.15), sent by the eNB to the MME to convey SON configuration for
+// another eNB. The SON Configuration Transfer IE is optional; SONConfigurationTransfer
+// is nil when absent. Only the base variant is modelled — EN-DC and inter-system
+// SON transfers round-trip as unknown IEs.
+type ENBConfigurationTransfer struct {
+	SONConfigurationTransfer SONConfigurationTransfer
+
+	unmodeledIEs
+}
+
+// ParseENBConfigurationTransfer decodes the message from an initiatingMessage
+// open-type payload.
+func ParseENBConfigurationTransfer(value []byte) (*ENBConfigurationTransfer, error) {
+	r := aper.NewReader(value)
+
+	extPresent, _, err := r.ReadSequencePreamble(true, 0)
+	if err != nil {
+		return nil, fmt.Errorf("s1ap: ENBConfigurationTransfer preamble: %w", err)
+	}
+
+	fields, err := decodeIEContainer(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if extPresent {
+		if err := r.SkipExtensionAdditions(); err != nil {
+			return nil, err
+		}
+	}
+
+	m := &ENBConfigurationTransfer{}
+
+	for _, f := range fields {
+		switch f.id {
+		case idSONConfigurationTransferECT:
+			m.SONConfigurationTransfer = SONConfigurationTransfer(f.value)
+		default:
+			m.unknownIEs = append(m.unknownIEs, f)
+		}
+	}
+
+	return m, nil
+}
+
+// MMEConfigurationTransfer is the MME CONFIGURATION TRANSFER message
+// (TS 36.413 §8.16), sent by the MME to relay a SON Configuration Transfer IE to
+// the target eNB.
+type MMEConfigurationTransfer struct {
+	SONConfigurationTransfer SONConfigurationTransfer
+
+	unmodeledIEs
+}
+
+func (m *MMEConfigurationTransfer) encodeBody(w *aper.Writer) error {
+	w.WriteSequencePreamble(true, false, nil)
+
+	var fields []ieField
+
+	if m.SONConfigurationTransfer != nil {
+		fields = append(fields, m.SONConfigurationTransfer.field(idSONConfigurationTransferMCT))
+	}
+
+	for _, e := range m.unknownIEs {
+		fields = append(fields, e.field())
+	}
+
+	return encodeIEContainer(w, fields)
+}
+
+// Marshal encodes the message as a complete S1AP-PDU.
+func (m *MMEConfigurationTransfer) Marshal() ([]byte, error) {
+	var w aper.Writer
+
+	if err := m.encodeBody(&w); err != nil {
+		return nil, err
+	}
+
+	return Marshal(&InitiatingMessage{
+		ProcedureCode: ProcMMEConfigurationTransfer,
+		Criticality:   CriticalityIgnore,
+		Value:         w.Bytes(),
+	})
+}

--- a/s1ap/config_transfer.go
+++ b/s1ap/config_transfer.go
@@ -10,10 +10,8 @@ import (
 )
 
 // SONConfigurationTransfer holds the SON Configuration Transfer IE
-// (TS 36.413 §9.2.3.26) as its raw open-type value bytes. The MME does not
-// interpret the SON Information it carries; per §8.15.2/§8.16.2 it relays the IE
-// verbatim from ENB CONFIGURATION TRANSFER into MME CONFIGURATION TRANSFER,
-// decoding only the leading Target eNB-ID to route it.
+// (TS 36.413 §9.2.3.26) as raw open-type bytes: the MME relays it verbatim and
+// decodes only the leading Target eNB-ID to route it.
 type SONConfigurationTransfer []byte
 
 func (c SONConfigurationTransfer) field(id ProtocolIEID) ieField {
@@ -23,10 +21,9 @@ func (c SONConfigurationTransfer) field(id ProtocolIEID) ieField {
 	}}
 }
 
-// TargetENBID decodes the leading Target eNB-ID, which names the eNB the IE is
-// destined for (TS 36.413 §9.2.3.26: SONConfigurationTransfer ::= SEQUENCE {
-// targeteNB-ID, sourceeNB-ID, sONInformation, iE-Extensions OPTIONAL, ... }).
-// Only the first field is decoded; the rest are relayed as opaque bytes.
+// TargetENBID decodes the leading Target eNB-ID, which names the destination eNB
+// (TS 36.413 §9.2.3.26). The remaining fields (source eNB-ID, SON Information) are
+// relayed as opaque bytes.
 func (c SONConfigurationTransfer) TargetENBID() (TargeteNBID, error) {
 	r := aper.NewReader(c)
 
@@ -38,10 +35,9 @@ func (c SONConfigurationTransfer) TargetENBID() (TargeteNBID, error) {
 }
 
 // ENBConfigurationTransfer is the ENB CONFIGURATION TRANSFER message
-// (TS 36.413 §8.15), sent by the eNB to the MME to convey SON configuration for
-// another eNB. The SON Configuration Transfer IE is optional; SONConfigurationTransfer
-// is nil when absent. Only the base variant is modelled — EN-DC and inter-system
-// SON transfers round-trip as unknown IEs.
+// (TS 36.413 §8.15), sent by an eNB to convey SON configuration for another eNB.
+// SONConfigurationTransfer is nil when the optional IE is absent. Only the base
+// variant is modelled; EN-DC and inter-system SON transfers round-trip as unknown IEs.
 type ENBConfigurationTransfer struct {
 	SONConfigurationTransfer SONConfigurationTransfer
 

--- a/s1ap/config_transfer_test.go
+++ b/s1ap/config_transfer_test.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ellanetworks/core/s1ap/aper"
+)
+
+// sonTransfer builds a SON Configuration Transfer value: a valid leading
+// Target eNB-ID (TS 36.413 §9.2.3.26) followed by opaque bytes standing in for
+// the source eNB-ID and SON Information, which the MME relays without decoding.
+func sonTransfer(t *testing.T, target TargeteNBID, opaque []byte) SONConfigurationTransfer {
+	t.Helper()
+
+	var w aper.Writer
+
+	w.WriteSequencePreamble(true, false, []bool{false})
+
+	if err := target.encode(&w); err != nil {
+		t.Fatalf("encode Target eNB-ID: %v", err)
+	}
+
+	return SONConfigurationTransfer(append(w.Bytes(), opaque...))
+}
+
+// enbConfigTransferWire builds an ENB CONFIGURATION TRANSFER initiatingMessage
+// open-type payload carrying the given SON Configuration Transfer IE, as an eNB
+// would send it.
+func enbConfigTransferWire(t *testing.T, son SONConfigurationTransfer) []byte {
+	t.Helper()
+
+	var w aper.Writer
+
+	w.WriteSequencePreamble(true, false, nil)
+
+	if err := encodeIEContainer(&w, []ieField{son.field(idSONConfigurationTransferECT)}); err != nil {
+		t.Fatalf("encode IE container: %v", err)
+	}
+
+	return w.Bytes()
+}
+
+func TestENBConfigurationTransfer_RelayRoundTrip(t *testing.T) {
+	target := TargeteNBID{
+		GlobalENBID: GlobalENBID{PLMNIdentity: PLMNIdentity{0x00, 0xf1, 0x10}, ENBID: ENBID{Kind: ENBIDMacro, Value: 0x00abc}},
+		SelectedTAI: TAI{PLMNIdentity: PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 7},
+	}
+	opaque := []byte{0xde, 0xad, 0xbe, 0xef}
+	son := sonTransfer(t, target, opaque)
+
+	// Decode the ENB CONFIGURATION TRANSFER as the MME receives it.
+	msg, err := ParseENBConfigurationTransfer(enbConfigTransferWire(t, son))
+	if err != nil {
+		t.Fatalf("ParseENBConfigurationTransfer: %v", err)
+	}
+
+	if msg.SONConfigurationTransfer == nil {
+		t.Fatal("SON Configuration Transfer IE missing")
+	}
+
+	if !bytes.Equal(msg.SONConfigurationTransfer, son) {
+		t.Fatalf("SON value not preserved: got %x want %x", msg.SONConfigurationTransfer, son)
+	}
+
+	// Routing: the leading Target eNB-ID must decode to the destination eNB.
+	got, err := msg.SONConfigurationTransfer.TargetENBID()
+	if err != nil {
+		t.Fatalf("TargetENBID: %v", err)
+	}
+
+	if got.GlobalENBID != target.GlobalENBID || got.SelectedTAI != target.SelectedTAI {
+		t.Fatalf("Target eNB-ID mismatch: got %+v want %+v", got, target)
+	}
+
+	// Relay: the same IE re-emitted as MME CONFIGURATION TRANSFER (proc 41),
+	// carried verbatim under id-SONConfigurationTransferMCT.
+	wire, err := (&MMEConfigurationTransfer{SONConfigurationTransfer: msg.SONConfigurationTransfer}).Marshal()
+	if err != nil {
+		t.Fatalf("MMEConfigurationTransfer.Marshal: %v", err)
+	}
+
+	pdu, err := Unmarshal(wire)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	im, ok := pdu.(*InitiatingMessage)
+	if !ok || im.ProcedureCode != ProcMMEConfigurationTransfer {
+		t.Fatalf("expected InitiatingMessage/ProcMMEConfigurationTransfer, got %T proc %d", pdu, pdu.procedureCode())
+	}
+
+	relayed := relayedSON(t, im.Value)
+	if !bytes.Equal(relayed, son) {
+		t.Fatalf("relayed SON not verbatim: got %x want %x", relayed, son)
+	}
+}
+
+// relayedSON extracts the SON Configuration Transfer IE (id-...MCT) value from an
+// MME CONFIGURATION TRANSFER body.
+func relayedSON(t *testing.T, value []byte) []byte {
+	t.Helper()
+
+	r := aper.NewReader(value)
+
+	if _, _, err := r.ReadSequencePreamble(true, 0); err != nil {
+		t.Fatalf("body preamble: %v", err)
+	}
+
+	fields, err := decodeIEContainer(r)
+	if err != nil {
+		t.Fatalf("decode container: %v", err)
+	}
+
+	for _, f := range fields {
+		if f.id == idSONConfigurationTransferMCT {
+			return f.value
+		}
+	}
+
+	t.Fatal("id-SONConfigurationTransferMCT not found in MME CONFIGURATION TRANSFER")
+
+	return nil
+}
+
+func TestENBConfigurationTransfer_NoSONIE(t *testing.T) {
+	var w aper.Writer
+
+	w.WriteSequencePreamble(true, false, nil)
+
+	if err := encodeIEContainer(&w, nil); err != nil {
+		t.Fatalf("encode empty container: %v", err)
+	}
+
+	msg, err := ParseENBConfigurationTransfer(w.Bytes())
+	if err != nil {
+		t.Fatalf("ParseENBConfigurationTransfer: %v", err)
+	}
+
+	if msg.SONConfigurationTransfer != nil {
+		t.Fatalf("expected nil SON Configuration Transfer, got %x", msg.SONConfigurationTransfer)
+	}
+}

--- a/s1ap/erab_modification.go
+++ b/s1ap/erab_modification.go
@@ -10,9 +10,8 @@ import (
 )
 
 // ERABToBeModifiedItemBearerModInd ::= SEQUENCE { e-RAB-ID, transportLayerAddress,
-// dL-GTP-TEID, iE-Extensions OPTIONAL } (extensible). For one E-RAB it names the new
-// downlink S1-U endpoint the eNB requests the S-GW relocate the GTP tunnel to
-// (TS 36.413 §9.2.1.31); this is the DC / secondary-node bearer relocation case.
+// dL-GTP-TEID, iE-Extensions OPTIONAL } (extensible). Names the new downlink S1-U
+// endpoint to relocate one E-RAB's GTP tunnel to (TS 36.413 §9.2.1.31).
 type ERABToBeModifiedItemBearerModInd struct {
 	ERABID                ERABID
 	TransportLayerAddress TransportLayerAddress
@@ -62,8 +61,7 @@ func decodeERABToBeModifiedItemBearerModInd(r *aper.Reader) (ERABToBeModifiedIte
 
 // ERABModificationIndication is the E-RAB MODIFICATION INDICATION message
 // (TS 36.413 §9.1.3.8), sent by the eNB to relocate the downlink S1-U endpoint of
-// already-established E-RABs. ToBeModified is mandatory; NotToBeModified lists the
-// unchanged E-RABs the eNB still wants kept, and is optional.
+// already-established E-RABs. ToBeModified is mandatory; NotToBeModified is optional.
 type ERABModificationIndication struct {
 	MMEUES1APID     MMEUES1APID
 	ENBUES1APID     ENBUES1APID

--- a/s1ap/erab_modification.go
+++ b/s1ap/erab_modification.go
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/s1ap/aper"
+)
+
+// ERABToBeModifiedItemBearerModInd ::= SEQUENCE { e-RAB-ID, transportLayerAddress,
+// dL-GTP-TEID, iE-Extensions OPTIONAL } (extensible). For one E-RAB it names the new
+// downlink S1-U endpoint the eNB requests the S-GW relocate the GTP tunnel to
+// (TS 36.413 §9.2.1.31); this is the DC / secondary-node bearer relocation case.
+type ERABToBeModifiedItemBearerModInd struct {
+	ERABID                ERABID
+	TransportLayerAddress TransportLayerAddress
+	DLGTPTEID             GTPTEID
+}
+
+func (it ERABToBeModifiedItemBearerModInd) encode(w *aper.Writer) error {
+	w.WriteSequencePreamble(true, false, []bool{false})
+
+	if err := it.ERABID.encode(w); err != nil {
+		return err
+	}
+
+	if err := it.TransportLayerAddress.encode(w); err != nil {
+		return err
+	}
+
+	return it.DLGTPTEID.encode(w)
+}
+
+func decodeERABToBeModifiedItemBearerModInd(r *aper.Reader) (ERABToBeModifiedItemBearerModInd, error) {
+	extPresent, opt, err := r.ReadSequencePreamble(true, 1)
+	if err != nil {
+		return ERABToBeModifiedItemBearerModInd{}, err
+	}
+
+	var it ERABToBeModifiedItemBearerModInd
+
+	if it.ERABID, err = decodeERABID(r); err != nil {
+		return it, err
+	}
+
+	if it.TransportLayerAddress, err = decodeTransportLayerAddress(r); err != nil {
+		return it, err
+	}
+
+	if it.DLGTPTEID, err = decodeGTPTEID(r); err != nil {
+		return it, err
+	}
+
+	if err := skipSequenceExtensions(r, opt[0], extPresent); err != nil {
+		return it, err
+	}
+
+	return it, nil
+}
+
+// ERABModificationIndication is the E-RAB MODIFICATION INDICATION message
+// (TS 36.413 §9.1.3.8), sent by the eNB to relocate the downlink S1-U endpoint of
+// already-established E-RABs. ToBeModified is mandatory; NotToBeModified lists the
+// unchanged E-RABs the eNB still wants kept, and is optional.
+type ERABModificationIndication struct {
+	MMEUES1APID     MMEUES1APID
+	ENBUES1APID     ENBUES1APID
+	ToBeModified    []ERABToBeModifiedItemBearerModInd
+	NotToBeModified []ERABToBeModifiedItemBearerModInd
+
+	unmodeledIEs
+}
+
+func (m *ERABModificationIndication) encodeBody(w *aper.Writer) error {
+	w.WriteSequencePreamble(true, false, nil)
+
+	fields := []ieField{
+		{id: idMMEUES1APID, crit: CriticalityReject, enc: m.MMEUES1APID.encode},
+		{id: idENBUES1APID, crit: CriticalityReject, enc: m.ENBUES1APID.encode},
+		{id: idERABToBeModifiedListBearerModInd, crit: CriticalityReject, enc: func(w *aper.Writer) error {
+			return encodeSingleContainerList(w, maxnoofERABs, idERABToBeModifiedItemBearerModInd, CriticalityReject, encoderList(m.ToBeModified))
+		}},
+	}
+
+	if len(m.NotToBeModified) > 0 {
+		fields = append(fields, ieField{id: idERABNotToBeModifiedListBearerModInd, crit: CriticalityReject, enc: func(w *aper.Writer) error {
+			return encodeSingleContainerList(w, maxnoofERABs, idERABNotToBeModifiedItemBearerModInd, CriticalityReject, encoderList(m.NotToBeModified))
+		}})
+	}
+
+	for _, e := range m.unknownIEs {
+		fields = append(fields, e.field())
+	}
+
+	return encodeIEContainer(w, fields)
+}
+
+// Marshal encodes the message as a complete S1AP-PDU (an eNB-side operation,
+// provided for interop testing; the MME only decodes this message).
+func (m *ERABModificationIndication) Marshal() ([]byte, error) {
+	var w aper.Writer
+
+	if err := m.encodeBody(&w); err != nil {
+		return nil, err
+	}
+
+	return Marshal(&InitiatingMessage{
+		ProcedureCode: ProcERABModificationIndication,
+		Criticality:   CriticalityReject,
+		Value:         w.Bytes(),
+	})
+}
+
+// ParseERABModificationIndication decodes the message from an initiatingMessage
+// open-type payload.
+func ParseERABModificationIndication(value []byte) (*ERABModificationIndication, error) {
+	r := aper.NewReader(value)
+
+	extPresent, _, err := r.ReadSequencePreamble(true, 0)
+	if err != nil {
+		return nil, fmt.Errorf("s1ap: ERABModificationIndication preamble: %w", err)
+	}
+
+	fields, err := decodeIEContainer(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if extPresent {
+		if err := r.SkipExtensionAdditions(); err != nil {
+			return nil, err
+		}
+	}
+
+	m := &ERABModificationIndication{}
+
+	var seenMME, seenENB, seenToBeModified bool
+
+	for _, f := range fields {
+		sub := aper.NewReader(f.value)
+
+		switch f.id {
+		case idMMEUES1APID:
+			m.MMEUES1APID, err = decodeMMEUES1APID(sub)
+			seenMME = true
+		case idENBUES1APID:
+			m.ENBUES1APID, err = decodeENBUES1APID(sub)
+			seenENB = true
+		case idERABToBeModifiedListBearerModInd:
+			m.ToBeModified, err = decodeItemList(sub, maxnoofERABs, decodeERABToBeModifiedItemBearerModInd)
+			seenToBeModified = true
+		case idERABNotToBeModifiedListBearerModInd:
+			m.NotToBeModified, err = decodeItemList(sub, maxnoofERABs, decodeERABToBeModifiedItemBearerModInd)
+		default:
+			m.unknownIEs = append(m.unknownIEs, f)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("s1ap: ERABModificationIndication IE %d: %w", f.id, err)
+		}
+	}
+
+	if !seenMME || !seenENB || !seenToBeModified {
+		return nil, fmt.Errorf("s1ap: ERABModificationIndication missing mandatory IE")
+	}
+
+	return m, nil
+}
+
+// erabModifyItemBearerModConf ::= SEQUENCE { e-RAB-ID, iE-Extensions OPTIONAL }
+// (extensible). It confirms one E-RAB whose downlink endpoint was relocated.
+type erabModifyItemBearerModConf struct {
+	erabID ERABID
+}
+
+func (it erabModifyItemBearerModConf) encode(w *aper.Writer) error {
+	w.WriteSequencePreamble(true, false, []bool{false})
+
+	return it.erabID.encode(w)
+}
+
+// ERABModificationConfirm is the E-RAB MODIFICATION CONFIRM message
+// (TS 36.413 §9.1.3.9), the MME's successful response listing the E-RABs whose
+// downlink endpoint it relocated.
+type ERABModificationConfirm struct {
+	MMEUES1APID   MMEUES1APID
+	ENBUES1APID   ENBUES1APID
+	ModifiedERABs []ERABID
+
+	unmodeledIEs
+}
+
+func (m *ERABModificationConfirm) encodeBody(w *aper.Writer) error {
+	w.WriteSequencePreamble(true, false, nil)
+
+	fields := []ieField{
+		{id: idMMEUES1APID, crit: CriticalityIgnore, enc: m.MMEUES1APID.encode},
+		{id: idENBUES1APID, crit: CriticalityIgnore, enc: m.ENBUES1APID.encode},
+	}
+
+	if len(m.ModifiedERABs) > 0 {
+		items := make([]erabModifyItemBearerModConf, len(m.ModifiedERABs))
+		for i, id := range m.ModifiedERABs {
+			items[i] = erabModifyItemBearerModConf{erabID: id}
+		}
+
+		fields = append(fields, ieField{
+			id:   idERABModifyListBearerModConf,
+			crit: CriticalityIgnore,
+			enc: func(w *aper.Writer) error {
+				return encodeSingleContainerList(w, maxnoofERABs, idERABModifyItemBearerModConf, CriticalityIgnore, encoderList(items))
+			},
+		})
+	}
+
+	for _, e := range m.unknownIEs {
+		fields = append(fields, e.field())
+	}
+
+	return encodeIEContainer(w, fields)
+}
+
+// Marshal encodes the message as a complete S1AP-PDU.
+func (m *ERABModificationConfirm) Marshal() ([]byte, error) {
+	var w aper.Writer
+
+	if err := m.encodeBody(&w); err != nil {
+		return nil, err
+	}
+
+	return Marshal(&SuccessfulOutcome{
+		ProcedureCode: ProcERABModificationIndication,
+		Criticality:   CriticalityReject,
+		Value:         w.Bytes(),
+	})
+}

--- a/s1ap/erab_modification_test.go
+++ b/s1ap/erab_modification_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ellanetworks/core/s1ap/aper"
+)
+
+// erabModIndicationWire builds an E-RAB MODIFICATION INDICATION initiatingMessage
+// open-type payload, as an eNB would send it.
+func erabModIndicationWire(t *testing.T, items []ERABToBeModifiedItemBearerModInd) []byte {
+	t.Helper()
+
+	var w aper.Writer
+
+	w.WriteSequencePreamble(true, false, nil)
+
+	err := encodeIEContainer(&w, []ieField{
+		{id: idMMEUES1APID, crit: CriticalityReject, enc: MMEUES1APID(1).encode},
+		{id: idENBUES1APID, crit: CriticalityReject, enc: ENBUES1APID(2).encode},
+		{id: idERABToBeModifiedListBearerModInd, crit: CriticalityReject, enc: func(w *aper.Writer) error {
+			return encodeSingleContainerList(w, maxnoofERABs, idERABToBeModifiedItemBearerModInd, CriticalityReject, encoderList(items))
+		}},
+	})
+	if err != nil {
+		t.Fatalf("encode indication: %v", err)
+	}
+
+	return w.Bytes()
+}
+
+func TestERABModificationIndication_Decode(t *testing.T) {
+	items := []ERABToBeModifiedItemBearerModInd{
+		{ERABID: 5, TransportLayerAddress: TransportLayerAddress{10, 0, 0, 1}, DLGTPTEID: 0x11223344},
+		{ERABID: 6, TransportLayerAddress: TransportLayerAddress{10, 0, 0, 2}, DLGTPTEID: 0x55667788},
+	}
+
+	msg, err := ParseERABModificationIndication(erabModIndicationWire(t, items))
+	if err != nil {
+		t.Fatalf("ParseERABModificationIndication: %v", err)
+	}
+
+	if msg.MMEUES1APID != 1 || msg.ENBUES1APID != 2 {
+		t.Fatalf("UE IDs = (%d,%d), want (1,2)", msg.MMEUES1APID, msg.ENBUES1APID)
+	}
+
+	if len(msg.ToBeModified) != 2 {
+		t.Fatalf("ToBeModified count = %d, want 2", len(msg.ToBeModified))
+	}
+
+	for i, want := range items {
+		got := msg.ToBeModified[i]
+		if got.ERABID != want.ERABID || got.DLGTPTEID != want.DLGTPTEID ||
+			!bytes.Equal(got.TransportLayerAddress, want.TransportLayerAddress) {
+			t.Fatalf("item %d = %+v, want %+v", i, got, want)
+		}
+	}
+}
+
+func TestERABModificationIndication_MissingMandatoryIE(t *testing.T) {
+	var w aper.Writer
+
+	w.WriteSequencePreamble(true, false, nil)
+
+	// Only the UE IDs, no E-RABToBeModified list (mandatory).
+	if err := encodeIEContainer(&w, []ieField{
+		{id: idMMEUES1APID, crit: CriticalityReject, enc: MMEUES1APID(1).encode},
+		{id: idENBUES1APID, crit: CriticalityReject, enc: ENBUES1APID(2).encode},
+	}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	if _, err := ParseERABModificationIndication(w.Bytes()); err == nil {
+		t.Fatal("expected error for missing E-RABToBeModified list, got nil")
+	}
+}
+
+func TestERABModificationConfirm_Marshal(t *testing.T) {
+	wire, err := (&ERABModificationConfirm{MMEUES1APID: 1, ENBUES1APID: 2, ModifiedERABs: []ERABID{5, 6}}).Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	pdu, err := Unmarshal(wire)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	so, ok := pdu.(*SuccessfulOutcome)
+	if !ok || so.ProcedureCode != ProcERABModificationIndication {
+		t.Fatalf("expected SuccessfulOutcome/ProcERABModificationIndication, got %T proc %d", pdu, pdu.procedureCode())
+	}
+
+	// The confirm body must carry the E-RABModifyListBearerModConf IE.
+	r := aper.NewReader(so.Value)
+	if _, _, err := r.ReadSequencePreamble(true, 0); err != nil {
+		t.Fatalf("body preamble: %v", err)
+	}
+
+	fields, err := decodeIEContainer(r)
+	if err != nil {
+		t.Fatalf("decode container: %v", err)
+	}
+
+	var seenList bool
+
+	for _, f := range fields {
+		if f.id == idERABModifyListBearerModConf {
+			seenList = true
+		}
+	}
+
+	if !seenList {
+		t.Fatal("E-RABModifyListBearerModConf IE missing from confirm")
+	}
+}

--- a/s1ap/ie_ids.go
+++ b/s1ap/ie_ids.go
@@ -74,4 +74,10 @@ const (
 	idUERadioCapabilityForPaging                ProtocolIEID = 117
 	idRRCEstablishmentCause                     ProtocolIEID = 134
 	idDefaultPagingDRX                          ProtocolIEID = 137
+	idERABToBeModifiedListBearerModInd          ProtocolIEID = 199
+	idERABToBeModifiedItemBearerModInd          ProtocolIEID = 200
+	idERABNotToBeModifiedListBearerModInd       ProtocolIEID = 201
+	idERABNotToBeModifiedItemBearerModInd       ProtocolIEID = 202
+	idERABModifyListBearerModConf               ProtocolIEID = 203
+	idERABModifyItemBearerModConf               ProtocolIEID = 204
 )

--- a/s1ap/ie_ids.go
+++ b/s1ap/ie_ids.go
@@ -54,6 +54,8 @@ const (
 	idENBStatusTransferTransparentContainer     ProtocolIEID = 90
 	idSourceToTargetTransparentContainer        ProtocolIEID = 104
 	idTargetToSourceTransparentContainer        ProtocolIEID = 123
+	idSONConfigurationTransferECT               ProtocolIEID = 129
+	idSONConfigurationTransferMCT               ProtocolIEID = 130
 	idSecurityKey                               ProtocolIEID = 73
 	idUERadioCapability                         ProtocolIEID = 74
 	idGUMMEI                                    ProtocolIEID = 75


### PR DESCRIPTION
# Description

- Serving‑TAI restriction: the MME now rejects a UE whose serving cell is outside the operator's served area matching the AMF.
- RAN Configuration Transfer: the MME now relays SON configuration between eNBs (proc 40→41), including a new in‑repo S1AP codec for the message, parity with the AMF's spec‑mandated relay.
 - E‑RAB Modification Indication: new S1AP codec + handler that relocates a bearer's downlink endpoint (the 4G peer of the AMF's PDU Session Resource Modify Indication), including the 4G‑only UE‑Context‑Release on omitted/duplicate E‑RABs.
- Standalone GUTI reallocation: the MME now reassigns the GUTI after a Service Request (new eps codec + T3450 procedure), mirroring the AMF's CONFIGURATION UPDATE for identity confidentiality.
- Removed AMF dead/redundant behavior: deleted the unreachable UE Context Modification handling, dropped the no‑value/harmful serving‑PLMN‑only Mobility Restriction List, and removed the redundant mobility PEI re‑request.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
