### PR TITLE
fix: 5G replay protection

### DIFF
--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -85,7 +85,7 @@ type UeContext struct {
 	kgnb                 []uint8
 	nh                   [32]uint8 // AS key-chain Next Hop, 256 bits (TS 33.501)
 	ncc                  uint8
-	ulCount              nascommon.Count
+	ulCount              nascommon.UplinkCounter
 	dlCount              nascommon.Count
 	cipheringAlg         uint8
 	integrityAlg         uint8
@@ -400,8 +400,10 @@ func (ue *UeContext) deriveAlgKeyLocked() error {
 
 // DeriveAnKey derives the access network key per TS 33.501.
 func (ue *UeContext) DeriveAnKey() error {
+	// The AN key is derived from the uplink NAS COUNT of the most recently
+	// accepted uplink NAS message (TS 33.501 §A.9).
 	P0 := make([]byte, 4)
-	binary.BigEndian.PutUint32(P0, ue.ulCount.Value())
+	binary.BigEndian.PutUint32(P0, ue.ulCount.LastAccepted().Value())
 	L0 := ueauth.KDFLen(P0)
 	P1 := []byte{security.AccessType3GPP}
 	L1 := ueauth.KDFLen(P1)
@@ -587,7 +589,8 @@ func (ue *UeContext) EncodeNASMessage(msg *nas.Message) ([]byte, error) {
 	case nas.SecurityHeaderTypeIntegrityProtectedAndCiphered:
 		needCiphering = true
 	case nas.SecurityHeaderTypeIntegrityProtectedWithNew5gNasSecurityContext:
-		ue.ulCount = 0
+		ue.ulCount.Reset()
+
 		ue.dlCount = 0
 	default:
 		return nil, fmt.Errorf("wrong security header type: 0x%0x", msg.SecurityHeaderType)

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -122,7 +122,7 @@ func (ue *UeContext) NasIntegrityVerified(payload []byte) bool {
 	receivedMac := payload[2:6]
 	sqn := payload[6]
 
-	cnt := ue.ulCount.ReconcileUplink(sqn) // never committed back to the context
+	cnt := ue.ulCount.Estimate(sqn) // never committed back to the context
 
 	mac, err := security.NASMacCalculate(ue.integrityAlg, ue.knasInt, cnt.Value(), security.Bearer3GPP, security.DirectionUplink, payload[6:])
 	if err != nil {
@@ -179,10 +179,10 @@ func decodeProtectedNAS(ue *UeContext, msg *nas.Message, payload []byte, conn *U
 
 	ciphered := false
 
-	// Work on a copy of the uplink count and commit it to the security context
+	// Work on a copy of the uplink counter and commit to the security context
 	// only once the MAC is verified, so an unauthenticated message cannot
 	// advance (desync) the count of a genuine UE (TS 33.501).
-	cnt := ue.ulCount
+	counter := ue.ulCount
 
 	switch msg.SecurityHeaderType {
 	case nas.SecurityHeaderTypeIntegrityProtected:
@@ -191,7 +191,7 @@ func decodeProtectedNAS(ue *UeContext, msg *nas.Message, payload []byte, conn *U
 	case nas.SecurityHeaderTypeIntegrityProtectedAndCipheredWithNew5gNasSecurityContext:
 		ciphered = true
 
-		cnt = 0
+		counter.Reset()
 	default:
 		// A reserved/unrecognized security header type is not a valid NAS message: a protocol
 		// error answered with a 5GMM STATUS #111 (§7), not silently ignored. The message is
@@ -199,7 +199,7 @@ func decodeProtectedNAS(ue *UeContext, msg *nas.Message, payload []byte, conn *U
 		return nil, statusDecode(nasreply.CauseProtocolErrorUnspecified, "wrong security header type: 0x%0x", msg.SecurityHeaderType)
 	}
 
-	cnt = cnt.ReconcileUplink(sequenceNumber)
+	cnt := counter.Estimate(sequenceNumber)
 
 	mac32, err := security.NASMacCalculate(ue.integrityAlg, ue.knasInt, cnt.Value(), security.Bearer3GPP,
 		security.DirectionUplink, payload)
@@ -248,7 +248,8 @@ func decodeProtectedNAS(ue *UeContext, msg *nas.Message, payload []byte, conn *U
 	}
 
 	if macVerified {
-		ue.ulCount = cnt
+		counter.Commit(cnt)
+		ue.ulCount = counter
 
 		// First verified message establishes secure exchange on the connection (TS 24.501).
 		conn.MarkSecureExchangeEstablished()

--- a/internal/amf/nas/handle_identity_response_test.go
+++ b/internal/amf/nas/handle_identity_response_test.go
@@ -420,7 +420,7 @@ func TestHandleIdentityResponse_AuthenticationProcess_RegistrationAccept(t *test
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
@@ -448,7 +448,7 @@ func TestHandleIdentityResponse_AuthenticationProcess_RegistrationAccept(t *test
 		t.Fatalf("expected a protected and ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -512,7 +512,7 @@ func TestHandleIdentityResponse_ContextSetup_RegistrationAccept(t *testing.T) {
 			ue.SetCipheringAlgForTest(algo)
 			ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 			if err != nil {
 				t.Fatalf("could not build registration request message: %v", err)
 			}
@@ -544,7 +544,7 @@ func TestHandleIdentityResponse_ContextSetup_RegistrationAccept(t *testing.T) {
 				t.Fatalf("expected a protected and ciphered NAS message")
 			}
 
-			if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+			if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 				t.Fatalf("could not decrypt NAS message: %v", err)
 			}
 
@@ -604,7 +604,7 @@ func TestHandleIdentityResponse_ContextSetup_Error(t *testing.T) {
 			ue.SetCipheringAlgForTest(algo)
 			ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+			registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 			if err != nil {
 				t.Fatalf("could not build registration request message: %v", err)
 			}

--- a/internal/amf/nas/handle_registration_complete_test.go
+++ b/internal/amf/nas/handle_registration_complete_test.go
@@ -54,7 +54,7 @@ func setupRegistrationCompleteUE(t *testing.T) (*amf.UeContext, *fakeNGAPSender)
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -814,7 +814,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationAccepted(t *testing.T
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
@@ -837,7 +837,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationAccepted(t *testing.T
 		t.Fatalf("expected a protected and ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -895,7 +895,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationRejectedWrongKey(t *t
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+	m, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}

--- a/internal/amf/nas/handle_service_request_test.go
+++ b/internal/amf/nas/handle_service_request_test.go
@@ -220,7 +220,7 @@ func TestHandleServiceRequest_NASContainer_DecryptFailure_ServiceReject(t *testi
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeSignalling)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeSignalling)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestHandleServiceRequest_UnknownUE_NASMessage_ServiceReject(t *testing.T) {
 	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	algo := security.AlgCiphering128NEA2
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -479,7 +479,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeSignaling_ServiceAccept(t *
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeSignalling)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeSignalling)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -502,7 +502,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeSignaling_ServiceAccept(t *
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -563,7 +563,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeData_ServiceAccept(t *testi
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -586,7 +586,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeData_ServiceAccept(t *testi
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -652,7 +652,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -675,7 +675,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -748,7 +748,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_NoPDUSession
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1})
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -814,7 +814,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 	_ = ue.CreateSmContext(1, "testref", &snssai)
 	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai})
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -837,7 +837,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -866,7 +866,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -950,7 +950,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai)
 	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -973,7 +973,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1006,7 +1006,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1090,7 +1090,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai)
 	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -1113,7 +1113,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1154,7 +1154,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1242,7 +1242,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
 	ue.Conn().UeContextRequest = true
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -1265,7 +1265,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1294,7 +1294,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1388,7 +1388,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		BinaryDataN1Message: n1msg,
 	})
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeMobileTerminatedServices)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeMobileTerminatedServices)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -1411,7 +1411,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount(), security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1440,7 +1440,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount()+1, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1473,7 +1473,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_DownlinkSignalingOnly_Se
 		t.Fatalf("expected a ciphered NAS message")
 	}
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value()+2, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount()+2, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -1557,7 +1557,7 @@ func TestHandleServiceRequest_OutOfRangePduSessionID_UplinkDataStatus(t *testing
 	// The read-side bounds checks in handleServiceRequest must still prevent a panic.
 	ue.SmContextList[255] = &amf.SmContext{Ref: "malicious-ref", Snssai: &snssai}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}
@@ -1616,7 +1616,7 @@ func TestHandleServiceRequest_OutOfRangePduSessionID_PDUSessionStatus(t *testing
 	// bypassing CreateSmContext validation to test the read-side safety net.
 	ue.SmContextList[200] = &amf.SmContext{Ref: "malicious-ref", Snssai: &snssai}
 
-	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCountForTest().Value(), nasMessage.ServiceTypeData)
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), nasMessage.ServiceTypeData)
 	if err != nil {
 		t.Fatalf("could not build service request: %v", err)
 	}

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -89,7 +89,7 @@ func decryptAndDecodeNasPdu(t *testing.T, ue *amf.UeContext, nasPdu []byte, dlCo
 	copy(payload, nasPdu)
 	payload = payload[7:]
 
-	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCountForTest().Value()+dlCountOffset, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
+	if err := security.NASEncrypt(ue.CipheringAlgForTest(), ue.KnasEncForTest(), ue.ULCount()+dlCountOffset, security.Bearer3GPP, security.DirectionDownlink, payload); err != nil {
 		t.Fatalf("could not decrypt NAS message: %v", err)
 	}
 
@@ -144,7 +144,7 @@ func buildMobilityRegUeAndAMF(t *testing.T) (*amf.UeContext, *fakeNGAPSender, *f
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
@@ -876,7 +876,7 @@ func TestMobilityReg_MultiSlice_AllowedNssaiContainsAllSlices(t *testing.T) {
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(security.AlgIntegrity128NIA0)
 
-	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCountForTest().Value())
+	registrationRequest, err := buildTestRegistrationRequestMessage(algo, &key, ue.ULCount())
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}

--- a/internal/amf/nas/reuse_bind_test.go
+++ b/internal/amf/nas/reuse_bind_test.go
@@ -86,7 +86,7 @@ func plainDeregistrationWithGuti(t *testing.T, guti []byte) []byte {
 func wrapIntegrityProtected(t *testing.T, ue *amf.UeContext, inner []byte, sqn uint8) []byte {
 	t.Helper()
 
-	cnt := ue.ULCountForTest().ReconcileUplink(sqn)
+	cnt := ue.ULCountForTest().Estimate(sqn)
 
 	seqAndMsg := append([]byte{sqn}, inner...)
 

--- a/internal/amf/nas_integrity_verified_test.go
+++ b/internal/amf/nas_integrity_verified_test.go
@@ -21,7 +21,7 @@ import (
 func wrapIntegrityProtected(t *testing.T, ue *UeContext, inner []byte, sqn uint8) []byte {
 	t.Helper()
 
-	cnt := ue.ulCount.ReconcileUplink(sqn)
+	cnt := ue.ulCount.Estimate(sqn)
 
 	seqAndMsg := append([]byte{sqn}, inner...)
 
@@ -122,11 +122,11 @@ func TestNasIntegrityVerified_DoesNotMutateCount(t *testing.T) {
 	ue := newSecuredUE(t)
 	pdu := wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)
 
-	before := ue.ulCount.Value()
+	before := ue.ulCount
 	_ = ue.NasIntegrityVerified(pdu)
 
-	if ue.ulCount.Value() != before {
-		t.Fatalf("ULCount must not change: before=%d after=%d", before, ue.ulCount.Value())
+	if ue.ulCount != before {
+		t.Fatalf("ULCount must not change: before=%d after=%d", before.NextExpected(), ue.ulCount.NextExpected())
 	}
 }
 
@@ -192,22 +192,22 @@ func TestDecodeNASMessage_MacFailedDoesNotAdvanceULCount(t *testing.T) {
 	bad := append([]byte(nil), pdu...)
 	bad[3] ^= 0xff // corrupt the MAC
 
-	before := ue.ulCount.Value()
+	before := ue.ulCount
 
 	if _, err := DecodeNASMessage(ue, bad); err != nil {
 		t.Fatalf("a mac-failed registration request must be admitted (on the pre-secure-exchange whitelist): %v", err)
 	}
 
-	if ue.ulCount.Value() != before {
-		t.Fatalf("a mac-failed message must not advance ULCount: before=%d after=%d", before, ue.ulCount.Value())
+	if ue.ulCount != before {
+		t.Fatalf("a mac-failed message must not advance ULCount: before=%d after=%d", before.NextExpected(), ue.ulCount.NextExpected())
 	}
 
 	if _, err := DecodeNASMessage(ue, pdu); err != nil {
 		t.Fatalf("a verified registration request must decode: %v", err)
 	}
 
-	if ue.ulCount.SQN() != 7 {
-		t.Fatalf("a verified message must advance ULCount to sqn=7, got %d", ue.ulCount.SQN())
+	if ue.ulCount.LastAccepted().SQN() != 7 {
+		t.Fatalf("a verified message must accept sqn=7, got %d", ue.ulCount.LastAccepted().SQN())
 	}
 }
 

--- a/internal/amf/nas_replay_test.go
+++ b/internal/amf/nas_replay_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+//
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import "testing"
+
+// TestNASUplinkReplayRejected checks that a protected uplink NAS message is
+// accepted once and a byte-identical replay is rejected, not re-accepted
+// (TS 24.501 §4.4.3.2, TS 33.501 §6.4.3).
+func TestNASUplinkReplayRejected(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	msg := wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 0)
+
+	res, err := DecodeNASMessage(ue, msg)
+	if err != nil {
+		t.Fatalf("valid message not accepted: %v", err)
+	}
+
+	if !res.IntegrityVerified {
+		t.Fatal("valid message not integrity-verified")
+	}
+
+	if ue.ULCount() != 1 {
+		t.Fatalf("after the accepted message ulCount = %d, want 1", ue.ULCount())
+	}
+
+	// The replay estimates to a NAS COUNT past the accepted one, so its MAC does
+	// not verify and the message is discarded.
+	if _, err := DecodeNASMessage(ue, msg); err == nil {
+		t.Fatal("replay accepted: a NAS COUNT must be accepted at most one time")
+	}
+
+	if ue.ULCount() != 1 {
+		t.Fatalf("replay advanced ulCount to %d, want 1", ue.ULCount())
+	}
+}
+
+// TestNASUplinkCountWrap checks the 16-bit overflow is maintained across a
+// sequence-number wrap (TS 24.501 §4.4.3.1): a message whose sequence wrapped to
+// 0 verifies against NAS COUNT (overflow 1, sequence 0), not (0, 0).
+func TestNASUplinkCountWrap(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(255)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 255)); err != nil {
+		t.Fatalf("sequence 255 not accepted: %v", err)
+	}
+
+	if ue.ULCount() != 256 {
+		t.Fatalf("after sequence 255 ulCount = %d, want 256", ue.ULCount())
+	}
+
+	// The UE's sequence wraps 255->0 and its overflow becomes 1.
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 0)); err != nil {
+		t.Fatalf("wrapped message not accepted: %v", err)
+	}
+
+	if ue.ULCount() != 257 {
+		t.Fatalf("after the wrapped message ulCount = %d, want 257", ue.ULCount())
+	}
+}

--- a/internal/amf/ue_accessors.go
+++ b/internal/amf/ue_accessors.go
@@ -163,13 +163,22 @@ func (ue *UeContext) MarkSecured() {
 	ue.secured = true
 }
 
+// ULCount returns the NAS COUNT the next uplink message must carry.
+func (ue *UeContext) ULCount() uint32 {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return ue.ulCount.NextExpected().Value()
+}
+
 // DecryptUplinkContents deciphers an uplink NAS container in place against the
-// UE's ciphering key and current uplink count (TS 33.501).
+// UE's ciphering key. The container rides the message it arrived in, so it is
+// ciphered with that message's NAS COUNT (TS 33.501).
 func (ue *UeContext) DecryptUplinkContents(contents []byte) error {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	return security.NASEncrypt(ue.cipheringAlg, ue.knasEnc, ue.ulCount.Value(), security.Bearer3GPP, security.DirectionUplink, contents)
+	return security.NASEncrypt(ue.cipheringAlg, ue.knasEnc, ue.ulCount.LastAccepted().Value(), security.Bearer3GPP, security.DirectionUplink, contents)
 }
 
 // SmContextSnapshot returns a locked shallow copy of the UE's PDU session SM

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -178,8 +178,17 @@ func (ue *UeContext) NCCForTest() uint8     { return ue.ncc }
 func (ue *UeContext) SetABBAForTest(a []uint8) { ue.abba = a }
 func (ue *UeContext) ABBAForTest() []uint8     { return ue.abba }
 
-func (ue *UeContext) SetULCountForTest(c nascommon.Count) { ue.ulCount = c }
-func (ue *UeContext) ULCountForTest() *nascommon.Count    { return &ue.ulCount }
+// SetULCountForTest seeds the uplink counter to expect c as the NAS COUNT of the
+// next uplink message.
+func (ue *UeContext) SetULCountForTest(c uint32) {
+	ue.ulCount.Reset()
+
+	if c > 0 {
+		ue.ulCount.Commit(nascommon.Count(c - 1))
+	}
+}
+
+func (ue *UeContext) ULCountForTest() nascommon.UplinkCounter { return ue.ulCount }
 
 func (ue *UeContext) SetDLCountForTest(c nascommon.Count) { ue.dlCount = c }
 func (ue *UeContext) DLCountForTest() *nascommon.Count    { return &ue.dlCount }

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -188,7 +188,7 @@ type UeContext struct {
 	knasInt      [16]byte
 	cipheringAlg byte
 	integrityAlg byte
-	ulCount      nascommon.Count
+	ulCount      nascommon.UplinkCounter
 	dlCount      nascommon.Count
 	secured      bool
 	// eksi is the eKSI (NAS key set identifier, TS 24.301 §9.9.3.21) of the current EPS

--- a/internal/mme/ue_accessors.go
+++ b/internal/mme/ue_accessors.go
@@ -90,12 +90,12 @@ func (ue *UeContext) EEA() byte {
 	return ue.cipheringAlg
 }
 
-// ULCount returns the expected uplink NAS COUNT.
+// ULCount returns the NAS COUNT the next uplink message must carry.
 func (ue *UeContext) ULCount() uint32 {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	return ue.ulCount.Value()
+	return ue.ulCount.NextExpected().Value()
 }
 
 // Secured reports whether the NAS security context is established.
@@ -106,23 +106,23 @@ func (ue *UeContext) Secured() bool {
 	return ue.secured
 }
 
-// AdvanceULCount increments the expected uplink NAS COUNT past an accepted
-// message (TS 24.301).
+// AdvanceULCount records the expected uplink NAS COUNT as accepted. A SERVICE
+// REQUEST is verified against that count by its short-MAC rather than by
+// TryUnprotectUplink, so its acceptance is committed here (TS 24.301 §5.6.1).
 func (ue *UeContext) AdvanceULCount() {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	ue.ulCount = ue.ulCount.Next()
+	ue.ulCount.Commit(ue.ulCount.NextExpected())
 }
 
-// CommitUplinkCount advances the expected uplink NAS COUNT past the verified
-// message, so a replay estimates to a stale count whose MAC fails to verify
-// (TS 24.301).
+// CommitUplinkCount records count as accepted, so a replay of its message
+// estimates to a different count whose MAC fails to verify (TS 24.301 §4.4.3).
 func (ue *UeContext) CommitUplinkCount(count uint32) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	ue.ulCount = nascommon.Count(count).Next()
+	ue.ulCount.Commit(nascommon.Count(count))
 }
 
 // TryUnprotectUplink verifies and deciphers a protected uplink NAS message
@@ -140,7 +140,7 @@ func (ue *UeContext) TryUnprotectUplink(nas []byte) (plain []byte, count uint32,
 
 	recvSeq := nas[5]
 
-	count = ue.ulCount.ReconcileUplink(recvSeq).Value()
+	count = ue.ulCount.Estimate(recvSeq).Value()
 
 	p, err := eps.Unprotect(nas, count, nascommon.DirectionUplink,
 		ue.knasInt, ue.knasEnc, IntegrityAlg(ue.integrityAlg), CipherAlg(ue.cipheringAlg))
@@ -194,7 +194,8 @@ func (ue *UeContext) InstallNASSecurityContext(eea, eia byte, _ AuthProof) error
 
 	// A new EPS security context starts both NAS COUNTs at zero, so the initial
 	// SECURITY MODE COMMAND rides downlink COUNT 0 (TS 24.301 §4.4.3.1).
-	ue.ulCount, ue.dlCount = 0, 0
+	ue.ulCount.Reset()
+	ue.dlCount = 0
 
 	return nil
 }
@@ -266,10 +267,15 @@ func (ue *UeContext) VerifyServiceRequestShortMAC(head []byte, gotMAC [2]byte, g
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	ul = ue.ulCount.Value()
-	expSeq = ue.ulCount.SQN() & 0x1f
+	expected := ue.ulCount.NextExpected()
 
-	want, err := eps.ServiceRequestShortMAC(head, ue.knasInt, ue.ulCount.Value(), nascommon.DirectionUplink, IntegrityAlg(ue.integrityAlg))
+	// Only 5 of the 8 sequence number bits ride a SERVICE REQUEST, so the message
+	// is bound to the expected count rather than to an estimate from the received
+	// sequence number (TS 24.301 §4.4.3.1).
+	ul = expected.Value()
+	expSeq = expected.SQN() & 0x1f
+
+	want, err := eps.ServiceRequestShortMAC(head, ue.knasInt, expected.Value(), nascommon.DirectionUplink, IntegrityAlg(ue.integrityAlg))
 	if err != nil {
 		return false, [2]byte{}, expSeq, ul
 	}
@@ -286,14 +292,10 @@ func (ue *UeContext) DeriveInitialKeNB() (kenb [32]byte, kenbCount uint32, err e
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	// K_eNB is derived from the uplink NAS COUNT of the most recently received
-	// uplink NAS message (the Security Mode Complete on attach, the Service
-	// Request on reconnect), i.e. one less than the next-expected count
-	// (TS 33.401).
-	kenbCount = ue.ulCount.Value()
-	if kenbCount > 0 {
-		kenbCount--
-	}
+	// K_eNB is derived from the uplink NAS COUNT of the most recently accepted
+	// uplink NAS message: the Security Mode Complete on attach, the Service
+	// Request on reconnect (TS 33.401 §A.3).
+	kenbCount = ue.ulCount.LastAccepted().Value()
 
 	kenb, err = DeriveKeNB(ue.kasme, kenbCount)
 	if err != nil {

--- a/internal/mme/ue_test_support.go
+++ b/internal/mme/ue_test_support.go
@@ -22,7 +22,18 @@ func (ue *UeContext) SetKnasEncForTest(k [16]byte) { ue.knasEnc = k }
 
 func (ue *UeContext) SetKASMEForTest(k []byte) { ue.kasme = k }
 
-func (ue *UeContext) SetULCountForTest(c uint32) { ue.ulCount = nascommon.Count(c) }
+// SetULCountForTest seeds the uplink counter to expect c as the NAS COUNT of the
+// next uplink message.
+func (ue *UeContext) SetULCountForTest(c uint32) {
+	ue.ulCount.Reset()
+
+	if c > 0 {
+		ue.ulCount.Commit(nascommon.Count(c - 1))
+	}
+}
+
+func (ue *UeContext) ULCountForTest() nascommon.UplinkCounter { return ue.ulCount }
+
 func (ue *UeContext) SetDLCountForTest(c uint32) { ue.dlCount = nascommon.Count(c) }
 func (ue *UeContext) DLCountForTest() uint32     { return ue.dlCount.Value() }
 

--- a/nas/common/count.go
+++ b/nas/common/count.go
@@ -32,11 +32,14 @@ func (c Count) Value() uint32 { return uint32(c) & countMask }
 // (TS 24.301 §4.4.3.1).
 func (c Count) Next() Count { return (c + 1) & countMask }
 
-// ReconcileUplink estimates the full NAS COUNT of a received uplink message from
-// its 8-bit sequence number: when the sequence number regresses relative to the
-// stored count, the overflow counter has wrapped and is incremented
-// (TS 24.301 §4.4.3.1).
-func (c Count) ReconcileUplink(recvSeq uint8) Count {
+// reconcileUplink estimates the full NAS COUNT of a received uplink message from
+// its 8-bit sequence number, taking c as the count the message is expected to
+// carry: a sequence number below the expected one places the message after a
+// wrap of the overflow counter (TS 24.301 §4.4.3.1, TS 24.501 §4.4.3.1).
+//
+// The estimate is only replay-safe when c is the expected count rather than the
+// last accepted one, so it is reached through UplinkCounter alone.
+func (c Count) reconcileUplink(recvSeq uint8) Count {
 	overflow := c.Overflow()
 	if recvSeq < c.SQN() {
 		overflow++

--- a/nas/common/count_test.go
+++ b/nas/common/count_test.go
@@ -48,29 +48,28 @@ func TestCountNextWrapsAt24Bits(t *testing.T) {
 }
 
 func TestReconcileUplinkNoWrap(t *testing.T) {
-	// A higher received sequence number keeps the overflow counter.
-	got := MakeCount(7, 10).ReconcileUplink(11)
+	// A sequence number above the expected one keeps the overflow counter.
+	got := MakeCount(7, 10).reconcileUplink(11)
 
 	if got != MakeCount(7, 11) {
-		t.Fatalf("ReconcileUplink(11) from (7,10) = (%d,%d), want (7,11)", got.Overflow(), got.SQN())
+		t.Fatalf("reconcileUplink(11) from (7,10) = (%d,%d), want (7,11)", got.Overflow(), got.SQN())
 	}
 }
 
 func TestReconcileUplinkWrap(t *testing.T) {
-	// A regressed received sequence number estimates an overflow wrap.
-	got := MakeCount(7, 250).ReconcileUplink(2)
+	// A sequence number below the expected one places the message after a wrap.
+	got := MakeCount(7, 250).reconcileUplink(2)
 
 	if got != MakeCount(8, 2) {
-		t.Fatalf("ReconcileUplink(2) from (7,250) = (%d,%d), want (8,2)", got.Overflow(), got.SQN())
+		t.Fatalf("reconcileUplink(2) from (7,250) = (%d,%d), want (8,2)", got.Overflow(), got.SQN())
 	}
 }
 
 func TestReconcileUplinkSameSQN(t *testing.T) {
-	// An equal sequence number is not a wrap (a retransmission estimates the same
-	// count, whose MAC then verifies).
-	got := MakeCount(7, 10).ReconcileUplink(10)
+	// The expected sequence number is the expected count.
+	got := MakeCount(7, 10).reconcileUplink(10)
 
 	if got != MakeCount(7, 10) {
-		t.Fatalf("ReconcileUplink(10) from (7,10) = (%d,%d), want (7,10)", got.Overflow(), got.SQN())
+		t.Fatalf("reconcileUplink(10) from (7,10) = (%d,%d), want (7,10)", got.Overflow(), got.SQN())
 	}
 }

--- a/nas/common/uplink_counter.go
+++ b/nas/common/uplink_counter.go
@@ -8,10 +8,11 @@ package common
 // been accepted yet.
 //
 // It holds replay protection (TS 24.301 §4.4.3.2, TS 24.501 §4.4.3.2): a given
-// NAS COUNT is accepted at most once. Estimate never returns a count at or below
-// the last accepted one, so a replayed message estimates to a count whose MAC
-// cannot verify. Both specs leave the mechanism to the implementation and
-// require the same result of it, so the 4G and 5G receivers share this type.
+// NAS COUNT is accepted at most once. Except across NAS COUNT wrap-around,
+// Estimate never returns a count at or below the last accepted one, so a
+// replayed message estimates to a count whose MAC cannot verify. Both specs
+// leave the mechanism to the implementation and require the same result of it,
+// so the 4G and 5G receivers share this type.
 type UplinkCounter struct {
 	last     Count
 	accepted bool

--- a/nas/common/uplink_counter.go
+++ b/nas/common/uplink_counter.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package common
+
+// UplinkCounter is the receiver side of the uplink NAS COUNT of a NAS security
+// context: the count of the last accepted message, and whether any message has
+// been accepted yet.
+//
+// It holds replay protection (TS 24.301 §4.4.3.2, TS 24.501 §4.4.3.2): a given
+// NAS COUNT is accepted at most once. Estimate never returns a count at or below
+// the last accepted one, so a replayed message estimates to a count whose MAC
+// cannot verify. Both specs leave the mechanism to the implementation and
+// require the same result of it, so the 4G and 5G receivers share this type.
+type UplinkCounter struct {
+	last     Count
+	accepted bool
+}
+
+// NextExpected returns the NAS COUNT the next uplink message must carry.
+func (u UplinkCounter) NextExpected() Count {
+	if !u.accepted {
+		return 0
+	}
+
+	return u.last.Next()
+}
+
+// Estimate returns the NAS COUNT to verify a received uplink message against,
+// formed from its sequence number and an estimate of the overflow counter
+// (TS 24.301 §4.4.3.1, TS 24.501 §4.4.3.1).
+func (u UplinkCounter) Estimate(recvSeq uint8) Count {
+	return u.NextExpected().reconcileUplink(recvSeq)
+}
+
+// LastAccepted returns the NAS COUNT of the most recently accepted message, zero
+// if none has been. It is the K_eNB/K_gNB derivation input (TS 33.401 §A.3,
+// TS 33.501 §A.9) and the count an uplink NAS message container is ciphered
+// with.
+func (u UplinkCounter) LastAccepted() Count {
+	return u.last
+}
+
+// Commit records count as accepted, once the integrity of its message has
+// verified (TS 24.301 §4.4.3.3, TS 24.501 §4.4.3.3).
+func (u *UplinkCounter) Commit(count Count) {
+	u.last = count
+	u.accepted = true
+}
+
+// Reset returns the counter to its state for a new NAS security context, whose
+// first uplink message carries NAS COUNT zero (TS 24.301 §4.4.3.1,
+// TS 24.501 §4.4.3.1).
+func (u *UplinkCounter) Reset() {
+	*u = UplinkCounter{}
+}

--- a/nas/common/uplink_counter_test.go
+++ b/nas/common/uplink_counter_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package common
+
+import "testing"
+
+func TestUplinkCounterFirstMessageIsZero(t *testing.T) {
+	var u UplinkCounter
+
+	if got := u.NextExpected(); got != 0 {
+		t.Fatalf("NextExpected() = %d, want 0", got)
+	}
+
+	if got := u.Estimate(0); got != 0 {
+		t.Fatalf("Estimate(0) = %d, want 0", got)
+	}
+}
+
+func TestUplinkCounterEstimateAdvances(t *testing.T) {
+	var u UplinkCounter
+
+	u.Commit(u.Estimate(0))
+
+	if got := u.Estimate(1); got != MakeCount(0, 1) {
+		t.Fatalf("Estimate(1) = (%d,%d), want (0,1)", got.Overflow(), got.SQN())
+	}
+}
+
+// A replayed message carries the sequence number of an already accepted one. Its
+// estimate must not be the count it was accepted at, or its MAC would verify a
+// second time (TS 24.301 §4.4.3.2, TS 24.501 §4.4.3.2).
+func TestUplinkCounterEstimateRejectsReplay(t *testing.T) {
+	var u UplinkCounter
+
+	u.Commit(MakeCount(7, 10))
+
+	if got := u.Estimate(10); got == MakeCount(7, 10) {
+		t.Fatalf("Estimate(10) = (%d,%d), want any count other than the accepted (7,10)", got.Overflow(), got.SQN())
+	}
+}
+
+func TestUplinkCounterEstimateWraps(t *testing.T) {
+	var u UplinkCounter
+
+	u.Commit(MakeCount(7, 255))
+
+	if got := u.Estimate(0); got != MakeCount(8, 0) {
+		t.Fatalf("Estimate(0) = (%d,%d), want (8,0)", got.Overflow(), got.SQN())
+	}
+}
+
+func TestUplinkCounterLastAccepted(t *testing.T) {
+	var u UplinkCounter
+
+	if got := u.LastAccepted(); got != 0 {
+		t.Fatalf("LastAccepted() = %d, want 0 before any message", got)
+	}
+
+	u.Commit(MakeCount(3, 9))
+
+	if got := u.LastAccepted(); got != MakeCount(3, 9) {
+		t.Fatalf("LastAccepted() = (%d,%d), want (3,9)", got.Overflow(), got.SQN())
+	}
+}
+
+func TestUplinkCounterResetExpectsZero(t *testing.T) {
+	var u UplinkCounter
+
+	u.Commit(MakeCount(3, 9))
+	u.Reset()
+
+	if got := u.NextExpected(); got != 0 {
+		t.Fatalf("NextExpected() after Reset() = %d, want 0", got)
+	}
+
+	if got := u.Estimate(0); got != 0 {
+		t.Fatalf("Estimate(0) after Reset() = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
# Description

Fix a 5G replay-protection bug where the AMF re-accepted a replayed uplink NAS message, by introducing a shared NAS COUNT counter type that tracks the last-accepted count so a replay estimates to a value whose MAC no longer verifies.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
