### PR TITLE
fix: paging failure-feedback loop

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -60,9 +60,6 @@ type SmfSbi interface {
 	UpdateSmContextHandoverFailed(ctx context.Context, smContextRef string, n2Data []byte) error
 	ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error
 	GetSessionPolicy(ctx context.Context, supi etsi.SUPI, snssai *models.Snssai, dnn string) (*smf.Policy, error)
-	// HandlePagingFailure re-arms downlink-data paging for a PDU session after
-	// paging is abandoned, so continued downlink data pages the UE again
-	// (TS 23.502 §4.2.3.3).
 	HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
 }
 
@@ -633,8 +630,8 @@ func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 	amf.pageRadios(context.Background(), ue, ngapBuf)
 }
 
-// abandonPaging runs when the retransmission budget is exhausted. The buffered N1N2 message
-// stays and mobile-reachable supervision continues (TS 24.501 §5.4.3).
+// abandonPaging runs when the retransmission budget is exhausted (TS 24.501 §5.4.3).
+// The anchor is notified so later downlink data re-pages the UE (TS 23.502 §4.2.3.3).
 func (amf *AMF) abandonPaging(ue *UeContext) {
 	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
 
@@ -643,8 +640,6 @@ func (amf *AMF) abandonPaging(ue *UeContext) {
 		return
 	}
 
-	// Notify the anchor so continued downlink data raises a fresh notification and
-	// pages the UE again, rather than staying buffered until the UE re-registers.
 	if err := amf.Session.HandlePagingFailure(context.Background(), ue.Supi(), msg.PduSessionID); err != nil {
 		logger.AmfLog.Warn("failed to re-arm paging after failure",
 			logger.SUPI(ue.Supi().String()), zap.Error(err))

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -60,6 +60,10 @@ type SmfSbi interface {
 	UpdateSmContextHandoverFailed(ctx context.Context, smContextRef string, n2Data []byte) error
 	ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error
 	GetSessionPolicy(ctx context.Context, supi etsi.SUPI, snssai *models.Snssai, dnn string) (*smf.Policy, error)
+	// HandlePagingFailure re-arms downlink-data paging for a PDU session after
+	// paging is abandoned, so continued downlink data pages the UE again
+	// (TS 23.502 §4.2.3.3).
+	HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
 }
 
 type NetworkFeatureSupport5GS struct {
@@ -633,6 +637,18 @@ func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 // stays and mobile-reachable supervision continues (TS 24.501 §5.4.3).
 func (amf *AMF) abandonPaging(ue *UeContext) {
 	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
+
+	msg := ue.N1N2Message()
+	if msg == nil {
+		return
+	}
+
+	// Notify the anchor so continued downlink data raises a fresh notification and
+	// pages the UE again, rather than staying buffered until the UE re-registers.
+	if err := amf.Session.HandlePagingFailure(context.Background(), ue.Supi(), msg.PduSessionID); err != nil {
+		logger.AmfLog.Warn("failed to re-arm paging after failure",
+			logger.SUPI(ue.Supi().String()), zap.Error(err))
+	}
 }
 
 // pageRadios sends the paging PDU to every radio whose supported TAIs intersect

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -51,6 +51,10 @@ func (s *deregisterTestSmf) DeactivateSmContext(_ context.Context, smContextRef 
 	return nil
 }
 
+func (s *deregisterTestSmf) HandlePagingFailure(_ context.Context, _ etsi.SUPI, _ uint8) error {
+	return nil
+}
+
 func (s *deregisterTestSmf) ReleaseSmContext(ctx context.Context, smContextRef string) error {
 	s.releaseCalls = append(s.releaseCalls, smContextRef)
 	if s.onRelease != nil {

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -102,10 +102,10 @@ func (f *fakeSmf) SessionCount() int                     { return 0 }
 func (f *fakeSmf) CreateSmContext(context.Context, etsi.SUPI, uint8, string, *models.Snssai, []byte) (string, []byte, error) {
 	return "", nil, nil
 }
-func (f *fakeSmf) ActivateSmContext(context.Context, string) ([]byte, error) { return nil, nil }
-func (f *fakeSmf) DeactivateSmContext(context.Context, string) error         { return nil }
+func (f *fakeSmf) ActivateSmContext(context.Context, string) ([]byte, error)   { return nil, nil }
+func (f *fakeSmf) DeactivateSmContext(context.Context, string) error           { return nil }
 func (f *fakeSmf) HandlePagingFailure(context.Context, etsi.SUPI, uint8) error { return nil }
-func (f *fakeSmf) ReleaseSmContext(context.Context, string) error            { return nil }
+func (f *fakeSmf) ReleaseSmContext(context.Context, string) error              { return nil }
 func (f *fakeSmf) UpdateSmContextN1Msg(context.Context, string, []byte) (*smf.UpdateResult, error) {
 	return nil, nil
 }

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -104,6 +104,7 @@ func (f *fakeSmf) CreateSmContext(context.Context, etsi.SUPI, uint8, string, *mo
 }
 func (f *fakeSmf) ActivateSmContext(context.Context, string) ([]byte, error) { return nil, nil }
 func (f *fakeSmf) DeactivateSmContext(context.Context, string) error         { return nil }
+func (f *fakeSmf) HandlePagingFailure(context.Context, etsi.SUPI, uint8) error { return nil }
 func (f *fakeSmf) ReleaseSmContext(context.Context, string) error            { return nil }
 func (f *fakeSmf) UpdateSmContextN1Msg(context.Context, string, []byte) (*smf.UpdateResult, error) {
 	return nil, nil

--- a/internal/amf/nas/handle_test.go
+++ b/internal/amf/nas/handle_test.go
@@ -436,6 +436,10 @@ func (s *fakeSmf) DeactivateSmContext(_ context.Context, _ string) error {
 	return s.Error
 }
 
+func (s *fakeSmf) HandlePagingFailure(_ context.Context, _ etsi.SUPI, _ uint8) error {
+	return s.Error
+}
+
 func (s *fakeSmf) UpdateSmContextN2InfoPduResSetupRsp(_ context.Context, _ string, _ []byte) error {
 	return s.Error
 }

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -296,6 +296,8 @@ func (f *fakeUPFClient) DeleteSession(ctx context.Context, remoteSEID uint64) er
 
 func (f *fakeUPFClient) FlushUsage(ctx context.Context, remoteSEID uint64) {}
 
+func (f *fakeUPFClient) ResetDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {}
+
 func (f *fakeUPFClient) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return nil
 }

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -117,6 +117,10 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string, _
 	return nil
 }
 
+func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+	return nil
+}
+
 func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) error {
 	f.released = true
 

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -56,9 +56,6 @@ type epsSessionManager interface {
 	// DeactivateEPSSession buffers the downlink bearer when the UE goes ECM-IDLE
 	// so downlink data triggers paging.
 	DeactivateEPSSession(ctx context.Context, imsi string, ebi uint8) error
-	// HandleEPSPagingFailure re-arms downlink-data paging for a PDN connection
-	// after paging is abandoned, so continued downlink data pages the UE again
-	// (TS 23.401 §5.3.4.3).
 	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error
 	// ReleaseEPSSession releases the anchor session identified by its unique ref
 	// (as returned in models.EPSBearer.Ref and stored on the PDN connection), so a

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -56,6 +56,10 @@ type epsSessionManager interface {
 	// DeactivateEPSSession buffers the downlink bearer when the UE goes ECM-IDLE
 	// so downlink data triggers paging.
 	DeactivateEPSSession(ctx context.Context, imsi string, ebi uint8) error
+	// HandleEPSPagingFailure re-arms downlink-data paging for a PDN connection
+	// after paging is abandoned, so continued downlink data pages the UE again
+	// (TS 23.401 §5.3.4.3).
+	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error
 	// ReleaseEPSSession releases the anchor session identified by its unique ref
 	// (as returned in models.EPSBearer.Ref and stored on the PDN connection), so a
 	// superseded context releases its own session and never a newer one that reused

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -119,6 +119,10 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string, _
 	return nil
 }
 
+func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+	return nil
+}
+
 func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) error {
 	f.released = true
 

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -109,6 +109,16 @@ func (m *MME) abandonPaging(ue *UeContext) {
 	m.mu.RUnlock()
 
 	logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
+
+	// Notify the anchor so continued downlink data raises a fresh notification and
+	// pages the UE again, rather than staying buffered until the UE re-registers.
+	ctx := context.Background()
+	for _, p := range m.SnapshotPDNs(ue) {
+		if err := m.Session.HandleEPSPagingFailure(ctx, imsi, p.Ebi); err != nil {
+			logger.MmeLog.Warn("failed to re-arm paging after failure",
+				zap.String("imsi", imsi), zap.Uint8("ebi", p.Ebi), zap.Error(err))
+		}
+	}
 }
 
 // buildPaging assembles the Paging message for a UE (TS 36.413). The TAI list is the

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -110,8 +110,6 @@ func (m *MME) abandonPaging(ue *UeContext) {
 
 	logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
 
-	// Notify the anchor so continued downlink data raises a fresh notification and
-	// pages the UE again, rather than staying buffered until the UE re-registers.
 	ctx := context.Background()
 	for _, p := range m.SnapshotPDNs(ue) {
 		if err := m.Session.HandleEPSPagingFailure(ctx, imsi, p.Ebi); err != nil {

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -142,6 +142,10 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string, _
 	return nil
 }
 
+func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+	return nil
+}
+
 func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) error {
 	f.released = true
 

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -10,9 +10,6 @@ import (
 	"github.com/ellanetworks/core/etsi"
 )
 
-// HandlePagingFailure re-arms downlink-data paging for a 5G PDU session after the
-// AMF abandons paging, so continued downlink data raises a fresh notification and
-// pages the UE again instead of staying buffered (TS 23.502 §4.2.3.3).
 func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
 	smContext := s.currentSession(supi, pduSessionID)
 	if smContext == nil {
@@ -24,9 +21,6 @@ func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessio
 	return nil
 }
 
-// HandleEPSPagingFailure re-arms downlink-data paging for a 4G PDN connection after
-// the MME abandons paging, so continued downlink data pages the UE again instead of
-// staying buffered (TS 23.401 §5.3.4.3).
 func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error {
 	supi, err := etsi.NewSUPIFromIMSI(imsi)
 	if err != nil {
@@ -43,9 +37,6 @@ func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8
 	return nil
 }
 
-// resetDownlinkDataNotification clears the UPF's buffered-data notification state
-// for the session so the next downlink packet raises a fresh Downlink Data
-// Notification. The 3GPP anchor sends this to the user plane on paging failure.
 func (s *SMF) resetDownlinkDataNotification(ctx context.Context, smContext *SMContext) {
 	smContext.Mutex.Lock()
 	pfcp := smContext.PFCPContext

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
+)
+
+// HandlePagingFailure re-arms downlink-data paging for a 5G PDU session after the
+// AMF abandons paging, so continued downlink data raises a fresh notification and
+// pages the UE again instead of staying buffered (TS 23.502 §4.2.3.3).
+func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
+	smContext := s.currentSession(supi, pduSessionID)
+	if smContext == nil {
+		return fmt.Errorf("no session for %s pdu %d", supi.String(), pduSessionID)
+	}
+
+	s.resetDownlinkDataNotification(ctx, smContext)
+
+	return nil
+}
+
+// HandleEPSPagingFailure re-arms downlink-data paging for a 4G PDN connection after
+// the MME abandons paging, so continued downlink data pages the UE again instead of
+// staying buffered (TS 23.401 §5.3.4.3).
+func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error {
+	supi, err := etsi.NewSUPIFromIMSI(imsi)
+	if err != nil {
+		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
+	}
+
+	smContext := s.currentSession(supi, ebi)
+	if smContext == nil {
+		return fmt.Errorf("no EPS session for %s", imsi)
+	}
+
+	s.resetDownlinkDataNotification(ctx, smContext)
+
+	return nil
+}
+
+// resetDownlinkDataNotification clears the UPF's buffered-data notification state
+// for the session so the next downlink packet raises a fresh Downlink Data
+// Notification. The 3GPP anchor sends this to the user plane on paging failure.
+func (s *SMF) resetDownlinkDataNotification(ctx context.Context, smContext *SMContext) {
+	smContext.Mutex.Lock()
+	pfcp := smContext.PFCPContext
+	smContext.Mutex.Unlock()
+
+	if pfcp == nil {
+		return
+	}
+
+	s.upf.ResetDownlinkDataNotification(ctx, pfcp.RemoteSEID)
+}

--- a/internal/smf/paging_failure_test.go
+++ b/internal/smf/paging_failure_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestHandlePagingFailure_ResetsDownlinkNotification(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	supi := testSUPI()
+	const pduSessionID = 1
+
+	smCtx := s.NewSession(supi, pduSessionID, testDNN, testSnssai)
+	smCtx.SetPFCPSession(s.AllocateLocalSEID())
+	smCtx.PFCPContext.RemoteSEID = 4242
+
+	if err := s.HandlePagingFailure(context.Background(), supi, pduSessionID); err != nil {
+		t.Fatalf("HandlePagingFailure: %v", err)
+	}
+
+	if got := upf.resetDDNCalls; len(got) != 1 || got[0] != 4242 {
+		t.Fatalf("reset calls = %v, want [4242]", got)
+	}
+}
+
+func TestHandleEPSPagingFailure_ResetsDownlinkNotification(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	supi := testSUPI()
+	const ebi = 5
+
+	smCtx := s.NewSession(supi, ebi, testDNN, testSnssai)
+	smCtx.SetPFCPSession(s.AllocateLocalSEID())
+	smCtx.PFCPContext.RemoteSEID = 7
+
+	if err := s.HandleEPSPagingFailure(context.Background(), testIMSI, ebi); err != nil {
+		t.Fatalf("HandleEPSPagingFailure: %v", err)
+	}
+
+	if got := upf.resetDDNCalls; len(got) != 1 || got[0] != 7 {
+		t.Fatalf("reset calls = %v, want [7]", got)
+	}
+}
+
+func TestHandlePagingFailure_NoSession(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	if err := s.HandlePagingFailure(context.Background(), testSUPI(), 1); err == nil {
+		t.Fatal("expected error for missing session")
+	}
+
+	if len(upf.resetDDNCalls) != 0 {
+		t.Fatalf("unexpected reset calls: %v", upf.resetDDNCalls)
+	}
+}

--- a/internal/smf/paging_failure_test.go
+++ b/internal/smf/paging_failure_test.go
@@ -13,6 +13,7 @@ func TestHandlePagingFailure_ResetsDownlinkNotification(t *testing.T) {
 	s := newTestSMF(pcf, store, upf, amfCb)
 
 	supi := testSUPI()
+
 	const pduSessionID = 1
 
 	smCtx := s.NewSession(supi, pduSessionID, testDNN, testSnssai)
@@ -33,6 +34,7 @@ func TestHandleEPSPagingFailure_ResetsDownlinkNotification(t *testing.T) {
 	s := newTestSMF(pcf, store, upf, amfCb)
 
 	supi := testSUPI()
+
 	const ebi = 5
 
 	smCtx := s.NewSession(supi, ebi, testDNN, testSnssai)

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -94,6 +94,11 @@ type UPFClient interface {
 	FlushUsage(ctx context.Context, remoteSEID uint64)
 	DeleteSession(ctx context.Context, remoteSEID uint64) error
 
+	// ResetDownlinkDataNotification re-arms downlink-data paging for a session
+	// after paging fails, so the next downlink packet raises a fresh notification
+	// (TS 23.401 §5.3.4.3, TS 23.502 §4.2.3.3).
+	ResetDownlinkDataNotification(ctx context.Context, remoteSEID uint64)
+
 	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error
 
 	// RegisterIPv6Session tells the UPF's RA responder about a new IPv6

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -94,9 +94,6 @@ type UPFClient interface {
 	FlushUsage(ctx context.Context, remoteSEID uint64)
 	DeleteSession(ctx context.Context, remoteSEID uint64) error
 
-	// ResetDownlinkDataNotification re-arms downlink-data paging for a session
-	// after paging fails, so the next downlink packet raises a fresh notification
-	// (TS 23.401 §5.3.4.3, TS 23.502 §4.2.3.3).
 	ResetDownlinkDataNotification(ctx context.Context, remoteSEID uint64)
 
 	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -167,6 +167,7 @@ type fakeUPF struct {
 	lastEstablish   *models.EstablishRequest
 	modifyCalls     []*models.ModifyRequest
 	deleteCalls     []deletionCall
+	resetDDNCalls   []uint64
 	lastIPv6Reg     *models.IPv6SessionRegistration
 	err             error
 }
@@ -200,6 +201,13 @@ func (f *fakeUPF) DeleteSession(_ context.Context, remoteSEID uint64) error {
 	f.deleteCalls = append(f.deleteCalls, deletionCall{remoteSEID})
 
 	return f.err
+}
+
+func (f *fakeUPF) ResetDownlinkDataNotification(_ context.Context, remoteSEID uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.resetDDNCalls = append(f.resetDDNCalls, remoteSEID)
 }
 
 func (f *fakeUPF) FlushUsage(_ context.Context, _ uint64) {}

--- a/internal/upf/engine/paging.go
+++ b/internal/upf/engine/paging.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package engine
+
+// ClearDownlinkDataNotification re-arms downlink-data paging for a session by
+// clearing its buffered-data notification state, so the next downlink packet
+// raises a fresh Downlink Data Notification (TS 23.401 §5.3.4.3, TS 23.502 §4.2.3.3).
+func (conn *SessionEngine) ClearDownlinkDataNotification(seid uint64) {
+	if conn.BpfObjects == nil {
+		return
+	}
+
+	conn.BpfObjects.ClearNotifiedForSEID(seid)
+}

--- a/internal/upf/engine/paging.go
+++ b/internal/upf/engine/paging.go
@@ -3,9 +3,6 @@
 
 package engine
 
-// ClearDownlinkDataNotification re-arms downlink-data paging for a session by
-// clearing its buffered-data notification state, so the next downlink packet
-// raises a fresh Downlink Data Notification (TS 23.401 §5.3.4.3, TS 23.502 §4.2.3.3).
 func (conn *SessionEngine) ClearDownlinkDataNotification(seid uint64) {
 	if conn.BpfObjects == nil {
 		return

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -426,6 +426,10 @@ func (a *smfUPFAdapter) DeleteSession(ctx context.Context, remoteSEID uint64) er
 	return a.engine.DeleteSession(ctx, &models.DeleteRequest{SEID: remoteSEID})
 }
 
+func (a *smfUPFAdapter) ResetDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {
+	a.engine.ClearDownlinkDataNotification(remoteSEID)
+}
+
 func (a *smfUPFAdapter) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return a.engine.UpdateFilters(ctx, policyID, direction, rules)
 }


### PR DESCRIPTION
# Description

After a failed paging cycle, continued downlink data re-triggers paging instead of staying stuck until the UE re-registers.

## Reference
- TS 23.401 §5.3.4.3
- TS 23.502 §4.2.3.3

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
