### PR TITLE
fix: suppress downlink data notification on paging failure

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -62,8 +62,8 @@ type SmfSbi interface {
 	ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error
 	GetSessionPolicy(ctx context.Context, supi etsi.SUPI, snssai *models.Snssai, dnn string) (*smf.Policy, error)
 	HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
-	// ClearPagingSuppression re-arms downlink data notification once the UE is
-	// reachable again (CM-CONNECTED), so subsequent downlink data pages it
+	// ClearPagingSuppression releases the suppression once the UE is reachable
+	// again (CM-CONNECTED), so subsequent downlink data pages it
 	// (TS 23.502 §4.2.3.3 step 3c).
 	ClearPagingSuppression(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
 }
@@ -651,14 +651,17 @@ func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 func (amf *AMF) abandonPaging(ue *UeContext) {
 	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
 
-	msg := ue.N1N2Message()
-	if msg == nil {
+	if amf.Session == nil {
 		return
 	}
 
-	if err := amf.Session.HandlePagingFailure(context.Background(), ue.Supi(), msg.PduSessionID); err != nil {
-		logger.AmfLog.Warn("failed to suppress downlink notification after paging failure",
-			logger.SUPI(ue.Supi().String()), zap.Error(err))
+	supi := ue.Supi()
+
+	for id := range ue.SmContextSnapshot() {
+		if err := amf.Session.HandlePagingFailure(context.Background(), supi, id); err != nil {
+			logger.AmfLog.Warn("failed to suppress downlink notification after paging failure",
+				logger.SUPI(supi.String()), zap.Error(err))
+		}
 	}
 }
 

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -597,7 +597,7 @@ func (a *AMF) NewUeConn(radio *Radio, ranUeNgapID models.RanUeNgapID) (*UeConn, 
 }
 
 // SendPaging pages an idle UE and arms its paging-supervision timer. The timer is
-// per-UE and persistent (T3513, TS 24.501 §5.4.3): paging targets a UE with no NAS
+// per-UE and persistent (T3513, TS 24.501 §5.6.2): paging targets a UE with no NAS
 // connection, so the timer cannot live on the connection object.
 func (amf *AMF) SendPaging(ctx context.Context, ue *UeContext, ngapBuf []byte) error {
 	if ue == nil {
@@ -614,7 +614,7 @@ func (amf *AMF) SendPaging(ctx context.Context, ue *UeContext, ngapBuf []byte) e
 }
 
 // armPaging starts the paging-supervision guard for a UE just paged: retransmit Paging on
-// each interval up to a bound, then abandon (T3513, TS 24.501 §5.4.3). Check-and-arm under
+// each interval up to a bound, then abandon (T3513, TS 24.501 §5.6.2). Check-and-arm under
 // the UE lock so a second downlink trigger cannot reset an in-flight supervision. No-op when
 // T3513 is disabled.
 func (amf *AMF) armPaging(ue *UeContext, ngapBuf []byte) {
@@ -630,7 +630,7 @@ func (amf *AMF) armPaging(ue *UeContext, ngapBuf []byte) {
 		func() { amf.abandonPaging(ue) })
 }
 
-// retransmitPaging resends the Paging each guard interval (T3513, TS 24.501 §5.4.3), or
+// retransmitPaging resends the Paging each guard interval (T3513, TS 24.501 §5.6.2), or
 // stops the guard once the UE has answered by re-establishing its connection.
 func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 	if ue.Conn() != nil {
@@ -642,10 +642,8 @@ func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 	amf.pageRadios(context.Background(), ue, ngapBuf)
 }
 
-// abandonPaging runs when the retransmission budget is exhausted (TS 24.501 §5.4.3).
-// It suppresses the anchor's downlink data notification so further downlink packets
-// do not re-page an unreachable UE; paging resumes when the UE returns and the user
-// plane is reactivated (TS 23.502 §4.2.3.3).
+// abandonPaging suppresses the anchor's downlink data notification so further
+// downlink packets do not re-page an unreachable UE (TS 23.502 §4.2.3.3).
 func (amf *AMF) abandonPaging(ue *UeContext) {
 	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
 

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -62,6 +62,10 @@ type SmfSbi interface {
 	ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error
 	GetSessionPolicy(ctx context.Context, supi etsi.SUPI, snssai *models.Snssai, dnn string) (*smf.Policy, error)
 	HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
+	// ClearPagingSuppression re-arms downlink data notification once the UE is
+	// reachable again (CM-CONNECTED), so subsequent downlink data pages it
+	// (TS 23.502 §4.2.3.3 step 3c).
+	ClearPagingSuppression(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
 }
 
 type NetworkFeatureSupport5GS struct {

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -643,7 +643,9 @@ func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 }
 
 // abandonPaging runs when the retransmission budget is exhausted (TS 24.501 §5.4.3).
-// The anchor is notified so later downlink data re-pages the UE (TS 23.502 §4.2.3.3).
+// It suppresses the anchor's downlink data notification so further downlink packets
+// do not re-page an unreachable UE; paging resumes when the UE returns and the user
+// plane is reactivated (TS 23.502 §4.2.3.3).
 func (amf *AMF) abandonPaging(ue *UeContext) {
 	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
 
@@ -653,7 +655,7 @@ func (amf *AMF) abandonPaging(ue *UeContext) {
 	}
 
 	if err := amf.Session.HandlePagingFailure(context.Background(), ue.Supi(), msg.PduSessionID); err != nil {
-		logger.AmfLog.Warn("failed to re-arm paging after failure",
+		logger.AmfLog.Warn("failed to suppress downlink notification after paging failure",
 			logger.SUPI(ue.Supi().String()), zap.Error(err))
 	}
 }

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -265,6 +265,28 @@ func (a *AMF) AttachUeConn(ue *UeContext, ueConn *UeConn) {
 			logger.AmfLog.Error("failed to release superseded RAN UE on adopt", zap.Error(err))
 		}
 	}
+
+	a.clearPagingSuppression(context.Background(), ue)
+}
+
+// clearPagingSuppression re-arms downlink data notification on the UE's sessions now
+// that it has re-established a signalling connection and is reachable again — the
+// integrated-core equivalent of the SMF resuming on a UE-reachability notification
+// (TS 23.502 §4.2.3.3 step 3c). Runs outside the registry lock: the anchor must not
+// be called while amf.mu is held.
+func (a *AMF) clearPagingSuppression(ctx context.Context, ue *UeContext) {
+	if a.Session == nil {
+		return
+	}
+
+	supi := ue.Supi()
+
+	for id := range ue.SmContextSnapshot() {
+		if err := a.Session.ClearPagingSuppression(ctx, supi, id); err != nil {
+			logger.AmfLog.Warn("failed to clear paging suppression on reconnect",
+				logger.SUPI(supi.String()), zap.Error(err))
+		}
+	}
 }
 
 // AllocateRegistrationArea assigns the UE's registered tracking area: the whole served

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -269,11 +269,8 @@ func (a *AMF) AttachUeConn(ue *UeContext, ueConn *UeConn) {
 	a.clearPagingSuppression(context.Background(), ue)
 }
 
-// clearPagingSuppression re-arms downlink data notification on the UE's sessions now
-// that it has re-established a signalling connection and is reachable again — the
-// integrated-core equivalent of the SMF resuming on a UE-reachability notification
-// (TS 23.502 §4.2.3.3 step 3c). Runs outside the registry lock: the anchor must not
-// be called while amf.mu is held.
+// clearPagingSuppression runs outside the registry lock: the anchor must not be
+// called while amf.mu is held.
 func (a *AMF) clearPagingSuppression(ctx context.Context, ue *UeContext) {
 	if a.Session == nil {
 		return

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -18,6 +18,7 @@ import (
 type deregisterTestSmf struct {
 	releaseCalls          []string
 	deactivateCalls       []string
+	suppressCalls         int
 	clearSuppressionCalls int
 	onRelease             func(context.Context, string) error
 
@@ -53,6 +54,7 @@ func (s *deregisterTestSmf) DeactivateSmContext(_ context.Context, smContextRef 
 }
 
 func (s *deregisterTestSmf) HandlePagingFailure(_ context.Context, _ etsi.SUPI, _ uint8) error {
+	s.suppressCalls++
 	return nil
 }
 
@@ -307,5 +309,21 @@ func TestAttachUeConn_ClearsPagingSuppression(t *testing.T) {
 
 	if fake.clearSuppressionCalls != 2 {
 		t.Fatalf("clear-suppression calls = %d, want 2 (one per SM context)", fake.clearSuppressionCalls)
+	}
+}
+
+func TestAbandonPaging_SuppressesAllSessions(t *testing.T) {
+	fake := &deregisterTestSmf{}
+	a := New(nil, nil, nil)
+	a.Session = fake
+
+	ue := NewUeContext()
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
+	ue.SmContextList[2] = &SmContext{Ref: "ref-2"}
+
+	a.abandonPaging(ue)
+
+	if fake.suppressCalls != 2 {
+		t.Fatalf("suppress calls = %d, want 2 (one per SM context)", fake.suppressCalls)
 	}
 }

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -16,9 +16,10 @@ import (
 )
 
 type deregisterTestSmf struct {
-	releaseCalls    []string
-	deactivateCalls []string
-	onRelease       func(context.Context, string) error
+	releaseCalls          []string
+	deactivateCalls       []string
+	clearSuppressionCalls int
+	onRelease             func(context.Context, string) error
 
 	// Optional hooks for reconcile tests; nil keeps the default (no-op) behaviour.
 	session       func(ref string) *smf.SMContext
@@ -52,6 +53,11 @@ func (s *deregisterTestSmf) DeactivateSmContext(_ context.Context, smContextRef 
 }
 
 func (s *deregisterTestSmf) HandlePagingFailure(_ context.Context, _ etsi.SUPI, _ uint8) error {
+	return nil
+}
+
+func (s *deregisterTestSmf) ClearPagingSuppression(_ context.Context, _ etsi.SUPI, _ uint8) error {
+	s.clearSuppressionCalls++
 	return nil
 }
 
@@ -280,5 +286,26 @@ func TestReconcileSessionsForUE_AppliesResolvedPolicy(t *testing.T) {
 
 	if req.NewPolicy == nil || req.NewPolicy.SessionAmbrDownlink != "2 Gbps" {
 		t.Fatalf("reconcile did not carry the resolved policy: %+v", req.NewPolicy)
+	}
+}
+
+func TestAttachUeConn_ClearsPagingSuppression(t *testing.T) {
+	fake := &deregisterTestSmf{}
+	a := New(nil, nil, nil)
+	a.Session = fake
+
+	radio := &Radio{Log: logger.AmfLog}
+	radio.BindAMFForTest(a)
+
+	ueConn := NewUeConnForTest(radio, 1, 10, logger.AmfLog)
+
+	ue := NewUeContext()
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
+	ue.SmContextList[2] = &SmContext{Ref: "ref-2"}
+
+	a.AttachUeConn(ue, ueConn)
+
+	if fake.clearSuppressionCalls != 2 {
+		t.Fatalf("clear-suppression calls = %d, want 2 (one per SM context)", fake.clearSuppressionCalls)
 	}
 }

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -105,7 +105,9 @@ func (f *fakeSmf) CreateSmContext(context.Context, etsi.SUPI, uint8, string, *mo
 func (f *fakeSmf) ActivateSmContext(context.Context, string) ([]byte, error)   { return nil, nil }
 func (f *fakeSmf) DeactivateSmContext(context.Context, string) error           { return nil }
 func (f *fakeSmf) HandlePagingFailure(context.Context, etsi.SUPI, uint8) error { return nil }
-func (f *fakeSmf) ReleaseSmContext(context.Context, string) error              { return nil }
+
+func (f *fakeSmf) ClearPagingSuppression(context.Context, etsi.SUPI, uint8) error { return nil }
+func (f *fakeSmf) ReleaseSmContext(context.Context, string) error                 { return nil }
 func (f *fakeSmf) UpdateSmContextN1Msg(context.Context, string, []byte) (*smf.UpdateResult, error) {
 	return nil, nil
 }

--- a/internal/amf/nas/handle_test.go
+++ b/internal/amf/nas/handle_test.go
@@ -440,6 +440,10 @@ func (s *fakeSmf) HandlePagingFailure(_ context.Context, _ etsi.SUPI, _ uint8) e
 	return s.Error
 }
 
+func (s *fakeSmf) ClearPagingSuppression(_ context.Context, _ etsi.SUPI, _ uint8) error {
+	return s.Error
+}
+
 func (s *fakeSmf) UpdateSmContextN2InfoPduResSetupRsp(_ context.Context, _ string, _ []byte) error {
 	return s.Error
 }

--- a/internal/amf/ngap/handle_test.go
+++ b/internal/amf/ngap/handle_test.go
@@ -112,6 +112,10 @@ func (f *fakeSmfSbi) ActivateSmContext(_ context.Context, smContextRef string) (
 	return nil, nil
 }
 
+func (f *fakeSmfSbi) ClearPagingSuppression(_ context.Context, _ etsi.SUPI, _ uint8) error {
+	return nil
+}
+
 func (f *fakeSmfSbi) ReleaseSmContext(ctx context.Context, smContextRef string) error {
 	f.ReleaseSmContextCalls = append(f.ReleaseSmContextCalls, smContextRef)
 	return nil

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -298,6 +298,8 @@ func (f *fakeUPFClient) FlushUsage(ctx context.Context, remoteSEID uint64) {}
 
 func (f *fakeUPFClient) SuppressDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {}
 
+func (f *fakeUPFClient) ClearDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {}
+
 func (f *fakeUPFClient) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return nil
 }

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -296,7 +296,7 @@ func (f *fakeUPFClient) DeleteSession(ctx context.Context, remoteSEID uint64) er
 
 func (f *fakeUPFClient) FlushUsage(ctx context.Context, remoteSEID uint64) {}
 
-func (f *fakeUPFClient) ResetDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {}
+func (f *fakeUPFClient) SuppressDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {}
 
 func (f *fakeUPFClient) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return nil

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -67,6 +67,7 @@ type fakeSessionManager struct {
 	staticIPChanged bool  // StaticIPChanged returns this
 	staticIPErr     error // when set, StaticIPChanged fails with it
 
+	suppressCalls         int // counts HandleEPSPagingFailure calls
 	clearSuppressionCalls int // counts ClearEPSPagingSuppression calls
 }
 
@@ -120,6 +121,7 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string, _
 }
 
 func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+	f.suppressCalls++
 	return nil
 }
 

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -66,6 +66,8 @@ type fakeSessionManager struct {
 	framedErr       error // when set, FramedRoutesChanged fails with it
 	staticIPChanged bool  // StaticIPChanged returns this
 	staticIPErr     error // when set, StaticIPChanged fails with it
+
+	clearSuppressionCalls int // counts ClearEPSPagingSuppression calls
 }
 
 func (f *fakeSessionManager) CreateEPSSession(_ context.Context, req models.EPSBearerRequest) (models.EPSBearer, error) {
@@ -118,6 +120,11 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string, _
 }
 
 func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+	return nil
+}
+
+func (f *fakeSessionManager) ClearEPSPagingSuppression(_ context.Context, _ string, _ uint8) error {
+	f.clearSuppressionCalls++
 	return nil
 }
 

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -57,6 +57,10 @@ type epsSessionManager interface {
 	// so downlink data triggers paging.
 	DeactivateEPSSession(ctx context.Context, imsi string, ebi uint8) error
 	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error
+	// ClearEPSPagingSuppression re-arms downlink data notification once the UE is
+	// reachable again (ECM-CONNECTED), so buffered-then-suppressed downlink data
+	// pages it (TS 24.301 §5.3.5; TS 23.401 §5.3.4.3).
+	ClearEPSPagingSuppression(ctx context.Context, imsi string, ebi uint8) error
 	// ReleaseEPSSession releases the anchor session identified by its unique ref
 	// (as returned in models.EPSBearer.Ref and stored on the PDN connection), so a
 	// superseded context releases its own session and never a newer one that reused

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -58,8 +58,8 @@ type epsSessionManager interface {
 	DeactivateEPSSession(ctx context.Context, imsi string, ebi uint8) error
 	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error
 	// ClearEPSPagingSuppression re-arms downlink data notification once the UE is
-	// reachable again (ECM-CONNECTED), so buffered-then-suppressed downlink data
-	// pages it (TS 24.301 §5.3.5; TS 23.401 §5.3.4.3).
+	// reachable again (ECM-CONNECTED), so subsequent downlink data pages it
+	// (TS 24.301 §5.3.5; TS 23.401 §5.3.4.3).
 	ClearEPSPagingSuppression(ctx context.Context, imsi string, ebi uint8) error
 	// ReleaseEPSSession releases the anchor session identified by its unique ref
 	// (as returned in models.EPSBearer.Ref and stored on the PDN connection), so a

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -57,8 +57,8 @@ type epsSessionManager interface {
 	// so downlink data triggers paging.
 	DeactivateEPSSession(ctx context.Context, imsi string, ebi uint8) error
 	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error
-	// ClearEPSPagingSuppression re-arms downlink data notification once the UE is
-	// reachable again (ECM-CONNECTED), so subsequent downlink data pages it
+	// ClearEPSPagingSuppression releases the suppression once the UE is reachable
+	// again (ECM-CONNECTED), so subsequent downlink data pages it
 	// (TS 24.301 §5.3.5; TS 23.401 §5.3.4.3).
 	ClearEPSPagingSuppression(ctx context.Context, imsi string, ebi uint8) error
 	// ReleaseEPSSession releases the anchor session identified by its unique ref

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -633,9 +633,33 @@ func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) {
 // releasing any superseded connection.
 func (m *MME) AttachUeConn(ue *UeContext, c *UeConn) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.attachUeConnLocked(ue, c)
+	m.mu.Unlock()
+
+	m.clearPagingSuppression(context.Background(), ue)
+}
+
+// clearPagingSuppression re-arms downlink data notification on the UE's sessions now
+// that it has re-established a signalling connection and is reachable again — the EPS
+// analogue of the mobile-reachable timer stopping on NAS-connection setup (TS 24.301
+// §5.3.5) and of the reachability recovery in TS 23.401 §5.3.4.3. Runs outside the
+// registry lock: the anchor must not be called while m.mu is held.
+func (m *MME) clearPagingSuppression(ctx context.Context, ue *UeContext) {
+	if m.Session == nil {
+		return
+	}
+
+	imsi := ue.imsiOrEmpty()
+	if imsi == "" {
+		return
+	}
+
+	for _, p := range m.SnapshotPDNs(ue) {
+		if err := m.Session.ClearEPSPagingSuppression(ctx, imsi, p.Ebi); err != nil {
+			logger.MmeLog.Warn("failed to clear paging suppression on reconnect",
+				zap.String("imsi", imsi), zap.Uint8("ebi", p.Ebi), zap.Error(err))
+		}
+	}
 }
 
 // freeUeConnLocked releases the UE's current S1-connection (moving it to

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -639,11 +639,8 @@ func (m *MME) AttachUeConn(ue *UeContext, c *UeConn) {
 	m.clearPagingSuppression(context.Background(), ue)
 }
 
-// clearPagingSuppression re-arms downlink data notification on the UE's sessions now
-// that it has re-established a signalling connection and is reachable again — the EPS
-// analogue of the mobile-reachable timer stopping on NAS-connection setup (TS 24.301
-// §5.3.5) and of the reachability recovery in TS 23.401 §5.3.4.3. Runs outside the
-// registry lock: the anchor must not be called while m.mu is held.
+// clearPagingSuppression runs outside the registry lock: the anchor must not be
+// called while m.mu is held.
 func (m *MME) clearPagingSuppression(ctx context.Context, ue *UeContext) {
 	if m.Session == nil {
 		return

--- a/internal/mme/mme_ue_test.go
+++ b/internal/mme/mme_ue_test.go
@@ -83,3 +83,20 @@ func TestAttachUeConn_ClearsEPSPagingSuppression(t *testing.T) {
 		t.Fatalf("clear-suppression calls = %d, want 2 (one per PDN)", fake.clearSuppressionCalls)
 	}
 }
+
+func TestAbandonPaging_SuppressesAllPDNs(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Pdns = map[uint8]*PdnConnection{
+		5: {Ebi: 5},
+		6: {Ebi: 6},
+	}
+
+	m.abandonPaging(ue)
+
+	fake := m.Session.(*fakeSessionManager)
+	if fake.suppressCalls != 2 {
+		t.Fatalf("suppress calls = %d, want 2 (one per PDN)", fake.suppressCalls)
+	}
+}

--- a/internal/mme/mme_ue_test.go
+++ b/internal/mme/mme_ue_test.go
@@ -66,3 +66,20 @@ func establishResumeForTest(m *MME, ue *UeContext, conn S1APWriter, enbUEID s1ap
 	m.AttachUeConn(ue, c)
 	c.MarkSecureExchangeEstablished()
 }
+
+func TestAttachUeConn_ClearsEPSPagingSuppression(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Pdns = map[uint8]*PdnConnection{
+		5: {Ebi: 5},
+		6: {Ebi: 6},
+	}
+
+	m.AttachUeConn(ue, m.NewUeConn(&captureConn{}, 9))
+
+	fake := m.Session.(*fakeSessionManager)
+	if fake.clearSuppressionCalls != 2 {
+		t.Fatalf("clear-suppression calls = %d, want 2 (one per PDN)", fake.clearSuppressionCalls)
+	}
+}

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -123,6 +123,10 @@ func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string,
 	return nil
 }
 
+func (f *fakeSessionManager) ClearEPSPagingSuppression(_ context.Context, _ string, _ uint8) error {
+	return nil
+}
+
 func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) error {
 	f.released = true
 

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -97,11 +97,9 @@ func (m *MME) retransmitPaging(ue *UeContext, pdu []byte, attempt int32) {
 	m.pageRadios(context.Background(), ue, pdu)
 }
 
-// abandonPaging runs once the retransmission budget is exhausted (TS 24.301
-// §5.6.2; TS 23.401 §5.3.4.3). It suppresses the anchor's downlink data
-// notification so further downlink packets do not re-page an unreachable UE; the
-// UE stays under mobile-reachable supervision until it returns or is implicitly
-// detached.
+// abandonPaging suppresses the anchor's downlink data notification so further
+// downlink packets do not re-page an unreachable UE (TS 23.401 §5.3.4.3); the UE
+// stays under mobile-reachable supervision until it returns or is implicitly detached.
 func (m *MME) abandonPaging(ue *UeContext) {
 	m.mu.RLock()
 

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -98,9 +98,10 @@ func (m *MME) retransmitPaging(ue *UeContext, pdu []byte, attempt int32) {
 }
 
 // abandonPaging runs once the retransmission budget is exhausted (TS 24.301
-// §5.6.2; TS 23.401 §5.3.4.3). The buffered downlink data remains at the anchor
-// and the UE stays under mobile-reachable supervision until it returns or is
-// implicitly detached.
+// §5.6.2; TS 23.401 §5.3.4.3). It suppresses the anchor's downlink data
+// notification so further downlink packets do not re-page an unreachable UE; the
+// UE stays under mobile-reachable supervision until it returns or is implicitly
+// detached.
 func (m *MME) abandonPaging(ue *UeContext) {
 	m.mu.RLock()
 
@@ -113,7 +114,7 @@ func (m *MME) abandonPaging(ue *UeContext) {
 	ctx := context.Background()
 	for _, p := range m.SnapshotPDNs(ue) {
 		if err := m.Session.HandleEPSPagingFailure(ctx, imsi, p.Ebi); err != nil {
-			logger.MmeLog.Warn("failed to re-arm paging after failure",
+			logger.MmeLog.Warn("failed to suppress downlink notification after paging failure",
 				zap.String("imsi", imsi), zap.Uint8("ebi", p.Ebi), zap.Error(err))
 		}
 	}

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -109,6 +109,10 @@ func (m *MME) abandonPaging(ue *UeContext) {
 
 	logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
 
+	if m.Session == nil {
+		return
+	}
+
 	ctx := context.Background()
 	for _, p := range m.SnapshotPDNs(ue) {
 		if err := m.Session.HandleEPSPagingFailure(ctx, imsi, p.Ebi); err != nil {

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -146,6 +146,10 @@ func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string,
 	return nil
 }
 
+func (f *fakeSessionManager) ClearEPSPagingSuppression(_ context.Context, _ string, _ uint8) error {
+	return nil
+}
+
 func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) error {
 	f.released = true
 

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -10,10 +10,6 @@ import (
 	"github.com/ellanetworks/core/etsi"
 )
 
-// HandlePagingFailure runs when the AMF abandons paging for an unreachable 5GS UE
-// (TS 23.502 §4.2.3.3): the SMF keeps the session's downlink data notification
-// suppressed so subsequent downlink packets do not re-page the UE. Paging resumes
-// only when the UE returns and the user plane is reactivated.
 func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
 	smContext := s.currentSession(supi, pduSessionID)
 	if smContext == nil {
@@ -25,10 +21,6 @@ func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessio
 	return nil
 }
 
-// HandleEPSPagingFailure runs when the MME abandons paging for an unreachable EPS
-// UE (TS 23.401 §5.3.4.3): the anchor keeps the session's downlink data
-// notification suppressed so subsequent downlink packets do not re-page the UE.
-// Paging resumes only when the UE returns and the bearer is reactivated.
 func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error {
 	supi, err := etsi.NewSUPIFromIMSI(imsi)
 	if err != nil {

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -10,17 +10,25 @@ import (
 	"github.com/ellanetworks/core/etsi"
 )
 
+// HandlePagingFailure runs when the AMF abandons paging for an unreachable 5GS UE
+// (TS 23.502 §4.2.3.3): the SMF keeps the session's downlink data notification
+// suppressed so subsequent downlink packets do not re-page the UE. Paging resumes
+// only when the UE returns and the user plane is reactivated.
 func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
 	smContext := s.currentSession(supi, pduSessionID)
 	if smContext == nil {
 		return fmt.Errorf("no session for %s pdu %d", supi.String(), pduSessionID)
 	}
 
-	s.resetDownlinkDataNotification(ctx, smContext)
+	s.suppressDownlinkDataNotification(ctx, smContext)
 
 	return nil
 }
 
+// HandleEPSPagingFailure runs when the MME abandons paging for an unreachable EPS
+// UE (TS 23.401 §5.3.4.3): the anchor keeps the session's downlink data
+// notification suppressed so subsequent downlink packets do not re-page the UE.
+// Paging resumes only when the UE returns and the bearer is reactivated.
 func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error {
 	supi, err := etsi.NewSUPIFromIMSI(imsi)
 	if err != nil {
@@ -32,12 +40,12 @@ func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8
 		return fmt.Errorf("no EPS session for %s", imsi)
 	}
 
-	s.resetDownlinkDataNotification(ctx, smContext)
+	s.suppressDownlinkDataNotification(ctx, smContext)
 
 	return nil
 }
 
-func (s *SMF) resetDownlinkDataNotification(ctx context.Context, smContext *SMContext) {
+func (s *SMF) suppressDownlinkDataNotification(ctx context.Context, smContext *SMContext) {
 	smContext.Mutex.Lock()
 	pfcp := smContext.PFCPContext
 	smContext.Mutex.Unlock()
@@ -46,5 +54,5 @@ func (s *SMF) resetDownlinkDataNotification(ctx context.Context, smContext *SMCo
 		return
 	}
 
-	s.upf.ResetDownlinkDataNotification(ctx, pfcp.RemoteSEID)
+	s.upf.SuppressDownlinkDataNotification(ctx, pfcp.RemoteSEID)
 }

--- a/internal/smf/paging_failure_test.go
+++ b/internal/smf/paging_failure_test.go
@@ -8,28 +8,12 @@ import (
 	"testing"
 )
 
-func TestHandlePagingFailure_ResetsDownlinkNotification(t *testing.T) {
-	pcf, store, upf, amfCb := defaultFakes()
-	s := newTestSMF(pcf, store, upf, amfCb)
-
-	supi := testSUPI()
-
-	const pduSessionID = 1
-
-	smCtx := s.NewSession(supi, pduSessionID, testDNN, testSnssai)
-	smCtx.SetPFCPSession(s.AllocateLocalSEID())
-	smCtx.PFCPContext.RemoteSEID = 4242
-
-	if err := s.HandlePagingFailure(context.Background(), supi, pduSessionID); err != nil {
-		t.Fatalf("HandlePagingFailure: %v", err)
-	}
-
-	if got := upf.resetDDNCalls; len(got) != 1 || got[0] != 4242 {
-		t.Fatalf("reset calls = %v, want [4242]", got)
-	}
-}
-
-func TestHandleEPSPagingFailure_ResetsDownlinkNotification(t *testing.T) {
+// TestHandleEPSPagingFailure_SuppressesDownlinkNotification pins the invariant
+// shared by TS 23.401 §5.3.4.3 (EPS) and TS 23.502 §4.2.3.3 (5GS): a failed page
+// must not be re-armed by the next downlink packet. The handler keeps the session's
+// downlink data-notification dedup set (suppressed), rather than clearing it, so an
+// unreachable UE is not paged again until it returns and the bearer is reactivated.
+func TestHandleEPSPagingFailure_SuppressesDownlinkNotification(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
 
@@ -45,8 +29,29 @@ func TestHandleEPSPagingFailure_ResetsDownlinkNotification(t *testing.T) {
 		t.Fatalf("HandleEPSPagingFailure: %v", err)
 	}
 
-	if got := upf.resetDDNCalls; len(got) != 1 || got[0] != 7 {
-		t.Fatalf("reset calls = %v, want [7]", got)
+	if got := upf.suppressDDNCalls; len(got) != 1 || got[0] != 7 {
+		t.Fatalf("suppress calls = %v, want [7]", got)
+	}
+}
+
+func TestHandlePagingFailure_SuppressesDownlinkNotification(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	supi := testSUPI()
+
+	const pduSessionID = 1
+
+	smCtx := s.NewSession(supi, pduSessionID, testDNN, testSnssai)
+	smCtx.SetPFCPSession(s.AllocateLocalSEID())
+	smCtx.PFCPContext.RemoteSEID = 4242
+
+	if err := s.HandlePagingFailure(context.Background(), supi, pduSessionID); err != nil {
+		t.Fatalf("HandlePagingFailure: %v", err)
+	}
+
+	if got := upf.suppressDDNCalls; len(got) != 1 || got[0] != 4242 {
+		t.Fatalf("suppress calls = %v, want [4242]", got)
 	}
 }
 
@@ -58,7 +63,7 @@ func TestHandlePagingFailure_NoSession(t *testing.T) {
 		t.Fatal("expected error for missing session")
 	}
 
-	if len(upf.resetDDNCalls) != 0 {
-		t.Fatalf("unexpected reset calls: %v", upf.resetDDNCalls)
+	if len(upf.suppressDDNCalls) != 0 {
+		t.Fatalf("unexpected suppress calls: %v", upf.suppressDDNCalls)
 	}
 }

--- a/internal/smf/paging_failure_test.go
+++ b/internal/smf/paging_failure_test.go
@@ -8,11 +8,6 @@ import (
 	"testing"
 )
 
-// TestHandleEPSPagingFailure_SuppressesDownlinkNotification pins the invariant
-// shared by TS 23.401 §5.3.4.3 (EPS) and TS 23.502 §4.2.3.3 (5GS): a failed page
-// must not be re-armed by the next downlink packet. The handler keeps the session's
-// downlink data-notification dedup set (suppressed), rather than clearing it, so an
-// unreachable UE is not paged again until it returns and the bearer is reactivated.
 func TestHandleEPSPagingFailure_SuppressesDownlinkNotification(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)

--- a/internal/smf/paging_recovery.go
+++ b/internal/smf/paging_recovery.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
+)
+
+func (s *SMF) ClearPagingSuppression(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
+	smContext := s.currentSession(supi, pduSessionID)
+	if smContext == nil {
+		return nil
+	}
+
+	s.clearDownlinkDataNotification(ctx, smContext)
+
+	return nil
+}
+
+func (s *SMF) ClearEPSPagingSuppression(ctx context.Context, imsi string, ebi uint8) error {
+	supi, err := etsi.NewSUPIFromIMSI(imsi)
+	if err != nil {
+		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
+	}
+
+	smContext := s.currentSession(supi, ebi)
+	if smContext == nil {
+		return nil
+	}
+
+	s.clearDownlinkDataNotification(ctx, smContext)
+
+	return nil
+}
+
+func (s *SMF) clearDownlinkDataNotification(ctx context.Context, smContext *SMContext) {
+	smContext.Mutex.Lock()
+	pfcp := smContext.PFCPContext
+	smContext.Mutex.Unlock()
+
+	if pfcp == nil {
+		return
+	}
+
+	s.upf.ClearDownlinkDataNotification(ctx, pfcp.RemoteSEID)
+}

--- a/internal/smf/paging_recovery_test.go
+++ b/internal/smf/paging_recovery_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestClearEPSPagingSuppression_ClearsDownlinkNotification(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	supi := testSUPI()
+
+	const ebi = 5
+
+	smCtx := s.NewSession(supi, ebi, testDNN, testSnssai)
+	smCtx.SetPFCPSession(s.AllocateLocalSEID())
+	smCtx.PFCPContext.RemoteSEID = 7
+
+	if err := s.ClearEPSPagingSuppression(context.Background(), testIMSI, ebi); err != nil {
+		t.Fatalf("ClearEPSPagingSuppression: %v", err)
+	}
+
+	if got := upf.clearDDNCalls; len(got) != 1 || got[0] != 7 {
+		t.Fatalf("clear calls = %v, want [7]", got)
+	}
+}
+
+func TestClearPagingSuppression_ClearsDownlinkNotification(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	supi := testSUPI()
+
+	const pduSessionID = 1
+
+	smCtx := s.NewSession(supi, pduSessionID, testDNN, testSnssai)
+	smCtx.SetPFCPSession(s.AllocateLocalSEID())
+	smCtx.PFCPContext.RemoteSEID = 4242
+
+	if err := s.ClearPagingSuppression(context.Background(), supi, pduSessionID); err != nil {
+		t.Fatalf("ClearPagingSuppression: %v", err)
+	}
+
+	if got := upf.clearDDNCalls; len(got) != 1 || got[0] != 4242 {
+		t.Fatalf("clear calls = %v, want [4242]", got)
+	}
+}
+
+// TestClearPagingSuppression_NoSession pins that clearing is best-effort: a UE that
+// reconnects with no anchor session is a silent no-op, not an error.
+func TestClearPagingSuppression_NoSession(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	if err := s.ClearPagingSuppression(context.Background(), testSUPI(), 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(upf.clearDDNCalls) != 0 {
+		t.Fatalf("unexpected clear calls: %v", upf.clearDDNCalls)
+	}
+}

--- a/internal/smf/paging_recovery_test.go
+++ b/internal/smf/paging_recovery_test.go
@@ -50,8 +50,6 @@ func TestClearPagingSuppression_ClearsDownlinkNotification(t *testing.T) {
 	}
 }
 
-// TestClearPagingSuppression_NoSession pins that clearing is best-effort: a UE that
-// reconnects with no anchor session is a silent no-op, not an error.
 func TestClearPagingSuppression_NoSession(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -94,7 +94,7 @@ type UPFClient interface {
 	FlushUsage(ctx context.Context, remoteSEID uint64)
 	DeleteSession(ctx context.Context, remoteSEID uint64) error
 
-	ResetDownlinkDataNotification(ctx context.Context, remoteSEID uint64)
+	SuppressDownlinkDataNotification(ctx context.Context, remoteSEID uint64)
 
 	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error
 

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -95,6 +95,7 @@ type UPFClient interface {
 	DeleteSession(ctx context.Context, remoteSEID uint64) error
 
 	SuppressDownlinkDataNotification(ctx context.Context, remoteSEID uint64)
+	ClearDownlinkDataNotification(ctx context.Context, remoteSEID uint64)
 
 	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error
 

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -168,6 +168,7 @@ type fakeUPF struct {
 	modifyCalls      []*models.ModifyRequest
 	deleteCalls      []deletionCall
 	suppressDDNCalls []uint64
+	clearDDNCalls    []uint64
 	lastIPv6Reg      *models.IPv6SessionRegistration
 	err              error
 }
@@ -208,6 +209,13 @@ func (f *fakeUPF) SuppressDownlinkDataNotification(_ context.Context, remoteSEID
 	defer f.mu.Unlock()
 
 	f.suppressDDNCalls = append(f.suppressDDNCalls, remoteSEID)
+}
+
+func (f *fakeUPF) ClearDownlinkDataNotification(_ context.Context, remoteSEID uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.clearDDNCalls = append(f.clearDDNCalls, remoteSEID)
 }
 
 func (f *fakeUPF) FlushUsage(_ context.Context, _ uint64) {}

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -162,14 +162,14 @@ func (f *fakeStore) InsertFlowReports(_ context.Context, reports []*models.FlowR
 }
 
 type fakeUPF struct {
-	mu              sync.Mutex
-	establishResult *models.EstablishResponse
-	lastEstablish   *models.EstablishRequest
-	modifyCalls     []*models.ModifyRequest
-	deleteCalls     []deletionCall
-	resetDDNCalls   []uint64
-	lastIPv6Reg     *models.IPv6SessionRegistration
-	err             error
+	mu               sync.Mutex
+	establishResult  *models.EstablishResponse
+	lastEstablish    *models.EstablishRequest
+	modifyCalls      []*models.ModifyRequest
+	deleteCalls      []deletionCall
+	suppressDDNCalls []uint64
+	lastIPv6Reg      *models.IPv6SessionRegistration
+	err              error
 }
 
 type deletionCall struct {
@@ -203,11 +203,11 @@ func (f *fakeUPF) DeleteSession(_ context.Context, remoteSEID uint64) error {
 	return f.err
 }
 
-func (f *fakeUPF) ResetDownlinkDataNotification(_ context.Context, remoteSEID uint64) {
+func (f *fakeUPF) SuppressDownlinkDataNotification(_ context.Context, remoteSEID uint64) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	f.resetDDNCalls = append(f.resetDDNCalls, remoteSEID)
+	f.suppressDDNCalls = append(f.suppressDDNCalls, remoteSEID)
 }
 
 func (f *fakeUPF) FlushUsage(_ context.Context, _ uint64) {}

--- a/internal/upf/engine/paging.go
+++ b/internal/upf/engine/paging.go
@@ -3,10 +3,33 @@
 
 package engine
 
-func (conn *SessionEngine) ClearDownlinkDataNotification(seid uint64) {
+import "github.com/ellanetworks/core/internal/upf/ebpf"
+
+// SuppressDownlinkDataNotification keeps a session's downlink data-notification
+// dedup set after a failed page, so an unreachable idle UE is not re-paged by every
+// subsequent downlink packet (TS 23.401 §5.3.4.3; TS 23.502 §4.2.3.3). The dedup is
+// released when the UE returns and the session is reactivated (ClearNotified in
+// establish/modify) or on delete, so downlink reachability recovers with no extra
+// state to unwind.
+func (conn *SessionEngine) SuppressDownlinkDataNotification(seid uint64) {
 	if conn.BpfObjects == nil {
 		return
 	}
 
-	conn.BpfObjects.ClearNotifiedForSEID(seid)
+	session := conn.GetSession(seid)
+	if session == nil {
+		return
+	}
+
+	for _, pdr := range session.ListPDRs() {
+		if !pdr.UEIP.IsValid() {
+			continue
+		}
+
+		conn.BpfObjects.MarkNotified(ebpf.DataNotification{
+			LocalSEID: seid,
+			PdrID:     uint16(pdr.PdrID),
+			QFI:       pdr.PdrInfo.Qer.Qfi,
+		})
+	}
 }

--- a/internal/upf/engine/paging.go
+++ b/internal/upf/engine/paging.go
@@ -9,6 +9,21 @@ import "github.com/ellanetworks/core/internal/upf/ebpf"
 // deduped after a failed page, so an unreachable idle UE is not re-paged by every
 // downlink packet (TS 23.401 §5.3.4.3; TS 23.502 §4.2.3.3).
 func (conn *SessionEngine) SuppressDownlinkDataNotification(seid uint64) {
+	conn.eachDownlinkNotification(seid, func(d ebpf.DataNotification) {
+		conn.BpfObjects.MarkNotified(d)
+	})
+}
+
+// ClearDownlinkDataNotification releases the suppression once the UE is reachable
+// again, so subsequent downlink data pages it (TS 24.301 §5.3.5; TS 23.502 §4.2.3.3
+// step 3c). It releases exactly the entries SuppressDownlinkDataNotification marks.
+func (conn *SessionEngine) ClearDownlinkDataNotification(seid uint64) {
+	conn.eachDownlinkNotification(seid, func(d ebpf.DataNotification) {
+		conn.BpfObjects.ClearNotified(d.LocalSEID, d.PdrID, d.QFI)
+	})
+}
+
+func (conn *SessionEngine) eachDownlinkNotification(seid uint64, apply func(ebpf.DataNotification)) {
 	if conn.BpfObjects == nil {
 		return
 	}
@@ -23,7 +38,7 @@ func (conn *SessionEngine) SuppressDownlinkDataNotification(seid uint64) {
 			continue
 		}
 
-		conn.BpfObjects.MarkNotified(ebpf.DataNotification{
+		apply(ebpf.DataNotification{
 			LocalSEID: seid,
 			PdrID:     uint16(pdr.PdrID),
 			QFI:       pdr.PdrInfo.Qer.Qfi,

--- a/internal/upf/engine/paging.go
+++ b/internal/upf/engine/paging.go
@@ -5,12 +5,9 @@ package engine
 
 import "github.com/ellanetworks/core/internal/upf/ebpf"
 
-// SuppressDownlinkDataNotification keeps a session's downlink data-notification
-// dedup set after a failed page, so an unreachable idle UE is not re-paged by every
-// subsequent downlink packet (TS 23.401 §5.3.4.3; TS 23.502 §4.2.3.3). The dedup is
-// released when the UE returns and the session is reactivated (ClearNotified in
-// establish/modify) or on delete, so downlink reachability recovers with no extra
-// state to unwind.
+// SuppressDownlinkDataNotification keeps the session's downlink data notification
+// deduped after a failed page, so an unreachable idle UE is not re-paged by every
+// downlink packet (TS 23.401 §5.3.4.3; TS 23.502 §4.2.3.3).
 func (conn *SessionEngine) SuppressDownlinkDataNotification(seid uint64) {
 	if conn.BpfObjects == nil {
 		return

--- a/internal/upf/engine/paging_test.go
+++ b/internal/upf/engine/paging_test.go
@@ -36,3 +36,26 @@ func TestSuppressDownlinkDataNotification_KeepsDownlinkDeduped(t *testing.T) {
 		t.Fatal("downlink notification still suppressed after ClearNotified")
 	}
 }
+
+func TestClearDownlinkDataNotification_ReleasesSuppression(t *testing.T) {
+	eng := newTestEngine()
+	eng.BpfObjects = ebpf.NewBpfObjects(false, false, 1, 0, 0, 0)
+
+	const seid = uint64(1)
+
+	addSessionWithPDRs(t, eng, seid, "policy")
+
+	downlink := ebpf.DataNotification{LocalSEID: seid, PdrID: 2, QFI: 0}
+
+	eng.SuppressDownlinkDataNotification(seid)
+
+	if !eng.BpfObjects.IsAlreadyNotified(downlink) {
+		t.Fatal("downlink notification not suppressed")
+	}
+
+	eng.ClearDownlinkDataNotification(seid)
+
+	if eng.BpfObjects.IsAlreadyNotified(downlink) {
+		t.Fatal("downlink notification still suppressed after clear")
+	}
+}

--- a/internal/upf/engine/paging_test.go
+++ b/internal/upf/engine/paging_test.go
@@ -9,12 +9,6 @@ import (
 	"github.com/ellanetworks/core/internal/upf/ebpf"
 )
 
-// TestSuppressDownlinkDataNotification_KeepsDownlinkDeduped reproduces the paging
-// storm of issue #1493 at the datapath: an unreachable idle UE was re-paged by
-// every downlink packet because the paging-failure path cleared the notify-once
-// dedup. Suppression keeps the downlink detection rule deduped so no further page
-// is triggered until the session is reactivated (TS 23.401 §5.3.4.3; TS 23.502
-// §4.2.3.3). The uplink rule never produces a notification and is left untouched.
 func TestSuppressDownlinkDataNotification_KeepsDownlinkDeduped(t *testing.T) {
 	eng := newTestEngine()
 	eng.BpfObjects = ebpf.NewBpfObjects(false, false, 1, 0, 0, 0)
@@ -29,17 +23,16 @@ func TestSuppressDownlinkDataNotification_KeepsDownlinkDeduped(t *testing.T) {
 	eng.SuppressDownlinkDataNotification(seid)
 
 	if !eng.BpfObjects.IsAlreadyNotified(downlink) {
-		t.Fatal("downlink notification not suppressed after paging failure: an unreachable UE would be re-paged by the next packet")
+		t.Fatal("downlink notification not suppressed")
 	}
 
 	if eng.BpfObjects.IsAlreadyNotified(uplink) {
-		t.Fatal("uplink rule marked notified: suppression must target downlink detection rules only")
+		t.Fatal("uplink rule marked notified, want downlink only")
 	}
 
-	// Reactivation clears the dedup, so paging recovers when the UE returns.
 	eng.BpfObjects.ClearNotified(seid, 2, 0)
 
 	if eng.BpfObjects.IsAlreadyNotified(downlink) {
-		t.Fatal("downlink notification still suppressed after reactivation: UE would never be paged again")
+		t.Fatal("downlink notification still suppressed after ClearNotified")
 	}
 }

--- a/internal/upf/engine/paging_test.go
+++ b/internal/upf/engine/paging_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/upf/ebpf"
+)
+
+// TestSuppressDownlinkDataNotification_KeepsDownlinkDeduped reproduces the paging
+// storm of issue #1493 at the datapath: an unreachable idle UE was re-paged by
+// every downlink packet because the paging-failure path cleared the notify-once
+// dedup. Suppression keeps the downlink detection rule deduped so no further page
+// is triggered until the session is reactivated (TS 23.401 §5.3.4.3; TS 23.502
+// §4.2.3.3). The uplink rule never produces a notification and is left untouched.
+func TestSuppressDownlinkDataNotification_KeepsDownlinkDeduped(t *testing.T) {
+	eng := newTestEngine()
+	eng.BpfObjects = ebpf.NewBpfObjects(false, false, 1, 0, 0, 0)
+
+	const seid = uint64(1)
+
+	addSessionWithPDRs(t, eng, seid, "policy")
+
+	downlink := ebpf.DataNotification{LocalSEID: seid, PdrID: 2, QFI: 0}
+	uplink := ebpf.DataNotification{LocalSEID: seid, PdrID: 1, QFI: 0}
+
+	eng.SuppressDownlinkDataNotification(seid)
+
+	if !eng.BpfObjects.IsAlreadyNotified(downlink) {
+		t.Fatal("downlink notification not suppressed after paging failure: an unreachable UE would be re-paged by the next packet")
+	}
+
+	if eng.BpfObjects.IsAlreadyNotified(uplink) {
+		t.Fatal("uplink rule marked notified: suppression must target downlink detection rules only")
+	}
+
+	// Reactivation clears the dedup, so paging recovers when the UE returns.
+	eng.BpfObjects.ClearNotified(seid, 2, 0)
+
+	if eng.BpfObjects.IsAlreadyNotified(downlink) {
+		t.Fatal("downlink notification still suppressed after reactivation: UE would never be paged again")
+	}
+}

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -430,6 +430,10 @@ func (a *smfUPFAdapter) SuppressDownlinkDataNotification(ctx context.Context, re
 	a.engine.SuppressDownlinkDataNotification(remoteSEID)
 }
 
+func (a *smfUPFAdapter) ClearDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {
+	a.engine.ClearDownlinkDataNotification(remoteSEID)
+}
+
 func (a *smfUPFAdapter) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
 	return a.engine.UpdateFilters(ctx, policyID, direction, rules)
 }

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -426,8 +426,8 @@ func (a *smfUPFAdapter) DeleteSession(ctx context.Context, remoteSEID uint64) er
 	return a.engine.DeleteSession(ctx, &models.DeleteRequest{SEID: remoteSEID})
 }
 
-func (a *smfUPFAdapter) ResetDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {
-	a.engine.ClearDownlinkDataNotification(remoteSEID)
+func (a *smfUPFAdapter) SuppressDownlinkDataNotification(ctx context.Context, remoteSEID uint64) {
+	a.engine.SuppressDownlinkDataNotification(remoteSEID)
 }
 
 func (a *smfUPFAdapter) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {


### PR DESCRIPTION
# Description

Stop paging storm by suppressing downlink data notification on paging failure instead of re-arming it. Suppressed downlink paging resumes as soon as a UE reconnects.

Fixes #1493 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
