### PR TITLE
chore(CI): bump rockcraft pack action and install snap

### DIFF
--- a/.github/workflows/image-build-tester.yaml
+++ b/.github/workflows/image-build-tester.yaml
@@ -23,10 +23,10 @@ jobs:
           rm -f rockcraft.yaml
           mv rockcraft-tester.yaml rockcraft.yaml
 
-      - uses: canonical/craft-actions/rockcraft-pack@acd2f2e61c7563b38ba89390ca0e910fa7d2784f # main
+      - uses: canonical/craft-actions/rockcraft/pack@adcd47eb054a3dcf0eabbdb81439aae5f3ce715e # main
         id: rockcraft
         with:
-          rockcraft-channel: stable
+          channel: stable
 
       - name: Save container image to file
         run: |

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - uses: canonical/craft-actions/rockcraft-pack@acd2f2e61c7563b38ba89390ca0e910fa7d2784f # main
+      - uses: canonical/craft-actions/rockcraft/pack@adcd47eb054a3dcf0eabbdb81439aae5f3ce715e # main
         id: rockcraft
         with:
-          rockcraft-channel: stable
+          channel: stable
 
       - name: Save container image to file
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
     uses: ./.github/workflows/clang-tidy.yaml
   license-headers:
     uses: ./.github/workflows/license-headers.yaml
+  snap-strict-test:
+    uses: ./.github/workflows/snap-strict-test.yaml
   image-build:
     needs: [go-unit-test, go-vet, go-lint]
     uses: ./.github/workflows/image-build.yaml

--- a/.github/workflows/snap-strict-test.yaml
+++ b/.github/workflows/snap-strict-test.yaml
@@ -45,6 +45,7 @@ jobs:
           sudo ip link set ella-n2 up
           sudo ip link add ella-n3 type veth peer name ella-n3-peer
           sudo ip link add ella-n6 type veth peer name ella-n6-peer
+          sudo ip addr add 10.5.0.1/24 dev ella-n3
           sudo ip addr add 10.6.0.1/24 dev ella-n6
           for dev in ella-n3 ella-n3-peer ella-n6 ella-n6-peer; do
             sudo ip link set "${dev}" up
@@ -54,7 +55,8 @@ jobs:
             .interfaces.n2.address = "10.3.0.2" |
             .interfaces.n3.name = "ella-n3" |
             .interfaces.n6.name = "ella-n6" |
-            .xdp."attach-mode" = "generic"
+            .xdp."attach-mode" = "generic" |
+            .logging.system.level = "debug"
           ' "${cfg}"
 
       - name: Start the datapath daemon
@@ -62,8 +64,19 @@ jobs:
 
       - name: Assert the service runs properly
         run: |
-          sleep 10
-          systemctl is-active snap.ella-core.cored
+          sleep 15
+          # A failed eBPF load (the class of regression this guards) is fatal and
+          # triggers a systemd restart, so a clean run has zero restarts.
+          restarts="$(systemctl show -p NRestarts --value snap.ella-core.cored)"
+          echo "restarts: ${restarts}"
+          if [ "${restarts}" != "0" ]; then
+            echo "::error::ella-core.cored crashed/restarted under strict confinement"
+            exit 1
+          fi
+          # The datapath is up only if the whole runtime came up: query the API.
+          status="$(curl -sk --max-time 10 https://127.0.0.1:5002/api/v1/status)"
+          echo "status: ${status}"
+          echo "${status}" | grep -q '"ready":true'
 
       - name: Dump daemon logs
         if: always()

--- a/.github/workflows/snap-strict-test.yaml
+++ b/.github/workflows/snap-strict-test.yaml
@@ -1,0 +1,70 @@
+name: Snap Strict Confinement Test
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+
+jobs:
+  snap-strict-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build snap
+        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 #v1.3.0
+        id: build
+
+      - name: Install the snap under strict confinement
+        run: |
+          sudo snap install --dangerous "${{ steps.build.outputs.snap }}"
+          snap list ella-core
+
+      - name: Require strict confinement to be enforced
+        # Without this, a runner running the snap unconfined would let the test
+        # pass even if a plug/permission were missing.
+        run: |
+          mode="$(sudo snap debug confinement)"
+          echo "system confinement: ${mode}"
+          if [ "${mode}" != "strict" ]; then
+            echo "::error::runner does not enforce strict confinement (${mode}); cannot validate the snap"
+            exit 1
+          fi
+
+      - name: Connect the snap plugs
+        run: |
+          for plug in network-control process-control system-observe firewall-control mount-observe; do
+            sudo snap connect ella-core:"${plug}"
+          done
+
+      - name: Provision test interfaces and configuration
+        run: |
+          sudo ip link add ella-n2 type dummy
+          sudo ip addr add 10.3.0.2/24 dev ella-n2
+          sudo ip link set ella-n2 up
+          sudo ip link add ella-n3 type veth peer name ella-n3-peer
+          sudo ip link add ella-n6 type veth peer name ella-n6-peer
+          sudo ip addr add 10.6.0.1/24 dev ella-n6
+          for dev in ella-n3 ella-n3-peer ella-n6 ella-n6-peer; do
+            sudo ip link set "${dev}" up
+          done
+          cfg=/var/snap/ella-core/common/core.yaml
+          sudo yq -i '
+            .interfaces.n2.address = "10.3.0.2" |
+            .interfaces.n3.name = "ella-n3" |
+            .interfaces.n6.name = "ella-n6" |
+            .xdp."attach-mode" = "generic"
+          ' "${cfg}"
+
+      - name: Start the datapath daemon
+        run: sudo snap start ella-core.cored
+
+      - name: Assert the service runs properly
+        run: |
+          sleep 10
+          systemctl is-active snap.ella-core.cored
+
+      - name: Dump daemon logs
+        if: always()
+        run: sudo snap logs ella-core.cored -n 200 || true


### PR DESCRIPTION
# Description

Replace the deprecated `canonical/craft-actions/rockcraft-pack` GitHub action with `canonical/craft-actions/rockcraft/pack`. We also build and run the Ella Core snap in the CI to avoid a regression like we observed in #1503 .

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
