### PR TITLE
docs: eBPF XDP checksum offload on veth pairs

### DIFF
--- a/docs/explanation/user_plane_packet_processing_with_ebpf.md
+++ b/docs/explanation/user_plane_packet_processing_with_ebpf.md
@@ -63,16 +63,9 @@ The solution is to attach a minimal XDP program that returns `XDP_PASS` to the p
 
 When an application transmits over a veth interface, the kernel defers computing the transport checksum: the packet carries `CHECKSUM_PARTIAL` metadata recording where the egress NIC should write the checksum later. GTP-U traffic sent by a co-hosted radio therefore reaches Ella Core's N3 interface with an incomplete outer UDP checksum.
 
-In **generic XDP mode**, the kernel does not update this metadata when the data plane removes the GTP-U header. The recorded checksum location then points at the wrong offset, and on egress the NIC writes a checksum into the packet body, corrupting the packet. The corruption is invisible to the XDP counters: packets are redirected successfully and lost afterwards. The typical symptom is a PDU session that establishes normally, with working ping and DNS, while TCP and large packets silently fail.
+In **generic XDP mode**, the kernel does not update this metadata when the data plane removes the GTP-U header. The recorded checksum location then points at the wrong offset, and depending on how the egress NIC driver consumes it, packets may be corrupted, dropped, or survive unharmed. The failure is invisible to the XDP counters. The typical symptom is a PDU session that establishes normally, with working ping and DNS, while TCP and large packets silently fail.
 
-The remedy is to disable TX checksum offload on both ends of the veth pair, forcing checksums to be completed in software before packets reach the data plane:
-
-```shell
-ethtool -K <host-side-veth> tx off
-ip netns exec <namespace> ethtool -K <peer-veth> tx off
-```
-
-Native XDP mode is not affected: redirected frames are forwarded as raw packets and carry no checksum-offload metadata.
+The remedy is to disable TX checksum offload on both ends of the veth pair (`ethtool -K <veth> tx off`), forcing checksums to be completed in software before packets reach the data plane. Native XDP mode is not affected: redirected frames are forwarded as raw packets and carry no checksum-offload metadata.
 
 ### IPv6 GTP-U transport
 

--- a/docs/explanation/user_plane_packet_processing_with_ebpf.md
+++ b/docs/explanation/user_plane_packet_processing_with_ebpf.md
@@ -59,6 +59,21 @@ Without an XDP program on the receiving peer, the veth driver will not deliver r
 
 The solution is to attach a minimal XDP program that returns `XDP_PASS` to the peer veth. This satisfies the kernel's requirement and keeps packets on the fast native XDP path. See [Use native XDP with veth interfaces](../how_to/native_xdp_veth.md) for setup instructions.
 
+### Checksum offload on veth pairs
+
+When an application transmits over a veth interface, the kernel defers computing the transport checksum: the packet carries `CHECKSUM_PARTIAL` metadata recording where the egress NIC should write the checksum later. GTP-U traffic sent by a co-hosted radio therefore reaches Ella Core's N3 interface with an incomplete outer UDP checksum.
+
+In **generic XDP mode**, the kernel does not update this metadata when the data plane removes the GTP-U header. The recorded checksum location then points at the wrong offset, and on egress the NIC writes a checksum into the packet body, corrupting the packet. The corruption is invisible to the XDP counters: packets are redirected successfully and lost afterwards. The typical symptom is a PDU session that establishes normally, with working ping and DNS, while TCP and large packets silently fail.
+
+The remedy is to disable TX checksum offload on both ends of the veth pair, forcing checksums to be completed in software before packets reach the data plane:
+
+```shell
+ethtool -K <host-side-veth> tx off
+ip netns exec <namespace> ethtool -K <peer-veth> tx off
+```
+
+Native XDP mode is not affected: redirected frames are forwarded as raw packets and carry no checksum-offload metadata.
+
 ### IPv6 GTP-U transport
 
 Ella Core supports GTP-U encapsulation with either an IPv4 or IPv6 outer header on the N3 / S1-U interface. The inner UE payload can be IPv4 or IPv6, independent of the transport address family. The chosen transport address family depends on how the N3 / S1-U interface is configured, and what the radio advertises. If both sides are dual-stack, Ella Core prefers IPv6.

--- a/docs/explanation/user_plane_packet_processing_with_ebpf.md
+++ b/docs/explanation/user_plane_packet_processing_with_ebpf.md
@@ -46,8 +46,8 @@ Detailed performance results are available [here](../reference/performance.md).
 
 Ella Core supports the following XDP attach modes:
 
-- **Native**: This is the most performant option, but it is only supported on [compatible drivers](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#xdp).
-- **Generic**: A fallback option that works on most drivers but with lower performance.
+- **Native**: The production-grade option. It offers the highest performance but is only supported on [compatible drivers](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#xdp).
+- **Generic**: A driver-independent fallback intended for prototyping and test/development only. It has lower performance and can be less reliable (see [Checksum offload on veth pairs](#checksum-offload-on-veth-pairs)). Do not use it in production.
 
 For more information on configuring XDP attach modes, refer to the [Configuration File](../reference/config_file.md) documentation.
 

--- a/docs/how_to/co_host_with_ocudu.md
+++ b/docs/how_to/co_host_with_ocudu.md
@@ -45,7 +45,11 @@ ip -n n3ns addr add 10.202.0.5/24 dev n3-ran-veth
 ip -n n3ns link set lo up
 ip -n n3ns link set dev n3-ran-veth up
 ip link set dev n3-upf-veth up
+ethtool -K n3-upf-veth tx off
+ip netns exec n3ns ethtool -K n3-ran-veth tx off
 ```
+
+Disabling TX checksum offload on both veth endpoints is required in `generic` XDP mode: without it, the data plane silently corrupts uplink traffic. See [Checksum offload on veth pairs](../explanation/user_plane_packet_processing_with_ebpf.md#checksum-offload-on-veth-pairs) for an explanation.
 
 ## 3. Configure Ella Core
 

--- a/docs/how_to/co_host_with_ocudu.md
+++ b/docs/how_to/co_host_with_ocudu.md
@@ -49,7 +49,7 @@ ethtool -K n3-upf-veth tx off
 ip netns exec n3ns ethtool -K n3-ran-veth tx off
 ```
 
-Disabling TX checksum offload on both veth endpoints is required in `generic` XDP mode: without it, the data plane silently corrupts uplink traffic. See [Checksum offload on veth pairs](../explanation/user_plane_packet_processing_with_ebpf.md#checksum-offload-on-veth-pairs) for an explanation.
+Disabling TX checksum offload on both veth endpoints is required in `generic` XDP mode — see [Checksum offload on veth pairs](../explanation/user_plane_packet_processing_with_ebpf.md#checksum-offload-on-veth-pairs).
 
 ## 3. Configure Ella Core
 

--- a/docs/how_to/install.md
+++ b/docs/how_to/install.md
@@ -141,6 +141,9 @@ Ensure your system meets the [requirements](../reference/system_reqs.md). Then, 
 
     Edit the file to match your network interfaces and desired configuration.
 
+    !!! note
+        This example uses `generic` XDP mode so it runs on any driver. For production, use `native` mode — see [XDP configuration](../explanation/user_plane_packet_processing_with_ebpf.md#configuration).
+
     Start the Ella Core container:
 
     ```shell

--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -40,7 +40,7 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
             - `cert` (string): The path to the TLS certificate file (optional).
             - `key` (string): The path to the TLS key file (optional).
 - `xdp` (object): The XDP configuration.
-    - `attach-mode` (string): The XDP attach mode. Options are `native` and `generic`. `native` is the most performant option and only works on supported drivers.
+    - `attach-mode` (string): The XDP attach mode. `native` is the production option (highest performance) and requires a compatible driver; `generic` is a driver-independent fallback for prototyping and test/development.
 - `telemetry` (object): The telemetry configuration.
     - `enabled` (boolean): Whether telemetry is enabled or not. Default is `false`.
     - `otlp-endpoint` (string): The endpoint for the OpenTelemetry Protocol (OTLP) collector.

--- a/docs/reference/production_hardening.md
+++ b/docs/reference/production_hardening.md
@@ -12,7 +12,7 @@ This reference document provides guidelines for operating Ella Core in a product
 - **Deploy with the snap**: Use the [Snap installation method](../how_to/install.md#__tabbed_1_1) to deploy Ella Core.
 - **Isolate network interfaces**: Use separate network interfaces for N2, N3, N6, and API traffic.
 - **Use TLS**: Configure TLS for the API interface in the configuration file. Use certificates from a trusted Certificate Authority (CA).
-- **Use XDP in native mode**: Configure Ella Core to use XDP in `native` mode. This requires a compatible network driver.
+- **Use XDP in native mode**: Configure Ella Core to use XDP in `native` mode.
 - **Set logging level to info**: Configure system logging level to `info` and use file output.
 - **Disable telemetry**: Disable telemetry in the configuration file.
 - **Rotate logs**: Implement log rotation for system and audit logs.


### PR DESCRIPTION
# Description

XDP generic is not to be used in production, reflecting the upstream eBPF recommendation.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
