### PR TITLE
feat: Refresh cell ID location when stale

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -717,11 +717,7 @@ func (amf *AMF) IsUERegistered(supi etsi.SUPI) bool {
 }
 
 // RefreshLocation triggers an active location refresh by sending a
-// LocationReportingControl(Direct) NGAP message to the RAN for the given UE
-// (TS 23.273 §6.5.1 "Otherwise" branch — invoke NG-RAN Location Reporting
-// procedure). Returns nil when the UE and its connection exist and the
-// message is sent; returns an error when the UE is not found or has no
-// active RAN connection.
+// LocationReportingControl(Direct) NGAP message to the RAN for the given UE.
 func (amf *AMF) RefreshLocation(ctx context.Context, supi etsi.SUPI) error {
 	ue, ok := amf.LookupUeBySupi(supi)
 	if !ok {
@@ -747,8 +743,6 @@ func (amf *AMF) RefreshLocation(ctx context.Context, supi etsi.SUPI) error {
 	}
 
 	ueConn.SendNGAP(ctx, send.NGAPProcedureLocationReportingControl, pkt)
-
-	ueConn.TouchLastSeen()
 
 	logger.AmfLog.Info("location refresh triggered via LocationReportingControl(Direct)",
 		logger.SUPI(supi.String()),

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -715,3 +715,46 @@ func (amf *AMF) IsUERegistered(supi etsi.SUPI) bool {
 
 	return ue.State() == Registered
 }
+
+// RefreshLocation triggers an active location refresh by sending a
+// LocationReportingControl(Direct) NGAP message to the RAN for the given UE
+// (TS 23.273 §6.5.1 "Otherwise" branch — invoke NG-RAN Location Reporting
+// procedure). Returns nil when the UE and its connection exist and the
+// message is sent; returns an error when the UE is not found or has no
+// active RAN connection.
+func (amf *AMF) RefreshLocation(ctx context.Context, supi etsi.SUPI) error {
+	ue, ok := amf.LookupUeBySupi(supi)
+	if !ok {
+		return fmt.Errorf("UE not found")
+	}
+
+	ueConn := ue.Conn()
+	if ueConn == nil {
+		return fmt.Errorf("UE has no active RAN connection")
+	}
+
+	eventType := ngapType.EventType{
+		Value: ngapType.EventTypePresentDirect,
+	}
+
+	pkt, err := send.BuildLocationReportingControl(
+		int64(ueConn.AmfUeNgapID),
+		int64(ueConn.RanUeNgapID),
+		eventType,
+	)
+	if err != nil {
+		return fmt.Errorf("build LocationReportingControl: %w", err)
+	}
+
+	ueConn.SendNGAP(ctx, send.NGAPProcedureLocationReportingControl, pkt)
+
+	ueConn.TouchLastSeen()
+
+	logger.AmfLog.Info("location refresh triggered via LocationReportingControl(Direct)",
+		logger.SUPI(supi.String()),
+		zap.Int64("amfUeNgapID", int64(ueConn.AmfUeNgapID)),
+		zap.Int64("ranUeNgapID", int64(ueConn.RanUeNgapID)),
+	)
+
+	return nil
+}

--- a/internal/decoder/ngap/location_report.go
+++ b/internal/decoder/ngap/location_report.go
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"fmt"
+
+	"github.com/free5gc/ngap/ngapType"
+)
+
+func buildLocationReport(locationReport ngapType.LocationReport) NGAPMessageValue {
+	ies := make([]IE, 0)
+
+	for i := 0; i < len(locationReport.ProtocolIEs.List); i++ {
+		ie := locationReport.ProtocolIEs.List[i]
+		switch ie.Id.Value {
+		case ngapType.ProtocolIEIDAMFUENGAPID:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       ie.Value.AMFUENGAPID.Value,
+			})
+		case ngapType.ProtocolIEIDRANUENGAPID:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       ie.Value.RANUENGAPID.Value,
+			})
+		case ngapType.ProtocolIEIDUserLocationInformation:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       buildUserLocationInformationIE(*ie.Value.UserLocationInformation),
+			})
+		case ngapType.ProtocolIEIDLocationReportingRequestType:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       buildLocationReportingRequestType(ie.Value.LocationReportingRequestType),
+			})
+		case ngapType.ProtocolIEIDUEPresenceInAreaOfInterestList:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       buildUEPresenceInAreaOfInterestList(*ie.Value.UEPresenceInAreaOfInterestList),
+			})
+		default:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Error:       fmt.Sprintf("unsupported ie type %d", ie.Id.Value),
+			})
+		}
+	}
+
+	return NGAPMessageValue{
+		IEs: ies,
+	}
+}
+
+type LocationReportingRequestType struct {
+	EventType                                 string               `json:"event_type"`
+	ReportArea                                string               `json:"report_area"`
+	AreaOfInterestList                        []AreaOfInterestItem `json:"area_of_interest_list,omitempty"`
+	LocationReportingReferenceIDToBeCancelled *int64               `json:"reference_id_to_be_cancelled,omitempty"`
+}
+
+type AreaOfInterestItem struct {
+	LocationReportingReferenceID int64 `json:"location_reporting_reference_id"`
+	GADIE                        any   `json:"gad_ie"`
+}
+
+func buildLocationReportingRequestType(lrrt *ngapType.LocationReportingRequestType) LocationReportingRequestType {
+	var out LocationReportingRequestType
+	if lrrt == nil {
+		return out
+	}
+
+	out.EventType = eventTypeToString(lrrt.EventType)
+	out.ReportArea = reportAreaToString(lrrt.ReportArea)
+
+	if lrrt.AreaOfInterestList != nil {
+		out.AreaOfInterestList = buildAreaOfInterestList(lrrt.AreaOfInterestList)
+	}
+
+	if lrrt.LocationReportingReferenceIDToBeCancelled != nil {
+		refID := lrrt.LocationReportingReferenceIDToBeCancelled.Value
+		out.LocationReportingReferenceIDToBeCancelled = &refID
+	}
+
+	return out
+}
+
+func buildAreaOfInterestList(aoiList *ngapType.AreaOfInterestList) []AreaOfInterestItem {
+	if aoiList == nil {
+		return nil
+	}
+
+	items := make([]AreaOfInterestItem, 0)
+
+	for i := 0; i < len(aoiList.List); i++ {
+		item := aoiList.List[i]
+		aoiItem := AreaOfInterestItem{
+			LocationReportingReferenceID: item.LocationReportingReferenceID.Value,
+		}
+
+		aoi := item.AreaOfInterest
+		if aoi.AreaOfInterestTAIList != nil || aoi.AreaOfInterestCellList != nil || aoi.AreaOfInterestRANNodeList != nil {
+			aoiItem.GADIE = map[string]any{
+				"error": "GAD decoding not implemented",
+			}
+		} else {
+			aoiItem.GADIE = map[string]any{
+				"error": "no area of interest defined",
+			}
+		}
+
+		items = append(items, aoiItem)
+	}
+
+	return items
+}
+
+type UEPresenceInAreaOfInterestList struct {
+	Items []UEPresenceInAreaOfInterestItem `json:"items"`
+}
+
+type UEPresenceInAreaOfInterestItem struct {
+	LocationReportingReferenceID int64  `json:"location_reporting_reference_id"`
+	UEPresence                   string `json:"ue_presence"` // "In", "Out"
+}
+
+func buildUEPresenceInAreaOfInterestList(list ngapType.UEPresenceInAreaOfInterestList) UEPresenceInAreaOfInterestList {
+	items := make([]UEPresenceInAreaOfInterestItem, 0)
+
+	for i := 0; i < len(list.List); i++ {
+		item := list.List[i]
+		uePresence := "Unknown"
+
+		switch item.UEPresence.Value {
+		case ngapType.UEPresencePresentIn:
+			uePresence = "In"
+		case ngapType.UEPresencePresentOut:
+			uePresence = "Out"
+		}
+
+		items = append(items, UEPresenceInAreaOfInterestItem{
+			LocationReportingReferenceID: item.LocationReportingReferenceID.Value,
+			UEPresence:                   uePresence,
+		})
+	}
+
+	return UEPresenceInAreaOfInterestList{Items: items}
+}
+
+func eventTypeToString(eventType ngapType.EventType) string {
+	switch eventType.Value {
+	case ngapType.EventTypePresentDirect:
+		return "Direct"
+	case ngapType.EventTypePresentChangeOfServeCell:
+		return "ChangeOfServingCell"
+	case ngapType.EventTypePresentUePresenceInAreaOfInterest:
+		return "UePresenceInAreaOfInterest"
+	case ngapType.EventTypePresentStopChangeOfServeCell:
+		return "StopChangeOfServingCell"
+	case ngapType.EventTypePresentStopUePresenceInAreaOfInterest:
+		return "StopUePresenceInAreaOfInterest"
+	case ngapType.EventTypePresentCancelLocationReportingForTheUe:
+		return "CancelLocationReportingForTheUe"
+	default:
+		return fmt.Sprintf("Unknown(%d)", eventType.Value)
+	}
+}
+
+func reportAreaToString(reportArea ngapType.ReportArea) string {
+	switch reportArea.Value {
+	case ngapType.ReportAreaPresentCell:
+		return "Cell"
+	default:
+		return fmt.Sprintf("Unknown(%d)", reportArea.Value)
+	}
+}

--- a/internal/decoder/ngap/location_reporting_control.go
+++ b/internal/decoder/ngap/location_reporting_control.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"fmt"
+
+	"github.com/free5gc/ngap/ngapType"
+)
+
+func buildLocationReportingControl(locationReportingControl ngapType.LocationReportingControl) NGAPMessageValue {
+	ies := make([]IE, 0)
+
+	for i := 0; i < len(locationReportingControl.ProtocolIEs.List); i++ {
+		ie := locationReportingControl.ProtocolIEs.List[i]
+		switch ie.Id.Value {
+		case ngapType.ProtocolIEIDAMFUENGAPID:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       ie.Value.AMFUENGAPID.Value,
+			})
+		case ngapType.ProtocolIEIDRANUENGAPID:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       ie.Value.RANUENGAPID.Value,
+			})
+		case ngapType.ProtocolIEIDLocationReportingRequestType:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Value:       buildLocationReportingRequestType(ie.Value.LocationReportingRequestType),
+			})
+		default:
+			ies = append(ies, IE{
+				ID:          protocolIEIDToEnum(ie.Id.Value),
+				Criticality: criticalityToEnum(ie.Criticality.Value),
+				Error:       fmt.Sprintf("unsupported ie type %d", ie.Id.Value),
+			})
+		}
+	}
+
+	return NGAPMessageValue{
+		IEs: ies,
+	}
+}

--- a/internal/decoder/ngap/ngap.go
+++ b/internal/decoder/ngap/ngap.go
@@ -163,6 +163,10 @@ func buildInitiatingMessage(initMsg ngapType.InitiatingMessage) NGAPMessageValue
 		return buildUplinkNonUEAssociatedNRPPaTransport(*initMsg.Value.UplinkNonUEAssociatedNRPPaTransport)
 	case ngapType.InitiatingMessagePresentErrorIndication:
 		return buildErrorIndication(*initMsg.Value.ErrorIndication)
+	case ngapType.InitiatingMessagePresentLocationReport:
+		return buildLocationReport(*initMsg.Value.LocationReport)
+	case ngapType.InitiatingMessagePresentLocationReportingControl:
+		return buildLocationReportingControl(*initMsg.Value.LocationReportingControl)
 	default:
 		return NGAPMessageValue{
 			Error: fmt.Sprintf("Unsupported message %d", initMsg.Value.Present),

--- a/internal/lmf/engine.go
+++ b/internal/lmf/engine.go
@@ -40,7 +40,16 @@ func (l *LMF) DetermineLocation(ctx context.Context, supi etsi.SUPI, method Posi
 // determineCellIDLocation computes location using the Cell ID method. It maps
 // the serving cell to its provisioned geographic position; if no coordinate is
 // available for the cell it returns ErrNoLocationEstimate (a Cell-ID estimate
-// without coordinates is not a valid TS 29.572 LocationData).
+// without coordinates is not a valid TS 29.572 LocationData). N3IWF is an
+// exception: it carries no cell identifier, so a coordinate-less result is
+// returned for non-3GPP access.
+//
+// Per TS 23.273 §6.5.1 step 12: if the AMF does not have a valid (fresh)
+// location, it invokes the NG-RAN Location Reporting procedure by sending
+// LocationReportingControl(Direct) to the RAN. The refresh is fire-and-forget:
+// the RAN's LocationReport arrives asynchronously on the dispatch goroutine
+// and updates the AMF's cached location, so the current request returns the
+// existing location and the next request benefits from the refresh.
 func (l *LMF) determineCellIDLocation(ctx context.Context, supi etsi.SUPI) (*models.LocationResult, error) {
 	if !l.isUERegistered(supi) {
 		return nil, fmt.Errorf("UE not registered: %w", ErrNotFound)
@@ -55,7 +64,42 @@ func (l *LMF) determineCellIDLocation(ctx context.Context, supi etsi.SUPI) (*mod
 		return nil, fmt.Errorf("no location available for UE: %w", ErrNotFound)
 	}
 
+	maxAge := l.maxLocationAge
+	if maxAge <= 0 {
+		maxAge = defaultMaxLocationAge
+	}
+
+	// TS 23.273 §6.5.1 step 12: check if the AMF's known location is fresh.
+	// If stale, actively refresh via LocationReportingControl(Direct). The
+	// refresh is async — the LocationReport arrives on the dispatch goroutine
+	// and updates the AMF's cache, so this request proceeds with the current
+	// (stale) location; the next request will see the refreshed value.
+	if IsLocationStale(loc, maxAge) {
+		logger.LmfLog.Info("location stale, triggering async refresh",
+			zap.String("supi", supi.String()),
+			zap.Int32("maxAge", maxAge),
+		)
+
+		if err := l.refreshLocation(ctx, supi); err != nil {
+			logger.LmfLog.Warn("location refresh failed, returning current location",
+				zap.String("supi", supi.String()),
+				zap.Error(err),
+			)
+		}
+	}
+
 	result := computeCellIDLocation(supi, loc)
+
+	// N3IWF has no cell coordinate — skip coordinate resolution.
+	if loc.N3gaLocation != nil {
+		logger.LmfLog.Info("location computed",
+			zap.String("supi", supi.String()),
+			zap.String("method", "cell_id"),
+			zap.String("access_type", result.AccessType),
+		)
+
+		return result, nil
+	}
 
 	coord, ok := l.resolveCellCoordinate(ctx, loc, nil)
 	if !ok {
@@ -182,6 +226,7 @@ func computeCellIDLocation(supi etsi.SUPI, loc coremodels.UserLocation) *models.
 			AccessType:          "NR",
 			AgeOfLocationInfo:   loc.NrLocation.AgeOfLocationInformation,
 			UeLocationTimestamp: loc.NrLocation.UeLocationTimestamp,
+			UserLocation:        loc,
 		}
 	}
 
@@ -194,17 +239,77 @@ func computeCellIDLocation(supi etsi.SUPI, loc coremodels.UserLocation) *models.
 			AccessType:          "EUTRA",
 			AgeOfLocationInfo:   loc.EutraLocation.AgeOfLocationInformation,
 			UeLocationTimestamp: loc.EutraLocation.UeLocationTimestamp,
+			UserLocation:        loc,
 		}
 	}
 
 	if loc.N3gaLocation != nil {
 		return &models.LocationResult{
-			SUPI:       supi.String(),
-			Shape:      models.GADCellID,
-			TAI:        loc.N3gaLocation.N3gppTai,
-			AccessType: "N3IWF",
+			SUPI:         supi.String(),
+			Shape:        models.GADCellID,
+			TAI:          loc.N3gaLocation.N3gppTai,
+			AccessType:   "N3IWF",
+			UserLocation: loc,
 		}
 	}
 
 	return nil
+}
+
+// IsLocationStale reports whether loc is considered stale relative to
+// maxAgeSeconds. A location is stale when its age (time since the AMF last
+// received a location update via NGAP) exceeds maxAgeSeconds, or when it is
+// an N3IWF location (which has no refresh mechanism and is always considered
+// valid once received).
+func IsLocationStale(loc interface{}, maxAgeSeconds int32) bool {
+	switch v := loc.(type) {
+	case *coremodels.NrLocation:
+		if v == nil {
+			return true
+		}
+
+		if v.UeLocationTimestamp == nil {
+			return true
+		}
+
+		return time.Since(*v.UeLocationTimestamp).Seconds() > float64(maxAgeSeconds)
+	case *coremodels.EutraLocation:
+		if v == nil {
+			return true
+		}
+
+		if v.UeLocationTimestamp == nil {
+			return true
+		}
+
+		return time.Since(*v.UeLocationTimestamp).Seconds() > float64(maxAgeSeconds)
+	case *coremodels.N3gaLocation:
+		// N3IWF has no cell-level refresh mechanism; treat as never stale.
+		return false
+	case coremodels.UserLocation:
+		// Check the nested location types directly.
+		if v.NrLocation != nil {
+			return IsLocationStale(v.NrLocation, maxAgeSeconds)
+		}
+
+		if v.EutraLocation != nil {
+			return IsLocationStale(v.EutraLocation, maxAgeSeconds)
+		}
+		// N3IWF or empty — N3IWF is never stale, empty is always stale.
+		return v.N3gaLocation == nil
+	default:
+		// Empty or unknown location is always stale.
+		return true
+	}
+}
+
+// refreshLocation triggers an active location refresh by asking the AMF to
+// send a LocationReportingControl(Direct) to the RAN (TS 23.273 §6.5.1
+// "Otherwise" branch — invoke NG-RAN Location Reporting procedure).
+func (l *LMF) refreshLocation(ctx context.Context, supi etsi.SUPI) error {
+	if l.amf == nil {
+		return fmt.Errorf("AMF is not available")
+	}
+
+	return l.amf.RefreshLocation(ctx, supi)
 }

--- a/internal/lmf/engine.go
+++ b/internal/lmf/engine.go
@@ -17,7 +17,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var ErrNotFound = errors.New("UE not found or not registered")
+var (
+	ErrNotFound       = errors.New("UE not found or not registered")
+	ErrRefreshTimeout = errors.New("location refresh timed out")
+)
 
 // DetermineLocation computes the current location of the UE identified by
 // supi using the configured positioning method. Returns the location result,
@@ -39,17 +42,7 @@ func (l *LMF) DetermineLocation(ctx context.Context, supi etsi.SUPI, method Posi
 
 // determineCellIDLocation computes location using the Cell ID method. It maps
 // the serving cell to its provisioned geographic position; if no coordinate is
-// available for the cell it returns ErrNoLocationEstimate (a Cell-ID estimate
-// without coordinates is not a valid TS 29.572 LocationData). N3IWF is an
-// exception: it carries no cell identifier, so a coordinate-less result is
-// returned for non-3GPP access.
-//
-// Per TS 23.273 §6.5.1 step 12: if the AMF does not have a valid (fresh)
-// location, it invokes the NG-RAN Location Reporting procedure by sending
-// LocationReportingControl(Direct) to the RAN. The refresh is fire-and-forget:
-// the RAN's LocationReport arrives asynchronously on the dispatch goroutine
-// and updates the AMF's cached location, so the current request returns the
-// existing location and the next request benefits from the refresh.
+// available for the cell it returns ErrNoLocationEstimate.
 func (l *LMF) determineCellIDLocation(ctx context.Context, supi etsi.SUPI) (*models.LocationResult, error) {
 	if !l.isUERegistered(supi) {
 		return nil, fmt.Errorf("UE not registered: %w", ErrNotFound)
@@ -69,29 +62,27 @@ func (l *LMF) determineCellIDLocation(ctx context.Context, supi etsi.SUPI) (*mod
 		maxAge = defaultMaxLocationAge
 	}
 
-	// TS 23.273 §6.5.1 step 12: check if the AMF's known location is fresh.
-	// If stale, actively refresh via LocationReportingControl(Direct). The
-	// refresh is async — the LocationReport arrives on the dispatch goroutine
-	// and updates the AMF's cache, so this request proceeds with the current
-	// (stale) location; the next request will see the refreshed value.
 	if IsLocationStale(loc, maxAge) {
-		logger.LmfLog.Info("location stale, triggering async refresh",
+		logger.LmfLog.Info("location stale, triggering refresh",
 			zap.String("supi", supi.String()),
 			zap.Int32("maxAge", maxAge),
 		)
 
-		if err := l.refreshLocation(ctx, supi); err != nil {
-			logger.LmfLog.Warn("location refresh failed, returning current location",
+		refreshed, err := l.refreshLocation(ctx, supi, loc)
+		if err != nil {
+			logger.LmfLog.Warn("location refresh failed, returning stale location",
 				zap.String("supi", supi.String()),
 				zap.Error(err),
 			)
+		} else {
+			loc = refreshed
 		}
 	}
 
 	result := computeCellIDLocation(supi, loc)
 
 	// N3IWF has no cell coordinate — skip coordinate resolution.
-	if loc.N3gaLocation != nil {
+	if loc.N3gaLocation != nil && loc.EutraLocation == nil && loc.NrLocation == nil {
 		logger.LmfLog.Info("location computed",
 			zap.String("supi", supi.String()),
 			zap.String("method", "cell_id"),
@@ -257,59 +248,90 @@ func computeCellIDLocation(supi etsi.SUPI, loc coremodels.UserLocation) *models.
 }
 
 // IsLocationStale reports whether loc is considered stale relative to
-// maxAgeSeconds. A location is stale when its age (time since the AMF last
-// received a location update via NGAP) exceeds maxAgeSeconds, or when it is
-// an N3IWF location (which has no refresh mechanism and is always considered
-// valid once received).
-func IsLocationStale(loc interface{}, maxAgeSeconds int32) bool {
-	switch v := loc.(type) {
-	case *coremodels.NrLocation:
-		if v == nil {
+// maxAgeSeconds.
+func IsLocationStale(loc coremodels.UserLocation, maxAgeSeconds int32) bool {
+	if loc.NrLocation != nil {
+		if loc.NrLocation.UeLocationTimestamp == nil {
 			return true
 		}
 
-		if v.UeLocationTimestamp == nil {
-			return true
-		}
-
-		return time.Since(*v.UeLocationTimestamp).Seconds() > float64(maxAgeSeconds)
-	case *coremodels.EutraLocation:
-		if v == nil {
-			return true
-		}
-
-		if v.UeLocationTimestamp == nil {
-			return true
-		}
-
-		return time.Since(*v.UeLocationTimestamp).Seconds() > float64(maxAgeSeconds)
-	case *coremodels.N3gaLocation:
-		// N3IWF has no cell-level refresh mechanism; treat as never stale.
-		return false
-	case coremodels.UserLocation:
-		// Check the nested location types directly.
-		if v.NrLocation != nil {
-			return IsLocationStale(v.NrLocation, maxAgeSeconds)
-		}
-
-		if v.EutraLocation != nil {
-			return IsLocationStale(v.EutraLocation, maxAgeSeconds)
-		}
-		// N3IWF or empty — N3IWF is never stale, empty is always stale.
-		return v.N3gaLocation == nil
-	default:
-		// Empty or unknown location is always stale.
-		return true
+		return time.Since(*loc.NrLocation.UeLocationTimestamp).Seconds() > float64(maxAgeSeconds)
 	}
+
+	if loc.EutraLocation != nil {
+		if loc.EutraLocation.UeLocationTimestamp == nil {
+			return true
+		}
+
+		return time.Since(*loc.EutraLocation.UeLocationTimestamp).Seconds() > float64(maxAgeSeconds)
+	}
+
+	// N3IWF or empty — N3IWF is never stale, empty is always stale.
+	return loc.N3gaLocation == nil
 }
 
-// refreshLocation triggers an active location refresh by asking the AMF to
-// send a LocationReportingControl(Direct) to the RAN (TS 23.273 §6.5.1
-// "Otherwise" branch — invoke NG-RAN Location Reporting procedure).
-func (l *LMF) refreshLocation(ctx context.Context, supi etsi.SUPI) error {
+// refreshLocation triggers an active location refresh through the AMF via the
+// NG-RAN location reporting procedure (TS 23.273 §6.5.1 step 12). It waits for
+// the AMF to receive a LocationReport from the RAN, polling the AMF's location
+// cache until the timestamp changes or the timeout expires.
+//
+// Returns the fresh location on success, or the stale location wrapped with
+// ErrRefreshTimeout if the refresh does not complete in time.
+func (l *LMF) refreshLocation(ctx context.Context, supi etsi.SUPI, loc coremodels.UserLocation) (coremodels.UserLocation, error) {
 	if l.amf == nil {
-		return fmt.Errorf("AMF is not available")
+		return coremodels.UserLocation{}, fmt.Errorf("AMF is not available")
 	}
 
-	return l.amf.RefreshLocation(ctx, supi)
+	ue, ok := l.amf.LookupUeBySupi(supi)
+	if !ok {
+		return coremodels.UserLocation{}, fmt.Errorf("UE not found: %w", ErrNotFound)
+	}
+
+	// Record the current timestamp before triggering the refresh.
+	staleTime := time.Time{}
+	if loc.NrLocation != nil && loc.NrLocation.UeLocationTimestamp != nil {
+		staleTime = *loc.NrLocation.UeLocationTimestamp
+	} else if loc.EutraLocation != nil && loc.EutraLocation.UeLocationTimestamp != nil {
+		staleTime = *loc.EutraLocation.UeLocationTimestamp
+	}
+
+	// Trigger the refresh (sends LocationReportingControl(Direct) to RAN).
+	if err := l.amf.RefreshLocation(ctx, supi); err != nil {
+		return coremodels.UserLocation{}, fmt.Errorf("send refresh request: %w", err)
+	}
+
+	// Wait for the RAN to respond with a LocationReport that updates the timestamp.
+	timeout := defaultRefreshTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if d := time.Until(deadline); d < timeout {
+			timeout = d
+		}
+	}
+
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	deadline := time.After(timeout)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return coremodels.UserLocation{}, fmt.Errorf("context cancelled: %w", ErrRefreshTimeout)
+		case <-deadline:
+			return coremodels.UserLocation{}, fmt.Errorf("refresh did not complete in %v: %w", timeout, ErrRefreshTimeout)
+		case <-ticker.C:
+			loc := ue.GetUserLocation()
+
+			var freshTime time.Time
+			if loc.NrLocation != nil && loc.NrLocation.UeLocationTimestamp != nil {
+				freshTime = *loc.NrLocation.UeLocationTimestamp
+			} else if loc.EutraLocation != nil && loc.EutraLocation.UeLocationTimestamp != nil {
+				freshTime = *loc.EutraLocation.UeLocationTimestamp
+			}
+
+			if !freshTime.IsZero() && !freshTime.Equal(staleTime) {
+				return loc, nil
+			}
+		}
+	}
 }

--- a/internal/lmf/engine_refresh_test.go
+++ b/internal/lmf/engine_refresh_test.go
@@ -5,14 +5,19 @@ package lmf
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/ngap"
+	"github.com/ellanetworks/core/internal/amf/ngap/decode"
 	"github.com/ellanetworks/core/internal/db"
 	coremodels "github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/sctp"
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
 )
 
@@ -363,8 +368,10 @@ func TestDetermineLocation_N3IWF(t *testing.T) {
 
 // TestIsLocationStale_NR verifies the staleness check for NR locations.
 func TestIsLocationStale_NR(t *testing.T) {
-	fresh := &coremodels.NrLocation{
-		UeLocationTimestamp: func() *time.Time { t := time.Now(); return &t }(),
+	fresh := coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			UeLocationTimestamp: func() *time.Time { t := time.Now(); return &t }(),
+		},
 	}
 	if IsLocationStale(fresh, 10) {
 		t.Error("expected fresh NR location to not be stale")
@@ -372,8 +379,10 @@ func TestIsLocationStale_NR(t *testing.T) {
 
 	staleTime := time.Now().Add(-20 * time.Second)
 
-	stale := &coremodels.NrLocation{
-		UeLocationTimestamp: &staleTime,
+	stale := coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			UeLocationTimestamp: &staleTime,
+		},
 	}
 	if !IsLocationStale(stale, 10) {
 		t.Error("expected stale NR location to be stale")
@@ -382,8 +391,10 @@ func TestIsLocationStale_NR(t *testing.T) {
 
 // TestIsLocationStale_EUTRA verifies the staleness check for E-UTRA locations.
 func TestIsLocationStale_EUTRA(t *testing.T) {
-	fresh := &coremodels.EutraLocation{
-		UeLocationTimestamp: func() *time.Time { t := time.Now(); return &t }(),
+	fresh := coremodels.UserLocation{
+		EutraLocation: &coremodels.EutraLocation{
+			UeLocationTimestamp: func() *time.Time { t := time.Now(); return &t }(),
+		},
 	}
 	if IsLocationStale(fresh, 10) {
 		t.Error("expected fresh E-UTRA location to not be stale")
@@ -391,8 +402,10 @@ func TestIsLocationStale_EUTRA(t *testing.T) {
 
 	staleTime := time.Now().Add(-20 * time.Second)
 
-	stale := &coremodels.EutraLocation{
-		UeLocationTimestamp: &staleTime,
+	stale := coremodels.UserLocation{
+		EutraLocation: &coremodels.EutraLocation{
+			UeLocationTimestamp: &staleTime,
+		},
 	}
 	if !IsLocationStale(stale, 10) {
 		t.Error("expected stale E-UTRA location to be stale")
@@ -402,10 +415,12 @@ func TestIsLocationStale_EUTRA(t *testing.T) {
 // TestIsLocationStale_N3IWF verifies that N3IWF locations are never considered
 // stale (they have no cell-level refresh mechanism).
 func TestIsLocationStale_N3IWF(t *testing.T) {
-	loc := &coremodels.N3gaLocation{
-		N3gppTai: &coremodels.Tai{
-			PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
-			Tac:    "0x00003c",
+	loc := coremodels.UserLocation{
+		N3gaLocation: &coremodels.N3gaLocation{
+			N3gppTai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00003c",
+			},
 		},
 	}
 	if IsLocationStale(loc, 10) {
@@ -415,7 +430,7 @@ func TestIsLocationStale_N3IWF(t *testing.T) {
 
 // TestIsLocationStale_Empty verifies that empty location returns true (always stale).
 func TestIsLocationStale_Empty(t *testing.T) {
-	var loc interface{} = coremodels.UserLocation{}
+	loc := coremodels.UserLocation{}
 	if !IsLocationStale(loc, 10) {
 		t.Error("expected empty location to be stale")
 	}
@@ -423,7 +438,9 @@ func TestIsLocationStale_Empty(t *testing.T) {
 
 // TestIsLocationStale_NR_NoTimestamp verifies that NR location without timestamp is stale.
 func TestIsLocationStale_NR_NoTimestamp(t *testing.T) {
-	loc := &coremodels.NrLocation{}
+	loc := coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{},
+	}
 	if !IsLocationStale(loc, 10) {
 		t.Error("expected NR location without timestamp to be stale")
 	}
@@ -431,7 +448,9 @@ func TestIsLocationStale_NR_NoTimestamp(t *testing.T) {
 
 // TestIsLocationStale_EUTRA_NoTimestamp verifies that E-UTRA location without timestamp is stale.
 func TestIsLocationStale_EUTRA_NoTimestamp(t *testing.T) {
-	loc := &coremodels.EutraLocation{}
+	loc := coremodels.UserLocation{
+		EutraLocation: &coremodels.EutraLocation{},
+	}
 	if !IsLocationStale(loc, 10) {
 		t.Error("expected E-UTRA location without timestamp to be stale")
 	}
@@ -522,5 +541,199 @@ func TestDetermineLocation_DefaultMaxAge(t *testing.T) {
 
 	if result.AccessType != "NR" {
 		t.Errorf("expected access_type NR, got %q", result.AccessType)
+	}
+}
+
+// TestRefreshLocation_Success verifies that when the RAN responds with a
+// LocationReport, the LMF receives the fresh location and uses it.
+func TestRefreshLocation_Success(t *testing.T) {
+	// NR Cell Identity is 28 bits: 0x00000004 -> hex "0000000" (7 chars)
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, testDBWithCell(t, db.RATNR, "262", "01", "0000000"))
+	lmfInstance.maxLocationAge = 10
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012348")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	staleTime := time.Now().Add(-20 * time.Second)
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			Tai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00001a",
+			},
+			Ncgi: &coremodels.Ncgi{
+				PlmnID:   &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				NrCellID: "0000000",
+			},
+			UeLocationTimestamp: &staleTime,
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	// Set up a fake gNB association so the AMF can send NGAP.
+	sender := &fakeNGAPSender{}
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	// Send a LocationReport message with EventType=Direct and NR user location.
+	// PLMN 262-01 in NGAP octets: reverse MCC="262"->"262", reverse MNC="01"->"10"
+	// Format for 2-digit MNC: mcc[1] mcc[2] f mcc[0] mnc[0] mnc[1] = "62f210"
+	plmnBytes, err := hex.DecodeString("62f210")
+	if err != nil {
+		t.Fatalf("failed to decode PLMN bytes: %v", err)
+	}
+	// NR Cell Identity is 28 bits: 0x00000004 -> bytes {0x00, 0x00, 0x00, 0x04}
+	// BitStringToHex truncates to 7 chars: "0000000"
+	nrLoc := ngapType.UserLocationInformationNR{
+		TAI: ngapType.TAI{
+			PLMNIdentity: ngapType.PLMNIdentity{
+				Value: plmnBytes,
+			},
+			TAC: ngapType.TAC{
+				Value: []byte{0x00, 0x1a},
+			},
+		},
+		NRCGI: ngapType.NRCGI{
+			PLMNIdentity: ngapType.PLMNIdentity{
+				Value: plmnBytes,
+			},
+			NRCellIdentity: ngapType.NRCellIdentity{
+				Value: aper.BitString{Bytes: []byte{0x00, 0x00, 0x00, 0x04}, BitLength: 28},
+			},
+		},
+	}
+	msg := decode.LocationReport{
+		AMFUENGAPID: 1,
+		RANUENGAPID: 1,
+		UserLocationInformation: &ngapType.UserLocationInformation{
+			Present:                   ngapType.UserLocationInformationPresentUserLocationInformationNR,
+			UserLocationInformationNR: &nrLoc,
+		},
+		LocationReportingRequestType: &ngapType.LocationReportingRequestType{
+			EventType: ngapType.EventType{
+				Value: ngapType.EventTypePresentDirect,
+			},
+			ReportArea: ngapType.ReportArea{
+				Value: ngapType.ReportAreaPresentCell,
+			},
+		},
+	}
+
+	// Simulate the RAN responding with a LocationReport.
+	// First verify the UE connection is registered.
+	foundUeConn := amfInstance.FindUEByAmfUeNgapID(radio, 1)
+	if foundUeConn == nil {
+		t.Fatal("AMF.FindUEByAmfUeNgapID returned nil - UE connection not registered")
+	}
+
+	t.Logf("Found UE connection: amfUeNgapID=%d, ranUeNgapID=%d", foundUeConn.AmfUeNgapID, foundUeConn.RanUeNgapID)
+
+	ngap.HandleLocationReport(context.Background(), amfInstance, radio, msg)
+
+	// Verify the AMF has updated the location.
+	loc := ue.GetUserLocation()
+	if loc.NrLocation == nil || loc.NrLocation.UeLocationTimestamp == nil {
+		t.Fatal("expected AMF to have updated location after LocationReport")
+	}
+
+	t.Logf("AMF location after LocationReport: cellID=%q, nrLocation=%+v, nrLocation.Ncgi=%+v, nrLocation.Ncgi.PlmnID=%+v",
+		loc.NrLocation.Ncgi.NrCellID, loc.NrLocation, loc.NrLocation.Ncgi, loc.NrLocation.Ncgi.PlmnID)
+
+	// Verify the database has the cell position.
+	rat, mcc, mnc, cellID := "nr", "262", "01", "0000000"
+
+	cp, err := lmfInstance.db.GetCellPositionByCell(context.Background(), rat, mcc, mnc, cellID)
+	if err != nil {
+		t.Fatalf("database lookup failed (rat=%s, mcc=%s, mnc=%s, cellID=%s): %v", rat, mcc, mnc, cellID, err)
+	}
+
+	t.Logf("Database cell position: lat=%f, lon=%f", cp.Latitude, cp.Longitude)
+
+	// Verify that resolveCellCoordinate works with the fresh location.
+	coord, ok := lmfInstance.resolveCellCoordinate(context.Background(), loc, nil)
+	if !ok {
+		t.Fatal("expected resolveCellCoordinate to return true for fresh location")
+	}
+
+	t.Logf("Resolved coordinate: lat=%f, lon=%f", coord.latitudeDegrees, coord.longitudeDegrees)
+
+	if coord.latitudeDegrees != cp.Latitude || coord.longitudeDegrees != cp.Longitude {
+		t.Errorf("expected coordinate lat=%f lon=%f, got lat=%f lon=%f", cp.Latitude, cp.Longitude, coord.latitudeDegrees, coord.longitudeDegrees)
+	}
+}
+
+// TestRefreshLocation_Timeout verifies that when the RAN does not respond,
+// the LMF returns the stale location after the timeout period (TS 23.273
+// §6.5.1 step 12 — the AMF may return last known location).
+func TestRefreshLocation_Timeout(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, testDBWithCell(t, db.RATNR, "262", "01", "0x00000003"))
+	lmfInstance.maxLocationAge = 10
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012349")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	staleTime := time.Now().Add(-20 * time.Second)
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			Tai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00001a",
+			},
+			Ncgi: &coremodels.Ncgi{
+				PlmnID:   &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				NrCellID: "0x00000003",
+			},
+			UeLocationTimestamp: &staleTime,
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	// Set up a fake gNB association (no LocationReport will be sent).
+	sender := &fakeNGAPSender{}
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	result, _, err := lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err != nil {
+		t.Fatalf("expected no error (stale location returned), got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.AccessType != "NR" {
+		t.Errorf("expected access_type NR, got %q", result.AccessType)
+	}
+
+	if result.NCGI == nil {
+		t.Error("expected NCGI to be set")
+	}
+
+	// Verify that a LocationReportingControl was sent via NGAP.
+	if sender.locationReportingControlCalls != 1 {
+		t.Errorf("expected 1 LocationReportingControl send, got %d", sender.locationReportingControlCalls)
 	}
 }

--- a/internal/lmf/engine_refresh_test.go
+++ b/internal/lmf/engine_refresh_test.go
@@ -1,0 +1,526 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package lmf
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/db"
+	coremodels "github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/sctp"
+	"go.uber.org/zap"
+)
+
+// locationReportingControlProcCode is the NGAP procedure code for
+// LocationReportingControl (TS 38.413 §9.2.3.2). Used to detect the message
+// in the fakeNGAPSender's byte-level inspection.
+const locationReportingControlProcCode = 16
+
+// fakeNGAPSender implements amf.NGAPWriter for tests, counting the number of
+// LocationReportingControl messages sent over the fake gNB association.
+type fakeNGAPSender struct {
+	locationReportingControlCalls int
+}
+
+// WriteMsg inspects the NGAP-PDU APER header to identify the procedure.
+// Byte 0 is the outcome choice (0x00 = InitiatingMessage), byte 1 is the
+// procedure code (TS 38.413).
+func (f *fakeNGAPSender) WriteMsg(b []byte, _ *sctp.SndRcvInfo) (int, error) {
+	if len(b) >= 2 && b[0] == 0x00 && int64(b[1]) == locationReportingControlProcCode {
+		f.locationReportingControlCalls++
+	}
+
+	return len(b), nil
+}
+
+// TestDetermineLocation_NR_StaleTriggersRefresh verifies that when the UE's NR
+// location is older than the configured maximum age, the LMF triggers the AMF to
+// send a LocationReportingControl(Direct) to the RAN (TS 23.273 §6.5.1 step 12).
+// The refresh is fire-and-forget: the current request returns the stale location
+// (with its provisioned cell coordinate), and the NGAP send is captured by the
+// fake gNB association.
+func TestDetermineLocation_NR_StaleTriggersRefresh(t *testing.T) {
+	maxAge := int32(10)
+
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, testDBWithCell(t, db.RATNR, "262", "01", "0x00000001"))
+	lmfInstance.maxLocationAge = maxAge
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012345")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	// Create a UE with a stale NR location (older than maxAge).
+	staleTime := time.Now().Add(-20 * time.Second)
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			Tai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00001a",
+			},
+			Ncgi: &coremodels.Ncgi{
+				PlmnID:   &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				NrCellID: "0x00000001",
+			},
+			UeLocationTimestamp: &staleTime,
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	// Set up a fake gNB association so the AMF can send NGAP.
+	sender := &fakeNGAPSender{}
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	result, _, err := lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// The stale location's cell is provisioned in the DB, so a coordinate
+	// should be returned (from the provisioned cell, not from a refresh).
+	if result.Latitude == 0 || result.Longitude == 0 {
+		t.Errorf("expected coordinate from cell-position table, got lat=%d lon=%d", result.Latitude, result.Longitude)
+	}
+
+	if result.AccessType != "NR" {
+		t.Errorf("expected access_type NR, got %q", result.AccessType)
+	}
+
+	if result.NCGI == nil {
+		t.Fatal("expected NCGI to be set")
+	}
+
+	// Verify that a LocationReportingControl was sent via NGAP.
+	if sender.locationReportingControlCalls != 1 {
+		t.Errorf("expected 1 LocationReportingControl send, got %d", sender.locationReportingControlCalls)
+	}
+}
+
+// TestDetermineLocation_NR_MissingLocationReturnsError verifies that when the UE
+// is registered but has NO location at all, the LMF returns an error immediately
+// (before any staleness check or refresh attempt).
+func TestDetermineLocation_NR_MissingLocationReturnsError(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, testDBWithCell(t, db.RATNR, "262", "01", "0x00000001"))
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012345")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	_, _, err = lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err == nil {
+		t.Fatal("expected error for UE with no location")
+	}
+}
+
+// TestDetermineLocation_NR_FreshNoRefresh verifies that when the UE has a fresh
+// location (within maxAge), the LMF returns it directly WITHOUT triggering a
+// LocationReportingControl to the RAN.
+func TestDetermineLocation_NR_FreshNoRefresh(t *testing.T) {
+	maxAge := int32(10)
+
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, testDBWithCell(t, db.RATNR, "001", "101", "0x00000001"))
+	lmfInstance.maxLocationAge = maxAge
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012345")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	freshTime := time.Now()
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			Tai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "001", Mnc: "101"},
+				Tac:    "0x00001a",
+			},
+			Ncgi: &coremodels.Ncgi{
+				PlmnID:   &coremodels.PlmnID{Mcc: "001", Mnc: "101"},
+				NrCellID: "0x00000001",
+			},
+			AgeOfLocationInformation: 3,
+			UeLocationTimestamp:      &freshTime,
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	// Set up a fake gNB association so we can verify no NGAP send.
+	sender := &fakeNGAPSender{}
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	result, _, err := lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.AccessType != "NR" {
+		t.Errorf("expected access_type NR, got %q", result.AccessType)
+	}
+
+	if result.NCGI == nil {
+		t.Fatal("expected NCGI to be set")
+	}
+
+	if sender.locationReportingControlCalls != 0 {
+		t.Errorf("expected no LocationReportingControl for fresh location, got %d sends", sender.locationReportingControlCalls)
+	}
+}
+
+// TestDetermineLocation_EUTRA_StaleTriggersRefresh verifies that E-UTRA locations
+// are also checked for staleness and trigger a refresh when stale. The fake gNB
+// association captures the NGAP send.
+func TestDetermineLocation_EUTRA_StaleTriggersRefresh(t *testing.T) {
+	maxAge := int32(10)
+
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, testDBWithCell(t, db.RATEUTRA, "262", "01", "0x00000002"))
+	lmfInstance.maxLocationAge = maxAge
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012346")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	staleTime := time.Now().Add(-20 * time.Second)
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		EutraLocation: &coremodels.EutraLocation{
+			Tai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00002b",
+			},
+			Ecgi: &coremodels.Ecgi{
+				PlmnID:      &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				EutraCellID: "0x00000002",
+			},
+			UeLocationTimestamp: &staleTime,
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	sender := &fakeNGAPSender{}
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	result, _, err := lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.AccessType != "EUTRA" {
+		t.Errorf("expected access_type EUTRA, got %q", result.AccessType)
+	}
+
+	if result.ECGI == nil {
+		t.Fatal("expected ECGI to be set")
+	}
+
+	if sender.locationReportingControlCalls != 1 {
+		t.Errorf("expected 1 LocationReportingControl send, got %d", sender.locationReportingControlCalls)
+	}
+}
+
+// TestDetermineLocation_NoCellPosition verifies that when the cell has no
+// provisioned position, the LMF returns ErrNoLocationEstimate even after
+// attempting a refresh.
+func TestDetermineLocation_NoCellPosition(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, nil)
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012345")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			Tai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00001a",
+			},
+			Ncgi: &coremodels.Ncgi{
+				PlmnID:   &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				NrCellID: "0x00000001",
+			},
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	_, _, err = lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err != ErrNoLocationEstimate {
+		t.Fatalf("expected ErrNoLocationEstimate, got: %v", err)
+	}
+}
+
+// TestDetermineLocation_N3IWF verifies that N3IWF (non-3GPP) access returns
+// a valid result without a cell coordinate (N3IWF has no cell ID).
+func TestDetermineLocation_N3IWF(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, nil)
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012347")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		N3gaLocation: &coremodels.N3gaLocation{
+			N3gppTai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00003c",
+			},
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	result, _, err := lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err != nil {
+		t.Fatalf("expected no error for N3IWF, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.AccessType != "N3IWF" {
+		t.Errorf("expected access_type N3IWF, got %q", result.AccessType)
+	}
+
+	if result.NCGI != nil {
+		t.Error("expected NCGI to be nil for N3IWF")
+	}
+
+	if result.ECGI != nil {
+		t.Error("expected ECGI to be nil for N3IWF")
+	}
+}
+
+// TestIsLocationStale_NR verifies the staleness check for NR locations.
+func TestIsLocationStale_NR(t *testing.T) {
+	fresh := &coremodels.NrLocation{
+		UeLocationTimestamp: func() *time.Time { t := time.Now(); return &t }(),
+	}
+	if IsLocationStale(fresh, 10) {
+		t.Error("expected fresh NR location to not be stale")
+	}
+
+	staleTime := time.Now().Add(-20 * time.Second)
+
+	stale := &coremodels.NrLocation{
+		UeLocationTimestamp: &staleTime,
+	}
+	if !IsLocationStale(stale, 10) {
+		t.Error("expected stale NR location to be stale")
+	}
+}
+
+// TestIsLocationStale_EUTRA verifies the staleness check for E-UTRA locations.
+func TestIsLocationStale_EUTRA(t *testing.T) {
+	fresh := &coremodels.EutraLocation{
+		UeLocationTimestamp: func() *time.Time { t := time.Now(); return &t }(),
+	}
+	if IsLocationStale(fresh, 10) {
+		t.Error("expected fresh E-UTRA location to not be stale")
+	}
+
+	staleTime := time.Now().Add(-20 * time.Second)
+
+	stale := &coremodels.EutraLocation{
+		UeLocationTimestamp: &staleTime,
+	}
+	if !IsLocationStale(stale, 10) {
+		t.Error("expected stale E-UTRA location to be stale")
+	}
+}
+
+// TestIsLocationStale_N3IWF verifies that N3IWF locations are never considered
+// stale (they have no cell-level refresh mechanism).
+func TestIsLocationStale_N3IWF(t *testing.T) {
+	loc := &coremodels.N3gaLocation{
+		N3gppTai: &coremodels.Tai{
+			PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+			Tac:    "0x00003c",
+		},
+	}
+	if IsLocationStale(loc, 10) {
+		t.Error("expected N3IWF location to never be stale")
+	}
+}
+
+// TestIsLocationStale_Empty verifies that empty location returns true (always stale).
+func TestIsLocationStale_Empty(t *testing.T) {
+	var loc interface{} = coremodels.UserLocation{}
+	if !IsLocationStale(loc, 10) {
+		t.Error("expected empty location to be stale")
+	}
+}
+
+// TestIsLocationStale_NR_NoTimestamp verifies that NR location without timestamp is stale.
+func TestIsLocationStale_NR_NoTimestamp(t *testing.T) {
+	loc := &coremodels.NrLocation{}
+	if !IsLocationStale(loc, 10) {
+		t.Error("expected NR location without timestamp to be stale")
+	}
+}
+
+// TestIsLocationStale_EUTRA_NoTimestamp verifies that E-UTRA location without timestamp is stale.
+func TestIsLocationStale_EUTRA_NoTimestamp(t *testing.T) {
+	loc := &coremodels.EutraLocation{}
+	if !IsLocationStale(loc, 10) {
+		t.Error("expected E-UTRA location without timestamp to be stale")
+	}
+}
+
+// TestComputeCellIDLocation_N3IWF_NoCoordinate verifies that N3IWF location
+// returns a result without requiring a cell position in the database.
+func TestComputeCellIDLocation_N3IWF_NoCoordinate(t *testing.T) {
+	supi, err := etsi.NewSUPIFromIMSI("123456789012347")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	lmfInstance := New(amf.New(nil, nil, nil), nil, nil)
+
+	result := computeCellIDLocation(supi, coremodels.UserLocation{
+		N3gaLocation: &coremodels.N3gaLocation{
+			N3gppTai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00003c",
+			},
+		},
+	})
+
+	if result == nil {
+		t.Fatal("expected non-nil result for N3IWF")
+	}
+
+	if result.AccessType != "N3IWF" {
+		t.Errorf("expected access_type N3IWF, got %q", result.AccessType)
+	}
+
+	coord, ok := lmfInstance.resolveCellCoordinate(context.Background(), result.GetUserLocation(), nil)
+	if ok {
+		t.Error("expected no coordinate for N3IWF location")
+	}
+
+	_ = coord
+}
+
+// TestDetermineLocation_DefaultMaxAge verifies that the default maxLocationAge
+// is 300 seconds (5 minutes), so Cell ID locations up to 5 minutes old are
+// considered fresh.
+func TestDetermineLocation_DefaultMaxAge(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+	lmfInstance := New(amfInstance, nil, testDBWithCell(t, db.RATNR, "262", "01", "0x00000001"))
+
+	if lmfInstance.maxLocationAge != defaultMaxLocationAge {
+		t.Errorf("expected default maxLocationAge %d, got %d", defaultMaxLocationAge, lmfInstance.maxLocationAge)
+	}
+
+	supi, err := etsi.NewSUPIFromIMSI("123456789012345")
+	if err != nil {
+		t.Fatalf("failed to create SUPI: %v", err)
+	}
+
+	fourMinutesAgo := time.Now().Add(-4 * time.Minute)
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.Location = coremodels.UserLocation{
+		NrLocation: &coremodels.NrLocation{
+			Tai: &coremodels.Tai{
+				PlmnID: &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				Tac:    "0x00001a",
+			},
+			Ncgi: &coremodels.Ncgi{
+				PlmnID:   &coremodels.PlmnID{Mcc: "262", Mnc: "01"},
+				NrCellID: "0x00000001",
+			},
+			AgeOfLocationInformation: 240,
+			UeLocationTimestamp:      &fourMinutesAgo,
+		},
+	}
+	ue.ForceStateForTest(amf.Registered)
+
+	if err := amfInstance.AddUeContextToPoolForTest(ue); err != nil {
+		t.Fatalf("failed to add UE to AMF: %v", err)
+	}
+
+	result, _, err := lmfInstance.DetermineLocation(context.Background(), supi, MethodCellID)
+	if err != nil {
+		t.Fatalf("expected no error for location within default maxAge, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.AccessType != "NR" {
+		t.Errorf("expected access_type NR, got %q", result.AccessType)
+	}
+}

--- a/internal/lmf/lmf.go
+++ b/internal/lmf/lmf.go
@@ -53,7 +53,18 @@ type LMF struct {
 	// ackSeq is the fallback downlink sequence counter for acknowledging a stray
 	// UE reply that arrives with no active session (TS 37.355 §4.3.2).
 	ackSeq atomic.Uint32
+	// maxLocationAge bounds how long the AMF's passively-maintained location is
+	// considered valid before the LMF triggers an active refresh via
+	// LocationReportingControl(Direct) (TS 23.273 §6.5.1 step 12).
+	maxLocationAge int32
 }
+
+// defaultMaxLocationAge is the default maximum age (in seconds) for the AMF's
+// passively-maintained location before the LMF triggers an active refresh.
+// TS 23.273 §6.5.1 does not mandate a specific value; 5 minutes balances
+// freshness against signalling load — Cell ID is coarse-grained and the AMF
+// gets location updates on every handover, path switch, and Location Report.
+const defaultMaxLocationAge = 300
 
 // New creates an LMF instance that reads UE location from the AMF (5G) and the
 // MME (4G).
@@ -61,13 +72,14 @@ func New(amfInstance *amf.AMF, mmeInstance *mme.MME, d *db.Database) *LMF {
 	logger.LmfLog.Info("LMF initialized")
 
 	return &LMF{
-		amf:         amfInstance,
-		mme:         mmeInstance,
-		db:          d,
-		sessionMgr:  NewSessionManager(d),
-		nrppaClient: nrppa.New(amfInstance),
-		lppaClient:  lppa.New(mmeInstance),
-		lppSessions: make(map[string]*lpp.Session),
+		amf:            amfInstance,
+		mme:            mmeInstance,
+		db:             d,
+		sessionMgr:     NewSessionManager(d),
+		nrppaClient:    nrppa.New(amfInstance),
+		lppaClient:     lppa.New(mmeInstance),
+		lppSessions:    make(map[string]*lpp.Session),
+		maxLocationAge: defaultMaxLocationAge,
 	}
 }
 

--- a/internal/lmf/lmf.go
+++ b/internal/lmf/lmf.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
@@ -52,19 +53,16 @@ type LMF struct {
 	lppMu       sync.RWMutex
 	// ackSeq is the fallback downlink sequence counter for acknowledging a stray
 	// UE reply that arrives with no active session (TS 37.355 §4.3.2).
-	ackSeq atomic.Uint32
-	// maxLocationAge bounds how long the AMF's passively-maintained location is
-	// considered valid before the LMF triggers an active refresh via
-	// LocationReportingControl(Direct) (TS 23.273 §6.5.1 step 12).
+	ackSeq         atomic.Uint32
 	maxLocationAge int32
 }
 
 // defaultMaxLocationAge is the default maximum age (in seconds) for the AMF's
 // passively-maintained location before the LMF triggers an active refresh.
-// TS 23.273 §6.5.1 does not mandate a specific value; 5 minutes balances
-// freshness against signalling load — Cell ID is coarse-grained and the AMF
-// gets location updates on every handover, path switch, and Location Report.
 const defaultMaxLocationAge = 300
+
+// defaultRefreshTimeout is the maximum time to wait for a location refresh.
+const defaultRefreshTimeout = 5 * time.Second
 
 // New creates an LMF instance that reads UE location from the AMF (5G) and the
 // MME (4G).

--- a/internal/lmf/models/location_result.go
+++ b/internal/lmf/models/location_result.go
@@ -58,4 +58,13 @@ type LocationResult struct {
 	UERxTxTimeDiff    *int32   `json:"ue_rx_tx_time_diff,omitempty"`  // UE Rx-Tx Time Difference (0..61565)
 	AoAAzimuthDegrees *float64 `json:"aoa_azimuth_degrees,omitempty"` // UL Angle of Arrival azimuth
 	AoAZenithDegrees  *float64 `json:"aoa_zenith_degrees,omitempty"`  // UL Angle of Arrival zenith
+
+	// UserLocation preserves the original UserLocation so callers can inspect
+	// the full NR/E-UTRA/N3IWF detail. Populated only internally.
+	UserLocation models.UserLocation `json:"-"`
+}
+
+// GetUserLocation returns the internal UserLocation that produced this result.
+func (r *LocationResult) GetUserLocation() models.UserLocation {
+	return r.UserLocation
 }


### PR DESCRIPTION
# Description

Refresh the Cell ID location from the RAN when it is older than 5 minutes. We currently return immediately with the potentially stale location to keep things simple. A second request will get the updated location if it has changed.

This includes the decoding logic for `LocationReportingControl` and `LocationReport` messages.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
