### PR TITLE
chore: replace free5gc util lib with ella networks maintained version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/free5gc/aper v1.1.1
 	github.com/free5gc/nas v1.2.3
 	github.com/free5gc/ngap v1.1.3
-	github.com/free5gc/util v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/gopacket v1.1.19
 	github.com/google/nftables v0.3.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/raft v1.7.3
@@ -31,15 +31,9 @@ require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/tools v0.47.0
 	gopkg.in/yaml.v2 v2.4.0
 )
-
-require (
-	github.com/google/gopacket v1.1.19
-	golang.org/x/tools v0.47.0
-)
-
-require golang.org/x/mod v0.37.0 // indirect
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -91,7 +85,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.0 // indirect
@@ -116,6 +109,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,6 @@ github.com/free5gc/ngap v1.1.3 h1:uT+IE5PkWOYjPdxCyOAwLDOXUiADcOQCs05CudyC36s=
 github.com/free5gc/ngap v1.1.3/go.mod h1:yGMO2GYV5DbbmudwD7Oo6dXQgz2ON29GhqtXDeXdyvA=
 github.com/free5gc/openapi v1.2.4 h1:uhyaTggUhd9xgMFcs5y2rCqFOfXuv6Zsr+cLUU/x6gs=
 github.com/free5gc/openapi v1.2.4/go.mod h1:V9CKQUqWp6kXL3SDtaIs4ZWeLipk5TSRXCnt+ntNceg=
-github.com/free5gc/util v1.3.2 h1:3BjZq050WbaLJY0w1Bn51YZlCirs2ARoCUxD3LDSdbo=
-github.com/free5gc/util v1.3.2/go.mod h1:wXObe2iF465VRdkE1Z5YkiSuHXlCT8HJ+yc7p9t5hMs=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gaissmai/bart v0.26.1 h1:+w4rnLGNlA2GDVn382Tfe3jOsK5vOr5n4KmigJ9lbTo=
@@ -221,7 +219,6 @@ github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNH
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/internal/tester/ue/auth.go
+++ b/internal/tester/ue/auth.go
@@ -6,9 +6,9 @@ package ue
 import (
 	"fmt"
 
+	"github.com/ellanetworks/core/internal/util/ueauth"
 	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/nas/security"
-	"github.com/free5gc/util/ueauth"
 )
 
 // TS 33.501 Annex A.9.
@@ -18,7 +18,7 @@ func AlgorithmKeyDerivation(cipheringAlg uint8, kamf []byte, knasEnc *[16]uint8,
 	P1 := []byte{cipheringAlg}
 	L1 := ueauth.KDFLen(P1)
 
-	kenc, err := ueauth.GetKDFValue(kamf, ueauth.FC_FOR_ALGORITHM_KEY_DERIVATION, P0, L0, P1, L1)
+	kenc, err := ueauth.GetKDFValue(kamf, ueauth.FCForAlgorithmKeyDerivation, P0, L0, P1, L1)
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func AlgorithmKeyDerivation(cipheringAlg uint8, kamf []byte, knasEnc *[16]uint8,
 	P1 = []byte{IntegrityAlg}
 	L1 = ueauth.KDFLen(P1)
 
-	kint, err := ueauth.GetKDFValue(kamf, ueauth.FC_FOR_ALGORITHM_KEY_DERIVATION, P0, L0, P1, L1)
+	kint, err := ueauth.GetKDFValue(kamf, ueauth.FCForAlgorithmKeyDerivation, P0, L0, P1, L1)
 	if err != nil {
 		return err
 	}

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -16,14 +16,14 @@ import (
 	"github.com/ellanetworks/core/internal/tester/air"
 	"github.com/ellanetworks/core/internal/tester/logger"
 	"github.com/ellanetworks/core/internal/tester/ue/sidf"
+	"github.com/ellanetworks/core/internal/util/milenage"
+	"github.com/ellanetworks/core/internal/util/ueauth"
 	"github.com/free5gc/nas"
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/nas/security"
 	"github.com/free5gc/ngap/ngapType"
 	"github.com/free5gc/openapi/models"
-	"github.com/free5gc/util/milenage"
-	"github.com/free5gc/util/ueauth"
 	"go.uber.org/zap"
 )
 
@@ -389,7 +389,7 @@ func (ue *UE) DeriveRESstarAndSetKey(authSubs models.AuthenticationSubscription,
 	}
 
 	key := append(CK, IK...)
-	FC := ueauth.FC_FOR_RES_STAR_XRES_STAR_DERIVATION
+	FC := ueauth.FCForResStarXresStarDerivation
 	P0 := []byte(snName)
 	P1 := RAND
 	P2 := RES
@@ -408,7 +408,7 @@ func (ue *UE) DeriveRESstarAndSetKey(authSubs models.AuthenticationSubscription,
 }
 
 func (ue *UE) DerivateKamf(key []byte, snName string, SQN, AK []byte) error {
-	FC := ueauth.FC_FOR_KAUSF_DERIVATION
+	FC := ueauth.FCForKausfDerivation
 	P0 := []byte(snName)
 	SQNxorAK := make([]byte, 6)
 
@@ -425,7 +425,7 @@ func (ue *UE) DerivateKamf(key []byte, snName string, SQN, AK []byte) error {
 
 	P0 = []byte(snName)
 
-	Kseaf, err := ueauth.GetKDFValue(Kausf, ueauth.FC_FOR_KSEAF_DERIVATION, P0, ueauth.KDFLen(P0))
+	Kseaf, err := ueauth.GetKDFValue(Kausf, ueauth.FCForKseafDerivation, P0, ueauth.KDFLen(P0))
 	if err != nil {
 		return fmt.Errorf("error while deriving Kseaf: %v", err)
 	}
@@ -438,7 +438,7 @@ func (ue *UE) DerivateKamf(key []byte, snName string, SQN, AK []byte) error {
 	P1 = []byte{0x00, 0x00}
 	L1 := ueauth.KDFLen(P1)
 
-	ue.UeSecurity.Kamf, err = ueauth.GetKDFValue(Kseaf, ueauth.FC_FOR_KAMF_DERIVATION, P0, L0, P1, L1)
+	ue.UeSecurity.Kamf, err = ueauth.GetKDFValue(Kseaf, ueauth.FCForKamfDerivation, P0, L0, P1, L1)
 	if err != nil {
 		return fmt.Errorf("error while deriving Kamf: %v", err)
 	}

--- a/internal/util/milenage/milenage.go
+++ b/internal/util/milenage/milenage.go
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// Copyright 2019 Communication Service/Software Laboratory, National Chiao Tung University (free5gc.org)
+// Modified by Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package milenage implements the 3GPP TS 35.205/35.206 MILENAGE authentication
+// functions used by the test UE to derive keys and handle resynchronisation.
+package milenage
+
+import (
+	"bytes"
+	"crypto/aes"
+	"fmt"
+)
+
+const (
+	kLen           = 16
+	opcLen         = 16
+	sqnLen         = 6
+	randLen        = 16
+	amfLen         = 2
+	macLen         = 8
+	resLen         = 8
+	ckLen          = 16
+	ikLen          = 16
+	akLen          = 6
+	autnLen        = 16
+	cipherBlockLen = 16
+)
+
+// Rotation constants r1..r5 from TS 35.206 §4.1.
+const (
+	r1 = 8
+	r3 = 4
+	r4 = 8
+	r5 = 12
+)
+
+// The AMF used to calculate MAC-S assumes a dummy value of all zeros.
+var resynchAMF = []byte{0x00, 0x00}
+
+type ParameterLengthError struct {
+	Name     string
+	Exact    int
+	Expected int
+}
+
+func (e *ParameterLengthError) Error() string {
+	return fmt.Sprintf("parameter[%s] length should be %d byte(s), not %d byte(s)", e.Name, e.Expected, e.Exact)
+}
+
+type MACFailureError struct {
+	MACName     string
+	ExpectedMAC []byte
+	ExactMAC    []byte
+}
+
+func (m *MACFailureError) Error() string {
+	return fmt.Sprintf("X%s[%x] not match %s[%x]", m.MACName, m.ExpectedMAC, m.MACName, m.ExactMAC)
+}
+
+func validateArg(arg []byte, argName string, expectedLen int) error {
+	if len(arg) != expectedLen {
+		return &ParameterLengthError{Name: argName, Exact: len(arg), Expected: expectedLen}
+	}
+
+	return nil
+}
+
+// xor returns (a XOR b) truncated to the shorter operand.
+func xor(a, b []byte) []byte {
+	outLen := len(a)
+	if len(b) < outLen {
+		outLen = len(b)
+	}
+
+	out := make([]byte, outLen)
+	for i := 0; i < outLen; i++ {
+		out[i] = a[i] ^ b[i]
+	}
+
+	return out
+}
+
+// f1 computes the network (MAC-A) and resync (MAC-S) authentication codes.
+func f1(opc, k, _rand, sqn, amf []byte) (macA, macS []byte, err error) {
+	macA, macS = make([]byte, macLen), make([]byte, macLen)
+
+	rijndaelInput := make([]byte, cipherBlockLen)
+	for i := 0; i < cipherBlockLen; i++ {
+		rijndaelInput[i] = _rand[i] ^ opc[i]
+	}
+
+	block, err := aes.NewCipher(k)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmp1 := make([]byte, block.BlockSize())
+	block.Encrypt(tmp1, rijndaelInput)
+
+	tmp2 := make([]byte, cipherBlockLen)
+	copy(tmp2[0:], sqn[0:6])
+	copy(tmp2[6:], amf[0:2])
+	copy(tmp2[8:], tmp2[0:8])
+
+	tmp3 := make([]byte, cipherBlockLen)
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp3[(i+(cipherBlockLen-r1))%cipherBlockLen] = tmp2[i] ^ opc[i]
+	}
+
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp3[i] ^= tmp1[i]
+	}
+
+	tmp1 = make([]byte, cipherBlockLen)
+	block.Encrypt(tmp1, tmp3)
+
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp1[i] ^= opc[i]
+	}
+
+	copy(macA[0:], tmp1[0:8])
+	copy(macS[0:], tmp1[8:16])
+
+	return macA, macS, nil
+}
+
+// f2345 computes RES (f2), CK (f3), IK (f4), AK (f5) and AK* (f5*).
+func f2345(opc, k, _rand []byte) (res, ck, ik, ak, akstar []byte, err error) {
+	res = make([]byte, resLen)
+	ck, ik = make([]byte, ckLen), make([]byte, ikLen)
+	ak, akstar = make([]byte, akLen), make([]byte, akLen)
+
+	tmp1 := make([]byte, cipherBlockLen)
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp1[i] = _rand[i] ^ opc[i]
+	}
+
+	block, err := aes.NewCipher(k)
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+
+	tmp2 := make([]byte, cipherBlockLen)
+	block.Encrypt(tmp2, tmp1)
+
+	/* f2 and f5: rotate by r2 (= 0, i.e. NOP) */
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp1[i] = tmp2[i] ^ opc[i]
+	}
+
+	tmp1[15] ^= 1 // XOR c2 (= ..01)
+
+	tmp3 := make([]byte, block.BlockSize())
+	block.Encrypt(tmp3, tmp1)
+
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp3[i] ^= opc[i]
+	}
+
+	copy(res[0:], tmp3[8:16]) // f2
+	copy(ak[0:], tmp3[0:6])   // f5
+
+	/* f3: rotate by r3 */
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp1[(i+(cipherBlockLen-r3))%cipherBlockLen] = tmp2[i] ^ opc[i]
+	}
+
+	tmp1[15] ^= 2 // XOR c3 (= ..02)
+
+	block.Encrypt(ck, tmp1)
+
+	for i := 0; i < cipherBlockLen; i++ {
+		ck[i] ^= opc[i]
+	}
+
+	/* f4: rotate by r4 */
+	for i := 0; i < ikLen; i++ {
+		tmp1[(i+(cipherBlockLen-r4))%cipherBlockLen] = tmp2[i] ^ opc[i]
+	}
+
+	tmp1[15] ^= 4 // XOR c4 (= ..04)
+
+	block.Encrypt(ik, tmp1)
+
+	for i := 0; i < ikLen; i++ {
+		ik[i] ^= opc[i]
+	}
+
+	/* f5*: rotate by r5 */
+	for i := 0; i < cipherBlockLen; i++ {
+		tmp1[(i+(cipherBlockLen-r5))%cipherBlockLen] = tmp2[i] ^ opc[i]
+	}
+
+	tmp1[15] ^= 8 // XOR c5 (= ..08)
+
+	block.Encrypt(tmp1, tmp1)
+
+	for i := 0; i < akLen; i++ {
+		akstar[i] = tmp1[i] ^ opc[i]
+	}
+
+	return res, ck, ik, ak, akstar, nil
+}
+
+// cutAUTN splits AUTN into (SQN XOR AK) || AMF || MAC-A.
+func cutAUTN(autn []byte) (sqn, amf, mac []byte) {
+	sqn = make([]byte, sqnLen)
+	amf = make([]byte, amfLen)
+	mac = make([]byte, macLen)
+
+	copy(sqn, autn[0:sqnLen])
+	copy(amf, autn[sqnLen:sqnLen+amfLen])
+	copy(mac, autn[sqnLen+amfLen:sqnLen+amfLen+macLen])
+
+	return sqn, amf, mac
+}
+
+// GenerateKeysWithAUTN derives SQN, AK, IK, CK and RES from AUTN and verifies MAC-A.
+func GenerateKeysWithAUTN(opc, k, rand, autn []byte) (sqnhe, ak, ik, ck, res []byte, err error) {
+	for _, a := range []struct {
+		val  []byte
+		name string
+		size int
+	}{{opc, "OPc", opcLen}, {k, "K", kLen}, {rand, "RAND", randLen}, {autn, "AUTN", autnLen}} {
+		if err = validateArg(a.val, a.name, a.size); err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+	}
+
+	res, ck, ik, ak, _, err = f2345(opc, k, rand)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("calculate F2345 failed: %w", err)
+	}
+
+	concSQNhe, amf, xmac := cutAUTN(autn)
+
+	sqnhe = xor(concSQNhe, ak)
+
+	mac, _, err := f1(opc, k, rand, sqnhe, amf)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("calculate F1 failed: %w", err)
+	}
+
+	if !bytes.Equal(xmac, mac) {
+		return nil, nil, nil, nil, nil, &MACFailureError{MACName: "MAC-A", ExpectedMAC: xmac, ExactMAC: mac}
+	}
+
+	return sqnhe, ak, ik, ck, res, nil
+}
+
+// GenerateAUTS builds the resynchronisation token AUTS = (SQNms XOR AK*) || MAC-S.
+func GenerateAUTS(opc, k, rand, sqnms []byte) (auts []byte, err error) {
+	for _, a := range []struct {
+		val  []byte
+		name string
+		size int
+	}{{opc, "OPc", opcLen}, {k, "K", kLen}, {rand, "RAND", randLen}, {sqnms, "SQNms", sqnLen}} {
+		if err = validateArg(a.val, a.name, a.size); err != nil {
+			return nil, err
+		}
+	}
+
+	_, _, _, _, akstar, err := f2345(opc, k, rand) //nolint:dogsled
+	if err != nil {
+		return nil, fmt.Errorf("calculate F2345 failed: %w", err)
+	}
+
+	concSQNms := xor(sqnms, akstar)
+
+	_, macS, err := f1(opc, k, rand, sqnms, resynchAMF)
+	if err != nil {
+		return nil, fmt.Errorf("calculate F1 failed: %w", err)
+	}
+
+	return append(concSQNms, macS...), nil
+}

--- a/internal/util/milenage/milenage_test.go
+++ b/internal/util/milenage/milenage_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package milenage_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/util/milenage"
+)
+
+// Test Set 1 from 3GPP TS 35.207 / TS 35.208 §4.3.
+const (
+	ts1OPc  = "cd63cb71954a9f4e48a5994e37a02baf"
+	ts1K    = "465b5ce8b199b49faa5f0a2ee238a6bc"
+	ts1RAND = "23553cbe9637a89d218ae64dae47bf35"
+	ts1SQN  = "ff9bb4d0b607"
+	ts1AMF  = "b9b9"
+	ts1MACA = "4a9ffac354dfafb3"                 // f1
+	ts1RES  = "a54211d5e3ba50bf"                 // f2
+	ts1CK   = "b40ba9a3c58b2a05bbf0d987b21bf8cb" // f3
+	ts1IK   = "f769bcd751044604127672711c6d3441" // f4
+	ts1AK   = "aa689c648370"                     // f5
+	ts1AKS  = "451e8beca43b"                     // f5*
+)
+
+func mustDecode(t *testing.T, s string) []byte {
+	t.Helper()
+
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode %q: %v", s, err)
+	}
+
+	return b
+}
+
+func xorBytes(a, b []byte) []byte {
+	out := make([]byte, len(a))
+	for i := range a {
+		out[i] = a[i] ^ b[i]
+	}
+
+	return out
+}
+
+func TestGenerateKeysWithAUTN(t *testing.T) {
+	opc := mustDecode(t, ts1OPc)
+	k := mustDecode(t, ts1K)
+	rand := mustDecode(t, ts1RAND)
+	sqn := mustDecode(t, ts1SQN)
+	ak := mustDecode(t, ts1AK)
+
+	// AUTN = (SQN XOR AK) || AMF || MAC-A.
+	autn := append(xorBytes(sqn, ak), mustDecode(t, ts1AMF)...)
+	autn = append(autn, mustDecode(t, ts1MACA)...)
+
+	gotSQN, gotAK, gotIK, gotCK, gotRES, err := milenage.GenerateKeysWithAUTN(opc, k, rand, autn)
+	if err != nil {
+		t.Fatalf("GenerateKeysWithAUTN: %v", err)
+	}
+
+	for _, c := range []struct {
+		name string
+		got  []byte
+		want string
+	}{
+		{"SQN", gotSQN, ts1SQN},
+		{"AK", gotAK, ts1AK},
+		{"IK", gotIK, ts1IK},
+		{"CK", gotCK, ts1CK},
+		{"RES", gotRES, ts1RES},
+	} {
+		if got := hex.EncodeToString(c.got); got != c.want {
+			t.Errorf("%s = %s, want %s", c.name, got, c.want)
+		}
+	}
+}
+
+func TestGenerateKeysWithAUTNMACFailure(t *testing.T) {
+	opc := mustDecode(t, ts1OPc)
+	k := mustDecode(t, ts1K)
+	rand := mustDecode(t, ts1RAND)
+	sqn := mustDecode(t, ts1SQN)
+	ak := mustDecode(t, ts1AK)
+
+	autn := append(xorBytes(sqn, ak), mustDecode(t, ts1AMF)...)
+	autn = append(autn, mustDecode(t, ts1MACA)...)
+	autn[len(autn)-1] ^= 0xff // corrupt MAC-A
+
+	if _, _, _, _, _, err := milenage.GenerateKeysWithAUTN(opc, k, rand, autn); err == nil {
+		t.Fatal("expected MAC failure, got nil")
+	}
+}
+
+func TestGenerateAUTS(t *testing.T) {
+	opc := mustDecode(t, ts1OPc)
+	k := mustDecode(t, ts1K)
+	rand := mustDecode(t, ts1RAND)
+	sqnms := mustDecode(t, ts1SQN)
+
+	auts, err := milenage.GenerateAUTS(opc, k, rand, sqnms)
+	if err != nil {
+		t.Fatalf("GenerateAUTS: %v", err)
+	}
+
+	// AUTS = (SQNms XOR AK*) || MAC-S; MAC-S uses the all-zero resync AMF
+	// (TS 33.102 §6.3.3), so only the AK*-masked prefix has a published vector.
+	if len(auts) != 14 {
+		t.Fatalf("AUTS length = %d, want 14", len(auts))
+	}
+
+	wantPrefix := hex.EncodeToString(xorBytes(sqnms, mustDecode(t, ts1AKS)))
+	if got := hex.EncodeToString(auts[:6]); got != wantPrefix {
+		t.Errorf("AUTS SQNms XOR AK* = %s, want %s", got, wantPrefix)
+	}
+}
+
+func TestValidatesArgLengths(t *testing.T) {
+	valid := make([]byte, 16)
+	sqn := make([]byte, 6)
+
+	if _, _, _, _, _, err := milenage.GenerateKeysWithAUTN(valid[:4], valid, valid, valid); err == nil {
+		t.Error("expected error for short OPc")
+	}
+
+	if _, err := milenage.GenerateAUTS(valid, valid, valid, sqn[:2]); err == nil {
+		t.Error("expected error for short SQNms")
+	}
+}


### PR DESCRIPTION
# Description

We already maintain our own milenage tooling, but the core tester code (used for integration tests) was still using the free5gc version.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
