### PR TITLE
fix: add mount-observe snap plug

### DIFF
--- a/docs/how_to/install.md
+++ b/docs/how_to/install.md
@@ -16,6 +16,7 @@ Ensure your system meets the [requirements](../reference/system_reqs.md). Then, 
     sudo snap connect ella-core:process-control
     sudo snap connect ella-core:system-observe
     sudo snap connect ella-core:firewall-control
+    sudo snap connect ella-core:mount-observe
     ```
 
     Configure Ella Core:

--- a/docs/tutorials/getting_started_hardware.md
+++ b/docs/tutorials/getting_started_hardware.md
@@ -45,6 +45,7 @@ sudo snap connect ella-core:network-control
 sudo snap connect ella-core:process-control
 sudo snap connect ella-core:system-observe
 sudo snap connect ella-core:firewall-control
+sudo snap connect ella-core:mount-observe
 ```
 
 Edit the configuration file:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,7 @@ apps:
       - process-control
       - system-observe
       - firewall-control
+      - mount-observe
 
 parts:
   core:


### PR DESCRIPTION
# Description

The latest cilium version (`cilium/ebpf v0.22.0`) reads `/proc/self/mountinfo` for its BPF-token probe. Under strict confinement, this requires a new `mount-observe` plug to avoid app armor blocking the read.

Fixes https://github.com/ellanetworks/core/discussions/1503

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
