### PR TITLE
fix: retry SCTP accept interrupted by a pending signal

### DIFF
--- a/internal/sctp/sctp_linux.go
+++ b/internal/sctp/sctp_linux.go
@@ -520,7 +520,7 @@ func (ln *sctpListener) Accept() (*SCTPConn, error) {
 
 	rerr := ln.rc.Read(func(fd uintptr) bool {
 		newFd, _, err = syscall.Accept4(int(fd), syscall.SOCK_CLOEXEC|syscall.SOCK_NONBLOCK)
-		if err == syscall.EAGAIN {
+		if acceptWouldBlock(err) {
 			return false // not ready; tell poller to park and retry
 		}
 
@@ -541,6 +541,13 @@ func (ln *sctpListener) Accept() (*SCTPConn, error) {
 	}
 
 	return conn, nil
+}
+
+// SCTP answers a would-block accept with EINTR when a signal is pending:
+// sctp_wait_for_accept tests signal_pending before the !timeo case
+// (net/sctp/socket.c).
+func acceptWouldBlock(err error) bool {
+	return err == syscall.EAGAIN || err == syscall.EINTR
 }
 
 // acceptErr reports a closed listener as net.ErrClosed: the poller surfaces the

--- a/internal/sctp/sctp_test.go
+++ b/internal/sctp/sctp_test.go
@@ -6,6 +6,7 @@ package sctp
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"syscall"
 	"testing"
@@ -71,14 +72,25 @@ func connectLoopback(port int) (int, error) {
 	sa := &syscall.SockaddrInet4{Port: port}
 	copy(sa.Addr[:], net.ParseIP("127.0.0.1").To4())
 
-	// An interrupted connect(2) continues in the background; a retry reports its progress.
+	// A signal restarts connect(2) under SA_RESTART, and the restart reports the
+	// association's state instead of re-blocking on the handshake.
+	deadline := time.Now().Add(5 * time.Second)
+
 	for {
 		err := syscall.Connect(fd, sa)
-		if err == nil || errors.Is(err, syscall.EISCONN) {
+		if err == nil || err == syscall.EISCONN {
 			return fd, nil
 		}
 
-		if errors.Is(err, syscall.EINTR) || errors.Is(err, syscall.EALREADY) || errors.Is(err, syscall.EINPROGRESS) {
+		if err == syscall.EALREADY || err == syscall.EINTR {
+			if time.Now().After(deadline) {
+				_ = syscall.Close(fd)
+
+				return -1, fmt.Errorf("connect did not complete: %w", err)
+			}
+
+			time.Sleep(time.Millisecond)
+
 			continue
 		}
 

--- a/internal/sctp/sctp_test.go
+++ b/internal/sctp/sctp_test.go
@@ -71,12 +71,21 @@ func connectLoopback(port int) (int, error) {
 	sa := &syscall.SockaddrInet4{Port: port}
 	copy(sa.Addr[:], net.ParseIP("127.0.0.1").To4())
 
-	if err := syscall.Connect(fd, sa); err != nil {
+	// An interrupted connect(2) continues in the background; a retry reports its progress.
+	for {
+		err := syscall.Connect(fd, sa)
+		if err == nil || errors.Is(err, syscall.EISCONN) {
+			return fd, nil
+		}
+
+		if errors.Is(err, syscall.EINTR) || errors.Is(err, syscall.EALREADY) || errors.Is(err, syscall.EINPROGRESS) {
+			continue
+		}
+
 		_ = syscall.Close(fd)
+
 		return -1, err
 	}
-
-	return fd, nil
 }
 
 // acceptOne connects a raw SCTP client to ln and returns the accepted
@@ -84,16 +93,16 @@ func connectLoopback(port int) (int, error) {
 func acceptOne(t *testing.T, ln *sctpListener, port int) *SCTPConn {
 	t.Helper()
 
-	connCh := make(chan *SCTPConn, 1)
+	type acceptResult struct {
+		conn *SCTPConn
+		err  error
+	}
+
+	connCh := make(chan acceptResult, 1)
 
 	go func() {
 		conn, err := ln.Accept()
-		if err != nil {
-			connCh <- nil
-			return
-		}
-
-		connCh <- conn
+		connCh <- acceptResult{conn: conn, err: err}
 	}()
 
 	clientFd, err := connectLoopback(port)
@@ -103,12 +112,42 @@ func acceptOne(t *testing.T, ln *sctpListener, port int) *SCTPConn {
 
 	t.Cleanup(func() { _ = syscall.Close(clientFd) })
 
-	conn := <-connCh
-	if conn == nil {
-		t.Fatal("Accept failed")
+	res := <-connCh
+	if res.err != nil {
+		t.Fatalf("Accept failed: %v (errno %d)", res.err, errnoOf(res.err))
 	}
 
-	return conn
+	return res.conn
+}
+
+// errnoOf extracts the numeric errno from err, or -1 if it carries none.
+func errnoOf(err error) int {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return int(errno)
+	}
+
+	return -1
+}
+
+// No deterministic test of Accept catches the loss of the EINTR case.
+func TestAcceptWouldBlock(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"EAGAIN", syscall.EAGAIN, true},
+		{"EINTR", syscall.EINTR, true},
+		{"nil", nil, false},
+		{"EBADF", syscall.EBADF, false},
+		{"EINVAL", syscall.EINVAL, false},
+		{"EMFILE", syscall.EMFILE, false},
+	} {
+		if got := acceptWouldBlock(c.err); got != c.want {
+			t.Errorf("acceptWouldBlock(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
 }
 
 // TestClose_Idempotent verifies that Close() releases the fd exactly once.


### PR DESCRIPTION
# Description

SCTP answers a would-block accept4 with EINTR rather than EAGAIN whenever a signal is pending on the calling thread so the Go runtime's own preemption signals made Accept report a spurious failure instead of parking on the poller.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
