### PR TITLE
fix: release superseded S1/NG connection on re-establishment 

### DIFF
--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -28,6 +28,7 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/nas/security"
+	"github.com/free5gc/ngap/ngapType"
 	"go.uber.org/zap"
 )
 
@@ -257,13 +258,15 @@ func (a *AMF) AttachUeConn(ue *UeContext, ueConn *UeConn) {
 	displaced := a.attachUeConnLocked(ue, ueConn)
 	a.mu.Unlock()
 
-	// Release the superseded UeConn (registry entry + AMF-UE-NGAP-ID) so it does not
-	// leak. The old RAN context at the gNB is stale, so this is a local cleanup with no
-	// Release Command.
+	// The UE re-established on a new connection, so the AMF must release the old NG
+	// connection toward the gNB (TS 23.502 §4.2.3.2, §4.2.6): the gNB may still hold
+	// the old RAN context and would otherwise leave it dangling and answer no later
+	// release request. SendUEContextReleaseCommand keeps the displaced UeConn (and its
+	// AMF-UE-NGAP-ID) registered until the Release Complete — or the release guard —
+	// reaps it, so the identifier is never reused while the gNB may still reference it.
 	if displaced != nil {
-		if err := a.RemoveUeConn(context.Background(), displaced); err != nil {
-			logger.AmfLog.Error("failed to release superseded RAN UE on adopt", zap.Error(err))
-		}
+		displaced.SendUEContextReleaseCommand(context.Background(),
+			ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentRadioConnectionWithUeLost)
 	}
 
 	a.clearPagingSuppression(context.Background(), ue)

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -258,12 +258,9 @@ func (a *AMF) AttachUeConn(ue *UeContext, ueConn *UeConn) {
 	displaced := a.attachUeConnLocked(ue, ueConn)
 	a.mu.Unlock()
 
-	// The UE re-established on a new connection, so the AMF must release the old NG
-	// connection toward the gNB (TS 23.502 §4.2.3.2, §4.2.6): the gNB may still hold
-	// the old RAN context and would otherwise leave it dangling and answer no later
-	// release request. SendUEContextReleaseCommand keeps the displaced UeConn (and its
-	// AMF-UE-NGAP-ID) registered until the Release Complete — or the release guard —
-	// reaps it, so the identifier is never reused while the gNB may still reference it.
+	// Release the displaced connection toward the gNB (TS 23.502 §4.2.6). It stays
+	// registered with its AMF-UE-NGAP-ID reserved until the Release Complete reaps it,
+	// so the gNB can reference it until then.
 	if displaced != nil {
 		displaced.SendUEContextReleaseCommand(context.Background(),
 			ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentRadioConnectionWithUeLost)

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -258,12 +258,12 @@ func (a *AMF) AttachUeConn(ue *UeContext, ueConn *UeConn) {
 	displaced := a.attachUeConnLocked(ue, ueConn)
 	a.mu.Unlock()
 
-	// Release the displaced connection toward the gNB (TS 23.502 §4.2.6). It stays
-	// registered with its AMF-UE-NGAP-ID reserved until the Release Complete reaps it,
-	// so the gNB can reference it until then.
+	// Release the displaced connection toward the gNB (TS 23.502 §4.2.6, TS 38.413
+	// §8.3.3.1). It stays registered with its AMF-UE-NGAP-ID reserved until the Release
+	// Complete reaps it, so the gNB can reference it until then.
 	if displaced != nil {
 		displaced.SendUEContextReleaseCommand(context.Background(),
-			ngapType.CausePresentRadioNetwork, ngapType.CauseRadioNetworkPresentRadioConnectionWithUeLost)
+			ngapType.CausePresentNas, ngapType.CauseNasPresentNormalRelease)
 	}
 
 	a.clearPagingSuppression(context.Background(), ue)

--- a/internal/amf/ngap/handle_handover_notify_test.go
+++ b/internal/amf/ngap/handle_handover_notify_test.go
@@ -245,9 +245,13 @@ func TestHandoverNotify_FromNonTarget_Dropped(t *testing.T) {
 	amfInstance.MarkHandoverPrepared(amfUe, map[uint8]struct{}{1: {}})
 
 	// An impostor UeConn on the target radio carrying the same AMF UE context but not
-	// the prepared target sends the notify.
+	// the prepared target sends the notify. Adopting it supersedes the UE's current
+	// connection, which legitimately releases that superseded connection; the notify
+	// itself must not add any further release.
 	impostor := amf.NewUeConnForTest(targetRan, 3, 4, logger.AmfLog)
 	impostor.AMFForTest().AttachUeConn(amfUe, impostor)
+
+	releasesBeforeNotify := len(sourceNGAPSender.SentUEContextReleaseCommands)
 
 	ngap.HandleHandoverNotify(context.Background(), amfInstance, targetRan, decode.HandoverNotify{AMFUENGAPID: 4, RANUENGAPID: 3})
 
@@ -256,8 +260,9 @@ func TestHandoverNotify_FromNonTarget_Dropped(t *testing.T) {
 			fakeSmf.N2HandoverCompleteCalls, fakeSmf.ReleaseSmContextCalls)
 	}
 
-	if len(sourceNGAPSender.SentUEContextReleaseCommands) != 0 {
-		t.Fatalf("a notify from a non-target must not release the source, got %d", len(sourceNGAPSender.SentUEContextReleaseCommands))
+	if len(sourceNGAPSender.SentUEContextReleaseCommands) != releasesBeforeNotify {
+		t.Fatalf("a notify from a non-target must not release the source, got %d new release(s)",
+			len(sourceNGAPSender.SentUEContextReleaseCommands)-releasesBeforeNotify)
 	}
 
 	if !amfInstance.HandoverInProgress(amfUe) {

--- a/internal/amf/ngap/handle_handover_notify_test.go
+++ b/internal/amf/ngap/handle_handover_notify_test.go
@@ -245,9 +245,8 @@ func TestHandoverNotify_FromNonTarget_Dropped(t *testing.T) {
 	amfInstance.MarkHandoverPrepared(amfUe, map[uint8]struct{}{1: {}})
 
 	// An impostor UeConn on the target radio carrying the same AMF UE context but not
-	// the prepared target sends the notify. Adopting it supersedes the UE's current
-	// connection, which legitimately releases that superseded connection; the notify
-	// itself must not add any further release.
+	// the prepared target sends the notify. Adopting it releases the superseded
+	// connection; the notify must add no further release.
 	impostor := amf.NewUeConnForTest(targetRan, 3, 4, logger.AmfLog)
 	impostor.AMFForTest().AttachUeConn(amfUe, impostor)
 

--- a/internal/amf/ngap/superseded_release_test.go
+++ b/internal/amf/ngap/superseded_release_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+//
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/amf/ngap"
+	"github.com/ellanetworks/core/internal/amf/ngap/decode"
+	"github.com/ellanetworks/core/internal/sctp"
+)
+
+// supersedeOntoNewConnection registers a UE on a first NG connection, then has it
+// re-establish on a second one, superseding the first. It returns the AMF and the old
+// connection's AMF/RAN NGAP IDs.
+func supersedeOntoNewConnection(t *testing.T) (amfInstance *amf.AMF, ran *amf.Radio, sender *fakeNGAPSender, oldAmfID, oldRanID int64) {
+	t.Helper()
+
+	amfInstance = newTestAMF()
+	ran = newTestRadio(amfInstance)
+	amfInstance.SetRadioForTest(new(sctp.SCTPConn), ran)
+	sender = ran.Conn.(*fakeNGAPSender)
+
+	amfUe := amf.NewUeContext()
+
+	oldConn, err := amfInstance.NewUeConn(ran, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	amfInstance.AttachUeConn(amfUe, oldConn)
+	oldAmfID = int64(oldConn.AmfUeNgapID)
+	oldRanID = int64(oldConn.RanUeNgapID)
+
+	newConn, err := amfInstance.NewUeConn(ran, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	amfInstance.AttachUeConn(amfUe, newConn) // supersede
+
+	return amfInstance, ran, sender, oldAmfID, oldRanID
+}
+
+// TestSupersededConnectionIsReleasedTowardGNB is the 5G/NGAP mirror of the S1AP fix for
+// issue #1482: when a UE re-establishes on a new NG connection, the AMF must release the
+// old (superseded) connection toward the gNB with a UE CONTEXT RELEASE COMMAND
+// (TS 23.502 §4.2.3.2, §4.2.6) — not drop it silently, which leaves the gNB's stale
+// context dangling and its later release request unanswerable.
+func TestSupersededConnectionIsReleasedTowardGNB(t *testing.T) {
+	_, _, sender, oldAmfID, oldRanID := supersedeOntoNewConnection(t)
+
+	var released bool
+
+	for _, cmd := range sender.SentUEContextReleaseCommands {
+		if cmd.AmfUeNgapID == oldAmfID && cmd.RanUeNgapID == oldRanID {
+			released = true
+		}
+	}
+
+	if !released {
+		t.Fatalf("issue #1482: AMF did not send a UE CONTEXT RELEASE COMMAND for the superseded "+
+			"context (AMF-UE-NGAP-ID %d); it dropped the old NG connection silently", oldAmfID)
+	}
+}
+
+// TestSupersededConnectionReleaseRequestNoErrorIndication verifies that a gNB release
+// request for the superseded context — one that crossed the AMF's own release command —
+// is not answered with an ERROR INDICATION (TS 38.413 §8.3.2.2 requires the release
+// procedure, i.e. a UE CONTEXT RELEASE COMMAND).
+func TestSupersededConnectionReleaseRequestNoErrorIndication(t *testing.T) {
+	amfInstance, ran, sender, oldAmfID, oldRanID := supersedeOntoNewConnection(t)
+
+	before := len(sender.SentErrorIndications)
+
+	ngap.HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, decode.UEContextReleaseRequest{
+		AMFUENGAPID: oldAmfID,
+		RANUENGAPID: oldRanID,
+	})
+
+	if len(sender.SentErrorIndications) != before {
+		t.Fatalf("issue #1482: AMF answered the gNB's release request for the superseded context "+
+			"(AMF-UE-NGAP-ID %d) with ERROR INDICATION; TS 38.413 §8.3.2.2 requires a UE CONTEXT "+
+			"RELEASE COMMAND", oldAmfID)
+	}
+}

--- a/internal/amf/ngap/superseded_release_test.go
+++ b/internal/amf/ngap/superseded_release_test.go
@@ -46,11 +46,9 @@ func supersedeOntoNewConnection(t *testing.T) (amfInstance *amf.AMF, ran *amf.Ra
 	return amfInstance, ran, sender, oldAmfID, oldRanID
 }
 
-// TestSupersededConnectionIsReleasedTowardGNB is the 5G/NGAP mirror of the S1AP fix for
-// issue #1482: when a UE re-establishes on a new NG connection, the AMF must release the
-// old (superseded) connection toward the gNB with a UE CONTEXT RELEASE COMMAND
-// (TS 23.502 §4.2.3.2, §4.2.6) — not drop it silently, which leaves the gNB's stale
-// context dangling and its later release request unanswerable.
+// TestSupersededConnectionIsReleasedTowardGNB checks that re-establishing a UE on a new
+// NG connection releases the superseded one toward the gNB with a UE CONTEXT RELEASE
+// COMMAND (TS 23.502 §4.2.3.2, §4.2.6).
 func TestSupersededConnectionIsReleasedTowardGNB(t *testing.T) {
 	_, _, sender, oldAmfID, oldRanID := supersedeOntoNewConnection(t)
 
@@ -63,15 +61,13 @@ func TestSupersededConnectionIsReleasedTowardGNB(t *testing.T) {
 	}
 
 	if !released {
-		t.Fatalf("issue #1482: AMF did not send a UE CONTEXT RELEASE COMMAND for the superseded "+
-			"context (AMF-UE-NGAP-ID %d); it dropped the old NG connection silently", oldAmfID)
+		t.Fatalf("no UE CONTEXT RELEASE COMMAND sent for the superseded context (AMF-UE-NGAP-ID %d)", oldAmfID)
 	}
 }
 
-// TestSupersededConnectionReleaseRequestNoErrorIndication verifies that a gNB release
-// request for the superseded context — one that crossed the AMF's own release command —
-// is not answered with an ERROR INDICATION (TS 38.413 §8.3.2.2 requires the release
-// procedure, i.e. a UE CONTEXT RELEASE COMMAND).
+// TestSupersededConnectionReleaseRequestNoErrorIndication checks that a gNB release
+// request for a superseded context is not answered with an Error Indication
+// (TS 38.413 §8.3.2.2).
 func TestSupersededConnectionReleaseRequestNoErrorIndication(t *testing.T) {
 	amfInstance, ran, sender, oldAmfID, oldRanID := supersedeOntoNewConnection(t)
 
@@ -83,8 +79,7 @@ func TestSupersededConnectionReleaseRequestNoErrorIndication(t *testing.T) {
 	})
 
 	if len(sender.SentErrorIndications) != before {
-		t.Fatalf("issue #1482: AMF answered the gNB's release request for the superseded context "+
-			"(AMF-UE-NGAP-ID %d) with ERROR INDICATION; TS 38.413 §8.3.2.2 requires a UE CONTEXT "+
-			"RELEASE COMMAND", oldAmfID)
+		t.Fatalf("release request for the superseded context (AMF-UE-NGAP-ID %d) answered with "+
+			"ERROR INDICATION; want UE CONTEXT RELEASE COMMAND (TS 38.413 §8.3.2.2)", oldAmfID)
 	}
 }

--- a/internal/amf/ran_ue_test.go
+++ b/internal/amf/ran_ue_test.go
@@ -34,8 +34,9 @@ func newBoundUeContext(t *testing.T, radio *amf.Radio) (*amf.UeContext, *amf.UeC
 	return ue, ueConn
 }
 
-// A UE re-attaching on a new connection must release its previous connection, so the
-// displaced UeConn + AMF-UE-NGAP-ID do not leak in the registry.
+// A UE re-attaching on a new connection must release its previous connection toward the
+// gNB and keep it detached (its AMF-UE-NGAP-ID reserved) until the Release Complete
+// reaps it, so the displaced UeConn is neither dropped silently nor leaked.
 func TestAttachUeConn_ReleasesDisplacedConn(t *testing.T) {
 	radio := newTestRadioForUeConn()
 
@@ -48,12 +49,28 @@ func TestAttachUeConn_ReleasesDisplacedConn(t *testing.T) {
 	second := amf.NewUeConnForTest(radio, 2, 11, logger.AmfLog)
 	amfInstance.AttachUeConn(ue, second)
 
-	if amfInstance.LookupUeConn(10) != nil {
-		t.Fatal("displaced UeConn was not released after re-attach (registry + NGAP-ID leak)")
+	// The displaced connection is detached from the UE (and commanded to release
+	// toward the gNB) but kept in the registry with its AMF-UE-NGAP-ID reserved, so the
+	// identifier cannot be reused while the gNB may still reference it.
+	if first.UeContext() != nil {
+		t.Fatal("displaced UeConn was not detached from the UE after re-attach")
+	}
+
+	if amfInstance.LookupUeConn(10) != first {
+		t.Fatal("displaced UeConn must stay registered (ID reserved) until its Release Complete")
 	}
 
 	if amfInstance.LookupUeConn(11) != second {
 		t.Fatal("new UeConn is not the UE's active connection after re-attach")
+	}
+
+	// The gNB's Release Complete (its supervision guard stopped, as the real handler
+	// does) reaps the detached connection and frees its AMF-UE-NGAP-ID.
+	first.StopReleaseGuard()
+	amfInstance.ReleaseUeConn(context.Background(), first)
+
+	if amfInstance.LookupUeConn(10) != nil {
+		t.Fatal("displaced UeConn was not reaped after its Release Complete (registry + NGAP-ID leak)")
 	}
 }
 

--- a/internal/amf/ran_ue_test.go
+++ b/internal/amf/ran_ue_test.go
@@ -34,9 +34,8 @@ func newBoundUeContext(t *testing.T, radio *amf.Radio) (*amf.UeContext, *amf.UeC
 	return ue, ueConn
 }
 
-// A UE re-attaching on a new connection must release its previous connection toward the
-// gNB and keep it detached (its AMF-UE-NGAP-ID reserved) until the Release Complete
-// reaps it, so the displaced UeConn is neither dropped silently nor leaked.
+// A UE re-attaching on a new connection releases its previous connection toward the gNB
+// and keeps it detached (its AMF-UE-NGAP-ID reserved) until the Release Complete reaps it.
 func TestAttachUeConn_ReleasesDisplacedConn(t *testing.T) {
 	radio := newTestRadioForUeConn()
 
@@ -49,9 +48,8 @@ func TestAttachUeConn_ReleasesDisplacedConn(t *testing.T) {
 	second := amf.NewUeConnForTest(radio, 2, 11, logger.AmfLog)
 	amfInstance.AttachUeConn(ue, second)
 
-	// The displaced connection is detached from the UE (and commanded to release
-	// toward the gNB) but kept in the registry with its AMF-UE-NGAP-ID reserved, so the
-	// identifier cannot be reused while the gNB may still reference it.
+	// The displaced connection stays registered with its AMF-UE-NGAP-ID reserved until
+	// its Release Complete, so the gNB can reference it until then.
 	if first.UeContext() != nil {
 		t.Fatal("displaced UeConn was not detached from the UE after re-attach")
 	}
@@ -64,8 +62,7 @@ func TestAttachUeConn_ReleasesDisplacedConn(t *testing.T) {
 		t.Fatal("new UeConn is not the UE's active connection after re-attach")
 	}
 
-	// The gNB's Release Complete (its supervision guard stopped, as the real handler
-	// does) reaps the detached connection and frees its AMF-UE-NGAP-ID.
+	// A Release Complete reaps the detached connection and frees its AMF-UE-NGAP-ID.
 	first.StopReleaseGuard()
 	amfInstance.ReleaseUeConn(context.Background(), first)
 

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -425,17 +425,6 @@ func (m *MME) ReleaseDetachedConn(conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enb
 	return true
 }
 
-// DetachedConn reports whether conn holds a UE-less connection (a superseded or
-// handover-source association) with the given S1AP ID pair.
-func (m *MME) DetachedConn(conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	c, ok := m.conns[uint32(mmeUEID)]
-
-	return ok && c.ue == nil && c.conn == conn && c.ENBUES1APID == enbUEID
-}
-
 func SendHandoverPreparationFailure(ctx context.Context, m *MME, conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID, cause s1ap.Cause) {
 	fail := &s1ap.HandoverPreparationFailure{MMEUES1APID: mmeUEID, ENBUES1APID: enbUEID, Cause: cause}
 
@@ -464,7 +453,7 @@ func SendUEContextRelease(ctx context.Context, m *MME, conn S1APWriter, mmeUEID 
 		return
 	}
 
-	logger.From(ctx, logger.MmeLog).Info("UE Context Release Command (handover)", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
+	logger.From(ctx, logger.MmeLog).Info("UE Context Release Command", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
 	m.SendToRadio(ctx, conn, S1APProcedureUEContextReleaseCommand, b)
 }
 

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -400,11 +400,11 @@ func (m *MME) abandonHandover(ue *UeContext) {
 	}
 }
 
-// ReleaseDetachedConn removes a UE-associated connection that holds no UE context —
-// a handover source detached at HANDOVER NOTIFY, a released target, or a connection
-// superseded by a UE re-establishing on a new one — when its UE Context Release
-// Complete arrives (or its release guard fires), identified by its own MME-UE-S1AP-ID
-// (TS 36.413 §8.3, §8.4). It reports whether it handled one.
+// ReleaseDetachedConn removes a UE-associated connection that holds no UE context — a
+// handover source detached at HANDOVER NOTIFY, a released target, or a superseded
+// connection — when its UE Context Release Complete arrives or its release guard fires,
+// identified by its own MME-UE-S1AP-ID (TS 36.413 §8.3, §8.4). It reports whether it
+// handled one.
 func (m *MME) ReleaseDetachedConn(conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) bool {
 	m.mu.Lock()
 
@@ -419,18 +419,14 @@ func (m *MME) ReleaseDetachedConn(conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enb
 
 	m.mu.Unlock()
 
-	// Cancel any release-supervision guard (a superseded connection arms one) so it
-	// does not fire after the connection is already reaped. Stopped outside m.mu: the
-	// guard's own callback re-acquires it.
+	// Stop the guard outside m.mu: its callback re-acquires the lock.
 	c.releaseGuard.Stop()
 
 	return true
 }
 
-// DetachedConn reports whether conn holds a UE-less (detached) connection with the
-// given S1AP ID pair — a superseded or handover-source association awaiting its Release
-// Complete. Its MME-UE-S1AP-ID is reserved but resolves to no UE, so a UE-associated
-// message naming it is answered from the detached state rather than as an unknown ID.
+// DetachedConn reports whether conn holds a UE-less connection (a superseded or
+// handover-source association) with the given S1AP ID pair.
 func (m *MME) DetachedConn(conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -401,21 +401,43 @@ func (m *MME) abandonHandover(ue *UeContext) {
 }
 
 // ReleaseDetachedConn removes a UE-associated connection that holds no UE context —
-// a handover source detached at HANDOVER NOTIFY, or a released target — when its UE
-// Context Release Complete arrives, identified by its own MME-UE-S1AP-ID (TS 36.413
-// §8.4). It reports whether it handled one.
+// a handover source detached at HANDOVER NOTIFY, a released target, or a connection
+// superseded by a UE re-establishing on a new one — when its UE Context Release
+// Complete arrives (or its release guard fires), identified by its own MME-UE-S1AP-ID
+// (TS 36.413 §8.3, §8.4). It reports whether it handled one.
 func (m *MME) ReleaseDetachedConn(conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) bool {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	c, ok := m.conns[uint32(mmeUEID)]
 	if !ok || c.ue != nil || c.conn != conn || c.ENBUES1APID != enbUEID {
+		m.mu.Unlock()
+
 		return false
 	}
 
 	m.releaseConnIDLocked(uint32(mmeUEID))
 
+	m.mu.Unlock()
+
+	// Cancel any release-supervision guard (a superseded connection arms one) so it
+	// does not fire after the connection is already reaped. Stopped outside m.mu: the
+	// guard's own callback re-acquires it.
+	c.releaseGuard.Stop()
+
 	return true
+}
+
+// DetachedConn reports whether conn holds a UE-less (detached) connection with the
+// given S1AP ID pair — a superseded or handover-source association awaiting its Release
+// Complete. Its MME-UE-S1AP-ID is reserved but resolves to no UE, so a UE-associated
+// message naming it is answered from the detached state rather than as an unknown ID.
+func (m *MME) DetachedConn(conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	c, ok := m.conns[uint32(mmeUEID)]
+
+	return ok && c.ue == nil && c.conn == conn && c.ENBUES1APID == enbUEID
 }
 
 func SendHandoverPreparationFailure(ctx context.Context, m *MME, conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID, cause s1ap.Cause) {

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -603,20 +603,16 @@ func (m *MME) NewUe(conn S1APWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
 
 // attachUeConnLocked binds the bare connection c to a held UE context — a returning
 // UE resuming from ECM-IDLE (S-TMSI) or reusing a native GUTI onto the connection its
-// Initial UE Message created — releasing any connection ue still holds and stopping
-// its idle/paging supervision. The caller holds m.mu. Secure exchange is established
-// by the subsequent decode, not here (the bare connection carries the message that
-// establishes it).
+// Initial UE Message created — detaching any connection ue still holds (returned as
+// superseded) and stopping its idle/paging supervision. The caller holds m.mu. Secure
+// exchange is established by the subsequent decode, not here (the bare connection
+// carries the message that establishes it).
 func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) (superseded *UeConn) {
 	m.stopIdleTimersLocked(ue)
 	m.stopPagingLocked(ue)
 
-	// A re-attach on a new connection supersedes the old one. Detach the old
-	// connection — keeping its MME-UE-S1AP-ID reserved (it stays in m.conns) — and
-	// return it so the caller releases it toward the eNB with a UE Context Release
-	// Command outside the registry lock (TS 23.401 §4.11, TS 36.413 §8.3.3.1). Dropping
-	// it silently would leave the eNB's context dangling and its later release request
-	// unanswerable.
+	// A superseding connection detaches the old one but keeps its MME-UE-S1AP-ID
+	// reserved in m.conns: the eNB can reference it until it is released (TS 23.401 §4.11).
 	if old := ue.Conn(); old != nil {
 		m.clearHandoverLocked(ue)
 		m.stopNASGuardLocked(ue)

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -613,16 +613,7 @@ func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) (superseded *UeConn) 
 
 	// A superseding connection detaches the old one but keeps its MME-UE-S1AP-ID
 	// reserved in m.conns: the eNB can reference it until it is released (TS 36.413 §8.3.3.1).
-	if old := ue.Conn(); old != nil {
-		m.clearHandoverLocked(ue)
-		m.stopNASGuardLocked(ue)
-		ue.clearKeyChainProc()
-
-		old.ue = nil
-		ue.active.Store(nil)
-
-		superseded = old
-	}
+	superseded = m.detachConnLocked(ue)
 
 	// If c was bound to a transient context — a fresh Attach context superseded by a
 	// native-GUTI reuse — detach it there so that discarded context does not appear
@@ -674,25 +665,38 @@ func (m *MME) clearPagingSuppression(ctx context.Context, ue *UeContext) {
 	}
 }
 
+// detachConnLocked unbinds the UE's current S1-connection and stops its connection-scoped
+// supervision, returning the connection (nil if none). The connection stays in m.conns;
+// the caller frees or reserves its MME-UE-S1AP-ID. The caller holds m.mu.
+func (m *MME) detachConnLocked(ue *UeContext) *UeConn {
+	old := ue.Conn()
+	if old == nil {
+		return nil
+	}
+
+	// Abort any in-flight handover so its supervision does not outlive ue.active and
+	// fire on a detached connection.
+	m.clearHandoverLocked(ue)
+	m.stopNASGuardLocked(ue)
+	// Detaching the connection ends any in-flight key-changing procedure on it
+	// (e.g. a security mode whose Complete never arrived), so the {NH, NCC} chain
+	// claim must not outlive it and block a later procedure (TS 33.401 §7.2.8).
+	ue.clearKeyChainProc()
+
+	old.ue = nil
+	ue.active.Store(nil)
+
+	return old
+}
+
 // freeUeConnLocked releases the UE's current S1-connection (moving it to
 // ECM-IDLE) and stops the connection-scoped NAS-guard supervision. The
 // persistent context, its idle timers, and its registry indexes are left intact.
 // The caller holds m.mu.
 func (m *MME) freeUeConnLocked(ue *UeContext) {
-	if ue.Conn() == nil {
-		return
+	if old := m.detachConnLocked(ue); old != nil {
+		m.releaseConnIDLocked(uint32(old.MMEUES1APID))
 	}
-
-	// Abort any in-flight handover so its supervision does not outlive ue.active and
-	// fire on a freed connection.
-	m.clearHandoverLocked(ue)
-	m.stopNASGuardLocked(ue)
-	// Releasing the connection ends any in-flight key-changing procedure on it
-	// (e.g. a security mode whose Complete never arrived), so the {NH, NCC} chain
-	// claim must not outlive it and block a later procedure (TS 33.401 §7.2.8).
-	ue.clearKeyChainProc()
-	m.releaseConnIDLocked(uint32(ue.Conn().MMEUES1APID))
-	ue.active.Store(nil)
 }
 
 // FreeUeConn releases the UE's S1-connection under m.mu, moving it to ECM-IDLE.

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -612,7 +612,7 @@ func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) (superseded *UeConn) 
 	m.stopPagingLocked(ue)
 
 	// A superseding connection detaches the old one but keeps its MME-UE-S1AP-ID
-	// reserved in m.conns: the eNB can reference it until it is released (TS 23.401 §4.11).
+	// reserved in m.conns: the eNB can reference it until it is released (TS 36.413 §8.3.3.1).
 	if old := ue.Conn(); old != nil {
 		m.clearHandoverLocked(ue)
 		m.stopNASGuardLocked(ue)

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -607,13 +607,26 @@ func (m *MME) NewUe(conn S1APWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
 // its idle/paging supervision. The caller holds m.mu. Secure exchange is established
 // by the subsequent decode, not here (the bare connection carries the message that
 // establishes it).
-func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) {
+func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) (superseded *UeConn) {
 	m.stopIdleTimersLocked(ue)
 	m.stopPagingLocked(ue)
-	// Release any connection the held context still had (a re-attach on a new
-	// connection supersedes the old one); the old RAN context is stale, so this is a
-	// local cleanup with no Release Command.
-	m.freeUeConnLocked(ue)
+
+	// A re-attach on a new connection supersedes the old one. Detach the old
+	// connection — keeping its MME-UE-S1AP-ID reserved (it stays in m.conns) — and
+	// return it so the caller releases it toward the eNB with a UE Context Release
+	// Command outside the registry lock (TS 23.401 §4.11, TS 36.413 §8.3.3.1). Dropping
+	// it silently would leave the eNB's context dangling and its later release request
+	// unanswerable.
+	if old := ue.Conn(); old != nil {
+		m.clearHandoverLocked(ue)
+		m.stopNASGuardLocked(ue)
+		ue.clearKeyChainProc()
+
+		old.ue = nil
+		ue.active.Store(nil)
+
+		superseded = old
+	}
 
 	// If c was bound to a transient context — a fresh Attach context superseded by a
 	// native-GUTI reuse — detach it there so that discarded context does not appear
@@ -627,14 +640,20 @@ func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) {
 
 	// Becoming connected is activity; refresh liveness at the bind point.
 	ue.TouchLastSeen()
+
+	return superseded
 }
 
 // AttachUeConn binds a bare connection to a held UE context under the registry lock,
 // releasing any superseded connection.
 func (m *MME) AttachUeConn(ue *UeContext, c *UeConn) {
 	m.mu.Lock()
-	m.attachUeConnLocked(ue, c)
+	superseded := m.attachUeConnLocked(ue, c)
 	m.mu.Unlock()
+
+	if superseded != nil {
+		m.releaseSupersededConn(context.Background(), superseded)
+	}
 
 	m.clearPagingSuppression(context.Background(), ue)
 }

--- a/internal/mme/s1ap/handle_ue_context_release_complete.go
+++ b/internal/mme/s1ap/handle_ue_context_release_complete.go
@@ -21,11 +21,12 @@ func HandleUEContextReleaseComplete(m *mme.MME, ctx context.Context, radio *mme.
 		return
 	}
 
-	// A Release Complete for a detached handover association (the source after notify,
-	// or a rejected/superseded target) removes only that connection, leaving the UE
-	// active on the other association (TS 36.413 §8.4).
+	// A Release Complete for a detached association — a handover source after notify, a
+	// rejected/superseded target, or a connection superseded by a UE re-establishing on
+	// a new one — removes only that connection, leaving the UE active on its current
+	// association (TS 36.413 §8.3, §8.4).
 	if m.ReleaseDetachedConn(radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID) {
-		logger.MmeLog.Info("UE Context Release Complete (handover association)", zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)))
+		logger.MmeLog.Info("UE Context Release Complete (detached association)", zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)))
 		return
 	}
 

--- a/internal/mme/s1ap/handle_ue_context_release_complete.go
+++ b/internal/mme/s1ap/handle_ue_context_release_complete.go
@@ -21,10 +21,8 @@ func HandleUEContextReleaseComplete(m *mme.MME, ctx context.Context, radio *mme.
 		return
 	}
 
-	// A Release Complete for a detached association — a handover source after notify, a
-	// rejected/superseded target, or a connection superseded by a UE re-establishing on
-	// a new one — removes only that connection, leaving the UE active on its current
-	// association (TS 36.413 §8.3, §8.4).
+	// A Release Complete for a detached association removes only that connection; the UE
+	// stays active on its current association (TS 36.413 §8.3, §8.4).
 	if m.ReleaseDetachedConn(radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID) {
 		logger.MmeLog.Info("UE Context Release Complete (detached association)", zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)))
 		return

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -23,11 +23,8 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 		return
 	}
 
-	// The eNB may request release of a connection the MME already superseded (a UE that
-	// re-established on a new one) and commanded to release; its request crossed the
-	// command. Re-issue the command so the eNB completes the procedure (TS 36.413
-	// §8.3.2.2), rather than the Error Indication resolveUE would send for an ID that
-	// resolves to no UE.
+	// A detached (superseded) connection has no UE but its eNB still holds the context,
+	// so answer with a release command (TS 36.413 §8.3.2.2).
 	if m.DetachedConn(radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID) {
 		mme.SendUEContextRelease(ctx, m, radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID, true, msg.Cause)
 		return

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -23,6 +23,16 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 		return
 	}
 
+	// The eNB may request release of a connection the MME already superseded (a UE that
+	// re-established on a new one) and commanded to release; its request crossed the
+	// command. Re-issue the command so the eNB completes the procedure (TS 36.413
+	// §8.3.2.2), rather than the Error Indication resolveUE would send for an ID that
+	// resolves to no UE.
+	if m.DetachedConn(radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID) {
+		mme.SendUEContextRelease(ctx, m, radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID, true, msg.Cause)
+		return
+	}
+
 	ue, ok := resolveUE(m, radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID)
 	if !ok {
 		return

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -23,10 +23,9 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 		return
 	}
 
-	// A detached (superseded) connection has no UE but its eNB still holds the context,
-	// so answer with a release command (TS 36.413 §8.3.2.2).
-	if m.DetachedConn(radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID) {
-		mme.SendUEContextRelease(ctx, m, radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID, true, msg.Cause)
+	// A detached connection has no UE but its eNB still holds the context, so answer with
+	// a release command (TS 36.413 §8.3.2.2).
+	if m.AnswerDetachedRelease(ctx, radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID, msg.Cause) {
 		return
 	}
 

--- a/internal/mme/s1ap/superseded_release_test.go
+++ b/internal/mme/s1ap/superseded_release_test.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/mme"
+	nascommon "github.com/ellanetworks/core/nas/common"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// resumeOntoNewConnection registers a secured, ECM-CONNECTED UE on oldConn
+// (eNB-UE-S1AP-ID 7) and then has it re-establish on a new S1 connection via a
+// verified TRACKING AREA UPDATE, mirroring the flow from issue #1482. It returns the
+// old connection's MME/eNB S1AP IDs.
+func resumeOntoNewConnection(t *testing.T, m *mme.MME, ue *mme.UeContext) (oldMMEID s1ap.MMEUES1APID, oldENBID s1ap.ENBUES1APID) {
+	t.Helper()
+
+	oldMMEID = ue.Conn().MMEUES1APID
+	oldENBID = ue.Conn().ENBUES1APID
+
+	plmn, err := m.OperatorPLMN(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	group, code := m.MmeIdentity()
+	if _, err := m.ReallocateGUTI(t.Context(), ue, plmn, group, code); err != nil {
+		t.Fatal(err)
+	}
+
+	tau, err := (&eps.TrackingAreaUpdateRequest{EPSUpdateType: 3}).Marshal() // periodic
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wire, err := eps.Protect(tau, eps.SHTIntegrityProtected, nascommon.NASCount(0, 0),
+		nascommon.DirectionUplink, ue.KnasIntForTest(), ue.KnasEncForTest(),
+		nascommon.AESCMACIntegrity{}, nascommon.AESCTRCipher{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plmnID := s1ap.PLMNIdentity{0x00, 0xf1, 0x10}
+
+	im, err := (&s1ap.InitialUEMessage{
+		ENBUES1APID:           1001,
+		NASPDU:                s1ap.NASPDU(wire),
+		TAI:                   s1ap.TAI{PLMNIdentity: plmnID, TAC: 1},
+		EUTRANCGI:             s1ap.EUTRANCGI{PLMNIdentity: plmnID, CellID: 1},
+		RRCEstablishmentCause: s1ap.RRCCauseEmergency,
+		STMSI:                 &s1ap.STMSI{MMEC: code, MTMSI: ue.TmsiForTest()},
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newConn := &captureConn{}
+	HandleInitialUEMessage(m, context.Background(), mme.NewRadioForTest(newConn), initiatingValue(t, im))
+
+	if ue.Conn().ENBUES1APID != 1001 {
+		t.Fatalf("resume did not bind the new connection (eNB-UE-S1AP-ID = %d)", ue.Conn().ENBUES1APID)
+	}
+
+	return oldMMEID, oldENBID
+}
+
+// isReleaseCommandFor reports whether pdu is a UE CONTEXT RELEASE COMMAND naming the
+// given S1AP ID pair.
+func isReleaseCommandFor(t *testing.T, pdu []byte, mmeID s1ap.MMEUES1APID, enbID s1ap.ENBUES1APID) bool {
+	t.Helper()
+
+	msg, err := s1ap.Unmarshal(pdu)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	im, ok := msg.(*s1ap.InitiatingMessage)
+	if !ok || im.ProcedureCode != s1ap.ProcUEContextRelease {
+		return false
+	}
+
+	cmd, err := s1ap.ParseUEContextReleaseCommand(im.Value)
+	if err != nil {
+		t.Fatalf("parse UE Context Release Command: %v", err)
+	}
+
+	return cmd.UES1APIDs.MMEUES1APID == mmeID && cmd.UES1APIDs.ENBUES1APID == enbID
+}
+
+func isErrorIndication(t *testing.T, pdu []byte) bool {
+	t.Helper()
+
+	msg, err := s1ap.Unmarshal(pdu)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	im, ok := msg.(*s1ap.InitiatingMessage)
+
+	return ok && im.ProcedureCode == s1ap.ProcErrorIndication
+}
+
+// TestSupersededConnectionIsReleasedTowardENB verifies the fix for the 4G/S1AP side of
+// issue #1482: when a UE re-establishes on a new S1 connection, the MME must release
+// the old (superseded) connection toward the eNB with a UE CONTEXT RELEASE COMMAND
+// (TS 23.401 §4.11, TS 36.413 §8.3.3.1) — not drop it silently, which leaves the eNB's
+// stale context dangling and its later release request unanswerable.
+func TestSupersededConnectionIsReleasedTowardENB(t *testing.T) {
+	m := newTestMME(t)
+	ue, oldConn := securedUE(t, m) // ECM-CONNECTED on oldConn, eNB-UE-S1AP-ID 7
+
+	oldMMEID, oldENBID := resumeOntoNewConnection(t, m, ue)
+
+	var released bool
+
+	for _, pdu := range oldConn.sent {
+		if isReleaseCommandFor(t, pdu, oldMMEID, oldENBID) {
+			released = true
+		}
+	}
+
+	if !released {
+		t.Fatalf("issue #1482: MME did not send a UE CONTEXT RELEASE COMMAND for the superseded "+
+			"context (MME-UE-S1AP-ID %d); it dropped the old S1 connection silently", oldMMEID)
+	}
+}
+
+// TestSupersededConnectionReleaseRequestGetsCommand verifies that an eNB release
+// request for the superseded context — one that crossed the MME's own release command —
+// is answered with a UE CONTEXT RELEASE COMMAND (TS 36.413 §8.3.2.2), never an Error
+// Indication with unknown-mme-ue-s1ap-id.
+func TestSupersededConnectionReleaseRequestGetsCommand(t *testing.T) {
+	m := newTestMME(t)
+	ue, oldConn := securedUE(t, m)
+
+	oldMMEID, oldENBID := resumeOntoNewConnection(t, m, ue)
+
+	relReq, err := (&s1ap.UEContextReleaseRequest{
+		MMEUES1APID: oldMMEID,
+		ENBUES1APID: oldENBID,
+		Cause:       s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkRadioConnectionWithUELost},
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := oldConn.count()
+	handleUEContextReleaseRequest(m, context.Background(), mme.NewRadioForTest(oldConn), initiatingValue(t, relReq))
+
+	sent := oldConn.sent[before:]
+	if len(sent) != 1 {
+		t.Fatalf("expected exactly one S1AP response to the release request, got %d", len(sent))
+	}
+
+	if isErrorIndication(t, sent[0]) {
+		t.Fatalf("issue #1482: MME answered the eNB's release request for the superseded context "+
+			"(MME-UE-S1AP-ID %d) with ERROR INDICATION; TS 36.413 §8.3.2.2 requires a UE CONTEXT "+
+			"RELEASE COMMAND", oldMMEID)
+	}
+
+	if !isReleaseCommandFor(t, sent[0], oldMMEID, oldENBID) {
+		t.Fatalf("expected a UE CONTEXT RELEASE COMMAND for the superseded context")
+	}
+}

--- a/internal/mme/s1ap/superseded_release_test.go
+++ b/internal/mme/s1ap/superseded_release_test.go
@@ -13,10 +13,9 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// resumeOntoNewConnection registers a secured, ECM-CONNECTED UE on oldConn
-// (eNB-UE-S1AP-ID 7) and then has it re-establish on a new S1 connection via a
-// verified TRACKING AREA UPDATE, mirroring the flow from issue #1482. It returns the
-// old connection's MME/eNB S1AP IDs.
+// resumeOntoNewConnection re-establishes ue on a new S1 connection (eNB-UE-S1AP-ID
+// 1001) via a verified TRACKING AREA UPDATE and returns the superseded connection's
+// S1AP ID pair.
 func resumeOntoNewConnection(t *testing.T, m *mme.MME, ue *mme.UeContext) (oldMMEID s1ap.MMEUES1APID, oldENBID s1ap.ENBUES1APID) {
 	t.Helper()
 
@@ -105,11 +104,9 @@ func isErrorIndication(t *testing.T, pdu []byte) bool {
 	return ok && im.ProcedureCode == s1ap.ProcErrorIndication
 }
 
-// TestSupersededConnectionIsReleasedTowardENB verifies the fix for the 4G/S1AP side of
-// issue #1482: when a UE re-establishes on a new S1 connection, the MME must release
-// the old (superseded) connection toward the eNB with a UE CONTEXT RELEASE COMMAND
-// (TS 23.401 §4.11, TS 36.413 §8.3.3.1) — not drop it silently, which leaves the eNB's
-// stale context dangling and its later release request unanswerable.
+// TestSupersededConnectionIsReleasedTowardENB checks that re-establishing a UE on a new
+// S1 connection releases the superseded one toward the eNB with a UE CONTEXT RELEASE
+// COMMAND (TS 23.401 §4.11, TS 36.413 §8.3.3.1).
 func TestSupersededConnectionIsReleasedTowardENB(t *testing.T) {
 	m := newTestMME(t)
 	ue, oldConn := securedUE(t, m) // ECM-CONNECTED on oldConn, eNB-UE-S1AP-ID 7
@@ -125,15 +122,13 @@ func TestSupersededConnectionIsReleasedTowardENB(t *testing.T) {
 	}
 
 	if !released {
-		t.Fatalf("issue #1482: MME did not send a UE CONTEXT RELEASE COMMAND for the superseded "+
-			"context (MME-UE-S1AP-ID %d); it dropped the old S1 connection silently", oldMMEID)
+		t.Fatalf("no UE CONTEXT RELEASE COMMAND sent for the superseded context (MME-UE-S1AP-ID %d)", oldMMEID)
 	}
 }
 
-// TestSupersededConnectionReleaseRequestGetsCommand verifies that an eNB release
-// request for the superseded context — one that crossed the MME's own release command —
-// is answered with a UE CONTEXT RELEASE COMMAND (TS 36.413 §8.3.2.2), never an Error
-// Indication with unknown-mme-ue-s1ap-id.
+// TestSupersededConnectionReleaseRequestGetsCommand checks that an eNB release request
+// for a superseded context is answered with a UE CONTEXT RELEASE COMMAND, not an Error
+// Indication (TS 36.413 §8.3.2.2).
 func TestSupersededConnectionReleaseRequestGetsCommand(t *testing.T) {
 	m := newTestMME(t)
 	ue, oldConn := securedUE(t, m)
@@ -158,9 +153,8 @@ func TestSupersededConnectionReleaseRequestGetsCommand(t *testing.T) {
 	}
 
 	if isErrorIndication(t, sent[0]) {
-		t.Fatalf("issue #1482: MME answered the eNB's release request for the superseded context "+
-			"(MME-UE-S1AP-ID %d) with ERROR INDICATION; TS 36.413 §8.3.2.2 requires a UE CONTEXT "+
-			"RELEASE COMMAND", oldMMEID)
+		t.Fatalf("release request for the superseded context (MME-UE-S1AP-ID %d) answered with "+
+			"ERROR INDICATION; want UE CONTEXT RELEASE COMMAND (TS 36.413 §8.3.2.2)", oldMMEID)
 	}
 
 	if !isReleaseCommandFor(t, sent[0], oldMMEID, oldENBID) {

--- a/internal/mme/s1ap/superseded_release_test.go
+++ b/internal/mme/s1ap/superseded_release_test.go
@@ -128,8 +128,9 @@ func TestSupersededConnectionIsReleasedTowardENB(t *testing.T) {
 
 // TestSupersededConnectionReleaseRequestGetsCommand checks that an eNB release request
 // for a superseded context is answered with a UE CONTEXT RELEASE COMMAND, not an Error
-// Indication (TS 36.413 §8.3.2.2).
-func TestSupersededConnectionReleaseRequestGetsCommand(t *testing.T) {
+// Indication (TS 36.413 §8.3.2.2). The proactive release is already in flight and
+// guarded, so the crossing request adds no Error Indication and no duplicate command.
+func TestSupersededConnectionReleaseRequestNoErrorIndication(t *testing.T) {
 	m := newTestMME(t)
 	ue, oldConn := securedUE(t, m)
 
@@ -147,17 +148,50 @@ func TestSupersededConnectionReleaseRequestGetsCommand(t *testing.T) {
 	before := oldConn.count()
 	handleUEContextReleaseRequest(m, context.Background(), mme.NewRadioForTest(oldConn), initiatingValue(t, relReq))
 
-	sent := oldConn.sent[before:]
-	if len(sent) != 1 {
-		t.Fatalf("expected exactly one S1AP response to the release request, got %d", len(sent))
+	for _, pdu := range oldConn.sent[before:] {
+		if isErrorIndication(t, pdu) {
+			t.Fatalf("release request for the superseded context (MME-UE-S1AP-ID %d) answered with "+
+				"ERROR INDICATION; want none (TS 36.413 §8.3.2.2)", oldMMEID)
+		}
 	}
 
-	if isErrorIndication(t, sent[0]) {
-		t.Fatalf("release request for the superseded context (MME-UE-S1AP-ID %d) answered with "+
-			"ERROR INDICATION; want UE CONTEXT RELEASE COMMAND (TS 36.413 §8.3.2.2)", oldMMEID)
+	if n := oldConn.count() - before; n != 0 {
+		t.Fatalf("crossing release request produced %d new PDU(s); want 0, a release is already in flight", n)
+	}
+}
+
+// TestDetachedReleaseRequestGuardsAndDedups covers the leak-proofing for a detached
+// connection that has no release in flight (a bare or handover-source association): the
+// first release request draws a command and arms the guard; a crossing second request is
+// suppressed.
+func TestDetachedReleaseRequestGuardsAndDedups(t *testing.T) {
+	m := newTestMME(t)
+	cc := &captureConn{}
+
+	const enbID s1ap.ENBUES1APID = 55
+
+	bare := m.NewUeConn(cc, enbID) // UE-less connection, as an Initial UE Message creates
+	if bare == nil {
+		t.Fatal("failed to allocate a bare connection")
 	}
 
-	if !isReleaseCommandFor(t, sent[0], oldMMEID, oldENBID) {
-		t.Fatalf("expected a UE CONTEXT RELEASE COMMAND for the superseded context")
+	cause := s1ap.Cause{Group: s1ap.CauseGroupNAS, Value: s1ap.CauseNASNormalRelease}
+
+	if !m.AnswerDetachedRelease(context.Background(), cc, bare.MMEUES1APID, enbID, cause) {
+		t.Fatal("AnswerDetachedRelease did not match the detached connection")
 	}
+
+	if !isReleaseCommandFor(t, cc.sent[0], bare.MMEUES1APID, enbID) {
+		t.Fatalf("first release request did not draw a UE CONTEXT RELEASE COMMAND")
+	}
+
+	if !m.AnswerDetachedRelease(context.Background(), cc, bare.MMEUES1APID, enbID, cause) {
+		t.Fatal("AnswerDetachedRelease stopped matching the detached connection")
+	}
+
+	if cc.count() != 1 {
+		t.Fatalf("duplicate release command not suppressed while a release is in flight: %d commands", cc.count())
+	}
+
+	m.ReleaseDetachedConn(cc, bare.MMEUES1APID, enbID) // reap + stop the guard
 }

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -17,11 +17,14 @@ import (
 // (S1AP §8.3 has no MME-side supervision timer, so this is a robustness guard).
 const releaseGuardTimeout = 5 * time.Second
 
-var causeSupersededConnection = s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkRadioConnectionWithUELost}
+// causeSupersededConnection is the release cause for the old S1 connection when a UE
+// re-establishes on a new one: a normal release of the superseded NAS signalling
+// connection (TS 36.413 §8.3.3.1).
+var causeSupersededConnection = s1ap.Cause{Group: s1ap.CauseGroupNAS, Value: s1ap.CauseNASNormalRelease}
 
 // releaseSupersededConn releases the detached old connection toward the eNB and guards
 // the Release Complete, so a lost Complete cannot leak the reserved MME-UE-S1AP-ID
-// (TS 23.401 §4.11).
+// (TS 36.413 §8.3.3.1).
 func (m *MME) releaseSupersededConn(ctx context.Context, c *UeConn) {
 	SendUEContextRelease(ctx, m, c.conn, c.MMEUES1APID, c.ENBUES1APID, true, causeSupersededConnection)
 

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -23,17 +23,45 @@ const releaseGuardTimeout = 5 * time.Second
 var causeSupersededConnection = s1ap.Cause{Group: s1ap.CauseGroupNAS, Value: s1ap.CauseNASNormalRelease}
 
 // releaseSupersededConn releases the detached old connection toward the eNB and guards
-// the Release Complete, so a lost Complete cannot leak the reserved MME-UE-S1AP-ID
-// (TS 36.413 §8.3.3.1).
+// the Release Complete (TS 36.413 §8.3.3.1).
 func (m *MME) releaseSupersededConn(ctx context.Context, c *UeConn) {
 	SendUEContextRelease(ctx, m, c.conn, c.MMEUES1APID, c.ENBUES1APID, true, causeSupersededConnection)
+	m.guardDetachedRelease(c)
+}
 
+// guardDetachedRelease supervises the Release Complete for a detached connection, so a
+// lost Complete cannot leak its reserved MME-UE-S1AP-ID.
+func (m *MME) guardDetachedRelease(c *UeConn) {
 	c.releaseGuard.Arm(releaseGuardTimeout, 0, nil, func() {
 		if m.ReleaseDetachedConn(c.conn, c.MMEUES1APID, c.ENBUES1APID) {
-			logger.MmeLog.Info("reaped superseded S1 connection after release timeout",
+			logger.MmeLog.Info("reaped detached S1 connection after release timeout",
 				zap.Uint32("mme-ue-id", uint32(c.MMEUES1APID)))
 		}
 	})
+}
+
+// AnswerDetachedRelease answers an eNB UE Context Release Request that names a detached
+// connection the MME still holds — superseded, handover source, or bare — with a UE
+// Context Release Command and guards the Complete, so the reserved MME-UE-S1AP-ID cannot
+// leak (TS 36.413 §8.3.2.2). A release already in flight for the connection keeps its own
+// command and guard. Reports whether conn held a matching detached connection.
+func (m *MME) AnswerDetachedRelease(ctx context.Context, conn S1APWriter, mmeUEID s1ap.MMEUES1APID, enbUEID s1ap.ENBUES1APID, cause s1ap.Cause) bool {
+	m.mu.RLock()
+	c, ok := m.conns[uint32(mmeUEID)]
+	matched := ok && c.ue == nil && c.conn == conn && c.ENBUES1APID == enbUEID
+
+	m.mu.RUnlock()
+
+	if !matched {
+		return false
+	}
+
+	if !c.releaseGuard.Active() {
+		SendUEContextRelease(ctx, m, conn, mmeUEID, enbUEID, true, cause)
+		m.guardDetachedRelease(c)
+	}
+
+	return true
 }
 
 // SendUEContextReleaseCommand builds a UE Context Release Command for this

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -17,17 +17,11 @@ import (
 // (S1AP §8.3 has no MME-side supervision timer, so this is a robustness guard).
 const releaseGuardTimeout = 5 * time.Second
 
-// causeSupersededConnection releases the old S1 connection when a UE re-establishes on
-// a new one: the radio connection on the old association is lost (TS 36.413 §9.2.1.3),
-// the same reason the eNB reports for the stale context (TS 23.401 §4.11).
 var causeSupersededConnection = s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkRadioConnectionWithUELost}
 
-// releaseSupersededConn commands the eNB to release a connection the UE has left for a
-// new one and supervises the Release Complete, so a lost Complete — or an eNB that has
-// already dropped the context — cannot leak the reserved MME-UE-S1AP-ID (TS 36.413
-// §8.3; TS 23.401 §4.11). The connection stays detached in m.conns until its Release
-// Complete or this guard reaps it, so the identifier is never reused while the eNB may
-// still reference it.
+// releaseSupersededConn releases the detached old connection toward the eNB and guards
+// the Release Complete, so a lost Complete cannot leak the reserved MME-UE-S1AP-ID
+// (TS 23.401 §4.11).
 func (m *MME) releaseSupersededConn(ctx context.Context, c *UeConn) {
 	SendUEContextRelease(ctx, m, c.conn, c.MMEUES1APID, c.ENBUES1APID, true, causeSupersededConnection)
 

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -17,6 +17,28 @@ import (
 // (S1AP §8.3 has no MME-side supervision timer, so this is a robustness guard).
 const releaseGuardTimeout = 5 * time.Second
 
+// causeSupersededConnection releases the old S1 connection when a UE re-establishes on
+// a new one: the radio connection on the old association is lost (TS 36.413 §9.2.1.3),
+// the same reason the eNB reports for the stale context (TS 23.401 §4.11).
+var causeSupersededConnection = s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkRadioConnectionWithUELost}
+
+// releaseSupersededConn commands the eNB to release a connection the UE has left for a
+// new one and supervises the Release Complete, so a lost Complete — or an eNB that has
+// already dropped the context — cannot leak the reserved MME-UE-S1AP-ID (TS 36.413
+// §8.3; TS 23.401 §4.11). The connection stays detached in m.conns until its Release
+// Complete or this guard reaps it, so the identifier is never reused while the eNB may
+// still reference it.
+func (m *MME) releaseSupersededConn(ctx context.Context, c *UeConn) {
+	SendUEContextRelease(ctx, m, c.conn, c.MMEUES1APID, c.ENBUES1APID, true, causeSupersededConnection)
+
+	c.releaseGuard.Arm(releaseGuardTimeout, 0, nil, func() {
+		if m.ReleaseDetachedConn(c.conn, c.MMEUES1APID, c.ENBUES1APID) {
+			logger.MmeLog.Info("reaped superseded S1 connection after release timeout",
+				zap.Uint32("mme-ue-id", uint32(c.MMEUES1APID)))
+		}
+	})
+}
+
 // SendUEContextReleaseCommand builds a UE Context Release Command for this
 // connection's S1AP identities and sends it to the eNB (TS 36.413 §8.3.1).
 func (c *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause s1ap.Cause) {

--- a/s1ap/cause.go
+++ b/s1ap/cause.go
@@ -36,10 +36,11 @@ var causeGroupRootCount = [causeRootGroups]int{
 // Ella Core emits. Each value is its group's enumeration index, so the same
 // number means different things in different groups — the group prefix names it.
 const (
-	CauseRadioNetworkUnspecified             = 0  // unspecified
-	CauseRadioNetworkUnknownMMEUES1APID      = 13 // unknown-mme-ue-s1ap-id
-	CauseRadioNetworkUnknownPairUES1APID     = 15 // unknown-pair-ue-s1ap-id
-	CauseRadioNetworkMultipleERABIDInstances = 31 // multiple-E-RAB-ID-instances
+	CauseRadioNetworkUnspecified               = 0  // unspecified
+	CauseRadioNetworkUnknownMMEUES1APID        = 13 // unknown-mme-ue-s1ap-id
+	CauseRadioNetworkUnknownPairUES1APID       = 15 // unknown-pair-ue-s1ap-id
+	CauseRadioNetworkRadioConnectionWithUELost = 21 // radio-connection-with-ue-lost
+	CauseRadioNetworkMultipleERABIDInstances   = 31 // multiple-E-RAB-ID-instances
 
 	CauseTransportResourceUnavailable = 0 // transport-resource-unavailable
 


### PR DESCRIPTION
# Description

When a UE re-established on a new S1/NG connection, Ella Core silently dropped the old connection and then answered the eNB/gNB's release request for it with an Error Indication instead of a UE CONTEXT RELEASE COMMAND, leaving the stale context dangling and stalling downlink-initiated connectivity for 20–120s; the fix proactively releases the superseded connection toward the RAN, symmetrically for 4G and 5G.

Fixes #1482. 

## Reference
- TS 23.401
- TS 23.502

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
