### PR TITLE
fix: send error indication on erroneous AP ID

### DIFF
--- a/internal/mme/s1ap/handle_handover_notify.go
+++ b/internal/mme/s1ap/handle_handover_notify.go
@@ -23,12 +23,21 @@ func handleHandoverNotify(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 
 	ue, ok := m.LookupUe(notify.MMEUES1APID)
 	if !ok {
+		// An MME-UE-S1AP-ID the MME never allocated is an erroneous (unknown local)
+		// AP ID (TS 36.413 §10.6).
+		sendErrorIndication(m, radio.Conn, &notify.MMEUES1APID, &notify.ENBUES1APID, causeUnknownMMEUES1APID)
+
 		return
 	}
 
 	admitted, releaseEBIs, ok := m.MarkHandoverCommitting(ue, radio.Conn, notify.ENBUES1APID)
 	if !ok {
-		logger.From(ctx, logger.MmeLog).Warn("Handover Notify with no matching prepared handover", zap.Uint32("target-mme-ue-id", uint32(notify.MMEUES1APID)))
+		// No prepared handover matches. A pair that still resolves to the UE's current
+		// connection is a stale notify for a completed handover; an erroneous pair draws
+		// an ERROR INDICATION from resolveUE (TS 36.413 §10.6).
+		if _, valid := resolveUE(m, radio.Conn, notify.MMEUES1APID, notify.ENBUES1APID); valid {
+			logger.From(ctx, logger.MmeLog).Warn("Handover Notify with no matching prepared handover", zap.Uint32("target-mme-ue-id", uint32(notify.MMEUES1APID)))
+		}
 
 		return
 	}

--- a/internal/mme/s1ap/handle_handover_notify.go
+++ b/internal/mme/s1ap/handle_handover_notify.go
@@ -23,8 +23,6 @@ func handleHandoverNotify(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 
 	ue, ok := m.LookupUe(notify.MMEUES1APID)
 	if !ok {
-		// An MME-UE-S1AP-ID the MME never allocated is an erroneous (unknown local)
-		// AP ID (TS 36.413 §10.6).
 		sendErrorIndication(m, radio.Conn, &notify.MMEUES1APID, &notify.ENBUES1APID, causeUnknownMMEUES1APID)
 
 		return
@@ -32,9 +30,8 @@ func handleHandoverNotify(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 
 	admitted, releaseEBIs, ok := m.MarkHandoverCommitting(ue, radio.Conn, notify.ENBUES1APID)
 	if !ok {
-		// No prepared handover matches. A pair that still resolves to the UE's current
-		// connection is a stale notify for a completed handover; an erroneous pair draws
-		// an ERROR INDICATION from resolveUE (TS 36.413 §10.6).
+		// A pair that still resolves to the UE's active connection is a stale notify for a
+		// completed handover; an erroneous pair draws an ERROR INDICATION (TS 36.413 §10.6).
 		if _, valid := resolveUE(m, radio.Conn, notify.MMEUES1APID, notify.ENBUES1APID); valid {
 			logger.From(ctx, logger.MmeLog).Warn("Handover Notify with no matching prepared handover", zap.Uint32("target-mme-ue-id", uint32(notify.MMEUES1APID)))
 		}

--- a/internal/mme/s1ap/handover_test.go
+++ b/internal/mme/s1ap/handover_test.go
@@ -849,6 +849,133 @@ func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
 	}
 }
 
+func handoverNotify(targetMME s1ap.MMEUES1APID, targetENB s1ap.ENBUES1APID) *s1ap.HandoverNotify {
+	return &s1ap.HandoverNotify{
+		MMEUES1APID: targetMME,
+		ENBUES1APID: targetENB,
+		EUTRANCGI:   s1ap.EUTRANCGI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, CellID: 1},
+		TAI:         s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 1},
+	}
+}
+
+// TestHandoverNotifyUnknownMMEUES1APIDSendsErrorIndication checks that a HANDOVER
+// NOTIFY carrying an MME-UE-S1AP-ID the MME never allocated draws an ERROR
+// INDICATION with the received AP IDs and cause unknown-mme-ue-s1ap-id, and leaves
+// the in-flight handover intact (TS 36.413 §10.6).
+func TestHandoverNotifyUnknownMMEUES1APIDSendsErrorIndication(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	_, targetENB := driveToPrepared(t, m, ue, source, target)
+
+	const unknownMME s1ap.MMEUES1APID = 0xFFFF00
+	if _, ok := m.LookupUe(unknownMME); ok {
+		t.Fatalf("test precondition: MME-UE-S1AP-ID %d must be unallocated", unknownMME)
+	}
+
+	before := target.count()
+
+	handleHandoverNotify(m, context.Background(), mme.NewRadioForTest(target), initiatingValue(t, mustMarshal(t, handoverNotify(unknownMME, targetENB).Marshal)))
+
+	if target.count() != before+1 {
+		t.Fatalf("expected one Error Indication to the target, got %d PDU(s)", target.count()-before)
+	}
+
+	ind := parseOutboundErrorIndication(t, target.sent[before])
+
+	if ind.MMEUES1APID == nil || *ind.MMEUES1APID != unknownMME {
+		t.Fatalf("Error Indication MME-UE-S1AP-ID = %v, want %d", ind.MMEUES1APID, unknownMME)
+	}
+
+	if ind.ENBUES1APID == nil || *ind.ENBUES1APID != targetENB {
+		t.Fatalf("Error Indication eNB-UE-S1AP-ID = %v, want %d", ind.ENBUES1APID, targetENB)
+	}
+
+	if ind.Cause == nil || *ind.Cause != causeUnknownMMEUES1APID {
+		t.Fatalf("Error Indication cause = %v, want unknown-mme-ue-s1ap-id", ind.Cause)
+	}
+
+	if !ue.HasHandoverForTest() {
+		t.Fatal("in-flight handover torn down by a Handover Notify with an unknown MME-UE-S1AP-ID")
+	}
+}
+
+// TestHandoverNotifyInconsistentENBUES1APIDSendsErrorIndication checks that a
+// HANDOVER NOTIFY carrying the prepared target MME-UE-S1AP-ID but an eNB-UE-S1AP-ID
+// that matches no prepared handover draws an ERROR INDICATION carrying the received
+// AP IDs, and does not commit the handover (TS 36.413 §10.6).
+func TestHandoverNotifyInconsistentENBUES1APIDSendsErrorIndication(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	targetMME, targetENB := driveToPrepared(t, m, ue, source, target)
+
+	const wrongENB s1ap.ENBUES1APID = 77
+	if wrongENB == targetENB {
+		t.Fatal("test precondition: wrongENB must differ from the prepared target eNB-UE-S1AP-ID")
+	}
+
+	before := target.count()
+
+	handleHandoverNotify(m, context.Background(), mme.NewRadioForTest(target), initiatingValue(t, mustMarshal(t, handoverNotify(targetMME, wrongENB).Marshal)))
+
+	if target.count() != before+1 {
+		t.Fatalf("expected one Error Indication to the target, got %d PDU(s)", target.count()-before)
+	}
+
+	ind := parseOutboundErrorIndication(t, target.sent[before])
+
+	if ind.MMEUES1APID == nil || *ind.MMEUES1APID != targetMME {
+		t.Fatalf("Error Indication MME-UE-S1AP-ID = %v, want %d", ind.MMEUES1APID, targetMME)
+	}
+
+	if ind.ENBUES1APID == nil || *ind.ENBUES1APID != wrongENB {
+		t.Fatalf("Error Indication eNB-UE-S1AP-ID = %v, want %d", ind.ENBUES1APID, wrongENB)
+	}
+
+	if ind.Cause == nil || ind.Cause.Group != s1ap.CauseGroupRadioNetwork {
+		t.Fatalf("Error Indication cause = %v, want a radio-network cause", ind.Cause)
+	}
+
+	if fsm := m.Session.(*fakeSessionManager); fsm.modifiedENB != (models.FTEID{}) {
+		t.Fatalf("user plane switched for an inconsistent Handover Notify: %+v", fsm.modifiedENB)
+	}
+
+	if !ue.HasHandoverForTest() {
+		t.Fatal("in-flight handover committed by a Handover Notify with an inconsistent eNB-UE-S1AP-ID")
+	}
+}
+
+// TestHandoverNotifyStaleDuplicateAfterCompletion checks that a HANDOVER NOTIFY
+// retransmitted after the handover has completed — its AP IDs now identify the UE's
+// active connection — is not answered with an ERROR INDICATION and does not release
+// the live UE (TS 36.413 §10.6).
+func TestHandoverNotifyStaleDuplicateAfterCompletion(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	targetMME, targetENB := driveToPrepared(t, m, ue, source, target)
+
+	notify := initiatingValue(t, mustMarshal(t, handoverNotify(targetMME, targetENB).Marshal))
+	handleHandoverNotify(m, context.Background(), mme.NewRadioForTest(target), notify)
+
+	if ue.Conn() == nil || ue.Conn().MMEUES1APID != targetMME || ue.Conn().ENBUES1APID != targetENB {
+		t.Fatal("handover did not complete onto the target")
+	}
+
+	before := target.count()
+
+	handleHandoverNotify(m, context.Background(), mme.NewRadioForTest(target), notify)
+
+	if target.count() != before {
+		t.Fatalf("stale Handover Notify drew %d response PDU(s); expected none", target.count()-before)
+	}
+
+	if ue.Conn() == nil || ue.Conn().MMEUES1APID != targetMME || ue.Conn().ENBUES1APID != targetENB {
+		t.Fatal("live UE torn down by a stale Handover Notify")
+	}
+}
+
 // TestHandoverTargetConnLossAborts checks that losing the target eNB association
 // mid-handover aborts the handover and removes the target connection by its own
 // id, leaving the UE on its source.


### PR DESCRIPTION
# Description

According to 3GPP specs (TS 36.413 §10.6 (4G/S1AP) and TS 38.413 §10.6 (5G/NGAP)):

> **Handling of AP ID**: for a UE-associated message that is not the first/first-returned/last message and carries an erroneous AP ID — either an unknown local AP ID or an inconsistent remote AP ID — the node shall initiate an  Error Indication with the received AP ID(s) and an appropriate cause.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
