### PR TITLE
fix: 4G superseded-session teardown before new session allocation

### DIFF
--- a/internal/smf/eps.go
+++ b/internal/smf/eps.go
@@ -84,6 +84,12 @@ func (s *SMF) CreateEPSSession(ctx context.Context, req models.EPSBearerRequest)
 		return models.EPSBearer{}, fmt.Errorf("negotiate PDN type: %w", err)
 	}
 
+	// Must precede establishSession: the superseded context's release frees the address by
+	// (imsi, dnn, ebi), which the new session would already hold (TS 24.301 §5.5.1.2.4 case f).
+	if existing := s.currentSession(supi, req.EPSBearerIdentity); existing != nil {
+		s.handlePduSessionContextReplacement(ctx, existing)
+	}
+
 	sc, addrs, err := s.establishSession(ctx, SessionRequest{
 		Supi:    supi,
 		Key:     req.EPSBearerIdentity,

--- a/internal/smf/eps_test.go
+++ b/internal/smf/eps_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"slices"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/models"
@@ -69,6 +70,42 @@ func TestCreateEPSSessionIPv4(t *testing.T) {
 
 	if upf.lastEstablish == nil || len(upf.lastEstablish.PDRs) < 2 {
 		t.Fatalf("expected an establish with >=2 PDRs, got %+v", upf.lastEstablish)
+	}
+}
+
+// TestCreateEPSSessionSupersedesPriorBearer covers a re-attach on the same (IMSI, EBI).
+// The prior context must be released before the new one allocates: released afterwards,
+// it frees the lease by (imsi, dnn, ebi) — the key both share — leaving a live session on
+// an address the pool believes free, which the next subscriber is then handed.
+func TestCreateEPSSessionSupersedesPriorBearer(t *testing.T) {
+	store, upf := epsTestSMF()
+	s := newTestSMF(&fakePCF{}, store, upf, &fakeAMF{})
+
+	first, err := s.CreateEPSSession(context.Background(), epsRequest(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := s.CreateEPSSession(context.Background(), epsRequest(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first.Ref == second.Ref {
+		t.Fatalf("re-attach must yield a distinct session, got %q twice", first.Ref)
+	}
+
+	if s.GetSession(first.Ref) != nil {
+		t.Fatalf("prior bearer context %q outlived the re-attach", first.Ref)
+	}
+
+	if s.GetSession(second.Ref) == nil {
+		t.Fatalf("re-attached session %q is not live", second.Ref)
+	}
+
+	want := []string{"alloc", "release", "alloc"}
+	if got := store.ops(); !slices.Equal(got, want) {
+		t.Fatalf("store ops = %v, want %v", got, want)
 	}
 }
 

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 	"testing"
 
@@ -36,6 +37,15 @@ type fakeStore struct {
 	staticIPv4      netip.Addr
 	staticIPv6      netip.Addr
 	staticIPErr     error
+	opLog           []string
+}
+
+// ops returns the IPv4 allocate/release calls in the order they arrived.
+func (f *fakeStore) ops() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return slices.Clone(f.opLog)
 }
 
 type fakePCF struct {
@@ -54,6 +64,8 @@ func (f *fakeStore) AllocateIP(_ context.Context, _ string, _ string, _ uint8) (
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	f.opLog = append(f.opLog, "alloc")
+
 	if f.allocateIPErr != nil {
 		return f.allocatedIP, f.allocateIPErr
 	}
@@ -65,6 +77,7 @@ func (f *fakeStore) ReleaseIP(_ context.Context, imsi string, _ string, _ uint8)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	f.opLog = append(f.opLog, "release")
 	f.releasedIPs = append(f.releasedIPs, imsi)
 
 	return f.releasedIP, f.err


### PR DESCRIPTION
# Description

Moved the superseded-session teardown before the new session allocates, mirroring what 5G already does . The stale context's release now runs while it still owns its lease, so it can't free the address the new session holds.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
