### PR TITLE
fix: release session on static IP change

### DIFF
--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -276,6 +276,10 @@ func (f *fakeSessionStore) ListFramedRoutes(_ context.Context, _ string, _ strin
 	return nil, nil
 }
 
+func (f *fakeSessionStore) GetStaticIP(_ context.Context, _ string, _ string, _ bool) (netip.Addr, bool, error) {
+	return netip.Addr{}, false, nil
+}
+
 type fakeUPFClient struct{}
 
 func (f *fakeUPFClient) EstablishSession(ctx context.Context, req *models.EstablishRequest) (*models.EstablishResponse, error) {

--- a/internal/api/server/api_static_ips.go
+++ b/internal/api/server/api_static_ips.go
@@ -342,8 +342,8 @@ func UpdateDataNetworkStaticIp(dbInstance *db.Database) http.Handler {
 
 		if err := dbInstance.UpdateStaticLeaseAddress(r.Context(), lease.ID, addr); err != nil {
 			switch {
-			case errors.Is(err, db.ErrLeaseActive):
-				writeError(r.Context(), w, http.StatusConflict, "static IP is in use by an active session", nil, logger.APILog)
+			case errors.Is(err, db.ErrNotFound):
+				writeError(r.Context(), w, http.StatusNotFound, "Static IP not found", nil, logger.APILog)
 			case errors.Is(err, db.ErrAlreadyExists):
 				writeError(r.Context(), w, http.StatusConflict, "address is already in use", nil, logger.APILog)
 			default:
@@ -400,8 +400,8 @@ func DeleteDataNetworkStaticIp(dbInstance *db.Database) http.Handler {
 		}
 
 		if err := dbInstance.DeleteStaticLease(r.Context(), lease.ID); err != nil {
-			if errors.Is(err, db.ErrLeaseActive) {
-				writeError(r.Context(), w, http.StatusConflict, "static IP is in use by an active session", nil, logger.APILog)
+			if errors.Is(err, db.ErrNotFound) {
+				writeError(r.Context(), w, http.StatusNotFound, "static IP reservation not found", nil, logger.APILog)
 				return
 			}
 

--- a/internal/api/server/api_static_ips_test.go
+++ b/internal/api/server/api_static_ips_test.go
@@ -340,7 +340,7 @@ func TestAPIStaticIPsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("mutation of an active reservation is 409", func(t *testing.T) {
+	t.Run("mutation of an active reservation succeeds (reconcile releases the session)", func(t *testing.T) {
 		ctx := context.Background()
 
 		dn, err := env.DB.GetDataNetwork(ctx, staticDN)
@@ -357,16 +357,20 @@ func TestAPIStaticIPsEndToEnd(t *testing.T) {
 			t.Fatalf("UpdateLeaseSession: %s", err)
 		}
 
-		if code, _, _ := updateStaticIp(url, client, token, staticDN, Imsi, "ipv4", "10.99.0.21"); code != http.StatusConflict {
-			t.Fatalf("PUT active: expected 409, got %d", code)
+		// Repinning while bound is allowed: the change is applied and the session
+		// reconcilers release the session so the UE re-establishes on the new IP.
+		if code, _, _ := updateStaticIp(url, client, token, staticDN, Imsi, "ipv4", "10.99.0.21"); code != http.StatusOK {
+			t.Fatalf("PUT active: expected 200, got %d", code)
 		}
 
-		if code, _, _ := deleteStaticIp(url, client, token, staticDN, Imsi, "ipv4"); code != http.StatusConflict {
-			t.Fatalf("DELETE active: expected 409, got %d", code)
+		// Deleting while bound is likewise allowed.
+		if code, _, _ := deleteStaticIp(url, client, token, staticDN, Imsi, "ipv4"); code != http.StatusOK {
+			t.Fatalf("DELETE active: expected 200, got %d", code)
 		}
 
-		if err := env.DB.ClearStaticLeaseSession(ctx, lease.ID); err != nil {
-			t.Fatalf("ClearStaticLeaseSession: %s", err)
+		// Restore an unbound reservation for the downstream delete subtest.
+		if code, _, _ := createStaticIp(url, client, token, staticDN, Imsi, "10.99.0.20"); code != http.StatusCreated {
+			t.Fatalf("restore reservation: expected 201, got %d", code)
 		}
 	})
 

--- a/internal/api/server/api_static_ips_test.go
+++ b/internal/api/server/api_static_ips_test.go
@@ -357,13 +357,10 @@ func TestAPIStaticIPsEndToEnd(t *testing.T) {
 			t.Fatalf("UpdateLeaseSession: %s", err)
 		}
 
-		// Repinning while bound is allowed: the change is applied and the session
-		// reconcilers release the session so the UE re-establishes on the new IP.
 		if code, _, _ := updateStaticIp(url, client, token, staticDN, Imsi, "ipv4", "10.99.0.21"); code != http.StatusOK {
 			t.Fatalf("PUT active: expected 200, got %d", code)
 		}
 
-		// Deleting while bound is likewise allowed.
 		if code, _, _ := deleteStaticIp(url, client, token, staticDN, Imsi, "ipv4"); code != http.StatusOK {
 			t.Fatalf("DELETE active: expected 200, got %d", code)
 		}

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -1838,7 +1838,7 @@ paths:
       operationId: createDataNetworkStaticIp
       tags: [Data Networks]
       summary: Create a static IP reservation
-      description: Pins an address to a subscriber on the data network. The IP version is inferred from the address family; IPv6 addresses must be /64-aligned.
+      description: Pins an address to a subscriber on the data network. The IP version is inferred from the address family; IPv6 addresses must be /64-aligned. If the subscriber has a live session, it is released so the UE re-establishes on the reserved address.
       parameters:
         - $ref: "#/components/parameters/DataNetworkNamePath"
       requestBody:
@@ -1864,7 +1864,7 @@ paths:
       operationId: updateDataNetworkStaticIp
       tags: [Data Networks]
       summary: Repin a static IP reservation
-      description: Changes the reserved address. Rejected while the reservation is bound to an active session.
+      description: Changes the reserved address. A change to a live session releases it so the UE re-establishes on the new address.
       parameters:
         - $ref: "#/components/parameters/DataNetworkNamePath"
         - $ref: "#/components/parameters/ImsiPath"
@@ -1890,7 +1890,7 @@ paths:
       operationId: deleteDataNetworkStaticIp
       tags: [Data Networks]
       summary: Delete a static IP reservation
-      description: Removes the reservation. Rejected while it is bound to an active session.
+      description: Removes the reservation. A change to a live session releases it so the UE re-establishes on a dynamic address.
       parameters:
         - $ref: "#/components/parameters/DataNetworkNamePath"
         - $ref: "#/components/parameters/ImsiPath"

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -458,9 +458,8 @@ func (db *Database) applyCreateStaticLease(ctx context.Context, lease *IPLease) 
 	return db.applyCreateLease(ctx, lease)
 }
 
-// applyUpdateStaticLeaseAddress repins a reserved static lease. The
-// sessionID IS NULL predicate makes the active-check atomic: zero rows
-// affected maps to ErrLeaseActive, a duplicate address to ErrAlreadyExists.
+// applyUpdateStaticLeaseAddress repins a reserved static lease. Zero rows
+// affected maps to ErrNotFound, a duplicate address to ErrAlreadyExists.
 func (db *Database) applyUpdateStaticLeaseAddress(ctx context.Context, lease *IPLease) (any, error) {
 	var outcome sqlair.Outcome
 
@@ -479,15 +478,14 @@ func (db *Database) applyUpdateStaticLeaseAddress(ctx context.Context, lease *IP
 	}
 
 	if rowsAffected == 0 {
-		return nil, ErrLeaseActive
+		return nil, ErrNotFound
 	}
 
 	return nil, nil
 }
 
-// applyDeleteStaticLease removes a reserved static lease. The sessionID IS
-// NULL guard makes the active-check atomic: zero rows affected maps to
-// ErrLeaseActive.
+// applyDeleteStaticLease removes a reserved static lease. Zero rows affected
+// maps to ErrNotFound.
 func (db *Database) applyDeleteStaticLease(ctx context.Context, p *stringPayload) (any, error) {
 	var outcome sqlair.Outcome
 
@@ -502,7 +500,7 @@ func (db *Database) applyDeleteStaticLease(ctx context.Context, p *stringPayload
 	}
 
 	if rowsAffected == 0 {
-		return nil, ErrLeaseActive
+		return nil, ErrNotFound
 	}
 
 	return nil, nil

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -10,12 +10,8 @@ import (
 )
 
 var (
-	ErrAlreadyExists = errors.New("already exists")
-	ErrNotFound      = errors.New("not found")
-	// ErrLeaseActive is returned when a repin or delete targets a static
-	// reservation bound to a session (op guard: WHERE sessionID IS NULL).
-	// Handlers map it to 409.
-	ErrLeaseActive         = errors.New("static IP is in use by an active session")
+	ErrAlreadyExists       = errors.New("already exists")
+	ErrNotFound            = errors.New("not found")
 	ErrDataNetworkNotFound = errors.New("data network not found")
 	ErrNoMatchingPolicy    = errors.New("no matching policy for slice and DNN")
 	// ErrDNNNotInSlice is returned by GetSessionPolicy when a policy matches the

--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -44,8 +44,8 @@ const (
 	getStaticLeaseStmt           = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND poolType==$IPLease.poolType AND imsi==$IPLease.imsi AND type='static'"
 	listStaticLeasesByDNStmt     = "SELECT &IPLease.* FROM %s WHERE poolID==$IPLease.poolID AND type='static' ORDER BY poolType, addressBin"
 	listStaticLeasesByIMSIStmt   = "SELECT &IPLease.* FROM %s WHERE imsi==$IPLease.imsi AND type='static' ORDER BY addressBin"
-	updateStaticLeaseAddressStmt = "UPDATE %s SET addressBin=$IPLease.addressBin WHERE id==$IPLease.id AND type='static' AND sessionID IS NULL"
-	deleteStaticLeaseStmt        = "DELETE FROM %s WHERE id==$IPLease.id AND type='static' AND sessionID IS NULL"
+	updateStaticLeaseAddressStmt = "UPDATE %s SET addressBin=$IPLease.addressBin WHERE id==$IPLease.id AND type='static'"
+	deleteStaticLeaseStmt        = "DELETE FROM %s WHERE id==$IPLease.id AND type='static'"
 )
 
 // IPLease represents a row in the ip_leases table.
@@ -1039,9 +1039,9 @@ func (db *Database) ClearStaticLeaseSession(ctx context.Context, leaseID string)
 	return nil
 }
 
-// UpdateStaticLeaseAddress repins a reserved static lease to a new
-// address. Returns ErrLeaseActive if the reservation is bound to a
-// session and ErrAlreadyExists if the address is already leased.
+// UpdateStaticLeaseAddress repins a reserved static lease to a new address.
+// Returns ErrNotFound if the reservation is gone, ErrAlreadyExists if the
+// address is already leased.
 func (db *Database) UpdateStaticLeaseAddress(ctx context.Context, leaseID string, addr netip.Addr) error {
 	_, span := tracer.Start(
 		ctx,
@@ -1075,8 +1075,8 @@ func (db *Database) UpdateStaticLeaseAddress(ctx context.Context, leaseID string
 	return nil
 }
 
-// DeleteStaticLease removes a reserved static lease. Returns
-// ErrLeaseActive if the reservation is bound to a session.
+// DeleteStaticLease removes a reserved static lease. Returns ErrNotFound if
+// the reservation is gone.
 func (db *Database) DeleteStaticLease(ctx context.Context, leaseID string) error {
 	_, span := tracer.Start(
 		ctx,

--- a/internal/db/ip_leases_test.go
+++ b/internal/db/ip_leases_test.go
@@ -1029,8 +1029,20 @@ func TestUpdateStaticLeaseAddress(t *testing.T) {
 		t.Fatalf("UpdateLeaseSession: %s", err)
 	}
 
-	if err := database.UpdateStaticLeaseAddress(ctx, got.ID, addr("192.168.1.40")); err != db.ErrLeaseActive {
-		t.Fatalf("expected ErrLeaseActive repinning active reservation, got %v", err)
+	// Repinning is allowed while the reservation is bound to an active session:
+	// the session reconcilers release the session so the UE re-establishes on the
+	// new address.
+	if err := database.UpdateStaticLeaseAddress(ctx, got.ID, addr("192.168.1.40")); err != nil {
+		t.Fatalf("expected repin of active reservation to succeed, got %v", err)
+	}
+
+	reboundAddr, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi)
+	if err != nil {
+		t.Fatalf("GetStaticLease after active repin: %s", err)
+	}
+
+	if reboundAddr.Address() != addr("192.168.1.40") {
+		t.Fatalf("expected repinned address 192.168.1.40, got %s", reboundAddr.Address())
 	}
 }
 
@@ -1051,24 +1063,20 @@ func TestDeleteStaticLease(t *testing.T) {
 		t.Fatalf("UpdateLeaseSession: %s", err)
 	}
 
-	if err := database.DeleteStaticLease(ctx, got.ID); err != db.ErrLeaseActive {
-		t.Fatalf("expected ErrLeaseActive deleting active reservation, got %v", err)
-	}
-
-	if _, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi); err != nil {
-		t.Fatalf("expected active reservation to persist, got %v", err)
-	}
-
-	if err := database.ClearStaticLeaseSession(ctx, got.ID); err != nil {
-		t.Fatalf("ClearStaticLeaseSession: %s", err)
-	}
-
+	// Deleting is allowed while the reservation is bound to an active session:
+	// the session reconcilers release the session so the UE re-establishes on a
+	// dynamic address.
 	if err := database.DeleteStaticLease(ctx, got.ID); err != nil {
-		t.Fatalf("DeleteStaticLease: %s", err)
+		t.Fatalf("expected delete of active reservation to succeed, got %v", err)
 	}
 
 	if _, err := database.GetStaticLease(ctx, poolID, "ipv4", imsi); err != db.ErrNotFound {
 		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+
+	// A second delete of a gone reservation reports ErrNotFound.
+	if err := database.DeleteStaticLease(ctx, got.ID); err != db.ErrNotFound {
+		t.Fatalf("expected ErrNotFound deleting gone reservation, got %v", err)
 	}
 }
 

--- a/internal/db/ip_leases_test.go
+++ b/internal/db/ip_leases_test.go
@@ -1029,9 +1029,7 @@ func TestUpdateStaticLeaseAddress(t *testing.T) {
 		t.Fatalf("UpdateLeaseSession: %s", err)
 	}
 
-	// Repinning is allowed while the reservation is bound to an active session:
-	// the session reconcilers release the session so the UE re-establishes on the
-	// new address.
+	// Repinning a bound reservation is allowed.
 	if err := database.UpdateStaticLeaseAddress(ctx, got.ID, addr("192.168.1.40")); err != nil {
 		t.Fatalf("expected repin of active reservation to succeed, got %v", err)
 	}
@@ -1063,9 +1061,7 @@ func TestDeleteStaticLease(t *testing.T) {
 		t.Fatalf("UpdateLeaseSession: %s", err)
 	}
 
-	// Deleting is allowed while the reservation is bound to an active session:
-	// the session reconcilers release the session so the UE re-establishes on a
-	// dynamic address.
+	// Deleting a bound reservation is allowed.
 	if err := database.DeleteStaticLease(ctx, got.ID); err != nil {
 		t.Fatalf("expected delete of active reservation to succeed, got %v", err)
 	}

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -37,9 +37,9 @@ var (
 	// AllocateIPv6Lease is the same for IPv6 /64 prefix delegation.
 	opAllocateIPv6Lease = registerChangesetOpReturning[allocateIPLeasePayload, string]("AllocateIPv6Lease", (*Database).applyAllocateIPLease, RequireSchema(12), AffectsTopic(TopicIPLeases))
 	// Static ops read/write ip_leases.poolType, added in v13.
-	opCreateStaticLease        = registerChangesetOp("CreateStaticLease", (*Database).applyCreateStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases))
-	opUpdateStaticLeaseAddress = registerChangesetOp("UpdateStaticLeaseAddress", (*Database).applyUpdateStaticLeaseAddress, RequireSchema(13), AffectsTopic(TopicIPLeases))
-	opDeleteStaticLease        = registerChangesetOp("DeleteStaticLease", (*Database).applyDeleteStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases))
+	opCreateStaticLease        = registerChangesetOp("CreateStaticLease", (*Database).applyCreateStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases), AffectsTopic(TopicSessionReconcile))
+	opUpdateStaticLeaseAddress = registerChangesetOp("UpdateStaticLeaseAddress", (*Database).applyUpdateStaticLeaseAddress, RequireSchema(13), AffectsTopic(TopicIPLeases), AffectsTopic(TopicSessionReconcile))
+	opDeleteStaticLease        = registerChangesetOp("DeleteStaticLease", (*Database).applyDeleteStaticLease, RequireSchema(13), AffectsTopic(TopicIPLeases), AffectsTopic(TopicSessionReconcile))
 )
 
 // Audit logs

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -54,16 +54,18 @@ var (
 // fakeSessionManager stands in for the SMF+PGW-C anchor. CreateEPSSession honors
 // the requested PDN type so tests can drive IPv4/IPv6/IPv4v6.
 type fakeSessionManager struct {
-	lastRequest   models.EPSBearerRequest
-	modifiedENB   models.FTEID // records the eNB F-TEID from the last ModifyEPSSession
-	released      bool
-	deactivated   bool
-	ambrUpdated   bool
-	ambrUplink    string // records the last UpdateEPSSessionAMBR uplink value
-	ambrDownlink  string
-	ambrErr       error // when set, UpdateEPSSessionAMBR fails with it
-	framedChanged bool  // FramedRoutesChanged returns this
-	framedErr     error // when set, FramedRoutesChanged fails with it
+	lastRequest     models.EPSBearerRequest
+	modifiedENB     models.FTEID // records the eNB F-TEID from the last ModifyEPSSession
+	released        bool
+	deactivated     bool
+	ambrUpdated     bool
+	ambrUplink      string // records the last UpdateEPSSessionAMBR uplink value
+	ambrDownlink    string
+	ambrErr         error // when set, UpdateEPSSessionAMBR fails with it
+	framedChanged   bool  // FramedRoutesChanged returns this
+	framedErr       error // when set, FramedRoutesChanged fails with it
+	staticIPChanged bool  // StaticIPChanged returns this
+	staticIPErr     error // when set, StaticIPChanged fails with it
 }
 
 func (f *fakeSessionManager) CreateEPSSession(_ context.Context, req models.EPSBearerRequest) (models.EPSBearer, error) {
@@ -123,6 +125,10 @@ func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) erro
 
 func (f *fakeSessionManager) FramedRoutesChanged(_ context.Context, _ string, _ uint8) (bool, error) {
 	return f.framedChanged, f.framedErr
+}
+
+func (f *fakeSessionManager) StaticIPChanged(_ context.Context, _ string, _ uint8) (bool, error) {
+	return f.staticIPChanged, f.staticIPErr
 }
 
 // fakeBearerStore resolves a fixed default-bearer QoS (QCI 9, APN "internet",

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -66,6 +66,11 @@ type epsSessionManager interface {
 	// default bearer (imsi, ebi) differ from those installed at establishment, so
 	// the reconciler reactivates the bearer on a change (TS 23.501 §5.6.14).
 	FramedRoutesChanged(ctx context.Context, imsi string, ebi uint8) (bool, error)
+
+	// StaticIPChanged reports whether the subscriber's reserved static IP for the
+	// default bearer (imsi, ebi) changed since establishment, so the reconciler
+	// reactivates the bearer on a change (TS 24.301 §6.4.4.2).
+	StaticIPChanged(ctx context.Context, imsi string, ebi uint8) (bool, error)
 }
 
 // credentialProvider is the UDM surface the MME requires for EPS authentication:

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -129,6 +129,10 @@ func (f *fakeSessionManager) FramedRoutesChanged(_ context.Context, _ string, _ 
 	return false, nil
 }
 
+func (f *fakeSessionManager) StaticIPChanged(_ context.Context, _ string, _ uint8) (bool, error) {
+	return false, nil
+}
+
 // fakeBearerStore resolves a fixed default-bearer QoS for any subscriber.
 type erroringSessionManager struct{ fakeSessionManager }
 

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -95,6 +95,24 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, p *PdnConnecti
 		return
 	}
 
+	// The UE IP is fixed for the PDN connection lifetime (TS 23.401 §5.3.1.2.1);
+	// a reservation change requires reactivation, not in-place modification.
+	staticChanged, err := m.Session.StaticIPChanged(ctx, ue.IMSI(), p.Ebi)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Warn("reconcile: failed to check static IP; deferring to next sweep",
+			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn), zap.Error(err))
+
+		return
+	}
+
+	if staticChanged {
+		logger.From(ctx, ue.Conn().Log).Info("static IP changed; reactivating EPS bearer",
+			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
+		m.reactivateBearer(ctx, ue, p)
+
+		return
+	}
+
 	qos, err := ResolveQoSByAPN(ctx, m, ue.IMSI(), p.Apn)
 	if err != nil {
 		// The subscriber's profile does not bind the APN: the subscription does

--- a/internal/mme/reconcile_test.go
+++ b/internal/mme/reconcile_test.go
@@ -146,6 +146,35 @@ func TestReconcileDataNetworkReactivatesOnFramedRouteChange(t *testing.T) {
 	}
 }
 
+// TestReconcileDataNetworkReactivatesOnStaticIPChange checks that a static-IP
+// reservation change alone (data-network config and framed routes unchanged)
+// reactivates the bearer with ESM cause #39, per TS 24.301 §6.4.4.2.
+func TestReconcileDataNetworkReactivatesOnStaticIPChange(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := connectedBearerUE(t, m)
+
+	qos, err := ResolveQoS(context.Background(), m, ue.imsiOrEmpty())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testPDN(ue).DnConfig = qos.DnFingerprint() // config matches; the static IP is the only change
+
+	m.Session.(*fakeSessionManager).staticIPChanged = true
+
+	m.ReconcileDataNetwork(context.Background())
+
+	defer ue.Conn().StopNASGuard()
+
+	if !testPDN(ue).Deactivating {
+		t.Fatal("UE not marked deactivating after a static IP change")
+	}
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected one Deactivate EPS Bearer Context Request, got %d", len(cc.sent))
+	}
+}
+
 func TestReconcileDataNetworkSkipsIdleUE(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := connectedBearerUE(t, m)

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -152,6 +152,10 @@ func (f *fakeSessionManager) FramedRoutesChanged(_ context.Context, _ string, _ 
 	return false, nil
 }
 
+func (f *fakeSessionManager) StaticIPChanged(_ context.Context, _ string, _ uint8) (bool, error) {
+	return false, nil
+}
+
 // fakeBearerStore resolves a fixed default-bearer QoS for any subscriber.
 type fakeBearerStore struct{}
 

--- a/internal/smf/eps.go
+++ b/internal/smf/eps.go
@@ -278,6 +278,26 @@ func (s *SMF) FramedRoutesChanged(ctx context.Context, imsi string, ebi uint8) (
 	return s.framedRoutesChanged(ctx, smContext)
 }
 
+// StaticIPChanged reports whether the subscriber's reserved static IP for the
+// EPS session (imsi, ebi) changed since establishment; an unknown session
+// reports no change.
+func (s *SMF) StaticIPChanged(ctx context.Context, imsi string, ebi uint8) (bool, error) {
+	supi, err := etsi.NewSUPIFromIMSI(imsi)
+	if err != nil {
+		return false, fmt.Errorf("invalid imsi %q: %w", imsi, err)
+	}
+
+	smContext := s.currentSession(supi, ebi)
+	if smContext == nil {
+		return false, nil
+	}
+
+	smContext.Mutex.Lock()
+	defer smContext.Mutex.Unlock()
+
+	return s.staticIPChanged(ctx, smContext)
+}
+
 // DeactivateEPSSession puts the retained 4G default bearer into buffering mode when
 // the UE goes ECM-IDLE: the downlink FAR buffers packets, so downlink
 // data raises a paging notification and never reaches the released eNB tunnel.

--- a/internal/smf/reconcile.go
+++ b/internal/smf/reconcile.go
@@ -157,6 +157,28 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 		return s.sendSessionRelease(ctx, smContext)
 	}
 
+	// The UE IP is fixed for the session lifetime (TS 23.501 §5.8.2.2); a
+	// reservation change requires release, not in-place modification.
+	staticChanged, err := s.staticIPChanged(ctx, smContext)
+	if err != nil {
+		logger.SmfLog.Warn("failed to resolve static IP during reconciliation; deferring to backstop",
+			logger.SUPI(smContext.Supi.String()),
+			logger.PDUSessionID(smContext.PDUSessionID),
+			zap.Error(err),
+		)
+
+		return nil
+	}
+
+	if staticChanged {
+		logger.SmfLog.Info("static IP changed, releasing session for re-establishment",
+			logger.SUPI(smContext.Supi.String()),
+			logger.PDUSessionID(smContext.PDUSessionID),
+		)
+
+		return s.sendSessionRelease(ctx, smContext)
+	}
+
 	oldQoS := smContext.PolicyData.QosData
 	oldAmbr := smContext.PolicyData.Ambr
 
@@ -501,6 +523,41 @@ func framedRoutesEqual(a, b []netip.Prefix) bool {
 	}
 
 	return true
+}
+
+// staticIPChanged reports whether the subscriber's reserved static IP changed
+// since it was cached at establishment. Caller holds smContext.Mutex.
+func (s *SMF) staticIPChanged(ctx context.Context, smContext *SMContext) (bool, error) {
+	imsi := smContext.Supi.IMSI()
+
+	if smContext.PDUIPV4Address != nil {
+		changed, err := s.staticReservationChanged(ctx, imsi, smContext.Dnn, false, smContext.StaticIPv4)
+		if err != nil || changed {
+			return changed, err
+		}
+	}
+
+	if smContext.PDUIPV6Prefix != nil {
+		changed, err := s.staticReservationChanged(ctx, imsi, smContext.Dnn, true, smContext.StaticIPv6)
+		if err != nil || changed {
+			return changed, err
+		}
+	}
+
+	return false, nil
+}
+
+func (s *SMF) staticReservationChanged(ctx context.Context, imsi, dnn string, ipv6 bool, cached netip.Addr) (bool, error) {
+	current, has, err := s.store.GetStaticIP(ctx, imsi, dnn, ipv6)
+	if err != nil {
+		return false, err
+	}
+
+	if has != cached.IsValid() {
+		return true, nil
+	}
+
+	return has && current != cached, nil
 }
 
 // sendSessionRelease performs the network-requested PDU session release

--- a/internal/smf/session.go
+++ b/internal/smf/session.go
@@ -23,6 +23,7 @@ import (
 var (
 	errUEAddressAllocation = errors.New("UE address allocation failed")
 	errFramedRouteResolve  = errors.New("framed route resolution failed")
+	errStaticIPResolve     = errors.New("static IP resolution failed")
 	errDataPathActivation  = errors.New("data path activation failed")
 	errUPFSession          = errors.New("UPF session establishment failed")
 )
@@ -86,6 +87,32 @@ func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMCont
 	}
 
 	sc.FramedRoutes = framed
+
+	// Cache the reserved static address per family so a reconcile can detect a
+	// reservation change; fail-closed on error.
+	if sc.PDUIPV4Address != nil {
+		addr, ok, err := s.store.GetStaticIP(ctx, req.Supi.IMSI(), req.Dnn, false)
+		if err != nil {
+			sc.Mutex.Unlock()
+			return nil, ueAddresses{}, fmt.Errorf("%w: %v", errStaticIPResolve, err)
+		}
+
+		if ok {
+			sc.StaticIPv4 = addr
+		}
+	}
+
+	if sc.PDUIPV6Prefix != nil {
+		addr, ok, err := s.store.GetStaticIP(ctx, req.Supi.IMSI(), req.Dnn, true)
+		if err != nil {
+			sc.Mutex.Unlock()
+			return nil, ueAddresses{}, fmt.Errorf("%w: %v", errStaticIPResolve, err)
+		}
+
+		if ok {
+			sc.StaticIPv6 = addr
+		}
+	}
 
 	sc.Tunnel = &UPTunnel{DataPath: &DataPath{UpLinkTunnel: &GTPTunnel{}, DownLinkTunnel: &GTPTunnel{}}}
 

--- a/internal/smf/sm_context.go
+++ b/internal/smf/sm_context.go
@@ -41,16 +41,19 @@ type SMContext struct {
 	// reused the (SUPI, id) slot. CanonicalName(SUPI, id) is the secondary index key.
 	Ref string
 
-	Supi                           etsi.SUPI
-	Dnn                            string
-	Snssai                         *models.Snssai
-	Tunnel                         *UPTunnel
-	PolicyData                     *Policy
-	PFCPContext                    *PFCPSessionContext
-	PDUSessionID                   uint8
-	FramedRoutes                   []netip.Prefix
-	PDUIPV4Address                 net.IP
-	PDUIPV6Prefix                  net.IP  // delegated /64 prefix base address (lower 64 bits = 0)
+	Supi           etsi.SUPI
+	Dnn            string
+	Snssai         *models.Snssai
+	Tunnel         *UPTunnel
+	PolicyData     *Policy
+	PFCPContext    *PFCPSessionContext
+	PDUSessionID   uint8
+	FramedRoutes   []netip.Prefix
+	PDUIPV4Address net.IP
+	PDUIPV6Prefix  net.IP // delegated /64 prefix base address (lower 64 bits = 0)
+	// Reserved static address cached at establishment; invalid if dynamic.
+	StaticIPv4                     netip.Addr
+	StaticIPv6                     netip.Addr
 	IPv6IID                        [8]byte // random Interface Identifier sent to UE
 	PDUSessionType                 uint8   // negotiated type: nasMessage.PDUSessionTypeIPv4/IPv6/IPv4IPv6
 	PDUSessionReleaseDueToDupPduID bool

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -76,6 +76,10 @@ type SessionStore interface {
 
 	ListFramedRoutes(ctx context.Context, imsi string, dnn string) ([]netip.Prefix, error)
 
+	// GetStaticIP returns the reserved static address for the DNN and family
+	// (ipv6 selects the IPv6 pool), and whether one exists.
+	GetStaticIP(ctx context.Context, imsi string, dnn string, ipv6 bool) (netip.Addr, bool, error)
+
 	IncrementDailyUsage(ctx context.Context, imsi string, uplinkBytes, downlinkBytes uint64) error
 
 	// InsertFlowReports persists flow measurement records in one transaction.

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -33,6 +33,9 @@ type fakeStore struct {
 	allocateIPv6Err error
 	framedRoutes    []netip.Prefix
 	framedRoutesErr error
+	staticIPv4      netip.Addr
+	staticIPv6      netip.Addr
+	staticIPErr     error
 }
 
 type fakePCF struct {
@@ -92,6 +95,22 @@ func (f *fakeStore) ListFramedRoutes(_ context.Context, _ string, _ string) ([]n
 	defer f.mu.Unlock()
 
 	return f.framedRoutes, f.framedRoutesErr
+}
+
+func (f *fakeStore) GetStaticIP(_ context.Context, _ string, _ string, ipv6 bool) (netip.Addr, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.staticIPErr != nil {
+		return netip.Addr{}, false, f.staticIPErr
+	}
+
+	addr := f.staticIPv4
+	if ipv6 {
+		addr = f.staticIPv6
+	}
+
+	return addr, addr.IsValid(), nil
 }
 
 func (f *fakePCF) GetSessionPolicy(_ context.Context, _ string, _ *models.Snssai, _ string) (*smf.Policy, error) {

--- a/internal/smf/static_ip_test.go
+++ b/internal/smf/static_ip_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf_test
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+)
+
+// TestStaticIPChanged covers the reconcile comparison used by the MME: a
+// reservation identical to the one cached at establishment is unchanged; a
+// repinned, deleted, or newly created reservation is a change; an unknown
+// session reports no change.
+func TestStaticIPChanged(t *testing.T) {
+	store, upf := epsTestSMF()
+	store.staticIPv4 = store.allocatedIP // session established on a pinned address
+
+	s := newTestSMF(&fakePCF{}, store, upf, &fakeAMF{})
+
+	imsi := epsRequest(1).IMSI
+	if _, err := s.CreateEPSSession(context.Background(), epsRequest(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := s.StaticIPChanged(context.Background(), imsi, epsTestEBI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if changed {
+		t.Fatal("unchanged static reservation reported as changed")
+	}
+
+	// Repin to a different address.
+	store.staticIPv4 = netip.AddrFrom4([4]byte{10, 45, 0, 8})
+
+	changed, err = s.StaticIPChanged(context.Background(), imsi, epsTestEBI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !changed {
+		t.Fatal("a repinned static reservation was not detected")
+	}
+
+	// Delete the reservation.
+	store.staticIPv4 = netip.Addr{}
+
+	changed, err = s.StaticIPChanged(context.Background(), imsi, epsTestEBI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !changed {
+		t.Fatal("a deleted static reservation was not detected")
+	}
+
+	changed, err = s.StaticIPChanged(context.Background(), "001010000000009", epsTestEBI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if changed {
+		t.Fatal("unknown session reported a static IP change")
+	}
+}
+
+// TestStaticIPChangedCreatedOnDynamicSession covers the reported bug: a session
+// established on a dynamic address must be reported as changed when the operator
+// later pins a static IP, so the reconciler releases it for re-establishment.
+func TestStaticIPChangedCreatedOnDynamicSession(t *testing.T) {
+	store, upf := epsTestSMF() // no static reservation at establishment
+
+	s := newTestSMF(&fakePCF{}, store, upf, &fakeAMF{})
+
+	imsi := epsRequest(1).IMSI
+	if _, err := s.CreateEPSSession(context.Background(), epsRequest(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := s.StaticIPChanged(context.Background(), imsi, epsTestEBI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if changed {
+		t.Fatal("dynamic session with no reservation reported as changed")
+	}
+
+	// Operator pins a static IP mid-session.
+	store.staticIPv4 = netip.AddrFrom4([4]byte{10, 45, 0, 9})
+
+	changed, err = s.StaticIPChanged(context.Background(), imsi, epsTestEBI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !changed {
+		t.Fatal("a static IP created on a dynamic session was not detected")
+	}
+}
+
+// TestReconcileSmContext_StaticIPCreatedReleasesSession asserts the 5G reconcile
+// path releases the session (cause #39) when a static reservation is created for
+// a session currently on a dynamic address.
+func TestReconcileSmContext_StaticIPCreatedReleasesSession(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	// The session was set up on a dynamic address (10.0.0.1); the operator now
+	// pins that subscriber to a static IP.
+	store.mu.Lock()
+	store.staticIPv4 = netip.MustParseAddr("10.0.0.1")
+	store.mu.Unlock()
+
+	if err := s.ReconcileSmContext(ctx, &models.SessionReconcileRequest{
+		SmContextRef: ref,
+		Reason:       models.ReconcilePolicyChange,
+	}); err != nil {
+		t.Fatalf("ReconcileSmContext failed: %v", err)
+	}
+
+	amfCb.mu.Lock()
+	releaseCalls := len(amfCb.releaseCalls)
+	amfCb.mu.Unlock()
+
+	if releaseCalls != 1 {
+		t.Fatalf("expected 1 release signaling call after static IP change, got %d", releaseCalls)
+	}
+}

--- a/internal/upf/ebpf/measure_test.go
+++ b/internal/upf/ebpf/measure_test.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// TestMeasureVerifiedInstructions logs the verifier's processed-instruction
+// count per program. Numbers are kernel-specific (this box's kernel prunes
+// differently than stock 5.15/6.x); use them for the relative picture, not the
+// absolute fit-under-1M verdict. Run with EBPF_REQUIRE_PRIVILEGED=1.
+func TestMeasureVerifiedInstructions(t *testing.T) {
+	requireProgTestRun(t)
+
+	obj := loadProgram(t, 0, 1)
+
+	for _, pr := range []struct {
+		name string
+		p    *ebpf.Program
+	}{
+		{"upf_entry", obj.UpfEntryFunc},
+		{"upf_uplink", obj.UpfUplinkFunc},
+		{"upf_downlink", obj.UpfDownlinkFunc},
+	} {
+		info, err := pr.p.Info()
+		if err != nil {
+			t.Fatalf("%s Info: %v", pr.name, err)
+		}
+
+		n, ok := info.VerifiedInstructions()
+		t.Logf("MEASURE %-13s verified_insns=%d ok=%v", pr.name, n, ok)
+	}
+}

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -131,6 +131,11 @@ func (a *smfDBAdapter) ReleaseIP(ctx context.Context, imsi string, dnn string, p
 
 	lease, err := a.db.GetLeaseBySession(ctx, pool.ID, pool.IPVersion, int(pduSessionID), imsi)
 	if err != nil {
+		// Reservation deleted while bound: nothing left to free.
+		if errors.Is(err, db.ErrNotFound) {
+			return netip.Addr{}, nil
+		}
+
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "lookup failed")
 
@@ -217,6 +222,11 @@ func (a *smfDBAdapter) ReleaseIPv6(ctx context.Context, imsi string, dnn string,
 
 	lease, err := a.db.GetLeaseBySession(ctx, pool.ID, pool.IPVersion, int(pduSessionID), imsi)
 	if err != nil {
+		// Reservation deleted while bound: nothing left to free.
+		if errors.Is(err, db.ErrNotFound) {
+			return netip.Addr{}, nil
+		}
+
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "lookup failed")
 
@@ -357,6 +367,36 @@ func (a *smfDBAdapter) ListFramedRoutes(ctx context.Context, imsi string, dnn st
 	}
 
 	return prefixes, nil
+}
+
+// GetStaticIP returns the reserved static address for the DNN and family, and
+// whether one exists (a missing reservation is not an error).
+func (a *smfDBAdapter) GetStaticIP(ctx context.Context, imsi string, dnn string, ipv6 bool) (netip.Addr, bool, error) {
+	var (
+		pool ipam.Pool
+		err  error
+	)
+
+	if ipv6 {
+		pool, err = a.resolveIPv6PoolByDNN(ctx, dnn)
+	} else {
+		pool, err = a.resolvePoolByDNN(ctx, dnn)
+	}
+
+	if err != nil {
+		return netip.Addr{}, false, fmt.Errorf("resolve pool: %w", err)
+	}
+
+	lease, err := a.db.GetStaticLease(ctx, pool.ID, pool.IPVersion, imsi)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return netip.Addr{}, false, nil
+		}
+
+		return netip.Addr{}, false, fmt.Errorf("get static lease: %w", err)
+	}
+
+	return lease.Address(), true, nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Immediately release the subscriber session when a user changes the static IP allocation for that subscriber via the UI/API.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
