### PR TITLE
feat: add static IP allocation support

### DIFF
--- a/client/data_networks.go
+++ b/client/data_networks.go
@@ -212,6 +212,121 @@ func (c *Client) ListDataNetworks(ctx context.Context, p *ListParams) (*ListData
 	return &dataNetworks, nil
 }
 
+type StaticIP struct {
+	IMSI        string `json:"imsi"`
+	DataNetwork string `json:"data_network"`
+	IPVersion   string `json:"ip_version"`
+	Address     string `json:"address"`
+	Status      string `json:"status"`
+	SessionID   *int   `json:"session_id"`
+}
+
+type StaticIPList struct {
+	Items      []StaticIP `json:"items"`
+	Page       int        `json:"page"`
+	PerPage    int        `json:"per_page"`
+	TotalCount int        `json:"total_count"`
+}
+
+type CreateStaticIPOptions struct {
+	IMSI    string `json:"imsi"`
+	Address string `json:"address"`
+}
+
+// ListDataNetworkStaticIps lists the static IP reservations for a data network.
+func (c *Client) ListDataNetworkStaticIps(ctx context.Context, dataNetwork string) (*StaticIPList, error) {
+	resp, err := c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "api/v1/networking/data-networks/" + dataNetwork + "/static-ips",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var list StaticIPList
+
+	err = resp.DecodeResult(&list)
+	if err != nil {
+		return nil, err
+	}
+
+	return &list, nil
+}
+
+// CreateDataNetworkStaticIp pins an address to a subscriber on a data network.
+// The IP version is inferred from the address family.
+func (c *Client) CreateDataNetworkStaticIp(ctx context.Context, dataNetwork string, opts *CreateStaticIPOptions) error {
+	payload := struct {
+		IMSI    string `json:"imsi"`
+		Address string `json:"address"`
+	}{
+		IMSI:    opts.IMSI,
+		Address: opts.Address,
+	}
+
+	var body bytes.Buffer
+
+	err := json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "api/v1/networking/data-networks/" + dataNetwork + "/static-ips",
+		Body:   &body,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateDataNetworkStaticIp repins a subscriber's reservation to a new address.
+func (c *Client) UpdateDataNetworkStaticIp(ctx context.Context, dataNetwork, imsi, ipVersion, address string) error {
+	payload := struct {
+		Address string `json:"address"`
+	}{
+		Address: address,
+	}
+
+	var body bytes.Buffer
+
+	err := json.NewEncoder(&body).Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "PUT",
+		Path:   "api/v1/networking/data-networks/" + dataNetwork + "/static-ips/" + imsi + "/" + ipVersion,
+		Body:   &body,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteDataNetworkStaticIp removes a subscriber's static IP reservation.
+func (c *Client) DeleteDataNetworkStaticIp(ctx context.Context, dataNetwork, imsi, ipVersion string) error {
+	_, err := c.Requester.Do(ctx, &RequestOptions{
+		Type:   SyncRequest,
+		Method: "DELETE",
+		Path:   "api/v1/networking/data-networks/" + dataNetwork + "/static-ips/" + imsi + "/" + ipVersion,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ListIPv4Allocations lists IPv4 allocations for a data network with pagination support.
 func (c *Client) ListIPv4Allocations(ctx context.Context, opts *ListIPAllocationsOptions, p *ListParams) (*ListIPAllocationsResponse, error) {
 	resp, err := c.Requester.Do(ctx, &RequestOptions{

--- a/client/data_networks_test.go
+++ b/client/data_networks_test.go
@@ -319,3 +319,158 @@ func TestListIPv4Allocations_Failure(t *testing.T) {
 		t.Fatalf("expected error, got none")
 	}
 }
+
+func TestListDataNetworkStaticIps_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"items": [{"imsi": "001010000000001", "data_network": "internet", "ip_version": "ipv4", "address": "10.45.0.10", "status": "reserved", "session_id": null}], "page": 1, "per_page": 1, "total_count": 1}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	resp, err := clientObj.ListDataNetworkStaticIps(context.Background(), "internet")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 static IP, got %d", len(resp.Items))
+	}
+
+	it := resp.Items[0]
+	if it.IMSI != "001010000000001" || it.IPVersion != "ipv4" || it.Address != "10.45.0.10" || it.Status != "reserved" {
+		t.Fatalf("unexpected item: %+v", it)
+	}
+
+	if it.SessionID != nil {
+		t.Fatalf("expected nil session_id for reserved, got %v", *it.SessionID)
+	}
+}
+
+func TestListDataNetworkStaticIps_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 404,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "Data Network not found"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	_, err := clientObj.ListDataNetworkStaticIps(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestCreateDataNetworkStaticIp_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 201,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Static IP created successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	err := clientObj.CreateDataNetworkStaticIp(context.Background(), "internet", &client.CreateStaticIPOptions{
+		IMSI:    "001010000000001",
+		Address: "10.45.0.10",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestCreateDataNetworkStaticIp_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 409,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "address is already in use"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	err := clientObj.CreateDataNetworkStaticIp(context.Background(), "internet", &client.CreateStaticIPOptions{
+		IMSI:    "001010000000001",
+		Address: "10.45.0.10",
+	})
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestUpdateDataNetworkStaticIp_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Static IP updated successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	err := clientObj.UpdateDataNetworkStaticIp(context.Background(), "internet", "001010000000001", "ipv4", "10.45.0.20")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestUpdateDataNetworkStaticIp_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 409,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "static IP is in use by an active session"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	err := clientObj.UpdateDataNetworkStaticIp(context.Background(), "internet", "001010000000001", "ipv4", "10.45.0.20")
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
+func TestDeleteDataNetworkStaticIp_Success(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 200,
+			Headers:    http.Header{},
+			Result:     []byte(`{"message": "Static IP deleted successfully"}`),
+		},
+		err: nil,
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	err := clientObj.DeleteDataNetworkStaticIp(context.Background(), "internet", "001010000000001", "ipv4")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestDeleteDataNetworkStaticIp_Failure(t *testing.T) {
+	fake := &fakeRequester{
+		response: &client.RequestResponse{
+			StatusCode: 409,
+			Headers:    http.Header{},
+			Result:     []byte(`{"error": "static IP is in use by an active session"}`),
+		},
+		err: errors.New("requester error"),
+	}
+	clientObj := &client.Client{Requester: fake}
+
+	err := clientObj.DeleteDataNetworkStaticIp(context.Background(), "internet", "001010000000001", "ipv4")
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}

--- a/docs/reference/api/networking.md
+++ b/docs/reference/api/networking.md
@@ -207,6 +207,107 @@ This path returns a paginated list of IPv6 address allocations (leases) for a sp
 
 Each item contains the subscriber's assigned IPv6 /64 prefix.
 
+## List Static IPs
+
+This path returns the static IP reservations for a specific data network.
+
+| Method | Path                           |
+| ------ | ------------------------------ |
+| GET    | `/api/v1/networking/data-networks/{name}/static-ips` |
+
+### Parameters
+
+None
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "items": [
+            {
+                "imsi": "001010100000001",
+                "data_network": "internet",
+                "ip_version": "ipv4",
+                "address": "172.250.0.10",
+                "status": "reserved",
+                "session_id": null
+            }
+        ],
+        "page": 1,
+        "per_page": 1,
+        "total_count": 1
+    }
+}
+```
+
+## Create a Static IP
+
+This path pins an address to a subscriber on a data network. The IP version is inferred from the address family; IPv6 addresses must be /64-aligned.
+
+| Method | Path                           |
+| ------ | ------------------------------ |
+| POST   | `/api/v1/networking/data-networks/{name}/static-ips` |
+
+### Parameters
+
+- `imsi` (string): The IMSI of the subscriber to pin.
+- `address` (string): An IPv4 address or /64-aligned IPv6 prefix within the data network pool. Example: `172.250.0.10`.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "message": "Static IP created successfully"
+    }
+}
+```
+
+## Update a Static IP
+
+This path repins a subscriber's reservation to a new address. It is rejected while the reservation is bound to an active session.
+
+| Method | Path                           |
+| ------ | ------------------------------ |
+| PUT    | `/api/v1/networking/data-networks/{name}/static-ips/{imsi}/{ip_version}` |
+
+### Parameters
+
+- `address` (string): The new IPv4 address or /64-aligned IPv6 prefix within the data network pool. Example: `172.250.0.20`.
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "message": "Static IP updated successfully"
+    }
+}
+```
+
+## Delete a Static IP
+
+This path removes a subscriber's static IP reservation. It is rejected while the reservation is bound to an active session.
+
+| Method | Path                           |
+| ------ | ------------------------------ |
+| DELETE | `/api/v1/networking/data-networks/{name}/static-ips/{imsi}/{ip_version}` |
+
+### Parameters
+
+None
+
+### Sample Response
+
+```json
+{
+    "result": {
+        "message": "Static IP deleted successfully"
+    }
+}
+```
+
 ## Delete a Data Network
 
 This path deletes a data network from Ella Core.

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -21,6 +21,7 @@ This path returns the list of network subscribers.
 | `page`     | query | int  | `1`     | `>= 1`  | 1-based page index.           |
 | `per_page` | query | int  | `25`    | `1…100` | Number of items per page.     |
 | `radio`    | query | str  |         |         | Filter by radio name. Returns only subscribers connected to the specified radio. |
+| `data_network` | query | str |     |         | Filter by data network name. Returns only subscribers whose profile reaches it. |
 
 ### Sample Response
 

--- a/integration/api_matrix_ha_static_ips_test.go
+++ b/integration/api_matrix_ha_static_ips_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runStaticIpsHAMatrix exercises static-IP CRUD across the 3-node cluster,
+// rotating the writer node (create on node 1, repin on node 2, delete on
+// node 3) and asserting every node converges on the reservation state.
+func runStaticIpsHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
+	if len(h.Clients) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(h.Clients))
+	}
+
+	sliceName := apiMatrixName("ha-staticip-slice")
+	dnName := apiMatrixName("ha-staticip-dn")
+	profile := apiMatrixName("ha-staticip-profile")
+	policy := apiMatrixName("ha-staticip-policy")
+	imsi := "001019999999993"
+
+	leader := h.Leader
+	nodes := h.Clients
+
+	if err := leader.CreateSlice(ctx, &client.CreateSliceOptions{Name: sliceName, Sst: 1, Sd: "abcdef"}); err != nil {
+		t.Fatalf("create dep slice: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := leader.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: sliceName}); err != nil {
+			t.Logf("cleanup: delete dep slice: %v", err)
+		}
+	})
+
+	if err := leader.CreateDataNetwork(ctx, &client.CreateDataNetworkOptions{
+		Name: dnName, IPv4Pool: "10.252.0.0/16", DNS: "8.8.8.8", Mtu: 1500,
+	}); err != nil {
+		t.Fatalf("create dep data network: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := leader.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: dnName}); err != nil {
+			t.Logf("cleanup: delete dep data network: %v", err)
+		}
+	})
+
+	if err := leader.CreateProfile(ctx, &client.CreateProfileOptions{
+		Name: profile, UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "100 Mbps",
+	}); err != nil {
+		t.Fatalf("create dep profile: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := leader.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: profile}); err != nil {
+			t.Logf("cleanup: delete dep profile: %v", err)
+		}
+	})
+
+	if err := leader.CreatePolicy(ctx, &client.CreatePolicyOptions{
+		Name: policy, ProfileName: profile, SliceName: sliceName, DataNetworkName: dnName,
+		SessionAmbrUplink: "50 Mbps", SessionAmbrDownlink: "100 Mbps", Var5qi: 9, Arp: 8,
+	}); err != nil {
+		t.Fatalf("create dep policy: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := leader.DeletePolicy(ctx, &client.DeletePolicyOptions{Name: policy}); err != nil {
+			t.Logf("cleanup: delete dep policy: %v", err)
+		}
+	})
+
+	if err := leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+		Imsi: imsi, Key: "640f441067cd56f1474cbcacd7a0588f", SequenceNumber: "000000000022",
+		ProfileName: profile, OPc: "cb698a2341629c3241ae01de9d89de4f",
+	}); err != nil {
+		t.Fatalf("create dep subscriber: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := leader.DeleteSubscriber(ctx, &client.DeleteSubscriberOptions{ID: imsi}); err != nil {
+			t.Logf("cleanup: delete dep subscriber: %v", err)
+		}
+	})
+
+	// Barrier so the dependency chain replicates before the first
+	// follower-proxied static-IP write validates against its local DB.
+	awaitConvergence(ctx, t, h)
+
+	findV4 := func(c *client.Client) *client.StaticIP {
+		resp, err := c.ListDataNetworkStaticIps(ctx, dnName)
+		if err != nil {
+			t.Fatalf("list static IPs: %v", err)
+		}
+
+		for i := range resp.Items {
+			if resp.Items[i].IPVersion == "ipv4" {
+				return &resp.Items[i]
+			}
+		}
+
+		return nil
+	}
+
+	if err := nodes[0].CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "10.252.0.10"}); err != nil {
+		t.Fatalf("create static IP on node 1: %v", err)
+	}
+
+	removed := false
+
+	t.Cleanup(func() {
+		if removed {
+			return
+		}
+
+		if err := leader.DeleteDataNetworkStaticIp(ctx, dnName, imsi, "ipv4"); err != nil {
+			t.Logf("cleanup: delete static IP: %v", err)
+		}
+	})
+
+	awaitConvergence(ctx, t, h)
+
+	for i, c := range nodes {
+		got := findV4(c)
+		if got == nil {
+			t.Fatalf("node %d: static IP missing after create", i+1)
+		}
+
+		if got.IMSI != imsi || got.Address != "10.252.0.10" || got.Status != "reserved" {
+			t.Fatalf("node %d: unexpected reservation after create: %+v", i+1, *got)
+		}
+	}
+
+	if err := nodes[1].UpdateDataNetworkStaticIp(ctx, dnName, imsi, "ipv4", "10.252.0.20"); err != nil {
+		t.Fatalf("repin static IP on node 2: %v", err)
+	}
+
+	awaitConvergence(ctx, t, h)
+
+	for i, c := range nodes {
+		got := findV4(c)
+		if got == nil || got.Address != "10.252.0.20" {
+			t.Fatalf("node %d: repin not converged, got %+v", i+1, got)
+		}
+	}
+
+	if err := nodes[2].DeleteDataNetworkStaticIp(ctx, dnName, imsi, "ipv4"); err != nil {
+		t.Fatalf("delete static IP on node 3: %v", err)
+	}
+
+	removed = true
+
+	awaitConvergence(ctx, t, h)
+
+	for i, c := range nodes {
+		if findV4(c) != nil {
+			t.Fatalf("node %d: static IP still present after delete", i+1)
+		}
+	}
+}

--- a/integration/api_matrix_ha_test.go
+++ b/integration/api_matrix_ha_test.go
@@ -19,6 +19,7 @@ var apiMatrixHAResources = map[string]apiMatrixHARunner{
 	"profiles":                   runProfilesHAMatrix,
 	"slices":                     runSlicesHAMatrix,
 	"data_networks":              runDataNetworksHAMatrix,
+	"static_ips":                 runStaticIpsHAMatrix,
 	"policies":                   runPoliciesHAMatrix,
 	"policy_rules":               runPolicyRulesHAMatrix,
 	"subscribers":                runSubscribersHAMatrix,

--- a/integration/api_matrix_static_ips_test.go
+++ b/integration/api_matrix_static_ips_test.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/client"
+)
+
+// runStaticIpsMatrix provisions the dependency chain a static IP requires
+// (slice → data network → profile → policy → subscriber) then exercises the
+// static-IP CRUD against a live core: create IPv4 + IPv6 pins, list, repin,
+// delete, and the reject paths (duplicate family, out-of-pool address).
+func runStaticIpsMatrix(ctx context.Context, t *testing.T, c *client.Client) {
+	sliceName := apiMatrixName("staticip-slice")
+	dnName := apiMatrixName("staticip-dn")
+	profile := apiMatrixName("staticip-profile")
+	policy := apiMatrixName("staticip-policy")
+	imsi := "001019999999992"
+
+	if err := c.CreateSlice(ctx, &client.CreateSliceOptions{Name: sliceName, Sst: 1, Sd: "abcdef"}); err != nil {
+		t.Fatalf("create dep slice: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteSlice(ctx, &client.DeleteSliceOptions{Name: sliceName}); err != nil {
+			t.Logf("cleanup: delete dep slice: %v", err)
+		}
+	})
+
+	if err := c.CreateDataNetwork(ctx, &client.CreateDataNetworkOptions{
+		Name: dnName, IPv4Pool: "10.252.0.0/16", IPv6Pool: "fd98::/48", DNS: "8.8.8.8", Mtu: 1500,
+	}); err != nil {
+		t.Fatalf("create dep data network: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteDataNetwork(ctx, &client.DeleteDataNetworkOptions{Name: dnName}); err != nil {
+			t.Logf("cleanup: delete dep data network: %v", err)
+		}
+	})
+
+	if err := c.CreateProfile(ctx, &client.CreateProfileOptions{
+		Name: profile, UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "100 Mbps",
+	}); err != nil {
+		t.Fatalf("create dep profile: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteProfile(ctx, &client.DeleteProfileOptions{Name: profile}); err != nil {
+			t.Logf("cleanup: delete dep profile: %v", err)
+		}
+	})
+
+	if err := c.CreatePolicy(ctx, &client.CreatePolicyOptions{
+		Name: policy, ProfileName: profile, SliceName: sliceName, DataNetworkName: dnName,
+		SessionAmbrUplink: "50 Mbps", SessionAmbrDownlink: "100 Mbps", Var5qi: 9, Arp: 8,
+	}); err != nil {
+		t.Fatalf("create dep policy: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeletePolicy(ctx, &client.DeletePolicyOptions{Name: policy}); err != nil {
+			t.Logf("cleanup: delete dep policy: %v", err)
+		}
+	})
+
+	if err := c.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+		Imsi: imsi, Key: "640f441067cd56f1474cbcacd7a0588f", SequenceNumber: "000000000022",
+		ProfileName: profile, OPc: "cb698a2341629c3241ae01de9d89de4f",
+	}); err != nil {
+		t.Fatalf("create dep subscriber: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := c.DeleteSubscriber(ctx, &client.DeleteSubscriberOptions{ID: imsi}); err != nil {
+			t.Logf("cleanup: delete dep subscriber: %v", err)
+		}
+	})
+
+	list := func() []client.StaticIP {
+		resp, err := c.ListDataNetworkStaticIps(ctx, dnName)
+		if err != nil {
+			t.Fatalf("list static IPs: %v", err)
+		}
+
+		return resp.Items
+	}
+
+	find := func(items []client.StaticIP, ipVersion string) *client.StaticIP {
+		for i := range items {
+			if items[i].IPVersion == ipVersion {
+				return &items[i]
+			}
+		}
+
+		return nil
+	}
+
+	if n := len(list()); n != 0 {
+		t.Fatalf("expected no static IPs before create, got %d", n)
+	}
+
+	if err := c.CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "10.252.0.10"}); err != nil {
+		t.Fatalf("create IPv4 static IP: %v", err)
+	}
+
+	v4 := find(list(), "ipv4")
+	if v4 == nil {
+		t.Fatal("IPv4 static IP not listed after create")
+	}
+
+	if v4.IMSI != imsi || v4.Address != "10.252.0.10" || v4.Status != "reserved" || v4.SessionID != nil {
+		t.Fatalf("unexpected IPv4 reservation: %+v", *v4)
+	}
+
+	// A second family for the same subscriber coexists.
+	if err := c.CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "fd98:0:0:1::"}); err != nil {
+		t.Fatalf("create IPv6 static IP: %v", err)
+	}
+
+	if n := len(list()); n != 2 {
+		t.Fatalf("expected 2 static IPs (v4+v6), got %d", n)
+	}
+
+	// A duplicate for the same (imsi, family) is rejected.
+	if err := c.CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "10.252.0.11"}); err == nil {
+		t.Fatal("expected duplicate IPv4 static IP to be rejected")
+	}
+
+	// An address outside the pool is rejected.
+	if err := c.CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "10.99.0.1"}); err == nil {
+		t.Fatal("expected out-of-pool static IP to be rejected")
+	}
+
+	// Repin the IPv4 reservation.
+	if err := c.UpdateDataNetworkStaticIp(ctx, dnName, imsi, "ipv4", "10.252.0.20"); err != nil {
+		t.Fatalf("update IPv4 static IP: %v", err)
+	}
+
+	if got := find(list(), "ipv4"); got == nil || got.Address != "10.252.0.20" {
+		t.Fatalf("repin not reflected: %+v", got)
+	}
+
+	// Delete the IPv4 reservation; the IPv6 one remains.
+	if err := c.DeleteDataNetworkStaticIp(ctx, dnName, imsi, "ipv4"); err != nil {
+		t.Fatalf("delete IPv4 static IP: %v", err)
+	}
+
+	items := list()
+	if len(items) != 1 || find(items, "ipv6") == nil {
+		t.Fatalf("expected only the IPv6 reservation after delete, got %+v", items)
+	}
+
+	if err := c.DeleteDataNetworkStaticIp(ctx, dnName, imsi, "ipv6"); err != nil {
+		t.Fatalf("delete IPv6 static IP: %v", err)
+	}
+
+	if n := len(list()); n != 0 {
+		t.Fatalf("expected no static IPs after delete, got %d", n)
+	}
+}

--- a/integration/api_matrix_static_ips_test.go
+++ b/integration/api_matrix_static_ips_test.go
@@ -117,7 +117,6 @@ func runStaticIpsMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("unexpected IPv4 reservation: %+v", *v4)
 	}
 
-	// A second family for the same subscriber coexists.
 	if err := c.CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "fd98:0:0:1::"}); err != nil {
 		t.Fatalf("create IPv6 static IP: %v", err)
 	}
@@ -126,17 +125,14 @@ func runStaticIpsMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("expected 2 static IPs (v4+v6), got %d", n)
 	}
 
-	// A duplicate for the same (imsi, family) is rejected.
 	if err := c.CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "10.252.0.11"}); err == nil {
 		t.Fatal("expected duplicate IPv4 static IP to be rejected")
 	}
 
-	// An address outside the pool is rejected.
 	if err := c.CreateDataNetworkStaticIp(ctx, dnName, &client.CreateStaticIPOptions{IMSI: imsi, Address: "10.99.0.1"}); err == nil {
 		t.Fatal("expected out-of-pool static IP to be rejected")
 	}
 
-	// Repin the IPv4 reservation.
 	if err := c.UpdateDataNetworkStaticIp(ctx, dnName, imsi, "ipv4", "10.252.0.20"); err != nil {
 		t.Fatalf("update IPv4 static IP: %v", err)
 	}
@@ -145,7 +141,6 @@ func runStaticIpsMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("repin not reflected: %+v", got)
 	}
 
-	// Delete the IPv4 reservation; the IPv6 one remains.
 	if err := c.DeleteDataNetworkStaticIp(ctx, dnName, imsi, "ipv4"); err != nil {
 		t.Fatalf("delete IPv4 static IP: %v", err)
 	}

--- a/integration/api_matrix_test.go
+++ b/integration/api_matrix_test.go
@@ -20,6 +20,7 @@ var apiMatrixResources = map[string]apiMatrixRunner{
 	"profiles":                   runProfilesMatrix,
 	"slices":                     runSlicesMatrix,
 	"data_networks":              runDataNetworksMatrix,
+	"static_ips":                 runStaticIpsMatrix,
 	"policies":                   runPoliciesMatrix,
 	"subscribers":                runSubscribersMatrix,
 	"routes":                     runRoutesMatrix,

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -55,6 +55,8 @@ var scenarioIPFamilyRestrictions = map[string]IPFamily{
 	"s1enb/registration/v4v6":                DualStack,
 	"s1enb/connectivity_dualstack":           DualStack,
 	"s1enb/connectivity_ipv6":                IPv6Only,
+	"gnb/static_ip_ipv6":                     IPv6Only,
+	"s1enb/static_ip_ipv6":                   IPv6Only,
 }
 
 // scenarioIPFamilyExclusions returns a map of scenario name → set of IP
@@ -82,6 +84,14 @@ var scenarioIPFamilyExclusions = map[string]map[IPFamily]bool{
 		IPv6Only: true,
 	},
 	"s1enb/connectivity": {
+		IPv6Only:  true,
+		DualStack: true,
+	},
+	"gnb/static_ip": {
+		IPv6Only:  true,
+		DualStack: true,
+	},
+	"s1enb/static_ip": {
 		IPv6Only:  true,
 		DualStack: true,
 	},

--- a/integration/fixture/apply.go
+++ b/integration/fixture/apply.go
@@ -4,6 +4,8 @@
 package fixture
 
 import (
+	"strings"
+
 	"github.com/ellanetworks/core/client"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
 )
@@ -62,6 +64,34 @@ func (f *F) Apply(spec scenarios.FixtureSpec) {
 	for _, s := range spec.Subscribers {
 		f.scopedSubscriber(s)
 	}
+
+	for _, s := range spec.StaticIPs {
+		f.scopedStaticIP(s)
+	}
+}
+
+func (f *F) scopedStaticIP(spec scenarios.StaticIPSpec) {
+	f.t.Helper()
+
+	if err := f.c.CreateDataNetworkStaticIp(f.ctx, spec.DataNetwork, &client.CreateStaticIPOptions{
+		IMSI:    spec.IMSI,
+		Address: spec.Address,
+	}); err != nil {
+		f.fatalf("create static IP %s for %s: %v", spec.Address, spec.IMSI, err)
+	}
+
+	dn, imsi, addr := spec.DataNetwork, spec.IMSI, spec.Address
+
+	ipVersion := "ipv4"
+	if strings.Contains(addr, ":") {
+		ipVersion = "ipv6"
+	}
+
+	f.t.Cleanup(func() {
+		if err := f.c.DeleteDataNetworkStaticIp(f.ctx, dn, imsi, ipVersion); err != nil {
+			f.t.Logf("cleanup: delete static IP %s for %s: %v", addr, imsi, err)
+		}
+	})
 }
 
 func (f *F) scopedProfile(spec scenarios.ProfileSpec) {

--- a/internal/api/server/api_static_ips.go
+++ b/internal/api/server/api_static_ips.go
@@ -1,0 +1,417 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/netip"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/ipam"
+	"github.com/ellanetworks/core/internal/logger"
+)
+
+const (
+	CreateStaticIPAction = "create_static_ip"
+	UpdateStaticIPAction = "update_static_ip"
+	DeleteStaticIPAction = "delete_static_ip"
+)
+
+type StaticIPItem struct {
+	IMSI        string `json:"imsi"`
+	DataNetwork string `json:"data_network"`
+	IPVersion   string `json:"ip_version"`
+	Address     string `json:"address"`
+	Status      string `json:"status"`
+	SessionID   *int   `json:"session_id"`
+}
+
+type ListStaticIPsResponse struct {
+	Items      []StaticIPItem `json:"items"`
+	Page       int            `json:"page"`
+	PerPage    int            `json:"per_page"`
+	TotalCount int            `json:"total_count"`
+}
+
+type CreateStaticIPParams struct {
+	IMSI    string `json:"imsi"`
+	Address string `json:"address"`
+}
+
+type UpdateStaticIPParams struct {
+	Address string `json:"address"`
+}
+
+// familyOfAddr maps a parsed address to its pool family ("ipv4"|"ipv6").
+func familyOfAddr(addr netip.Addr) (string, bool) {
+	addr = addr.Unmap()
+
+	switch {
+	case addr.Is4():
+		return "ipv4", true
+	case addr.Is6():
+		return "ipv6", true
+	default:
+		return "", false
+	}
+}
+
+// poolForFamily returns the data network's pool for the given family, or an
+// error (surfaced as 400) when the network has no pool for it.
+func poolForFamily(dn *db.DataNetwork, family string) (ipam.Pool, error) {
+	if family == "ipv6" {
+		if dn.IPv6Pool == "" {
+			return ipam.Pool{}, errors.New("data network has no IPv6 pool")
+		}
+
+		return ipam.NewPool6(dn.ID, dn.IPv6Pool, 64)
+	}
+
+	if dn.IPv4Pool == "" {
+		return ipam.Pool{}, errors.New("data network has no IPv4 pool")
+	}
+
+	return ipam.NewPool(dn.ID, dn.IPv4Pool)
+}
+
+// validateStaticAddress rejects addresses that are not /64-aligned (IPv6) or
+// fall outside the pool's usable range.
+func validateStaticAddress(pool ipam.Pool, addr netip.Addr, family string) error {
+	if family == "ipv6" && netip.PrefixFrom(addr, 64).Masked().Addr() != addr {
+		return errors.New("IPv6 address must be /64-aligned")
+	}
+
+	off := pool.OffsetOf(addr)
+	if off < pool.FirstUsable() || off-pool.FirstUsable() >= pool.Size() {
+		return errors.New("address is outside the data network pool")
+	}
+
+	return nil
+}
+
+// dataNetworkBoundToProfile reports whether any policy on the profile reaches
+// the data network.
+func dataNetworkBoundToProfile(ctx context.Context, dbInstance *db.Database, profileID, dnID string) (bool, error) {
+	policies, err := dbInstance.ListPoliciesByProfile(ctx, profileID)
+	if err != nil {
+		return false, err
+	}
+
+	for _, p := range policies {
+		if p.DataNetworkID == dnID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func staticLeaseStatus(sessionID *int) string {
+	if sessionID == nil {
+		return "reserved"
+	}
+
+	return "active"
+}
+
+func ListDataNetworkStaticIps(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		if name == "" {
+			writeError(r.Context(), w, http.StatusBadRequest, "Missing name parameter", nil, logger.APILog)
+			return
+		}
+
+		dn, err := dbInstance.GetDataNetwork(r.Context(), name)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusNotFound, "Data Network not found", nil, logger.APILog)
+			return
+		}
+
+		leases, err := dbInstance.ListStaticLeasesByDataNetwork(r.Context(), dn.ID)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to list static IPs", err, logger.APILog)
+			return
+		}
+
+		items := make([]StaticIPItem, 0, len(leases))
+		for i := range leases {
+			items = append(items, StaticIPItem{
+				IMSI:        leases[i].IMSI,
+				DataNetwork: name,
+				IPVersion:   leases[i].PoolType,
+				Address:     leases[i].Address().String(),
+				Status:      staticLeaseStatus(leases[i].SessionID),
+				SessionID:   leases[i].SessionID,
+			})
+		}
+
+		writeResponse(r.Context(), w, ListStaticIPsResponse{
+			Items:      items,
+			Page:       1,
+			PerPage:    len(items),
+			TotalCount: len(items),
+		}, http.StatusOK, logger.APILog)
+	})
+}
+
+func CreateDataNetworkStaticIp(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		email, ok := r.Context().Value(contextKeyEmail).(string)
+		if !ok {
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get email", errors.New("missing email in context"), logger.APILog)
+			return
+		}
+
+		name := r.PathValue("name")
+		if name == "" {
+			writeError(r.Context(), w, http.StatusBadRequest, "Missing name parameter", nil, logger.APILog)
+			return
+		}
+
+		var params CreateStaticIPParams
+		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "Invalid request data", err, logger.APILog)
+			return
+		}
+
+		if params.IMSI == "" || params.Address == "" {
+			writeError(r.Context(), w, http.StatusBadRequest, "imsi and address are required", nil, logger.APILog)
+			return
+		}
+
+		addr, err := netip.ParseAddr(params.Address)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "invalid address format", nil, logger.APILog)
+			return
+		}
+
+		addr = addr.Unmap()
+
+		family, ok := familyOfAddr(addr)
+		if !ok {
+			writeError(r.Context(), w, http.StatusBadRequest, "invalid address format", nil, logger.APILog)
+			return
+		}
+
+		dn, err := dbInstance.GetDataNetwork(r.Context(), name)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusNotFound, "Data Network not found", nil, logger.APILog)
+			return
+		}
+
+		sub, err := dbInstance.GetSubscriber(r.Context(), params.IMSI)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				writeError(r.Context(), w, http.StatusNotFound, "Subscriber not found", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get subscriber", err, logger.APILog)
+
+			return
+		}
+
+		pool, err := poolForFamily(dn, family)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, err.Error(), nil, logger.APILog)
+			return
+		}
+
+		if err := validateStaticAddress(pool, addr, family); err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, err.Error(), nil, logger.APILog)
+			return
+		}
+
+		bound, err := dataNetworkBoundToProfile(r.Context(), dbInstance, sub.ProfileID, dn.ID)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to resolve subscriber policies", err, logger.APILog)
+			return
+		}
+
+		if !bound {
+			writeError(r.Context(), w, http.StatusConflict, "data network is not bound to the subscriber's profile", nil, logger.APILog)
+			return
+		}
+
+		if _, err := dbInstance.GetStaticLease(r.Context(), dn.ID, family, params.IMSI); err == nil {
+			writeError(r.Context(), w, http.StatusConflict, "a static IP is already assigned for this data network and IP version", nil, logger.APILog)
+			return
+		} else if !errors.Is(err, db.ErrNotFound) {
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to check existing static IP", err, logger.APILog)
+			return
+		}
+
+		if err := dbInstance.CreateStaticLease(r.Context(), params.IMSI, dn.ID, family, addr); err != nil {
+			if errors.Is(err, db.ErrAlreadyExists) {
+				writeError(r.Context(), w, http.StatusConflict, "address is already in use", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to create static IP", err, logger.APILog)
+
+			return
+		}
+
+		writeResponse(r.Context(), w, SuccessResponse{Message: "Static IP created successfully"}, http.StatusCreated, logger.APILog)
+
+		logger.LogAuditEvent(r.Context(), CreateStaticIPAction, email, getClientIP(r), fmt.Sprintf("User pinned %s to subscriber %s on data network %s", addr, params.IMSI, name))
+	})
+}
+
+func UpdateDataNetworkStaticIp(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		email, ok := r.Context().Value(contextKeyEmail).(string)
+		if !ok {
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get email", errors.New("missing email in context"), logger.APILog)
+			return
+		}
+
+		name := r.PathValue("name")
+		imsi := r.PathValue("imsi")
+		ipVersion := r.PathValue("ip_version")
+
+		if name == "" || imsi == "" {
+			writeError(r.Context(), w, http.StatusBadRequest, "Missing name or imsi parameter", nil, logger.APILog)
+			return
+		}
+
+		if ipVersion != "ipv4" && ipVersion != "ipv6" {
+			writeError(r.Context(), w, http.StatusBadRequest, "ip_version must be ipv4 or ipv6", nil, logger.APILog)
+			return
+		}
+
+		var params UpdateStaticIPParams
+		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "Invalid request data", err, logger.APILog)
+			return
+		}
+
+		if params.Address == "" {
+			writeError(r.Context(), w, http.StatusBadRequest, "address is required", nil, logger.APILog)
+			return
+		}
+
+		addr, err := netip.ParseAddr(params.Address)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, "invalid address format", nil, logger.APILog)
+			return
+		}
+
+		addr = addr.Unmap()
+
+		family, ok := familyOfAddr(addr)
+		if !ok || family != ipVersion {
+			writeError(r.Context(), w, http.StatusBadRequest, "address family does not match ip_version", nil, logger.APILog)
+			return
+		}
+
+		dn, err := dbInstance.GetDataNetwork(r.Context(), name)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusNotFound, "Data Network not found", nil, logger.APILog)
+			return
+		}
+
+		lease, err := dbInstance.GetStaticLease(r.Context(), dn.ID, ipVersion, imsi)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				writeError(r.Context(), w, http.StatusNotFound, "static IP reservation not found", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get static IP", err, logger.APILog)
+
+			return
+		}
+
+		pool, err := poolForFamily(dn, family)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, err.Error(), nil, logger.APILog)
+			return
+		}
+
+		if err := validateStaticAddress(pool, addr, family); err != nil {
+			writeError(r.Context(), w, http.StatusBadRequest, err.Error(), nil, logger.APILog)
+			return
+		}
+
+		if err := dbInstance.UpdateStaticLeaseAddress(r.Context(), lease.ID, addr); err != nil {
+			switch {
+			case errors.Is(err, db.ErrLeaseActive):
+				writeError(r.Context(), w, http.StatusConflict, "static IP is in use by an active session", nil, logger.APILog)
+			case errors.Is(err, db.ErrAlreadyExists):
+				writeError(r.Context(), w, http.StatusConflict, "address is already in use", nil, logger.APILog)
+			default:
+				writeError(r.Context(), w, http.StatusInternalServerError, "Failed to update static IP", err, logger.APILog)
+			}
+
+			return
+		}
+
+		writeResponse(r.Context(), w, SuccessResponse{Message: "Static IP updated successfully"}, http.StatusOK, logger.APILog)
+
+		logger.LogAuditEvent(r.Context(), UpdateStaticIPAction, email, getClientIP(r), fmt.Sprintf("User repinned subscriber %s (%s) to %s on data network %s", imsi, ipVersion, addr, name))
+	})
+}
+
+func DeleteDataNetworkStaticIp(dbInstance *db.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		email, ok := r.Context().Value(contextKeyEmail).(string)
+		if !ok {
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get email", errors.New("missing email in context"), logger.APILog)
+			return
+		}
+
+		name := r.PathValue("name")
+		imsi := r.PathValue("imsi")
+		ipVersion := r.PathValue("ip_version")
+
+		if name == "" || imsi == "" {
+			writeError(r.Context(), w, http.StatusBadRequest, "Missing name or imsi parameter", nil, logger.APILog)
+			return
+		}
+
+		if ipVersion != "ipv4" && ipVersion != "ipv6" {
+			writeError(r.Context(), w, http.StatusBadRequest, "ip_version must be ipv4 or ipv6", nil, logger.APILog)
+			return
+		}
+
+		dn, err := dbInstance.GetDataNetwork(r.Context(), name)
+		if err != nil {
+			writeError(r.Context(), w, http.StatusNotFound, "Data Network not found", nil, logger.APILog)
+			return
+		}
+
+		lease, err := dbInstance.GetStaticLease(r.Context(), dn.ID, ipVersion, imsi)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				writeError(r.Context(), w, http.StatusNotFound, "static IP reservation not found", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to get static IP", err, logger.APILog)
+
+			return
+		}
+
+		if err := dbInstance.DeleteStaticLease(r.Context(), lease.ID); err != nil {
+			if errors.Is(err, db.ErrLeaseActive) {
+				writeError(r.Context(), w, http.StatusConflict, "static IP is in use by an active session", nil, logger.APILog)
+				return
+			}
+
+			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to delete static IP", err, logger.APILog)
+
+			return
+		}
+
+		writeResponse(r.Context(), w, SuccessResponse{Message: "Static IP deleted successfully"}, http.StatusOK, logger.APILog)
+
+		logger.LogAuditEvent(r.Context(), DeleteStaticIPAction, email, getClientIP(r), fmt.Sprintf("User removed static IP for subscriber %s (%s) on data network %s", imsi, ipVersion, name))
+	})
+}

--- a/internal/api/server/api_static_ips_test.go
+++ b/internal/api/server/api_static_ips_test.go
@@ -1,0 +1,435 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	staticDN      = "static-dn"
+	staticSlice   = "static-slice"
+	staticProfile = "static-profile"
+	staticIPv4    = "10.99.0.0/24"
+	staticIPv6    = "2001:db8:aaaa::/48"
+)
+
+type staticIPItem struct {
+	IMSI        string `json:"imsi"`
+	DataNetwork string `json:"data_network"`
+	IPVersion   string `json:"ip_version"`
+	Address     string `json:"address"`
+	Status      string `json:"status"`
+	SessionID   *int   `json:"session_id"`
+}
+
+type listStaticIPsResult struct {
+	Items      []staticIPItem `json:"items"`
+	TotalCount int            `json:"total_count"`
+}
+
+type listStaticIPsResponse struct {
+	Result listStaticIPsResult `json:"result"`
+	Error  string              `json:"error,omitempty"`
+}
+
+type messageResponse struct {
+	Result struct {
+		Message string `json:"message"`
+	} `json:"result"`
+	Error string `json:"error,omitempty"`
+}
+
+func listStaticIps(url string, client *http.Client, token string) (int, *listStaticIPsResponse, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url+"/api/v1/networking/data-networks/"+staticDN+"/static-ips", nil)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	var out listStaticIPsResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return 0, nil, err
+	}
+
+	return res.StatusCode, &out, nil
+}
+
+func createStaticIp(url string, client *http.Client, token, dn, imsi, address string) (int, *messageResponse, error) {
+	body, _ := json.Marshal(map[string]string{"imsi": imsi, "address": address})
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url+"/api/v1/networking/data-networks/"+dn+"/static-ips", strings.NewReader(string(body)))
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	var out messageResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return 0, nil, err
+	}
+
+	return res.StatusCode, &out, nil
+}
+
+func updateStaticIp(url string, client *http.Client, token, dn, imsi, ipVersion, address string) (int, *messageResponse, error) {
+	body, _ := json.Marshal(map[string]string{"address": address})
+
+	req, err := http.NewRequestWithContext(context.Background(), "PUT", url+"/api/v1/networking/data-networks/"+dn+"/static-ips/"+imsi+"/"+ipVersion, strings.NewReader(string(body)))
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	var out messageResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return 0, nil, err
+	}
+
+	return res.StatusCode, &out, nil
+}
+
+func deleteStaticIp(url string, client *http.Client, token, dn, imsi, ipVersion string) (int, *messageResponse, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "DELETE", url+"/api/v1/networking/data-networks/"+dn+"/static-ips/"+imsi+"/"+ipVersion, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	var out messageResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return 0, nil, err
+	}
+
+	return res.StatusCode, &out, nil
+}
+
+func TestAPIStaticIPsEndToEnd(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+	url := env.Server.URL
+
+	token, err := initializeAndRefresh(url, client)
+	if err != nil {
+		t.Fatalf("couldn't create first user and login: %s", err)
+	}
+
+	// Provision the profile → slice → data network → policy → subscriber chain.
+	mustCreate := func(name string, code int, resErr string, callErr error) {
+		t.Helper()
+
+		if callErr != nil {
+			t.Fatalf("%s: %s", name, callErr)
+		}
+
+		if code != http.StatusCreated {
+			t.Fatalf("%s: expected 201, got %d (%s)", name, code, resErr)
+		}
+	}
+
+	sc, sliceResp, err := createSlice(url, client, token, &CreateSliceParams{Name: staticSlice, Sst: 1})
+	mustCreate("createSlice", sc, errStr(sliceResp), err)
+
+	sc, dnResp, err := createDataNetwork(url, client, token, &CreateDataNetworkParams{
+		Name: staticDN, IPv4Pool: staticIPv4, IPv6Pool: staticIPv6, DNS: DNS, MTU: MTU,
+	})
+	mustCreate("createDataNetwork", sc, errStrDN(dnResp), err)
+
+	sc, profResp, err := createProfile(url, client, token, &CreateProfileParams{
+		Name: staticProfile, UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "200 Mbps",
+	})
+	mustCreate("createProfile", sc, errStrProf(profResp), err)
+
+	sc, polResp, err := createPolicy(url, client, token, &CreatePolicyParams{
+		Name: "static-policy", ProfileName: staticProfile, SliceName: staticSlice,
+		SessionAmbrUplink: "100 Mbps", SessionAmbrDownlink: "200 Mbps",
+		Var5qi: 9, Arp: 1, DataNetworkName: staticDN,
+	})
+	mustCreate("createPolicy", sc, errStrPol(polResp), err)
+
+	sc, subResp, err := createSubscriber(url, client, token, &CreateSubscriberParams{
+		Imsi: Imsi, Key: Key, Opc: Opc, SequenceNumber: SequenceNumber, ProfileName: staticProfile,
+	})
+	mustCreate("createSubscriber", sc, errStrSub(subResp), err)
+
+	// A subscriber whose profile reaches a different data network, so its
+	// policy does not bind staticDN (used for the not-bound 409).
+	orphanIMSI := "001010100009999"
+	sc, _, err = createDataNetwork(url, client, token, &CreateDataNetworkParams{Name: "other-dn", IPv4Pool: "10.77.0.0/24", DNS: DNS, MTU: MTU})
+	mustCreate("createDataNetwork(other)", sc, "", err)
+	sc, _, err = createProfile(url, client, token, &CreateProfileParams{Name: "orphan-profile", UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "100 Mbps"})
+	mustCreate("createProfile(orphan)", sc, "", err)
+	sc, _, err = createPolicy(url, client, token, &CreatePolicyParams{
+		Name: "orphan-policy", ProfileName: "orphan-profile", SliceName: staticSlice,
+		SessionAmbrUplink: "100 Mbps", SessionAmbrDownlink: "100 Mbps", Var5qi: 9, Arp: 1, DataNetworkName: "other-dn",
+	})
+	mustCreate("createPolicy(orphan)", sc, "", err)
+	sc, _, err = createSubscriber(url, client, token, &CreateSubscriberParams{Imsi: orphanIMSI, Key: Key, Opc: Opc, SequenceNumber: SequenceNumber, ProfileName: "orphan-profile"})
+	mustCreate("createSubscriber(orphan)", sc, "", err)
+
+	t.Run("create IPv4 happy path", func(t *testing.T) {
+		code, resp, err := createStaticIp(url, client, token, staticDN, Imsi, "10.99.0.10")
+		if err != nil || code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d (%s / %v)", code, resp.Error, err)
+		}
+	})
+
+	t.Run("list reflects the reservation", func(t *testing.T) {
+		code, resp, err := listStaticIps(url, client, token)
+		if err != nil || code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (%v)", code, err)
+		}
+
+		if len(resp.Result.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(resp.Result.Items))
+		}
+
+		it := resp.Result.Items[0]
+		if it.IMSI != Imsi || it.IPVersion != "ipv4" || it.Address != "10.99.0.10" || it.Status != "reserved" {
+			t.Fatalf("unexpected item: %+v", it)
+		}
+	})
+
+	t.Run("duplicate for same imsi+family is 409", func(t *testing.T) {
+		code, _, _ := createStaticIp(url, client, token, staticDN, Imsi, "10.99.0.11")
+		if code != http.StatusConflict {
+			t.Fatalf("expected 409, got %d", code)
+		}
+	})
+
+	t.Run("address outside pool CIDR is 400", func(t *testing.T) {
+		code, _, _ := createStaticIp(url, client, token, staticDN, Imsi, "10.88.0.1")
+		if code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", code)
+		}
+	})
+
+	t.Run("IPv6 not /64-aligned is 400", func(t *testing.T) {
+		code, _, _ := createStaticIp(url, client, token, staticDN, Imsi, "2001:db8:aaaa:1::5")
+		if code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", code)
+		}
+	})
+
+	t.Run("IPv6 aligned happy path", func(t *testing.T) {
+		code, resp, err := createStaticIp(url, client, token, staticDN, Imsi, "2001:db8:aaaa:1::")
+		if err != nil || code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d (%s)", code, resp.Error)
+		}
+	})
+
+	t.Run("subscriber holds both families on the same DN", func(t *testing.T) {
+		code, resp, err := listStaticIps(url, client, token)
+		if err != nil || code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (%v)", code, err)
+		}
+
+		families := map[string]string{}
+
+		for _, it := range resp.Result.Items {
+			if it.IMSI == Imsi {
+				families[it.IPVersion] = it.Address
+			}
+		}
+
+		if families["ipv4"] != "10.99.0.10" || families["ipv6"] != "2001:db8:aaaa:1::" {
+			t.Fatalf("expected subscriber to hold both v4 and v6 pins, got %+v", families)
+		}
+	})
+
+	t.Run("subscriber not found is 404", func(t *testing.T) {
+		code, _, _ := createStaticIp(url, client, token, staticDN, "000000000000000", "10.99.0.12")
+		if code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", code)
+		}
+	})
+
+	t.Run("data network not found is 404", func(t *testing.T) {
+		code, _, _ := createStaticIp(url, client, token, "no-such-dn", Imsi, "10.99.0.12")
+		if code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", code)
+		}
+	})
+
+	t.Run("data network not bound to profile is 409", func(t *testing.T) {
+		code, _, _ := createStaticIp(url, client, token, staticDN, orphanIMSI, "10.99.0.13")
+		if code != http.StatusConflict {
+			t.Fatalf("expected 409, got %d", code)
+		}
+	})
+
+	t.Run("repin (PUT) happy path", func(t *testing.T) {
+		code, resp, err := updateStaticIp(url, client, token, staticDN, Imsi, "ipv4", "10.99.0.20")
+		if err != nil || code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (%s)", code, resp.Error)
+		}
+
+		_, list, _ := listStaticIps(url, client, token)
+
+		found := false
+
+		for _, it := range list.Result.Items {
+			if it.IPVersion == "ipv4" && it.Address == "10.99.0.20" {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Fatalf("repinned address 10.99.0.20 not found in list")
+		}
+	})
+
+	t.Run("mutation of an active reservation is 409", func(t *testing.T) {
+		ctx := context.Background()
+
+		dn, err := env.DB.GetDataNetwork(ctx, staticDN)
+		if err != nil {
+			t.Fatalf("GetDataNetwork: %s", err)
+		}
+
+		lease, err := env.DB.GetStaticLease(ctx, dn.ID, "ipv4", Imsi)
+		if err != nil {
+			t.Fatalf("GetStaticLease: %s", err)
+		}
+
+		if err := env.DB.UpdateLeaseSession(ctx, lease.ID, 1); err != nil {
+			t.Fatalf("UpdateLeaseSession: %s", err)
+		}
+
+		if code, _, _ := updateStaticIp(url, client, token, staticDN, Imsi, "ipv4", "10.99.0.21"); code != http.StatusConflict {
+			t.Fatalf("PUT active: expected 409, got %d", code)
+		}
+
+		if code, _, _ := deleteStaticIp(url, client, token, staticDN, Imsi, "ipv4"); code != http.StatusConflict {
+			t.Fatalf("DELETE active: expected 409, got %d", code)
+		}
+
+		if err := env.DB.ClearStaticLeaseSession(ctx, lease.ID); err != nil {
+			t.Fatalf("ClearStaticLeaseSession: %s", err)
+		}
+	})
+
+	t.Run("delete happy path then 404", func(t *testing.T) {
+		if code, resp, err := deleteStaticIp(url, client, token, staticDN, Imsi, "ipv4"); err != nil || code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (%s)", code, resp.Error)
+		}
+
+		if code, _, _ := deleteStaticIp(url, client, token, staticDN, Imsi, "ipv4"); code != http.StatusNotFound {
+			t.Fatalf("delete again: expected 404, got %d", code)
+		}
+	})
+
+	t.Run("role gating", func(t *testing.T) {
+		roClient := newTestClient(env.Server)
+
+		roToken, err := createUserAndLogin(url, token, "static-ro@ellanetworks.com", RoleReadOnly, roClient)
+		if err != nil {
+			t.Fatalf("create read-only user: %s", err)
+		}
+
+		if code, _, _ := listStaticIps(url, roClient, roToken); code != http.StatusOK {
+			t.Fatalf("read-only list: expected 200, got %d", code)
+		}
+
+		if code, _, _ := createStaticIp(url, roClient, roToken, staticDN, Imsi, "10.99.0.30"); code != http.StatusForbidden {
+			t.Fatalf("read-only create: expected 403, got %d", code)
+		}
+	})
+}
+
+func errStr(r *CreateSliceResponse) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.Error
+}
+
+func errStrDN(r *CreateDataNetworkResponse) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.Error
+}
+
+func errStrProf(r *CreateProfileResponse) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.Error
+}
+
+func errStrPol(r *CreatePolicyResponse) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.Error
+}
+
+func errStrSub(r *CreateSubscriberResponse) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.Error
+}

--- a/internal/api/server/api_static_ips_test.go
+++ b/internal/api/server/api_static_ips_test.go
@@ -58,6 +58,7 @@ func listStaticIps(url string, client *http.Client, token string) (int, *listSta
 	if err != nil {
 		return 0, nil, err
 	}
+
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			panic(err)
@@ -86,6 +87,7 @@ func createStaticIp(url string, client *http.Client, token, dn, imsi, address st
 	if err != nil {
 		return 0, nil, err
 	}
+
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			panic(err)
@@ -114,6 +116,7 @@ func updateStaticIp(url string, client *http.Client, token, dn, imsi, ipVersion,
 	if err != nil {
 		return 0, nil, err
 	}
+
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			panic(err)
@@ -140,6 +143,7 @@ func deleteStaticIp(url string, client *http.Client, token, dn, imsi, ipVersion 
 	if err != nil {
 		return 0, nil, err
 	}
+
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			panic(err)

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -166,6 +166,7 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 		page := atoiDefault(q.Get("page"), 1)
 		perPage := atoiDefault(q.Get("per_page"), 25)
 		radioFilter := q.Get("radio")
+		dataNetworkFilter := q.Get("data_network")
 
 		if page < 1 {
 			writeError(r.Context(), w, http.StatusBadRequest, "page must be >= 1", nil, logger.APILog)
@@ -231,7 +232,30 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 			dbPerPage = MaxNumSubscribers
 		}
 
-		dbSubscribers, total, err := dbInstance.ListSubscribersPage(ctx, dbPage, dbPerPage)
+		var dataNetworkID string
+
+		if dataNetworkFilter != "" {
+			dn, dnErr := dbInstance.GetDataNetwork(ctx, dataNetworkFilter)
+			if dnErr != nil {
+				writeError(r.Context(), w, http.StatusNotFound, "Data Network not found", nil, logger.APILog)
+				return
+			}
+
+			dataNetworkID = dn.ID
+		}
+
+		var (
+			dbSubscribers []db.Subscriber
+			total         int
+			err           error
+		)
+
+		if dataNetworkID != "" {
+			dbSubscribers, total, err = dbInstance.ListSubscribersByDataNetworkPage(ctx, dataNetworkID, dbPage, dbPerPage)
+		} else {
+			dbSubscribers, total, err = dbInstance.ListSubscribersPage(ctx, dbPage, dbPerPage)
+		}
+
 		if err != nil {
 			writeError(r.Context(), w, http.StatusInternalServerError, "Failed to list subscribers", err, logger.APILog)
 			return

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -1256,3 +1256,111 @@ func TestCreateTooManySubscribers(t *testing.T) {
 		t.Fatalf("expected error %q, got %q", "Maximum number of subscribers reached (1000)", createSubscriberResponse.Error)
 	}
 }
+
+func listSubscribersByDataNetwork(url string, client *http.Client, token, dn string) (int, *ListSubscriberResponse, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url+"/api/v1/subscribers?data_network="+dn, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	var out ListSubscriberResponse
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return 0, nil, err
+	}
+
+	return res.StatusCode, &out, nil
+}
+
+func TestListSubscribers_DataNetworkFilter(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+	url := env.Server.URL
+
+	token, err := initializeAndRefresh(url, client)
+	if err != nil {
+		t.Fatalf("couldn't create first user and login: %s", err)
+	}
+
+	mustOK := func(name string, code int, callErr error) {
+		t.Helper()
+
+		if callErr != nil {
+			t.Fatalf("%s: %s", name, callErr)
+		}
+
+		if code != http.StatusCreated {
+			t.Fatalf("%s: expected 201, got %d", name, code)
+		}
+	}
+
+	sc, _, err := createSlice(url, client, token, &CreateSliceParams{Name: "filter-slice", Sst: 1})
+	mustOK("createSlice", sc, err)
+
+	// Two profile → data network → subscriber chains, each reaching only its own DN.
+	for _, chain := range []struct{ dn, pool, profile, policy, imsi string }{
+		{"filter-dn-1", "10.61.0.0/24", "filter-profile-1", "filter-policy-1", "001010100000061"},
+		{"filter-dn-2", "10.62.0.0/24", "filter-profile-2", "filter-policy-2", "001010100000062"},
+	} {
+		sc, _, err = createDataNetwork(url, client, token, &CreateDataNetworkParams{Name: chain.dn, IPv4Pool: chain.pool, DNS: DNS, MTU: MTU})
+		mustOK("createDataNetwork "+chain.dn, sc, err)
+
+		sc, _, err = createProfile(url, client, token, &CreateProfileParams{Name: chain.profile, UeAmbrUplink: "100 Mbps", UeAmbrDownlink: "100 Mbps"})
+		mustOK("createProfile "+chain.profile, sc, err)
+
+		sc, _, err = createPolicy(url, client, token, &CreatePolicyParams{
+			Name: chain.policy, ProfileName: chain.profile, SliceName: "filter-slice",
+			SessionAmbrUplink: "100 Mbps", SessionAmbrDownlink: "100 Mbps", Var5qi: 9, Arp: 1, DataNetworkName: chain.dn,
+		})
+		mustOK("createPolicy "+chain.policy, sc, err)
+
+		sc, _, err = createSubscriber(url, client, token, &CreateSubscriberParams{Imsi: chain.imsi, Key: Key, Opc: Opc, SequenceNumber: SequenceNumber, ProfileName: chain.profile})
+		mustOK("createSubscriber "+chain.imsi, sc, err)
+	}
+
+	t.Run("filter returns only entitled subscribers", func(t *testing.T) {
+		code, resp, err := listSubscribersByDataNetwork(url, client, token, "filter-dn-1")
+		if err != nil || code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (%v)", code, err)
+		}
+
+		if len(resp.Result.Items) != 1 || resp.Result.Items[0].Imsi != "001010100000061" {
+			t.Fatalf("expected only 001010100000061, got %+v", resp.Result.Items)
+		}
+
+		code, resp, err = listSubscribersByDataNetwork(url, client, token, "filter-dn-2")
+		if err != nil || code != http.StatusOK {
+			t.Fatalf("expected 200, got %d (%v)", code, err)
+		}
+
+		if len(resp.Result.Items) != 1 || resp.Result.Items[0].Imsi != "001010100000062" {
+			t.Fatalf("expected only 001010100000062, got %+v", resp.Result.Items)
+		}
+	})
+
+	t.Run("unknown data network is 404", func(t *testing.T) {
+		code, _, _ := listSubscribersByDataNetwork(url, client, token, "no-such-dn")
+		if code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", code)
+		}
+	})
+}

--- a/internal/api/server/authorization_middleware.go
+++ b/internal/api/server/authorization_middleware.go
@@ -26,7 +26,7 @@ var PermissionsByRole = map[RoleID][]string{
 		PermListMyAPITokens, PermCreateMyAPIToken, PermDeleteMyAPIToken,
 		PermReadOperator,
 		PermListSubscribers, PermReadSubscriber,
-		PermListDataNetworks, PermReadDataNetwork,
+		PermListDataNetworks, PermReadDataNetwork, PermListDataNetworkStaticIPs,
 		PermListPolicies, PermReadPolicy,
 		PermListProfiles, PermReadProfile,
 		PermListSlices, PermReadSlice,
@@ -49,6 +49,7 @@ var PermissionsByRole = map[RoleID][]string{
 		PermListMyAPITokens, PermCreateMyAPIToken, PermDeleteMyAPIToken,
 		PermReadOperator, PermUpdateOperatorTracking, PermUpdateOperatorNASSecurity, PermUpdateOperatorHomeNetwork, PermReadHomeNetworkPrivateKey, PermUpdateOperatorSPN,
 		PermListDataNetworks, PermCreateDataNetwork, PermUpdateDataNetwork, PermReadDataNetwork, PermDeleteDataNetwork,
+		PermListDataNetworkStaticIPs, PermCreateDataNetworkStaticIP, PermUpdateDataNetworkStaticIP, PermDeleteDataNetworkStaticIP,
 		PermListSubscribers, PermCreateSubscriber, PermUpdateSubscriber, PermReadSubscriber, PermDeleteSubscriber, PermReadSubscriberCredentials,
 		PermListPolicies, PermCreatePolicy, PermUpdatePolicy, PermReadPolicy, PermDeletePolicy,
 		PermListProfiles, PermCreateProfile, PermUpdateProfile, PermReadProfile, PermDeleteProfile,
@@ -94,6 +95,12 @@ const (
 	PermUpdateDataNetwork = "data_network:update"
 	PermReadDataNetwork   = "data_network:read"
 	PermDeleteDataNetwork = "data_network:delete"
+
+	// Static IP permissions (data network sub-resource)
+	PermListDataNetworkStaticIPs  = "data_network:list_static_ips"
+	PermCreateDataNetworkStaticIP = "data_network:create_static_ip"
+	PermUpdateDataNetworkStaticIP = "data_network:update_static_ip"
+	PermDeleteDataNetworkStaticIP = "data_network:delete_static_ip"
 
 	// Operator permissions
 	PermReadOperator              = "operator:read"

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -898,6 +898,11 @@ paths:
           schema:
             type: string
           description: Filter subscribers connected to a specific radio by name.
+        - name: data_network
+          in: query
+          schema:
+            type: string
+          description: Filter subscribers whose profile reaches the named data network.
       responses:
         "200":
           description: Paginated list of subscribers.
@@ -907,6 +912,8 @@ paths:
                 $ref: "#/components/schemas/ListSubscribersResponseEnvelope"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       operationId: createSubscriber
       tags: [Subscribers]

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -1808,6 +1808,96 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/networking/data-networks/{name}/static-ips:
+    get:
+      operationId: listDataNetworkStaticIps
+      tags: [Data Networks]
+      summary: List static IP reservations for a data network
+      description: Returns the static IP reservations (both families) for the specified data network.
+      parameters:
+        - $ref: "#/components/parameters/DataNetworkNamePath"
+      responses:
+        "200":
+          description: List of static IP reservations.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StaticIPListResponseEnvelope"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      operationId: createDataNetworkStaticIp
+      tags: [Data Networks]
+      summary: Create a static IP reservation
+      description: Pins an address to a subscriber on the data network. The IP version is inferred from the address family; IPv6 addresses must be /64-aligned.
+      parameters:
+        - $ref: "#/components/parameters/DataNetworkNamePath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateStaticIPParams"
+      responses:
+        "201":
+          $ref: "#/components/responses/Success"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /api/v1/networking/data-networks/{name}/static-ips/{imsi}/{ip_version}:
+    put:
+      operationId: updateDataNetworkStaticIp
+      tags: [Data Networks]
+      summary: Repin a static IP reservation
+      description: Changes the reserved address. Rejected while the reservation is bound to an active session.
+      parameters:
+        - $ref: "#/components/parameters/DataNetworkNamePath"
+        - $ref: "#/components/parameters/ImsiPath"
+        - $ref: "#/components/parameters/IPVersionPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateStaticIPParams"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    delete:
+      operationId: deleteDataNetworkStaticIp
+      tags: [Data Networks]
+      summary: Delete a static IP reservation
+      description: Removes the reservation. Rejected while it is bound to an active session.
+      parameters:
+        - $ref: "#/components/parameters/DataNetworkNamePath"
+        - $ref: "#/components/parameters/ImsiPath"
+        - $ref: "#/components/parameters/IPVersionPath"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
   # -- Routes --------------------------------------------------------------
   /api/v1/networking/routes:
     get:
@@ -3207,6 +3297,14 @@ components:
       schema:
         type: string
       description: Data network name (DNN).
+    IPVersionPath:
+      name: ip_version
+      in: path
+      required: true
+      schema:
+        type: string
+        enum: [ipv4, ipv6]
+      description: IP family of the reservation.
     RouteIdPath:
       name: id
       in: path
@@ -4509,6 +4607,71 @@ components:
       properties:
         result:
           $ref: "#/components/schemas/ListIPAllocationsResponse"
+
+    StaticIP:
+      type: object
+      properties:
+        imsi:
+          type: string
+          description: IMSI of the subscriber holding the reservation.
+        data_network:
+          type: string
+          description: Data network name (DNN).
+        ip_version:
+          type: string
+          enum: [ipv4, ipv6]
+        address:
+          type: string
+          description: "Pinned IPv4 address or IPv6 /64 prefix."
+        status:
+          type: string
+          enum: [reserved, active]
+          description: "\"active\" when bound to a session, otherwise \"reserved\"."
+        session_id:
+          type: integer
+          nullable: true
+          description: PDU session ID when active, or null when reserved.
+      required: [imsi, data_network, ip_version, address, status, session_id]
+
+    StaticIPList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/StaticIP"
+        page:
+          type: integer
+        per_page:
+          type: integer
+        total_count:
+          type: integer
+      required: [items, page, per_page, total_count]
+
+    StaticIPListResponseEnvelope:
+      type: object
+      properties:
+        result:
+          $ref: "#/components/schemas/StaticIPList"
+
+    CreateStaticIPParams:
+      type: object
+      required: [imsi, address]
+      properties:
+        imsi:
+          type: string
+          description: "15-digit IMSI of the subscriber to pin."
+        address:
+          type: string
+          description: "IPv4 address or /64-aligned IPv6 prefix within the data network pool."
+
+    UpdateStaticIPParams:
+      type: object
+      required: [address]
+      properties:
+        address:
+          type: string
+          description: "New IPv4 address or /64-aligned IPv6 prefix within the data network pool."
 
     # -- Routes ----------------------------------------------------------
     Route:

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -157,6 +157,10 @@ func NewHandler(cfg HandlerConfig) http.Handler {
 	mux.HandleFunc("DELETE /api/v1/networking/data-networks/{name}", Authenticate(jwtSecret, dbInstance, Authorize(PermDeleteDataNetwork, DeleteDataNetwork(dbInstance))).ServeHTTP)
 	mux.HandleFunc("GET /api/v1/networking/data-networks/{name}/ipv4-allocations", Authenticate(jwtSecret, dbInstance, Authorize(PermReadDataNetwork, ListIPv4Allocations(dbInstance))).ServeHTTP)
 	mux.HandleFunc("GET /api/v1/networking/data-networks/{name}/ipv6-allocations", Authenticate(jwtSecret, dbInstance, Authorize(PermReadDataNetwork, ListIPv6Allocations(dbInstance))).ServeHTTP)
+	mux.HandleFunc("GET /api/v1/networking/data-networks/{name}/static-ips", Authenticate(jwtSecret, dbInstance, Authorize(PermListDataNetworkStaticIPs, ListDataNetworkStaticIps(dbInstance))).ServeHTTP)
+	mux.HandleFunc("POST /api/v1/networking/data-networks/{name}/static-ips", Authenticate(jwtSecret, dbInstance, Authorize(PermCreateDataNetworkStaticIP, CreateDataNetworkStaticIp(dbInstance))).ServeHTTP)
+	mux.HandleFunc("PUT /api/v1/networking/data-networks/{name}/static-ips/{imsi}/{ip_version}", Authenticate(jwtSecret, dbInstance, Authorize(PermUpdateDataNetworkStaticIP, UpdateDataNetworkStaticIp(dbInstance))).ServeHTTP)
+	mux.HandleFunc("DELETE /api/v1/networking/data-networks/{name}/static-ips/{imsi}/{ip_version}", Authenticate(jwtSecret, dbInstance, Authorize(PermDeleteDataNetworkStaticIP, DeleteDataNetworkStaticIp(dbInstance))).ServeHTTP)
 
 	// Routes (Authenticated)
 	mux.HandleFunc("GET /api/v1/networking/routes", Authenticate(jwtSecret, dbInstance, Authorize(PermListRoutes, ListRoutes(dbInstance, bgpService))).ServeHTTP)

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -435,12 +435,9 @@ func (db *Database) applyUpdateLeaseNode(ctx context.Context, lease *IPLease) (a
 }
 
 // applyCreateStaticLease inserts an admin-pinned reservation. The
-// SELECT-then-INSERT runs under leaderCaptureAndPropose's proposeMu, so
-// the one-per-(imsi, pool, family) check and the write are serialised
-// against every other replicated allocation — a second static for the
-// same tuple can't race in. A duplicate address in the pool is caught by
-// the UNIQUE(poolID, addressBin) constraint. The reservation starts
-// unbound (sessionID NULL, nodeID 0).
+// SELECT-then-INSERT runs under proposeMu, so the one-per-(imsi, pool,
+// family) check is race-free; a duplicate address is caught by
+// UNIQUE(poolID, addressBin).
 func (db *Database) applyCreateStaticLease(ctx context.Context, lease *IPLease) (any, error) {
 	existing := IPLease{PoolID: lease.PoolID, PoolType: lease.PoolType, IMSI: lease.IMSI}
 
@@ -462,10 +459,8 @@ func (db *Database) applyCreateStaticLease(ctx context.Context, lease *IPLease) 
 }
 
 // applyUpdateStaticLeaseAddress repins a reserved static lease. The
-// sessionID IS NULL predicate rejects an active reservation atomically:
-// zero rows affected means the reservation was bound between the
-// handler's pre-check and this write, mapped to ErrLeaseActive. A
-// collision with another lease's address surfaces as ErrAlreadyExists.
+// sessionID IS NULL predicate makes the active-check atomic: zero rows
+// affected maps to ErrLeaseActive, a duplicate address to ErrAlreadyExists.
 func (db *Database) applyUpdateStaticLeaseAddress(ctx context.Context, lease *IPLease) (any, error) {
 	var outcome sqlair.Outcome
 
@@ -490,9 +485,9 @@ func (db *Database) applyUpdateStaticLeaseAddress(ctx context.Context, lease *IP
 	return nil, nil
 }
 
-// applyDeleteStaticLease removes a reserved static lease. Like the repin
-// op, the sessionID IS NULL guard makes the active check atomic: zero
-// rows affected maps to ErrLeaseActive.
+// applyDeleteStaticLease removes a reserved static lease. The sessionID IS
+// NULL guard makes the active-check atomic: zero rows affected maps to
+// ErrLeaseActive.
 func (db *Database) applyDeleteStaticLease(ctx context.Context, p *stringPayload) (any, error) {
 	var outcome sqlair.Outcome
 
@@ -579,11 +574,8 @@ func (db *Database) applyAllocateIPLease(ctx context.Context, p *allocateIPLease
 	sessionID := p.SessionID
 
 	// Step 0: an admin-pinned static reservation takes precedence over
-	// dynamic allocation. Bind it to this session (and the serving node on
-	// failover, mirroring the dynamic re-registration branch below) and
-	// return its reserved address. The Step 2 merge-scan lists every lease
-	// in the pool, so a reserved static address is never handed out
-	// dynamically even when no session holds it yet.
+	// dynamic allocation. The merge-scan below lists every lease in the
+	// pool, so a reserved static address is never handed out dynamically.
 	static := IPLease{PoolID: p.PoolID, PoolType: p.PoolType, IMSI: p.IMSI}
 
 	err = runner.Query(ctx, db.getStaticLeaseStmt, static).Get(&static)
@@ -614,13 +606,11 @@ func (db *Database) applyAllocateIPLease(ctx context.Context, p *allocateIPLease
 		return nil, fmt.Errorf("get static lease: %w", err)
 	}
 
-	// Step 1: a dynamic lease already held by *this* session
-	// (re-registration on retry or failover). Keyed on sessionID so a
-	// second, distinct session to the same pool does not collapse onto
-	// the first session's lease but falls through to a fresh address —
-	// a subscriber may hold multiple concurrent sessions on one DN, each
-	// with its own IP (TS 23.501 §5.6.1, TS 23.401 §5.10.1). Update the
-	// owning node and return its address.
+	// Step 1: re-registration of a dynamic lease already held by *this*
+	// session (retry or failover). Keyed on sessionID so a distinct second
+	// session on the same pool gets a fresh address — a subscriber may hold
+	// concurrent sessions on one DN, each with its own IP (TS 23.501
+	// §5.6.1, TS 23.401 §5.10.1).
 	existing := IPLease{PoolID: p.PoolID, PoolType: p.PoolType, IMSI: p.IMSI, SessionID: &sessionID}
 
 	err = runner.Query(ctx, db.getDynamicLeaseBySessionStmt, existing).Get(&existing)

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -434,6 +434,85 @@ func (db *Database) applyUpdateLeaseNode(ctx context.Context, lease *IPLease) (a
 	return nil, nil
 }
 
+// applyCreateStaticLease inserts an admin-pinned reservation. The
+// SELECT-then-INSERT runs under leaderCaptureAndPropose's proposeMu, so
+// the one-per-(imsi, pool, family) check and the write are serialised
+// against every other replicated allocation — a second static for the
+// same tuple can't race in. A duplicate address in the pool is caught by
+// the UNIQUE(poolID, addressBin) constraint. The reservation starts
+// unbound (sessionID NULL, nodeID 0).
+func (db *Database) applyCreateStaticLease(ctx context.Context, lease *IPLease) (any, error) {
+	existing := IPLease{PoolID: lease.PoolID, PoolType: lease.PoolType, IMSI: lease.IMSI}
+
+	err := db.runner(ctx).Query(ctx, db.getStaticLeaseStmt, existing).Get(&existing)
+	switch {
+	case err == nil:
+		return nil, ErrAlreadyExists
+	case errors.Is(err, sql.ErrNoRows):
+	default:
+		return nil, fmt.Errorf("get static lease: %w", err)
+	}
+
+	lease.Type = "static"
+	lease.SessionID = nil
+	lease.NodeID = 0
+	lease.CreatedAt = time.Now().Unix()
+
+	return db.applyCreateLease(ctx, lease)
+}
+
+// applyUpdateStaticLeaseAddress repins a reserved static lease. The
+// sessionID IS NULL predicate rejects an active reservation atomically:
+// zero rows affected means the reservation was bound between the
+// handler's pre-check and this write, mapped to ErrLeaseActive. A
+// collision with another lease's address surfaces as ErrAlreadyExists.
+func (db *Database) applyUpdateStaticLeaseAddress(ctx context.Context, lease *IPLease) (any, error) {
+	var outcome sqlair.Outcome
+
+	err := db.runner(ctx).Query(ctx, db.updateStaticLeaseAddressStmt, lease).Get(&outcome)
+	if err != nil {
+		if isUniqueNameError(err) {
+			return nil, ErrAlreadyExists
+		}
+
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	rowsAffected, err := outcome.Result().RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return nil, ErrLeaseActive
+	}
+
+	return nil, nil
+}
+
+// applyDeleteStaticLease removes a reserved static lease. Like the repin
+// op, the sessionID IS NULL guard makes the active check atomic: zero
+// rows affected maps to ErrLeaseActive.
+func (db *Database) applyDeleteStaticLease(ctx context.Context, p *stringPayload) (any, error) {
+	var outcome sqlair.Outcome
+
+	err := db.runner(ctx).Query(ctx, db.deleteStaticLeaseStmt, IPLease{ID: p.Value}).Get(&outcome)
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	rowsAffected, err := outcome.Result().RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return nil, ErrLeaseActive
+	}
+
+	return nil, nil
+}
+
 // allocateIPLeasePayload is the wire payload for AllocateIPLease. The
 // caller does not pre-resolve the address — that is the whole point of
 // this op. The leader's apply function picks the address atomically
@@ -498,6 +577,36 @@ func (db *Database) applyAllocateIPLease(ctx context.Context, p *allocateIPLease
 	}
 
 	sessionID := p.SessionID
+
+	// Step 0: an admin-pinned static reservation takes precedence over
+	// dynamic allocation. Bind it to this session (and the serving node on
+	// failover, mirroring the dynamic re-registration branch below) and
+	// return its reserved address. The Step 2 merge-scan lists every lease
+	// in the pool, so a reserved static address is never handed out
+	// dynamically even when no session holds it yet.
+	static := IPLease{PoolID: p.PoolID, PoolType: p.PoolType, IMSI: p.IMSI}
+
+	err = runner.Query(ctx, db.getStaticLeaseStmt, static).Get(&static)
+	switch {
+	case err == nil:
+		static.SessionID = &sessionID
+		if static.NodeID != p.NodeID {
+			static.NodeID = p.NodeID
+			if _, applyErr := db.applyUpdateLeaseNode(ctx, &static); applyErr != nil {
+				return nil, fmt.Errorf("bind static lease node: %w", applyErr)
+			}
+		} else {
+			if _, applyErr := db.applyUpdateLeaseSession(ctx, &static); applyErr != nil {
+				return nil, fmt.Errorf("bind static lease session: %w", applyErr)
+			}
+		}
+
+		return static.Address().String(), nil
+	case errors.Is(err, sql.ErrNoRows):
+		// no static reservation; fall through to the dynamic path
+	default:
+		return nil, fmt.Errorf("get static lease: %w", err)
+	}
 
 	// Step 1: existing dynamic lease (re-registration). Update the
 	// owning node and session and return its address.

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -529,7 +529,7 @@ type allocateIPLeasePayload struct {
 //
 // Every query and write goes through db.runner(ctx) so they target the
 // pinned SQLite connection set up by applyWithPinnedConn. Calling the
-// public DB methods (GetDataNetworkByID, GetDynamicLease, etc.) here
+// public DB methods (GetDataNetworkByID, GetLeaseBySession, etc.) here
 // would dispatch to db.conn() — the shared pool with MaxOpenConns=1
 // whose only connection is already held by the active capture, and
 // every such SELECT would deadlock until the proposeTimeout context

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -589,41 +589,47 @@ func (db *Database) applyAllocateIPLease(ctx context.Context, p *allocateIPLease
 	err = runner.Query(ctx, db.getStaticLeaseStmt, static).Get(&static)
 	switch {
 	case err == nil:
-		static.SessionID = &sessionID
-		if static.NodeID != p.NodeID {
-			static.NodeID = p.NodeID
-			if _, applyErr := db.applyUpdateLeaseNode(ctx, &static); applyErr != nil {
-				return nil, fmt.Errorf("bind static lease node: %w", applyErr)
+		// A pinned address binds exactly one session. Claim it when it is
+		// unheld or already held by this same session (retry/failover); a
+		// concurrent second session to the same DN falls through to a
+		// dynamic address, since one address cannot serve two sessions.
+		if static.SessionID == nil || *static.SessionID == sessionID {
+			static.SessionID = &sessionID
+			if static.NodeID != p.NodeID {
+				static.NodeID = p.NodeID
+				if _, applyErr := db.applyUpdateLeaseNode(ctx, &static); applyErr != nil {
+					return nil, fmt.Errorf("bind static lease node: %w", applyErr)
+				}
+			} else {
+				if _, applyErr := db.applyUpdateLeaseSession(ctx, &static); applyErr != nil {
+					return nil, fmt.Errorf("bind static lease session: %w", applyErr)
+				}
 			}
-		} else {
-			if _, applyErr := db.applyUpdateLeaseSession(ctx, &static); applyErr != nil {
-				return nil, fmt.Errorf("bind static lease session: %w", applyErr)
-			}
-		}
 
-		return static.Address().String(), nil
+			return static.Address().String(), nil
+		}
 	case errors.Is(err, sql.ErrNoRows):
 		// no static reservation; fall through to the dynamic path
 	default:
 		return nil, fmt.Errorf("get static lease: %w", err)
 	}
 
-	// Step 1: existing dynamic lease (re-registration). Update the
-	// owning node and session and return its address.
-	existing := IPLease{PoolID: p.PoolID, PoolType: p.PoolType, IMSI: p.IMSI}
+	// Step 1: a dynamic lease already held by *this* session
+	// (re-registration on retry or failover). Keyed on sessionID so a
+	// second, distinct session to the same pool does not collapse onto
+	// the first session's lease but falls through to a fresh address —
+	// a subscriber may hold multiple concurrent sessions on one DN, each
+	// with its own IP (TS 23.501 §5.6.1, TS 23.401 §5.10.1). Update the
+	// owning node and return its address.
+	existing := IPLease{PoolID: p.PoolID, PoolType: p.PoolType, IMSI: p.IMSI, SessionID: &sessionID}
 
-	err = runner.Query(ctx, db.getDynamicLeaseStmt, existing).Get(&existing)
+	err = runner.Query(ctx, db.getDynamicLeaseBySessionStmt, existing).Get(&existing)
 	switch {
 	case err == nil:
-		existing.SessionID = &sessionID
 		if existing.NodeID != p.NodeID {
 			existing.NodeID = p.NodeID
 			if _, applyErr := db.applyUpdateLeaseNode(ctx, &existing); applyErr != nil {
 				return nil, fmt.Errorf("update lease node: %w", applyErr)
-			}
-		} else {
-			if _, applyErr := db.applyUpdateLeaseSession(ctx, &existing); applyErr != nil {
-				return nil, fmt.Errorf("update lease session: %w", applyErr)
 			}
 		}
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -82,6 +82,10 @@ type Database struct {
 	countLeasesByIMSIStmt        *sqlair.Statement
 	listLeasesByPoolPageStmt     *sqlair.Statement
 	listAllLeasesStmt            *sqlair.Statement
+	getStaticLeaseStmt           *sqlair.Statement
+	listStaticLeasesByIMSIStmt   *sqlair.Statement
+	updateStaticLeaseAddressStmt *sqlair.Statement
+	deleteStaticLeaseStmt        *sqlair.Statement
 
 	// API Token statements
 	listAPITokensStmt   *sqlair.Statement
@@ -1275,6 +1279,10 @@ func (db *Database) PrepareStatements() error {
 		{&db.countLeasesByIMSIStmt, fmt.Sprintf(countLeasesByIMSIStmt, IPLeasesTableName), []any{NumItems{}, IPLease{}}},
 		{&db.listLeasesByPoolPageStmt, fmt.Sprintf(listLeasesByPoolPageStmt, IPLeasesTableName), []any{ListArgs{}, IPLease{}, NumItems{}}},
 		{&db.listAllLeasesStmt, fmt.Sprintf(listAllLeasesStmt, IPLeasesTableName), []any{IPLease{}}},
+		{&db.getStaticLeaseStmt, fmt.Sprintf(getStaticLeaseStmt, IPLeasesTableName), []any{IPLease{}}},
+		{&db.listStaticLeasesByIMSIStmt, fmt.Sprintf(listStaticLeasesByIMSIStmt, IPLeasesTableName), []any{IPLease{}}},
+		{&db.updateStaticLeaseAddressStmt, fmt.Sprintf(updateStaticLeaseAddressStmt, IPLeasesTableName), []any{IPLease{}}},
+		{&db.deleteStaticLeaseStmt, fmt.Sprintf(deleteStaticLeaseStmt, IPLeasesTableName), []any{IPLease{}}},
 
 		// API Tokens
 		{&db.listAPITokensStmt, fmt.Sprintf(listAPITokensPagedStmt, APITokensTableName), []any{ListArgs{}, APIToken{}, NumItems{}}},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -64,7 +64,7 @@ type Database struct {
 
 	// IP Lease statements
 	createLeaseStmt              *sqlair.Statement
-	getDynamicLeaseStmt          *sqlair.Statement
+	getDynamicLeaseBySessionStmt *sqlair.Statement
 	getLeaseBySessionStmt        *sqlair.Statement
 	updateLeaseSessionStmt       *sqlair.Statement
 	updateLeaseNodeStmt          *sqlair.Statement
@@ -84,6 +84,7 @@ type Database struct {
 	listAllLeasesStmt            *sqlair.Statement
 	getStaticLeaseStmt           *sqlair.Statement
 	listStaticLeasesByIMSIStmt   *sqlair.Statement
+	listStaticLeasesByDNStmt     *sqlair.Statement
 	updateStaticLeaseAddressStmt *sqlair.Statement
 	deleteStaticLeaseStmt        *sqlair.Statement
 
@@ -1261,7 +1262,7 @@ func (db *Database) PrepareStatements() error {
 
 		// IP Leases
 		{&db.createLeaseStmt, fmt.Sprintf(createLeaseStmt, IPLeasesTableName), []any{IPLease{}}},
-		{&db.getDynamicLeaseStmt, fmt.Sprintf(getDynamicLeaseStmt, IPLeasesTableName), []any{IPLease{}}},
+		{&db.getDynamicLeaseBySessionStmt, fmt.Sprintf(getDynamicLeaseBySessionStmt, IPLeasesTableName), []any{IPLease{}}},
 		{&db.getLeaseBySessionStmt, fmt.Sprintf(getLeaseBySessionStmt, IPLeasesTableName), []any{IPLease{}}},
 		{&db.updateLeaseSessionStmt, fmt.Sprintf(updateLeaseSessionStmt, IPLeasesTableName), []any{IPLease{}}},
 		{&db.updateLeaseNodeStmt, fmt.Sprintf(updateLeaseNodeStmt, IPLeasesTableName), []any{IPLease{}}},
@@ -1281,6 +1282,7 @@ func (db *Database) PrepareStatements() error {
 		{&db.listAllLeasesStmt, fmt.Sprintf(listAllLeasesStmt, IPLeasesTableName), []any{IPLease{}}},
 		{&db.getStaticLeaseStmt, fmt.Sprintf(getStaticLeaseStmt, IPLeasesTableName), []any{IPLease{}}},
 		{&db.listStaticLeasesByIMSIStmt, fmt.Sprintf(listStaticLeasesByIMSIStmt, IPLeasesTableName), []any{IPLease{}}},
+		{&db.listStaticLeasesByDNStmt, fmt.Sprintf(listStaticLeasesByDNStmt, IPLeasesTableName), []any{IPLease{}}},
 		{&db.updateStaticLeaseAddressStmt, fmt.Sprintf(updateStaticLeaseAddressStmt, IPLeasesTableName), []any{IPLease{}}},
 		{&db.deleteStaticLeaseStmt, fmt.Sprintf(deleteStaticLeaseStmt, IPLeasesTableName), []any{IPLease{}}},
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -55,6 +55,7 @@ type Database struct {
 
 	// Subscriber statements
 	listSubscribersStmt         *sqlair.Statement
+	listSubscribersByDNStmt     *sqlair.Statement
 	countSubscribersStmt        *sqlair.Statement
 	getSubscriberStmt           *sqlair.Statement
 	createSubscriberStmt        *sqlair.Statement
@@ -1253,6 +1254,7 @@ func (db *Database) PrepareStatements() error {
 	stmts := []stmtDef{
 		// Subscribers
 		{&db.listSubscribersStmt, fmt.Sprintf(listSubscribersPagedStmt, SubscribersTableName), []any{ListArgs{}, Subscriber{}, NumItems{}}},
+		{&db.listSubscribersByDNStmt, fmt.Sprintf(listSubscribersByDNStmt, SubscribersTableName, PoliciesTableName), []any{ListArgs{}, Subscriber{}, NumItems{}, Policy{}}},
 		{&db.countSubscribersStmt, fmt.Sprintf(countSubscribersStmt, SubscribersTableName), []any{NumItems{}}},
 		{&db.getSubscriberStmt, fmt.Sprintf(getSubscriberStmt, SubscribersTableName), []any{Subscriber{}}},
 		{&db.createSubscriberStmt, fmt.Sprintf(createSubscriberStmt, SubscribersTableName), []any{Subscriber{}}},

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -12,10 +12,9 @@ import (
 var (
 	ErrAlreadyExists = errors.New("already exists")
 	ErrNotFound      = errors.New("not found")
-	// ErrLeaseActive is returned when a static lease mutation (repin or
-	// delete) targets a reservation currently bound to a session. The
-	// guard is enforced atomically inside the op (WHERE sessionID IS
-	// NULL); handlers map it to 409.
+	// ErrLeaseActive is returned when a repin or delete targets a static
+	// reservation bound to a session (op guard: WHERE sessionID IS NULL).
+	// Handlers map it to 409.
 	ErrLeaseActive         = errors.New("static IP is in use by an active session")
 	ErrDataNetworkNotFound = errors.New("data network not found")
 	ErrNoMatchingPolicy    = errors.New("no matching policy for slice and DNN")

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -10,8 +10,13 @@ import (
 )
 
 var (
-	ErrAlreadyExists       = errors.New("already exists")
-	ErrNotFound            = errors.New("not found")
+	ErrAlreadyExists = errors.New("already exists")
+	ErrNotFound      = errors.New("not found")
+	// ErrLeaseActive is returned when a static lease mutation (repin or
+	// delete) targets a reservation currently bound to a session. The
+	// guard is enforced atomically inside the op (WHERE sessionID IS
+	// NULL); handlers map it to 409.
+	ErrLeaseActive         = errors.New("static IP is in use by an active session")
 	ErrDataNetworkNotFound = errors.New("data network not found")
 	ErrNoMatchingPolicy    = errors.New("no matching policy for slice and DNN")
 	// ErrDNNNotInSlice is returned by GetSessionPolicy when a policy matches the

--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -843,10 +843,9 @@ func (db *Database) CountLeasesByIMSI(ctx context.Context, imsi string) (int, er
 	return result.Count, nil
 }
 
-// CreateStaticLease pins an address to a subscriber for a data network
-// (pool) and family. The reservation is created unbound. Returns
-// ErrAlreadyExists when a static lease already exists for (poolID,
-// poolType, imsi) or when the address is already leased in the pool.
+// CreateStaticLease pins an address to a subscriber for a data network and
+// family. Returns ErrAlreadyExists when a static lease already exists for
+// (poolID, poolType, imsi) or the address is already leased.
 func (db *Database) CreateStaticLease(ctx context.Context, imsi, poolID, poolType string, addr netip.Addr) error {
 	_, span := tracer.Start(
 		ctx,
@@ -1006,10 +1005,9 @@ func (db *Database) ListStaticLeasesByDataNetwork(ctx context.Context, poolID st
 	return leases, nil
 }
 
-// ClearStaticLeaseSession returns a static lease to the reserved state by
-// nulling its sessionID. Called on session release so listActiveLeases
-// and the BGP advertisement (sessionID IS NOT NULL) drop the address
-// while the reservation row persists.
+// ClearStaticLeaseSession returns a static lease to reserved by nulling its
+// sessionID, so listActiveLeases and BGP (sessionID IS NOT NULL) drop the
+// address while the row persists.
 func (db *Database) ClearStaticLeaseSession(ctx context.Context, leaseID string) error {
 	_, span := tracer.Start(
 		ctx,

--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -41,6 +41,10 @@ const (
 	countLeasesByIMSIStmt        = "SELECT COUNT(*) AS &NumItems.count FROM %s WHERE imsi==$IPLease.imsi"
 	listLeasesByPoolPageStmt     = "SELECT &IPLease.*, COUNT(*) OVER() AS &NumItems.count FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType ORDER BY addressBin LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
 	listAllLeasesStmt            = "SELECT &IPLease.* FROM %s"
+	getStaticLeaseStmt           = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType AND imsi==$IPLease.imsi AND type='static'"
+	listStaticLeasesByIMSIStmt   = "SELECT &IPLease.* FROM %s WHERE imsi==$IPLease.imsi AND type='static' ORDER BY addressBin"
+	updateStaticLeaseAddressStmt = "UPDATE %s SET addressBin=$IPLease.addressBin WHERE id==$IPLease.id AND type='static' AND sessionID IS NULL"
+	deleteStaticLeaseStmt        = "DELETE FROM %s WHERE id==$IPLease.id AND type='static' AND sessionID IS NULL"
 )
 
 // IPLease represents a row in the ip_leases table.
@@ -875,4 +879,231 @@ func (db *Database) CountLeasesByIMSI(ctx context.Context, imsi string) (int, er
 	span.SetStatus(codes.Ok, "")
 
 	return result.Count, nil
+}
+
+// CreateStaticLease pins an address to a subscriber for a data network
+// (pool) and family. The reservation is created unbound. Returns
+// ErrAlreadyExists when a static lease already exists for (poolID,
+// poolType, imsi) or when the address is already leased in the pool.
+func (db *Database) CreateStaticLease(ctx context.Context, imsi, poolID, poolType string, addr netip.Addr) error {
+	_, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (static)", "INSERT", IPLeasesTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("INSERT"),
+			attribute.String("db.collection", IPLeasesTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "insert"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "insert").Inc()
+
+	b := addr.As16()
+	lease := &IPLease{
+		PoolID:     poolID,
+		PoolType:   poolType,
+		AddressBin: b[:],
+		IMSI:       imsi,
+	}
+
+	_, err := opCreateStaticLease.Invoke(db, lease)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return nil
+}
+
+// GetStaticLease returns the static reservation for (poolID, poolType,
+// imsi), or ErrNotFound.
+func (db *Database) GetStaticLease(ctx context.Context, poolID, poolType, imsi string) (*IPLease, error) {
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (static)", "SELECT", IPLeasesTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("SELECT"),
+			attribute.String("db.collection", IPLeasesTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "select"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "select").Inc()
+
+	row := IPLease{PoolID: poolID, PoolType: poolType, IMSI: imsi}
+
+	err := db.conn().Query(ctx, db.getStaticLeaseStmt, row).Get(&row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Ok, "no rows")
+			return nil, ErrNotFound
+		}
+
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "query failed")
+
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return &row, nil
+}
+
+// ListStaticLeasesByIMSI returns every static reservation held by a
+// subscriber across data networks and families.
+func (db *Database) ListStaticLeasesByIMSI(ctx context.Context, imsi string) ([]IPLease, error) {
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (static by imsi)", "SELECT", IPLeasesTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("SELECT"),
+			attribute.String("db.collection", IPLeasesTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "select"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "select").Inc()
+
+	var leases []IPLease
+
+	err := db.conn().Query(ctx, db.listStaticLeasesByIMSIStmt, IPLease{IMSI: imsi}).GetAll(&leases)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Ok, "no rows")
+			return nil, nil
+		}
+
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "query failed")
+
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return leases, nil
+}
+
+// ClearStaticLeaseSession returns a static lease to the reserved state by
+// nulling its sessionID. Called on session release so listActiveLeases
+// and the BGP advertisement (sessionID IS NOT NULL) drop the address
+// while the reservation row persists.
+func (db *Database) ClearStaticLeaseSession(ctx context.Context, leaseID string) error {
+	_, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (static clear)", "UPDATE", IPLeasesTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("UPDATE"),
+			attribute.String("db.collection", IPLeasesTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "update"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "update").Inc()
+
+	_, err := opUpdateLeaseSession.Invoke(db, &IPLease{ID: leaseID})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return nil
+}
+
+// UpdateStaticLeaseAddress repins a reserved static lease to a new
+// address. Returns ErrLeaseActive if the reservation is bound to a
+// session and ErrAlreadyExists if the address is already leased.
+func (db *Database) UpdateStaticLeaseAddress(ctx context.Context, leaseID string, addr netip.Addr) error {
+	_, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (static repin)", "UPDATE", IPLeasesTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("UPDATE"),
+			attribute.String("db.collection", IPLeasesTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "update"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "update").Inc()
+
+	b := addr.As16()
+
+	_, err := opUpdateStaticLeaseAddress.Invoke(db, &IPLease{ID: leaseID, AddressBin: b[:]})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return nil
+}
+
+// DeleteStaticLease removes a reserved static lease. Returns
+// ErrLeaseActive if the reservation is bound to a session.
+func (db *Database) DeleteStaticLease(ctx context.Context, leaseID string) error {
+	_, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (static)", "DELETE", IPLeasesTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("DELETE"),
+			attribute.String("db.collection", IPLeasesTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "delete"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "delete").Inc()
+
+	_, err := opDeleteStaticLease.Invoke(db, &stringPayload{Value: leaseID})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return nil
 }

--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -23,7 +23,7 @@ const IPLeasesTableName = "ip_leases"
 
 const (
 	createLeaseStmt              = "INSERT INTO %s (id, poolID, poolType, addressBin, imsi, sessionID, type, createdAt, nodeID) VALUES ($IPLease.id, $IPLease.poolID, $IPLease.poolType, $IPLease.addressBin, $IPLease.imsi, $IPLease.sessionID, $IPLease.type, $IPLease.createdAt, $IPLease.nodeID)"
-	getDynamicLeaseStmt          = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType AND imsi==$IPLease.imsi AND type='dynamic'"
+	getDynamicLeaseBySessionStmt = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType AND imsi==$IPLease.imsi AND sessionID==$IPLease.sessionID AND type='dynamic'"
 	getLeaseBySessionStmt        = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType AND sessionID==$IPLease.sessionID AND imsi==$IPLease.imsi"
 	updateLeaseSessionStmt       = "UPDATE %s SET sessionID=$IPLease.sessionID WHERE id==$IPLease.id"
 	updateLeaseNodeStmt          = "UPDATE %s SET nodeID=$IPLease.nodeID, sessionID=$IPLease.sessionID WHERE id==$IPLease.id"
@@ -42,6 +42,7 @@ const (
 	listLeasesByPoolPageStmt     = "SELECT &IPLease.*, COUNT(*) OVER() AS &NumItems.count FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType ORDER BY addressBin LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
 	listAllLeasesStmt            = "SELECT &IPLease.* FROM %s"
 	getStaticLeaseStmt           = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType AND imsi==$IPLease.imsi AND type='static'"
+	listStaticLeasesByDNStmt     = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND type='static' ORDER BY poolType, addressBin"
 	listStaticLeasesByIMSIStmt   = "SELECT &IPLease.* FROM %s WHERE imsi==$IPLease.imsi AND type='static' ORDER BY addressBin"
 	updateStaticLeaseAddressStmt = "UPDATE %s SET addressBin=$IPLease.addressBin WHERE id==$IPLease.id AND type='static' AND sessionID IS NULL"
 	deleteStaticLeaseStmt        = "DELETE FROM %s WHERE id==$IPLease.id AND type='static' AND sessionID IS NULL"
@@ -217,45 +218,6 @@ func (db *Database) CreateLease(ctx context.Context, lease *IPLease, address net
 	span.SetStatus(codes.Ok, "")
 
 	return nil
-}
-
-// GetDynamicLease returns the dynamic lease for (poolID, poolType, imsi), or ErrNotFound.
-func (db *Database) GetDynamicLease(ctx context.Context, poolID string, poolType string, imsi string) (*IPLease, error) {
-	ctx, span := tracer.Start(
-		ctx,
-		fmt.Sprintf("%s %s (dynamic)", "SELECT", IPLeasesTableName),
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			semconv.DBSystemNameSQLite,
-			semconv.DBOperationName("SELECT"),
-			attribute.String("db.collection", IPLeasesTableName),
-		),
-	)
-	defer span.End()
-
-	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "select"))
-	defer timer.ObserveDuration()
-
-	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "select").Inc()
-
-	row := IPLease{PoolID: poolID, PoolType: poolType, IMSI: imsi}
-
-	err := db.conn().Query(ctx, db.getDynamicLeaseStmt, row).Get(&row)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			span.SetStatus(codes.Ok, "no rows")
-			return nil, ErrNotFound
-		}
-
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "query failed")
-
-		return nil, fmt.Errorf("query failed: %w", err)
-	}
-
-	span.SetStatus(codes.Ok, "")
-
-	return &row, nil
 }
 
 // GetLeaseBySession returns the lease matching (poolID, poolType, sessionID, imsi), or ErrNotFound.
@@ -987,6 +949,46 @@ func (db *Database) ListStaticLeasesByIMSI(ctx context.Context, imsi string) ([]
 	var leases []IPLease
 
 	err := db.conn().Query(ctx, db.listStaticLeasesByIMSIStmt, IPLease{IMSI: imsi}).GetAll(&leases)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Ok, "no rows")
+			return nil, nil
+		}
+
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "query failed")
+
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return leases, nil
+}
+
+// ListStaticLeasesByDataNetwork returns every static reservation in a pool
+// (both families), ordered by family then address.
+func (db *Database) ListStaticLeasesByDataNetwork(ctx context.Context, poolID string) ([]IPLease, error) {
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (static by data network)", "SELECT", IPLeasesTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("SELECT"),
+			attribute.String("db.collection", IPLeasesTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(IPLeasesTableName, "select"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "select").Inc()
+
+	var leases []IPLease
+
+	err := db.conn().Query(ctx, db.listStaticLeasesByDNStmt, IPLease{PoolID: poolID}).GetAll(&leases)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Ok, "no rows")

--- a/internal/db/ip_leases_test.go
+++ b/internal/db/ip_leases_test.go
@@ -138,10 +138,10 @@ func TestCreateAndGetLease(t *testing.T) {
 		t.Fatalf("CreateLease: %s", err)
 	}
 
-	// Should be retrievable as a dynamic lease.
-	got, err := database.GetDynamicLease(ctx, poolID, "ipv4", imsi)
+	// Should be retrievable by its session.
+	got, err := database.GetLeaseBySession(ctx, poolID, "ipv4", sessionID, imsi)
 	if err != nil {
-		t.Fatalf("GetDynamicLease: %s", err)
+		t.Fatalf("GetLeaseBySession: %s", err)
 	}
 
 	if got.Address() != addr("192.168.1.10") {
@@ -228,9 +228,9 @@ func TestUpdateLeaseSession(t *testing.T) {
 		t.Fatalf("CreateLease: %s", err)
 	}
 
-	got, err := database.GetDynamicLease(ctx, poolID, "ipv4", imsi)
+	got, err := database.GetLeaseBySession(ctx, poolID, "ipv4", sessID, imsi)
 	if err != nil {
-		t.Fatalf("GetDynamicLease: %s", err)
+		t.Fatalf("GetLeaseBySession: %s", err)
 	}
 
 	// Update session.
@@ -238,9 +238,9 @@ func TestUpdateLeaseSession(t *testing.T) {
 		t.Fatalf("UpdateLeaseSession: %s", err)
 	}
 
-	got2, err := database.GetDynamicLease(ctx, poolID, "ipv4", imsi)
+	got2, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 100, imsi)
 	if err != nil {
-		t.Fatalf("GetDynamicLease after update: %s", err)
+		t.Fatalf("GetLeaseBySession after update: %s", err)
 	}
 
 	if got2.SessionID == nil || *got2.SessionID != 100 {
@@ -300,16 +300,16 @@ func TestDeleteDynamicLease(t *testing.T) {
 		t.Fatalf("CreateLease: %s", err)
 	}
 
-	got, err := database.GetDynamicLease(ctx, poolID, "ipv4", imsi)
+	got, err := database.GetLeaseBySession(ctx, poolID, "ipv4", sessionID, imsi)
 	if err != nil {
-		t.Fatalf("GetDynamicLease: %s", err)
+		t.Fatalf("GetLeaseBySession: %s", err)
 	}
 
 	if err := database.DeleteDynamicLease(ctx, got.ID); err != nil {
 		t.Fatalf("DeleteDynamicLease: %s", err)
 	}
 
-	_, err = database.GetDynamicLease(ctx, poolID, "ipv4", imsi)
+	_, err = database.GetLeaseBySession(ctx, poolID, "ipv4", sessionID, imsi)
 	if err != db.ErrNotFound {
 		t.Fatalf("expected ErrNotFound after delete, got %v", err)
 	}
@@ -863,6 +863,38 @@ func TestCreateStaticLease_Uniqueness(t *testing.T) {
 	}
 }
 
+func TestCreateStaticLease_MultiplePerSubscriber(t *testing.T) {
+	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	// A subscriber may hold one static per family on the same data network.
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.10")); err != nil {
+		t.Fatalf("CreateStaticLease ipv4: %s", err)
+	}
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv6", addr("2001:db8:abcd:1::")); err != nil {
+		t.Fatalf("CreateStaticLease ipv6: %s", err)
+	}
+
+	byIMSI, err := database.ListStaticLeasesByIMSI(ctx, imsi)
+	if err != nil {
+		t.Fatalf("ListStaticLeasesByIMSI: %s", err)
+	}
+
+	if len(byIMSI) != 2 {
+		t.Fatalf("expected 2 static leases for subscriber, got %d", len(byIMSI))
+	}
+
+	byDN, err := database.ListStaticLeasesByDataNetwork(ctx, poolID)
+	if err != nil {
+		t.Fatalf("ListStaticLeasesByDataNetwork: %s", err)
+	}
+
+	if len(byDN) != 2 {
+		t.Fatalf("expected 2 static leases in the data network, got %d", len(byDN))
+	}
+}
+
 func TestGetAndListStaticLease(t *testing.T) {
 	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
 	ctx := context.Background()
@@ -1051,8 +1083,9 @@ func TestAllocateIPLease_PrefersStatic(t *testing.T) {
 		t.Fatalf("expected static lease bound to node 1, got type=%s node=%d", bound.Type, bound.NodeID)
 	}
 
-	// Failover: re-establishing on another node re-binds the same address.
-	got2, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 8, 2)
+	// Failover: the same session re-establishing on another node keeps the
+	// pinned address and updates the owning node.
+	got2, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 7, 2)
 	if err != nil {
 		t.Fatalf("AllocateIPLease (failover): %s", err)
 	}
@@ -1061,13 +1094,89 @@ func TestAllocateIPLease_PrefersStatic(t *testing.T) {
 		t.Fatalf("expected same static address on failover, got %s", got2)
 	}
 
-	rebound, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 8, imsi)
+	rebound, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 7, imsi)
 	if err != nil {
 		t.Fatalf("GetLeaseBySession after failover: %s", err)
 	}
 
-	if rebound.NodeID != 2 || rebound.SessionID == nil || *rebound.SessionID != 8 {
-		t.Fatalf("expected re-bind to node 2 session 8, got node=%d session=%v", rebound.NodeID, rebound.SessionID)
+	if rebound.NodeID != 2 || rebound.SessionID == nil || *rebound.SessionID != 7 {
+		t.Fatalf("expected re-bind to node 2 session 7, got node=%d session=%v", rebound.NodeID, rebound.SessionID)
+	}
+}
+
+func TestAllocateIPLease_MultipleSessionsSameDNGetDistinctIPs(t *testing.T) {
+	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	first, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 5, 1)
+	if err != nil {
+		t.Fatalf("AllocateIPLease (session 5): %s", err)
+	}
+
+	// A second concurrent session for the same subscriber on the same pool
+	// must get its own address, not collapse onto the first session's lease.
+	second, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 6, 1)
+	if err != nil {
+		t.Fatalf("AllocateIPLease (session 6): %s", err)
+	}
+
+	if first == second {
+		t.Fatalf("expected distinct addresses per session, both got %s", first)
+	}
+
+	// Both leases coexist and each is reachable by its own session.
+	l5, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 5, imsi)
+	if err != nil {
+		t.Fatalf("GetLeaseBySession(5): %s", err)
+	}
+
+	l6, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 6, imsi)
+	if err != nil {
+		t.Fatalf("GetLeaseBySession(6): %s", err)
+	}
+
+	if l5.Address() != first || l6.Address() != second {
+		t.Fatalf("session→lease mismatch: 5=%s (want %s), 6=%s (want %s)", l5.Address(), first, l6.Address(), second)
+	}
+
+	// Re-establishing session 5 (retry) returns its own address, unchanged.
+	again, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 5, 1)
+	if err != nil {
+		t.Fatalf("AllocateIPLease (session 5 retry): %s", err)
+	}
+
+	if again != first {
+		t.Fatalf("expected session 5 retry to return %s, got %s", first, again)
+	}
+}
+
+func TestAllocateIPLease_StaticHeldByOtherSessionFallsToDynamic(t *testing.T) {
+	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.50")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	// Session 7 claims the pinned address.
+	pinned, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 7, 1)
+	if err != nil {
+		t.Fatalf("AllocateIPLease (session 7): %s", err)
+	}
+
+	if pinned != addr("192.168.1.50") {
+		t.Fatalf("expected pinned 192.168.1.50, got %s", pinned)
+	}
+
+	// A second concurrent session cannot take the same pinned address; it
+	// gets a dynamic one instead.
+	other, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 8, 1)
+	if err != nil {
+		t.Fatalf("AllocateIPLease (session 8): %s", err)
+	}
+
+	if other == addr("192.168.1.50") {
+		t.Fatalf("second session was handed the pinned static address")
 	}
 }
 

--- a/internal/db/ip_leases_test.go
+++ b/internal/db/ip_leases_test.go
@@ -574,6 +574,26 @@ func TestOnDeleteCascade_Subscriber(t *testing.T) {
 	}
 }
 
+// A static reservation is cleaned up with its subscriber via the
+// ip_leases.imsi ON DELETE CASCADE, so a deleted subscriber leaves no
+// orphaned pin holding an address.
+func TestOnDeleteCascade_Subscriber_Static(t *testing.T) {
+	database, poolID, imsi := setupLeaseTestDB(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.42")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	if err := database.DeleteSubscriber(ctx, imsi); err != nil {
+		t.Fatalf("DeleteSubscriber: %s", err)
+	}
+
+	if _, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi); err != db.ErrNotFound {
+		t.Fatalf("expected static reservation removed with subscriber, got %v", err)
+	}
+}
+
 func TestOnDeleteCascade_DataNetwork(t *testing.T) {
 	database, poolID, imsi := setupLeaseTestDB(t)
 	ctx := context.Background()

--- a/internal/db/ip_leases_test.go
+++ b/internal/db/ip_leases_test.go
@@ -138,7 +138,6 @@ func TestCreateAndGetLease(t *testing.T) {
 		t.Fatalf("CreateLease: %s", err)
 	}
 
-	// Should be retrievable by its session.
 	got, err := database.GetLeaseBySession(ctx, poolID, "ipv4", sessionID, imsi)
 	if err != nil {
 		t.Fatalf("GetLeaseBySession: %s", err)
@@ -995,7 +994,6 @@ func TestUpdateStaticLeaseAddress(t *testing.T) {
 		t.Fatalf("expected repinned address 192.168.1.20, got %s", repinned.Address())
 	}
 
-	// Repin onto an address held by another lease is rejected.
 	imsi2 := "001010123456790"
 	createExtraSubscriber(t, database, imsi2, profileID)
 
@@ -1007,7 +1005,6 @@ func TestUpdateStaticLeaseAddress(t *testing.T) {
 		t.Fatalf("expected ErrAlreadyExists repinning onto taken address, got %v", err)
 	}
 
-	// A bound reservation cannot be repinned.
 	if err := database.UpdateLeaseSession(ctx, got.ID, 5); err != nil {
 		t.Fatalf("UpdateLeaseSession: %s", err)
 	}
@@ -1030,7 +1027,6 @@ func TestDeleteStaticLease(t *testing.T) {
 		t.Fatalf("GetStaticLease: %s", err)
 	}
 
-	// A bound reservation cannot be deleted; the row survives.
 	if err := database.UpdateLeaseSession(ctx, got.ID, 5); err != nil {
 		t.Fatalf("UpdateLeaseSession: %s", err)
 	}
@@ -1043,7 +1039,6 @@ func TestDeleteStaticLease(t *testing.T) {
 		t.Fatalf("expected active reservation to persist, got %v", err)
 	}
 
-	// Once reserved again, delete succeeds.
 	if err := database.ClearStaticLeaseSession(ctx, got.ID); err != nil {
 		t.Fatalf("ClearStaticLeaseSession: %s", err)
 	}
@@ -1113,8 +1108,6 @@ func TestAllocateIPLease_MultipleSessionsSameDNGetDistinctIPs(t *testing.T) {
 		t.Fatalf("AllocateIPLease (session 5): %s", err)
 	}
 
-	// A second concurrent session for the same subscriber on the same pool
-	// must get its own address, not collapse onto the first session's lease.
 	second, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 6, 1)
 	if err != nil {
 		t.Fatalf("AllocateIPLease (session 6): %s", err)
@@ -1124,7 +1117,6 @@ func TestAllocateIPLease_MultipleSessionsSameDNGetDistinctIPs(t *testing.T) {
 		t.Fatalf("expected distinct addresses per session, both got %s", first)
 	}
 
-	// Both leases coexist and each is reachable by its own session.
 	l5, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 5, imsi)
 	if err != nil {
 		t.Fatalf("GetLeaseBySession(5): %s", err)
@@ -1139,7 +1131,6 @@ func TestAllocateIPLease_MultipleSessionsSameDNGetDistinctIPs(t *testing.T) {
 		t.Fatalf("session→lease mismatch: 5=%s (want %s), 6=%s (want %s)", l5.Address(), first, l6.Address(), second)
 	}
 
-	// Re-establishing session 5 (retry) returns its own address, unchanged.
 	again, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 5, 1)
 	if err != nil {
 		t.Fatalf("AllocateIPLease (session 5 retry): %s", err)
@@ -1158,7 +1149,6 @@ func TestAllocateIPLease_StaticHeldByOtherSessionFallsToDynamic(t *testing.T) {
 		t.Fatalf("CreateStaticLease: %s", err)
 	}
 
-	// Session 7 claims the pinned address.
 	pinned, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 7, 1)
 	if err != nil {
 		t.Fatalf("AllocateIPLease (session 7): %s", err)
@@ -1168,8 +1158,6 @@ func TestAllocateIPLease_StaticHeldByOtherSessionFallsToDynamic(t *testing.T) {
 		t.Fatalf("expected pinned 192.168.1.50, got %s", pinned)
 	}
 
-	// A second concurrent session cannot take the same pinned address; it
-	// gets a dynamic one instead.
 	other, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 8, 1)
 	if err != nil {
 		t.Fatalf("AllocateIPLease (session 8): %s", err)
@@ -1184,7 +1172,7 @@ func TestAllocateIPLease_DynamicSkipsReservedStatic(t *testing.T) {
 	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
 	ctx := context.Background()
 
-	// Reserve the first usable address (192.168.1.1) for imsi, unbound.
+	// Pin .1 — the first usable address, which a dynamic alloc picks first.
 	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.1")); err != nil {
 		t.Fatalf("CreateStaticLease: %s", err)
 	}
@@ -1192,8 +1180,7 @@ func TestAllocateIPLease_DynamicSkipsReservedStatic(t *testing.T) {
 	imsi2 := "001010123456790"
 	createExtraSubscriber(t, database, imsi2, profileID)
 
-	// A dynamic allocation for another subscriber must skip the reserved
-	// address even though no session holds it yet.
+	// Even unbound, the reservation must be skipped by dynamic allocation.
 	got, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi2, 3, 1)
 	if err != nil {
 		t.Fatalf("AllocateIPLease: %s", err)

--- a/internal/db/ip_leases_test.go
+++ b/internal/db/ip_leases_test.go
@@ -822,3 +822,279 @@ func TestListLeaseAddressesByPool_NumericOrder(t *testing.T) {
 		}
 	}
 }
+
+func createExtraSubscriber(t *testing.T, database *db.Database, imsi, profileID string) {
+	t.Helper()
+
+	sub := &db.Subscriber{
+		Imsi:           imsi,
+		SequenceNumber: "000000000001",
+		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
+		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
+		ProfileID:      profileID,
+	}
+
+	if err := database.CreateSubscriber(context.Background(), sub); err != nil {
+		t.Fatalf("CreateSubscriber: %s", err)
+	}
+}
+
+func TestCreateStaticLease_Uniqueness(t *testing.T) {
+	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.10")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	// Second static for the same (imsi, pool, family) is rejected in-code.
+	err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.11"))
+	if err != db.ErrAlreadyExists {
+		t.Fatalf("expected ErrAlreadyExists for duplicate tuple, got %v", err)
+	}
+
+	// A different subscriber cannot pin an address already leased in the pool.
+	imsi2 := "001010123456790"
+	createExtraSubscriber(t, database, imsi2, profileID)
+
+	err = database.CreateStaticLease(ctx, imsi2, poolID, "ipv4", addr("192.168.1.10"))
+	if err != db.ErrAlreadyExists {
+		t.Fatalf("expected ErrAlreadyExists for duplicate address, got %v", err)
+	}
+}
+
+func TestGetAndListStaticLease(t *testing.T) {
+	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.10")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	got, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease: %s", err)
+	}
+
+	if got.Address() != addr("192.168.1.10") {
+		t.Fatalf("expected address 192.168.1.10, got %s", got.Address())
+	}
+
+	if got.Type != "static" {
+		t.Fatalf("expected type static, got %s", got.Type)
+	}
+
+	if got.SessionID != nil {
+		t.Fatalf("expected reserved lease (nil sessionID), got %v", *got.SessionID)
+	}
+
+	if _, err := database.GetStaticLease(ctx, poolID, "ipv4", "001010999999999"); err != db.ErrNotFound {
+		t.Fatalf("expected ErrNotFound for missing static lease, got %v", err)
+	}
+
+	leases, err := database.ListStaticLeasesByIMSI(ctx, imsi)
+	if err != nil {
+		t.Fatalf("ListStaticLeasesByIMSI: %s", err)
+	}
+
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 static lease, got %d", len(leases))
+	}
+}
+
+func TestClearStaticLeaseSession(t *testing.T) {
+	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.10")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	got, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease: %s", err)
+	}
+
+	if err := database.UpdateLeaseSession(ctx, got.ID, 5); err != nil {
+		t.Fatalf("UpdateLeaseSession: %s", err)
+	}
+
+	if err := database.ClearStaticLeaseSession(ctx, got.ID); err != nil {
+		t.Fatalf("ClearStaticLeaseSession: %s", err)
+	}
+
+	cleared, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease after clear: %s", err)
+	}
+
+	if cleared.SessionID != nil {
+		t.Fatalf("expected reserved lease after clear, got sessionID %v", *cleared.SessionID)
+	}
+
+	if cleared.Address() != addr("192.168.1.10") {
+		t.Fatalf("expected row to persist at 192.168.1.10, got %s", cleared.Address())
+	}
+}
+
+func TestUpdateStaticLeaseAddress(t *testing.T) {
+	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.10")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	got, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease: %s", err)
+	}
+
+	if err := database.UpdateStaticLeaseAddress(ctx, got.ID, addr("192.168.1.20")); err != nil {
+		t.Fatalf("UpdateStaticLeaseAddress: %s", err)
+	}
+
+	repinned, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease after repin: %s", err)
+	}
+
+	if repinned.Address() != addr("192.168.1.20") {
+		t.Fatalf("expected repinned address 192.168.1.20, got %s", repinned.Address())
+	}
+
+	// Repin onto an address held by another lease is rejected.
+	imsi2 := "001010123456790"
+	createExtraSubscriber(t, database, imsi2, profileID)
+
+	if err := database.CreateStaticLease(ctx, imsi2, poolID, "ipv4", addr("192.168.1.30")); err != nil {
+		t.Fatalf("CreateStaticLease imsi2: %s", err)
+	}
+
+	if err := database.UpdateStaticLeaseAddress(ctx, got.ID, addr("192.168.1.30")); err != db.ErrAlreadyExists {
+		t.Fatalf("expected ErrAlreadyExists repinning onto taken address, got %v", err)
+	}
+
+	// A bound reservation cannot be repinned.
+	if err := database.UpdateLeaseSession(ctx, got.ID, 5); err != nil {
+		t.Fatalf("UpdateLeaseSession: %s", err)
+	}
+
+	if err := database.UpdateStaticLeaseAddress(ctx, got.ID, addr("192.168.1.40")); err != db.ErrLeaseActive {
+		t.Fatalf("expected ErrLeaseActive repinning active reservation, got %v", err)
+	}
+}
+
+func TestDeleteStaticLease(t *testing.T) {
+	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.10")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	got, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease: %s", err)
+	}
+
+	// A bound reservation cannot be deleted; the row survives.
+	if err := database.UpdateLeaseSession(ctx, got.ID, 5); err != nil {
+		t.Fatalf("UpdateLeaseSession: %s", err)
+	}
+
+	if err := database.DeleteStaticLease(ctx, got.ID); err != db.ErrLeaseActive {
+		t.Fatalf("expected ErrLeaseActive deleting active reservation, got %v", err)
+	}
+
+	if _, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi); err != nil {
+		t.Fatalf("expected active reservation to persist, got %v", err)
+	}
+
+	// Once reserved again, delete succeeds.
+	if err := database.ClearStaticLeaseSession(ctx, got.ID); err != nil {
+		t.Fatalf("ClearStaticLeaseSession: %s", err)
+	}
+
+	if err := database.DeleteStaticLease(ctx, got.ID); err != nil {
+		t.Fatalf("DeleteStaticLease: %s", err)
+	}
+
+	if _, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi); err != db.ErrNotFound {
+		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestAllocateIPLease_PrefersStatic(t *testing.T) {
+	database, poolID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.50")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	got, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 7, 1)
+	if err != nil {
+		t.Fatalf("AllocateIPLease: %s", err)
+	}
+
+	if got != addr("192.168.1.50") {
+		t.Fatalf("expected static address 192.168.1.50, got %s", got)
+	}
+
+	bound, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 7, imsi)
+	if err != nil {
+		t.Fatalf("GetLeaseBySession: %s", err)
+	}
+
+	if bound.Type != "static" || bound.NodeID != 1 {
+		t.Fatalf("expected static lease bound to node 1, got type=%s node=%d", bound.Type, bound.NodeID)
+	}
+
+	// Failover: re-establishing on another node re-binds the same address.
+	got2, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi, 8, 2)
+	if err != nil {
+		t.Fatalf("AllocateIPLease (failover): %s", err)
+	}
+
+	if got2 != addr("192.168.1.50") {
+		t.Fatalf("expected same static address on failover, got %s", got2)
+	}
+
+	rebound, err := database.GetLeaseBySession(ctx, poolID, "ipv4", 8, imsi)
+	if err != nil {
+		t.Fatalf("GetLeaseBySession after failover: %s", err)
+	}
+
+	if rebound.NodeID != 2 || rebound.SessionID == nil || *rebound.SessionID != 8 {
+		t.Fatalf("expected re-bind to node 2 session 8, got node=%d session=%v", rebound.NodeID, rebound.SessionID)
+	}
+}
+
+func TestAllocateIPLease_DynamicSkipsReservedStatic(t *testing.T) {
+	database, poolID, imsi, profileID := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	// Reserve the first usable address (192.168.1.1) for imsi, unbound.
+	if err := database.CreateStaticLease(ctx, imsi, poolID, "ipv4", addr("192.168.1.1")); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	imsi2 := "001010123456790"
+	createExtraSubscriber(t, database, imsi2, profileID)
+
+	// A dynamic allocation for another subscriber must skip the reserved
+	// address even though no session holds it yet.
+	got, err := database.AllocateIPLease(ctx, poolID, "ipv4", imsi2, 3, 1)
+	if err != nil {
+		t.Fatalf("AllocateIPLease: %s", err)
+	}
+
+	if got == addr("192.168.1.1") {
+		t.Fatalf("dynamic allocation handed out the reserved static address 192.168.1.1")
+	}
+
+	if got != addr("192.168.1.2") {
+		t.Fatalf("expected next free address 192.168.1.2, got %s", got)
+	}
+}

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -36,6 +36,13 @@ var (
 	opAllocateIPLease = registerChangesetOpReturning[allocateIPLeasePayload, string]("AllocateIPLease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
 	// AllocateIPv6Lease is the same for IPv6 /64 prefix delegation.
 	opAllocateIPv6Lease = registerChangesetOpReturning[allocateIPLeasePayload, string]("AllocateIPv6Lease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
+	// Static leases carry poolType (ip_leases.poolType added in v13).
+	// CreateStaticLease enforces one-per-(imsi,pool,family) atomically
+	// under proposeMu; the repin/delete ops guard sessionID IS NULL so a
+	// bound reservation can't be mutated out from under a live session.
+	opCreateStaticLease        = registerChangesetOp("CreateStaticLease", (*Database).applyCreateStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases))
+	opUpdateStaticLeaseAddress = registerChangesetOp("UpdateStaticLeaseAddress", (*Database).applyUpdateStaticLeaseAddress, RequireSchema(13), AffectsTopic(TopicIPLeases))
+	opDeleteStaticLease        = registerChangesetOp("DeleteStaticLease", (*Database).applyDeleteStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases))
 )
 
 // Audit logs

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -36,10 +36,7 @@ var (
 	opAllocateIPLease = registerChangesetOpReturning[allocateIPLeasePayload, string]("AllocateIPLease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
 	// AllocateIPv6Lease is the same for IPv6 /64 prefix delegation.
 	opAllocateIPv6Lease = registerChangesetOpReturning[allocateIPLeasePayload, string]("AllocateIPv6Lease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
-	// Static leases carry poolType (ip_leases.poolType added in v13).
-	// CreateStaticLease enforces one-per-(imsi,pool,family) atomically
-	// under proposeMu; the repin/delete ops guard sessionID IS NULL so a
-	// bound reservation can't be mutated out from under a live session.
+	// Static ops read/write ip_leases.poolType, added in v13.
 	opCreateStaticLease        = registerChangesetOp("CreateStaticLease", (*Database).applyCreateStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases))
 	opUpdateStaticLeaseAddress = registerChangesetOp("UpdateStaticLeaseAddress", (*Database).applyUpdateStaticLeaseAddress, RequireSchema(13), AffectsTopic(TopicIPLeases))
 	opDeleteStaticLease        = registerChangesetOp("DeleteStaticLease", (*Database).applyDeleteStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases))

--- a/internal/db/subscribers.go
+++ b/internal/db/subscribers.go
@@ -99,9 +99,8 @@ func (db *Database) ListSubscribersPage(ctx context.Context, page int, perPage i
 	return subs, count, nil
 }
 
-// ListSubscribersByDataNetworkPage returns a page of subscribers whose profile
-// has a policy binding the given data network. Used to populate the static-IP
-// picker with only the subscribers eligible for that network.
+// ListSubscribersByDataNetworkPage returns a page of subscribers whose
+// profile has a policy binding the given data network.
 func (db *Database) ListSubscribersByDataNetworkPage(ctx context.Context, dataNetworkID string, page, perPage int) ([]Subscriber, int, error) {
 	ctx, span := tracer.Start(
 		ctx,

--- a/internal/db/subscribers.go
+++ b/internal/db/subscribers.go
@@ -23,6 +23,7 @@ const SubscribersTableName = "subscribers"
 
 const (
 	listSubscribersPagedStmt  = "SELECT &Subscriber.*, COUNT(*) OVER() AS &NumItems.count from %s LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
+	listSubscribersByDNStmt   = "SELECT &Subscriber.*, COUNT(*) OVER() AS &NumItems.count FROM %s WHERE profileID IN (SELECT profileID FROM %s WHERE dataNetworkID==$Policy.dataNetworkID) ORDER BY imsi LIMIT $ListArgs.limit OFFSET $ListArgs.offset"
 	getSubscriberStmt         = "SELECT &Subscriber.* from %s WHERE imsi==$Subscriber.imsi"
 	createSubscriberStmt      = "INSERT INTO %s (id, imsi, sequenceNumber, permanentKey, opc, profileID) VALUES ($Subscriber.id, $Subscriber.imsi, $Subscriber.sequenceNumber, $Subscriber.permanentKey, $Subscriber.opc, $Subscriber.profileID)"
 	editSubscriberProfileStmt = "UPDATE %s SET profileID=$Subscriber.profileID WHERE imsi==$Subscriber.imsi"
@@ -80,6 +81,61 @@ func (db *Database) ListSubscribersPage(ctx context.Context, page int, perPage i
 			}
 
 			return nil, fallbackCount, nil
+		}
+
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "query failed")
+
+		return nil, 0, fmt.Errorf("query failed: %w", err)
+	}
+
+	count := 0
+	if len(counts) > 0 {
+		count = counts[0].Count
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return subs, count, nil
+}
+
+// ListSubscribersByDataNetworkPage returns a page of subscribers whose profile
+// has a policy binding the given data network. Used to populate the static-IP
+// picker with only the subscribers eligible for that network.
+func (db *Database) ListSubscribersByDataNetworkPage(ctx context.Context, dataNetworkID string, page, perPage int) ([]Subscriber, int, error) {
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s (paged by data network)", "SELECT", SubscribersTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("SELECT"),
+			attribute.String("db.collection", SubscribersTableName),
+			attribute.Int("page", page),
+			attribute.Int("per_page", perPage),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(SubscribersTableName, "select"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(SubscribersTableName, "select").Inc()
+
+	var subs []Subscriber
+
+	var counts []NumItems
+
+	args := ListArgs{
+		Limit:  perPage,
+		Offset: (page - 1) * perPage,
+	}
+
+	err := db.conn().Query(ctx, db.listSubscribersByDNStmt, args, Policy{DataNetworkID: dataNetworkID}).GetAll(&subs, &counts)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Ok, "no rows")
+			return nil, 0, nil
 		}
 
 		span.RecordError(err)

--- a/internal/db/subscribers_test.go
+++ b/internal/db/subscribers_test.go
@@ -304,3 +304,38 @@ func TestCountSubscribersInProfile(t *testing.T) {
 		t.Fatalf("Expected 2 subscribers in profile, but got %d", count)
 	}
 }
+
+func TestListSubscribersByDataNetworkPage(t *testing.T) {
+	database, dnID, imsi, _ := setupLeaseTestDBWithProfile(t)
+	ctx := context.Background()
+
+	// The subscriber's profile has a policy binding this data network.
+	subs, count, err := database.ListSubscribersByDataNetworkPage(ctx, dnID, 1, 25)
+	if err != nil {
+		t.Fatalf("ListSubscribersByDataNetworkPage: %s", err)
+	}
+
+	if count != 1 || len(subs) != 1 || subs[0].Imsi != imsi {
+		t.Fatalf("expected 1 entitled subscriber %s, got count=%d subs=%v", imsi, count, subs)
+	}
+
+	// A data network the profile does not reach returns none.
+	other := &db.DataNetwork{Name: "other-dn", IPv4Pool: "10.5.0.0/24", DNS: "8.8.8.8", MTU: 1400}
+	if err := database.CreateDataNetwork(ctx, other); err != nil {
+		t.Fatalf("CreateDataNetwork: %s", err)
+	}
+
+	createdOther, err := database.GetDataNetwork(ctx, other.Name)
+	if err != nil {
+		t.Fatalf("GetDataNetwork: %s", err)
+	}
+
+	subs, count, err = database.ListSubscribersByDataNetworkPage(ctx, createdOther.ID, 1, 25)
+	if err != nil {
+		t.Fatalf("ListSubscribersByDataNetworkPage(other): %s", err)
+	}
+
+	if count != 0 || len(subs) != 0 {
+		t.Fatalf("expected no subscribers for unbound data network, got count=%d subs=%v", count, subs)
+	}
+}

--- a/internal/tester/scenarios/fixture.go
+++ b/internal/tester/scenarios/fixture.go
@@ -22,6 +22,9 @@ type FixtureSpec struct {
 
 	Subscribers []SubscriberSpec
 
+	// StaticIPs are pinned after subscribers and data networks exist.
+	StaticIPs []StaticIPSpec
+
 	// ExtraArgs are passed verbatim to `core-tester run <scenario>`, for the
 	// scenario-specific flags it declares via BindFlags.
 	ExtraArgs []string
@@ -82,6 +85,14 @@ type SubscriberSpec struct {
 	OPc            string
 	SequenceNumber string
 	ProfileName    string
+}
+
+// StaticIPSpec pins an address to a subscriber for a data network. The IP
+// version is inferred from the address family.
+type StaticIPSpec struct {
+	IMSI        string
+	DataNetwork string
+	Address     string
 }
 
 func DefaultSubscriber() SubscriberSpec {

--- a/internal/tester/scenarios/gnb/static_ip.go
+++ b/internal/tester/scenarios/gnb/static_ip.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package gnb
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"time"
+
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/internal/tester/testutil/procedure"
+	"github.com/spf13/pflag"
+)
+
+const (
+	staticIPv4IMSI = "001017271246700"
+	staticIPv4Pin  = "10.45.9.9"
+)
+
+type staticIPParams struct {
+	ExpectedIP string
+}
+
+func bindStaticIPFlags(fs *pflag.FlagSet) any {
+	p := &staticIPParams{}
+	fs.StringVar(&p.ExpectedIP, "expected-ip", "", "address the pinned subscriber must be assigned")
+
+	return p
+}
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "gnb/static_ip",
+		BindFlags: bindStaticIPFlags,
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			return runStaticIP(ctx, env, params.(*staticIPParams), staticIPv4IMSI, false)
+		},
+		Fixture: func(_ scenarios.Env) scenarios.FixtureSpec {
+			return staticIPFixture(staticIPv4IMSI, staticIPv4Pin)
+		},
+	})
+}
+
+func staticIPFixture(imsi, pin string) scenarios.FixtureSpec {
+	return scenarios.FixtureSpec{
+		Subscribers: []scenarios.SubscriberSpec{scenarios.DefaultSubscriberWith(imsi, "")},
+		StaticIPs:   []scenarios.StaticIPSpec{{IMSI: imsi, DataNetwork: scenarios.DefaultDNN, Address: pin}},
+		ExtraArgs:   []string{"--expected-ip", pin},
+	}
+}
+
+// runStaticIP registers a UE for a subscriber that has a pinned address and
+// asserts the PDU session establishment assigns exactly that address.
+func runStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, imsi string, ipv6 bool) error {
+	if p.ExpectedIP == "" {
+		return fmt.Errorf("--expected-ip is required")
+	}
+
+	subs, err := buildSubscribers(1, imsi)
+	if err != nil {
+		return fmt.Errorf("build subscriber: %v", err)
+	}
+
+	sub := subs[0]
+
+	gNodeB, err := startGNB(env)
+	if err != nil {
+		return err
+	}
+
+	defer gNodeB.Close()
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+
+	newUE, err := newDefaultUE(gNodeB, sub.IMSI[5:], sub.Key, sub.OPc, sub.SequenceNumber, env.PDUSessionType())
+	if err != nil {
+		return fmt.Errorf("create UE: %v", err)
+	}
+
+	gNodeB.AddUE(ranUENGAPID, newUE)
+
+	if _, err := procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: scenarios.DefaultPDUSessionID,
+		UE:           newUE,
+	}); err != nil {
+		return fmt.Errorf("initial registration: %v", err)
+	}
+
+	session, err := newUE.WaitForPDUSession(scenarios.DefaultPDUSessionID, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("wait for PDU session: %v", err)
+	}
+
+	got := session.UEIP
+	if ipv6 {
+		got = session.UEIPV6
+	}
+
+	if err := assertPinnedAddress(got, p.ExpectedIP); err != nil {
+		return err
+	}
+
+	return procedure.Deregistration(&procedure.DeregistrationOpts{
+		UE:          newUE,
+		AMFUENGAPID: gNodeB.GetAMFUENGAPID(ranUENGAPID),
+		RANUENGAPID: ranUENGAPID,
+	})
+}
+
+// assertPinnedAddress compares the assigned and pinned addresses by value so
+// that differences in textual formatting (e.g. IPv6 zero-compression) do not
+// cause spurious failures.
+func assertPinnedAddress(got, want string) error {
+	gotAddr, err := netip.ParseAddr(got)
+	if err != nil {
+		return fmt.Errorf("parse assigned address %q: %w", got, err)
+	}
+
+	wantAddr, err := netip.ParseAddr(want)
+	if err != nil {
+		return fmt.Errorf("parse pinned address %q: %w", want, err)
+	}
+
+	if gotAddr != wantAddr {
+		return fmt.Errorf("UE was assigned %q, expected pinned address %q", got, want)
+	}
+
+	return nil
+}

--- a/internal/tester/scenarios/gnb/static_ip.go
+++ b/internal/tester/scenarios/gnb/static_ip.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"time"
 
+	"github.com/ellanetworks/core/client"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
 	"github.com/ellanetworks/core/internal/tester/testutil/procedure"
 	"github.com/spf13/pflag"
@@ -52,8 +53,8 @@ func staticIPFixture(imsi, pin string) scenarios.FixtureSpec {
 }
 
 // runStaticIP registers a UE for a subscriber that has a pinned address and
-// asserts the PDU session establishment assigns exactly that address.
-func runStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, imsi string, ipv6 bool) error {
+// asserts the established PDU session is assigned exactly that address.
+func runStaticIP(ctx context.Context, env scenarios.Env, p *staticIPParams, imsi string, ipv6 bool) error {
 	if p.ExpectedIP == "" {
 		return fmt.Errorf("--expected-ip is required")
 	}
@@ -89,14 +90,13 @@ func runStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, imsi s
 		return fmt.Errorf("initial registration: %v", err)
 	}
 
-	session, err := newUE.WaitForPDUSession(scenarios.DefaultPDUSessionID, 5*time.Second)
-	if err != nil {
+	if _, err := newUE.WaitForPDUSession(scenarios.DefaultPDUSessionID, 5*time.Second); err != nil {
 		return fmt.Errorf("wait for PDU session: %v", err)
 	}
 
-	got := session.UEIP
-	if ipv6 {
-		got = session.UEIPV6
+	got, err := assignedSessionAddress(ctx, env, imsi, ipv6)
+	if err != nil {
+		return err
 	}
 
 	if err := assertPinnedAddress(got, p.ExpectedIP); err != nil {
@@ -108,6 +108,43 @@ func runStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, imsi s
 		AMFUENGAPID: gNodeB.GetAMFUENGAPID(ranUENGAPID),
 		RANUENGAPID: ranUENGAPID,
 	})
+}
+
+// assignedSessionAddress polls the core's subscriber record for the address
+// its active session was assigned. For IPv6 the pinned /64 prefix is delivered
+// via Router Advertisement and is absent from the NAS PDU-address IE, so the
+// core's session record is the authoritative source for both families.
+func assignedSessionAddress(ctx context.Context, env scenarios.Env, imsi string, ipv6 bool) (string, error) {
+	cl, err := client.New(&client.Config{BaseURL: env.APIAddress})
+	if err != nil {
+		return "", fmt.Errorf("create core client: %w", err)
+	}
+
+	cl.SetToken(env.APIToken)
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	for {
+		sub, err := cl.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsi})
+		if err == nil {
+			for _, s := range sub.Sessions {
+				addr := s.IPv4Address
+				if ipv6 {
+					addr = s.IPv6Prefix
+				}
+
+				if addr != "" {
+					return addr, nil
+				}
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("no active session with an assigned address for %s", imsi)
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
 }
 
 // assertPinnedAddress compares the assigned and pinned addresses by value so

--- a/internal/tester/scenarios/gnb/static_ip_ipv6.go
+++ b/internal/tester/scenarios/gnb/static_ip_ipv6.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package gnb
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+)
+
+const (
+	staticIPv6IMSI = "001017271246701"
+	staticIPv6Pin  = "fd45:0:0:9::"
+)
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "gnb/static_ip_ipv6",
+		BindFlags: bindStaticIPFlags,
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			return runStaticIP(ctx, env, params.(*staticIPParams), staticIPv6IMSI, true)
+		},
+		Fixture: func(_ scenarios.Env) scenarios.FixtureSpec {
+			return staticIPFixture(staticIPv6IMSI, staticIPv6Pin)
+		},
+	})
+}

--- a/internal/tester/scenarios/s1enb/static_ip.go
+++ b/internal/tester/scenarios/s1enb/static_ip.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1enb
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"time"
+
+	"github.com/ellanetworks/core/internal/tester/s1enb"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/spf13/pflag"
+)
+
+const (
+	staticIPv4IMSI = "001017271246702"
+	staticIPv4Pin  = "10.45.11.11"
+)
+
+type staticIPParams struct {
+	ExpectedIP string
+}
+
+func bindStaticIPFlags(fs *pflag.FlagSet) any {
+	p := &staticIPParams{}
+	fs.StringVar(&p.ExpectedIP, "expected-ip", "", "address the pinned subscriber must be assigned")
+
+	return p
+}
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "s1enb/static_ip",
+		BindFlags: bindStaticIPFlags,
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			return runS1ENBStaticIP(ctx, env, params.(*staticIPParams), staticIPv4IMSI, false)
+		},
+		Fixture: func(_ scenarios.Env) scenarios.FixtureSpec {
+			return staticIPFixture(staticIPv4IMSI, staticIPv4Pin)
+		},
+	})
+}
+
+func staticIPFixture(imsi, pin string) scenarios.FixtureSpec {
+	return scenarios.FixtureSpec{
+		Subscribers: []scenarios.SubscriberSpec{scenarios.DefaultSubscriberWith(imsi, "")},
+		StaticIPs:   []scenarios.StaticIPSpec{{IMSI: imsi, DataNetwork: scenarios.DefaultDNN, Address: pin}},
+		ExtraArgs:   []string{"--expected-ip", pin},
+	}
+}
+
+// runS1ENBStaticIP attaches a UE for a subscriber that has a pinned address
+// and asserts the EPS attach assigns exactly that address.
+func runS1ENBStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, imsi string, ipv6 bool) error {
+	if p.ExpectedIP == "" {
+		return fmt.Errorf("--expected-ip is required")
+	}
+
+	s1mme, err := s1mmeAddress(env.FirstCore())
+	if err != nil {
+		return err
+	}
+
+	k, opc, err := defaultKeyAndOPc()
+	if err != nil {
+		return err
+	}
+
+	enbID, err := strconv.ParseUint(scenarios.DefaultGNBID, 16, 32)
+	if err != nil {
+		return fmt.Errorf("parse eNB ID %q: %w", scenarios.DefaultGNBID, err)
+	}
+
+	g := env.FirstGNB()
+
+	e, err := s1enb.Start(&s1enb.StartOpts{
+		ENBID: uint32(enbID), MCC: scenarios.DefaultMCC, MNC: scenarios.DefaultMNC, TAC: scenarios.DefaultTAC,
+		Name: s1enbName, CoreS1MMEAddress: s1mme,
+		ENBAddress: g.N2Address, ENBN3Address: g.N3Address, EnableDatapath: true,
+	})
+	if err != nil {
+		return fmt.Errorf("start eNB: %w", err)
+	}
+
+	defer func() { _ = e.Close() }()
+
+	ue := e.NewUE(imsi, k, opc)
+	if ipv6 {
+		ue.RequestPDNType(eps.PDNTypeIPv6)
+	}
+
+	res, err := e.Attach(ue, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("attach: %w", err)
+	}
+
+	got := res.UEIPv4
+	if ipv6 {
+		got = res.UEIPv6
+	}
+
+	if err := assertPinnedAddress(got, p.ExpectedIP); err != nil {
+		return err
+	}
+
+	return e.Detach(ue, res.MMEUES1APID, res.ENBUES1APID, 10*time.Second)
+}
+
+// assertPinnedAddress compares the assigned and pinned addresses by value so
+// that textual formatting differences do not cause spurious failures.
+func assertPinnedAddress(got, want string) error {
+	gotAddr, err := netip.ParseAddr(got)
+	if err != nil {
+		return fmt.Errorf("parse assigned address %q: %w", got, err)
+	}
+
+	wantAddr, err := netip.ParseAddr(want)
+	if err != nil {
+		return fmt.Errorf("parse pinned address %q: %w", want, err)
+	}
+
+	if gotAddr != wantAddr {
+		return fmt.Errorf("UE was assigned %q, expected pinned address %q", got, want)
+	}
+
+	return nil
+}

--- a/internal/tester/scenarios/s1enb/static_ip.go
+++ b/internal/tester/scenarios/s1enb/static_ip.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ellanetworks/core/client"
 	"github.com/ellanetworks/core/internal/tester/s1enb"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
 	"github.com/ellanetworks/core/nas/eps"
@@ -54,8 +55,8 @@ func staticIPFixture(imsi, pin string) scenarios.FixtureSpec {
 }
 
 // runS1ENBStaticIP attaches a UE for a subscriber that has a pinned address
-// and asserts the EPS attach assigns exactly that address.
-func runS1ENBStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, imsi string, ipv6 bool) error {
+// and asserts the EPS session is assigned exactly that address.
+func runS1ENBStaticIP(ctx context.Context, env scenarios.Env, p *staticIPParams, imsi string, ipv6 bool) error {
 	if p.ExpectedIP == "" {
 		return fmt.Errorf("--expected-ip is required")
 	}
@@ -98,9 +99,9 @@ func runS1ENBStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, i
 		return fmt.Errorf("attach: %w", err)
 	}
 
-	got := res.UEIPv4
-	if ipv6 {
-		got = res.UEIPv6
+	got, err := assignedSessionAddress(ctx, env, imsi, ipv6)
+	if err != nil {
+		return err
 	}
 
 	if err := assertPinnedAddress(got, p.ExpectedIP); err != nil {
@@ -108,6 +109,43 @@ func runS1ENBStaticIP(_ context.Context, env scenarios.Env, p *staticIPParams, i
 	}
 
 	return e.Detach(ue, res.MMEUES1APID, res.ENBUES1APID, 10*time.Second)
+}
+
+// assignedSessionAddress polls the core's subscriber record for the address
+// its active session was assigned. For IPv6 the pinned /64 prefix is delivered
+// via Router Advertisement and is absent from the NAS PDN-address IE, so the
+// core's session record is the authoritative source for both families.
+func assignedSessionAddress(ctx context.Context, env scenarios.Env, imsi string, ipv6 bool) (string, error) {
+	cl, err := client.New(&client.Config{BaseURL: env.APIAddress})
+	if err != nil {
+		return "", fmt.Errorf("create core client: %w", err)
+	}
+
+	cl.SetToken(env.APIToken)
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	for {
+		sub, err := cl.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: imsi})
+		if err == nil {
+			for _, s := range sub.Sessions {
+				addr := s.IPv4Address
+				if ipv6 {
+					addr = s.IPv6Prefix
+				}
+
+				if addr != "" {
+					return addr, nil
+				}
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("no active session with an assigned address for %s", imsi)
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
 }
 
 // assertPinnedAddress compares the assigned and pinned addresses by value so

--- a/internal/tester/scenarios/s1enb/static_ip_ipv6.go
+++ b/internal/tester/scenarios/s1enb/static_ip_ipv6.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1enb
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+)
+
+const (
+	staticIPv6IMSI = "001017271246703"
+	staticIPv6Pin  = "fd45:0:0:11::"
+)
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "s1enb/static_ip_ipv6",
+		BindFlags: bindStaticIPFlags,
+		Run: func(ctx context.Context, env scenarios.Env, params any) error {
+			return runS1ENBStaticIP(ctx, env, params.(*staticIPParams), staticIPv6IMSI, true)
+		},
+		Fixture: func(_ scenarios.Env) scenarios.FixtureSpec {
+			return staticIPFixture(staticIPv6IMSI, staticIPv6Pin)
+		},
+	})
+}

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -147,11 +147,9 @@ func (a *smfDBAdapter) ReleaseIP(ctx context.Context, imsi string, dnn string, p
 	return lease.Address(), nil
 }
 
-// releaseLease ends a lease's hold on the session. A static reservation
-// returns to the reserved state (row kept, sessionID nulled) so the pin
-// survives for the next session; a dynamic lease is deleted. The explicit
-// clear is required so listActiveLeases / BGP advertisement (sessionID IS
-// NOT NULL) drop the address when the session ends.
+// releaseLease clears a static reservation to reserved (row kept) or
+// deletes a dynamic lease. The explicit clear is required so
+// listActiveLeases / BGP (sessionID IS NOT NULL) drop the address.
 func (a *smfDBAdapter) releaseLease(ctx context.Context, lease *db.IPLease) error {
 	if lease.Type == "static" {
 		if err := a.db.ClearStaticLeaseSession(ctx, lease.ID); err != nil {

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -137,14 +137,35 @@ func (a *smfDBAdapter) ReleaseIP(ctx context.Context, imsi string, dnn string, p
 		return netip.Addr{}, fmt.Errorf("lookup lease: %w", err)
 	}
 
-	if err := a.db.DeleteDynamicLease(ctx, lease.ID); err != nil {
+	if err := a.releaseLease(ctx, lease); err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "delete failed")
+		span.SetStatus(codes.Error, "release failed")
 
-		return netip.Addr{}, fmt.Errorf("delete lease: %w", err)
+		return netip.Addr{}, err
 	}
 
 	return lease.Address(), nil
+}
+
+// releaseLease ends a lease's hold on the session. A static reservation
+// returns to the reserved state (row kept, sessionID nulled) so the pin
+// survives for the next session; a dynamic lease is deleted. The explicit
+// clear is required so listActiveLeases / BGP advertisement (sessionID IS
+// NOT NULL) drop the address when the session ends.
+func (a *smfDBAdapter) releaseLease(ctx context.Context, lease *db.IPLease) error {
+	if lease.Type == "static" {
+		if err := a.db.ClearStaticLeaseSession(ctx, lease.ID); err != nil {
+			return fmt.Errorf("clear static lease session: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := a.db.DeleteDynamicLease(ctx, lease.ID); err != nil {
+		return fmt.Errorf("delete lease: %w", err)
+	}
+
+	return nil
 }
 
 func (a *smfDBAdapter) AllocateIPv6(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error) {
@@ -204,7 +225,7 @@ func (a *smfDBAdapter) ReleaseIPv6(ctx context.Context, imsi string, dnn string,
 		return netip.Addr{}, fmt.Errorf("lookup lease: %w", err)
 	}
 
-	if err := a.db.DeleteDynamicLease(ctx, lease.ID); err != nil {
+	if err := a.releaseLease(ctx, lease); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "release IPv6 failed")
 

--- a/pkg/runtime/smf_adapters_test.go
+++ b/pkg/runtime/smf_adapters_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"path/filepath"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/db"
+)
+
+// setupAdapterTestDB creates a database with a data network, profile,
+// slice, policy, and subscriber, returning the adapter under test, the
+// data network name, its pool ID, and the subscriber IMSI.
+func setupAdapterTestDB(t *testing.T) (*smfDBAdapter, string, string, string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	database, err := db.NewDatabaseWithoutRaft(ctx, filepath.Join(t.TempDir(), "db.sqlite3"))
+	if err != nil {
+		t.Fatalf("NewDatabase: %s", err)
+	}
+
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Fatalf("Close: %s", err)
+		}
+	})
+
+	dnn := &db.DataNetwork{Name: "test-dnn", IPv4Pool: "192.168.1.0/24", DNS: "8.8.8.8", MTU: 1400}
+	if err := database.CreateDataNetwork(ctx, dnn); err != nil {
+		t.Fatalf("CreateDataNetwork: %s", err)
+	}
+
+	createdDNN, err := database.GetDataNetwork(ctx, dnn.Name)
+	if err != nil {
+		t.Fatalf("GetDataNetwork: %s", err)
+	}
+
+	profile := &db.Profile{Name: "test-profile", UeAmbrUplink: "200 Mbps", UeAmbrDownlink: "200 Mbps"}
+	if err := database.CreateProfile(ctx, profile); err != nil {
+		t.Fatalf("CreateProfile: %s", err)
+	}
+
+	createdProfile, err := database.GetProfile(ctx, profile.Name)
+	if err != nil {
+		t.Fatalf("GetProfile: %s", err)
+	}
+
+	slice := &db.NetworkSlice{Name: "test-slice", Sst: 1}
+	if err := database.CreateNetworkSlice(ctx, slice); err != nil {
+		t.Fatalf("CreateNetworkSlice: %s", err)
+	}
+
+	createdSlice, err := database.GetNetworkSlice(ctx, slice.Name)
+	if err != nil {
+		t.Fatalf("GetNetworkSlice: %s", err)
+	}
+
+	policy := &db.Policy{Name: "test-policy", DataNetworkID: createdDNN.ID, ProfileID: createdProfile.ID, SliceID: createdSlice.ID}
+	if err := database.CreatePolicy(ctx, policy); err != nil {
+		t.Fatalf("CreatePolicy: %s", err)
+	}
+
+	imsi := "001010123456789"
+	sub := &db.Subscriber{
+		Imsi:           imsi,
+		SequenceNumber: "000000000001",
+		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
+		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
+		ProfileID:      createdProfile.ID,
+	}
+
+	if err := database.CreateSubscriber(ctx, sub); err != nil {
+		t.Fatalf("CreateSubscriber: %s", err)
+	}
+
+	return &smfDBAdapter{db: database}, dnn.Name, createdDNN.ID, imsi
+}
+
+func TestReleaseIP_StaticKeepsReservation(t *testing.T) {
+	adapter, dnn, poolID, imsi := setupAdapterTestDB(t)
+	ctx := context.Background()
+
+	pinned := netip.MustParseAddr("192.168.1.50")
+	if err := adapter.db.CreateStaticLease(ctx, imsi, poolID, "ipv4", pinned); err != nil {
+		t.Fatalf("CreateStaticLease: %s", err)
+	}
+
+	got, err := adapter.AllocateIP(ctx, imsi, dnn, 7)
+	if err != nil {
+		t.Fatalf("AllocateIP: %s", err)
+	}
+
+	if got != pinned {
+		t.Fatalf("expected pinned address %s, got %s", pinned, got)
+	}
+
+	released, err := adapter.ReleaseIP(ctx, imsi, dnn, 7)
+	if err != nil {
+		t.Fatalf("ReleaseIP: %s", err)
+	}
+
+	if released != pinned {
+		t.Fatalf("expected released address %s, got %s", pinned, released)
+	}
+
+	// Reservation row persists, returned to reserved state.
+	reserved, err := adapter.db.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease after release: %s", err)
+	}
+
+	if reserved.SessionID != nil {
+		t.Fatalf("expected reserved lease after release, got sessionID %v", *reserved.SessionID)
+	}
+
+	if reserved.Address() != pinned {
+		t.Fatalf("expected reservation to persist at %s, got %s", pinned, reserved.Address())
+	}
+}
+
+func TestReleaseIP_DynamicDeletesLease(t *testing.T) {
+	adapter, dnn, poolID, imsi := setupAdapterTestDB(t)
+	ctx := context.Background()
+
+	got, err := adapter.AllocateIP(ctx, imsi, dnn, 9)
+	if err != nil {
+		t.Fatalf("AllocateIP: %s", err)
+	}
+
+	if _, err := adapter.db.GetLeaseBySession(ctx, poolID, "ipv4", 9, imsi); err != nil {
+		t.Fatalf("expected dynamic lease for session 9, got %v", err)
+	}
+
+	released, err := adapter.ReleaseIP(ctx, imsi, dnn, 9)
+	if err != nil {
+		t.Fatalf("ReleaseIP: %s", err)
+	}
+
+	if released != got {
+		t.Fatalf("expected released address %s, got %s", got, released)
+	}
+
+	if _, err := adapter.db.GetLeaseBySession(ctx, poolID, "ipv4", 9, imsi); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("expected dynamic lease deleted (ErrNotFound), got %v", err)
+	}
+}

--- a/pkg/runtime/smf_adapters_test.go
+++ b/pkg/runtime/smf_adapters_test.go
@@ -110,7 +110,6 @@ func TestReleaseIP_StaticKeepsReservation(t *testing.T) {
 		t.Fatalf("expected released address %s, got %s", pinned, released)
 	}
 
-	// Reservation row persists, returned to reserved state.
 	reserved, err := adapter.db.GetStaticLease(ctx, poolID, "ipv4", imsi)
 	if err != nil {
 		t.Fatalf("GetStaticLease after release: %s", err)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1855,9 +1855,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1875,9 +1872,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1895,9 +1889,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1915,9 +1906,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/ui/src/components/CreateStaticIpModal.tsx
+++ b/ui/src/components/CreateStaticIpModal.tsx
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Autocomplete,
+  Button,
+  Alert,
+  Collapse,
+} from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  createStaticIp,
+  updateStaticIp,
+  listEligibleSubscribers,
+} from "@/queries/data_networks";
+
+interface StaticIpEdit {
+  imsi: string;
+  ipVersion: string;
+  address: string;
+}
+
+interface CreateStaticIpModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  dataNetwork: string;
+  ipv4Pool?: string;
+  ipv6Pool?: string;
+  edit?: StaticIpEdit;
+}
+
+const CreateStaticIpModal: React.FC<CreateStaticIpModalProps> = ({
+  open,
+  onClose,
+  onSuccess,
+  dataNetwork,
+  ipv4Pool,
+  ipv6Pool,
+  edit,
+}) => {
+  const { accessToken, authReady } = useAuth();
+  const isEdit = !!edit;
+
+  const [imsi, setImsi] = useState<string>(edit?.imsi ?? "");
+  const [address, setAddress] = useState<string>(edit?.address ?? "");
+  const [loading, setLoading] = useState(false);
+  const [alert, setAlert] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setImsi(edit?.imsi ?? "");
+      setAddress(edit?.address ?? "");
+      setAlert("");
+    }
+  }, [open, edit]);
+
+  const { data: subscribers } = useQuery({
+    queryKey: ["eligible-subscribers", dataNetwork],
+    queryFn: () => listEligibleSubscribers(accessToken!, dataNetwork),
+    enabled: open && !isEdit && authReady && !!accessToken,
+  });
+
+  const poolHelp = isEdit
+    ? edit?.ipVersion === "ipv6"
+      ? `IPv6 pool: ${ipv6Pool ?? "—"}`
+      : `IPv4 pool: ${ipv4Pool ?? "—"}`
+    : [
+        ipv4Pool && `IPv4 pool: ${ipv4Pool}`,
+        ipv6Pool && `IPv6 pool: ${ipv6Pool}`,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+
+  const canSubmit = imsi.trim() !== "" && address.trim() !== "" && !loading;
+
+  const handleSubmit = async () => {
+    if (!accessToken) return;
+
+    setLoading(true);
+    setAlert("");
+
+    try {
+      if (isEdit && edit) {
+        await updateStaticIp(
+          accessToken,
+          dataNetwork,
+          edit.imsi,
+          edit.ipVersion,
+          address.trim(),
+        );
+      } else {
+        await createStaticIp(
+          accessToken,
+          dataNetwork,
+          imsi.trim(),
+          address.trim(),
+        );
+      }
+
+      onClose();
+      onSuccess();
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : "Unknown error occurred.";
+      setAlert(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{isEdit ? "Edit Static IP" : "Add Static IP"}</DialogTitle>
+      <DialogContent dividers>
+        <Collapse in={!!alert}>
+          <Alert onClose={() => setAlert("")} sx={{ mb: 2 }} severity="error">
+            {alert}
+          </Alert>
+        </Collapse>
+        {isEdit ? (
+          <TextField
+            fullWidth
+            label="Subscriber"
+            value={imsi}
+            margin="normal"
+            disabled
+          />
+        ) : (
+          <Autocomplete
+            options={(subscribers ?? []).map((s) => s.imsi)}
+            value={imsi || null}
+            onChange={(_, value) => setImsi(value ?? "")}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Subscriber"
+                margin="normal"
+                autoFocus
+              />
+            )}
+          />
+        )}
+        <TextField
+          fullWidth
+          label="Address"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          margin="normal"
+          helperText={poolHelp}
+          placeholder="e.g., 10.45.0.10 or 2001:db8:1::"
+          autoFocus={isEdit}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="success"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        >
+          {loading ? "Saving..." : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CreateStaticIpModal;

--- a/ui/src/components/NGAPMessageRender.tsx
+++ b/ui/src/components/NGAPMessageRender.tsx
@@ -45,8 +45,7 @@ const extractIEFields = (x: any): IEFields => {
   if (!x || typeof x !== "object") return {};
   const idEnum = (x.ID ?? x.id) as EnumLike | undefined;
   const criticalityEnum = (x.Criticality ?? x.criticality) as
-    | EnumLike
-    | undefined;
+    EnumLike | undefined;
   const value = (x.Value ?? x.value) as unknown;
   const error = (x.Error ?? x.error) as string | undefined;
   return { idEnum, criticalityEnum, value, error };

--- a/ui/src/components/NGAPMessageRender.tsx
+++ b/ui/src/components/NGAPMessageRender.tsx
@@ -45,7 +45,8 @@ const extractIEFields = (x: any): IEFields => {
   if (!x || typeof x !== "object") return {};
   const idEnum = (x.ID ?? x.id) as EnumLike | undefined;
   const criticalityEnum = (x.Criticality ?? x.criticality) as
-    EnumLike | undefined;
+    | EnumLike
+    | undefined;
   const value = (x.Value ?? x.value) as unknown;
   const error = (x.Error ?? x.error) as string | undefined;
   return { idEnum, criticalityEnum, value, error };

--- a/ui/src/pages/DataNetworkDetail.tsx
+++ b/ui/src/pages/DataNetworkDetail.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Ella Networks Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Box,
   Button,
@@ -18,7 +18,11 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import { Edit as EditIcon } from "@mui/icons-material";
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+} from "@mui/icons-material";
 import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
 import { useTheme, createTheme, ThemeProvider } from "@mui/material/styles";
 import {
@@ -27,18 +31,20 @@ import {
   type GridPaginationModel,
   type GridRenderCellParams,
 } from "@mui/x-data-grid";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getDataNetwork,
   deleteDataNetwork,
   listIPv4Allocations,
   listIPv6Allocations,
+  deleteStaticIp,
   type APIDataNetwork,
   type APIIPAllocation,
 } from "@/queries/data_networks";
 import { useAuth } from "@/contexts/AuthContext";
 import { useSnackbar } from "@/contexts/SnackbarContext";
 import EditDataNetworkModal from "@/components/EditDataNetworkModal";
+import CreateStaticIpModal from "@/components/CreateStaticIpModal";
 import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
 
@@ -69,8 +75,19 @@ const DataNetworkDetail: React.FC = () => {
     [theme],
   );
 
+  const queryClient = useQueryClient();
   const [isEditModalOpen, setEditModalOpen] = useState(false);
   const [isDeleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [staticModal, setStaticModal] = useState<
+    | { mode: "create" }
+    | { mode: "edit"; imsi: string; ipVersion: string; address: string }
+    | null
+  >(null);
+  const [deleteStatic, setDeleteStatic] = useState<{
+    imsi: string;
+    ipVersion: string;
+    address: string;
+  } | null>(null);
 
   useEffect(() => {
     if (authReady && !accessToken) navigate("/login");
@@ -133,8 +150,88 @@ const DataNetworkDetail: React.FC = () => {
     }
   };
 
-  const allocationColumns: GridColDef<APIIPAllocation>[] = useMemo(
-    () => [
+  const invalidateStaticIps = () => {
+    queryClient.invalidateQueries({ queryKey: ["ipv4-allocations", name] });
+    queryClient.invalidateQueries({ queryKey: ["ipv6-allocations", name] });
+    refetch();
+  };
+
+  const handleStaticDeleteConfirm = async () => {
+    if (!deleteStatic || !accessToken || !name) return;
+
+    try {
+      await deleteStaticIp(
+        accessToken,
+        name,
+        deleteStatic.imsi,
+        deleteStatic.ipVersion,
+      );
+      setDeleteStatic(null);
+      invalidateStaticIps();
+      showSnackbar("Static IP deleted successfully.", "success");
+    } catch (err) {
+      setDeleteStatic(null);
+      showSnackbar(
+        `Failed to delete static IP: ${err instanceof Error ? err.message : "Unknown error"}`,
+        "error",
+      );
+    }
+  };
+
+  const staticActionsColumn = useCallback(
+    (ipVersion: string): GridColDef<APIIPAllocation> => ({
+      field: "actions",
+      headerName: "Actions",
+      width: 100,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams<APIIPAllocation>) => {
+        if (params.row.type !== "static") return null;
+
+        const active = params.row.session_id != null;
+
+        return (
+          <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+            <IconButton
+              size="small"
+              disabled={active}
+              aria-label="Edit static IP"
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                setStaticModal({
+                  mode: "edit",
+                  imsi: params.row.imsi,
+                  ipVersion,
+                  address: params.row.address,
+                });
+              }}
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              color="error"
+              disabled={active}
+              aria-label="Delete static IP"
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                setDeleteStatic({
+                  imsi: params.row.imsi,
+                  ipVersion,
+                  address: params.row.address,
+                });
+              }}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        );
+      },
+    }),
+    [],
+  );
+
+  const allocationColumns: GridColDef<APIIPAllocation>[] = useMemo(() => {
+    const cols: GridColDef<APIIPAllocation>[] = [
       {
         field: "address",
         headerName: "Address",
@@ -236,12 +333,17 @@ const DataNetworkDetail: React.FC = () => {
           </Box>
         ),
       },
-    ],
-    [theme],
-  );
+    ];
 
-  const ipv6AllocationColumns: GridColDef<APIIPAllocation>[] = useMemo(
-    () => [
+    if (canEdit) {
+      cols.push(staticActionsColumn("ipv4"));
+    }
+
+    return cols;
+  }, [theme, canEdit, staticActionsColumn]);
+
+  const ipv6AllocationColumns: GridColDef<APIIPAllocation>[] = useMemo(() => {
+    const cols: GridColDef<APIIPAllocation>[] = [
       {
         field: "address",
         headerName: "Prefix",
@@ -345,9 +447,14 @@ const DataNetworkDetail: React.FC = () => {
           </Box>
         ),
       },
-    ],
-    [theme],
-  );
+    ];
+
+    if (canEdit) {
+      cols.push(staticActionsColumn("ipv6"));
+    }
+
+    return cols;
+  }, [theme, canEdit, staticActionsColumn]);
 
   if (!authReady || isLoading) {
     return (
@@ -647,6 +754,26 @@ const DataNetworkDetail: React.FC = () => {
         <Box sx={{ mt: 3 }}>
           <Box
             sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              mb: 1.5,
+            }}
+          >
+            <Typography variant="h6">IP Allocations</Typography>
+            {canEdit && (
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={() => setStaticModal({ mode: "create" })}
+              >
+                Add static IP
+              </Button>
+            )}
+          </Box>
+          <Box
+            sx={{
               display: "grid",
               gridTemplateColumns: {
                 xs: "1fr",
@@ -761,6 +888,42 @@ const DataNetworkDetail: React.FC = () => {
           onConfirm={handleDeleteConfirm}
           title="Confirm Deletion"
           description={`Are you sure you want to delete the data network "${name}"? This action cannot be undone.`}
+        />
+      )}
+      {staticModal && (
+        <CreateStaticIpModal
+          open
+          onClose={() => setStaticModal(null)}
+          onSuccess={() => {
+            invalidateStaticIps();
+            showSnackbar(
+              staticModal.mode === "edit"
+                ? "Static IP updated successfully."
+                : "Static IP created successfully.",
+              "success",
+            );
+          }}
+          dataNetwork={name!}
+          ipv4Pool={dataNetwork.ipv4_pool}
+          ipv6Pool={dataNetwork.ipv6_pool}
+          edit={
+            staticModal.mode === "edit"
+              ? {
+                  imsi: staticModal.imsi,
+                  ipVersion: staticModal.ipVersion,
+                  address: staticModal.address,
+                }
+              : undefined
+          }
+        />
+      )}
+      {deleteStatic && (
+        <DeleteConfirmationModal
+          open
+          onClose={() => setDeleteStatic(null)}
+          onConfirm={handleStaticDeleteConfirm}
+          title="Confirm Deletion"
+          description={`Remove the static IP ${deleteStatic.address} (${deleteStatic.ipVersion}) for subscriber ${deleteStatic.imsi}?`}
         />
       )}
     </Box>

--- a/ui/src/queries/data_networks.tsx
+++ b/ui/src/queries/data_networks.tsx
@@ -137,3 +137,59 @@ export async function listIPv6Allocations(
     { authToken },
   );
 }
+
+export type EligibleSubscriber = {
+  imsi: string;
+};
+
+type ListSubscribersResponse = {
+  items: EligibleSubscriber[];
+};
+
+export async function listEligibleSubscribers(
+  authToken: string,
+  dataNetwork: string,
+): Promise<EligibleSubscriber[]> {
+  const resp = await apiFetch<ListSubscribersResponse>(
+    `/api/v1/subscribers?data_network=${encodeURIComponent(dataNetwork)}&per_page=100`,
+    { authToken },
+  );
+  return resp.items ?? [];
+}
+
+export const createStaticIp = async (
+  authToken: string,
+  dataNetwork: string,
+  imsi: string,
+  address: string,
+): Promise<void> => {
+  await apiFetchVoid(
+    `/api/v1/networking/data-networks/${encodeURIComponent(dataNetwork)}/static-ips`,
+    { method: "POST", authToken, body: { imsi, address } },
+  );
+};
+
+export const updateStaticIp = async (
+  authToken: string,
+  dataNetwork: string,
+  imsi: string,
+  ipVersion: string,
+  address: string,
+): Promise<void> => {
+  await apiFetchVoid(
+    `/api/v1/networking/data-networks/${encodeURIComponent(dataNetwork)}/static-ips/${encodeURIComponent(imsi)}/${encodeURIComponent(ipVersion)}`,
+    { method: "PUT", authToken, body: { address } },
+  );
+};
+
+export const deleteStaticIp = async (
+  authToken: string,
+  dataNetwork: string,
+  imsi: string,
+  ipVersion: string,
+): Promise<void> => {
+  await apiFetchVoid(
+    `/api/v1/networking/data-networks/${encodeURIComponent(dataNetwork)}/static-ips/${encodeURIComponent(imsi)}/${encodeURIComponent(ipVersion)}`,
+    { method: "DELETE", authToken },
+  );
+};


### PR DESCRIPTION
# Description

Add the ability for users to decide which IP addresses their mobile subscribers get. Administrators can manage static IPs via the data networks page in the UI or data networks API.

Fixes #1338 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
