### PR TITLE
docs: correct generic XDP checksum failure mode

### DIFF
--- a/docs/explanation/user_plane_packet_processing_with_ebpf.md
+++ b/docs/explanation/user_plane_packet_processing_with_ebpf.md
@@ -63,7 +63,7 @@ The solution is to attach a minimal XDP program that returns `XDP_PASS` to the p
 
 When an application transmits over a veth interface, the kernel defers computing the transport checksum: the packet carries `CHECKSUM_PARTIAL` metadata recording where the egress NIC should write the checksum later. GTP-U traffic sent by a co-hosted radio therefore reaches Ella Core's N3 interface with an incomplete outer UDP checksum.
 
-In **generic XDP mode**, the kernel does not update this metadata when the data plane removes the GTP-U header. The recorded checksum location then points at the wrong offset, and depending on how the egress NIC driver consumes it, packets may be corrupted, dropped, or survive unharmed. The failure is invisible to the XDP counters. The typical symptom is a PDU session that establishes normally, with working ping and DNS, while TCP and large packets silently fail.
+In **generic XDP mode**, the kernel does not update this metadata when the data plane removes the GTP-U header. The egress path then completes the checksum at the stale offset, corrupting the decapsulated frame at a position that depends on the removed header length. The failure is invisible to the XDP counters and to packet captures on the host.
 
 The remedy is to disable TX checksum offload on both ends of the veth pair (`ethtool -K <veth> tx off`), forcing checksums to be completed in software before packets reach the data plane. Native XDP mode is not affected: redirected frames are forwarded as raw packets and carry no checksum-offload metadata.
 

--- a/docs/how_to/co_host_with_ocudu.md
+++ b/docs/how_to/co_host_with_ocudu.md
@@ -47,6 +47,7 @@ ip -n n3ns link set dev n3-ran-veth up
 ip link set dev n3-upf-veth up
 ethtool -K n3-upf-veth tx off
 ip netns exec n3ns ethtool -K n3-ran-veth tx off
+ethtool -K eth0 gro off
 ```
 
 Disabling TX checksum offload on both veth endpoints is required in `generic` XDP mode — see [Checksum offload on veth pairs](../explanation/user_plane_packet_processing_with_ebpf.md#checksum-offload-on-veth-pairs).


### PR DESCRIPTION
# Description

States the veth checksum corruption's actual behavior and adds `ethtool -K eth0 gro off` to the co-host setup block so TCP downlink survives the tunnel MTU check in generic mode.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
