### PR TITLE
fix: key SMF sessions and IP leases by access-qualified session id

### DIFF
--- a/internal/amf/ngap/handle_handover_request_acknowledge_test.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge_test.go
@@ -35,7 +35,7 @@ func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *fakeNGAPSender, *am
 
 	smfInstance := smf.New(nil, nil, nil, nil)
 
-	smCtx := smfInstance.NewSession(supi, pduSessionID, dnn, &models.Snssai{Sst: 1})
+	smCtx := smfInstance.NewSession(supi, smf.Access5G, pduSessionID, dnn, &models.Snssai{Sst: 1})
 	smCtx.PolicyData = &smf.Policy{
 		Ambr: models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"},
 		QosData: models.QosData{
@@ -56,7 +56,7 @@ func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *fakeNGAPSender, *am
 	amfUe := amf.NewUeContext()
 	amfUe.SetSupiForTest(supi)
 	amfUe.SmContextList[pduSessionID] = &amf.SmContext{
-		Ref:    smf.CanonicalName(supi, pduSessionID),
+		Ref:    smf.CanonicalName(supi, smf.Access5G, pduSessionID),
 		Snssai: &models.Snssai{Sst: 1},
 	}
 

--- a/internal/amf/ngap/handle_handover_required_test.go
+++ b/internal/amf/ngap/handle_handover_required_test.go
@@ -224,7 +224,7 @@ func TestHandoverRequired(t *testing.T) {
 
 	smfInstance := smf.New(nil, nil, nil, nil)
 
-	smCtx := smfInstance.NewSession(supi, pduSessionID, dnn, &models.Snssai{Sst: 1})
+	smCtx := smfInstance.NewSession(supi, smf.Access5G, pduSessionID, dnn, &models.Snssai{Sst: 1})
 	smCtx.PolicyData = &smf.Policy{
 		Ambr: models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"},
 		QosData: models.QosData{
@@ -255,7 +255,7 @@ func TestHandoverRequired(t *testing.T) {
 	amfUe.SetUESecurityCapabilityForTest(secCap)
 	amfUe.Ambr = &models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"}
 	amfUe.SmContextList[pduSessionID] = &amf.SmContext{
-		Ref:    smf.CanonicalName(supi, pduSessionID),
+		Ref:    smf.CanonicalName(supi, smf.Access5G, pduSessionID),
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
@@ -520,7 +520,7 @@ func TestHandoverRequired_UnknownTarget(t *testing.T) {
 	}
 
 	smfInstance := smf.New(nil, nil, nil, nil)
-	smfInstance.NewSession(supi, pduSessionID, dnn, &models.Snssai{Sst: 1})
+	smfInstance.NewSession(supi, smf.Access5G, pduSessionID, dnn, &models.Snssai{Sst: 1})
 
 	amfUe := amf.NewUeContext()
 	amfUe.SetSupiForTest(supi)
@@ -533,7 +533,7 @@ func TestHandoverRequired_UnknownTarget(t *testing.T) {
 	secCap.SetLen(2)
 	amfUe.SetUESecurityCapabilityForTest(secCap)
 	amfUe.SmContextList[pduSessionID] = &amf.SmContext{
-		Ref:    smf.CanonicalName(supi, pduSessionID),
+		Ref:    smf.CanonicalName(supi, smf.Access5G, pduSessionID),
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
@@ -638,7 +638,7 @@ func TestHandoverRequired_GuardExpiryReleasesTarget(t *testing.T) {
 
 	smfInstance := smf.New(nil, nil, nil, nil)
 
-	smCtx := smfInstance.NewSession(supi, pduSessionID, dnn, &models.Snssai{Sst: 1})
+	smCtx := smfInstance.NewSession(supi, smf.Access5G, pduSessionID, dnn, &models.Snssai{Sst: 1})
 	smCtx.PolicyData = &smf.Policy{
 		Ambr:    models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"},
 		QosData: models.QosData{QFI: 1, Var5qi: 9, Arp: &models.Arp{PriorityLevel: 8}},
@@ -661,7 +661,7 @@ func TestHandoverRequired_GuardExpiryReleasesTarget(t *testing.T) {
 	amfUe.SetUESecurityCapabilityForTest(secCap)
 	amfUe.Ambr = &models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"}
 	amfUe.SmContextList[pduSessionID] = &amf.SmContext{
-		Ref:    smf.CanonicalName(supi, pduSessionID),
+		Ref:    smf.CanonicalName(supi, smf.Access5G, pduSessionID),
 		Snssai: &models.Snssai{Sst: 1},
 	}
 
@@ -812,7 +812,7 @@ func TestHandoverRequired_SourceDropReleasesTarget(t *testing.T) {
 
 	smfInstance := smf.New(nil, nil, nil, nil)
 
-	smCtx := smfInstance.NewSession(supi, pduSessionID, dnn, &models.Snssai{Sst: 1})
+	smCtx := smfInstance.NewSession(supi, smf.Access5G, pduSessionID, dnn, &models.Snssai{Sst: 1})
 	smCtx.PolicyData = &smf.Policy{
 		Ambr:    models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"},
 		QosData: models.QosData{QFI: 1, Var5qi: 9, Arp: &models.Arp{PriorityLevel: 8}},
@@ -830,7 +830,7 @@ func TestHandoverRequired_SourceDropReleasesTarget(t *testing.T) {
 	secCap.SetLen(2)
 	amfUe.SetUESecurityCapabilityForTest(secCap)
 	amfUe.Ambr = &models.Ambr{Uplink: "1 Gbps", Downlink: "1 Gbps"}
-	amfUe.SmContextList[pduSessionID] = &amf.SmContext{Ref: smf.CanonicalName(supi, pduSessionID), Snssai: &models.Snssai{Sst: 1}}
+	amfUe.SmContextList[pduSessionID] = &amf.SmContext{Ref: smf.CanonicalName(supi, smf.Access5G, pduSessionID), Snssai: &models.Snssai{Sst: 1}}
 
 	sourceRan := &amf.Radio{Log: logger.AmfLog, Conn: &fakeNGAPSender{}}
 	amfInstance := amf.New(&fakeDBInstance{Operator: &db.Operator{Mcc: "001", Mnc: "01"}}, nil, &fakeSmfSbi{SMF: smfInstance})

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -345,7 +345,7 @@ func mockSessionForSubscriber(amfInstance *amf.AMF, testSmfInstance *smf.SMF, im
 	ue.ForceStateForTest(amf.Registered)
 
 	pduSessionID := uint8(1)
-	sc := testSmfInstance.NewSession(supi, pduSessionID, dnn, nil)
+	sc := testSmfInstance.NewSession(supi, smf.Access5G, pduSessionID, dnn, nil)
 
 	err = ue.CreateSmContext(pduSessionID, sc.Ref, nil)
 	if err != nil {

--- a/internal/sctp/write_bench_test.go
+++ b/internal/sctp/write_bench_test.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+//go:build linux && !386
+
+package sctp
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+)
+
+// The write queue adds a payload copy, a channel send and a goroutine wakeup per
+// message; the sendmsg syscall itself is unchanged, only moved off the caller.
+// These measure that added cost at NGAP-representative sizes.
+func BenchmarkWriteQueueOverhead(b *testing.B) {
+	for _, size := range []int{256, 1024, 8192, 65536} {
+		payload := make([]byte, size)
+		info := &SndRcvInfo{PPID: PPIDWireOrder(testPPID)}
+
+		b.Run(fmt.Sprintf("copy+enqueue/%dB", size), func(b *testing.B) {
+			ch := make(chan queuedWrite, writeQueueDepth)
+			done := make(chan struct{})
+
+			go func() {
+				defer close(done)
+
+				for range ch {
+				}
+			}()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				qw := queuedWrite{b: append([]byte(nil), payload...)}
+				cp := *info
+				qw.info = &cp
+
+				ch <- qw
+			}
+
+			b.StopTimer()
+			close(ch)
+			<-done
+		})
+
+		b.Run(fmt.Sprintf("handoff_only/%dB", size), func(b *testing.B) {
+			ch := make(chan queuedWrite, writeQueueDepth)
+			done := make(chan struct{})
+
+			go func() {
+				defer close(done)
+
+				for range ch {
+				}
+			}()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				ch <- queuedWrite{b: payload, info: info}
+			}
+
+			b.StopTimer()
+			close(ch)
+			<-done
+		})
+	}
+}
+
+// The sendmsg the queue defers, measured on a real association with a draining
+// peer, so the added cost above can be read as a fraction of it.
+func BenchmarkWriteMsgSyncSyscall(b *testing.B) {
+	const port = 29441
+
+	netAddr, err := net.ResolveIPAddr("ip", "127.0.0.1")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	cfg := socketConfig{
+		InitMsg: InitMsg{NumOstreams: 2, MaxInstreams: 5, MaxAttempts: 2, MaxInitTimeout: 2},
+		Control: func(_, _ string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				_ = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 4<<20)
+			})
+		},
+	}
+
+	ln, err := cfg.Listen("sctp", &SCTPAddr{IPAddrs: []net.IPAddr{*netAddr}, Port: port})
+	if err != nil {
+		b.Skipf("listen: %v", err)
+	}
+
+	defer func() { _ = ln.Close() }()
+
+	accepts := make(chan *SCTPConn, 1)
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			accepts <- nil
+			return
+		}
+
+		accepts <- conn
+	}()
+
+	clientFd, err := connectLoopback(port)
+	if err != nil {
+		b.Fatalf("connect: %v", err)
+	}
+
+	defer func() { _ = syscall.Close(clientFd) }()
+
+	conn := <-accepts
+	if conn == nil {
+		b.Fatal("accept failed")
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	go func() {
+		buf := make([]byte, 1<<16)
+		for {
+			if _, err := syscall.Read(clientFd, buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	payload := make([]byte, 1024)
+	info := &SndRcvInfo{PPID: PPIDWireOrder(testPPID)}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := conn.writeMsgSync(payload, info); err != nil {
+			b.Fatalf("writeMsgSync: %v", err)
+		}
+	}
+}

--- a/internal/smf/access.go
+++ b/internal/smf/access.go
@@ -18,3 +18,21 @@ func (sc *SMContext) IsEPS() bool { return sc.Access == Access4G }
 // usesPSC reports whether the user-plane GTP-U carries the PDU Session Container
 // (and thus the QFI). 5G N3/N9 do; 4G S1-U does not. TS 23.501, TS 38.415.
 func (a AccessType) usesPSC() bool { return a == Access5G }
+
+// keyID maps a wire session identity into the SMF's converged id space. A 5G
+// session keeps its UE-assigned PDU session identity (1..15, TS 24.007
+// §11.2.3.1b); a 4G PDN connection is numbered 64+EBI, inside the
+// core-network-allocated PduSessionId range 64..95 that is only visible in the
+// core network (TS 29.571 §5.2.2). The two accesses therefore occupy disjoint
+// ids, and a lookup keyed on one access cannot resolve a session of the other.
+func (a AccessType) keyID(id uint8) uint8 {
+	if a == Access4G {
+		return 64 + id
+	}
+
+	return id
+}
+
+// keyID returns the session's id in the converged id space; it is the id the
+// session is indexed and its IP leases are keyed by.
+func (sc *SMContext) keyID() uint8 { return sc.Access.keyID(sc.PDUSessionID) }

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -50,6 +50,13 @@ func (s *SMF) CreateSmContext(ctx context.Context, supi etsi.SUPI, pduSessionID 
 	)
 	defer span.End()
 
+	// UE-assignable PDU session identity values are 1..15 (TS 24.007
+	// §11.2.3.1b); larger values would alias the converged-id range that names
+	// 4G PDN connections (AccessType.keyID).
+	if pduSessionID < 1 || pduSessionID > 15 {
+		return "", nil, fmt.Errorf("PDU session id %d out of range (1..15)", pduSessionID)
+	}
+
 	// Decode before any state changes so a failure can still build a reject.
 	m := nas.NewMessage()
 
@@ -97,7 +104,7 @@ func (s *SMF) CreateSmContext(ctx context.Context, supi etsi.SUPI, pduSessionID 
 
 	defer func() { recordSessionEstablishmentResult(metrics.RAT5G, establishmentResult) }()
 
-	if existing := s.currentSession(supi, pduSessionID); existing != nil {
+	if existing := s.currentSession(supi, Access5G, pduSessionID); existing != nil {
 		s.handlePduSessionContextReplacement(ctx, existing)
 	}
 

--- a/internal/smf/cross_access_test.go
+++ b/internal/smf/cross_access_test.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf_test
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+)
+
+// A default-bearer EBI (5..15, TS 24.007 §11.2.3.1b) and a 5G PDU session id
+// (1..15) can carry the same numeric value; sessions and leases are keyed in
+// the converged id space (TS 29.571 core-allocated range for 4G), so an EPS
+// operation must never resolve a 5G session.
+func TestModifyEPSSessionRejects5GPDUSession(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	ref, rejectN1, err := s.CreateSmContext(ctx, testSUPI(), 5, testDNN, testSnssai, buildPDUSessionEstRequest())
+	if err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if rejectN1 != nil {
+		t.Fatalf("CreateSmContext rejected the establishment: %d-byte N1 reject", len(rejectN1))
+	}
+
+	upf.mu.Lock()
+	modifiesBefore := len(upf.modifyCalls)
+	upf.mu.Unlock()
+
+	enb := models.FTEID{TEID: 0x6001, Addr: netip.MustParseAddr("192.168.40.10")}
+
+	if err := s.ModifyEPSSession(ctx, testIMSI, 5, enb); err == nil {
+		t.Error("ModifyEPSSession(ebi=5) = nil, want error: the only session with id 5 was established over 5G")
+	}
+
+	sc := s.GetSession(ref)
+	if sc == nil {
+		t.Fatal("5G session with PDU session id 5 is no longer in the pool")
+	}
+
+	sc.Mutex.Lock()
+	an := sc.Tunnel.ANInformation
+	sc.Mutex.Unlock()
+
+	if an.TEID == enb.TEID && net.IP(enb.Addr.AsSlice()).Equal(an.IPv4Address) {
+		t.Errorf("5G session's AN endpoint = eNB S1-U %v/0x%x, want it unchanged", an.IPv4Address, an.TEID)
+	}
+
+	upf.mu.Lock()
+	modifiesAfter := len(upf.modifyCalls)
+	upf.mu.Unlock()
+
+	if modifiesAfter != modifiesBefore {
+		t.Errorf("UPF ModifySession calls = %d, want %d", modifiesAfter, modifiesBefore)
+	}
+}
+
+func TestCreateEPSSessionKeeps5GSessionWithSameID(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	ref5g, rejectN1, err := s.CreateSmContext(ctx, testSUPI(), 5, testDNN, testSnssai, buildPDUSessionEstRequest())
+	if err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if rejectN1 != nil {
+		t.Fatalf("CreateSmContext rejected the establishment: %d-byte N1 reject", len(rejectN1))
+	}
+
+	bearer, err := s.CreateEPSSession(ctx, epsRequest(1))
+	if err != nil {
+		t.Fatalf("CreateEPSSession: %v", err)
+	}
+
+	if s.GetSession(ref5g) == nil {
+		t.Error("5G session with PDU session id 5 released by an EPS create for EBI 5")
+	}
+
+	if s.GetSession(bearer.Ref) == nil {
+		t.Error("EPS session for EBI 5 is not live")
+	}
+
+	if bearer.Ref == ref5g {
+		t.Errorf("EPS create returned the 5G session's ref %q", ref5g)
+	}
+}
+
+func TestCreateSmContextKeepsEPSSessionWithSameID(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	bearer, err := s.CreateEPSSession(ctx, epsRequest(1))
+	if err != nil {
+		t.Fatalf("CreateEPSSession: %v", err)
+	}
+
+	ref5g, rejectN1, err := s.CreateSmContext(ctx, testSUPI(), 5, testDNN, testSnssai, buildPDUSessionEstRequest())
+	if err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if rejectN1 != nil {
+		t.Fatalf("CreateSmContext rejected the establishment: %d-byte N1 reject", len(rejectN1))
+	}
+
+	if s.GetSession(bearer.Ref) == nil {
+		t.Error("EPS session for EBI 5 released by a 5G establishment for PDU session id 5")
+	}
+
+	if s.GetSession(ref5g) == nil {
+		t.Error("5G session with PDU session id 5 is not live")
+	}
+}
+
+// Leases must be keyed in the converged id space too, so coexisting sessions
+// with the same wire id cannot share an address (TS 29.571 core-allocated
+// range keeps them distinct).
+func TestLeaseKeysDistinctAcrossAccesses(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	ctx := context.Background()
+
+	if _, _, err := s.CreateSmContext(ctx, testSUPI(), 5, testDNN, testSnssai, buildPDUSessionEstRequest()); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if _, err := s.CreateEPSSession(ctx, epsRequest(1)); err != nil {
+		t.Fatalf("CreateEPSSession: %v", err)
+	}
+
+	ids := store.allocSessionIDs()
+	if len(ids) != 2 {
+		t.Fatalf("lease allocations = %d, want 2", len(ids))
+	}
+
+	if ids[0] == ids[1] {
+		t.Errorf("both accesses allocated under lease session id %d, want distinct ids", ids[0])
+	}
+}

--- a/internal/smf/eps.go
+++ b/internal/smf/eps.go
@@ -86,7 +86,7 @@ func (s *SMF) CreateEPSSession(ctx context.Context, req models.EPSBearerRequest)
 
 	// Must precede establishSession: the superseded context's release frees the address by
 	// (imsi, dnn, ebi), which the new session would already hold (TS 24.301 §5.5.1.2.4 case f).
-	if existing := s.currentSession(supi, req.EPSBearerIdentity); existing != nil {
+	if existing := s.currentSession(supi, Access4G, req.EPSBearerIdentity); existing != nil {
 		s.handlePduSessionContextReplacement(ctx, existing)
 	}
 
@@ -152,7 +152,7 @@ func (s *SMF) ModifyEPSSession(ctx context.Context, imsi string, ebi uint8, enb 
 		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
 	}
 
-	smContext := s.currentSession(supi, ebi)
+	smContext := s.currentSession(supi, Access4G, ebi)
 	if smContext == nil {
 		return fmt.Errorf("no EPS session for %s", imsi)
 	}
@@ -224,7 +224,7 @@ func (s *SMF) UpdateEPSSessionAMBR(ctx context.Context, imsi string, ebi uint8, 
 		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
 	}
 
-	smContext := s.currentSession(supi, ebi)
+	smContext := s.currentSession(supi, Access4G, ebi)
 	if smContext == nil {
 		return fmt.Errorf("no EPS session for %s", imsi)
 	}
@@ -273,7 +273,7 @@ func (s *SMF) FramedRoutesChanged(ctx context.Context, imsi string, ebi uint8) (
 		return false, fmt.Errorf("invalid imsi %q: %w", imsi, err)
 	}
 
-	smContext := s.currentSession(supi, ebi)
+	smContext := s.currentSession(supi, Access4G, ebi)
 	if smContext == nil {
 		return false, nil
 	}
@@ -293,7 +293,7 @@ func (s *SMF) StaticIPChanged(ctx context.Context, imsi string, ebi uint8) (bool
 		return false, fmt.Errorf("invalid imsi %q: %w", imsi, err)
 	}
 
-	smContext := s.currentSession(supi, ebi)
+	smContext := s.currentSession(supi, Access4G, ebi)
 	if smContext == nil {
 		return false, nil
 	}
@@ -313,7 +313,7 @@ func (s *SMF) DeactivateEPSSession(ctx context.Context, imsi string, ebi uint8) 
 		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
 	}
 
-	smContext := s.currentSession(supi, ebi)
+	smContext := s.currentSession(supi, Access4G, ebi)
 	if smContext == nil {
 		return fmt.Errorf("no EPS session for %s", imsi)
 	}

--- a/internal/smf/eps_abort_test.go
+++ b/internal/smf/eps_abort_test.go
@@ -24,8 +24,8 @@ func TestAbortSessionOwnsByHandle(t *testing.T) {
 
 	const ebi uint8 = 5
 
-	scA := s.NewSession(supi, ebi, "internet", nil) // first create
-	scB := s.NewSession(supi, ebi, "internet", nil) // second create — a distinct instance
+	scA := s.NewSession(supi, Access4G, ebi, "internet", nil) // first create
+	scB := s.NewSession(supi, Access4G, ebi, "internet", nil) // second create — a distinct instance
 
 	// Two sessions for the same (SUPI,EBI) get distinct refs and coexist in the pool;
 	// the latest is the current one for the (SUPI,EBI) slot.
@@ -33,7 +33,7 @@ func TestAbortSessionOwnsByHandle(t *testing.T) {
 		t.Fatalf("two sessions for the same (SUPI,EBI) must get distinct refs, got %q twice", scA.Ref)
 	}
 
-	if s.currentSession(supi, ebi) != scB {
+	if s.currentSession(supi, Access4G, ebi) != scB {
 		t.Fatalf("expected scB to be the current session for the (SUPI,EBI)")
 	}
 
@@ -45,14 +45,14 @@ func TestAbortSessionOwnsByHandle(t *testing.T) {
 		t.Fatalf("abort did not remove scA")
 	}
 
-	if s.GetSession(scB.Ref) != scB || s.currentSession(supi, ebi) != scB {
+	if s.GetSession(scB.Ref) != scB || s.currentSession(supi, Access4G, ebi) != scB {
 		t.Fatalf("abort of a stale context disturbed the live session scB")
 	}
 
 	// Aborting the current owner does remove it, from both the pool and the index.
 	s.abortSession(context.Background(), scB)
 
-	if s.GetSession(scB.Ref) != nil || s.currentSession(supi, ebi) != nil {
+	if s.GetSession(scB.Ref) != nil || s.currentSession(supi, Access4G, ebi) != nil {
 		t.Fatalf("abort of the current context did not remove it")
 	}
 }

--- a/internal/smf/ipalloc.go
+++ b/internal/smf/ipalloc.go
@@ -128,7 +128,7 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, dn DNNStore, sc *SMContex
 	)
 
 	if sc.PDUSessionType == nasMessage.PDUSessionTypeIPv4 || sc.PDUSessionType == nasMessage.PDUSessionTypeIPv4IPv6 {
-		ipv4, err := dn.AllocateIP(ctx, imsi, sc.PDUSessionID)
+		ipv4, err := dn.AllocateIP(ctx, imsi, sc.keyID())
 		if err != nil {
 			return netip.Addr{}, ueAddresses{}, fmt.Errorf("allocate UE IPv4: %w", err)
 		}
@@ -139,7 +139,7 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, dn DNNStore, sc *SMContex
 	}
 
 	if sc.PDUSessionType == nasMessage.PDUSessionTypeIPv6 || sc.PDUSessionType == nasMessage.PDUSessionTypeIPv4IPv6 {
-		ipv6Prefix, err := dn.AllocateIPv6(ctx, imsi, sc.PDUSessionID)
+		ipv6Prefix, err := dn.AllocateIPv6(ctx, imsi, sc.keyID())
 		if err != nil {
 			s.releaseAllocatedAddresses(ctx, dn, sc)
 			return netip.Addr{}, ueAddresses{}, fmt.Errorf("allocate UE IPv6 prefix: %w", err)
@@ -169,7 +169,7 @@ func (s *SMF) allocateUEAddresses(ctx context.Context, dn DNNStore, sc *SMContex
 // clears them, so a later rollback does not double-release.
 func (s *SMF) releaseAllocatedAddresses(ctx context.Context, dn DNNStore, smContext *SMContext) {
 	if smContext.PDUIPV4Address != nil {
-		if _, err := dn.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID); err != nil {
+		if _, err := dn.ReleaseIP(ctx, smContext.Supi.IMSI(), smContext.keyID()); err != nil {
 			logger.WithTrace(ctx, logger.SmfLog).Error("failed to release IPv4 address", zap.Error(err))
 		}
 
@@ -177,7 +177,7 @@ func (s *SMF) releaseAllocatedAddresses(ctx context.Context, dn DNNStore, smCont
 	}
 
 	if smContext.PDUIPV6Prefix != nil {
-		if _, err := dn.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.PDUSessionID); err != nil {
+		if _, err := dn.ReleaseIPv6(ctx, smContext.Supi.IMSI(), smContext.keyID()); err != nil {
 			logger.WithTrace(ctx, logger.SmfLog).Error("failed to release IPv6 address", zap.Error(err))
 		}
 

--- a/internal/smf/ipv6_integration_test.go
+++ b/internal/smf/ipv6_integration_test.go
@@ -495,7 +495,7 @@ func setupIPv6SessionWithTunnel(t *testing.T, s *smf.SMF) (*smf.SMContext, strin
 	t.Helper()
 
 	supi := testSUPI()
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 
 	seid := s.AllocateLocalSEID()
 	smCtx.SetPFCPSession(seid)
@@ -631,7 +631,7 @@ func TestRemoveSession_IPv6Only_ReleasesIPv6(t *testing.T) {
 	supi := testSUPI()
 	ctx := context.Background()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 	smCtx.PDUIPV6Prefix = net.ParseIP("2001:db8::").To16()
 
 	ref := smCtx.Ref
@@ -656,7 +656,7 @@ func TestRemoveSession_DualStack_ReleasesBoth(t *testing.T) {
 	supi := testSUPI()
 	ctx := context.Background()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 	smCtx.PDUIPV4Address = net.ParseIP("10.0.0.1").To4()
 	smCtx.PDUIPV6Prefix = net.ParseIP("2001:db8:abcd::").To16()
 

--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -120,7 +120,7 @@ func setupSessionWithTunnel(t *testing.T, s *smf.SMF) (*smf.SMContext, string) {
 	t.Helper()
 
 	supi := testSUPI()
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 
 	seid := s.AllocateLocalSEID()
 	smCtx.SetPFCPSession(seid)
@@ -203,7 +203,7 @@ func TestActivateTunnelAndPDR_HappyPath(t *testing.T) {
 	s := newTestSMF(pcf, store, upf, amfCb)
 	supi := testSUPI()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 	smCtx.Tunnel = &smf.UPTunnel{
 		DataPath: &smf.DataPath{
 			UpLinkTunnel:   &smf.GTPTunnel{},
@@ -287,7 +287,7 @@ func TestActivateTunnelAndPDR_FixedRuleIDs(t *testing.T) {
 			pcf, store, upf, amfCb := defaultFakes()
 			s := newTestSMF(pcf, store, upf, amfCb)
 
-			smCtx := s.NewSession(testSUPI(), 1, testDNN, testSnssai)
+			smCtx := s.NewSession(testSUPI(), smf.Access5G, 1, testDNN, testSnssai)
 			smCtx.Tunnel = &smf.UPTunnel{
 				DataPath: &smf.DataPath{
 					UpLinkTunnel:   &smf.GTPTunnel{},
@@ -530,7 +530,7 @@ func TestReleaseSmContext_NoTunnel(t *testing.T) {
 	ctx := context.Background()
 	supi := testSUPI()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 	ref := smCtx.Ref
 
 	err := s.ReleaseSmContext(ctx, ref)
@@ -860,7 +860,7 @@ func TestRemoveSession_NilPDUAddress_SkipsIPRelease(t *testing.T) {
 	supi := testSUPI()
 	bgCtx := context.Background()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai) // PDUAddress is nil by default
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai) // PDUAddress is nil by default
 	ref := smCtx.Ref
 
 	s.RemoveSession(bgCtx, ref)
@@ -1983,8 +1983,7 @@ func TestHandleDownlinkDataReportEPS(t *testing.T) {
 	s.SetMME(mmeCb)
 
 	supi := testSUPI()
-	smCtx := s.NewSession(supi, 5, testDNN, testSnssai) // EPS session keyed by the default bearer EBI
-	smCtx.Access = smf.Access4G
+	smCtx := s.NewSession(supi, smf.Access4G, 5, testDNN, testSnssai) // EPS session keyed by the default bearer EBI
 	seid := s.AllocateLocalSEID()
 	smCtx.SetPFCPSession(seid)
 

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
-	smContext := s.currentSession(supi, pduSessionID)
+	smContext := s.currentSession(supi, Access5G, pduSessionID)
 	if smContext == nil {
 		return fmt.Errorf("no session for %s pdu %d", supi.String(), pduSessionID)
 	}
@@ -27,7 +27,7 @@ func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8
 		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
 	}
 
-	smContext := s.currentSession(supi, ebi)
+	smContext := s.currentSession(supi, Access4G, ebi)
 	if smContext == nil {
 		return fmt.Errorf("no EPS session for %s", imsi)
 	}

--- a/internal/smf/paging_failure_test.go
+++ b/internal/smf/paging_failure_test.go
@@ -6,6 +6,8 @@ package smf_test
 import (
 	"context"
 	"testing"
+
+	"github.com/ellanetworks/core/internal/smf"
 )
 
 func TestHandleEPSPagingFailure_SuppressesDownlinkNotification(t *testing.T) {
@@ -16,7 +18,7 @@ func TestHandleEPSPagingFailure_SuppressesDownlinkNotification(t *testing.T) {
 
 	const ebi = 5
 
-	smCtx := s.NewSession(supi, ebi, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access4G, ebi, testDNN, testSnssai)
 	smCtx.SetPFCPSession(s.AllocateLocalSEID())
 	smCtx.PFCPContext.RemoteSEID = 7
 
@@ -37,7 +39,7 @@ func TestHandlePagingFailure_SuppressesDownlinkNotification(t *testing.T) {
 
 	const pduSessionID = 1
 
-	smCtx := s.NewSession(supi, pduSessionID, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, pduSessionID, testDNN, testSnssai)
 	smCtx.SetPFCPSession(s.AllocateLocalSEID())
 	smCtx.PFCPContext.RemoteSEID = 4242
 

--- a/internal/smf/paging_recovery.go
+++ b/internal/smf/paging_recovery.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *SMF) ClearPagingSuppression(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
-	smContext := s.currentSession(supi, pduSessionID)
+	smContext := s.currentSession(supi, Access5G, pduSessionID)
 	if smContext == nil {
 		return nil
 	}
@@ -27,7 +27,7 @@ func (s *SMF) ClearEPSPagingSuppression(ctx context.Context, imsi string, ebi ui
 		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
 	}
 
-	smContext := s.currentSession(supi, ebi)
+	smContext := s.currentSession(supi, Access4G, ebi)
 	if smContext == nil {
 		return nil
 	}

--- a/internal/smf/paging_recovery_test.go
+++ b/internal/smf/paging_recovery_test.go
@@ -6,6 +6,8 @@ package smf_test
 import (
 	"context"
 	"testing"
+
+	"github.com/ellanetworks/core/internal/smf"
 )
 
 func TestClearEPSPagingSuppression_ClearsDownlinkNotification(t *testing.T) {
@@ -16,7 +18,7 @@ func TestClearEPSPagingSuppression_ClearsDownlinkNotification(t *testing.T) {
 
 	const ebi = 5
 
-	smCtx := s.NewSession(supi, ebi, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access4G, ebi, testDNN, testSnssai)
 	smCtx.SetPFCPSession(s.AllocateLocalSEID())
 	smCtx.PFCPContext.RemoteSEID = 7
 
@@ -37,7 +39,7 @@ func TestClearPagingSuppression_ClearsDownlinkNotification(t *testing.T) {
 
 	const pduSessionID = 1
 
-	smCtx := s.NewSession(supi, pduSessionID, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, pduSessionID, testDNN, testSnssai)
 	smCtx.SetPFCPSession(s.AllocateLocalSEID())
 	smCtx.PFCPContext.RemoteSEID = 4242
 

--- a/internal/smf/session.go
+++ b/internal/smf/session.go
@@ -59,7 +59,7 @@ func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMCont
 		return nil, ueAddresses{}, fmt.Errorf("%w: %v", errUEAddressAllocation, err)
 	}
 
-	sc := s.NewSession(req.Supi, req.Key, req.Dnn, req.Snssai)
+	sc := s.NewSession(req.Supi, req.Access, req.Key, req.Dnn, req.Snssai)
 
 	committed := false
 
@@ -72,7 +72,6 @@ func (s *SMF) establishSession(ctx context.Context, req SessionRequest) (*SMCont
 	// Build under the session lock so a concurrent reader for the same key never
 	// sees a half-built context.
 	sc.Mutex.Lock()
-	sc.Access = req.Access
 	sc.PDUSessionType = req.PDUType
 	sc.PolicyData = req.Policy
 
@@ -166,13 +165,13 @@ func (s *SMF) abortSession(ctx context.Context, sc *SMContext) {
 			logger.SmfLog.Warn("failed to resolve data network to release UE addresses after aborted session", zap.String("imsi", imsi), zap.Error(err))
 		} else {
 			if sc.PDUIPV4Address != nil {
-				if _, err := dn.ReleaseIP(ctx, imsi, sc.PDUSessionID); err != nil {
+				if _, err := dn.ReleaseIP(ctx, imsi, sc.keyID()); err != nil {
 					logger.SmfLog.Warn("failed to release UE IPv4 after aborted session", zap.String("imsi", imsi), zap.Error(err))
 				}
 			}
 
 			if sc.PDUIPV6Prefix != nil {
-				if _, err := dn.ReleaseIPv6(ctx, imsi, sc.PDUSessionID); err != nil {
+				if _, err := dn.ReleaseIPv6(ctx, imsi, sc.keyID()); err != nil {
 					logger.SmfLog.Warn("failed to release UE IPv6 after aborted session", zap.String("imsi", imsi), zap.Error(err))
 				}
 			}

--- a/internal/smf/sm_context.go
+++ b/internal/smf/sm_context.go
@@ -36,9 +36,9 @@ type SMContext struct {
 	Mutex sync.Mutex
 
 	// Ref is the session's unique pool key, assigned once at creation and never
-	// reused: two sessions for the same (SUPI, PDU session id) get distinct Refs, so a
+	// reused: two sessions for the same (SUPI, access, id) get distinct Refs, so a
 	// release targets the exact instance and cannot tear down a newer session that
-	// reused the (SUPI, id) slot. CanonicalName(SUPI, id) is the secondary index key.
+	// reused the slot. CanonicalName is the secondary index key.
 	Ref string
 
 	Supi           etsi.SUPI
@@ -61,8 +61,9 @@ type SMContext struct {
 	// Access is the radio access the session was established over. Access4G marks
 	// a 4G EPS session (PGW-C role): its PDUSessionID is the default bearer's EPS
 	// bearer identity (5..15), which overlaps the 5G PDU session id range, so the
-	// RAT cannot be inferred from the id. Downlink data for an EPS session is
-	// paged via the MME (TS 23.401 §5.3.4.3), not the 5G N2 path.
+	// RAT cannot be inferred from the wire id; session and lease keys use the
+	// converged id (keyID). Downlink data for an EPS session is paged via the MME
+	// (TS 23.401 §5.3.4.3).
 	Access AccessType
 
 	// outstandingPTIs holds the PTI of each 5GSM procedure awaiting a UE
@@ -130,8 +131,11 @@ func (smContext *SMContext) IsPTIInUse(pti uint8) bool {
 	return ok
 }
 
-func CanonicalName(identifier etsi.SUPI, pduSessID uint8) string {
-	return fmt.Sprintf("%s-%d", identifier.String(), pduSessID)
+// CanonicalName is the secondary index key for a (SUPI, access, id) slot. The
+// id is mapped into the converged id space (AccessType.keyID), so a 4G EBI and
+// a 5G PDU session id with the same numeric value name different slots.
+func CanonicalName(identifier etsi.SUPI, access AccessType, id uint8) string {
+	return fmt.Sprintf("%s-%d", identifier.String(), access.keyID(id))
 }
 
 func (smContext *SMContext) SetPolicyData(policy *Policy) {
@@ -152,5 +156,5 @@ func (smContext *SMContext) SetPFCPSession(seid uint64) {
 }
 
 func (smContext *SMContext) CanonicalName() string {
-	return CanonicalName(smContext.Supi, smContext.PDUSessionID)
+	return CanonicalName(smContext.Supi, smContext.Access, smContext.PDUSessionID)
 }

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -58,19 +58,21 @@ type PCF interface {
 }
 
 // DNNStore is the session-data surface bound to one data network resolved once
-// via SessionStore.ResolveDNN.
+// via SessionStore.ResolveDNN. Leases are keyed by the session's converged id
+// (SMContext.keyID), so 4G and 5G sessions with the same wire id hold distinct
+// leases.
 type DNNStore interface {
-	AllocateIP(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
+	AllocateIP(ctx context.Context, imsi string, sessionKeyID uint8) (netip.Addr, error)
 
 	// ReleaseIP frees the session's lease and returns the freed IPv4 address so
 	// the caller can withdraw the BGP route.
-	ReleaseIP(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
+	ReleaseIP(ctx context.Context, imsi string, sessionKeyID uint8) (netip.Addr, error)
 
 	// AllocateIPv6 assigns a /64 prefix from the data network's IPv6 pool and
 	// returns its base address (lower 64 bits = 0).
-	AllocateIPv6(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
+	AllocateIPv6(ctx context.Context, imsi string, sessionKeyID uint8) (netip.Addr, error)
 
-	ReleaseIPv6(ctx context.Context, imsi string, pduSessionID uint8) (netip.Addr, error)
+	ReleaseIPv6(ctx context.Context, imsi string, sessionKeyID uint8) (netip.Addr, error)
 
 	ListFramedRoutes(ctx context.Context, imsi string) ([]netip.Prefix, error)
 
@@ -254,19 +256,20 @@ func (s *SMF) AllocateLocalSEID() uint64 {
 }
 
 // NewSession creates a new SMContext with a unique Ref and adds it to the pool,
-// making it the current session for its (SUPI, PDU session id). It never overwrites
-// or orphans a prior session for the same (SUPI, id): that session keeps its own Ref
+// making it the current session for its (SUPI, access, id). It never overwrites
+// or orphans a prior session for the same slot: that session keeps its own Ref
 // and pool entry until it is explicitly released.
-func (s *SMF) NewSession(supi etsi.SUPI, pduSessionID uint8, dnn string, snssai *models.Snssai) *SMContext {
+func (s *SMF) NewSession(supi etsi.SUPI, access AccessType, pduSessionID uint8, dnn string, snssai *models.Snssai) *SMContext {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.refSeq++
-	key := CanonicalName(supi, pduSessionID)
+	key := CanonicalName(supi, access, pduSessionID)
 
 	ctx := &SMContext{
 		PDUSessionID: pduSessionID,
 		Supi:         supi,
+		Access:       access,
 		Dnn:          dnn,
 		Snssai:       snssai,
 		Ref:          fmt.Sprintf("%s#%d", key, s.refSeq),
@@ -286,28 +289,28 @@ func (s *SMF) GetSession(ref string) *SMContext {
 	return s.pool[ref]
 }
 
-// currentSession returns the live session for a (SUPI, PDU session id), or nil.
+// currentSession returns the live session for a (SUPI, access, id), or nil.
 // Use it for operations that act on whichever session is current (modify, AMBR,
 // idle deactivation, duplicate detection) — never for a release, which must target
 // a specific instance by its Ref so it cannot tear down a newer session.
-func (s *SMF) currentSession(supi etsi.SUPI, pduSessionID uint8) *SMContext {
+func (s *SMF) currentSession(supi etsi.SUPI, access AccessType, pduSessionID uint8) *SMContext {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.byKey[CanonicalName(supi, pduSessionID)]
+	return s.byKey[CanonicalName(supi, access, pduSessionID)]
 }
 
 // dropFromPool removes sc from the pool by its unique Ref, and from the secondary
-// index only if sc is still the current session for its (SUPI, id) — so releasing a
-// superseded session cannot evict the newer one that replaced it. Caller must not
-// hold s.mu.
+// index only if sc is still the current session for its (SUPI, access, id) — so
+// releasing a superseded session cannot evict the newer one that replaced it.
+// Caller must not hold s.mu.
 func (s *SMF) dropFromPool(sc *SMContext) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	delete(s.pool, sc.Ref)
 
-	key := CanonicalName(sc.Supi, sc.PDUSessionID)
+	key := sc.CanonicalName()
 	if s.byKey[key] == sc {
 		delete(s.byKey, key)
 	}

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -39,6 +39,7 @@ type fakeStore struct {
 	staticIPv6      netip.Addr
 	staticIPErr     error
 	opLog           []string
+	allocSessionLog []uint8
 }
 
 func (f *fakeStore) ResolveDNN(_ context.Context, _ string) (smf.DNNStore, error) {
@@ -53,6 +54,14 @@ func (f *fakeStore) ops() []string {
 	return slices.Clone(f.opLog)
 }
 
+// allocSessionIDs returns the session key id of each IPv4 allocation in order.
+func (f *fakeStore) allocSessionIDs() []uint8 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return slices.Clone(f.allocSessionLog)
+}
+
 type fakePCF struct {
 	mu     sync.Mutex
 	policy *smf.Policy
@@ -65,11 +74,12 @@ type usageEntry struct {
 	downlinkBytes uint64
 }
 
-func (f *fakeStore) AllocateIP(_ context.Context, _ string, _ uint8) (netip.Addr, error) {
+func (f *fakeStore) AllocateIP(_ context.Context, _ string, sessionKeyID uint8) (netip.Addr, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.opLog = append(f.opLog, "alloc")
+	f.allocSessionLog = append(f.allocSessionLog, sessionKeyID)
 
 	if f.allocateIPErr != nil {
 		return f.allocatedIP, f.allocateIPErr
@@ -407,7 +417,7 @@ func TestNewSession_AddsToPool(t *testing.T) {
 	s := newTestSMF(pcf, store, upf, amfCb)
 	supi := testSUPI()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 	if smCtx == nil {
 		t.Fatal("expected non-nil SMContext")
 	}
@@ -444,7 +454,7 @@ func TestRemoveSession_RemovesFromPool(t *testing.T) {
 	supi := testSUPI()
 	bgCtx := context.Background()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 	ref := smCtx.Ref
 
 	s.RemoveSession(bgCtx, ref)
@@ -461,7 +471,7 @@ func TestRemoveSession_ReleasesIP(t *testing.T) {
 	supi := testSUPI()
 	bgCtx := context.Background()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 	smCtx.PDUIPV4Address = net.ParseIP("10.0.0.1").To4()
 	ref := smCtx.Ref
 
@@ -499,13 +509,13 @@ func TestSessionCount(t *testing.T) {
 		t.Fatal("expected 0 sessions initially")
 	}
 
-	s.NewSession(supi, 1, testDNN, testSnssai)
+	s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 
 	if s.SessionCount() != 1 {
 		t.Fatal("expected 1 session")
 	}
 
-	s.NewSession(supi, 2, testDNN, testSnssai)
+	s.NewSession(supi, smf.Access5G, 2, testDNN, testSnssai)
 
 	if s.SessionCount() != 2 {
 		t.Fatal("expected 2 sessions")
@@ -517,9 +527,9 @@ func TestSessionsByDNN(t *testing.T) {
 	s := newTestSMF(pcf, store, upf, amfCb)
 	supi := testSUPI()
 
-	s.NewSession(supi, 1, "internet", testSnssai)
-	s.NewSession(supi, 2, "ims", testSnssai)
-	s.NewSession(supi, 3, "internet", testSnssai)
+	s.NewSession(supi, smf.Access5G, 1, "internet", testSnssai)
+	s.NewSession(supi, smf.Access5G, 2, "ims", testSnssai)
+	s.NewSession(supi, smf.Access5G, 3, "internet", testSnssai)
 
 	internet := s.SessionsByDNN("internet")
 	if len(internet) != 2 {
@@ -542,7 +552,7 @@ func TestGetSessionBySEID(t *testing.T) {
 	s := newTestSMF(pcf, store, upf, amfCb)
 	supi := testSUPI()
 
-	smCtx := s.NewSession(supi, 1, testDNN, testSnssai)
+	smCtx := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
 
 	seid := s.AllocateLocalSEID()
 	smCtx.SetPFCPSession(seid)
@@ -650,7 +660,7 @@ func TestConcurrentSessionCreation(t *testing.T) {
 			defer wg.Done()
 
 			supi := testSUPI()
-			s.NewSession(supi, id, testDNN, testSnssai)
+			s.NewSession(supi, smf.Access5G, id, testDNN, testSnssai)
 		}(uint8(i))
 	}
 
@@ -666,8 +676,8 @@ func TestNewSession_DistinctInstancesCoexist(t *testing.T) {
 	s := newTestSMF(pcf, store, upf, amfCb)
 	supi := testSUPI()
 
-	ctx1 := s.NewSession(supi, 1, testDNN, testSnssai)
-	ctx2 := s.NewSession(supi, 1, "ims", testSnssai)
+	ctx1 := s.NewSession(supi, smf.Access5G, 1, testDNN, testSnssai)
+	ctx2 := s.NewSession(supi, smf.Access5G, 1, "ims", testSnssai)
 
 	// Two sessions for the same (SUPI, id) get distinct refs and both stay in the
 	// pool, each retrievable by its own ref — neither overwrites the other.


### PR DESCRIPTION
# Description

 A 4G default-bearer EBI and a 5G PDU session id with the same numeric value shared one (SUPI, id) slot in the SMF's session index and IP-lease key, letting EPS operations mutate a live 5G session's data path and cross-RAT establishments silently tear down the other access's session.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
