### PR TITLE
chore: replace ishidawataru/sctp lib in integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-autopilot v0.3.0
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
-	github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/moby/moby/client v0.5.1
 	github.com/osrg/gobgp/v4 v4.7.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/hashicorp/raft-boltdb/v2 v2.3.1 h1:ackhdCNPKblmOhjEU9+4lHSJYFkJd6Jqyv
 github.com/hashicorp/raft-boltdb/v2 v2.3.1/go.mod h1:n4S+g43dXF1tqDT+yzcXHhXM6y7MrlUd3TTwGRcUvQE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987 h1:pf7+hef676aOjZ9XcvEw5qhdTPPaFVfavOQS+IntVOY=
-github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=

--- a/internal/sctp/const_abi_test.go
+++ b/internal/sctp/const_abi_test.go
@@ -3,7 +3,30 @@
 
 package sctp
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
+
+// getAddrsOld is passed to the kernel as struct sctp_getaddrs_old, which
+// rejects anything shorter and reads past anything longer.
+func TestGetAddrsOldMatchesKernelLayout(t *testing.T) {
+	var param getAddrsOld
+
+	// sctp_assoc_t (4) + int (4) + a pointer aligned to its own width.
+	want := 8 + unsafe.Sizeof(uintptr(0))
+	if got := unsafe.Sizeof(param); got != want {
+		t.Errorf("sizeof(getAddrsOld) = %d, want %d", got, want)
+	}
+
+	if got := unsafe.Offsetof(param.AddrNum); got != 4 {
+		t.Errorf("offsetof(AddrNum) = %d, want 4", got)
+	}
+
+	if got := unsafe.Offsetof(param.Addrs); got != unsafe.Sizeof(uintptr(0)) {
+		t.Errorf("offsetof(Addrs) = %d, want %d", got, unsafe.Sizeof(uintptr(0)))
+	}
+}
 
 // These constants are kernel ABI (include/uapi/linux/sctp.h). Most are declared
 // positionally with iota, so adding or removing a member silently renumbers the
@@ -23,6 +46,7 @@ func TestConstantsMatchKernelABI(t *testing.T) {
 		{"SCTP_SOCKOPT_BINDX_ADD", sctpOptBindxAdd, 100},
 		{"SCTP_GET_PEER_ADDRS", sctpOptGetPeerAddrs, 108},
 		{"SCTP_GET_LOCAL_ADDRS", sctpOptGetLocalAddrs, 109},
+		{"SCTP_SOCKOPT_CONNECTX3", sctpOptConnectX3, 111},
 		{"SCTP_CMSG_INIT", sctpCMsgInit, 0},
 		{"SCTP_CMSG_SNDRCV", sctpCMsgSndRcv, 1},
 		{"SCTP_DATA_IO_EVENT", sctpEventDataIO, 1},

--- a/internal/sctp/const_abi_test.go
+++ b/internal/sctp/const_abi_test.go
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Ella Networks Inc.
 // SPDX-License-Identifier: BUSL-1.1
+//go:build linux && !386
 
 package sctp
 
@@ -23,8 +24,10 @@ func TestGetAddrsOldMatchesKernelLayout(t *testing.T) {
 		t.Errorf("offsetof(AddrNum) = %d, want 4", got)
 	}
 
-	if got := unsafe.Offsetof(param.Addrs); got != unsafe.Sizeof(uintptr(0)) {
-		t.Errorf("offsetof(Addrs) = %d, want %d", got, unsafe.Sizeof(uintptr(0)))
+	// 8 on both LP64 and ILP32: two 32-bit fields precede it, and the pointer's
+	// own alignment never pushes it past that.
+	if got := unsafe.Offsetof(param.Addrs); got != 8 {
+		t.Errorf("offsetof(Addrs) = %d, want 8", got)
 	}
 }
 

--- a/internal/sctp/dial_linux.go
+++ b/internal/sctp/dial_linux.go
@@ -39,7 +39,7 @@ import (
 var aLongTimeAgo = time.Unix(1, 0)
 
 // dialedEvents matches what serveConn subscribes to. PartialDelivery is
-// required for correctness, not observability: without it the kernel abandons a
+// required for correctness: without it the kernel abandons a
 // partial message silently and the next message is read as its continuation.
 const dialedEvents = sctpEventDataIO | sctpEventShutdown | sctpEventAssociation | sctpEventPartialDelivery
 

--- a/internal/sctp/dial_linux.go
+++ b/internal/sctp/dial_linux.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime"
+	"os"
 	"syscall"
 	"time"
 	"unsafe"
@@ -45,12 +45,21 @@ const dialedEvents = sctpEventDataIO | sctpEventShutdown | sctpEventAssociation 
 
 const assocChangeBufSize = 512
 
+// ErrMissingAddress is returned by Dial when raddr names no address to connect
+// to. It is a sentinel rather than a formatted error because the alternative is
+// silently connecting to the wildcard address.
+var ErrMissingAddress = errors.New("sctp: dial requires a remote address")
+
 // getAddrsOld is struct sctp_getaddrs_old (include/uapi/linux/sctp.h). AddrNum
 // holds the byte length of the packed sockaddr array, not a count of addresses.
+//
+// Addrs is a real pointer rather than a uintptr so the garbage collector tracks
+// the buffer it refers to; a uintptr would be outside the unsafe.Pointer rules
+// and would need pinning by hand. Width and offsets are unchanged.
 type getAddrsOld struct {
 	AssocID int32
 	AddrNum int32
-	Addrs   uintptr
+	Addrs   unsafe.Pointer
 }
 
 // sctpConnect starts the association handshake towards every address in raddr.
@@ -63,19 +72,45 @@ func sctpConnect(fd int, raddr *SCTPAddr) error {
 
 	param := getAddrsOld{
 		AddrNum: int32(len(buf)),
-		Addrs:   uintptr(unsafe.Pointer(&buf[0])),
+		Addrs:   unsafe.Pointer(&buf[0]),
 	}
 
 	// The kernel reads the length with get_user(int, optlen), so it must be a
 	// 4-byte int rather than a uintptr.
 	optlen := int32(unsafe.Sizeof(param))
 
-	err := getsockopt(fd, sctpOptConnectX3, unsafe.Pointer(&param), unsafe.Pointer(&optlen))
+	return getsockopt(fd, sctpOptConnectX3, unsafe.Pointer(&param), unsafe.Pointer(&optlen))
+}
 
-	// param.Addrs is an integer to the collector, so buf is pinned by hand.
-	runtime.KeepAlive(buf)
+// validNetwork reports the network name to use, or an error for one this
+// package does not speak. An empty name means "sctp", matching ResolveSCTPAddr.
+func validNetwork(network string) (string, error) {
+	switch network {
+	case "":
+		return "sctp", nil
+	case "sctp", "sctp4", "sctp6":
+		return network, nil
+	default:
+		return "", net.UnknownNetworkError(network)
+	}
+}
 
-	return err
+// dialError gives every dial failure the shape the net package uses, so callers
+// can classify it with errors.Is or net.Error.Timeout.
+func dialError(network string, laddr, raddr *SCTPAddr, err error) error {
+	opErr := &net.OpError{Op: "dial", Net: network, Err: err}
+
+	// Assigned only when non-nil: a typed-nil in the net.Addr interface would
+	// reach SCTPAddr.String and panic when OpError formats itself.
+	if laddr != nil {
+		opErr.Source = laddr
+	}
+
+	if raddr != nil {
+		opErr.Addr = raddr
+	}
+
+	return opErr
 }
 
 // Dial establishes an SCTP association with raddr, binding to laddr when it is
@@ -84,8 +119,23 @@ func sctpConnect(fd int, raddr *SCTPAddr) error {
 // the kernel retries the INIT, which InitMsg.MaxAttempts and
 // InitMsg.MaxInitTimeout govern.
 func Dial(ctx context.Context, network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTPConn, error) {
+	resolved, err := validNetwork(network)
+	if err != nil {
+		// Reported against the name the caller passed, not the resolved one.
+		return nil, dialError(network, laddr, raddr, err)
+	}
+
+	conn, err := dial(ctx, resolved, laddr, raddr, options)
+	if err != nil {
+		return nil, dialError(resolved, laddr, raddr, err)
+	}
+
+	return conn, nil
+}
+
+func dial(ctx context.Context, network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTPConn, error) {
 	if raddr == nil || len(raddr.IPAddrs) == 0 {
-		return nil, fmt.Errorf("sctp: dial requires a remote address")
+		return nil, ErrMissingAddress
 	}
 
 	af, ipv6only := favoriteAddrFamily(network, laddr, raddr, "dial")
@@ -129,19 +179,20 @@ func Dial(ctx context.Context, network string, laddr, raddr *SCTPAddr, options I
 		}
 	}
 
+	// newSCTPConn owns the descriptor from here whether or not it succeeds.
 	conn := newSCTPConn(sock)
+	ownsSock = false
+
 	if conn == nil {
 		return nil, fmt.Errorf("sctp: could not hand socket to the runtime poller")
 	}
-
-	ownsSock = false
 
 	// Before connecting: the handshake's outcome is one of these events, and the
 	// kernel only generates an event subscribed to at the time it occurs.
 	if err := conn.subscribeEvents(dialedEvents); err != nil {
 		_ = conn.Abort()
 
-		return nil, fmt.Errorf("subscribe events: %w", err)
+		return nil, err
 	}
 
 	if err := conn.connect(ctx, raddr); err != nil {
@@ -149,7 +200,7 @@ func Dial(ctx context.Context, network string, laddr, raddr *SCTPAddr, options I
 		// spend the drain timeout establishing that.
 		_ = conn.Abort()
 
-		return nil, fmt.Errorf("dial %s: %w", raddr.String(), err)
+		return nil, err
 	}
 
 	return conn, nil
@@ -183,20 +234,22 @@ func (c *SCTPConn) connect(ctx context.Context, raddr *SCTPAddr) error {
 
 // awaitAssocChange waits for the kernel to report how the handshake ended.
 //
-// Write readiness cannot be used as the completion signal: sctp_poll marks a
-// socket writable as soon as its send buffer has room, which holds throughout
-// the handshake (net/sctp/socket.c). The outcome arrives instead as an
-// SCTP_ASSOC_CHANGE notification on the receive queue — SCTP_COMM_UP on
-// success, SCTP_CANT_STR_ASSOC when the INIT is aborted or runs out of attempts
-// — which is delivered through sk_data_ready.
+// The outcome arrives as an SCTP_ASSOC_CHANGE notification on the receive queue:
+// SCTP_COMM_UP on success, SCTP_CANT_STR_ASSOC when the INIT is aborted or runs
+// out of attempts (net/sctp/sm_sideeffect.c sctp_cmd_init_failed). Write
+// readiness would also signal completion — sctp_poll suppresses EPOLLOUT while
+// the socket is CLOSED, which covers the whole handshake — but it cannot say
+// why a handshake failed, and the notification can.
 func (c *SCTPConn) awaitAssocChange(ctx context.Context) error {
+	// Cleared unconditionally. The watcher below installs aLongTimeAgo for any
+	// cancellable context, not only one carrying a deadline, and a deadline left
+	// behind on a conn that dialled successfully would fail every later read.
+	defer func() { _ = c.setReadDeadline(time.Time{}) }()
+
 	if deadline, ok := ctx.Deadline(); ok {
 		if err := c.setReadDeadline(deadline); err != nil {
 			return err
 		}
-
-		// Cleared so the deadline cannot expire a later read on the association.
-		defer func() { _ = c.setReadDeadline(time.Time{}) }()
 	}
 
 	if done := ctx.Done(); done != nil {
@@ -213,8 +266,8 @@ func (c *SCTPConn) awaitAssocChange(ctx context.Context) error {
 			}
 		}()
 
-		// Registered after the deadline reset so it runs first, and waits for the
-		// watcher so no deadline can be installed after that reset.
+		// Registered after the reset so it runs first, and waits for the watcher
+		// so no deadline can be installed after that reset.
 		defer func() {
 			close(stop)
 			<-watcherDone
@@ -226,12 +279,7 @@ func (c *SCTPConn) awaitAssocChange(ctx context.Context) error {
 	for {
 		delivery, err := c.readMsgOnce(buf)
 		if err != nil {
-			// A cancelled context unparks the read through the deadline above.
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return ctxErr
-			}
-
-			return err
+			return dialCtxErr(ctx, err)
 		}
 
 		change, ok := delivery.notification.(*SCTPAssocChangeEvent)
@@ -240,11 +288,29 @@ func (c *SCTPConn) awaitAssocChange(ctx context.Context) error {
 		}
 
 		if change.State() == SCTPCommUp {
-			return nil
+			// A cancellation landing as the association comes up still means the
+			// caller no longer wants it (net/fd_unix.go, Go issue 16523).
+			return ctx.Err()
 		}
 
 		return c.assocFailure(change)
 	}
+}
+
+// dialCtxErr reports why the handshake read ended. The read deadline is only
+// ever installed from ctx, so its expiry means ctx is done or about to be: the
+// poller's timer and the context's fire at the same instant and either can win,
+// which would otherwise make the returned error nondeterministic.
+func dialCtxErr(ctx context.Context, err error) error {
+	if ctx.Done() != nil && errors.Is(err, os.ErrDeadlineExceeded) {
+		<-ctx.Done()
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+
+	return err
 }
 
 // assocFailure turns a non-COMM_UP association change into an error, preferring

--- a/internal/sctp/dial_linux.go
+++ b/internal/sctp/dial_linux.go
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+//go:build linux && !386
+
+// Copyright 2019 Wataru Ishida. All rights reserved.
+// Modified by Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sctp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"runtime"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"go.uber.org/zap"
+)
+
+// aLongTimeAgo unparks any goroutine waiting on the descriptor when installed
+// as its deadline.
+var aLongTimeAgo = time.Unix(1, 0)
+
+// dialedEvents matches what serveConn subscribes to. PartialDelivery is
+// required for correctness, not observability: without it the kernel abandons a
+// partial message silently and the next message is read as its continuation.
+const dialedEvents = sctpEventDataIO | sctpEventShutdown | sctpEventAssociation | sctpEventPartialDelivery
+
+const assocChangeBufSize = 512
+
+// getAddrsOld is struct sctp_getaddrs_old (include/uapi/linux/sctp.h). AddrNum
+// holds the byte length of the packed sockaddr array, not a count of addresses.
+type getAddrsOld struct {
+	AssocID int32
+	AddrNum int32
+	Addrs   uintptr
+}
+
+// sctpConnect starts the association handshake towards every address in raddr.
+// On a non-blocking socket it reports EINPROGRESS.
+func sctpConnect(fd int, raddr *SCTPAddr) error {
+	buf := raddr.toRawSockAddrBuf()
+	if len(buf) == 0 {
+		return syscall.EINVAL
+	}
+
+	param := getAddrsOld{
+		AddrNum: int32(len(buf)),
+		Addrs:   uintptr(unsafe.Pointer(&buf[0])),
+	}
+
+	// The kernel reads the length with get_user(int, optlen), so it must be a
+	// 4-byte int rather than a uintptr.
+	optlen := int32(unsafe.Sizeof(param))
+
+	err := getsockopt(fd, sctpOptConnectX3, unsafe.Pointer(&param), unsafe.Pointer(&optlen))
+
+	// param.Addrs is an integer to the collector, so buf is pinned by hand.
+	runtime.KeepAlive(buf)
+
+	return err
+}
+
+// Dial establishes an SCTP association with raddr, binding to laddr when it is
+// non-nil and requesting a multihomed association when laddr names several
+// addresses. ctx bounds the handshake; without a deadline it lasts as long as
+// the kernel retries the INIT, which InitMsg.MaxAttempts and
+// InitMsg.MaxInitTimeout govern.
+func Dial(ctx context.Context, network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTPConn, error) {
+	if raddr == nil || len(raddr.IPAddrs) == 0 {
+		return nil, fmt.Errorf("sctp: dial requires a remote address")
+	}
+
+	af, ipv6only := favoriteAddrFamily(network, laddr, raddr, "dial")
+
+	// SOCK_NONBLOCK makes the handshake asynchronous: the kernel reads O_NONBLOCK
+	// off the socket's file to decide whether connectx waits.
+	sock, err := syscall.Socket(
+		af,
+		syscall.SOCK_STREAM|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC,
+		syscall.IPPROTO_SCTP,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ownsSock := true
+
+	defer func() {
+		if ownsSock {
+			if cerr := syscall.Close(sock); cerr != nil {
+				logger.AmfLog.Warn("failed to close socket", zap.Error(cerr))
+			}
+		}
+	}()
+
+	if err := setDefaultSockopts(sock, af, ipv6only); err != nil {
+		return nil, err
+	}
+
+	if err := setInitOpts(sock, options); err != nil {
+		return nil, err
+	}
+
+	if err := setNoDelay(sock); err != nil {
+		return nil, err
+	}
+
+	if laddr != nil {
+		if err := sctpBind(sock, bindAddr(laddr, af), sctpBindxAddAddr); err != nil {
+			return nil, err
+		}
+	}
+
+	conn := newSCTPConn(sock)
+	if conn == nil {
+		return nil, fmt.Errorf("sctp: could not hand socket to the runtime poller")
+	}
+
+	ownsSock = false
+
+	// Before connecting: the handshake's outcome is one of these events, and the
+	// kernel only generates an event subscribed to at the time it occurs.
+	if err := conn.subscribeEvents(dialedEvents); err != nil {
+		_ = conn.Abort()
+
+		return nil, fmt.Errorf("subscribe events: %w", err)
+	}
+
+	if err := conn.connect(ctx, raddr); err != nil {
+		// Abort: there is no association to shut down gracefully, and Close would
+		// spend the drain timeout establishing that.
+		_ = conn.Abort()
+
+		return nil, fmt.Errorf("dial %s: %w", raddr.String(), err)
+	}
+
+	return conn, nil
+}
+
+// bindAddr substitutes the family's wildcard for an address with no IPs, which
+// bindx cannot express as an empty list. The copy keeps a caller reusing its
+// SCTPAddr across dials from seeing it mutated.
+func bindAddr(laddr *SCTPAddr, af int) *SCTPAddr {
+	if len(laddr.IPAddrs) > 0 {
+		return laddr
+	}
+
+	wildcard := net.IPv4zero
+	if af == syscall.AF_INET6 {
+		wildcard = net.IPv6zero
+	}
+
+	return &SCTPAddr{IPAddrs: []net.IPAddr{{IP: wildcard}}, Port: laddr.Port}
+}
+
+// connect runs the association handshake to completion.
+func (c *SCTPConn) connect(ctx context.Context, raddr *SCTPAddr) error {
+	err := c.controlFd(func(fd int) error { return sctpConnect(fd, raddr) })
+	if err != nil && !errors.Is(err, syscall.EINPROGRESS) {
+		return err
+	}
+
+	return c.awaitAssocChange(ctx)
+}
+
+// awaitAssocChange waits for the kernel to report how the handshake ended.
+//
+// Write readiness cannot be used as the completion signal: sctp_poll marks a
+// socket writable as soon as its send buffer has room, which holds throughout
+// the handshake (net/sctp/socket.c). The outcome arrives instead as an
+// SCTP_ASSOC_CHANGE notification on the receive queue — SCTP_COMM_UP on
+// success, SCTP_CANT_STR_ASSOC when the INIT is aborted or runs out of attempts
+// — which is delivered through sk_data_ready.
+func (c *SCTPConn) awaitAssocChange(ctx context.Context) error {
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := c.setReadDeadline(deadline); err != nil {
+			return err
+		}
+
+		// Cleared so the deadline cannot expire a later read on the association.
+		defer func() { _ = c.setReadDeadline(time.Time{}) }()
+	}
+
+	if done := ctx.Done(); done != nil {
+		stop := make(chan struct{})
+		watcherDone := make(chan struct{})
+
+		go func() {
+			defer close(watcherDone)
+
+			select {
+			case <-done:
+				_ = c.setReadDeadline(aLongTimeAgo)
+			case <-stop:
+			}
+		}()
+
+		// Registered after the deadline reset so it runs first, and waits for the
+		// watcher so no deadline can be installed after that reset.
+		defer func() {
+			close(stop)
+			<-watcherDone
+		}()
+	}
+
+	buf := make([]byte, assocChangeBufSize)
+
+	for {
+		delivery, err := c.readMsgOnce(buf)
+		if err != nil {
+			// A cancelled context unparks the read through the deadline above.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+
+			return err
+		}
+
+		change, ok := delivery.notification.(*SCTPAssocChangeEvent)
+		if !ok {
+			continue
+		}
+
+		if change.State() == SCTPCommUp {
+			return nil
+		}
+
+		return c.assocFailure(change)
+	}
+}
+
+// assocFailure turns a non-COMM_UP association change into an error, preferring
+// the socket's errno: ECONNREFUSED when the peer ABORTs the INIT, ETIMEDOUT
+// when the attempts are exhausted.
+func (c *SCTPConn) assocFailure(change *SCTPAssocChangeEvent) error {
+	var code int
+
+	if err := c.controlFd(func(fd int) error {
+		var err error
+
+		code, err = syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_ERROR)
+
+		return err
+	}); err == nil && code != 0 {
+		return syscall.Errno(code)
+	}
+
+	return fmt.Errorf("sctp: association not established (state %d, error %d)", change.State(), change.Error())
+}

--- a/internal/sctp/dial_test.go
+++ b/internal/sctp/dial_test.go
@@ -1,0 +1,403 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+//go:build linux && !386
+
+package sctp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"reflect"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// dialTestInit keeps the INIT retry budget short.
+var dialTestInit = InitMsg{NumOstreams: 2, MaxInstreams: 2, MaxAttempts: 2, MaxInitTimeout: 1}
+
+// echoStream is non-zero so a reply that lost its ancillary data is
+// distinguishable from one that kept it.
+const echoStream = 1
+
+// echoServer starts a Server on 127.0.0.1:port that echoes every dispatched
+// message straight back to its sender.
+func echoServer(t *testing.T, port int, ppid uint32) *Server {
+	t.Helper()
+
+	srv := NewServer(Config{
+		PPID:   ppid,
+		Name:   "TEST",
+		Logger: zap.NewNop(),
+	}, Callbacks{
+		Dispatch: func(_ context.Context, conn *SCTPConn, msg []byte) {
+			if _, err := conn.WriteMsg(msg, &SndRcvInfo{PPID: PPIDWireOrder(ppid), Stream: echoStream}); err != nil {
+				t.Errorf("echo write: %v", err)
+			}
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := srv.ListenAndServe(ctx, "127.0.0.1", port, ""); err != nil {
+		cancel()
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		srv.Shutdown(context.Background())
+	})
+
+	return srv
+}
+
+// dialLoopback dials 127.0.0.1:port and registers cleanup.
+func dialLoopback(t *testing.T, port int) *SCTPConn {
+	t.Helper()
+
+	raddr, err := ResolveSCTPAddr("sctp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatalf("ResolveSCTPAddr: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "sctp", nil, raddr, dialTestInit)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			t.Logf("client close: %v", err)
+		}
+	})
+
+	return conn
+}
+
+// TestDial_RoundTrip covers the client path end to end: handshake, write to a
+// Server, and a reply with its SCTP metadata intact.
+func TestDial_RoundTrip(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29601
+
+	echoServer(t, port, testPPID)
+
+	conn := dialLoopback(t, port)
+
+	payload := []byte("round-trip")
+	if _, err := conn.WriteMsg(payload, &SndRcvInfo{PPID: PPIDWireOrder(testPPID), Stream: echoStream}); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+
+	if err := conn.setReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+
+	buf := make([]byte, 2048)
+
+	n, info, err := conn.ReadMsg(buf)
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+
+	if string(buf[:n]) != string(payload) {
+		t.Errorf("payload = %q, want %q", buf[:n], payload)
+	}
+
+	if info == nil {
+		t.Fatal("ReadMsg returned no SndRcvInfo; the DATA_IO subscription did not take effect")
+	}
+
+	if got := PPIDWireOrder(info.PPID); got != testPPID {
+		t.Errorf("ppid = %d, want %d", got, testPPID)
+	}
+
+	if info.Stream != echoStream {
+		t.Errorf("stream = %d, want %d", info.Stream, echoStream)
+	}
+}
+
+// TestDial_RemoteAddrResolved verifies the dialled conn knows its peer.
+func TestDial_RemoteAddrResolved(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29602
+
+	echoServer(t, port, testPPID)
+
+	conn := dialLoopback(t, port)
+
+	remote := conn.RemoteAddr()
+	if remote == nil {
+		t.Fatal("RemoteAddr is nil on an established association")
+	}
+
+	want := "127.0.0.1:" + strconv.Itoa(port)
+	if remote.String() != want {
+		t.Errorf("RemoteAddr = %s, want %s", remote, want)
+	}
+}
+
+// TestDial_PeerShutdownReportsEOF verifies ReadMsg turns end-of-association
+// events into io.EOF rather than a zero-length message, which would spin a
+// caller's read loop.
+func TestDial_PeerShutdownReportsEOF(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29603
+
+	srv := echoServer(t, port, testPPID)
+
+	conn := dialLoopback(t, port)
+
+	// Make the server notice the association before shutting it down.
+	if _, err := conn.WriteMsg([]byte("hello"), &SndRcvInfo{PPID: PPIDWireOrder(testPPID)}); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+
+	if err := conn.setReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+
+	buf := make([]byte, 2048)
+	if _, _, err := conn.ReadMsg(buf); err != nil {
+		t.Fatalf("ReadMsg echo: %v", err)
+	}
+
+	srv.Shutdown(context.Background())
+
+	for {
+		_, _, err := conn.ReadMsg(buf)
+		if errors.Is(err, io.EOF) {
+			return
+		}
+
+		if err != nil {
+			t.Fatalf("ReadMsg after peer shutdown = %v, want io.EOF", err)
+		}
+	}
+}
+
+// TestDial_NoListenerFails covers the failure half of the handshake: the peer
+// ABORTs the INIT and SO_ERROR carries the reason.
+func TestDial_NoListenerFails(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	// Nothing listens here; the kernel answers the INIT with an ABORT.
+	raddr, err := ResolveSCTPAddr("sctp", "127.0.0.1:29604")
+	if err != nil {
+		t.Fatalf("ResolveSCTPAddr: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+
+	conn, err := Dial(ctx, "sctp", nil, raddr, dialTestInit)
+	if err == nil {
+		_ = conn.Close()
+
+		t.Fatal("Dial to a port with no listener succeeded")
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("dial hit the context deadline instead of the peer's refusal: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("refused dial took %v; the ABORT should surface immediately", elapsed)
+	}
+}
+
+// TestDial_ContextBoundsUnreachablePeer verifies the context deadline
+// interrupts a handshake in progress. 192.0.2.1 is TEST-NET-1 (RFC 5737), which
+// no host answers; on a machine with no route to it connectx fails immediately
+// instead, so only boundedness is asserted unconditionally.
+func TestDial_ContextBoundsUnreachablePeer(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	raddr, err := ResolveSCTPAddr("sctp", "192.0.2.1:29605")
+	if err != nil {
+		t.Fatalf("ResolveSCTPAddr: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+
+	conn, err := Dial(ctx, "sctp", nil, raddr, InitMsg{NumOstreams: 2, MaxInstreams: 2})
+	if err == nil {
+		_ = conn.Close()
+
+		t.Fatal("Dial to an unreachable peer succeeded")
+	}
+
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Fatalf("Dial was not bounded by the context: took %v", elapsed)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
+	t.Logf("no route to TEST-NET-1; connectx refused early with %v (deadline path not exercised)", err)
+}
+
+// TestDial_RejectsMissingRemote guards against connecting to the wildcard
+// address, which is what toRawSockAddrBuf yields for an empty address.
+func TestDial_RejectsMissingRemote(t *testing.T) {
+	for name, raddr := range map[string]*SCTPAddr{
+		"nil":       nil,
+		"no ip":     {Port: 38412},
+		"empty set": {IPAddrs: []net.IPAddr{}, Port: 38412},
+	} {
+		t.Run(name, func(t *testing.T) {
+			conn, err := Dial(context.Background(), "sctp", nil, raddr, dialTestInit)
+			if err == nil {
+				_ = conn.Close()
+
+				t.Fatal("Dial accepted an address with no remote IP")
+			}
+		})
+	}
+}
+
+func TestResolveSCTPAddr(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		network string
+		address string
+		want    *SCTPAddr
+		wantErr bool
+	}{
+		{
+			name:    "host and port",
+			network: "sctp",
+			address: "127.0.0.1:38412",
+			want:    &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, Port: 38412},
+		},
+		{
+			name:    "empty network defaults to sctp",
+			network: "",
+			address: "127.0.0.1:38412",
+			want:    &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, Port: 38412},
+		},
+		{
+			name:    "multihomed",
+			network: "sctp",
+			address: "127.0.0.1/127.0.0.2:38412",
+			want: &SCTPAddr{
+				IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}, {IP: net.ParseIP("127.0.0.2")}},
+				Port:    38412,
+			},
+		},
+		{
+			name:    "wildcard host",
+			network: "sctp",
+			address: ":38412",
+			want:    &SCTPAddr{IPAddrs: []net.IPAddr{}, Port: 38412},
+		},
+		{
+			name:    "ipv6 literal",
+			network: "sctp6",
+			address: "[::1]:38412",
+			want:    &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("::1")}}, Port: 38412},
+		},
+		{
+			name:    "unknown network",
+			network: "udp",
+			address: "127.0.0.1:38412",
+			wantErr: true,
+		},
+		{
+			name:    "missing port",
+			network: "sctp",
+			address: "127.0.0.1",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveSCTPAddr(tc.network, tc.address)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveSCTPAddr(%q, %q) = %v, want error", tc.network, tc.address, got)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ResolveSCTPAddr(%q, %q): %v", tc.network, tc.address, err)
+			}
+
+			if got.Port != tc.want.Port {
+				t.Errorf("port = %d, want %d", got.Port, tc.want.Port)
+			}
+
+			if len(got.IPAddrs) != len(tc.want.IPAddrs) {
+				t.Fatalf("IPAddrs = %v, want %v", got.IPAddrs, tc.want.IPAddrs)
+			}
+
+			for i := range got.IPAddrs {
+				if !got.IPAddrs[i].IP.Equal(tc.want.IPAddrs[i].IP) {
+					t.Errorf("IPAddrs[%d] = %v, want %v", i, got.IPAddrs[i].IP, tc.want.IPAddrs[i].IP)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveSCTPAddrRoundTrip pins ResolveSCTPAddr as the inverse of
+// SCTPAddr.String.
+func TestResolveSCTPAddrRoundTrip(t *testing.T) {
+	for _, addr := range []*SCTPAddr{
+		{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, Port: 38412},
+		{IPAddrs: []net.IPAddr{{IP: net.ParseIP("10.0.0.1")}, {IP: net.ParseIP("10.0.0.2")}}, Port: 36412},
+		{IPAddrs: []net.IPAddr{{IP: net.ParseIP("::1")}}, Port: 38412},
+	} {
+		t.Run(addr.String(), func(t *testing.T) {
+			got, err := ResolveSCTPAddr("sctp", addr.String())
+			if err != nil {
+				t.Fatalf("ResolveSCTPAddr(%q): %v", addr.String(), err)
+			}
+
+			if got.String() != addr.String() {
+				t.Errorf("round trip = %s, want %s", got, addr)
+			}
+		})
+	}
+}
+
+// TestBindAddrDoesNotMutateCaller pins the copy-on-wildcard behaviour: the
+// tester reuses one local SCTPAddr across every dial and reconnect.
+func TestBindAddrDoesNotMutateCaller(t *testing.T) {
+	laddr := &SCTPAddr{Port: 38412}
+
+	got := bindAddr(laddr, syscall.AF_INET)
+	if len(laddr.IPAddrs) != 0 {
+		t.Errorf("bindAddr mutated the caller's address: %v", laddr.IPAddrs)
+	}
+
+	want := []net.IPAddr{{IP: net.IPv4zero}}
+	if !reflect.DeepEqual(got.IPAddrs, want) {
+		t.Errorf("bind address = %v, want %v", got.IPAddrs, want)
+	}
+
+	explicit := &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("10.0.0.1")}}, Port: 38412}
+	if bindAddr(explicit, syscall.AF_INET) != explicit {
+		t.Error("bindAddr copied an address that already had IPs")
+	}
+}

--- a/internal/sctp/dial_test.go
+++ b/internal/sctp/dial_test.go
@@ -9,8 +9,10 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -27,16 +29,16 @@ const echoStream = 1
 
 // echoServer starts a Server on 127.0.0.1:port that echoes every dispatched
 // message straight back to its sender.
-func echoServer(t *testing.T, port int, ppid uint32) *Server {
+func echoServer(t *testing.T, port int) *Server {
 	t.Helper()
 
 	srv := NewServer(Config{
-		PPID:   ppid,
+		PPID:   testPPID,
 		Name:   "TEST",
 		Logger: zap.NewNop(),
 	}, Callbacks{
 		Dispatch: func(_ context.Context, conn *SCTPConn, msg []byte) {
-			if _, err := conn.WriteMsg(msg, &SndRcvInfo{PPID: PPIDWireOrder(ppid), Stream: echoStream}); err != nil {
+			if _, err := conn.WriteMsg(msg, &SndRcvInfo{PPID: PPIDWireOrder(testPPID), Stream: echoStream}); err != nil {
 				t.Errorf("echo write: %v", err)
 			}
 		},
@@ -51,7 +53,11 @@ func echoServer(t *testing.T, port int, ppid uint32) *Server {
 
 	t.Cleanup(func() {
 		cancel()
-		srv.Shutdown(context.Background())
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+
+		srv.Shutdown(shutdownCtx)
 	})
 
 	return srv
@@ -90,7 +96,7 @@ func TestDial_RoundTrip(t *testing.T) {
 
 	const port = 29601
 
-	echoServer(t, port, testPPID)
+	echoServer(t, port)
 
 	conn := dialLoopback(t, port)
 
@@ -133,7 +139,7 @@ func TestDial_RemoteAddrResolved(t *testing.T) {
 
 	const port = 29602
 
-	echoServer(t, port, testPPID)
+	echoServer(t, port)
 
 	conn := dialLoopback(t, port)
 
@@ -156,7 +162,7 @@ func TestDial_PeerShutdownReportsEOF(t *testing.T) {
 
 	const port = 29603
 
-	srv := echoServer(t, port, testPPID)
+	srv := echoServer(t, port)
 
 	conn := dialLoopback(t, port)
 
@@ -174,7 +180,10 @@ func TestDial_PeerShutdownReportsEOF(t *testing.T) {
 		t.Fatalf("ReadMsg echo: %v", err)
 	}
 
-	srv.Shutdown(context.Background())
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+
+	srv.Shutdown(shutdownCtx)
 
 	for {
 		_, _, err := conn.ReadMsg(buf)
@@ -215,6 +224,16 @@ func TestDial_NoListenerFails(t *testing.T) {
 		t.Fatalf("dial hit the context deadline instead of the peer's refusal: %v", err)
 	}
 
+	// The kernel's ABORT reaches the caller as an errno, not as a bare failure.
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Errorf("err = %v, want ECONNREFUSED", err)
+	}
+
+	var netErr net.Error
+	if !errors.As(err, &netErr) {
+		t.Errorf("err %v (%T) does not satisfy net.Error", err, err)
+	}
+
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Errorf("refused dial took %v; the ABORT should surface immediately", elapsed)
 	}
@@ -253,6 +272,12 @@ func TestDial_ContextBoundsUnreachablePeer(t *testing.T) {
 		return
 	}
 
+	// Only an immediate failure can be the no-route case; anything that ran to
+	// the deadline must report the deadline.
+	if elapsed > 50*time.Millisecond {
+		t.Fatalf("dial ran for %v then failed with %v, want context.DeadlineExceeded", elapsed, err)
+	}
+
 	t.Logf("no route to TEST-NET-1; connectx refused early with %v (deadline path not exercised)", err)
 }
 
@@ -265,11 +290,23 @@ func TestDial_RejectsMissingRemote(t *testing.T) {
 		"empty set": {IPAddrs: []net.IPAddr{}, Port: 38412},
 	} {
 		t.Run(name, func(t *testing.T) {
+			start := time.Now()
+
 			conn, err := Dial(context.Background(), "sctp", nil, raddr, dialTestInit)
 			if err == nil {
 				_ = conn.Close()
 
 				t.Fatal("Dial accepted an address with no remote IP")
+			}
+
+			// Without the guard the wildcard sockaddr dials localhost, which also
+			// fails — but only after a round trip, and with a different error.
+			if !errors.Is(err, ErrMissingAddress) {
+				t.Errorf("err = %v, want ErrMissingAddress", err)
+			}
+
+			if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+				t.Errorf("rejected in %v; the guard should not reach the network", elapsed)
 			}
 		})
 	}
@@ -400,4 +437,294 @@ func TestBindAddrDoesNotMutateCaller(t *testing.T) {
 	if bindAddr(explicit, syscall.AF_INET) != explicit {
 		t.Error("bindAddr copied an address that already had IPs")
 	}
+}
+
+// TestDial_BoundToLocalAddress exercises the bind path every production caller
+// uses: the association must come up sourced from the address named in laddr.
+func TestDial_BoundToLocalAddress(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29606
+
+	echoServer(t, port)
+
+	laddr := &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.2")}}}
+	raddr := &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, Port: port}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "sctp", laddr, raddr, dialTestInit)
+	if err != nil {
+		t.Fatalf("Dial from %s: %v", laddr, err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	local := conn.LocalAddr()
+	if local == nil {
+		t.Fatal("LocalAddr is nil on an established association")
+	}
+
+	if !strings.HasPrefix(local.String(), "127.0.0.2:") {
+		t.Errorf("LocalAddr = %s, want a 127.0.0.2 source", local)
+	}
+}
+
+// TestDial_Multihomed exercises the reason sctpConnect packs a list of
+// sockaddrs at all: bindx and connectx both take every address at once.
+func TestDial_Multihomed(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29607
+
+	srv := NewServer(Config{PPID: testPPID, Name: "TEST", Logger: zap.NewNop()},
+		Callbacks{Dispatch: func(context.Context, *SCTPConn, []byte) {}})
+
+	// Listening on the wildcard so the server answers on both loopback aliases.
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+
+	if err := srv.ListenAndServe(srvCtx, "0.0.0.0", port, ""); err != nil {
+		srvCancel()
+		t.Fatalf("ListenAndServe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		srvCancel()
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+
+		srv.Shutdown(shutdownCtx)
+	})
+
+	laddr := &SCTPAddr{IPAddrs: []net.IPAddr{
+		{IP: net.ParseIP("127.0.0.2")},
+		{IP: net.ParseIP("127.0.0.3")},
+	}}
+
+	raddr, err := ResolveSCTPAddr("sctp", "127.0.0.1:"+strconv.Itoa(port))
+	if err != nil {
+		t.Fatalf("ResolveSCTPAddr: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "sctp", laddr, raddr, dialTestInit)
+	if err != nil {
+		t.Fatalf("multihomed Dial: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	// Both bound addresses should show up in the association's local set.
+	local := conn.LocalAddr()
+	if local == nil {
+		t.Fatal("LocalAddr is nil")
+	}
+
+	for _, want := range []string{"127.0.0.2", "127.0.0.3"} {
+		if !strings.Contains(local.String(), want) {
+			t.Errorf("LocalAddr = %s, missing bound address %s", local, want)
+		}
+	}
+}
+
+// TestDial_IPv6 covers the AF_INET6 path through favoriteAddrFamily and bindx.
+func TestDial_IPv6(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29608
+
+	srv := NewServer(Config{PPID: testPPID, Name: "TEST", Logger: zap.NewNop()},
+		Callbacks{Dispatch: func(context.Context, *SCTPConn, []byte) {}})
+
+	srvCtx, srvCancel := context.WithCancel(context.Background())
+
+	if err := srv.ListenAndServe(srvCtx, "::1", port, ""); err != nil {
+		srvCancel()
+		t.Skipf("no IPv6 loopback listener: %v", err)
+	}
+
+	t.Cleanup(func() {
+		srvCancel()
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+
+		srv.Shutdown(shutdownCtx)
+	})
+
+	raddr, err := ResolveSCTPAddr("sctp6", "[::1]:"+strconv.Itoa(port))
+	if err != nil {
+		t.Fatalf("ResolveSCTPAddr: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "sctp6", nil, raddr, dialTestInit)
+	if err != nil {
+		t.Fatalf("Dial over IPv6: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	if remote := conn.RemoteAddr(); remote == nil || !strings.Contains(remote.String(), "::1") {
+		t.Errorf("RemoteAddr = %v, want ::1", remote)
+	}
+}
+
+// TestDial_CancelDoesNotPoisonConn covers Go issue 16523: a cancellation racing
+// the handshake must never yield a conn whose reads are already expired.
+//
+// The cancel is jittered across the handshake window, so some iterations cancel
+// before the association comes up (Dial fails, which is fine) and some land
+// just after (Dial must then either fail or return a usable conn).
+func TestDial_CancelDoesNotPoisonConn(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const cancelDialAttempts = 400
+
+	const port = 29609
+
+	echoServer(t, port)
+
+	raddr := &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, Port: port}
+
+	dialed := 0
+
+	for i := 0; i < cancelDialAttempts; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func(delay time.Duration) {
+			time.Sleep(delay)
+			cancel()
+		}(time.Duration(i%50) * time.Microsecond)
+
+		conn, err := Dial(ctx, "sctp", nil, raddr, dialTestInit)
+		if err != nil {
+			cancel()
+			continue
+		}
+
+		dialed++
+
+		// Bounce a message off the echo server rather than reading blind: a
+		// healthy conn answers in microseconds and a poisoned one fails just as
+		// fast with a deadline error, so neither outcome parks the test. Setting
+		// a read deadline here instead would clear the very poison being looked
+		// for.
+		if _, werr := conn.WriteMsg([]byte("ping"), &SndRcvInfo{PPID: PPIDWireOrder(testPPID)}); werr != nil {
+			_ = conn.Close()
+
+			cancel()
+
+			continue
+		}
+
+		_, _, rerr := conn.ReadMsg(make([]byte, 256))
+
+		_ = conn.Close()
+
+		cancel()
+
+		if rerr != nil && errors.Is(rerr, os.ErrDeadlineExceeded) {
+			t.Fatalf("iteration %d: Dial returned a conn with an expired read deadline", i)
+		}
+	}
+
+	t.Logf("%d/%d dials completed before cancellation", dialed, cancelDialAttempts)
+}
+
+// TestDial_ClearsReadDeadline pins that a dial's own deadline does not outlive
+// it. Deliberately does not set a read deadline of its own, which would mask a
+// stale one.
+func TestDial_ClearsReadDeadline(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29610
+
+	echoServer(t, port)
+
+	raddr := &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, Port: port}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	conn, err := Dial(ctx, "sctp", nil, raddr, dialTestInit)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	// Outlive the dial's deadline before using the association.
+	time.Sleep(600 * time.Millisecond)
+
+	if _, err := conn.WriteMsg([]byte("after"), &SndRcvInfo{PPID: PPIDWireOrder(testPPID)}); err != nil {
+		t.Fatalf("WriteMsg after the dial deadline passed: %v", err)
+	}
+
+	done := make(chan error, 1)
+
+	go func() {
+		_, _, rerr := conn.ReadMsg(make([]byte, 2048))
+		done <- rerr
+	}()
+
+	select {
+	case rerr := <-done:
+		if rerr != nil && errors.Is(rerr, os.ErrDeadlineExceeded) {
+			t.Fatalf("read failed with the dial's deadline: %v", rerr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("read never returned")
+	}
+}
+
+// TestDial_RejectsUnknownNetwork covers the network-name guard, which stands
+// between an unvalidated string and an out-of-range index in
+// favoriteAddrFamily.
+func TestDial_RejectsUnknownNetwork(t *testing.T) {
+	raddr := &SCTPAddr{IPAddrs: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, Port: 29611}
+
+	conn, err := Dial(context.Background(), "tcp", nil, raddr, dialTestInit)
+	if err == nil {
+		_ = conn.Close()
+
+		t.Fatal("Dial accepted network \"tcp\"")
+	}
+
+	var unknown net.UnknownNetworkError
+	if !errors.As(err, &unknown) {
+		t.Errorf("err = %v (%T), want net.UnknownNetworkError", err, err)
+	}
+}
+
+// TestDial_EmptyNetworkMatchesResolve pins the two halves of the API to the same
+// contract: ResolveSCTPAddr documents "" as sctp, so Dial must not reject or
+// crash on it.
+func TestDial_EmptyNetworkMatchesResolve(t *testing.T) {
+	skipIfNoSCTP(t)
+
+	const port = 29612
+
+	echoServer(t, port)
+
+	raddr, err := ResolveSCTPAddr("", "127.0.0.1:"+strconv.Itoa(port))
+	if err != nil {
+		t.Fatalf("ResolveSCTPAddr: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "", nil, raddr, dialTestInit)
+	if err != nil {
+		t.Fatalf("Dial with an empty network: %v", err)
+	}
+
+	_ = conn.Close()
 }

--- a/internal/sctp/sctp.go
+++ b/internal/sctp/sctp.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -75,6 +76,7 @@ const (
 	sctpOptBindxRem      = 101
 	sctpOptGetPeerAddrs  = 108
 	sctpOptGetLocalAddrs = 109
+	sctpOptConnectX3     = 111
 )
 
 const (
@@ -327,6 +329,53 @@ func (a *SCTPAddr) String() string {
 }
 
 func (a *SCTPAddr) Network() string { return "sctp" }
+
+// ResolveSCTPAddr parses "host:port", or "host1/host2/...:port" for a
+// multihomed association — the inverse of SCTPAddr.String. Only the final
+// element carries the port.
+func ResolveSCTPAddr(network, address string) (*SCTPAddr, error) {
+	var tcpNet string
+
+	// SCTP shares TCP's address syntax, so parsing is delegated to the resolver.
+	switch network {
+	case "", "sctp":
+		tcpNet = "tcp"
+	case "sctp4":
+		tcpNet = "tcp4"
+	case "sctp6":
+		tcpNet = "tcp6"
+	default:
+		return nil, fmt.Errorf("sctp: unknown network %q", network)
+	}
+
+	elems := strings.Split(address, "/")
+	last := len(elems) - 1
+
+	ipAddrs := make([]net.IPAddr, 0, len(elems))
+
+	// The leading elements are bare hosts; ResolveTCPAddr requires a port.
+	for _, host := range elems[:last] {
+		addr, err := net.ResolveTCPAddr(tcpNet, host+":0")
+		if err != nil {
+			return nil, err
+		}
+
+		ipAddrs = append(ipAddrs, net.IPAddr{IP: addr.IP, Zone: addr.Zone})
+	}
+
+	addr, err := net.ResolveTCPAddr(tcpNet, elems[last])
+	if err != nil {
+		return nil, err
+	}
+
+	// An omitted host means the wildcard, which SCTPAddr represents as an empty
+	// list rather than an entry with a nil IP.
+	if addr.IP != nil {
+		ipAddrs = append(ipAddrs, net.IPAddr{IP: addr.IP, Zone: addr.Zone})
+	}
+
+	return &SCTPAddr{IPAddrs: ipAddrs, Port: addr.Port}, nil
+}
 
 func sctpBind(fd int, addr *SCTPAddr, flags int) error {
 	var option uintptr

--- a/internal/sctp/sctp.go
+++ b/internal/sctp/sctp.go
@@ -444,6 +444,9 @@ func newSCTPConn(fd int) *SCTPConn {
 
 	f := os.NewFile(uintptr(fd), "sctp")
 	if f == nil {
+		// Ownership was taken regardless, so the caller must not close as well.
+		_ = syscall.Close(fd)
+
 		return nil
 	}
 
@@ -566,7 +569,9 @@ func sctpGetAddrs(fd, id, optname int) (*SCTPAddr, error) {
 	param := getaddrs{
 		assocID: int32(id),
 	}
-	optlen := unsafe.Sizeof(param)
+
+	// A 4-byte int, for the reason sctpConnect documents.
+	optlen := int32(unsafe.Sizeof(param))
 
 	err := getsockopt(fd, uintptr(optname), unsafe.Pointer(&param), unsafe.Pointer(&optlen))
 	if err != nil {

--- a/internal/sctp/sctp_linux.go
+++ b/internal/sctp/sctp_linux.go
@@ -271,6 +271,32 @@ func (c *SCTPConn) readMsg(b []byte) (int, *SndRcvInfo, Notification, error) {
 	return reassemble(c.readMsgOnce, b)
 }
 
+// ReadMsg reads one complete message into b and returns its SCTP receive
+// metadata. Events are consumed rather than surfaced; one that ends the
+// association reports io.EOF. Server instead dispatches them via readMsg.
+func (c *SCTPConn) ReadMsg(b []byte) (int, *SndRcvInfo, error) {
+	for {
+		n, info, notification, err := c.readMsg(b)
+		if err != nil {
+			return n, info, err
+		}
+
+		if notification == nil {
+			return n, info, nil
+		}
+
+		switch event := notification.(type) {
+		case *SCTPShutdownEventNotification:
+			return 0, nil, io.EOF
+		case *SCTPAssocChangeEvent:
+			switch event.State() {
+			case SCTPCommLost, SCTPShutdownComp, SCTPCantStrAssoc:
+				return 0, nil, io.EOF
+			}
+		}
+	}
+}
+
 func reassemble(read func([]byte) (delivery, error), b []byte) (int, *SndRcvInfo, Notification, error) {
 	total := 0
 

--- a/internal/sctp/sctp_linux.go
+++ b/internal/sctp/sctp_linux.go
@@ -22,6 +22,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -85,7 +86,16 @@ func (r listenRawConn) Write(func(fd uintptr) (done bool)) error {
 	return fmt.Errorf("sctp: Write not supported on a listener control connection")
 }
 
-// On an accepted association only the writer goroutine calls writeMsgSync.
+// retryableIO reports an error that means "nothing happened, go round again":
+// EAGAIN once the poller reports readiness, and EINTR when a signal arrives
+// mid-syscall, which acceptWouldBlock treats the same way.
+func retryableIO(err error) bool {
+	return errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EINTR)
+}
+
+// writeMsgSync sends one message. Accepted associations funnel through the
+// writer goroutine; dialled ones call it from the caller's goroutine, which is
+// safe because RawConn.Write serialises on the descriptor's write lock.
 func (c *SCTPConn) writeMsgSync(b []byte, info *SndRcvInfo) (int, error) {
 	if c.rc == nil {
 		return 0, syscall.EBADF
@@ -111,7 +121,7 @@ func (c *SCTPConn) writeMsgSync(b []byte, info *SndRcvInfo) (int, error) {
 
 	werr := c.rc.Write(func(fd uintptr) bool {
 		n, err = syscall.SendmsgN(int(fd), b, cbuf, nil, 0)
-		return err != syscall.EAGAIN
+		return !retryableIO(err)
 	})
 	if werr != nil {
 		return 0, werr
@@ -230,7 +240,7 @@ func (c *SCTPConn) readMsgOnce(b []byte) (delivery, error) {
 
 	rerr := c.rc.Read(func(fd uintptr) bool {
 		n, oobn, recvflags, _, err = syscall.Recvmsg(int(fd), b, oob[:], 0)
-		return err != syscall.EAGAIN
+		return !retryableIO(err)
 	})
 	if rerr != nil {
 		return delivery{}, rerr
@@ -290,7 +300,12 @@ func (c *SCTPConn) ReadMsg(b []byte) (int, *SndRcvInfo, error) {
 			return 0, nil, io.EOF
 		case *SCTPAssocChangeEvent:
 			switch event.State() {
-			case SCTPCommLost, SCTPShutdownComp, SCTPCantStrAssoc:
+			// SCTPRestart belongs here: the peer re-INITed the same 5-tuple and
+			// the kernel swapped the TCB underneath, so every stream, TSN and
+			// piece of application state on the old association is gone
+			// (net/sctp/sm_statefuns.c sctp_sf_do_dupcook_a). Continuing to read
+			// would hand the caller a different association's traffic.
+			case SCTPCommLost, SCTPShutdownComp, SCTPCantStrAssoc, SCTPRestart:
 				return 0, nil, io.EOF
 			}
 		}
@@ -560,9 +575,9 @@ func (ln *sctpListener) Accept() (*SCTPConn, error) {
 		return nil, ln.acceptErr(err)
 	}
 
+	// newSCTPConn owns newFd whether or not it succeeds.
 	conn := newSCTPConn(newFd)
 	if conn == nil {
-		_ = syscall.Close(newFd)
 		return nil, fmt.Errorf("failed to wrap accepted fd %d", newFd)
 	}
 

--- a/internal/sctp/writer_test.go
+++ b/internal/sctp/writer_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
 	"runtime"
 	"syscall"
 	"testing"
@@ -241,10 +242,21 @@ func TestWriter_WriteDeadlineFailsAssociation(t *testing.T) {
 	// Stay well under writeQueueDepth so the deadline, not queue overflow, is
 	// what fails the association.
 	payload := make([]byte, 4096)
+
 	for i := 0; i < 16; i++ {
-		if _, err := serverConn.WriteMsg(payload, &SndRcvInfo{PPID: PPIDWireOrder(testPPID), Stream: 0}); err != nil {
-			t.Fatalf("enqueue %d: %v", i, err)
+		_, err := serverConn.WriteMsg(payload, &SndRcvInfo{PPID: PPIDWireOrder(testPPID), Stream: 0})
+		if err == nil {
+			continue
 		}
+
+		// The writer goroutine can abort mid-loop — that is the outcome under
+		// test, so stop enqueuing rather than failing on it. Anything else is a
+		// real error.
+		if errors.Is(err, net.ErrClosed) {
+			break
+		}
+
+		t.Fatalf("enqueue %d: %v", i, err)
 	}
 
 	select {

--- a/internal/tester/enb/server.go
+++ b/internal/tester/enb/server.go
@@ -4,16 +4,22 @@
 package enb
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
+	"time"
 
+	"github.com/ellanetworks/core/internal/sctp"
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/logger"
 	"github.com/ellanetworks/core/ngap"
-	"github.com/ishidawataru/sctp"
 	"go.uber.org/zap"
 )
+
+// n2DialTimeout bounds the handshake so a core that never answers the INIT
+// fails start-up instead of hanging.
+const n2DialTimeout = 2 * time.Second
 
 type NgeNB struct {
 	*gnb.GnodeB
@@ -44,18 +50,17 @@ func Start(
 		},
 	}
 
-	n2Conn, err := sctp.DialSCTPExt(
+	dialCtx, cancel := context.WithTimeout(context.Background(), n2DialTimeout)
+	defer cancel()
+
+	n2Conn, err := sctp.Dial(
+		dialCtx,
 		"sctp",
 		localAddr,
 		rem,
 		sctp.InitMsg{NumOstreams: 2, MaxInstreams: 2})
 	if err != nil {
 		return nil, fmt.Errorf("could not dial SCTP: %w", err)
-	}
-
-	err = n2Conn.SubscribeEvents(sctp.SCTP_EVENT_DATA_IO)
-	if err != nil {
-		return nil, fmt.Errorf("could not subscribe SCTP events: %w", err)
 	}
 
 	var (

--- a/internal/tester/gnb/send.go
+++ b/internal/tester/gnb/send.go
@@ -6,8 +6,8 @@ package gnb
 import (
 	"fmt"
 
+	"github.com/ellanetworks/core/internal/sctp"
 	"github.com/ellanetworks/core/internal/tester/logger"
-	"github.com/ishidawataru/sctp"
 	"go.uber.org/zap"
 )
 
@@ -216,14 +216,6 @@ func writeToConn(conn *sctp.SCTPConn, packet []byte, msgType NGAPProcedure) erro
 		return fmt.Errorf("ran conn is nil")
 	}
 
-	// Deliberately no RemoteAddr() pre-check. SCTPConn.RemoteAddr converts an
-	// unsafe.Pointer to uintptr and passes it through an intermediate Go
-	// function before it reaches syscall.Syscall6, which only pins the buffer
-	// when the conversion appears directly in the syscall argument list. When
-	// entering that function grows the goroutine stack, the kernel writes the
-	// peer addresses to the abandoned stack, the address count stays zero and
-	// RemoteAddr reports nil for a perfectly healthy association. SCTPWrite
-	// below surfaces a genuinely unusable association with the real errno.
 	sid, err := getSCTPStreamID(msgType)
 	if err != nil {
 		return fmt.Errorf("could not determine SCTP stream ID from NGAP message type (%s): %s", msgType, err.Error())
@@ -235,10 +227,10 @@ func writeToConn(conn *sctp.SCTPConn, packet []byte, msgType NGAPProcedure) erro
 
 	info := sctp.SndRcvInfo{
 		Stream: sid,
-		PPID:   ngapPPID,
+		PPID:   sctp.PPIDWireOrder(ngapPPID),
 	}
 
-	if _, err := conn.SCTPWrite(packet, &info); err != nil {
+	if _, err := conn.WriteMsg(packet, &info); err != nil {
 		return fmt.Errorf("send write to sctp connection: %s", err.Error())
 	}
 

--- a/internal/tester/gnb/server.go
+++ b/internal/tester/gnb/server.go
@@ -14,10 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ellanetworks/core/internal/sctp"
 	"github.com/ellanetworks/core/internal/tester/air"
 	"github.com/ellanetworks/core/internal/tester/logger"
 	"github.com/ellanetworks/core/ngap"
-	"github.com/ishidawataru/sctp"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/zap"
 )
@@ -27,6 +27,9 @@ const (
 
 	n2DialAttempts = 5
 	n2DialBackoff  = 200 * time.Millisecond
+	// n2DialTimeout bounds one handshake so a core that never answers the INIT
+	// cannot stall the failover below.
+	n2DialTimeout = 2 * time.Second
 )
 
 // dialN2 establishes the N2 SCTP association, retrying with a fresh socket on
@@ -37,10 +40,7 @@ func dialN2(local, rem *sctp.SCTPAddr, address string) (*sctp.SCTPConn, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < n2DialAttempts; attempt++ {
-		conn, err := sctp.DialSCTPExt(
-			"sctp", local, rem,
-			sctp.InitMsg{NumOstreams: 2, MaxInstreams: 2},
-		)
+		conn, err := dialN2Once(local, rem)
 		if err == nil {
 			return conn, nil
 		}
@@ -55,15 +55,20 @@ func dialN2(local, rem *sctp.SCTPAddr, address string) (*sctp.SCTPConn, error) {
 	return nil, fmt.Errorf("dial %s: %w", address, lastErr)
 }
 
+// dialN2Once performs a single bounded handshake attempt.
+func dialN2Once(local, rem *sctp.SCTPAddr) (*sctp.SCTPConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), n2DialTimeout)
+	defer cancel()
+
+	return sctp.Dial(ctx, "sctp", local, rem, sctp.InitMsg{NumOstreams: 2, MaxInstreams: 2})
+}
+
+// ngapPPID is the SCTP payload protocol identifier for NGAP (TS 38.412), in
+// host order; sctp.PPIDWireOrder byte-swaps it at each write.
+const ngapPPID uint32 = 60
+
 // ErrNoActivePeer indicates no N2 peer is currently usable. Returned by
 // SendToRan when every configured peer has failed.
-// ngapPPID is the SCTP payload protocol identifier for NGAP (60, TS 38.412),
-// pre-encoded in network byte order the way the SCTP socket layer expects. The
-// pinned ishidawataru/sctp release writes SndRcvInfo.PPID verbatim, so the
-// value must already be byte-swapped; the AMF converts it back with
-// sctp.PPIDWireOrder. internal/tester/s1enb declares its S1AP PPID the same way.
-const ngapPPID uint32 = 0x3c000000
-
 var ErrNoActivePeer = errors.New("gnb: no active N2 peer")
 
 // ErrNoRotationCandidate indicates RotateToNextPeer was called but no other
@@ -531,13 +536,6 @@ func (g *GnodeB) n2DialAndActivateLocked(idx int) error {
 		return err
 	}
 
-	if err := conn.SubscribeEvents(sctp.SCTP_EVENT_DATA_IO); err != nil {
-		_ = conn.Close()
-		peer.state = n2StateFailed
-
-		return fmt.Errorf("subscribe SCTP events on %s: %w", peer.address, err)
-	}
-
 	peer.conn = conn
 	peer.state = n2StateActive
 	g.n2Active = idx
@@ -583,7 +581,7 @@ func (g *GnodeB) runReceiver(idx int, conn *sctp.SCTPConn) {
 	buf := make([]byte, SCTPReadBufferSize)
 
 	for {
-		n, info, err := conn.SCTPRead(buf)
+		n, info, err := conn.ReadMsg(buf)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				logger.GnbLogger.Debug("SCTP peer closed (EOF)", zap.Int("peer", idx))

--- a/internal/tester/gnb/server.go
+++ b/internal/tester/gnb/server.go
@@ -34,9 +34,10 @@ const (
 
 // dialN2 establishes the N2 SCTP association, retrying with a fresh socket on
 // transient connect failures (e.g. EISCONN from a lingering association left by
-// a prior gNB process on the same source address). Bounded so a genuinely
-// unreachable core still fails within ~2s.
-func dialN2(local, rem *sctp.SCTPAddr, address string) (*sctp.SCTPConn, error) {
+// a prior gNB process on the same source address). Each attempt is bounded by
+// n2DialTimeout, so an unreachable core fails the whole loop in ~12s rather
+// than hanging on the kernel's INIT retries.
+func dialN2(local, rem *sctp.SCTPAddr) (*sctp.SCTPConn, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < n2DialAttempts; attempt++ {
@@ -52,7 +53,7 @@ func dialN2(local, rem *sctp.SCTPAddr, address string) (*sctp.SCTPConn, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("dial %s: %w", address, lastErr)
+	return nil, fmt.Errorf("%d attempts: %w", n2DialAttempts, lastErr)
 }
 
 // dialN2Once performs a single bounded handshake attempt.
@@ -530,7 +531,7 @@ func (g *GnodeB) n2DialAndActivateLocked(idx int) error {
 		return fmt.Errorf("resolve %s: %w", peer.address, err)
 	}
 
-	conn, err := dialN2(g.n2Local, rem, peer.address)
+	conn, err := dialN2(g.n2Local, rem)
 	if err != nil {
 		peer.state = n2StateFailed
 		return err

--- a/internal/tester/s1enb/server.go
+++ b/internal/tester/s1enb/server.go
@@ -18,17 +18,19 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ellanetworks/core/internal/sctp"
 	"github.com/ellanetworks/core/internal/tester/logger"
 	"github.com/ellanetworks/core/s1ap"
-	"github.com/ishidawataru/sctp"
 	"go.uber.org/zap"
 )
 
-// s1apPPID is the SCTP payload protocol identifier for S1AP (18, TS 36.412),
-// pre-encoded in network byte order the way the SCTP socket layer expects. The pinned
-// ishidawataru/sctp release writes SndRcvInfo.PPID verbatim, so the value must
-// already be byte-swapped; the MME converts it back with sctp.PPIDWireOrder.
-const s1apPPID uint32 = 0x12000000
+// s1apPPID is the SCTP payload protocol identifier for S1AP (TS 36.412), in
+// host order; sctp.PPIDWireOrder byte-swaps it at each write.
+const s1apPPID uint32 = 18
+
+// s1DialTimeout bounds one handshake so an MME that never answers the INIT
+// cannot stall the failover to the next peer.
+const s1DialTimeout = 2 * time.Second
 
 // ErrNoActiveMME indicates no S1-MME peer is usable. Returned by
 // SendMessage when every configured peer has failed.
@@ -272,17 +274,13 @@ func (e *ENB) dialAndActivateLocked(idx int) error {
 		return fmt.Errorf("resolve %s: %w", peer.address, err)
 	}
 
-	conn, err := sctp.DialSCTPExt("sctp", e.mmeLocal, rem, sctp.InitMsg{NumOstreams: 2, MaxInstreams: 2})
+	dialCtx, cancel := context.WithTimeout(context.Background(), s1DialTimeout)
+	defer cancel()
+
+	conn, err := sctp.Dial(dialCtx, "sctp", e.mmeLocal, rem, sctp.InitMsg{NumOstreams: 2, MaxInstreams: 2})
 	if err != nil {
 		peer.state = mmeStateFailed
 		return fmt.Errorf("dial %s: %w", peer.address, err)
-	}
-
-	if err := conn.SubscribeEvents(sctp.SCTP_EVENT_DATA_IO); err != nil {
-		_ = conn.Close()
-		peer.state = mmeStateFailed
-
-		return fmt.Errorf("subscribe SCTP events on %s: %w", peer.address, err)
 	}
 
 	peer.conn = conn
@@ -487,7 +485,7 @@ func writeMessage(conn *sctp.SCTPConn, pdu []byte, ueAssociated bool) error {
 		stream = 1
 	}
 
-	if _, err := conn.SCTPWrite(pdu, &sctp.SndRcvInfo{Stream: stream, PPID: s1apPPID}); err != nil {
+	if _, err := conn.WriteMsg(pdu, &sctp.SndRcvInfo{Stream: stream, PPID: sctp.PPIDWireOrder(s1apPPID)}); err != nil {
 		return fmt.Errorf("s1enb: SCTP write: %w", err)
 	}
 
@@ -570,7 +568,7 @@ func (e *ENB) runReceiver(idx int, conn *sctp.SCTPConn) {
 	buf := make([]byte, 65535)
 
 	for {
-		n, info, err := conn.SCTPRead(buf)
+		n, info, err := conn.ReadMsg(buf)
 		if err != nil {
 			e.promoteNextFromReceiver(idx, conn)
 			return

--- a/internal/tester/s1enb/server.go
+++ b/internal/tester/s1enb/server.go
@@ -280,7 +280,7 @@ func (e *ENB) dialAndActivateLocked(idx int) error {
 	conn, err := sctp.Dial(dialCtx, "sctp", e.mmeLocal, rem, sctp.InitMsg{NumOstreams: 2, MaxInstreams: 2})
 	if err != nil {
 		peer.state = mmeStateFailed
-		return fmt.Errorf("dial %s: %w", peer.address, err)
+		return err
 	}
 
 	peer.conn = conn

--- a/internal/tester/testutil/sctp.go
+++ b/internal/tester/testutil/sctp.go
@@ -6,8 +6,7 @@ package testutil
 import (
 	"fmt"
 
-	coresctp "github.com/ellanetworks/core/internal/sctp"
-	"github.com/ishidawataru/sctp"
+	"github.com/ellanetworks/core/internal/sctp"
 )
 
 func ValidateSCTP(info *sctp.SndRcvInfo, expectedPPID uint32, expectedStreamID uint16) error {
@@ -15,8 +14,8 @@ func ValidateSCTP(info *sctp.SndRcvInfo, expectedPPID uint32, expectedStreamID u
 		return fmt.Errorf("missing SCTP SndRcvInfo")
 	}
 
-	if info.PPID != coresctp.PPIDWireOrder(expectedPPID) {
-		return fmt.Errorf("ppid=%d want %d (NGAP)", info.PPID, coresctp.PPIDWireOrder(expectedPPID))
+	if info.PPID != sctp.PPIDWireOrder(expectedPPID) {
+		return fmt.Errorf("ppid=%d want %d (NGAP)", info.PPID, sctp.PPIDWireOrder(expectedPPID))
 	}
 
 	if info.Stream != expectedStreamID {


### PR DESCRIPTION
# Description

Replace `ishidawataru/sctp` in core-tester with the in-repo `internal/sctp` package, dropping the external dependency.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
