### PR TITLE
perf: eliminate redundant DB reads during signalling

### DIFF
--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -509,6 +509,7 @@ func (ue *UeContext) ClearRegistrationRequestData() {
 	defer ue.mu.Unlock()
 
 	conn.RegistrationRequest = nil
+	conn.RegistrationRequestPlain = nil
 	conn.RegistrationType5GS = 0
 	conn.IdentityTypeUsedForRegistration = 0
 	conn.resyncTried = false

--- a/internal/amf/config.go
+++ b/internal/amf/config.go
@@ -33,6 +33,10 @@ func (amf *AMF) OperatorInfo(ctx context.Context) (*OperatorInfo, error) {
 		return nil, fmt.Errorf("failed to get operator: %s", err)
 	}
 
+	return amf.operatorInfoFrom(operator)
+}
+
+func (amf *AMF) operatorInfoFrom(operator *db.Operator) (*OperatorInfo, error) {
 	supportedTAIs, err := getSupportedTAIs(operator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get supported TAIs: %w", err)
@@ -41,7 +45,7 @@ func (amf *AMF) OperatorInfo(ctx context.Context) (*OperatorInfo, error) {
 	// 3GPP TS 23.003: AMF Identifier = <AMF Region ID><AMF Set ID><AMF Pointer>
 	amfID := fmt.Sprintf("%06x", (operator.AmfRegionID<<16)|(operator.AmfSetID<<6)|amf.DBInstance.NodeID())
 
-	operatorInfo := &OperatorInfo{
+	return &OperatorInfo{
 		Tais: supportedTAIs,
 		Guami: &models.Guami{
 			PlmnID: &models.PlmnID{
@@ -50,9 +54,7 @@ func (amf *AMF) OperatorInfo(ctx context.Context) (*OperatorInfo, error) {
 			},
 			AmfID: amfID,
 		},
-	}
-
-	return operatorInfo, nil
+	}, nil
 }
 
 func (amf *AMF) ListOperatorSnssai(ctx context.Context) ([]models.Snssai, error) {

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -178,7 +178,7 @@ func decodePlainNAS(msg *nas.Message, payload []byte) (*DecodeResult, error) {
 		return nil, silentDecode(nasreply.ReasonIntegrityFail, "plain NAS message type %d not permitted by TS 24.501 §4.4.4.3", msgType)
 	}
 
-	return &DecodeResult{Message: msg, IntegrityVerified: false}, nil
+	return &DecodeResult{Message: msg, IntegrityVerified: false, Plain: body}, nil
 }
 
 func decodeProtectedNAS(ue *UeContext, msg *nas.Message, payload []byte, conn *UeConn) (*DecodeResult, error) {
@@ -272,5 +272,5 @@ func decodeProtectedNAS(ue *UeContext, msg *nas.Message, payload []byte, conn *U
 		conn.MarkSecureExchangeEstablished()
 	}
 
-	return &DecodeResult{Message: msg, IntegrityVerified: macVerified}, nil
+	return &DecodeResult{Message: msg, IntegrityVerified: macVerified, Plain: body}, nil
 }

--- a/internal/amf/nas/context_setup.go
+++ b/internal/amf/nas/context_setup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 )
 
-func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nasMessage.RegistrationRequest) {
+func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nasMessage.RegistrationRequest, plain []byte) {
 	ctx, span := gmmTracer.Start(ctx, "nas/context_setup")
 	defer span.End()
 
@@ -24,6 +24,7 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, 
 	}
 
 	conn.RegistrationRequest = msg
+	conn.RegistrationRequestPlain = plain
 
 	switch conn.RegistrationType5GS {
 	case nasMessage.RegistrationType5GSInitialRegistration:

--- a/internal/amf/nas/gmm_handler.go
+++ b/internal/amf/nas/gmm_handler.go
@@ -18,12 +18,12 @@ var gmmTracer = otel.Tracer("ella-core/amf/nas/handler")
 // HandleGmmMessage dispatches an inbound GMM message to its handler. integrityVerified
 // is true only when the message carried a verified MAC; it is false when the decoder
 // admitted the message without verified integrity (plain, or MAC-failed but whitelisted).
-func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nas.GmmMessage, integrityVerified bool) nasreply.Disposition {
+func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nas.GmmMessage, plain []byte, integrityVerified bool) nasreply.Disposition {
 	msgType := msg.GetMessageType()
 
 	switch msgType {
 	case nas.MsgTypeRegistrationRequest:
-		return handleRegistrationRequest(ctx, amfInstance, ue, msg, integrityVerified)
+		return handleRegistrationRequest(ctx, amfInstance, ue, msg, plain, integrityVerified)
 	case nas.MsgTypeULNASTransport:
 		return handleULNASTransport(ctx, amfInstance, ue, msg.ULNASTransport)
 	case nas.MsgTypeConfigurationUpdateComplete:

--- a/internal/amf/nas/gmm_handler_test.go
+++ b/internal/amf/nas/gmm_handler_test.go
@@ -22,7 +22,7 @@ func TestHandleGmmMessage_UnknownMessageType_NoOp(t *testing.T) {
 	m := nas.NewGmmMessage()
 	m.SetMessageType(0xFF) // unassigned message type
 
-	HandleGmmMessage(context.Background(), amfInstance, ue, m, true)
+	HandleGmmMessage(context.Background(), amfInstance, ue, m, nil, true)
 }
 
 // TestHandleGmmMessage_DispatchesToConfigurationUpdateComplete verifies HandleGmmMessage
@@ -47,7 +47,7 @@ func TestHandleGmmMessage_DispatchesToConfigurationUpdateComplete(t *testing.T) 
 	m.ConfigurationUpdateComplete = cuc
 	m.SetMessageType(nas.MsgTypeConfigurationUpdateComplete)
 
-	HandleGmmMessage(context.Background(), amfInstance, ue, m, true)
+	HandleGmmMessage(context.Background(), amfInstance, ue, m, nil, true)
 }
 
 // TestHandleGmmMessage_DispatchesToStatus5GMM verifies HandleGmmMessage routes a
@@ -64,5 +64,5 @@ func TestHandleGmmMessage_DispatchesToStatus5GMM(t *testing.T) {
 
 	m := buildTestStatus5gmm()
 
-	HandleGmmMessage(context.Background(), amfInstance, ue, m, true)
+	HandleGmmMessage(context.Background(), amfInstance, ue, m, nil, true)
 }

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -102,8 +102,6 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 			return fmt.Errorf("failed to decrypt NAS message - sent registration reject: %v", err)
 		}
 
-		plain = slices.Clone(contents)
-
 		m := nas.NewMessage()
 
 		if err := m.GmmMessageDecode(&contents); err != nil {
@@ -294,9 +292,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	state := ue.State()
 	step := ue.RegStep()
 
-	// TS 24.501 §5.5.1.2.8 case e: an identical retransmission before the accept is
-	// ignored, not restarted — restarting would abandon the in-flight auth and, for
-	// a UE retransmitting faster than one auth round-trip, never converge.
+	// TS 24.501 §5.5.1.2.8 case e: an identical retransmission before the accept is ignored.
 	if step == amf.RegStepAuthenticating || step == amf.RegStepSecurityMode {
 		if conn := ue.Conn(); conn != nil && len(plain) > 0 && bytes.Equal(plain, conn.RegistrationRequestPlain) {
 			logger.From(ctx, logger.AmfLog).Info("duplicate Registration Request with identical IEs before Registration Accept; ignoring (TS 24.501 §5.5.1.2.8 case e)")
@@ -353,8 +349,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 		return nasreply.Handled()
 	case step == amf.RegStepContextSetup:
-		// TS 24.501 §5.5.1.2.8 case d: resend the ACCEPT for an identical
-		// retransmission, else abort and progress the new request.
+		// TS 24.501 §5.5.1.2.8 case d: an identical retransmission gets the ACCEPT resent.
 		conn := ue.Conn()
 		if conn != nil && len(plain) > 0 && bytes.Equal(plain, conn.RegistrationRequestPlain) {
 			logger.From(ctx, logger.AmfLog).Info("duplicate Registration Request with identical IEs; resending Registration Accept")

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
@@ -58,28 +59,8 @@ func getRegistrationType5GSName(regType5Gs uint8) string {
 	}
 }
 
-// registrationRequestsIdentical reports whether two REGISTRATION REQUEST messages
-// carry the same IEs, comparing their re-encoded bytes (TS 24.501 §5.5.1.2.8 case d).
-func registrationRequestsIdentical(a, b *nasMessage.RegistrationRequest) bool {
-	if a == nil || b == nil {
-		return false
-	}
-
-	var bufA, bufB bytes.Buffer
-
-	if err := a.EncodeRegistrationRequest(&bufA); err != nil {
-		return false
-	}
-
-	if err := b.EncodeRegistrationRequest(&bufB); err != nil {
-		return false
-	}
-
-	return bytes.Equal(bufA.Bytes(), bufB.Bytes())
-}
-
 // handleRegistrationRequestMessage processes the cleartext IEs of the Registration Request (TS 24.501).
-func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, registrationRequest *nasMessage.RegistrationRequest, integrityVerified bool) error {
+func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, registrationRequest *nasMessage.RegistrationRequest, plain []byte, integrityVerified bool) error {
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		return fmt.Errorf("amf.UeConn is nil")
@@ -121,6 +102,8 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 			return fmt.Errorf("failed to decrypt NAS message - sent registration reject: %v", err)
 		}
 
+		plain = slices.Clone(contents)
+
 		m := nas.NewMessage()
 
 		if err := m.GmmMessageDecode(&contents); err != nil {
@@ -146,6 +129,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	}
 
 	conn.RegistrationRequest = registrationRequest
+	conn.RegistrationRequestPlain = slices.Clone(plain)
 	conn.SetRegistrationType5GS(registrationRequest.GetRegistrationType5GS())
 
 	regName := getRegistrationType5GSName(conn.RegistrationType5GS)
@@ -288,7 +272,7 @@ func acceptRegistrationUESecurityCapability(ctx context.Context, ue *amf.UeConte
 // the new registration re-authenticates and re-derives everything. The shared UeConn
 // transfers to the fresh context; the old context is superseded only once the new
 // registration is accepted (reg_initial).
-func restartRegistrationOnFreshContext(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nas.GmmMessage, integrityVerified bool) {
+func restartRegistrationOnFreshContext(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nas.GmmMessage, plain []byte, integrityVerified bool) {
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		logger.From(ctx, logger.AmfLog).Warn("ue is not connected to RAN")
@@ -303,16 +287,16 @@ func restartRegistrationOnFreshContext(ctx context.Context, amfInstance *amf.AMF
 	fresh.SetSupi(supi)
 	amfInstance.AttachUeConn(fresh, ueConn)
 
-	HandleGmmMessage(ctx, amfInstance, fresh, msg, integrityVerified)
+	HandleGmmMessage(ctx, amfInstance, fresh, msg, plain, integrityVerified)
 }
 
-func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nas.GmmMessage, integrityVerified bool) nasreply.Disposition {
+func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msg *nas.GmmMessage, plain []byte, integrityVerified bool) nasreply.Disposition {
 	state := ue.State()
 	step := ue.RegStep()
 
 	switch {
 	case state == amf.Deregistered, state == amf.Registered, step == amf.RegStepAuthenticating:
-		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, msg.RegistrationRequest, integrityVerified); err != nil {
+		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, msg.RegistrationRequest, plain, integrityVerified); err != nil {
 			// Release the half-registered UE at the point of failure; a failed
 			// handleRegistrationRequestMessage (which may already have sent a REGISTRATION
 			// REJECT) releases nothing, leaking its open RAN connection under no supervision.
@@ -354,7 +338,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 		return nasreply.Handled()
 
 	case step == amf.RegStepSecurityMode:
-		restartRegistrationOnFreshContext(ctx, amfInstance, ue, msg, integrityVerified)
+		restartRegistrationOnFreshContext(ctx, amfInstance, ue, msg, plain, integrityVerified)
 
 		return nasreply.Handled()
 	case step == amf.RegStepContextSetup:
@@ -363,21 +347,21 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 		// IEs mean a retransmission: resend the ACCEPT and restart T3550 without
 		// re-authenticating. Differing IEs abort the prior registration and progress the new one.
 		conn := ue.Conn()
-		if conn != nil && registrationRequestsIdentical(msg.RegistrationRequest, conn.RegistrationRequest) {
+		if conn != nil && len(plain) > 0 && bytes.Equal(plain, conn.RegistrationRequestPlain) {
 			logger.From(ctx, logger.AmfLog).Info("duplicate Registration Request with identical IEs; resending Registration Accept")
 			amf.ResendRegistrationAccept(ctx, amfInstance, ue)
 
 			return nasreply.Handled()
 		}
 
-		restartRegistrationOnFreshContext(ctx, amfInstance, ue, msg, integrityVerified)
+		restartRegistrationOnFreshContext(ctx, amfInstance, ue, msg, plain, integrityVerified)
 
 		return nasreply.Handled()
 	case state == amf.DeregistrationInitiated && isInitialRegistration(msg.RegistrationRequest):
 		// A UE-initiated initial or emergency registration during a network-initiated
 		// de-registration aborts the de-registration and progresses the registration
 		// (TS 24.501 §5.5.2.3.5 case d).
-		restartRegistrationOnFreshContext(ctx, amfInstance, ue, msg, integrityVerified)
+		restartRegistrationOnFreshContext(ctx, amfInstance, ue, msg, plain, integrityVerified)
 
 		return nasreply.Handled()
 	default:

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -294,13 +294,9 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	state := ue.State()
 	step := ue.RegStep()
 
-	// TS 24.501 §5.5.1.2.8 case e: a second REGISTRATION REQUEST received while a
-	// registration is in progress and no REGISTRATION ACCEPT/REJECT has been sent
-	// yet. Identical IEs mean a retransmission — continue the in-flight procedure
-	// (its own T3560/T3550 guard drives progress) and ignore the duplicate rather
-	// than restarting, which would abandon the pending authentication and, for a
-	// UE retransmitting faster than one auth round-trip, prevent convergence.
-	// Differing IEs fall through to abort-and-progress the new request.
+	// TS 24.501 §5.5.1.2.8 case e: an identical retransmission before the accept is
+	// ignored, not restarted — restarting would abandon the in-flight auth and, for
+	// a UE retransmitting faster than one auth round-trip, never converge.
 	if step == amf.RegStepAuthenticating || step == amf.RegStepSecurityMode {
 		if conn := ue.Conn(); conn != nil && len(plain) > 0 && bytes.Equal(plain, conn.RegistrationRequestPlain) {
 			logger.From(ctx, logger.AmfLog).Info("duplicate Registration Request with identical IEs before Registration Accept; ignoring (TS 24.501 §5.5.1.2.8 case e)")
@@ -357,10 +353,8 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 		return nasreply.Handled()
 	case step == amf.RegStepContextSetup:
-		// A REGISTRATION REQUEST received after the REGISTRATION ACCEPT was sent and
-		// before REGISTRATION COMPLETE arrives (TS 24.501 §5.5.1.2.8 case d). Identical
-		// IEs mean a retransmission: resend the ACCEPT and restart T3550 without
-		// re-authenticating. Differing IEs abort the prior registration and progress the new one.
+		// TS 24.501 §5.5.1.2.8 case d: resend the ACCEPT for an identical
+		// retransmission, else abort and progress the new request.
 		conn := ue.Conn()
 		if conn != nil && len(plain) > 0 && bytes.Equal(plain, conn.RegistrationRequestPlain) {
 			logger.From(ctx, logger.AmfLog).Info("duplicate Registration Request with identical IEs; resending Registration Accept")

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -294,6 +294,21 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	state := ue.State()
 	step := ue.RegStep()
 
+	// TS 24.501 §5.5.1.2.8 case e: a second REGISTRATION REQUEST received while a
+	// registration is in progress and no REGISTRATION ACCEPT/REJECT has been sent
+	// yet. Identical IEs mean a retransmission — continue the in-flight procedure
+	// (its own T3560/T3550 guard drives progress) and ignore the duplicate rather
+	// than restarting, which would abandon the pending authentication and, for a
+	// UE retransmitting faster than one auth round-trip, prevent convergence.
+	// Differing IEs fall through to abort-and-progress the new request.
+	if step == amf.RegStepAuthenticating || step == amf.RegStepSecurityMode {
+		if conn := ue.Conn(); conn != nil && len(plain) > 0 && bytes.Equal(plain, conn.RegistrationRequestPlain) {
+			logger.From(ctx, logger.AmfLog).Info("duplicate Registration Request with identical IEs before Registration Accept; ignoring (TS 24.501 §5.5.1.2.8 case e)")
+
+			return nasreply.Handled()
+		}
+	}
+
 	switch {
 	case state == amf.Deregistered, state == amf.Registered, step == amf.RegStepAuthenticating:
 		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, msg.RegistrationRequest, plain, integrityVerified); err != nil {

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -619,7 +619,6 @@ func TestHandleRegistrationRequest_ContextSetup_DifferingIEs_Progresses(t *testi
 	ue.Suci = "testsuci"
 	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
 	ue.ForceRegStepForTest(amf.RegStepContextSetup)
-	// No stored prior request bytes, so the incoming one differs and the procedure progresses.
 
 	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
 	if err != nil {
@@ -653,11 +652,8 @@ func TestHandleRegistrationRequest_ContextSetup_DifferingIEs_Progresses(t *testi
 	}
 }
 
-// TestHandleRegistrationRequest_ContextSetup_UnmodeledIEDiffers_Progresses validates
-// that a REGISTRATION REQUEST whose bytes differ from the stored request only by an
-// IE the NAS decoder does not model is treated as a differing request and progressed
-// (TS 24.501 §5.5.1.2.8 case d): the comparison is on message bytes, so an IE that is
-// invisible to the decoder still distinguishes the requests.
+// A request differing only by a decoder-invisible IE (0x35) must still be treated
+// as differing, since the comparison is on message bytes (TS 24.501 §5.5.1.2.8 case d).
 func TestHandleRegistrationRequest_ContextSetup_UnmodeledIEDiffers_Progresses(t *testing.T) {
 	ctx := context.TODO()
 	amfInstance := amf.New(&fakeDBInstance{
@@ -702,8 +698,8 @@ func TestHandleRegistrationRequest_ContextSetup_UnmodeledIEDiffers_Progresses(t 
 	conn.RegistrationRequestPlain = stored
 	conn.RegistrationAcceptPdu = []byte{0x7e, 0x00, 0x42}
 
-	// Requested mapped NSSAI (IEI 0x35), absent from the decoder's IE set: the
-	// decoded struct equals the stored one while the bytes differ.
+	// Requested mapped NSSAI (0x35): not modelled by the decoder, so the structs
+	// are equal while the bytes differ.
 	incoming := append(append([]byte{}, stored...), 0x35, 0x02, 0x01, 0x01)
 
 	handleRegistrationRequest(ctx, amfInstance, ue, m, incoming, true)
@@ -779,10 +775,8 @@ func TestHandleRegistrationRequest_UEStateAuthentication_RestartsRegistration(t 
 	}
 }
 
-// TestHandleRegistrationRequest_Authenticating_IdenticalIEs_Ignored validates that
-// an identical REGISTRATION REQUEST received while authentication is in progress
-// (before REGISTRATION ACCEPT) is ignored, continuing the in-flight procedure
-// rather than restarting it (TS 24.501 §5.5.1.2.8 case e).
+// An identical retransmission during authentication is ignored, not restarted
+// (TS 24.501 §5.5.1.2.8 case e).
 func TestHandleRegistrationRequest_Authenticating_IdenticalIEs_Ignored(t *testing.T) {
 	ctx := context.TODO()
 	amfInstance := amf.New(&fakeDBInstance{

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -63,7 +63,7 @@ func TestHandleRegistrationRequest_NilRanUE(t *testing.T) {
 
 	ue := amf.NewUeContext()
 
-	handleRegistrationRequest(ctx, &amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, &amfInstance, ue, m, nil, true)
 }
 
 // TestHandleRegistrationRequest_ErrorMissingIdentity validates the graceful
@@ -85,7 +85,7 @@ func TestHandleRegistrationRequest_ErrorMissingIdentity(t *testing.T) {
 
 	m.RegistrationRequest.MobileIdentity5GS = nasType.MobileIdentity5GS{}
 
-	handleRegistrationRequest(ctx, &amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, &amfInstance, ue, m, nil, true)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered, got %v", ue.State())
@@ -114,7 +114,7 @@ func TestHandleRegistrationRequest_ErrorMissingOperatorInfo(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered, got %v", ue.State())
@@ -155,7 +155,7 @@ func TestHandleRegistrationRequest_RejectTrackingAreaNotAllowed(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -207,7 +207,7 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability(t *testing.T)
 
 	m.UESecurityCapability = nil
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -262,7 +262,7 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability_Mobility(t *t
 	m.SetRegistrationType5GS(nasMessage.RegistrationType5GSMobilityRegistrationUpdating)
 	m.UESecurityCapability = nil
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -315,7 +315,7 @@ func TestHandleRegistrationRequest_PeriodicAllowsMissingSecurityCapability(t *te
 	m.SetRegistrationType5GS(nasMessage.RegistrationType5GSPeriodicRegistrationUpdating)
 	m.UESecurityCapability = nil
 
-	if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, m.RegistrationRequest, true); err != nil {
+	if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, m.RegistrationRequest, nil, true); err != nil {
 		t.Fatalf("periodic registration without UE security capability should not be rejected here, got: %v", err)
 	}
 
@@ -361,7 +361,7 @@ func TestHandleRegistrationRequest_Timers_Stopped(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.PagingActiveForTest() {
 		t.Fatalf("timer T3513 should have been stopped")
@@ -391,7 +391,7 @@ func TestHandleRegistrationRequest_IdentityRequest_MissingSUCI_SUPI(t *testing.T
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -448,7 +448,7 @@ func TestHandleRegistrationRequest_AuthenticationRequest(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -516,7 +516,7 @@ func TestHandleRegistrationRequest_RegistrationAccepted(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -566,11 +566,20 @@ func TestHandleRegistrationRequest_ContextSetup_IdenticalIEs_ResendsAccept(t *te
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
+	full := new(nas.Message)
+	full.GmmMessage = m
+
+	plain, err := full.PlainNasEncode()
+	if err != nil {
+		t.Fatalf("encode plain RegistrationRequest: %v", err)
+	}
+
 	conn := ue.Conn()
 	conn.RegistrationRequest = m.RegistrationRequest
+	conn.RegistrationRequestPlain = plain
 	conn.RegistrationAcceptPdu = []byte{0x7e, 0x00, 0x42}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, plain, true)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("expected the Registration Accept to be resent, got %d downlinks", len(ngapSender.SentDownlinkNASTransport))
@@ -610,14 +619,22 @@ func TestHandleRegistrationRequest_ContextSetup_DifferingIEs_Progresses(t *testi
 	ue.Suci = "testsuci"
 	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
 	ue.ForceRegStepForTest(amf.RegStepContextSetup)
-	// No stored prior request, so the incoming one differs and the procedure progresses.
+	// No stored prior request bytes, so the incoming one differs and the procedure progresses.
 
 	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
 	if err != nil {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	full := new(nas.Message)
+	full.GmmMessage = m
+
+	plain, err := full.PlainNasEncode()
+	if err != nil {
+		t.Fatalf("encode plain RegistrationRequest: %v", err)
+	}
+
+	handleRegistrationRequest(ctx, amfInstance, ue, m, plain, true)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("expected the new registration to progress with an Authentication Request, got %d downlinks", len(ngapSender.SentDownlinkNASTransport))
@@ -633,6 +650,78 @@ func TestHandleRegistrationRequest_ContextSetup_DifferingIEs_Progresses(t *testi
 
 	if nm.GmmHeader.GetMessageType() != nas.MsgTypeAuthenticationRequest {
 		t.Fatalf("expected AuthenticationRequest, got message type %d", nm.GmmHeader.GetMessageType())
+	}
+}
+
+// TestHandleRegistrationRequest_ContextSetup_UnmodeledIEDiffers_Progresses validates
+// that a REGISTRATION REQUEST whose bytes differ from the stored request only by an
+// IE the NAS decoder does not model is treated as a differing request and progressed
+// (TS 24.501 §5.5.1.2.8 case d): the comparison is on message bytes, so an IE that is
+// invisible to the decoder still distinguishes the requests.
+func TestHandleRegistrationRequest_ContextSetup_UnmodeledIEDiffers_Progresses(t *testing.T) {
+	ctx := context.TODO()
+	amfInstance := amf.New(&fakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}, &fakeAusf{
+		AvKgAka: &ausf.AuthResult{
+			Rand: hex.EncodeToString(make([]byte, 16)),
+			Autn: hex.EncodeToString(make([]byte, 16)),
+		},
+		Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+		Kseaf: []byte("testkey"),
+	}, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	ue.Suci = "testsuci"
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+	ue.ForceRegStepForTest(amf.RegStepContextSetup)
+
+	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	full := new(nas.Message)
+	full.GmmMessage = m
+
+	stored, err := full.PlainNasEncode()
+	if err != nil {
+		t.Fatalf("encode plain RegistrationRequest: %v", err)
+	}
+
+	conn := ue.Conn()
+	conn.RegistrationRequest = m.RegistrationRequest
+	conn.RegistrationRequestPlain = stored
+	conn.RegistrationAcceptPdu = []byte{0x7e, 0x00, 0x42}
+
+	// Requested mapped NSSAI (IEI 0x35), absent from the decoder's IE set: the
+	// decoded struct equals the stored one while the bytes differ.
+	incoming := append(append([]byte{}, stored...), 0x35, 0x02, 0x01, 0x01)
+
+	handleRegistrationRequest(ctx, amfInstance, ue, m, incoming, true)
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("expected the new registration to progress with an Authentication Request, got %d downlinks", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	resp := ngapSender.SentDownlinkNASTransport[0]
+	nm := new(nas.Message)
+	nm.SecurityHeaderType = nas.GetSecurityHeaderType(resp.NasPdu) & 0x0f
+
+	if err := nm.PlainNasDecode(&resp.NasPdu); err != nil {
+		t.Fatalf("could not decode NAS message: %v", err)
+	}
+
+	if nm.GmmHeader.GetMessageType() != nas.MsgTypeAuthenticationRequest {
+		t.Fatalf("expected AuthenticationRequest for a byte-differing duplicate, got message type %d", nm.GmmHeader.GetMessageType())
 	}
 }
 
@@ -670,7 +759,7 @@ func TestHandleRegistrationRequest_UEStateAuthentication_RestartsRegistration(t 
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message (AuthenticationRequest), got %d", len(ngapSender.SentDownlinkNASTransport))
@@ -734,7 +823,7 @@ func TestHandleRegistrationRequest_SecurityMode_AuthenticationRequest(t *testing
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	// The prior registration is aborted: its context is deregistered and its NAS
 	// connection — carrying T3560 — is released. The new registration runs on a fresh
@@ -819,7 +908,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationAccepted(t *testing.T
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -903,7 +992,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationRejectedWrongKey(t *t
 	key = [16]uint8{0x00, 0x00, 0x00, 0x00, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	ue.SetKnasEncForTest(key)
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -971,7 +1060,7 @@ func TestHandleRegistrationRequest_CipheredNAS_MacFailed_SkipContainer(t *testin
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, false)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message, got %d", len(ngapSender.SentDownlinkNASTransport))
@@ -1032,7 +1121,7 @@ func TestHandleRegistrationRequest_NgKsi_Increment(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.NgKsiForTest().Ksi != 4 {
 		t.Fatalf("expected ngKSI=4 (next after 3), got %d", ue.NgKsiForTest().Ksi)
@@ -1072,7 +1161,7 @@ func TestHandleRegistrationRequest_NgKsi_WrapAt6(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.NgKsiForTest().Ksi != 0 {
 		t.Fatalf("expected ngKSI=0 (wrapped from 6), got %d", ue.NgKsiForTest().Ksi)
@@ -1112,7 +1201,7 @@ func TestHandleRegistrationRequest_NgKsi_NoKeyAvailable(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	if ue.NgKsiForTest().Ksi != 0 {
 		t.Fatalf("expected ngKSI=0 (reset from no-key-available=7), got %d", ue.NgKsiForTest().Ksi)
@@ -1356,7 +1445,7 @@ func TestHandleRegistrationRequest_InitialRegistrationAbortsNetworkDeregistratio
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, m, nil, true)
 
 	// Progressed, not rejected: the de-registration must have been aborted.
 	if ue.State() == amf.DeregistrationInitiated {

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -779,6 +779,62 @@ func TestHandleRegistrationRequest_UEStateAuthentication_RestartsRegistration(t 
 	}
 }
 
+// TestHandleRegistrationRequest_Authenticating_IdenticalIEs_Ignored validates that
+// an identical REGISTRATION REQUEST received while authentication is in progress
+// (before REGISTRATION ACCEPT) is ignored, continuing the in-flight procedure
+// rather than restarting it (TS 24.501 §5.5.1.2.8 case e).
+func TestHandleRegistrationRequest_Authenticating_IdenticalIEs_Ignored(t *testing.T) {
+	ctx := context.TODO()
+	amfInstance := amf.New(&fakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}, &fakeAusf{
+		AvKgAka: &ausf.AuthResult{
+			Rand: hex.EncodeToString(make([]byte, 16)),
+			Autn: hex.EncodeToString(make([]byte, 16)),
+		},
+		Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+		Kseaf: []byte("testkey"),
+	}, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	ue.Suci = "testsuci"
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+	ue.ForceRegStepForTest(amf.RegStepAuthenticating)
+
+	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	full := new(nas.Message)
+	full.GmmMessage = m
+
+	plain, err := full.PlainNasEncode()
+	if err != nil {
+		t.Fatalf("encode plain RegistrationRequest: %v", err)
+	}
+
+	ue.Conn().RegistrationRequestPlain = plain
+
+	handleRegistrationRequest(ctx, amfInstance, ue, m, plain, true)
+
+	if len(ngapSender.SentDownlinkNASTransport) != 0 {
+		t.Fatalf("an identical pre-accept duplicate must be ignored (no downlink), got %d", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	if ue.RegStep() != amf.RegStepAuthenticating {
+		t.Fatalf("an identical pre-accept duplicate must not restart; RegStep = %v", ue.RegStep())
+	}
+}
+
 // TestHandleRegistrationRequest_SecurityMode_AuthenticationRequest validates
 // that a registration request coming in while the security mode procedure is
 // on-going resets the state of the UE to deregistered, triggering a new

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -829,6 +829,60 @@ func TestHandleRegistrationRequest_Authenticating_IdenticalIEs_Ignored(t *testin
 	}
 }
 
+// An identical retransmission during the security mode procedure is ignored, not
+// restarted (TS 24.501 §5.5.1.2.8 case e).
+func TestHandleRegistrationRequest_SecurityMode_IdenticalIEs_Ignored(t *testing.T) {
+	ctx := context.TODO()
+	amfInstance := amf.New(&fakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}, &fakeAusf{
+		AvKgAka: &ausf.AuthResult{
+			Rand: hex.EncodeToString(make([]byte, 16)),
+			Autn: hex.EncodeToString(make([]byte, 16)),
+		},
+		Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+		Kseaf: []byte("testkey"),
+	}, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	ue.Suci = "testsuci"
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+	ue.ForceRegStepForTest(amf.RegStepSecurityMode)
+
+	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	full := new(nas.Message)
+	full.GmmMessage = m
+
+	plain, err := full.PlainNasEncode()
+	if err != nil {
+		t.Fatalf("encode plain RegistrationRequest: %v", err)
+	}
+
+	ue.Conn().RegistrationRequestPlain = plain
+
+	handleRegistrationRequest(ctx, amfInstance, ue, m, plain, true)
+
+	if len(ngapSender.SentDownlinkNASTransport) != 0 {
+		t.Fatalf("an identical pre-accept duplicate must be ignored (no downlink), got %d", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	if ue.RegStep() != amf.RegStepSecurityMode {
+		t.Fatalf("an identical pre-accept duplicate must not restart; RegStep = %v", ue.RegStep())
+	}
+}
+
 // TestHandleRegistrationRequest_SecurityMode_AuthenticationRequest validates
 // that a registration request coming in while the security mode procedure is
 // on-going resets the state of the UE to deregistered, triggering a new
@@ -1327,6 +1381,61 @@ func buildTestRegistrationRequestMessageWithNgKsi(cipherAlg uint8, key *[16]uint
 	registrationRequest.PDUSessionStatus = nil
 
 	return m, nil
+}
+
+// A container-carrying registration stores the outer message bytes for duplicate
+// detection, so a retransmission (which arrives as the same outer message) still
+// compares equal — the container's inner contents would not (TS 24.501 §5.5.1.2.8).
+func TestHandleRegistrationRequestMessage_ContainerStoresOuterBytes(t *testing.T) {
+	ctx := context.TODO()
+	supi := mustSUPIFromPrefixed("imsi-001019756139935")
+	amfInstance := amf.New(&fakeDBInstance{
+		Operator: &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: "[\"000001\"]"},
+	}, &fakeAusf{
+		AvKgAka: &ausf.AuthResult{Rand: hex.EncodeToString(make([]byte, 16)), Autn: hex.EncodeToString(make([]byte, 16))},
+		Supi:    supi,
+		Kseaf:   []byte("testkey"),
+	}, nil)
+
+	ue, _, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
+	algo := security.AlgCiphering128NEA2
+
+	ue.Suci = "testsuci"
+	ue.SetSupiForTest(supi)
+	ue.SetSecuredForTest(true)
+	ue.SetKnasEncForTest(key)
+	ue.SetCipheringAlgForTest(algo)
+
+	m, err := buildTestRegistrationRequestMessage(algo, &key, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	full := new(nas.Message)
+	full.GmmMessage = m
+
+	outer, err := full.PlainNasEncode()
+	if err != nil {
+		t.Fatalf("encode outer RegistrationRequest: %v", err)
+	}
+
+	inner := append([]byte(nil), m.RegistrationRequest.GetNASMessageContainerContents()...)
+
+	_ = handleRegistrationRequestMessage(ctx, amfInstance, ue, m.RegistrationRequest, outer, true)
+
+	stored := ue.Conn().RegistrationRequestPlain
+	if !bytes.Equal(stored, outer) {
+		t.Fatalf("stored plain must be the outer message bytes for duplicate detection")
+	}
+
+	if bytes.Equal(stored, inner) {
+		t.Fatal("stored plain must not be the inner container contents")
+	}
 }
 
 func buildUeAndRadio() (*amf.UeContext, *fakeNGAPSender, error) {

--- a/internal/amf/nas/handle_security_mode_complete.go
+++ b/internal/amf/nas/handle_security_mode_complete.go
@@ -5,6 +5,7 @@ package nas
 
 import (
 	"context"
+	"slices"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
@@ -58,6 +59,7 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 
 	if msg.NASMessageContainer != nil {
 		contents := msg.GetNASMessageContainerContents()
+		plain := slices.Clone(contents)
 
 		m := nas.NewMessage()
 		if err := m.GmmMessageDecode(&contents); err != nil {
@@ -71,12 +73,12 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 			return nasreply.Handled()
 		}
 
-		contextSetup(ctx, amfInstance, ue, m.RegistrationRequest)
+		contextSetup(ctx, amfInstance, ue, m.RegistrationRequest, plain)
 
 		return nasreply.Handled()
 	}
 
-	contextSetup(ctx, amfInstance, ue, conn.RegistrationRequest)
+	contextSetup(ctx, amfInstance, ue, conn.RegistrationRequest, conn.RegistrationRequestPlain)
 
 	return nasreply.Handled()
 }

--- a/internal/amf/nas/nas_gate_test.go
+++ b/internal/amf/nas/nas_gate_test.go
@@ -145,7 +145,7 @@ func TestHandleGmmMessage_UnimplementedType_ReturnsStatus97(t *testing.T) {
 	msg := nas.NewGmmMessage()
 	msg.SetMessageType(nas.MsgTypeRegistrationReject) // a downlink type never handled inbound
 
-	d := HandleGmmMessage(context.Background(), amf.New(nil, nil, nil), ue, msg, true)
+	d := HandleGmmMessage(context.Background(), amf.New(nil, nil, nil), ue, msg, nil, true)
 
 	if d.Action != nasreply.ActionStatus || d.Domain != nasreply.DomainMM || d.Cause != nasreply.CauseMessageTypeNotImplemented {
 		t.Errorf("disposition = %+v, want a 5GMM STATUS #97 (message type non-existent or not implemented)", d)

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -115,7 +115,7 @@ func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn
 		logger.SUPI(ue.UeContext().Supi().String()),
 	)
 
-	return HandleGmmMessage(ctx, amfInstance, ue.UeContext(), msg.GmmMessage, integrityVerified)
+	return HandleGmmMessage(ctx, amfInstance, ue.UeContext(), msg.GmmMessage, result.Plain, integrityVerified)
 }
 
 // dispositionForUnresolved classifies a fresh-connection NAS PDU that established or resolved

--- a/internal/amf/nas/security_mode.go
+++ b/internal/amf/nas/security_mode.go
@@ -42,7 +42,7 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) 
 
 	if ue.SecurityContextIsValid() {
 		logger.From(ctx, logger.AmfLog).Debug("UE has a valid security context - skip security mode control procedure")
-		contextSetup(ctx, amfInstance, ue, conn.RegistrationRequest)
+		contextSetup(ctx, amfInstance, ue, conn.RegistrationRequest, conn.RegistrationRequestPlain)
 
 		return
 	}

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -15,6 +15,10 @@ import (
 type DecodeResult struct {
 	Message           *nas.Message
 	IntegrityVerified bool
+	// Plain is the plain NAS message bytes (deciphered when the message arrived
+	// protected), for handlers that must compare a message against a
+	// retransmission byte-for-byte (TS 24.501 §5.5.1.2.8).
+	Plain []byte
 }
 
 // plainNasAllowed reports whether a NAS message type may be processed without a verified

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -15,9 +15,8 @@ import (
 type DecodeResult struct {
 	Message           *nas.Message
 	IntegrityVerified bool
-	// Plain is the plain NAS message bytes (deciphered when the message arrived
-	// protected), for handlers that must compare a message against a
-	// retransmission byte-for-byte (TS 24.501 §5.5.1.2.8).
+	// Plain is the deciphered NAS bytes, for byte-for-byte duplicate detection
+	// (TS 24.501 §5.5.1.2.8).
 	Plain []byte
 }
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -101,7 +101,12 @@ type UeConn struct {
 	// (TS 24.501 §5.4.1.3.7 f)/NOTE 4).
 	resyncTried bool
 
-	RegistrationRequest             *nasMessage.RegistrationRequest
+	RegistrationRequest *nasMessage.RegistrationRequest
+	// RegistrationRequestPlain is the plain NAS bytes of RegistrationRequest, the
+	// comparison basis for duplicate detection (TS 24.501 §5.5.1.2.8 case d): a
+	// retransmission is byte-identical, and byte equality is immune to decoder
+	// lossiness for IEs the decoder does not model.
+	RegistrationRequestPlain        []byte
 	RegistrationType5GS             uint8
 	IdentityTypeUsedForRegistration uint8
 	RetransmissionOfInitialNASMsg   bool

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -102,10 +102,8 @@ type UeConn struct {
 	resyncTried bool
 
 	RegistrationRequest *nasMessage.RegistrationRequest
-	// RegistrationRequestPlain is the plain NAS bytes of RegistrationRequest, the
-	// comparison basis for duplicate detection (TS 24.501 §5.5.1.2.8 case d): a
-	// retransmission is byte-identical, and byte equality is immune to decoder
-	// lossiness for IEs the decoder does not model.
+	// RegistrationRequestPlain is compared byte-for-byte for duplicate detection
+	// (TS 24.501 §5.5.1.2.8), immune to the decoder dropping IEs it does not model.
 	RegistrationRequestPlain        []byte
 	RegistrationType5GS             uint8
 	IdentityTypeUsedForRegistration uint8

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -455,7 +455,7 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 		return
 	}
 
-	operatorInfo, err := amfInstance.OperatorInfo(ctx)
+	operatorInfo, err := amfInstance.operatorInfoFrom(operator)
 	if err != nil {
 		logger.From(ctx, logger.AmfLog).Error("cannot SendConfigurationUpdateCommand: failed to get operator info", zap.Error(err))
 		return

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -248,19 +248,23 @@ func (f *fakePCF) GetSessionPolicy(_ context.Context, _ string, _ *models.Snssai
 
 type fakeSessionStore struct{}
 
-func (f *fakeSessionStore) AllocateIP(_ context.Context, _ string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeSessionStore) ResolveDNN(_ context.Context, _ string) (smf.DNNStore, error) {
+	return f, nil
+}
+
+func (f *fakeSessionStore) AllocateIP(_ context.Context, _ string, _ uint8) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("not implemented in test")
 }
 
-func (f *fakeSessionStore) ReleaseIP(_ context.Context, _ string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeSessionStore) ReleaseIP(_ context.Context, _ string, _ uint8) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("not implemented in test")
 }
 
-func (f *fakeSessionStore) AllocateIPv6(_ context.Context, _ string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeSessionStore) AllocateIPv6(_ context.Context, _ string, _ uint8) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("not implemented in test")
 }
 
-func (f *fakeSessionStore) ReleaseIPv6(_ context.Context, _ string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeSessionStore) ReleaseIPv6(_ context.Context, _ string, _ uint8) (netip.Addr, error) {
 	return netip.Addr{}, fmt.Errorf("not implemented in test")
 }
 
@@ -272,11 +276,11 @@ func (f *fakeSessionStore) InsertFlowReports(_ context.Context, _ []*models.Flow
 	return nil
 }
 
-func (f *fakeSessionStore) ListFramedRoutes(_ context.Context, _ string, _ string) ([]netip.Prefix, error) {
+func (f *fakeSessionStore) ListFramedRoutes(_ context.Context, _ string) ([]netip.Prefix, error) {
 	return nil, nil
 }
 
-func (f *fakeSessionStore) GetStaticIP(_ context.Context, _ string, _ string, _ bool) (netip.Addr, bool, error) {
+func (f *fakeSessionStore) GetStaticIP(_ context.Context, _ string, _ bool) (netip.Addr, bool, error) {
 	return netip.Addr{}, false, nil
 }
 

--- a/internal/mme/config.go
+++ b/internal/mme/config.go
@@ -15,15 +15,12 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// OperatorConfig is a point-in-time view of the operator row. Handlers that
-// need several derived values fetch one OperatorConfig and derive from it, so
-// a single procedure step reads the row once and sees one consistent version.
+// OperatorConfig is a point-in-time view of the operator row: a handler needing
+// several derived values reads the row once and derives from this snapshot.
 type OperatorConfig struct {
 	op *db.Operator
 }
 
-// Operator fetches the operator row once for derivation via OperatorConfig
-// accessors.
 func (m *MME) Operator(ctx context.Context) (OperatorConfig, error) {
 	op, err := m.Bearer.GetOperator(ctx)
 	if err != nil {
@@ -109,8 +106,7 @@ func (o OperatorConfig) ServesTAI(tai s1ap.TAI) (bool, error) {
 	return slices.Contains(tacs, uint16(tai.TAC)), nil
 }
 
-// OperatorPLMN returns the operator's serving PLMN. Handlers needing more than
-// one operator-derived value should fetch Operator once and derive.
+// OperatorPLMN returns the operator's serving PLMN (TS 23.003).
 func (m *MME) OperatorPLMN(ctx context.Context) (models.PlmnID, error) {
 	ctx, span := Tracer.Start(ctx, "mme/get_operator_plmn")
 	defer span.End()

--- a/internal/mme/config.go
+++ b/internal/mme/config.go
@@ -7,53 +7,44 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 
+	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/s1ap"
 )
 
-// OperatorPLMN returns the operator's serving PLMN (TS 23.003), the network's
-// identity advertised in S1 Setup and used for K_ASME derivation and the TAI.
-func (m *MME) OperatorPLMN(ctx context.Context) (models.PlmnID, error) {
-	ctx, span := Tracer.Start(ctx, "mme/get_operator_plmn")
-	defer span.End()
+// OperatorConfig is a point-in-time view of the operator row. Handlers that
+// need several derived values fetch one OperatorConfig and derive from it, so
+// a single procedure step reads the row once and sees one consistent version.
+type OperatorConfig struct {
+	op *db.Operator
+}
 
+// Operator fetches the operator row once for derivation via OperatorConfig
+// accessors.
+func (m *MME) Operator(ctx context.Context) (OperatorConfig, error) {
 	op, err := m.Bearer.GetOperator(ctx)
 	if err != nil {
-		return models.PlmnID{}, fmt.Errorf("get operator: %w", err)
+		return OperatorConfig{}, fmt.Errorf("get operator: %w", err)
 	}
 
-	return models.PlmnID{Mcc: op.Mcc, Mnc: op.Mnc}, nil
+	return OperatorConfig{op: op}, nil
 }
 
-// defaultMMEGroupID is the fixed MME Group ID of the GUMMEI (TS 23.003).
-// Ella Core is a single MME pool, so the group is constant; per-node identity
-// comes from the MME Code.
-const defaultMMEGroupID uint16 = 1
-
-// MmeIdentity returns the GUMMEI components (TS 23.003): a fixed MME Group
-// ID, and an MME Code derived from the cluster node ID so each HA node advertises
-// a distinct GUMMEI and a UE's GUTI routes back to its owning node.
-// The MME Code is 8 bits, so distinct codes hold for clusters up to 256 nodes;
-// beyond that the low 8 bits could collide.
-func (m *MME) MmeIdentity() (uint16, uint8) {
-	return defaultMMEGroupID, uint8(m.Bearer.NodeID() & 0xFF)
+// PLMN returns the operator's serving PLMN (TS 23.003), the network's
+// identity advertised in S1 Setup and used for K_ASME derivation and the TAI.
+func (o OperatorConfig) PLMN() models.PlmnID {
+	return models.PlmnID{Mcc: o.op.Mcc, Mnc: o.op.Mnc}
 }
 
-// OperatorTACs returns the operator's E-UTRAN-valid Tracking Area Codes. A TAC is
+// TACs returns the operator's E-UTRAN-valid Tracking Area Codes. A TAC is
 // an OCTET STRING configured as hex. The E-UTRAN TAC is 2 octets and the 5GS TAC 3
 // (TS 23.003); a configured value above 16 bits is a 5GS-only TAC, excluded here so
 // it cannot match a 16-bit eNB TAC.
-func (m *MME) OperatorTACs(ctx context.Context) ([]uint16, error) {
-	ctx, span := Tracer.Start(ctx, "mme/get_operator_tacs")
-	defer span.End()
-
-	op, err := m.Bearer.GetOperator(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get operator: %w", err)
-	}
-
-	tacs, err := op.GetSupportedTacs()
+func (o OperatorConfig) TACs() ([]uint16, error) {
+	tacs, err := o.op.GetSupportedTacs()
 	if err != nil {
 		return nil, fmt.Errorf("get supported TACs: %w", err)
 	}
@@ -76,6 +67,75 @@ func (m *MME) OperatorTACs(ctx context.Context) ([]uint16, error) {
 	return out, nil
 }
 
+// ServedTAIs is the network's served tracking areas: the operator PLMN paired with
+// each served TAC. Every UE is registered in this area (TS 23.401 §5.3.4).
+func (o OperatorConfig) ServedTAIs() ([]models.Tai, error) {
+	plmn := o.PLMN()
+
+	tacs, err := o.TACs()
+	if err != nil {
+		return nil, fmt.Errorf("operator TACs: %w", err)
+	}
+
+	out := make([]models.Tai, 0, len(tacs))
+
+	for _, tac := range tacs {
+		p := plmn
+		out = append(out, models.Tai{PlmnID: &p, Tac: fmt.Sprintf("%06x", tac)})
+	}
+
+	return out, nil
+}
+
+// ServesTAI reports whether tai — a UE's serving-cell TAI — is served: operator PLMN
+// and an operator E-UTRAN TAC. This per-UE gate (EMM cause #12, TS 24.301 §5.5.1.2.5)
+// is finer than the node-level S1 Setup gate, which admits an eNB broadcasting any
+// served TAI even when it also broadcasts an unserved one.
+func (o OperatorConfig) ServesTAI(tai s1ap.TAI) (bool, error) {
+	served, err := EncodePLMN(o.PLMN())
+	if err != nil {
+		return false, err
+	}
+
+	if tai.PLMNIdentity != served {
+		return false, nil
+	}
+
+	tacs, err := o.TACs()
+	if err != nil {
+		return false, err
+	}
+
+	return slices.Contains(tacs, uint16(tai.TAC)), nil
+}
+
+// OperatorPLMN returns the operator's serving PLMN. Handlers needing more than
+// one operator-derived value should fetch Operator once and derive.
+func (m *MME) OperatorPLMN(ctx context.Context) (models.PlmnID, error) {
+	ctx, span := Tracer.Start(ctx, "mme/get_operator_plmn")
+	defer span.End()
+
+	o, err := m.Operator(ctx)
+	if err != nil {
+		return models.PlmnID{}, err
+	}
+
+	return o.PLMN(), nil
+}
+
+// OperatorTACs returns the operator's E-UTRAN-valid Tracking Area Codes.
+func (m *MME) OperatorTACs(ctx context.Context) ([]uint16, error) {
+	ctx, span := Tracer.Start(ctx, "mme/get_operator_tacs")
+	defer span.End()
+
+	o, err := m.Operator(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return o.TACs()
+}
+
 func (m *MME) OperatorTAC(ctx context.Context) (uint16, error) {
 	tacs, err := m.OperatorTACs(ctx)
 	if err != nil {
@@ -87,4 +147,18 @@ func (m *MME) OperatorTAC(ctx context.Context) (uint16, error) {
 	}
 
 	return tacs[0], nil
+}
+
+// defaultMMEGroupID is the fixed MME Group ID of the GUMMEI (TS 23.003).
+// Ella Core is a single MME pool, so the group is constant; per-node identity
+// comes from the MME Code.
+const defaultMMEGroupID uint16 = 1
+
+// MmeIdentity returns the GUMMEI components (TS 23.003): a fixed MME Group
+// ID, and an MME Code derived from the cluster node ID so each HA node advertises
+// a distinct GUMMEI and a UE's GUTI routes back to its owning node.
+// The MME Code is 8 bits, so distinct codes hold for clusters up to 256 nodes;
+// beyond that the low 8 bits could collide.
+func (m *MME) MmeIdentity() (uint16, uint8) {
+	return defaultMMEGroupID, uint8(m.Bearer.NodeID() & 0xFF)
 }

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -239,12 +239,14 @@ func buildProtectedAttachAccept(ctx context.Context, m *mme.MME, ue *mme.UeConte
 		return nil, err
 	}
 
-	plmn, err := m.OperatorPLMN(ctx)
+	operator, err := m.Operator(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	served, err := m.ServedTAIs(ctx)
+	plmn := operator.PLMN()
+
+	served, err := operator.ServedTAIs()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -905,6 +905,38 @@ func TestAttachDuplicatePreAcceptIdenticalIEsIgnored(t *testing.T) {
 	}
 }
 
+// An identical retransmission during the security mode procedure is ignored, not
+// restarted (TS 24.301 §5.5.1.2.7 case e).
+func TestAttachDuplicatePreAcceptSecurityModeIdenticalIEsIgnored(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+	ue.ForceRegStepForTest(mme.RegStepSecurityMode)
+
+	attach := &eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		NASKeySetIdentifier: 7,
+		EPSMobileIdentity:   eps.EPSMobileIdentity{Type: eps.IdentityIMSI, Digits: "001010000000001"},
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}.Marshal(),
+	}
+
+	plain, err := attach.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ue.Conn().AttachRequestPlain = plain
+
+	handleAttachRequest(context.Background(), m, ue, plain, false)
+
+	if cc.count() != 0 {
+		t.Fatalf("an identical pre-accept duplicate must be ignored (no downlink), got %d", cc.count())
+	}
+
+	if ue.RegStep() != mme.RegStepSecurityMode {
+		t.Fatalf("an identical pre-accept duplicate must not restart the procedure; RegStep = %s", ue.RegStep())
+	}
+}
+
 // TestAttachDuplicateDifferingIEsProgresses verifies an ATTACH REQUEST with differing
 // IEs while awaiting ATTACH COMPLETE aborts the previous attach and progresses the new
 // one — here re-identifying via authentication (TS 24.301 §5.5.1.2.7 case d).

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -873,9 +873,7 @@ func TestAttachDuplicateIdenticalIEsResendsAccept(t *testing.T) {
 	}
 }
 
-// TestAttachDuplicatePreAcceptIdenticalIEsIgnored verifies that an identical ATTACH
-// REQUEST received while authentication is in progress (before ATTACH ACCEPT) is
-// ignored, continuing the in-flight procedure rather than restarting it
+// An identical retransmission during authentication is ignored, not restarted
 // (TS 24.301 §5.5.1.2.7 case e).
 func TestAttachDuplicatePreAcceptIdenticalIEsIgnored(t *testing.T) {
 	m := newTestMME(t)
@@ -894,7 +892,6 @@ func TestAttachDuplicatePreAcceptIdenticalIEsIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The attach being served mid-authentication (no accept sent yet).
 	ue.Conn().AttachRequestPlain = plain
 
 	handleAttachRequest(context.Background(), m, ue, plain, false)

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -873,6 +873,41 @@ func TestAttachDuplicateIdenticalIEsResendsAccept(t *testing.T) {
 	}
 }
 
+// TestAttachDuplicatePreAcceptIdenticalIEsIgnored verifies that an identical ATTACH
+// REQUEST received while authentication is in progress (before ATTACH ACCEPT) is
+// ignored, continuing the in-flight procedure rather than restarting it
+// (TS 24.301 §5.5.1.2.7 case e).
+func TestAttachDuplicatePreAcceptIdenticalIEsIgnored(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+	ue.ForceRegStepForTest(mme.RegStepAuthenticating)
+
+	attach := &eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		NASKeySetIdentifier: 7,
+		EPSMobileIdentity:   eps.EPSMobileIdentity{Type: eps.IdentityIMSI, Digits: "001010000000001"},
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}.Marshal(),
+	}
+
+	plain, err := attach.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The attach being served mid-authentication (no accept sent yet).
+	ue.Conn().AttachRequestPlain = plain
+
+	handleAttachRequest(context.Background(), m, ue, plain, false)
+
+	if cc.count() != 0 {
+		t.Fatalf("an identical pre-accept duplicate must be ignored (no downlink), got %d", cc.count())
+	}
+
+	if ue.RegStep() != mme.RegStepAuthenticating {
+		t.Fatalf("an identical pre-accept duplicate must not restart the procedure; RegStep = %s", ue.RegStep())
+	}
+}
+
 // TestAttachDuplicateDifferingIEsProgresses verifies an ATTACH REQUEST with differing
 // IEs while awaiting ATTACH COMPLETE aborts the previous attach and progresses the new
 // one — here re-identifying via authentication (TS 24.301 §5.5.1.2.7 case d).

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -54,6 +54,22 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, pla
 		return nasreply.Handled()
 	}
 
+	// An ATTACH REQUEST received while an attach is in progress and no ATTACH
+	// ACCEPT/REJECT has been sent yet (TS 24.301 §5.5.1.2.7 case e). Identical IEs
+	// mean a retransmission — continue the in-flight procedure (its T3460/T3450
+	// guard drives progress) and ignore the duplicate rather than restarting, which
+	// would abandon the pending authentication and, for a UE retransmitting faster
+	// than one auth round-trip, prevent convergence. Differing IEs fall through to
+	// supersede the earlier attach.
+	if step := ue.RegStep(); step == mme.RegStepAuthenticating || step == mme.RegStepSecurityMode {
+		if len(plain) > 0 && bytes.Equal(plain, ue.Conn().AttachRequestPlain) {
+			logger.From(ctx, logger.MmeLog).Info("duplicate Attach Request with identical IEs before Attach Accept; ignoring (TS 24.301 §5.5.1.2.7 case e)",
+				zap.Uint32("mme-ue-id", uint32(ue.Conn().MMEUES1APID)))
+
+			return nasreply.Handled()
+		}
+	}
+
 	// The UE's serving cell must be in this MME's served area, or ATTACH REJECT #12
 	// (ServesTAI, TS 24.301 §5.5.1.2.5).
 	if served, err := m.ServesTAI(ctx, ue.Conn().ServingTAI); err != nil {

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -54,9 +54,7 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, pla
 		return nasreply.Handled()
 	}
 
-	// TS 24.301 §5.5.1.2.7 case e: an identical retransmission before the accept is
-	// ignored, not restarted — restarting would abandon the in-flight auth and, for
-	// a UE retransmitting faster than one auth round-trip, never converge.
+	// TS 24.301 §5.5.1.2.7 case e: an identical retransmission before the accept is ignored.
 	if step := ue.RegStep(); step == mme.RegStepAuthenticating || step == mme.RegStepSecurityMode {
 		if len(plain) > 0 && bytes.Equal(plain, ue.Conn().AttachRequestPlain) {
 			logger.From(ctx, logger.MmeLog).Info("duplicate Attach Request with identical IEs before Attach Accept; ignoring (TS 24.301 §5.5.1.2.7 case e)",

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -54,13 +54,9 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, pla
 		return nasreply.Handled()
 	}
 
-	// An ATTACH REQUEST received while an attach is in progress and no ATTACH
-	// ACCEPT/REJECT has been sent yet (TS 24.301 §5.5.1.2.7 case e). Identical IEs
-	// mean a retransmission — continue the in-flight procedure (its T3460/T3450
-	// guard drives progress) and ignore the duplicate rather than restarting, which
-	// would abandon the pending authentication and, for a UE retransmitting faster
-	// than one auth round-trip, prevent convergence. Differing IEs fall through to
-	// supersede the earlier attach.
+	// TS 24.301 §5.5.1.2.7 case e: an identical retransmission before the accept is
+	// ignored, not restarted — restarting would abandon the in-flight auth and, for
+	// a UE retransmitting faster than one auth round-trip, never converge.
 	if step := ue.RegStep(); step == mme.RegStepAuthenticating || step == mme.RegStepSecurityMode {
 		if len(plain) > 0 && bytes.Equal(plain, ue.Conn().AttachRequestPlain) {
 			logger.From(ctx, logger.MmeLog).Info("duplicate Attach Request with identical IEs before Attach Accept; ignoring (TS 24.301 §5.5.1.2.7 case e)",

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -166,12 +166,14 @@ type tauAcceptOptions struct {
 // EMM cause #18, since the MME has no SGs interface, to stop the UE attempting CS
 // registration.
 func trackingAreaUpdateAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext, opts tauAcceptOptions) (*eps.TrackingAreaUpdateAccept, error) {
-	plmn, err := m.OperatorPLMN(ctx)
+	operator, err := m.Operator(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	served, err := m.ServedTAIs(ctx)
+	plmn := operator.PLMN()
+
+	served, err := operator.ServedTAIs()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -31,10 +31,8 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		zap.String("update-type", epsUpdateTypeName(req.EPSUpdateType)),
 		zap.Bool("active-flag", req.ActiveFlag))
 
-	// A TAU REQUEST received after the accept was sent and before TAU COMPLETE
-	// arrives (TS 24.301 §5.5.3.2.7 case d): identical IEs mean a retransmission —
-	// resend the accept and restart T3450 without reallocating another GUTI.
-	// Differing IEs fall through and supersede the earlier TAU with the new one.
+	// TS 24.301 §5.5.3.2.7 case d: resend the stored accept for an identical
+	// retransmission rather than rebuilding it, which would reallocate another GUTI.
 	if len(ue.Conn().TauAcceptPdu) > 0 && bytes.Equal(plain, ue.Conn().TauRequestPlain) {
 		logger.From(ctx, logger.MmeLog).Info("duplicate Tracking Area Update Request with identical IEs; resending Tracking Area Update Accept",
 			zap.String("imsi", ue.IMSI()))

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -31,8 +31,7 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		zap.String("update-type", epsUpdateTypeName(req.EPSUpdateType)),
 		zap.Bool("active-flag", req.ActiveFlag))
 
-	// TS 24.301 §5.5.3.2.7 case d: resend the stored accept for an identical
-	// retransmission rather than rebuilding it, which would reallocate another GUTI.
+	// TS 24.301 §5.5.3.2.7 case d: an identical retransmission gets the stored accept.
 	if len(ue.Conn().TauAcceptPdu) > 0 && bytes.Equal(plain, ue.Conn().TauRequestPlain) {
 		logger.From(ctx, logger.MmeLog).Info("duplicate Tracking Area Update Request with identical IEs; resending Tracking Area Update Accept",
 			zap.String("imsi", ue.IMSI()))

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -4,6 +4,7 @@
 package nas
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/ellanetworks/core/internal/logger"
@@ -29,6 +30,18 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		zap.String("imsi", ue.IMSI()),
 		zap.String("update-type", epsUpdateTypeName(req.EPSUpdateType)),
 		zap.Bool("active-flag", req.ActiveFlag))
+
+	// A TAU REQUEST received after the accept was sent and before TAU COMPLETE
+	// arrives (TS 24.301 §5.5.3.2.7 case d): identical IEs mean a retransmission —
+	// resend the accept and restart T3450 without reallocating another GUTI.
+	// Differing IEs fall through and supersede the earlier TAU with the new one.
+	if len(ue.Conn().TauAcceptPdu) > 0 && bytes.Equal(plain, ue.Conn().TauRequestPlain) {
+		logger.From(ctx, logger.MmeLog).Info("duplicate Tracking Area Update Request with identical IEs; resending Tracking Area Update Accept",
+			zap.String("imsi", ue.IMSI()))
+		ue.Conn().ResendTauAccept(ctx)
+
+		return nasreply.Handled()
+	}
 
 	// The UE's serving cell must be in this MME's served area, as at attach, or TAU
 	// REJECT #12 (TS 24.301 §5.5.3.2.5).
@@ -67,6 +80,9 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	}
 
 	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultAccept)
+
+	ue.Conn().TauRequestPlain = plain
+	ue.Conn().TauAcceptPdu = naspdu
 
 	// A fully connected UE (bearers up) keeps its connection; a UE resuming for this
 	// TAU needs re-establishment or a deferred release.
@@ -119,6 +135,9 @@ func rejectTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 func handleTrackingAreaUpdateComplete(ctx context.Context, m *mme.MME, ue *mme.UeContext) nasreply.Disposition {
 	ue.Conn().StopNASGuard()
 	m.CommitGUTIRealloc(ue)
+
+	ue.Conn().TauRequestPlain = nil
+	ue.Conn().TauAcceptPdu = nil
 
 	logger.From(ctx, logger.MmeLog).Info("Tracking Area Update Complete", zap.String("imsi", ue.IMSI()))
 

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -4,6 +4,7 @@
 package nas
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestTrackingAreaUpdateTrackingAreaNotAllowed(t *testing.T) {
 	// Served PLMN 001/01 but TAC 2, which the operator does not serve (it serves TAC 1).
 	ue.Conn().ServingTAI = s1ap.TAI{PLMNIdentity: s1ap.PLMNIdentity{0x00, 0xf1, 0x10}, TAC: 2}
 
-	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, false, nil))
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
 
 	if len(cc.sent) == 0 {
 		t.Fatal("expected a TAU Reject, got no downlink")
@@ -42,15 +43,10 @@ func TestTrackingAreaUpdateTrackingAreaNotAllowed(t *testing.T) {
 // trackingAreaUpdateNAS builds a protected TRACKING AREA UPDATE REQUEST at the
 // UE's current uplink NAS COUNT, optionally carrying an EPS bearer context status
 // IE (IEI 0x57) when bearerStatus is non-nil.
-func trackingAreaUpdateNAS(t *testing.T, ue *mme.UeContext, activeFlag bool, bearerStatus *uint16) []byte {
+func trackingAreaUpdateNAS(t *testing.T, ue *mme.UeContext, bearerStatus *uint16) []byte {
 	t.Helper()
 
-	updateType := uint8(0)
-	if activeFlag {
-		updateType |= 0x08
-	}
-
-	plain := []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), updateType}
+	plain := []byte{0x07, byte(eps.MsgTrackingAreaUpdateRequest), 0x00}
 
 	if bearerStatus != nil {
 		plain = append(plain, 0x57, 0x02, byte(*bearerStatus), byte(*bearerStatus>>8))
@@ -72,7 +68,7 @@ func TestTrackingAreaUpdateConnectedAccepted(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m) // ECM-CONNECTED, secured, EMM-REGISTERED
 
-	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, false, nil))
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
 
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected one downlink (TAU Accept), got %d", len(cc.sent))
@@ -108,6 +104,44 @@ func TestTrackingAreaUpdateConnectedAccepted(t *testing.T) {
 	}
 }
 
+// TestTrackingAreaUpdateDuplicateResendsAccept checks that a retransmitted TAU
+// REQUEST with identical IEs, received before TAU COMPLETE, is answered by resending
+// the original TAU Accept (byte-identical inner message, so no second GUTI
+// reallocation) per TS 24.301 §5.5.3.2.7 case d.
+func TestTrackingAreaUpdateDuplicateResendsAccept(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m) // ECM-CONNECTED, secured, EMM-REGISTERED
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+
+	if len(cc.sent) != 2 {
+		t.Fatalf("expected two downlinks (TAU Accept and its resend), got %d", len(cc.sent))
+	}
+
+	var plains [2][]byte
+
+	for i := range plains {
+		dl := decodeDownlinkNAS(t, cc.sent[i])
+
+		plain, err := eps.Unprotect(dl, nascommon.NASCount(0, dl[5]), nascommon.DirectionDownlink,
+			ue.KnasIntForTest(), ue.KnasEncForTest(), nascommon.AESCMACIntegrity{}, nascommon.AESCTRCipher{})
+		if err != nil {
+			t.Fatalf("unprotect downlink %d: %v", i, err)
+		}
+
+		if mt, err := eps.PeekMessageType(plain); err != nil || mt != eps.MsgTrackingAreaUpdateAccept {
+			t.Fatalf("downlink %d message = %#x (err %v), want TAU Accept", i, mt, err)
+		}
+
+		plains[i] = plain
+	}
+
+	if !bytes.Equal(plains[0], plains[1]) {
+		t.Fatal("resent TAU Accept differs from the original; a duplicate TAU REQUEST must resend the stored accept")
+	}
+}
+
 // TestTrackingAreaUpdateReconcilesBearerContextStatus checks that when the UE
 // reports its EPS bearer context status, the MME deactivates locally the bearers
 // the UE marks inactive and reflects the resulting active set in the TAU Accept
@@ -121,7 +155,7 @@ func TestTrackingAreaUpdateReconcilesBearerContextStatus(t *testing.T) {
 	ue.EnsurePDN(6)     // an additional PDN connection
 
 	status := uint16(1 << 5) // the UE reports only EBI 5 active
-	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, false, &status))
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, &status))
 
 	if _, ok := ue.Pdns[6]; ok {
 		t.Fatal("EBI 6 should be released locally after the UE reports it inactive")

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -66,7 +66,7 @@ func trackingAreaUpdateNAS(t *testing.T, ue *mme.UeContext, bearerStatus *uint16
 // registered and connected (TS 24.301 §5.5.3.2.4).
 func TestTrackingAreaUpdateConnectedAccepted(t *testing.T) {
 	m := newTestMME(t)
-	ue, cc := securedUE(t, m) // ECM-CONNECTED, secured, EMM-REGISTERED
+	ue, cc := securedUE(t, m)
 
 	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
 
@@ -104,10 +104,8 @@ func TestTrackingAreaUpdateConnectedAccepted(t *testing.T) {
 	}
 }
 
-// TestTrackingAreaUpdateDuplicateResendsAccept checks that a retransmitted TAU
-// REQUEST with identical IEs, received before TAU COMPLETE, is answered by resending
-// the original TAU Accept (byte-identical inner message, so no second GUTI
-// reallocation) per TS 24.301 §5.5.3.2.7 case d.
+// An identical TAU retransmission resends the stored accept byte-for-byte, so no
+// second GUTI is reallocated (TS 24.301 §5.5.3.2.7 case d).
 func TestTrackingAreaUpdateDuplicateResendsAccept(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m) // ECM-CONNECTED, secured, EMM-REGISTERED

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -180,27 +180,15 @@ func (m *MME) pageRadios(ctx context.Context, ue *UeContext, b []byte) {
 	}
 }
 
-// ServedTAIs is the network's served tracking areas: the operator PLMN paired with
-// each served TAC. Every UE is registered in this area (TS 23.401 §5.3.4).
+// ServedTAIs is the network's served tracking areas, per
+// OperatorConfig.ServedTAIs.
 func (m *MME) ServedTAIs(ctx context.Context) ([]models.Tai, error) {
-	plmn, err := m.OperatorPLMN(ctx)
+	o, err := m.Operator(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("operator PLMN: %w", err)
+		return nil, err
 	}
 
-	tacs, err := m.OperatorTACs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("operator TACs: %w", err)
-	}
-
-	out := make([]models.Tai, 0, len(tacs))
-
-	for _, tac := range tacs {
-		p := plmn
-		out = append(out, models.Tai{PlmnID: &p, Tac: fmt.Sprintf("%06x", tac)})
-	}
-
-	return out, nil
+	return o.ServedTAIs()
 }
 
 // areaToS1APTAIs encodes a registration area as the S1AP TAI list carried in Paging.

--- a/internal/mme/plmn.go
+++ b/internal/mme/plmn.go
@@ -6,38 +6,21 @@ package mme
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/ellanetworks/core/internal/models"
 	nascommon "github.com/ellanetworks/core/nas/common"
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// ServesTAI reports whether tai — a UE's serving-cell TAI — is served: operator PLMN
-// and an operator E-UTRAN TAC. This per-UE gate (EMM cause #12, TS 24.301 §5.5.1.2.5)
-// is finer than the node-level S1 Setup gate, which admits an eNB broadcasting any
-// served TAI even when it also broadcasts an unserved one.
+// ServesTAI reports whether tai — a UE's serving-cell TAI — is served, per
+// OperatorConfig.ServesTAI.
 func (m *MME) ServesTAI(ctx context.Context, tai s1ap.TAI) (bool, error) {
-	plmn, err := m.OperatorPLMN(ctx)
+	o, err := m.Operator(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	served, err := EncodePLMN(plmn)
-	if err != nil {
-		return false, err
-	}
-
-	if tai.PLMNIdentity != served {
-		return false, nil
-	}
-
-	tacs, err := m.OperatorTACs(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	return slices.Contains(tacs, uint16(tai.TAC)), nil
+	return o.ServesTAI(tai)
 }
 
 // EncodePLMN encodes an MCC/MNC pair into the 3-octet TBCD PLMN identity

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -85,6 +85,13 @@ type UeConn struct {
 	AttachRequestPlain []byte
 	AttachAcceptPdu    []byte
 
+	// In-flight TAU working-state (TS 24.301 §5.5.3.2.7 case d): TauRequestPlain is
+	// the plaintext TRACKING AREA UPDATE REQUEST being served, TauAcceptPdu the
+	// protected accept awaiting TRACKING AREA UPDATE COMPLETE; both are cleared when
+	// the complete commits the reallocated GUTI.
+	TauRequestPlain []byte
+	TauAcceptPdu    []byte
+
 	// TauReleaseOnComplete defers the S1 release of a no-active TAU until the
 	// GUTI reallocation it carried is acknowledged.
 	TauReleaseOnComplete bool

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -85,10 +85,8 @@ type UeConn struct {
 	AttachRequestPlain []byte
 	AttachAcceptPdu    []byte
 
-	// In-flight TAU working-state (TS 24.301 §5.5.3.2.7 case d): TauRequestPlain is
-	// the plaintext TRACKING AREA UPDATE REQUEST being served, TauAcceptPdu the
-	// protected accept awaiting TRACKING AREA UPDATE COMPLETE; both are cleared when
-	// the complete commits the reallocated GUTI.
+	// In-flight TAU working-state (TS 24.301 §5.5.3.2.7 case d), like the attach
+	// state above; cleared when TAU COMPLETE commits the reallocated GUTI.
 	TauRequestPlain []byte
 	TauAcceptPdu    []byte
 

--- a/internal/mme/s1ap/handle_enb_configuration_update.go
+++ b/internal/mme/s1ap/handle_enb_configuration_update.go
@@ -23,13 +23,15 @@ func handleENBConfigurationUpdate(m *mme.MME, ctx context.Context, radio *mme.Ra
 		return
 	}
 
-	plmn, err := m.OperatorPLMN(ctx)
+	operator, err := m.Operator(ctx)
 	if err != nil {
-		logger.From(ctx, radio.Log).Error("failed to get operator PLMN for ENB Configuration Update", zap.Error(err))
+		logger.From(ctx, radio.Log).Error("failed to get operator for ENB Configuration Update", zap.Error(err))
 		return
 	}
 
-	tacs, err := m.OperatorTACs(ctx)
+	plmn := operator.PLMN()
+
+	tacs, err := operator.TACs()
 	if err != nil {
 		logger.From(ctx, radio.Log).Error("failed to get operator TACs for ENB Configuration Update", zap.Error(err))
 		return

--- a/internal/mme/s1ap/handle_s1_setup.go
+++ b/internal/mme/s1ap/handle_s1_setup.go
@@ -31,13 +31,15 @@ var causeNoServedTAC = s1ap.Cause{Group: s1ap.CauseGroupMisc, Value: s1ap.CauseM
 // the eNB broadcasts a TAI this MME serves, otherwise an S1 Setup Failure
 // (TS 36.413).
 func handleS1Setup(m *mme.MME, ctx context.Context, conn *sctp.SCTPConn, value []byte) {
-	plmn, err := m.OperatorPLMN(ctx)
+	operator, err := m.Operator(ctx)
 	if err != nil {
-		logger.From(ctx, m.RadioLog(conn)).Error("failed to get operator PLMN for S1 Setup", zap.Error(err))
+		logger.From(ctx, m.RadioLog(conn)).Error("failed to get operator for S1 Setup", zap.Error(err))
 		return
 	}
 
-	tacs, err := m.OperatorTACs(ctx)
+	plmn := operator.PLMN()
+
+	tacs, err := operator.TACs()
 	if err != nil {
 		logger.From(ctx, m.RadioLog(conn)).Error("failed to get operator TACs for S1 Setup", zap.Error(err))
 		return

--- a/internal/mme/send.go
+++ b/internal/mme/send.go
@@ -73,8 +73,7 @@ func (c *UeConn) ResendAttachAccept(ctx context.Context) {
 	c.ArmNASGuard("Attach Accept", c.AttachAcceptPdu)
 }
 
-// ResendTauAccept resends the stored TRACKING AREA UPDATE ACCEPT and restarts its
-// T3450 guard, for a retransmitted TAU REQUEST with identical IEs
+// ResendTauAccept resends the stored TAU ACCEPT and restarts its T3450 guard
 // (TS 24.301 §5.5.3.2.7 case d).
 func (c *UeConn) ResendTauAccept(ctx context.Context) {
 	if c == nil || len(c.TauAcceptPdu) == 0 {

--- a/internal/mme/send.go
+++ b/internal/mme/send.go
@@ -73,6 +73,18 @@ func (c *UeConn) ResendAttachAccept(ctx context.Context) {
 	c.ArmNASGuard("Attach Accept", c.AttachAcceptPdu)
 }
 
+// ResendTauAccept resends the stored TRACKING AREA UPDATE ACCEPT and restarts its
+// T3450 guard, for a retransmitted TAU REQUEST with identical IEs
+// (TS 24.301 §5.5.3.2.7 case d).
+func (c *UeConn) ResendTauAccept(ctx context.Context) {
+	if c == nil || len(c.TauAcceptPdu) == 0 {
+		return
+	}
+
+	c.SendDownlinkNASTransport(ctx, c.TauAcceptPdu)
+	c.ArmNASGuard("Tracking Area Update Accept", c.TauAcceptPdu)
+}
+
 // SendDownlinkNASTransport wraps NAS bytes (plain or security-protected) in a Downlink NAS
 // Transport and sends them to the UE's eNB through the single send chokepoint.
 func (c *UeConn) SendDownlinkNASTransport(ctx context.Context, nas []byte) {

--- a/internal/sctp/addr_cache_test.go
+++ b/internal/sctp/addr_cache_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+//go:build linux && !386
+
+package sctp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestSCTPConn_AddrAccessorsCached verifies LocalAddr/RemoteAddr resolve the
+// association's loopback addresses and that repeated calls return the cached
+// resolution.
+func TestSCTPConn_AddrAccessorsCached(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29409
+
+	srv := NewServer(Config{
+		PPID:   testPPID,
+		Name:   "TEST",
+		Logger: zap.NewNop(),
+	}, Callbacks{
+		Dispatch: func(_ context.Context, _ *SCTPConn, _ []byte) {},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := srv.ListenAndServe(ctx, "127.0.0.1", port, ""); err != nil {
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+
+	fd, err := connectLoopback(port)
+	if err != nil {
+		t.Fatalf("connectLoopback: %v", err)
+	}
+
+	client := NewSCTPConn(fd)
+
+	defer func() { _ = client.Close() }()
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	var remote1 any
+
+	for remote1 == nil && time.Now().Before(deadline) {
+		remote1 = client.RemoteAddr()
+	}
+
+	if remote1 == nil {
+		t.Fatal("RemoteAddr = nil after association establishment")
+	}
+
+	if got := remote1.(*SCTPAddr).String(); !strings.Contains(got, "127.0.0.1") {
+		t.Errorf("RemoteAddr = %q, want loopback address", got)
+	}
+
+	if remote2 := client.RemoteAddr(); remote2 != remote1 {
+		t.Errorf("second RemoteAddr returned a fresh resolution, want the cached one")
+	}
+
+	local1 := client.LocalAddr()
+	if local1 == nil {
+		t.Fatal("LocalAddr = nil for established association")
+	}
+
+	if local2 := client.LocalAddr(); local2 != local1 {
+		t.Errorf("second LocalAddr returned a fresh resolution, want the cached one")
+	}
+}

--- a/internal/sctp/addr_cache_test.go
+++ b/internal/sctp/addr_cache_test.go
@@ -13,9 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestSCTPConn_AddrAccessorsCached verifies LocalAddr/RemoteAddr resolve the
-// association's loopback addresses and that repeated calls return the cached
-// resolution.
+// Repeated LocalAddr/RemoteAddr calls return the cached resolution.
 func TestSCTPConn_AddrAccessorsCached(t *testing.T) {
 	skipIfNoSCTP(t)
 

--- a/internal/sctp/nodelay_test.go
+++ b/internal/sctp/nodelay_test.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// nodelayValue reads SCTP_NODELAY from the connection's socket.
 func nodelayValue(t *testing.T, conn *SCTPConn) int32 {
 	t.Helper()
 
@@ -31,8 +30,7 @@ func nodelayValue(t *testing.T, conn *SCTPConn) int32 {
 	return v
 }
 
-// TestServer_AcceptedConnHasNoDelay verifies an accepted association carries
-// SCTP_NODELAY inherited from the listener.
+// An accepted association inherits SCTP_NODELAY from the listener.
 func TestServer_AcceptedConnHasNoDelay(t *testing.T) {
 	skipIfNoSCTP(t)
 

--- a/internal/sctp/nodelay_test.go
+++ b/internal/sctp/nodelay_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+//go:build linux && !386
+
+package sctp
+
+import (
+	"context"
+	"testing"
+	"time"
+	"unsafe"
+
+	"go.uber.org/zap"
+)
+
+// nodelayValue reads SCTP_NODELAY from the connection's socket.
+func nodelayValue(t *testing.T, conn *SCTPConn) int32 {
+	t.Helper()
+
+	var v int32
+
+	optlen := uint32(unsafe.Sizeof(v))
+
+	err := conn.controlFd(func(fd int) error {
+		return getsockopt(fd, SCTPNoDelay, uintptr(unsafe.Pointer(&v)), uintptr(unsafe.Pointer(&optlen)))
+	})
+	if err != nil {
+		t.Fatalf("getsockopt SCTP_NODELAY: %v", err)
+	}
+
+	return v
+}
+
+// TestServer_AcceptedConnHasNoDelay verifies an accepted association carries
+// SCTP_NODELAY inherited from the listener.
+func TestServer_AcceptedConnHasNoDelay(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29407
+
+	accepted := make(chan *SCTPConn, 1)
+
+	srv := NewServer(Config{
+		PPID:   testPPID,
+		Name:   "TEST",
+		Logger: zap.NewNop(),
+	}, Callbacks{
+		Dispatch: func(_ context.Context, conn *SCTPConn, _ []byte) {
+			select {
+			case accepted <- conn:
+			default:
+			}
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := srv.ListenAndServe(ctx, "127.0.0.1", port, ""); err != nil {
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+
+	fd, err := connectLoopback(port)
+	if err != nil {
+		t.Fatalf("connectLoopback: %v", err)
+	}
+
+	client := NewSCTPConn(fd)
+
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.WriteMsg([]byte("probe"), &SndRcvInfo{PPID: PPIDWireOrder(testPPID), Stream: 0}); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+
+	select {
+	case conn := <-accepted:
+		if got := nodelayValue(t, conn); got == 0 {
+			t.Errorf("accepted conn SCTP_NODELAY = %d, want non-zero", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no message dispatched within 5s")
+	}
+}

--- a/internal/sctp/sctp.go
+++ b/internal/sctp/sctp.go
@@ -239,6 +239,15 @@ func setAssocInfo(fd int, info AssocInfo) error {
 	return err
 }
 
+// setNoDelay disables the Nagle-like transmit delay (RFC 6458 §8.1.4). With
+// the delay active, the second of two back-to-back small PDUs is held until
+// the peer's delayed SACK, stalling signalling by the peer's SACK timeout.
+func setNoDelay(fd int) error {
+	on := int32(1)
+
+	return setsockopt(fd, SCTPNoDelay, uintptr(unsafe.Pointer(&on)), unsafe.Sizeof(on))
+}
+
 type SCTPAddr struct {
 	IPAddrs []net.IPAddr
 	Port    int

--- a/internal/sctp/sctp.go
+++ b/internal/sctp/sctp.go
@@ -348,6 +348,13 @@ type SCTPConn struct {
 	file   *os.File
 	rc     syscall.RawConn
 	closed atomic.Bool
+
+	// The address sets of a one-to-one association are fixed after
+	// establishment (inbound dynamic address reconfiguration is discarded
+	// under the kernel default net.sctp.addip_enable=0), so both accessors
+	// cache their first successful resolution.
+	localAddr  atomic.Pointer[SCTPAddr]
+	remoteAddr atomic.Pointer[SCTPAddr]
 }
 
 // controlFd runs fn with the raw file descriptor held by the runtime poller.
@@ -526,7 +533,13 @@ func (c *SCTPConn) getAddrs(optname int) *SCTPAddr {
 }
 
 func (c *SCTPConn) LocalAddr() net.Addr {
+	if addr := c.localAddr.Load(); addr != nil {
+		return addr
+	}
+
 	if addr := c.getAddrs(SCTPGetLocalAddrs); addr != nil {
+		c.localAddr.Store(addr)
+
 		return addr
 	}
 
@@ -534,7 +547,13 @@ func (c *SCTPConn) LocalAddr() net.Addr {
 }
 
 func (c *SCTPConn) RemoteAddr() net.Addr {
+	if addr := c.remoteAddr.Load(); addr != nil {
+		return addr
+	}
+
 	if addr := c.getAddrs(SCTPGetPeerAddrs); addr != nil {
+		c.remoteAddr.Store(addr)
+
 		return addr
 	}
 

--- a/internal/sctp/sctp.go
+++ b/internal/sctp/sctp.go
@@ -239,9 +239,9 @@ func setAssocInfo(fd int, info AssocInfo) error {
 	return err
 }
 
-// setNoDelay disables the Nagle-like transmit delay (RFC 6458 §8.1.4). With
-// the delay active, the second of two back-to-back small PDUs is held until
-// the peer's delayed SACK, stalling signalling by the peer's SACK timeout.
+// setNoDelay disables the Nagle-like transmit delay (RFC 6458 §8.1.4), which
+// otherwise holds the second of two back-to-back small PDUs until the peer's
+// delayed SACK.
 func setNoDelay(fd int) error {
 	on := int32(1)
 
@@ -349,10 +349,8 @@ type SCTPConn struct {
 	rc     syscall.RawConn
 	closed atomic.Bool
 
-	// The address sets of a one-to-one association are fixed after
-	// establishment (inbound dynamic address reconfiguration is discarded
-	// under the kernel default net.sctp.addip_enable=0), so both accessors
-	// cache their first successful resolution.
+	// Cached: the address sets are fixed after establishment (inbound ASCONF is
+	// discarded under the kernel default net.sctp.addip_enable=0).
 	localAddr  atomic.Pointer[SCTPAddr]
 	remoteAddr atomic.Pointer[SCTPAddr]
 }

--- a/internal/sctp/sctp_linux.go
+++ b/internal/sctp/sctp_linux.go
@@ -302,8 +302,7 @@ func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, rtoIn
 		return nil, err
 	}
 
-	// One-to-one associations inherit the option from the listener, like the
-	// RTO/association options above.
+	// Inherited by accepted associations, like the options above.
 	if err = setNoDelay(sock); err != nil {
 		return nil, err
 	}

--- a/internal/sctp/sctp_linux.go
+++ b/internal/sctp/sctp_linux.go
@@ -302,6 +302,12 @@ func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, rtoIn
 		return nil, err
 	}
 
+	// One-to-one associations inherit the option from the listener, like the
+	// RTO/association options above.
+	if err = setNoDelay(sock); err != nil {
+		return nil, err
+	}
+
 	if laddr != nil {
 		if len(laddr.IPAddrs) == 0 {
 			switch af {

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -211,9 +211,6 @@ func (s *SMF) handlePduSessionContextReplacement(ctx context.Context, smCtxt *SM
 
 	// Stop the superseded context's outstanding procedure retransmission.
 	smCtxt.stopProcedureTimer()
-
-	// RemoveSession tears down the user plane (ordered before the lease release) and
-	// drops the context from the pool.
 	s.RemoveSession(ctx, smCtxt.Ref)
 }
 

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 )
 
 func nasToNgapPDUSessionType(nasType uint8) aper.Enumerated {
@@ -213,14 +212,9 @@ func (s *SMF) handlePduSessionContextReplacement(ctx context.Context, smCtxt *SM
 	// Stop the superseded context's outstanding procedure retransmission.
 	smCtxt.stopProcedureTimer()
 
+	// RemoveSession tears down the user plane (ordered before the lease release) and
+	// drops the context from the pool.
 	s.RemoveSession(ctx, smCtxt.Ref)
-
-	if smCtxt.Tunnel != nil {
-		err := s.releaseTunnel(ctx, smCtxt)
-		if err != nil {
-			logger.WithTrace(ctx, logger.SmfLog).Error("release tunnel failed", zap.Error(err), logger.SUPI(smCtxt.Supi.String()), logger.PDUSessionID(smCtxt.PDUSessionID))
-		}
-	}
 }
 
 // establishmentRejectCause maps a session-policy lookup failure to the 5GSM

--- a/internal/smf/iid.go
+++ b/internal/smf/iid.go
@@ -10,6 +10,7 @@ import (
 
 // GenerateIID returns a cryptographically random 64-bit IPv6 Interface
 // Identifier sent to the UE in the PDU Session Establishment Accept (TS 24.501).
+// Each session has its own /64, so the IID needs no cross-session uniqueness.
 func GenerateIID() ([8]byte, error) {
 	var iid [8]byte
 
@@ -18,39 +19,4 @@ func GenerateIID() ([8]byte, error) {
 	}
 
 	return iid, nil
-}
-
-// iIDMaxRetries bounds the unique-IID search so a pathological run of collisions
-// cannot loop forever; collisions in a 64-bit space are already astronomically rare.
-const iIDMaxRetries = 3
-
-// assignIID returns an IID not already in use by another session on the DNN.
-func (s *SMF) assignIID(dnn string) ([8]byte, error) {
-	s.mu.RLock()
-	seen := make(map[[8]byte]bool, len(s.pool))
-
-	for _, ctx := range s.pool {
-		if ctx.Dnn == dnn {
-			seen[ctx.IPv6IID] = true
-		}
-	}
-
-	s.mu.RUnlock()
-
-	var iid [8]byte
-
-	for i := 0; i < iIDMaxRetries; i++ {
-		var err error
-
-		iid, err = GenerateIID()
-		if err != nil {
-			return iid, err
-		}
-
-		if !seen[iid] {
-			return iid, nil
-		}
-	}
-
-	return iid, fmt.Errorf("failed to generate unique IID after %d retries", iIDMaxRetries)
 }

--- a/internal/smf/ipalloc.go
+++ b/internal/smf/ipalloc.go
@@ -148,7 +148,7 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, dn DNNStore, sc *SMContex
 		sc.PDUIPV6Prefix = netipToIP(ipv6Prefix)
 		addrs.IPv6Prefix = ipv6Prefix
 
-		iid, err := s.assignIID(sc.Dnn)
+		iid, err := GenerateIID()
 		if err != nil {
 			s.releaseAllocatedAddresses(ctx, dn, sc)
 			return netip.Addr{}, ueAddresses{}, fmt.Errorf("assign IPv6 IID: %w", err)

--- a/internal/smf/ipalloc.go
+++ b/internal/smf/ipalloc.go
@@ -119,7 +119,7 @@ func narrowPDUType(requested, negotiated uint8) pduTypeNarrowing {
 // them on sc, and returns the downlink-PDR key (the IPv4 address, or the /64
 // prefix base for IPv6-only). On failure it releases whatever it had allocated.
 // The caller holds sc.Mutex.
-func (s *SMF) allocateUEAddresses(ctx context.Context, sc *SMContext) (netip.Addr, ueAddresses, error) {
+func (s *SMF) allocateUEAddresses(ctx context.Context, dn DNNStore, sc *SMContext) (netip.Addr, ueAddresses, error) {
 	imsi := sc.Supi.IMSI()
 
 	var (
@@ -128,7 +128,7 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, sc *SMContext) (netip.Add
 	)
 
 	if sc.PDUSessionType == nasMessage.PDUSessionTypeIPv4 || sc.PDUSessionType == nasMessage.PDUSessionTypeIPv4IPv6 {
-		ipv4, err := s.store.AllocateIP(ctx, imsi, sc.Dnn, sc.PDUSessionID)
+		ipv4, err := dn.AllocateIP(ctx, imsi, sc.PDUSessionID)
 		if err != nil {
 			return netip.Addr{}, ueAddresses{}, fmt.Errorf("allocate UE IPv4: %w", err)
 		}
@@ -139,9 +139,9 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, sc *SMContext) (netip.Add
 	}
 
 	if sc.PDUSessionType == nasMessage.PDUSessionTypeIPv6 || sc.PDUSessionType == nasMessage.PDUSessionTypeIPv4IPv6 {
-		ipv6Prefix, err := s.store.AllocateIPv6(ctx, imsi, sc.Dnn, sc.PDUSessionID)
+		ipv6Prefix, err := dn.AllocateIPv6(ctx, imsi, sc.PDUSessionID)
 		if err != nil {
-			s.releaseAllocatedAddresses(ctx, sc)
+			s.releaseAllocatedAddresses(ctx, dn, sc)
 			return netip.Addr{}, ueAddresses{}, fmt.Errorf("allocate UE IPv6 prefix: %w", err)
 		}
 
@@ -150,7 +150,7 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, sc *SMContext) (netip.Add
 
 		iid, err := s.assignIID(sc.Dnn)
 		if err != nil {
-			s.releaseAllocatedAddresses(ctx, sc)
+			s.releaseAllocatedAddresses(ctx, dn, sc)
 			return netip.Addr{}, ueAddresses{}, fmt.Errorf("assign IPv6 IID: %w", err)
 		}
 
@@ -167,9 +167,9 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, sc *SMContext) (netip.Add
 
 // releaseAllocatedAddresses releases the UE IP leases recorded on smContext and
 // clears them, so a later rollback does not double-release.
-func (s *SMF) releaseAllocatedAddresses(ctx context.Context, smContext *SMContext) {
+func (s *SMF) releaseAllocatedAddresses(ctx context.Context, dn DNNStore, smContext *SMContext) {
 	if smContext.PDUIPV4Address != nil {
-		if _, err := s.store.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.Dnn, smContext.PDUSessionID); err != nil {
+		if _, err := dn.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID); err != nil {
 			logger.WithTrace(ctx, logger.SmfLog).Error("failed to release IPv4 address", zap.Error(err))
 		}
 
@@ -177,7 +177,7 @@ func (s *SMF) releaseAllocatedAddresses(ctx context.Context, smContext *SMContex
 	}
 
 	if smContext.PDUIPV6Prefix != nil {
-		if _, err := s.store.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.Dnn, smContext.PDUSessionID); err != nil {
+		if _, err := dn.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID); err != nil {
 			logger.WithTrace(ctx, logger.SmfLog).Error("failed to release IPv6 address", zap.Error(err))
 		}
 

--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -2488,5 +2490,82 @@ func TestUpdateSmContextN1Msg_ModificationRejected(t *testing.T) {
 
 	if got := m.PDUSessionModificationReject.GetCauseValue(); got != nasMessage.Cause5GSMRequestRejectedUnspecified {
 		t.Errorf("reject cause = %d, want %d (request rejected, unspecified)", got, nasMessage.Cause5GSMRequestRejectedUnspecified)
+	}
+}
+
+// teardownRecorder is a shared, ordered log used by the store and UPF fakes to
+// assert that the NAT-bearing user-plane teardown (DeleteSession) happens before
+// the IP lease release (see releaseUserPlaneThenAddresses).
+type teardownRecorder struct {
+	mu  sync.Mutex
+	seq []string
+}
+
+func (r *teardownRecorder) record(event string) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.seq = append(r.seq, event)
+}
+
+func (r *teardownRecorder) events() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.seq)
+}
+
+// TestReleaseSmContext_PurgesDatapathBeforeReleasingLease guards the fix for the
+// cross-subscriber misdelivery bug: the IP lease must not return to the allocator
+// until the UPF session (and its NAT conntrack) is torn down, or a reallocation
+// could inherit the previous subscriber's live flows.
+func TestReleaseSmContext_PurgesDatapathBeforeReleasingLease(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+
+	rec := &teardownRecorder{}
+	store.teardownSeq = rec
+	upf.teardownSeq = rec
+
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	if err := s.ReleaseSmContext(context.Background(), ref); err != nil {
+		t.Fatalf("ReleaseSmContext failed: %v", err)
+	}
+
+	got := rec.events()
+	if len(got) != 2 || got[0] != "delete-session" || got[1] != "release-ip" {
+		t.Fatalf("teardown order = %v, want [delete-session release-ip]", got)
+	}
+}
+
+// TestReleaseSmContext_KeepsLeaseWhenDatapathTeardownFails guards the fail-safe:
+// if the user-plane teardown fails, the IP lease is kept (the address stays bound
+// to this subscriber) rather than released for reuse with stale conntrack.
+func TestReleaseSmContext_KeepsLeaseWhenDatapathTeardownFails(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	_, ref := setupSessionWithTunnel(t, s)
+
+	upf.mu.Lock()
+	upf.err = fmt.Errorf("PFCP delete failed")
+	upf.mu.Unlock()
+
+	if err := s.ReleaseSmContext(context.Background(), ref); err == nil {
+		t.Fatal("expected an error when user-plane teardown fails")
+	}
+
+	store.mu.Lock()
+	released := len(store.releasedIPs)
+	store.mu.Unlock()
+
+	if released != 0 {
+		t.Fatalf("IP lease was released (%d) despite datapath teardown failure; it must be kept", released)
 	}
 }

--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -2493,9 +2493,8 @@ func TestUpdateSmContextN1Msg_ModificationRejected(t *testing.T) {
 	}
 }
 
-// teardownRecorder is a shared, ordered log used by the store and UPF fakes to
-// assert that the NAT-bearing user-plane teardown (DeleteSession) happens before
-// the IP lease release (see releaseUserPlaneThenAddresses).
+// teardownRecorder is an ordered log shared by the store and UPF fakes to assert
+// DeleteSession happens before the IP lease release.
 type teardownRecorder struct {
 	mu  sync.Mutex
 	seq []string
@@ -2519,10 +2518,8 @@ func (r *teardownRecorder) events() []string {
 	return slices.Clone(r.seq)
 }
 
-// TestReleaseSmContext_PurgesDatapathBeforeReleasingLease guards the fix for the
-// cross-subscriber misdelivery bug: the IP lease must not return to the allocator
-// until the UPF session (and its NAT conntrack) is torn down, or a reallocation
-// could inherit the previous subscriber's live flows.
+// The IP lease must not be released until the UPF session (and its NAT conntrack)
+// is torn down, else a reallocation could inherit the previous subscriber's flows.
 func TestReleaseSmContext_PurgesDatapathBeforeReleasingLease(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 
@@ -2544,9 +2541,8 @@ func TestReleaseSmContext_PurgesDatapathBeforeReleasingLease(t *testing.T) {
 	}
 }
 
-// TestReleaseSmContext_KeepsLeaseWhenDatapathTeardownFails guards the fail-safe:
-// if the user-plane teardown fails, the IP lease is kept (the address stays bound
-// to this subscriber) rather than released for reuse with stale conntrack.
+// On teardown failure the lease is kept, so the address is not reused with stale
+// conntrack.
 func TestReleaseSmContext_KeepsLeaseWhenDatapathTeardownFails(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)

--- a/internal/smf/network_requested_procedure.go
+++ b/internal/smf/network_requested_procedure.go
@@ -62,7 +62,13 @@ func (s *SMF) startRelease(ctx context.Context, smContext *SMContext, pti, cause
 // front on the release trigger and again on completion. Caller must hold
 // smContext.Mutex.
 func (s *SMF) releaseUserPlane(ctx context.Context, smContext *SMContext) {
-	s.releaseAllocatedAddresses(ctx, smContext)
+	dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
+	if err != nil {
+		logger.WithTrace(ctx, logger.SmfLog).Error("failed to resolve data network to release UE addresses",
+			zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+	} else {
+		s.releaseAllocatedAddresses(ctx, dn, smContext)
+	}
 
 	if err := s.releaseTunnel(ctx, smContext); err != nil {
 		logger.WithTrace(ctx, logger.SmfLog).Warn("release tunnel failed, continuing release",

--- a/internal/smf/network_requested_procedure.go
+++ b/internal/smf/network_requested_procedure.go
@@ -62,18 +62,7 @@ func (s *SMF) startRelease(ctx context.Context, smContext *SMContext, pti, cause
 // front on the release trigger and again on completion. Caller must hold
 // smContext.Mutex.
 func (s *SMF) releaseUserPlane(ctx context.Context, smContext *SMContext) {
-	dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
-	if err != nil {
-		logger.WithTrace(ctx, logger.SmfLog).Error("failed to resolve data network to release UE addresses",
-			zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
-	} else {
-		s.releaseAllocatedAddresses(ctx, dn, smContext)
-	}
-
-	if err := s.releaseTunnel(ctx, smContext); err != nil {
-		logger.WithTrace(ctx, logger.SmfLog).Warn("release tunnel failed, continuing release",
-			zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
-	}
+	_ = s.releaseUserPlaneThenAddresses(ctx, smContext)
 }
 
 // teardownAndRemove releases the session's user-plane resources (idempotently) and

--- a/internal/smf/reconcile.go
+++ b/internal/smf/reconcile.go
@@ -495,7 +495,12 @@ func (s *SMF) applySessionQERs(ctx context.Context, smContext *SMContext, policy
 // framed routes differ from those installed on the session at establishment.
 // Caller holds smContext.Mutex.
 func (s *SMF) framedRoutesChanged(ctx context.Context, smContext *SMContext) (bool, error) {
-	current, err := s.store.ListFramedRoutes(ctx, smContext.Supi.IMSI(), smContext.Dnn)
+	dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
+	if err != nil {
+		return false, err
+	}
+
+	current, err := dn.ListFramedRoutes(ctx, smContext.Supi.IMSI())
 	if err != nil {
 		return false, err
 	}
@@ -530,15 +535,20 @@ func framedRoutesEqual(a, b []netip.Prefix) bool {
 func (s *SMF) staticIPChanged(ctx context.Context, smContext *SMContext) (bool, error) {
 	imsi := smContext.Supi.IMSI()
 
+	dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
+	if err != nil {
+		return false, err
+	}
+
 	if smContext.PDUIPV4Address != nil {
-		changed, err := s.staticReservationChanged(ctx, imsi, smContext.Dnn, false, smContext.StaticIPv4)
+		changed, err := staticReservationChanged(ctx, dn, imsi, false, smContext.StaticIPv4)
 		if err != nil || changed {
 			return changed, err
 		}
 	}
 
 	if smContext.PDUIPV6Prefix != nil {
-		changed, err := s.staticReservationChanged(ctx, imsi, smContext.Dnn, true, smContext.StaticIPv6)
+		changed, err := staticReservationChanged(ctx, dn, imsi, true, smContext.StaticIPv6)
 		if err != nil || changed {
 			return changed, err
 		}
@@ -547,8 +557,8 @@ func (s *SMF) staticIPChanged(ctx context.Context, smContext *SMContext) (bool, 
 	return false, nil
 }
 
-func (s *SMF) staticReservationChanged(ctx context.Context, imsi, dnn string, ipv6 bool, cached netip.Addr) (bool, error) {
-	current, has, err := s.store.GetStaticIP(ctx, imsi, dnn, ipv6)
+func staticReservationChanged(ctx context.Context, dn DNNStore, imsi string, ipv6 bool, cached netip.Addr) (bool, error) {
+	current, has, err := dn.GetStaticIP(ctx, imsi, ipv6)
 	if err != nil {
 		return false, err
 	}

--- a/internal/smf/release.go
+++ b/internal/smf/release.go
@@ -76,7 +76,7 @@ func (s *SMF) releaseUserPlaneThenAddresses(ctx context.Context, sc *SMContext) 
 		logger.WithTrace(ctx, logger.SmfLog).Warn("resolve data network for UE address release failed; keeping IP lease",
 			zap.Error(err), logger.SUPI(sc.Supi.String()), logger.PDUSessionID(sc.PDUSessionID), logger.DNN(sc.Dnn))
 
-		return nil
+		return fmt.Errorf("resolve data network for address release: %w", err)
 	}
 
 	s.releaseAllocatedAddresses(ctx, dn, sc)

--- a/internal/smf/release.go
+++ b/internal/smf/release.go
@@ -54,15 +54,11 @@ func (s *SMF) ReleaseSmContext(ctx context.Context, smContextRef string) error {
 	return err
 }
 
-// releaseUserPlaneThenAddresses tears down the session's user plane (the UPF
-// session and, inside DeleteSession, its NAT conntrack) and only then releases the
-// UE IP leases. The order is load-bearing: an address returned to the allocator
-// before its conntrack entries are purged can be re-leased to another subscriber
-// that then receives the previous subscriber's in-flight downlink flows. If the
-// user-plane teardown fails the leases are kept — the address stays bound to this
-// IMSI, so it cannot be handed to a different subscriber with stale datapath state
-// — until the UE reattaches (which reuses the same (pool, IMSI, PDU-session-ID)
-// lease) or an operator reclaims it. Caller holds sc.Mutex.
+// releaseUserPlaneThenAddresses purges the UPF session (and its NAT conntrack)
+// before releasing the IP leases: an address freed while its conntrack survives
+// can be re-leased to another subscriber that then receives the previous
+// subscriber's flows. On teardown failure the leases are kept, so the address
+// stays bound to this IMSI. Caller holds sc.Mutex.
 func (s *SMF) releaseUserPlaneThenAddresses(ctx context.Context, sc *SMContext) error {
 	if err := s.releaseTunnel(ctx, sc); err != nil {
 		logger.WithTrace(ctx, logger.SmfLog).Warn("user-plane teardown failed; keeping IP lease to prevent reuse with stale NAT conntrack",

--- a/internal/smf/release.go
+++ b/internal/smf/release.go
@@ -42,37 +42,50 @@ func (s *SMF) ReleaseSmContext(ctx context.Context, smContextRef string) error {
 	// not keep firing against a released session.
 	smContext.stopProcedureTimer()
 
-	if smContext.PDUIPV4Address != nil || smContext.PDUIPV6Prefix != nil {
-		dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
-		if err != nil {
-			logger.SmfLog.Warn("resolve data network for UE address release failed", zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
-		} else {
-			if smContext.PDUIPV4Address != nil {
-				_, releaseErr := dn.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID)
-				if releaseErr != nil {
-					logger.SmfLog.Warn("release UE IP address failed", zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
-				}
-			}
-
-			if smContext.PDUIPV6Prefix != nil {
-				_, releaseErr := dn.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID)
-				if releaseErr != nil {
-					logger.SmfLog.Warn("release UE IPv6 address failed", zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
-				}
-			}
-		}
-	}
-
-	err := s.releaseTunnel(ctx, smContext)
+	err := s.releaseUserPlaneThenAddresses(ctx, smContext)
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to release tunnel")
+		span.SetStatus(codes.Error, "failed to release user plane")
 	}
 
 	// Remove from pool after all network I/O is complete.
 	s.dropFromPool(smContext)
 
 	return err
+}
+
+// releaseUserPlaneThenAddresses tears down the session's user plane (the UPF
+// session and, inside DeleteSession, its NAT conntrack) and only then releases the
+// UE IP leases. The order is load-bearing: an address returned to the allocator
+// before its conntrack entries are purged can be re-leased to another subscriber
+// that then receives the previous subscriber's in-flight downlink flows. If the
+// user-plane teardown fails the leases are kept — the address stays bound to this
+// IMSI, so it cannot be handed to a different subscriber with stale datapath state
+// — until the UE reattaches (which reuses the same (pool, IMSI, PDU-session-ID)
+// lease) or an operator reclaims it. Caller holds sc.Mutex.
+func (s *SMF) releaseUserPlaneThenAddresses(ctx context.Context, sc *SMContext) error {
+	if err := s.releaseTunnel(ctx, sc); err != nil {
+		logger.WithTrace(ctx, logger.SmfLog).Warn("user-plane teardown failed; keeping IP lease to prevent reuse with stale NAT conntrack",
+			zap.Error(err), logger.SUPI(sc.Supi.String()), logger.PDUSessionID(sc.PDUSessionID), logger.DNN(sc.Dnn))
+
+		return err
+	}
+
+	if sc.PDUIPV4Address == nil && sc.PDUIPV6Prefix == nil {
+		return nil
+	}
+
+	dn, err := s.store.ResolveDNN(ctx, sc.Dnn)
+	if err != nil {
+		logger.WithTrace(ctx, logger.SmfLog).Warn("resolve data network for UE address release failed; keeping IP lease",
+			zap.Error(err), logger.SUPI(sc.Supi.String()), logger.PDUSessionID(sc.PDUSessionID), logger.DNN(sc.Dnn))
+
+		return nil
+	}
+
+	s.releaseAllocatedAddresses(ctx, dn, sc)
+
+	return nil
 }
 
 func (s *SMF) releaseTunnel(ctx context.Context, smContext *SMContext) error {

--- a/internal/smf/release.go
+++ b/internal/smf/release.go
@@ -42,17 +42,24 @@ func (s *SMF) ReleaseSmContext(ctx context.Context, smContextRef string) error {
 	// not keep firing against a released session.
 	smContext.stopProcedureTimer()
 
-	if smContext.PDUIPV4Address != nil {
-		_, releaseErr := s.store.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.Dnn, smContext.PDUSessionID)
-		if releaseErr != nil {
-			logger.SmfLog.Warn("release UE IP address failed", zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
-		}
-	}
+	if smContext.PDUIPV4Address != nil || smContext.PDUIPV6Prefix != nil {
+		dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
+		if err != nil {
+			logger.SmfLog.Warn("resolve data network for UE address release failed", zap.Error(err), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
+		} else {
+			if smContext.PDUIPV4Address != nil {
+				_, releaseErr := dn.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID)
+				if releaseErr != nil {
+					logger.SmfLog.Warn("release UE IP address failed", zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
+				}
+			}
 
-	if smContext.PDUIPV6Prefix != nil {
-		_, releaseErr := s.store.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.Dnn, smContext.PDUSessionID)
-		if releaseErr != nil {
-			logger.SmfLog.Warn("release UE IPv6 address failed", zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
+			if smContext.PDUIPV6Prefix != nil {
+				_, releaseErr := dn.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID)
+				if releaseErr != nil {
+					logger.SmfLog.Warn("release UE IPv6 address failed", zap.Error(releaseErr), logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID), logger.DNN(smContext.Dnn), zap.String("smContextRef", smContextRef))
+				}
+			}
 		}
 	}
 

--- a/internal/smf/session.go
+++ b/internal/smf/session.go
@@ -54,6 +54,11 @@ type ueAddresses struct {
 // partial session back and wraps a sentinel error for the adapter to map to its
 // NAS cause.
 func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMContext, ueAddresses, error) {
+	dn, err := s.store.ResolveDNN(ctx, req.Dnn)
+	if err != nil {
+		return nil, ueAddresses{}, fmt.Errorf("%w: %v", errUEAddressAllocation, err)
+	}
+
 	sc := s.NewSession(req.Supi, req.Key, req.Dnn, req.Snssai)
 
 	committed := false
@@ -71,7 +76,7 @@ func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMCont
 	sc.PDUSessionType = req.PDUType
 	sc.PolicyData = req.Policy
 
-	dlPdrIP, addrs, err := s.allocateUEAddresses(ctx, sc)
+	dlPdrIP, addrs, err := s.allocateUEAddresses(ctx, dn, sc)
 	if err != nil {
 		sc.Mutex.Unlock()
 		return nil, ueAddresses{}, fmt.Errorf("%w: %v", errUEAddressAllocation, err)
@@ -80,7 +85,7 @@ func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMCont
 	// Framed routes are per-subscriber subscription data (TS 23.501 §5.6.14): they
 	// attach to the session context, not the profile-shared Policy. A resolution
 	// failure rejects establishment, fail-closed.
-	framed, err := s.store.ListFramedRoutes(ctx, req.Supi.IMSI(), req.Dnn)
+	framed, err := dn.ListFramedRoutes(ctx, req.Supi.IMSI())
 	if err != nil {
 		sc.Mutex.Unlock()
 		return nil, ueAddresses{}, fmt.Errorf("%w: %v", errFramedRouteResolve, err)
@@ -91,7 +96,7 @@ func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMCont
 	// Cache the reserved static address per family so a reconcile can detect a
 	// reservation change; fail-closed on error.
 	if sc.PDUIPV4Address != nil {
-		addr, ok, err := s.store.GetStaticIP(ctx, req.Supi.IMSI(), req.Dnn, false)
+		addr, ok, err := dn.GetStaticIP(ctx, req.Supi.IMSI(), false)
 		if err != nil {
 			sc.Mutex.Unlock()
 			return nil, ueAddresses{}, fmt.Errorf("%w: %v", errStaticIPResolve, err)
@@ -103,7 +108,7 @@ func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMCont
 	}
 
 	if sc.PDUIPV6Prefix != nil {
-		addr, ok, err := s.store.GetStaticIP(ctx, req.Supi.IMSI(), req.Dnn, true)
+		addr, ok, err := dn.GetStaticIP(ctx, req.Supi.IMSI(), true)
 		if err != nil {
 			sc.Mutex.Unlock()
 			return nil, ueAddresses{}, fmt.Errorf("%w: %v", errStaticIPResolve, err)
@@ -150,15 +155,22 @@ func (s *SMF) abortSession(ctx context.Context, sc *SMContext) {
 		}
 	}
 
-	if sc.PDUIPV4Address != nil {
-		if _, err := s.store.ReleaseIP(ctx, imsi, sc.Dnn, sc.PDUSessionID); err != nil {
-			logger.SmfLog.Warn("failed to release UE IPv4 after aborted session", zap.String("imsi", imsi), zap.Error(err))
-		}
-	}
+	if sc.PDUIPV4Address != nil || sc.PDUIPV6Prefix != nil {
+		dn, err := s.store.ResolveDNN(ctx, sc.Dnn)
+		if err != nil {
+			logger.SmfLog.Warn("failed to resolve data network to release UE addresses after aborted session", zap.String("imsi", imsi), zap.Error(err))
+		} else {
+			if sc.PDUIPV4Address != nil {
+				if _, err := dn.ReleaseIP(ctx, imsi, sc.PDUSessionID); err != nil {
+					logger.SmfLog.Warn("failed to release UE IPv4 after aborted session", zap.String("imsi", imsi), zap.Error(err))
+				}
+			}
 
-	if sc.PDUIPV6Prefix != nil {
-		if _, err := s.store.ReleaseIPv6(ctx, imsi, sc.Dnn, sc.PDUSessionID); err != nil {
-			logger.SmfLog.Warn("failed to release UE IPv6 after aborted session", zap.String("imsi", imsi), zap.Error(err))
+			if sc.PDUIPV6Prefix != nil {
+				if _, err := dn.ReleaseIPv6(ctx, imsi, sc.PDUSessionID); err != nil {
+					logger.SmfLog.Warn("failed to release UE IPv6 after aborted session", zap.String("imsi", imsi), zap.Error(err))
+				}
+			}
 		}
 	}
 

--- a/internal/smf/session.go
+++ b/internal/smf/session.go
@@ -151,9 +151,8 @@ func (s *SMF) abortSession(ctx context.Context, sc *SMContext) {
 
 	if sc.Tunnel != nil {
 		if err := s.releaseTunnel(ctx, sc); err != nil {
-			// Keep the IP lease: releasing it before the NAT conntrack is purged could
-			// hand the address, with stale flows, to another subscriber
-			// (see releaseUserPlaneThenAddresses).
+			// Keep the lease so the address is not reused before its NAT conntrack is
+			// purged (see releaseUserPlaneThenAddresses).
 			logger.SmfLog.Warn("failed to release tunnel for aborted session; keeping IP lease", zap.String("imsi", imsi), zap.Error(err))
 			s.dropFromPool(sc)
 

--- a/internal/smf/session.go
+++ b/internal/smf/session.go
@@ -151,7 +151,13 @@ func (s *SMF) abortSession(ctx context.Context, sc *SMContext) {
 
 	if sc.Tunnel != nil {
 		if err := s.releaseTunnel(ctx, sc); err != nil {
-			logger.SmfLog.Warn("failed to release tunnel for aborted session", zap.String("imsi", imsi), zap.Error(err))
+			// Keep the IP lease: releasing it before the NAT conntrack is purged could
+			// hand the address, with stale flows, to another subscriber
+			// (see releaseUserPlaneThenAddresses).
+			logger.SmfLog.Warn("failed to release tunnel for aborted session; keeping IP lease", zap.String("imsi", imsi), zap.Error(err))
+			s.dropFromPool(sc)
+
+			return
 		}
 	}
 

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -57,26 +57,34 @@ type PCF interface {
 	GetSessionPolicy(ctx context.Context, imsi string, snssai *models.Snssai, dnn string) (*Policy, error)
 }
 
-// SessionStore is the minimal DB surface the SMF needs for session-level
-// data operations (IP management, usage accounting, flow reports).
-type SessionStore interface {
-	AllocateIP(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error)
+// DNNStore is the session-data surface bound to one resolved data network.
+// A procedure resolves its DNN once via SessionStore.ResolveDNN and performs
+// every lease and route operation against that single consistent view.
+type DNNStore interface {
+	AllocateIP(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
 
 	// ReleaseIP frees the session's lease and returns the freed IPv4 address so
 	// the caller can withdraw the BGP route.
-	ReleaseIP(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error)
+	ReleaseIP(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
 
 	// AllocateIPv6 assigns a /64 prefix from the data network's IPv6 pool and
 	// returns its base address (lower 64 bits = 0).
-	AllocateIPv6(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error)
+	AllocateIPv6(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
 
-	ReleaseIPv6(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error)
+	ReleaseIPv6(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
 
-	ListFramedRoutes(ctx context.Context, imsi string, dnn string) ([]netip.Prefix, error)
+	ListFramedRoutes(ctx context.Context, imsi string) ([]netip.Prefix, error)
 
-	// GetStaticIP returns the reserved static address for the DNN and family
-	// (ipv6 selects the IPv6 pool), and whether one exists.
-	GetStaticIP(ctx context.Context, imsi string, dnn string, ipv6 bool) (netip.Addr, bool, error)
+	// GetStaticIP returns the reserved static address for the family (ipv6
+	// selects the IPv6 pool), and whether one exists.
+	GetStaticIP(ctx context.Context, imsi string, ipv6 bool) (netip.Addr, bool, error)
+}
+
+// SessionStore is the minimal DB surface the SMF needs for session-level
+// data operations (IP management, usage accounting, flow reports).
+type SessionStore interface {
+	// ResolveDNN reads the data network once and returns its bound DNNStore.
+	ResolveDNN(ctx context.Context, dnn string) (DNNStore, error)
 
 	IncrementDailyUsage(ctx context.Context, imsi string, uplinkBytes, downlinkBytes uint64) error
 
@@ -330,17 +338,22 @@ func (s *SMF) RemoveSession(ctx context.Context, ref string) {
 
 	s.dropFromPool(smCtx)
 
-	if smCtx.PDUIPV4Address != nil {
-		_, err := s.store.ReleaseIP(ctx, smCtx.Supi.IMSI(), smCtx.Dnn, smCtx.PDUSessionID)
+	if smCtx.PDUIPV4Address != nil || smCtx.PDUIPV6Prefix != nil {
+		dn, err := s.store.ResolveDNN(ctx, smCtx.Dnn)
 		if err != nil {
-			logger.SmfLog.Error("release UE IP-Address failed", zap.Error(err), zap.String("smContextRef", ref))
-		}
-	}
+			logger.SmfLog.Error("resolve data network for UE address release failed", zap.Error(err), zap.String("smContextRef", ref))
+		} else {
+			if smCtx.PDUIPV4Address != nil {
+				if _, err := dn.ReleaseIP(ctx, smCtx.Supi.IMSI(), smCtx.PDUSessionID); err != nil {
+					logger.SmfLog.Error("release UE IP-Address failed", zap.Error(err), zap.String("smContextRef", ref))
+				}
+			}
 
-	if smCtx.PDUIPV6Prefix != nil {
-		_, err := s.store.ReleaseIPv6(ctx, smCtx.Supi.IMSI(), smCtx.Dnn, smCtx.PDUSessionID)
-		if err != nil {
-			logger.SmfLog.Error("release UE IPv6-Address failed", zap.Error(err), zap.String("smContextRef", ref))
+			if smCtx.PDUIPV6Prefix != nil {
+				if _, err := dn.ReleaseIPv6(ctx, smCtx.Supi.IMSI(), smCtx.PDUSessionID); err != nil {
+					logger.SmfLog.Error("release UE IPv6-Address failed", zap.Error(err), zap.String("smContextRef", ref))
+				}
+			}
 		}
 	}
 

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -57,9 +57,8 @@ type PCF interface {
 	GetSessionPolicy(ctx context.Context, imsi string, snssai *models.Snssai, dnn string) (*Policy, error)
 }
 
-// DNNStore is the session-data surface bound to one resolved data network.
-// A procedure resolves its DNN once via SessionStore.ResolveDNN and performs
-// every lease and route operation against that single consistent view.
+// DNNStore is the session-data surface bound to one data network resolved once
+// via SessionStore.ResolveDNN.
 type DNNStore interface {
 	AllocateIP(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
 
@@ -83,7 +82,6 @@ type DNNStore interface {
 // SessionStore is the minimal DB surface the SMF needs for session-level
 // data operations (IP management, usage accounting, flow reports).
 type SessionStore interface {
-	// ResolveDNN reads the data network once and returns its bound DNNStore.
 	ResolveDNN(ctx context.Context, dnn string) (DNNStore, error)
 
 	IncrementDailyUsage(ctx context.Context, imsi string, uplinkBytes, downlinkBytes uint64) error
@@ -329,17 +327,14 @@ func (s *SMF) GetSessionBySEID(seid uint64) *SMContext {
 	return nil
 }
 
-// RemoveSession tears down a session's user plane, releases its IP address(es),
-// and removes it from the pool. Caller holds the session's Mutex.
+// RemoveSession tears down a session's user plane, releases its addresses, and
+// removes it from the pool. Caller holds the session's Mutex.
 func (s *SMF) RemoveSession(ctx context.Context, ref string) {
 	smCtx := s.GetSession(ref)
 	if smCtx == nil {
 		return
 	}
 
-	// Tear down the user plane (and NAT conntrack) before releasing the leases, so
-	// the address is not reallocatable while stale conntrack survives; see
-	// releaseUserPlaneThenAddresses. Callers hold smCtx.Mutex.
 	_ = s.releaseUserPlaneThenAddresses(ctx, smCtx)
 
 	s.dropFromPool(smCtx)

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -329,33 +329,20 @@ func (s *SMF) GetSessionBySEID(seid uint64) *SMContext {
 	return nil
 }
 
-// RemoveSession removes a session from the pool and releases its IP address(es).
+// RemoveSession tears down a session's user plane, releases its IP address(es),
+// and removes it from the pool. Caller holds the session's Mutex.
 func (s *SMF) RemoveSession(ctx context.Context, ref string) {
 	smCtx := s.GetSession(ref)
 	if smCtx == nil {
 		return
 	}
 
+	// Tear down the user plane (and NAT conntrack) before releasing the leases, so
+	// the address is not reallocatable while stale conntrack survives; see
+	// releaseUserPlaneThenAddresses. Callers hold smCtx.Mutex.
+	_ = s.releaseUserPlaneThenAddresses(ctx, smCtx)
+
 	s.dropFromPool(smCtx)
-
-	if smCtx.PDUIPV4Address != nil || smCtx.PDUIPV6Prefix != nil {
-		dn, err := s.store.ResolveDNN(ctx, smCtx.Dnn)
-		if err != nil {
-			logger.SmfLog.Error("resolve data network for UE address release failed", zap.Error(err), zap.String("smContextRef", ref))
-		} else {
-			if smCtx.PDUIPV4Address != nil {
-				if _, err := dn.ReleaseIP(ctx, smCtx.Supi.IMSI(), smCtx.PDUSessionID); err != nil {
-					logger.SmfLog.Error("release UE IP-Address failed", zap.Error(err), zap.String("smContextRef", ref))
-				}
-			}
-
-			if smCtx.PDUIPV6Prefix != nil {
-				if _, err := dn.ReleaseIPv6(ctx, smCtx.Supi.IMSI(), smCtx.PDUSessionID); err != nil {
-					logger.SmfLog.Error("release UE IPv6-Address failed", zap.Error(err), zap.String("smContextRef", ref))
-				}
-			}
-		}
-	}
 
 	logger.SmfLog.Info("SM Context removed", zap.String("smContextRef", ref))
 }

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -21,7 +21,7 @@ import (
 
 type fakeStore struct {
 	mu              sync.Mutex
-	teardownSeq     *teardownRecorder // shared with fakeUPF to assert teardown ordering
+	teardownSeq     *teardownRecorder
 	allocatedIP     netip.Addr
 	allocatedIPv6   netip.Addr
 	releasedIP      netip.Addr
@@ -41,8 +41,6 @@ type fakeStore struct {
 	opLog           []string
 }
 
-// ResolveDNN returns the fake itself: every DNN resolves to the one fake data
-// network the store models.
 func (f *fakeStore) ResolveDNN(_ context.Context, _ string) (smf.DNNStore, error) {
 	return f, nil
 }
@@ -172,7 +170,7 @@ func (f *fakeStore) InsertFlowReports(_ context.Context, reports []*models.FlowR
 
 type fakeUPF struct {
 	mu               sync.Mutex
-	teardownSeq      *teardownRecorder // shared with fakeStore to assert teardown ordering
+	teardownSeq      *teardownRecorder
 	establishResult  *models.EstablishResponse
 	lastEstablish    *models.EstablishRequest
 	modifyCalls      []*models.ModifyRequest

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -21,6 +21,7 @@ import (
 
 type fakeStore struct {
 	mu              sync.Mutex
+	teardownSeq     *teardownRecorder // shared with fakeUPF to assert teardown ordering
 	allocatedIP     netip.Addr
 	allocatedIPv6   netip.Addr
 	releasedIP      netip.Addr
@@ -80,6 +81,8 @@ func (f *fakeStore) AllocateIP(_ context.Context, _ string, _ uint8) (netip.Addr
 }
 
 func (f *fakeStore) ReleaseIP(_ context.Context, imsi string, _ uint8) (netip.Addr, error) {
+	f.teardownSeq.record("release-ip")
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -169,6 +172,7 @@ func (f *fakeStore) InsertFlowReports(_ context.Context, reports []*models.FlowR
 
 type fakeUPF struct {
 	mu               sync.Mutex
+	teardownSeq      *teardownRecorder // shared with fakeStore to assert teardown ordering
 	establishResult  *models.EstablishResponse
 	lastEstablish    *models.EstablishRequest
 	modifyCalls      []*models.ModifyRequest
@@ -202,6 +206,8 @@ func (f *fakeUPF) ModifySession(_ context.Context, req *models.ModifyRequest) er
 }
 
 func (f *fakeUPF) DeleteSession(_ context.Context, remoteSEID uint64) error {
+	f.teardownSeq.record("delete-session")
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -40,6 +40,12 @@ type fakeStore struct {
 	opLog           []string
 }
 
+// ResolveDNN returns the fake itself: every DNN resolves to the one fake data
+// network the store models.
+func (f *fakeStore) ResolveDNN(_ context.Context, _ string) (smf.DNNStore, error) {
+	return f, nil
+}
+
 // ops returns the IPv4 allocate/release calls in the order they arrived.
 func (f *fakeStore) ops() []string {
 	f.mu.Lock()
@@ -60,7 +66,7 @@ type usageEntry struct {
 	downlinkBytes uint64
 }
 
-func (f *fakeStore) AllocateIP(_ context.Context, _ string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeStore) AllocateIP(_ context.Context, _ string, _ uint8) (netip.Addr, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -73,7 +79,7 @@ func (f *fakeStore) AllocateIP(_ context.Context, _ string, _ string, _ uint8) (
 	return f.allocatedIP, f.err
 }
 
-func (f *fakeStore) ReleaseIP(_ context.Context, imsi string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeStore) ReleaseIP(_ context.Context, imsi string, _ uint8) (netip.Addr, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -83,7 +89,7 @@ func (f *fakeStore) ReleaseIP(_ context.Context, imsi string, _ string, _ uint8)
 	return f.releasedIP, f.err
 }
 
-func (f *fakeStore) AllocateIPv6(_ context.Context, _ string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeStore) AllocateIPv6(_ context.Context, _ string, _ uint8) (netip.Addr, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -94,7 +100,7 @@ func (f *fakeStore) AllocateIPv6(_ context.Context, _ string, _ string, _ uint8)
 	return f.allocatedIPv6, f.err
 }
 
-func (f *fakeStore) ReleaseIPv6(_ context.Context, imsi string, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeStore) ReleaseIPv6(_ context.Context, imsi string, _ uint8) (netip.Addr, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -103,14 +109,14 @@ func (f *fakeStore) ReleaseIPv6(_ context.Context, imsi string, _ string, _ uint
 	return f.releasedIPv6, f.err
 }
 
-func (f *fakeStore) ListFramedRoutes(_ context.Context, _ string, _ string) ([]netip.Prefix, error) {
+func (f *fakeStore) ListFramedRoutes(_ context.Context, _ string) ([]netip.Prefix, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	return f.framedRoutes, f.framedRoutesErr
 }
 
-func (f *fakeStore) GetStaticIP(_ context.Context, _ string, _ string, ipv6 bool) (netip.Addr, bool, error) {
+func (f *fakeStore) GetStaticIP(_ context.Context, _ string, ipv6 bool) (netip.Addr, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/observability/grafana/dashboards/network_health.json
+++ b/observability/grafana/dashboards/network_health.json
@@ -128,7 +128,7 @@
             "uid": "${DS_MIMIR}"
           },
           "editorMode": "builder",
-          "expr": "app_connected_radios{job=~\"$job\",instance=~\"$instance\"}",
+          "expr": "sum(app_connected_radios{job=~\"$job\",instance=~\"$instance\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -336,7 +336,7 @@
             "uid": "${DS_MIMIR}"
           },
           "editorMode": "builder",
-          "expr": "app_sessions_total{job=~\"$job\",instance=~\"$instance\"}",
+          "expr": "sum(app_sessions_total{job=~\"$job\",instance=~\"$instance\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1315,7 +1315,7 @@
             "uid": "${DS_MIMIR}"
           },
           "editorMode": "builder",
-          "expr": "app_sessions_total{job=~\"$job\",instance=~\"$instance\"}",
+          "expr": "sum(app_sessions_total{job=~\"$job\",instance=~\"$instance\"})",
           "legendFormat": "Active PDU Sessions",
           "range": true,
           "refId": "A"

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -51,42 +51,70 @@ type smfDBAdapter struct {
 	db *db.Database
 }
 
-// resolvePoolByDNN looks up the IP pool for a data network by name.
-func (a *smfDBAdapter) resolvePoolByDNN(ctx context.Context, dnn string) (ipam.Pool, error) {
-	dn, err := a.db.GetDataNetwork(ctx, dnn)
-	if err != nil {
-		return ipam.Pool{}, fmt.Errorf("get data network: %w", err)
-	}
+// smfDNNStore is smf.DNNStore bound to one data-network row read at resolve
+// time. Pool derivation errors are held per family and surfaced when that
+// family is used, so an IPv4-only data network still serves IPv4 sessions.
+type smfDNNStore struct {
+	a    *smfDBAdapter
+	dnn  string
+	dnID string
 
-	return ipam.NewPool(dn.ID, dn.IPv4Pool)
+	pool4    ipam.Pool
+	pool4Err error
+	pool6    ipam.Pool
+	pool6Err error
 }
 
-// resolveIPv6PoolByDNN looks up the IPv6 prefix delegation pool for a data
-// network by name. It delegates /64 prefixes from the configured IPv6 CIDR.
-func (a *smfDBAdapter) resolveIPv6PoolByDNN(ctx context.Context, dnn string) (ipam.Pool, error) {
+// ResolveDNN reads the data network once and derives both address pools from
+// that row.
+func (a *smfDBAdapter) ResolveDNN(ctx context.Context, dnn string) (smf.DNNStore, error) {
+	ctx, span := tracer.Start(ctx, "smf/resolve_dnn",
+		trace.WithAttributes(attribute.String("dnn", dnn)),
+	)
+	defer span.End()
+
 	dn, err := a.db.GetDataNetwork(ctx, dnn)
 	if err != nil {
-		return ipam.Pool{}, fmt.Errorf("get data network: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "get data network failed")
+
+		return nil, fmt.Errorf("get data network: %w", err)
 	}
+
+	s := &smfDNNStore{a: a, dnn: dnn, dnID: dn.ID}
+	s.pool4, s.pool4Err = ipam.NewPool(dn.ID, dn.IPv4Pool)
 
 	if dn.IPv6Pool == "" {
-		return ipam.Pool{}, fmt.Errorf("data network %q has no IPv6 pool configured", dnn)
+		s.pool6Err = fmt.Errorf("data network %q has no IPv6 pool configured", dnn)
+	} else {
+		// The IPv6 pool delegates /64 prefixes from the configured CIDR.
+		s.pool6, s.pool6Err = ipam.NewPool6(dn.ID, dn.IPv6Pool, 64)
 	}
 
-	return ipam.NewPool6(dn.ID, dn.IPv6Pool, 64)
+	return s, nil
 }
 
-func (a *smfDBAdapter) AllocateIP(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error) {
+// pool returns the family's address pool, or the error recorded for it at
+// resolve time.
+func (s *smfDNNStore) pool(ipv6 bool) (ipam.Pool, error) {
+	if ipv6 {
+		return s.pool6, s.pool6Err
+	}
+
+	return s.pool4, s.pool4Err
+}
+
+func (s *smfDNNStore) AllocateIP(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error) {
 	ctx, span := tracer.Start(ctx, "smf/allocate_ip",
 		trace.WithAttributes(
 			attribute.String("imsi", imsi),
-			attribute.String("dnn", dnn),
+			attribute.String("dnn", s.dnn),
 			attribute.Int("pdu_session_id", int(pduSessionID)),
 		),
 	)
 	defer span.End()
 
-	pool, err := a.resolvePoolByDNN(ctx, dnn)
+	pool, err := s.pool(false)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "resolve pool failed")
@@ -98,7 +126,7 @@ func (a *smfDBAdapter) AllocateIP(ctx context.Context, imsi string, dnn string, 
 	// leader inside leaderCaptureAndPropose's proposeMu, so concurrent
 	// allocations from any node serialise correctly. The legacy
 	// pre-pick-on-follower path is gone.
-	addr, err := a.db.AllocateIPLease(ctx, pool.ID, pool.IPVersion, imsi, int(pduSessionID), a.db.NodeID())
+	addr, err := s.a.db.AllocateIPLease(ctx, pool.ID, pool.IPVersion, imsi, int(pduSessionID), s.a.db.NodeID())
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "allocate failed")
@@ -111,17 +139,17 @@ func (a *smfDBAdapter) AllocateIP(ctx context.Context, imsi string, dnn string, 
 	return addr, nil
 }
 
-func (a *smfDBAdapter) ReleaseIP(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error) {
+func (s *smfDNNStore) ReleaseIP(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error) {
 	ctx, span := tracer.Start(ctx, "smf/release_ip",
 		trace.WithAttributes(
 			attribute.String("imsi", imsi),
-			attribute.String("dnn", dnn),
+			attribute.String("dnn", s.dnn),
 			attribute.Int("pdu_session_id", int(pduSessionID)),
 		),
 	)
 	defer span.End()
 
-	pool, err := a.resolvePoolByDNN(ctx, dnn)
+	pool, err := s.pool(false)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "resolve pool failed")
@@ -129,7 +157,7 @@ func (a *smfDBAdapter) ReleaseIP(ctx context.Context, imsi string, dnn string, p
 		return netip.Addr{}, fmt.Errorf("resolve pool: %w", err)
 	}
 
-	lease, err := a.db.GetLeaseBySession(ctx, pool.ID, pool.IPVersion, int(pduSessionID), imsi)
+	lease, err := s.a.db.GetLeaseBySession(ctx, pool.ID, pool.IPVersion, int(pduSessionID), imsi)
 	if err != nil {
 		// Reservation deleted while bound: nothing left to free.
 		if errors.Is(err, db.ErrNotFound) {
@@ -142,7 +170,7 @@ func (a *smfDBAdapter) ReleaseIP(ctx context.Context, imsi string, dnn string, p
 		return netip.Addr{}, fmt.Errorf("lookup lease: %w", err)
 	}
 
-	if err := a.releaseLease(ctx, lease); err != nil {
+	if err := s.a.releaseLease(ctx, lease); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "release failed")
 
@@ -171,17 +199,17 @@ func (a *smfDBAdapter) releaseLease(ctx context.Context, lease *db.IPLease) erro
 	return nil
 }
 
-func (a *smfDBAdapter) AllocateIPv6(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error) {
+func (s *smfDNNStore) AllocateIPv6(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error) {
 	ctx, span := tracer.Start(ctx, "smf/allocate_ipv6",
 		trace.WithAttributes(
 			attribute.String("imsi", imsi),
-			attribute.String("dnn", dnn),
+			attribute.String("dnn", s.dnn),
 			attribute.Int("pdu_session_id", int(pduSessionID)),
 		),
 	)
 	defer span.End()
 
-	pool, err := a.resolveIPv6PoolByDNN(ctx, dnn)
+	pool, err := s.pool(true)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "resolve IPv6 pool failed")
@@ -189,7 +217,7 @@ func (a *smfDBAdapter) AllocateIPv6(ctx context.Context, imsi string, dnn string
 		return netip.Addr{}, fmt.Errorf("resolve IPv6 pool: %w", err)
 	}
 
-	addr, err := a.db.AllocateIPv6Lease(ctx, pool.ID, pool.IPVersion, imsi, int(pduSessionID), a.db.NodeID())
+	addr, err := s.a.db.AllocateIPv6Lease(ctx, pool.ID, pool.IPVersion, imsi, int(pduSessionID), s.a.db.NodeID())
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "allocate IPv6 failed")
@@ -202,17 +230,17 @@ func (a *smfDBAdapter) AllocateIPv6(ctx context.Context, imsi string, dnn string
 	return addr, nil
 }
 
-func (a *smfDBAdapter) ReleaseIPv6(ctx context.Context, imsi string, dnn string, pduSessionID uint8) (netip.Addr, error) {
+func (s *smfDNNStore) ReleaseIPv6(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error) {
 	ctx, span := tracer.Start(ctx, "smf/release_ipv6",
 		trace.WithAttributes(
 			attribute.String("imsi", imsi),
-			attribute.String("dnn", dnn),
+			attribute.String("dnn", s.dnn),
 			attribute.Int("pdu_session_id", int(pduSessionID)),
 		),
 	)
 	defer span.End()
 
-	pool, err := a.resolveIPv6PoolByDNN(ctx, dnn)
+	pool, err := s.pool(true)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "resolve IPv6 pool failed")
@@ -220,7 +248,7 @@ func (a *smfDBAdapter) ReleaseIPv6(ctx context.Context, imsi string, dnn string,
 		return netip.Addr{}, fmt.Errorf("resolve IPv6 pool: %w", err)
 	}
 
-	lease, err := a.db.GetLeaseBySession(ctx, pool.ID, pool.IPVersion, int(pduSessionID), imsi)
+	lease, err := s.a.db.GetLeaseBySession(ctx, pool.ID, pool.IPVersion, int(pduSessionID), imsi)
 	if err != nil {
 		// Reservation deleted while bound: nothing left to free.
 		if errors.Is(err, db.ErrNotFound) {
@@ -233,7 +261,7 @@ func (a *smfDBAdapter) ReleaseIPv6(ctx context.Context, imsi string, dnn string,
 		return netip.Addr{}, fmt.Errorf("lookup lease: %w", err)
 	}
 
-	if err := a.releaseLease(ctx, lease); err != nil {
+	if err := s.a.releaseLease(ctx, lease); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "release IPv6 failed")
 
@@ -341,16 +369,11 @@ func (a *smfDBAdapter) InsertFlowReports(ctx context.Context, reports []*models.
 	return a.db.InsertFlowReports(ctx, batch)
 }
 
-// ListFramedRoutes resolves the data network by name, then returns the
-// subscriber's framed-route prefixes on it (TS 23.501 §5.6.14). Prefixes are
-// stored normalized, so parsing is total.
-func (a *smfDBAdapter) ListFramedRoutes(ctx context.Context, imsi string, dnn string) ([]netip.Prefix, error) {
-	dn, err := a.db.GetDataNetwork(ctx, dnn)
-	if err != nil {
-		return nil, fmt.Errorf("get data network: %w", err)
-	}
-
-	rows, err := a.db.ListFramedRoutesBySubscriberDataNetwork(ctx, imsi, dn.ID)
+// ListFramedRoutes returns the subscriber's framed-route prefixes on the data
+// network (TS 23.501 §5.6.14). Prefixes are stored normalized, so parsing is
+// total.
+func (s *smfDNNStore) ListFramedRoutes(ctx context.Context, imsi string) ([]netip.Prefix, error) {
+	rows, err := s.a.db.ListFramedRoutesBySubscriberDataNetwork(ctx, imsi, s.dnID)
 	if err != nil {
 		return nil, fmt.Errorf("list framed routes: %w", err)
 	}
@@ -369,25 +392,15 @@ func (a *smfDBAdapter) ListFramedRoutes(ctx context.Context, imsi string, dnn st
 	return prefixes, nil
 }
 
-// GetStaticIP returns the reserved static address for the DNN and family, and
+// GetStaticIP returns the reserved static address for the family, and
 // whether one exists (a missing reservation is not an error).
-func (a *smfDBAdapter) GetStaticIP(ctx context.Context, imsi string, dnn string, ipv6 bool) (netip.Addr, bool, error) {
-	var (
-		pool ipam.Pool
-		err  error
-	)
-
-	if ipv6 {
-		pool, err = a.resolveIPv6PoolByDNN(ctx, dnn)
-	} else {
-		pool, err = a.resolvePoolByDNN(ctx, dnn)
-	}
-
+func (s *smfDNNStore) GetStaticIP(ctx context.Context, imsi string, ipv6 bool) (netip.Addr, bool, error) {
+	pool, err := s.pool(ipv6)
 	if err != nil {
 		return netip.Addr{}, false, fmt.Errorf("resolve pool: %w", err)
 	}
 
-	lease, err := a.db.GetStaticLease(ctx, pool.ID, pool.IPVersion, imsi)
+	lease, err := s.a.db.GetStaticLease(ctx, pool.ID, pool.IPVersion, imsi)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return netip.Addr{}, false, nil

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -51,9 +51,8 @@ type smfDBAdapter struct {
 	db *db.Database
 }
 
-// smfDNNStore is smf.DNNStore bound to one data-network row read at resolve
-// time. Pool derivation errors are held per family and surfaced when that
-// family is used, so an IPv4-only data network still serves IPv4 sessions.
+// smfDNNStore is smf.DNNStore bound to one data-network row. A pool derivation
+// error is held per family so an IPv4-only data network still serves IPv4.
 type smfDNNStore struct {
 	a    *smfDBAdapter
 	dnn  string
@@ -65,8 +64,6 @@ type smfDNNStore struct {
 	pool6Err error
 }
 
-// ResolveDNN reads the data network once and derives both address pools from
-// that row.
 func (a *smfDBAdapter) ResolveDNN(ctx context.Context, dnn string) (smf.DNNStore, error) {
 	ctx, span := tracer.Start(ctx, "smf/resolve_dnn",
 		trace.WithAttributes(attribute.String("dnn", dnn)),
@@ -87,15 +84,12 @@ func (a *smfDBAdapter) ResolveDNN(ctx context.Context, dnn string) (smf.DNNStore
 	if dn.IPv6Pool == "" {
 		s.pool6Err = fmt.Errorf("data network %q has no IPv6 pool configured", dnn)
 	} else {
-		// The IPv6 pool delegates /64 prefixes from the configured CIDR.
 		s.pool6, s.pool6Err = ipam.NewPool6(dn.ID, dn.IPv6Pool, 64)
 	}
 
 	return s, nil
 }
 
-// pool returns the family's address pool, or the error recorded for it at
-// resolve time.
 func (s *smfDNNStore) pool(ipv6 bool) (ipam.Pool, error) {
 	if ipv6 {
 		return s.pool6, s.pool6Err

--- a/pkg/runtime/smf_adapters_test.go
+++ b/pkg/runtime/smf_adapters_test.go
@@ -92,7 +92,12 @@ func TestReleaseIP_StaticKeepsReservation(t *testing.T) {
 		t.Fatalf("CreateStaticLease: %s", err)
 	}
 
-	got, err := adapter.AllocateIP(ctx, imsi, dnn, 7)
+	dn, err := adapter.ResolveDNN(ctx, dnn)
+	if err != nil {
+		t.Fatalf("ResolveDNN: %s", err)
+	}
+
+	got, err := dn.AllocateIP(ctx, imsi, 7)
 	if err != nil {
 		t.Fatalf("AllocateIP: %s", err)
 	}
@@ -101,7 +106,7 @@ func TestReleaseIP_StaticKeepsReservation(t *testing.T) {
 		t.Fatalf("expected pinned address %s, got %s", pinned, got)
 	}
 
-	released, err := adapter.ReleaseIP(ctx, imsi, dnn, 7)
+	released, err := dn.ReleaseIP(ctx, imsi, 7)
 	if err != nil {
 		t.Fatalf("ReleaseIP: %s", err)
 	}
@@ -128,7 +133,12 @@ func TestReleaseIP_DynamicDeletesLease(t *testing.T) {
 	adapter, dnn, poolID, imsi := setupAdapterTestDB(t)
 	ctx := context.Background()
 
-	got, err := adapter.AllocateIP(ctx, imsi, dnn, 9)
+	dn, err := adapter.ResolveDNN(ctx, dnn)
+	if err != nil {
+		t.Fatalf("ResolveDNN: %s", err)
+	}
+
+	got, err := dn.AllocateIP(ctx, imsi, 9)
 	if err != nil {
 		t.Fatalf("AllocateIP: %s", err)
 	}
@@ -137,7 +147,7 @@ func TestReleaseIP_DynamicDeletesLease(t *testing.T) {
 		t.Fatalf("expected dynamic lease for session 9, got %v", err)
 	}
 
-	released, err := adapter.ReleaseIP(ctx, imsi, dnn, 9)
+	released, err := dn.ReleaseIP(ctx, imsi, 9)
 	if err != nil {
 		t.Fatalf("ReleaseIP: %s", err)
 	}


### PR DESCRIPTION
# Description

This PR includes performance and correctness related improvements:
- Eliminate redundant database reads during signaling
- Set `SCTP_NODELAY` on the listener socket
- Cache SCTP addresses 
- Duplicate registration comparison
- Cross-subscriber traffic misdelivery

The result is faster and correcter signalling in Ella Core. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
