### PR TITLE
feat: add ESM information request procedure and other 3gpp conformance gaps

### DIFF
--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -257,8 +257,7 @@ func BuildRegistrationAccept(
 			EMF:         nfs.Emf,
 			IWKN26:      nfs.IwkN26 != 0,
 			MPSI:        nfs.Mpsi != 0,
-			// EMCN3 and MCSI live in octet 4, which the element omits unless it is
-			// asked for (TS 24.501 §9.11.3.5).
+			// EMCN3 and MCSI are dropped unless octet 4 is asked for.
 			HasOctet4: true,
 			EMCN3:     nfs.EmcN3 != 0,
 			MCSI:      nfs.Mcsi != 0,

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -257,8 +257,11 @@ func BuildRegistrationAccept(
 			EMF:         nfs.Emf,
 			IWKN26:      nfs.IwkN26 != 0,
 			MPSI:        nfs.Mpsi != 0,
-			EMCN3:       nfs.EmcN3 != 0,
-			MCSI:        nfs.Mcsi != 0,
+			// EMCN3 and MCSI live in octet 4, which the element omits unless it is
+			// asked for (TS 24.501 §9.11.3.5).
+			HasOctet4: true,
+			EMCN3:     nfs.EmcN3 != 0,
+			MCSI:      nfs.Mcsi != 0,
 		}
 	}
 

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -311,11 +311,9 @@ func decodeProtectedNAS(ue *UeContext, headerType fgs.SecurityHeaderType, payloa
 	plain, _, uerr := fgs.Unprotect(payload, cnt, nas.DirectionUplink, ue.sc,
 		fgs.SHTIntegrityProtected, fgs.SHTIntegrityProtectedCiphered, fgs.SHTIntegrityProtectedCipheredNewContext)
 	if uerr == nil {
-		// TS 24.501 §4.4.5: once ciphering has started the receiver discards an
-		// unciphered message that should have been ciphered. Checked before the
-		// commit so a discarded message does not advance the count, and before
-		// MarkSecureExchangeEstablished so the initial NAS message of a new
-		// connection stays outside the guard.
+		// Before the commit so a discarded message does not advance the count, and
+		// before MarkSecureExchangeEstablished so the initial NAS message of a new
+		// connection stays outside the guard (TS 24.501 §4.4.5).
 		if conn.SecureExchangeEstablished() && headerType == fgs.SHTIntegrityProtected && cipheringRequiredFor(plain) {
 			logger.AmfLog.Warn("discarding unciphered NAS message received after ciphering started")
 

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -252,7 +252,7 @@ func decodePlainNAS(payload []byte) (*DecodeResult, error) {
 		return nil, silentDecode(nasreply.ReasonIntegrityFail, "plain NAS message type %d not permitted by TS 24.501 §4.4.4.3", msgType)
 	}
 
-	return &DecodeResult{MessageType: msgType, IsGMM: true, IntegrityVerified: false, Plain: payload}, nil
+	return &DecodeResult{MessageType: msgType, IsGMM: true, IntegrityVerified: false, ArrivedPlain: true, Plain: payload}, nil
 }
 
 func decodeProtectedNAS(ue *UeContext, headerType fgs.SecurityHeaderType, payload []byte, conn *UeConn) (*DecodeResult, error) {

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -311,6 +311,17 @@ func decodeProtectedNAS(ue *UeContext, headerType fgs.SecurityHeaderType, payloa
 	plain, _, uerr := fgs.Unprotect(payload, cnt, nas.DirectionUplink, ue.sc,
 		fgs.SHTIntegrityProtected, fgs.SHTIntegrityProtectedCiphered, fgs.SHTIntegrityProtectedCipheredNewContext)
 	if uerr == nil {
+		// TS 24.501 §4.4.5: once ciphering has started the receiver discards an
+		// unciphered message that should have been ciphered. Checked before the
+		// commit so a discarded message does not advance the count, and before
+		// MarkSecureExchangeEstablished so the initial NAS message of a new
+		// connection stays outside the guard.
+		if conn.SecureExchangeEstablished() && headerType == fgs.SHTIntegrityProtected && cipheringRequiredFor(plain) {
+			logger.AmfLog.Warn("discarding unciphered NAS message received after ciphering started")
+
+			return nil, silentDecode(nasreply.ReasonIntegrityFail, "NAS discarded: unciphered after ciphering started (TS 24.501 §4.4.5)")
+		}
+
 		// MAC verified: commit the estimated count and establish secure exchange on the
 		// connection before dispatch, so a replay estimates to a count whose MAC fails
 		// (TS 24.501 §4.4.4.3).

--- a/internal/amf/nas/gmm_handler.go
+++ b/internal/amf/nas/gmm_handler.go
@@ -20,7 +20,7 @@ var gmmTracer = otel.Tracer("ella-core/amf/nas/handler")
 // HandleGmmMessage dispatches an inbound GMM message to its handler. integrityVerified
 // is true only when the message carried a verified MAC; it is false when the decoder
 // admitted the message without verified integrity (plain, or MAC-failed but whitelisted).
-func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msgType uint8, plain []byte, integrityVerified bool) nasreply.Disposition {
+func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, msgType uint8, plain []byte, integrityVerified, arrivedPlain bool) nasreply.Disposition {
 	msg, err := fgs.ParseMessage(plain)
 	if err != nil && !nas.SoftOnly(err) {
 		logger.From(ctx, logger.AmfLog).Warn("failed to decode GMM message",
@@ -35,7 +35,7 @@ func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConte
 
 	switch msg := msg.(type) {
 	case *fgs.RegistrationRequest:
-		return handleRegistrationRequest(ctx, amfInstance, ue, msg, plain, integrityVerified)
+		return handleRegistrationRequest(ctx, amfInstance, ue, msg, plain, integrityVerified, arrivedPlain)
 	case *fgs.ULNASTransport:
 		return handleULNASTransport(ctx, amfInstance, ue, msg)
 	case *fgs.ConfigurationUpdateComplete:

--- a/internal/amf/nas/gmm_handler_test.go
+++ b/internal/amf/nas/gmm_handler_test.go
@@ -18,7 +18,7 @@ func TestHandleGmmMessage_UnknownMessageType_NoOp(t *testing.T) {
 	ue := amf.NewUeContext()
 	amfInstance := amf.New(nil, nil, nil)
 
-	HandleGmmMessage(context.Background(), amfInstance, ue, 0xFF, nil, true) // unassigned message type
+	HandleGmmMessage(context.Background(), amfInstance, ue, 0xFF, nil, true, false) // unassigned message type
 }
 
 // TestHandleGmmMessage_DispatchesToConfigurationUpdateComplete verifies HandleGmmMessage
@@ -34,7 +34,7 @@ func TestHandleGmmMessage_DispatchesToConfigurationUpdateComplete(t *testing.T) 
 
 	amfInstance := amf.New(nil, nil, nil)
 
-	HandleGmmMessage(context.Background(), amfInstance, ue, uint8(fgs.MsgConfigurationUpdateComplete), nil, true)
+	HandleGmmMessage(context.Background(), amfInstance, ue, uint8(fgs.MsgConfigurationUpdateComplete), nil, true, false)
 }
 
 // TestHandleGmmMessage_DispatchesToStatus5GMM verifies HandleGmmMessage routes a
@@ -49,5 +49,5 @@ func TestHandleGmmMessage_DispatchesToStatus5GMM(t *testing.T) {
 
 	amfInstance := amf.New(nil, nil, nil)
 
-	HandleGmmMessage(context.Background(), amfInstance, ue, uint8(fgs.MsgGMMStatus), buildTestStatus5gmmPlain(t), true)
+	HandleGmmMessage(context.Background(), amfInstance, ue, uint8(fgs.MsgGMMStatus), buildTestStatus5gmmPlain(t), true, false)
 }

--- a/internal/amf/nas/handle_deregistration_accept_test.go
+++ b/internal/amf/nas/handle_deregistration_accept_test.go
@@ -70,7 +70,7 @@ func TestHandleGmmMessage_DeregistrationAcceptDispatch(t *testing.T) {
 		t.Fatalf("could not build a DEREGISTRATION ACCEPT: %v", err)
 	}
 
-	HandleGmmMessage(t.Context(), conn.AMFForTest(), ue, uint8(fgs.MsgDeregistrationAcceptUETerm), plain, true)
+	HandleGmmMessage(t.Context(), conn.AMFForTest(), ue, uint8(fgs.MsgDeregistrationAcceptUETerm), plain, true, false)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("expected UE to be deregistered, but was: %s", ue.State())

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -103,6 +103,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 	conn.RegistrationRequest = req
 	conn.RegistrationRequestPlain = slices.Clone(plain)
+	conn.RegistrationRequestProtected = integrityVerified
 	conn.SetRegistrationType5GS(uint8(req.RegistrationType))
 
 	regName := registrationTypeName(conn.RegistrationType5GS)

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -188,7 +188,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	}
 
 	if req.UESecurityCapability != nil {
-		acceptRegistrationUESecurityCapability(ctx, ue, req.UESecurityCapability)
+		acceptRegistrationUESecurityCapability(ctx, ue, req.UESecurityCapability, integrityVerified)
 	}
 
 	return nil
@@ -199,7 +199,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 // Registration overwrite the stored value; Mobility and Periodic Registration
 // Update keep it on match and log a mismatch. With no stored value, the received
 // caps are adopted through the same audited write path.
-func acceptRegistrationUESecurityCapability(ctx context.Context, ue *amf.UeContext, received *fgs.UESecurityCapability) {
+func acceptRegistrationUESecurityCapability(ctx context.Context, ue *amf.UeContext, received *fgs.UESecurityCapability, integrityVerified bool) {
 	conn := ue.Conn()
 	if conn == nil {
 		return
@@ -221,6 +221,14 @@ func acceptRegistrationUESecurityCapability(ctx context.Context, ue *amf.UeConte
 		// protection relies on the SMC replay check (TS 33.501).
 		ue.SetUESecurityCapability(received, amf.MintAuthProofForRegistrationRequest())
 	case amf.VerifyMismatch:
+		// TS 24.501 §5.5.1.3.4 has the AMF store what the request carries. Only an
+		// unverified request is refused: that is where a downgrade could enter
+		// (TS 33.501 §6.7.2).
+		if integrityVerified {
+			ue.SetUESecurityCapability(received, amf.MintAuthProofForRegistrationRequest())
+			return
+		}
+
 		logger.From(ctx, logger.AmfLog).Warn(
 			"UE security capabilities in Mobility/Periodic Registration differ from stored values; ignoring received values (TS 33.501)",
 			zap.String("registrationType", registrationTypeName(conn.RegistrationType5GS)),

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -45,7 +45,7 @@ func isInitialRegistration(req *fgs.RegistrationRequest) bool {
 func registrationTypeName(t fgs.RegistrationType) string { return t.String() }
 
 // handleRegistrationRequestMessage processes the cleartext IEs of the Registration Request (TS 24.501).
-func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, plain []byte, integrityVerified bool) error {
+func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, plain []byte, integrityVerified, arrivedPlain bool) error {
 	conn := ue.Conn()
 	if conn == nil {
 		return fmt.Errorf("no active NAS connection")
@@ -103,7 +103,11 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 	conn.RegistrationRequest = req
 	conn.RegistrationRequestPlain = slices.Clone(plain)
-	conn.RegistrationRequestProtected = integrityVerified
+	// TS 24.501 §4.4.6: only case a) — a UE with no valid 5G NAS security context,
+	// which therefore sends the request plain — has to replay it in the SECURITY
+	// MODE COMPLETE. A protected request whose MAC did not verify is case b), where
+	// the request the UE sent is complete as it stands.
+	conn.RegistrationRequestReplayRequired = arrivedPlain
 	conn.SetRegistrationType5GS(uint8(req.RegistrationType))
 
 	regName := registrationTypeName(conn.RegistrationType5GS)
@@ -237,7 +241,7 @@ func acceptRegistrationUESecurityCapability(ctx context.Context, ue *amf.UeConte
 // the new registration re-authenticates and re-derives everything. The shared UeConn
 // transfers to the fresh context; the old context is superseded only once the new
 // registration is accepted (reg_initial).
-func restartRegistrationOnFreshContext(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, plain []byte, integrityVerified bool) {
+func restartRegistrationOnFreshContext(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, plain []byte, integrityVerified, arrivedPlain bool) {
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		logger.From(ctx, logger.AmfLog).Warn("ue is not connected to RAN")
@@ -252,10 +256,10 @@ func restartRegistrationOnFreshContext(ctx context.Context, amfInstance *amf.AMF
 	fresh.SetSupi(supi)
 	amfInstance.AttachUeConn(fresh, ueConn)
 
-	handleRegistrationRequest(ctx, amfInstance, fresh, req, plain, integrityVerified)
+	handleRegistrationRequest(ctx, amfInstance, fresh, req, plain, integrityVerified, arrivedPlain)
 }
 
-func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, plain []byte, integrityVerified bool) nasreply.Disposition {
+func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, plain []byte, integrityVerified, arrivedPlain bool) nasreply.Disposition {
 	state := ue.State()
 	step := ue.RegStep()
 
@@ -270,7 +274,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 	switch {
 	case state == amf.Deregistered, state == amf.Registered, step == amf.RegStepAuthenticating:
-		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, req, plain, integrityVerified); err != nil {
+		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, req, plain, integrityVerified, arrivedPlain); err != nil {
 			// Release the half-registered UE at the point of failure; a failed
 			// handleRegistrationRequestMessage (which may already have sent a REGISTRATION
 			// REJECT) releases nothing, leaking its open RAN connection under no supervision.
@@ -312,7 +316,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 		return nasreply.Handled()
 
 	case step == amf.RegStepSecurityMode:
-		restartRegistrationOnFreshContext(ctx, amfInstance, ue, req, plain, integrityVerified)
+		restartRegistrationOnFreshContext(ctx, amfInstance, ue, req, plain, integrityVerified, arrivedPlain)
 
 		return nasreply.Handled()
 	case step == amf.RegStepContextSetup:
@@ -325,14 +329,14 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 			return nasreply.Handled()
 		}
 
-		restartRegistrationOnFreshContext(ctx, amfInstance, ue, req, plain, integrityVerified)
+		restartRegistrationOnFreshContext(ctx, amfInstance, ue, req, plain, integrityVerified, arrivedPlain)
 
 		return nasreply.Handled()
 	case state == amf.DeregistrationInitiated && isInitialRegistration(req):
 		// A UE-initiated initial or emergency registration during a network-initiated
 		// de-registration aborts the de-registration and progresses the registration
 		// (TS 24.501 §5.5.2.3.5 case d).
-		restartRegistrationOnFreshContext(ctx, amfInstance, ue, req, plain, integrityVerified)
+		restartRegistrationOnFreshContext(ctx, amfInstance, ue, req, plain, integrityVerified, arrivedPlain)
 
 		return nasreply.Handled()
 	default:

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -221,9 +221,6 @@ func acceptRegistrationUESecurityCapability(ctx context.Context, ue *amf.UeConte
 		// protection relies on the SMC replay check (TS 33.501).
 		ue.SetUESecurityCapability(received, amf.MintAuthProofForRegistrationRequest())
 	case amf.VerifyMismatch:
-		// TS 24.501 §5.5.1.3.4 has the AMF store what the request carries. Only an
-		// unverified request is refused: that is where a downgrade could enter
-		// (TS 33.501 §6.7.2).
 		if integrityVerified {
 			ue.SetUESecurityCapability(received, amf.MintAuthProofForRegistrationRequest())
 			return

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -103,10 +103,6 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 
 	conn.RegistrationRequest = req
 	conn.RegistrationRequestPlain = slices.Clone(plain)
-	// TS 24.501 §4.4.6: only case a) — a UE with no valid 5G NAS security context,
-	// which therefore sends the request plain — has to replay it in the SECURITY
-	// MODE COMPLETE. A protected request whose MAC did not verify is case b), where
-	// the request the UE sent is complete as it stands.
 	conn.RegistrationRequestReplayRequired = arrivedPlain
 	conn.SetRegistrationType5GS(uint8(req.RegistrationType))
 

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -1228,7 +1228,7 @@ func TestAcceptRegistrationUESecurityCapability_InitialOverwrites(t *testing.T) 
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeInitial
 	ue.SetUESecurityCapabilityForTest(&fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0}) // EA1/2/3 + IA1/2/3
 
-	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x80, IA: 0x80}) // only EA1 + IA1
+	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x80, IA: 0x80}, false) // only EA1 + IA1
 
 	if !ue.UESecurityCapabilityForTest().Equal(fgs.UESecurityCapability{EA: 0x80, IA: 0x80}) {
 		t.Fatalf("Initial Registration must replace stored caps, got %#v", ue.UESecurityCapabilityForTest())
@@ -1240,7 +1240,7 @@ func TestAcceptRegistrationUESecurityCapability_EmergencyOverwrites(t *testing.T
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeEmergency
 	ue.SetUESecurityCapabilityForTest(&fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0})
 
-	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x00, IA: 0x00})
+	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x00, IA: 0x00}, false)
 
 	if !ue.UESecurityCapabilityForTest().Equal(fgs.UESecurityCapability{EA: 0x00, IA: 0x00}) {
 		t.Fatalf("Emergency Registration must replace stored caps, got %#v", ue.UESecurityCapabilityForTest())
@@ -1252,7 +1252,7 @@ func TestAcceptRegistrationUESecurityCapability_MobilityNoStored(t *testing.T) {
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
 	ue.SetUESecurityCapabilityForTest(nil)
 
-	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0})
+	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0}, false)
 
 	if !ue.UESecurityCapabilityForTest().Equal(fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0}) {
 		t.Fatalf("Mobility Update with no stored caps must adopt received caps, got %#v", ue.UESecurityCapabilityForTest())
@@ -1267,7 +1267,7 @@ func TestAcceptRegistrationUESecurityCapability_MobilityRejectsDowngrade(t *test
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
 	ue.SetUESecurityCapabilityForTest(&fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0})
 
-	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x00, IA: 0x00})
+	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x00, IA: 0x00}, false)
 
 	if !ue.UESecurityCapabilityForTest().Equal(fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0}) {
 		t.Fatalf("Mobility Update must NOT overwrite stored caps with forged downgrade (TS 33.501): %#v", ue.UESecurityCapabilityForTest())
@@ -1279,7 +1279,7 @@ func TestAcceptRegistrationUESecurityCapability_PeriodicRejectsDowngrade(t *test
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypePeriodicUpdating
 	ue.SetUESecurityCapabilityForTest(&fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0})
 
-	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x00, IA: 0x00})
+	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0x00, IA: 0x00}, false)
 
 	if !ue.UESecurityCapabilityForTest().Equal(fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0}) {
 		t.Fatalf("Periodic Update must NOT overwrite stored caps with forged downgrade")
@@ -1291,7 +1291,7 @@ func TestAcceptRegistrationUESecurityCapability_MobilityIdenticalCapsNoop(t *tes
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
 	ue.SetUESecurityCapabilityForTest(&fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0})
 
-	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0})
+	acceptRegistrationUESecurityCapability(context.Background(), ue, &fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0}, false)
 
 	if !ue.UESecurityCapabilityForTest().Equal(fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0}) {
 		t.Fatalf("Mobility Update with identical caps must be a no-op")
@@ -1417,5 +1417,23 @@ func TestHandleRegistrationRequest_ContextSetup_AfterSecurityModeContainer_Resen
 
 	if ue.State() == amf.Deregistered {
 		t.Fatal("an identical duplicate must not deregister the UE")
+	}
+}
+
+// TS 24.501 §5.5.1.3.4: the AMF stores what the request carries. A mobility
+// update reaches a committed context only when its MAC verified, so a changed
+// capability there is authenticated and replaying the stale one would make the
+// UE reject the SECURITY MODE COMMAND (TS 33.501 §6.7.2 step 2a).
+func TestAcceptRegistrationUESecurityCapability_MobilityStoresVerifiedChange(t *testing.T) {
+	ue := newBoundUe(t)
+	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
+	ue.SetUESecurityCapabilityForTest(&fgs.UESecurityCapability{EA: 0xE0, IA: 0xE0})
+
+	changed := fgs.UESecurityCapability{EA: 0xC0, IA: 0xC0}
+
+	acceptRegistrationUESecurityCapability(context.Background(), ue, &changed, true)
+
+	if !ue.UESecurityCapabilityForTest().Equal(changed) {
+		t.Fatalf("stored capability = %#v, want the verified %#v", ue.UESecurityCapabilityForTest(), changed)
 	}
 }

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -54,7 +54,7 @@ func TestHandleRegistrationRequest_NilRanUE(t *testing.T) {
 
 	ue := amf.NewUeContext()
 
-	handleRegistrationRequest(ctx, &amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, &amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 }
 
 // TestHandleRegistrationRequest_ErrorMissingIdentity validates the graceful
@@ -74,7 +74,7 @@ func TestHandleRegistrationRequest_ErrorMissingIdentity(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, &amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, &amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered, got %v", ue.State())
@@ -103,7 +103,7 @@ func TestHandleRegistrationRequest_ErrorMissingOperatorInfo(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered, got %v", ue.State())
@@ -144,7 +144,7 @@ func TestHandleRegistrationRequest_RejectTrackingAreaNotAllowed(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -180,7 +180,7 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability(t *testing.T)
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -218,7 +218,7 @@ func TestHandleRegistrationRequest_RejectMissingSecurityCapability_Mobility(t *t
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -255,7 +255,7 @@ func TestHandleRegistrationRequest_PeriodicAllowsMissingSecurityCapability(t *te
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, regReqFgs(t, m), m, true); err != nil {
+	if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, regReqFgs(t, m), m, true, false); err != nil {
 		t.Fatalf("periodic registration without UE security capability should not be rejected here, got: %v", err)
 	}
 
@@ -294,7 +294,7 @@ func TestHandleRegistrationRequest_Timers_Stopped(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.PagingActiveForTest() {
 		t.Fatalf("timer T3513 should have been stopped")
@@ -324,7 +324,7 @@ func TestHandleRegistrationRequest_IdentityRequest_MissingSUCI_SUPI(t *testing.T
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -367,7 +367,7 @@ func TestHandleRegistrationRequest_AuthenticationRequest(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -421,7 +421,7 @@ func TestHandleRegistrationRequest_RegistrationAccepted(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -475,7 +475,7 @@ func TestHandleRegistrationRequest_ContextSetup_IdenticalIEs_ResendsAccept(t *te
 	conn.RegistrationRequestPlain = m
 	conn.RegistrationAcceptPdu = []byte{0x7e, 0x00, 0x42}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("expected the Registration Accept to be resent, got %d downlinks", len(ngapSender.SentDownlinkNASTransport))
@@ -521,7 +521,7 @@ func TestHandleRegistrationRequest_ContextSetup_DifferingIEs_Progresses(t *testi
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("expected the new registration to progress with an Authentication Request, got %d downlinks", len(ngapSender.SentDownlinkNASTransport))
@@ -573,7 +573,7 @@ func TestHandleRegistrationRequest_ContextSetup_UnmodeledIEDiffers_Progresses(t 
 	// it, so the two differ in bytes while every field the AMF reads is equal.
 	incoming := append(append([]byte{}, m...), 0x35, 0x02, 0x01, 0x01)
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, incoming), incoming, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, incoming), incoming, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("expected the new registration to progress with an Authentication Request, got %d downlinks", len(ngapSender.SentDownlinkNASTransport))
@@ -617,7 +617,7 @@ func TestHandleRegistrationRequest_UEStateAuthentication_RestartsRegistration(t 
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message (AuthenticationRequest), got %d", len(ngapSender.SentDownlinkNASTransport))
@@ -662,7 +662,7 @@ func TestHandleRegistrationRequest_Authenticating_IdenticalIEs_Ignored(t *testin
 
 	ue.Conn().RegistrationRequestPlain = m
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 0 {
 		t.Fatalf("an identical pre-accept duplicate must be ignored (no downlink), got %d", len(ngapSender.SentDownlinkNASTransport))
@@ -708,7 +708,7 @@ func TestHandleRegistrationRequest_SecurityMode_IdenticalIEs_Ignored(t *testing.
 
 	ue.Conn().RegistrationRequestPlain = m
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 0 {
 		t.Fatalf("an identical pre-accept duplicate must be ignored (no downlink), got %d", len(ngapSender.SentDownlinkNASTransport))
@@ -763,7 +763,7 @@ func TestHandleRegistrationRequest_SecurityMode_AuthenticationRequest(t *testing
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	// The prior registration is aborted: its context is deregistered and its NAS
 	// connection — carrying T3560 — is released. The new registration runs on a fresh
@@ -834,7 +834,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationAccepted(t *testing.T
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message")
@@ -896,7 +896,7 @@ func TestHandleRegistrationRequest_CipheredNAS_RegistrationRejectedWrongKey(t *t
 	key = [16]uint8{0x00, 0x00, 0x00, 0x00, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
 	ue.SetKnasEncForTest(key)
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.State() != amf.Deregistered {
 		t.Fatalf("UE should be released to Deregistered after the reject, got %v", ue.State())
@@ -950,7 +950,7 @@ func TestHandleRegistrationRequest_CipheredNAS_MacFailed_SkipContainer(t *testin
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, false)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, false, false)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("should have sent a Downlink NAS Transport message, got %d", len(ngapSender.SentDownlinkNASTransport))
@@ -997,7 +997,7 @@ func TestHandleRegistrationRequest_NgKsi_Increment(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.NgKsiForTest().Ksi != 4 {
 		t.Fatalf("expected ngKSI=4 (next after 3), got %d", ue.NgKsiForTest().Ksi)
@@ -1037,7 +1037,7 @@ func TestHandleRegistrationRequest_NgKsi_WrapAt6(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.NgKsiForTest().Ksi != 0 {
 		t.Fatalf("expected ngKSI=0 (wrapped from 6), got %d", ue.NgKsiForTest().Ksi)
@@ -1077,7 +1077,7 @@ func TestHandleRegistrationRequest_NgKsi_NoKeyAvailable(t *testing.T) {
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	if ue.NgKsiForTest().Ksi != 0 {
 		t.Fatalf("expected ngKSI=0 (reset from no-key-available=7), got %d", ue.NgKsiForTest().Ksi)
@@ -1169,7 +1169,7 @@ func TestHandleRegistrationRequestMessage_ContainerStoresOuterBytes(t *testing.T
 	outer := m
 	inner := append([]byte(nil), regReqFgs(t, outer).NASMessageContainer...)
 
-	_ = handleRegistrationRequestMessage(ctx, amfInstance, ue, regReqFgs(t, outer), outer, true)
+	_ = handleRegistrationRequestMessage(ctx, amfInstance, ue, regReqFgs(t, outer), outer, true, false)
 
 	stored := ue.Conn().RegistrationRequestPlain
 	if !bytes.Equal(stored, outer) {
@@ -1324,7 +1324,7 @@ func TestHandleRegistrationRequest_InitialRegistrationAbortsNetworkDeregistratio
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
 
 	// Progressed, not rejected: the de-registration must have been aborted.
 	if ue.State() == amf.DeregistrationInitiated {
@@ -1409,7 +1409,7 @@ func TestHandleRegistrationRequest_ContextSetup_AfterSecurityModeContainer_Resen
 
 	before := len(ngapSender.SentDownlinkNASTransport)
 
-	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, complete), complete, true)
+	handleRegistrationRequest(ctx, amfInstance, ue, mustParseRegistrationRequest(t, complete), complete, true, false)
 
 	if got := len(ngapSender.SentDownlinkNASTransport) - before; got != 1 {
 		t.Fatalf("expected the Registration Accept to be resent, got %d downlinks", got)

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -1420,10 +1420,6 @@ func TestHandleRegistrationRequest_ContextSetup_AfterSecurityModeContainer_Resen
 	}
 }
 
-// TS 24.501 §5.5.1.3.4: the AMF stores what the request carries. A mobility
-// update reaches a committed context only when its MAC verified, so a changed
-// capability there is authenticated and replaying the stale one would make the
-// UE reject the SECURITY MODE COMMAND (TS 33.501 §6.7.2 step 2a).
 func TestAcceptRegistrationUESecurityCapability_MobilityStoresVerifiedChange(t *testing.T) {
 	ue := newBoundUe(t)
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating

--- a/internal/amf/nas/handle_security_mode_complete.go
+++ b/internal/amf/nas/handle_security_mode_complete.go
@@ -72,9 +72,14 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return nasreply.Handled()
 	}
 
-	// TS 24.501 §4.4.6 case a: a UE whose REGISTRATION REQUEST was cleartext-only
-	// repeats it here, so its absence leaves the non-cleartext IEs unauthenticated.
-	if !conn.RegistrationRequestProtected {
+	// TS 24.501 §4.4.6 case a: a UE with no valid 5G NAS security context sends the
+	// REGISTRATION REQUEST plain and repeats it here, in both sub-cases 1) and 2).
+	// Its absence leaves the stored request unverified, so it is not built on.
+	//
+	// Case b) is excluded: there the UE protected the request, and it omits the
+	// container whenever it had no non-cleartext IEs to send (§5.4.2.3), so
+	// demanding one would abort a registration the spec completes.
+	if conn.RegistrationRequestReplayRequired {
 		abortRegistration(ctx, amfInstance, ue, "NAS message container", errNoRegistrationContainer)
 
 		return nasreply.Handled()

--- a/internal/amf/nas/handle_security_mode_complete.go
+++ b/internal/amf/nas/handle_security_mode_complete.go
@@ -72,13 +72,7 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return nasreply.Handled()
 	}
 
-	// TS 24.501 §4.4.6 case a: a UE with no valid 5G NAS security context sends the
-	// REGISTRATION REQUEST plain and repeats it here, in both sub-cases 1) and 2).
-	// Its absence leaves the stored request unverified, so it is not built on.
-	//
-	// Case b) is excluded: there the UE protected the request, and it omits the
-	// container whenever it had no non-cleartext IEs to send (§5.4.2.3), so
-	// demanding one would abort a registration the spec completes.
+	// TS 24.501 §4.4.6 case a) requires the replay in both its sub-cases.
 	if conn.RegistrationRequestReplayRequired {
 		abortRegistration(ctx, amfInstance, ue, "NAS message container", errNoRegistrationContainer)
 
@@ -90,8 +84,6 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 	return nasreply.Handled()
 }
 
-// errNoRegistrationContainer reports a SECURITY MODE COMPLETE that omits the
-// REGISTRATION REQUEST a cleartext-only initial message has to repeat.
 var errNoRegistrationContainer = errors.New("SECURITY MODE COMPLETE carries no NAS message container")
 
 // imeiFromPEI renders a decoded IMEISV mobile identity as the shared equipment

--- a/internal/amf/nas/handle_security_mode_complete.go
+++ b/internal/amf/nas/handle_security_mode_complete.go
@@ -5,6 +5,7 @@ package nas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -71,10 +72,22 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return nasreply.Handled()
 	}
 
+	// TS 24.501 §4.4.6 case a: a UE whose REGISTRATION REQUEST was cleartext-only
+	// repeats it here, so its absence leaves the non-cleartext IEs unauthenticated.
+	if !conn.RegistrationRequestProtected {
+		abortRegistration(ctx, amfInstance, ue, "NAS message container", errNoRegistrationContainer)
+
+		return nasreply.Handled()
+	}
+
 	contextSetup(ctx, amfInstance, ue, conn.RegistrationRequest, conn.RegistrationRequestPlain)
 
 	return nasreply.Handled()
 }
+
+// errNoRegistrationContainer reports a SECURITY MODE COMPLETE that omits the
+// REGISTRATION REQUEST a cleartext-only initial message has to repeat.
+var errNoRegistrationContainer = errors.New("SECURITY MODE COMPLETE carries no NAS message container")
 
 // imeiFromPEI renders a decoded IMEISV mobile identity as the shared equipment
 // identity type (TS 24.501 §9.11.3.4).

--- a/internal/amf/nas/handle_security_mode_complete.go
+++ b/internal/amf/nas/handle_security_mode_complete.go
@@ -72,7 +72,6 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 		return nasreply.Handled()
 	}
 
-	// TS 24.501 §4.4.6 case a) requires the replay in both its sub-cases.
 	if conn.RegistrationRequestReplayRequired {
 		abortRegistration(ctx, amfInstance, ue, "NAS message container", errNoRegistrationContainer)
 

--- a/internal/amf/nas/handle_security_mode_complete_test.go
+++ b/internal/amf/nas/handle_security_mode_complete_test.go
@@ -289,6 +289,112 @@ func TestHandleSecurityMode_InvalidNASMessageContainer_Error(t *testing.T) {
 	}
 }
 
+func TestHandleSecurityMode_CleartextRegistrationNotReplayed_Aborts(t *testing.T) {
+	amfInstance := amf.New(
+		&fakeDBInstance{
+			Operator: &db.Operator{
+				Mcc:           "001",
+				Mnc:           "01",
+				SupportedTACs: "[\"1\"]",
+			},
+		},
+		&fakeAusf{
+			AvKgAka: &ausf.AuthResult{
+				Rand: hex.EncodeToString(make([]byte, 16)),
+				Autn: hex.EncodeToString(make([]byte, 16)),
+			},
+			Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+			Kseaf: []byte("testkey"),
+		},
+		&fakeSmf{},
+	)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.ForceRegStepForTest(amf.RegStepSecurityMode)
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+
+	conn := ue.Conn()
+	conn.RegistrationType5GS = fgs.RegistrationTypeInitial
+	conn.RegistrationRequest = &fgs.RegistrationRequest{
+		RegistrationType:     fgs.RegistrationTypeInitial,
+		MobileIdentity:       testMobileIdentity(),
+		UESecurityCapability: &fgs.UESecurityCapability{EA: 0xc0, IA: 0xc0},
+	}
+	conn.RegistrationRequestProtected = false
+
+	handleSecurityModeComplete(t.Context(), amfInstance, ue, buildTestSecurityModeCompleteMessage(), true)
+
+	if len(ngapSender.SentUEContextReleaseCommand) != 1 {
+		t.Fatalf("UE Context Release Command count is %d, want 1", len(ngapSender.SentUEContextReleaseCommand))
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 0 {
+		t.Fatalf("Downlink NAS Transport count is %d, want 0", len(ngapSender.SentDownlinkNASTransport))
+	}
+}
+
+func TestHandleSecurityMode_ProtectedRegistrationNeedsNoReplay(t *testing.T) {
+	amfInstance := amf.New(
+		&fakeDBInstance{
+			Operator: &db.Operator{
+				Mcc:           "001",
+				Mnc:           "01",
+				SupportedTACs: "[\"1\"]",
+			},
+		},
+		&fakeAusf{
+			AvKgAka: &ausf.AuthResult{
+				Rand: hex.EncodeToString(make([]byte, 16)),
+				Autn: hex.EncodeToString(make([]byte, 16)),
+			},
+			Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+			Kseaf: []byte("testkey"),
+		},
+		&fakeSmf{},
+	)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.ForceRegStepForTest(amf.RegStepSecurityMode)
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+
+	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
+
+	ue.SetKnasEncForTest(key)
+	ue.SetKnasIntForTest(key)
+	ue.SetCipheringAlgForTest(nas.CipheringAES)
+	ue.SetIntegrityAlgForTest(nas.IntegrityNull)
+
+	conn := ue.Conn()
+	conn.RegistrationType5GS = fgs.RegistrationTypeInitial
+	conn.RegistrationRequest = &fgs.RegistrationRequest{
+		RegistrationType:     fgs.RegistrationTypeInitial,
+		FOR:                  true,
+		MobileIdentity:       testMobileIdentity(),
+		UESecurityCapability: &fgs.UESecurityCapability{EA: 0xc0, IA: 0xc0},
+	}
+	conn.RegistrationRequestProtected = true
+
+	handleSecurityModeComplete(t.Context(), amfInstance, ue, buildTestSecurityModeCompleteMessage(), true)
+
+	if len(ngapSender.SentUEContextReleaseCommand) != 0 {
+		t.Fatalf("UE Context Release Command count is %d, want 0", len(ngapSender.SentUEContextReleaseCommand))
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("Downlink NAS Transport count is %d, want 1", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgRegistrationAccept))
+}
+
 func buildTestSecurityModeCompleteMessage() *fgs.SecurityModeComplete {
 	return &fgs.SecurityModeComplete{}
 }

--- a/internal/amf/nas/handle_security_mode_complete_test.go
+++ b/internal/amf/nas/handle_security_mode_complete_test.go
@@ -289,7 +289,7 @@ func TestHandleSecurityMode_InvalidNASMessageContainer_Error(t *testing.T) {
 	}
 }
 
-func TestHandleSecurityMode_CleartextRegistrationNotReplayed_Aborts(t *testing.T) {
+func TestHandleSecurityMode_PlainRegistrationNotReplayed_Aborts(t *testing.T) {
 	amfInstance := amf.New(
 		&fakeDBInstance{
 			Operator: &db.Operator{
@@ -324,7 +324,7 @@ func TestHandleSecurityMode_CleartextRegistrationNotReplayed_Aborts(t *testing.T
 		MobileIdentity:       testMobileIdentity(),
 		UESecurityCapability: &fgs.UESecurityCapability{EA: 0xc0, IA: 0xc0},
 	}
-	conn.RegistrationRequestProtected = false
+	conn.RegistrationRequestReplayRequired = true
 
 	handleSecurityModeComplete(t.Context(), amfInstance, ue, buildTestSecurityModeCompleteMessage(), true)
 
@@ -380,12 +380,78 @@ func TestHandleSecurityMode_ProtectedRegistrationNeedsNoReplay(t *testing.T) {
 		MobileIdentity:       testMobileIdentity(),
 		UESecurityCapability: &fgs.UESecurityCapability{EA: 0xc0, IA: 0xc0},
 	}
-	conn.RegistrationRequestProtected = true
+	conn.RegistrationRequestReplayRequired = false
 
 	handleSecurityModeComplete(t.Context(), amfInstance, ue, buildTestSecurityModeCompleteMessage(), true)
 
 	if len(ngapSender.SentUEContextReleaseCommand) != 0 {
 		t.Fatalf("UE Context Release Command count is %d, want 0", len(ngapSender.SentUEContextReleaseCommand))
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("Downlink NAS Transport count is %d, want 1", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgRegistrationAccept))
+}
+
+// TS 24.501 §4.4.6 case b) 3): a UE that holds a 5G NAS security context protects
+// the REGISTRATION REQUEST and omits the NAS message container when it has no
+// non-cleartext IEs to send. Its MAC failing against the AMF's state — a key or
+// NAS COUNT desync — does not turn it into case a), so the guard must not abort
+// a registration the UE never had to replay.
+func TestHandleSecurityMode_ProtectedRegistrationWithFailedMACNeedsNoReplay(t *testing.T) {
+	amfInstance := amf.New(
+		&fakeDBInstance{
+			Operator: &db.Operator{
+				Mcc:           "001",
+				Mnc:           "01",
+				SupportedTACs: "[\"1\"]",
+			},
+		},
+		&fakeAusf{
+			AvKgAka: &ausf.AuthResult{
+				Rand: hex.EncodeToString(make([]byte, 16)),
+				Autn: hex.EncodeToString(make([]byte, 16)),
+			},
+			Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+			Kseaf: []byte("testkey"),
+		},
+		&fakeSmf{},
+	)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.ForceRegStepForTest(amf.RegStepSecurityMode)
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+
+	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
+
+	ue.SetKnasEncForTest(key)
+	ue.SetKnasIntForTest(key)
+	ue.SetCipheringAlgForTest(nas.CipheringAES)
+	ue.SetIntegrityAlgForTest(nas.IntegrityNull)
+
+	m, err := buildTestRegistrationRequestMessage(nas.CipheringAES, &key, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	// The request arrived security protected; its MAC did not verify.
+	if err := handleRegistrationRequestMessage(t.Context(), amfInstance, ue,
+		mustParseRegistrationRequest(t, m), m, false, false); err != nil {
+		t.Fatalf("handle registration request message: %v", err)
+	}
+
+	ue.ForceRegStepForTest(amf.RegStepSecurityMode)
+
+	handleSecurityModeComplete(t.Context(), amfInstance, ue, buildTestSecurityModeCompleteMessage(), true)
+
+	if len(ngapSender.SentUEContextReleaseCommand) != 0 {
+		t.Fatalf("UE Context Release Command count is %d, want 0; the registration was aborted", len(ngapSender.SentUEContextReleaseCommand))
 	}
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {

--- a/internal/amf/nas/handle_security_mode_complete_test.go
+++ b/internal/amf/nas/handle_security_mode_complete_test.go
@@ -395,8 +395,6 @@ func TestHandleSecurityMode_ProtectedRegistrationNeedsNoReplay(t *testing.T) {
 	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgRegistrationAccept))
 }
 
-// TS 24.501 §4.4.6 case b) 3): a failed MAC does not turn a protected request
-// into case a), so the guard must not demand a replay the UE never owed.
 func TestHandleSecurityMode_ProtectedRegistrationWithFailedMACNeedsNoReplay(t *testing.T) {
 	amfInstance := amf.New(
 		&fakeDBInstance{

--- a/internal/amf/nas/handle_security_mode_complete_test.go
+++ b/internal/amf/nas/handle_security_mode_complete_test.go
@@ -395,11 +395,8 @@ func TestHandleSecurityMode_ProtectedRegistrationNeedsNoReplay(t *testing.T) {
 	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgRegistrationAccept))
 }
 
-// TS 24.501 §4.4.6 case b) 3): a UE that holds a 5G NAS security context protects
-// the REGISTRATION REQUEST and omits the NAS message container when it has no
-// non-cleartext IEs to send. Its MAC failing against the AMF's state — a key or
-// NAS COUNT desync — does not turn it into case a), so the guard must not abort
-// a registration the UE never had to replay.
+// TS 24.501 §4.4.6 case b) 3): a failed MAC does not turn a protected request
+// into case a), so the guard must not demand a replay the UE never owed.
 func TestHandleSecurityMode_ProtectedRegistrationWithFailedMACNeedsNoReplay(t *testing.T) {
 	amfInstance := amf.New(
 		&fakeDBInstance{
@@ -440,7 +437,6 @@ func TestHandleSecurityMode_ProtectedRegistrationWithFailedMACNeedsNoReplay(t *t
 		t.Fatalf("could not build registration request message: %v", err)
 	}
 
-	// The request arrived security protected; its MAC did not verify.
 	if err := handleRegistrationRequestMessage(t.Context(), amfInstance, ue,
 		mustParseRegistrationRequest(t, m), m, false, false); err != nil {
 		t.Fatalf("handle registration request message: %v", err)

--- a/internal/amf/nas/handle_ul_nas_transport.go
+++ b/internal/amf/nas/handle_ul_nas_transport.go
@@ -203,6 +203,16 @@ func establishPDUSession(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeCo
 
 	if ulNasTransport.SNSSAI != nil {
 		snssai = util.SnssaiToModels(*ulNasTransport.SNSSAI)
+
+		// A requested S-NSSAI the network does not allow is not routed to an SMF
+		// (TS 24.501 §5.4.5.2.5 case 13).
+		if !ue.IsAllowedNssai(snssai) {
+			logger.From(ctx, logger.AmfLog).Warn("requested S-NSSAI is not in the allowed NSSAI",
+				zap.Any("snssai", snssai), logger.PDUSessionID(pduSessionID))
+			sendPayloadNotForwarded(ctx, ueConn, pduSessionID, smMessage)
+
+			return
+		}
 	} else {
 		if len(ue.AllowedNssai) == 0 {
 			logger.From(ctx, logger.AmfLog).Warn("allowed nssai is empty in UE context")

--- a/internal/amf/nas/handle_ul_nas_transport.go
+++ b/internal/amf/nas/handle_ul_nas_transport.go
@@ -131,7 +131,6 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		}
 	}
 
-	// TS 24.501 §5.4.5.2.5 case 13.
 	if ulNasTransport.SNSSAI != nil && requestType != nil {
 		switch *requestType {
 		case fgs.RequestTypeInitialRequest, fgs.RequestTypeModificationRequest:

--- a/internal/amf/nas/handle_ul_nas_transport.go
+++ b/internal/amf/nas/handle_ul_nas_transport.go
@@ -131,6 +131,23 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		}
 	}
 
+	// TS 24.501 §5.4.5.2.5 case 13: on an initial or a modification request, a
+	// requested S-NSSAI the network does not allow is not routed to an SMF. The
+	// element the case names is the one this message carries, not the one the
+	// stored context holds.
+	if ulNasTransport.SNSSAI != nil && requestType != nil {
+		switch *requestType {
+		case fgs.RequestTypeInitialRequest, fgs.RequestTypeModificationRequest:
+			if snssai := util.SnssaiToModels(*ulNasTransport.SNSSAI); !ue.IsAllowedNssai(snssai) {
+				logger.From(ctx, logger.AmfLog).Warn("requested S-NSSAI is not in the allowed NSSAI",
+					zap.Any("snssai", snssai), logger.PDUSessionID(uint8(pduSessionID)))
+				sendPayloadNotForwarded(ctx, ueConn, uint8(pduSessionID), smMessage)
+
+				return
+			}
+		}
+	}
+
 	smContext, smContextExist := ue.SmContextFindByPDUSessionID(uint8(pduSessionID))
 
 	isInitialRequest := requestType != nil &&
@@ -201,18 +218,10 @@ func establishPDUSession(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeCo
 		dnn    string
 	)
 
+	// A requested S-NSSAI has already been checked against the allowed NSSAI
+	// (TS 24.501 §5.4.5.2.5 case 13).
 	if ulNasTransport.SNSSAI != nil {
 		snssai = util.SnssaiToModels(*ulNasTransport.SNSSAI)
-
-		// A requested S-NSSAI the network does not allow is not routed to an SMF
-		// (TS 24.501 §5.4.5.2.5 case 13).
-		if !ue.IsAllowedNssai(snssai) {
-			logger.From(ctx, logger.AmfLog).Warn("requested S-NSSAI is not in the allowed NSSAI",
-				zap.Any("snssai", snssai), logger.PDUSessionID(pduSessionID))
-			sendPayloadNotForwarded(ctx, ueConn, pduSessionID, smMessage)
-
-			return
-		}
 	} else {
 		if len(ue.AllowedNssai) == 0 {
 			logger.From(ctx, logger.AmfLog).Warn("allowed nssai is empty in UE context")

--- a/internal/amf/nas/handle_ul_nas_transport.go
+++ b/internal/amf/nas/handle_ul_nas_transport.go
@@ -131,10 +131,7 @@ func transport5GSMMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		}
 	}
 
-	// TS 24.501 §5.4.5.2.5 case 13: on an initial or a modification request, a
-	// requested S-NSSAI the network does not allow is not routed to an SMF. The
-	// element the case names is the one this message carries, not the one the
-	// stored context holds.
+	// TS 24.501 §5.4.5.2.5 case 13.
 	if ulNasTransport.SNSSAI != nil && requestType != nil {
 		switch *requestType {
 		case fgs.RequestTypeInitialRequest, fgs.RequestTypeModificationRequest:
@@ -218,8 +215,7 @@ func establishPDUSession(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeCo
 		dnn    string
 	)
 
-	// A requested S-NSSAI has already been checked against the allowed NSSAI
-	// (TS 24.501 §5.4.5.2.5 case 13).
+	// Already checked against the allowed NSSAI by the caller.
 	if ulNasTransport.SNSSAI != nil {
 		snssai = util.SnssaiToModels(*ulNasTransport.SNSSAI)
 	} else {

--- a/internal/amf/nas/handle_ul_nas_transport_test.go
+++ b/internal/amf/nas/handle_ul_nas_transport_test.go
@@ -307,6 +307,45 @@ func TestTransport5GSMMessage_InitialRequest_NotAllowedNssai_NotForwarded(t *tes
 	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgDLNASTransport))
 }
 
+// TS 24.501 §5.4.5.2.5 case 13 names "initial request" or "modification request",
+// so a modification request for an existing session is checked against the
+// allowed NSSAI too, and on the S-NSSAI this message carries.
+func TestTransport5GSMMessage_ModificationRequest_NotAllowedNssai_NotForwarded(t *testing.T) {
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001010000000001"))
+	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
+
+	var pduSessionID uint8 = 5
+
+	// The session's own S-NSSAI is allowed; the one the message requests is not.
+	_ = ue.CreateSmContext(pduSessionID, "testref", &models.Snssai{Sst: 1, Sd: "010203"})
+
+	smPayload := []byte{0x2E, 0x01, 0x00, 0xC1, 0x00}
+
+	msg := buildTestULNASTransport(fgs.PayloadContainerTypeN1SMInfo, smPayload, pduSessionIDPtr(fgs.PDUSessionID(pduSessionID)))
+	setRequestType(msg, fgs.RequestTypeModificationRequest)
+
+	msg.SNSSAI = &fgs.SNSSAI{SST: 2, SD: &[3]byte{4, 5, 6}}
+
+	fakeSmf := &fakeSmf{}
+
+	transport5GSMMessage(t.Context(), amf.New(&fakeDBInstance{}, nil, fakeSmf), ue, fgsULNAS(t, msg))
+
+	if len(fakeSmf.UpdateN1MsgCalls) != 0 {
+		t.Fatalf("UpdateSmContextN1Msg call count is %d, want 0", len(fakeSmf.UpdateN1MsgCalls))
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlink NAS transport count is %d, want 1", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgDLNASTransport))
+}
+
 func TestTransport5GSMMessage_NoSmContext_ModificationRequest_SendsDLNASTransport(t *testing.T) {
 	ue, ngapSender, err := buildUeAndRadio()
 	if err != nil {

--- a/internal/amf/nas/handle_ul_nas_transport_test.go
+++ b/internal/amf/nas/handle_ul_nas_transport_test.go
@@ -268,6 +268,45 @@ func TestTransport5GSMMessage_ExistingPduSession_NotAllowedNssai_SendsDLNASTrans
 	assertPlainGmm(t, resp.NASPDU, uint8(fgs.MsgDLNASTransport))
 }
 
+func TestTransport5GSMMessage_InitialRequest_NotAllowedNssai_NotForwarded(t *testing.T) {
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001010000000001"))
+	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
+
+	var pduSessionID uint8 = 1
+
+	smPayload := []byte{0x2E, 0x01, 0x00, 0xC1, 0x00}
+
+	msg := buildTestULNASTransport(fgs.PayloadContainerTypeN1SMInfo, smPayload, pduSessionIDPtr(fgs.PDUSessionID(pduSessionID)))
+	setRequestType(msg, fgs.RequestTypeInitialRequest)
+
+	// SST=2 is outside the UE's allowed NSSAI.
+	msg.SNSSAI = &fgs.SNSSAI{SST: 2, SD: &[3]byte{4, 5, 6}}
+	msg.DNN = new(fgs.DNN("internet"))
+
+	fakeSmf := &fakeSmf{CreateSmContextRef: "new-ctx-ref"}
+
+	transport5GSMMessage(t.Context(), amf.New(&fakeDBInstance{}, nil, fakeSmf), ue, fgsULNAS(t, msg))
+
+	if len(fakeSmf.CreateSmContextCalls) != 0 {
+		t.Fatalf("CreateSmContext call count is %d, want 0", len(fakeSmf.CreateSmContextCalls))
+	}
+
+	if _, exists := ue.SmContextFindByPDUSessionID(pduSessionID); exists {
+		t.Error("an SM context was created for an S-NSSAI outside the allowed NSSAI")
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlink NAS transport count is %d, want 1", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgDLNASTransport))
+}
+
 func TestTransport5GSMMessage_NoSmContext_ModificationRequest_SendsDLNASTransport(t *testing.T) {
 	ue, ngapSender, err := buildUeAndRadio()
 	if err != nil {
@@ -798,6 +837,7 @@ func TestTransport5GSMMessage_NoSmContext_InitialRequest_WithSNSSAIAndDNN_Create
 	}
 
 	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001010000000001"))
+	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
 
 	var pduSessionID uint8 = 1
 

--- a/internal/amf/nas/handle_ul_nas_transport_test.go
+++ b/internal/amf/nas/handle_ul_nas_transport_test.go
@@ -284,7 +284,6 @@ func TestTransport5GSMMessage_InitialRequest_NotAllowedNssai_NotForwarded(t *tes
 	msg := buildTestULNASTransport(fgs.PayloadContainerTypeN1SMInfo, smPayload, pduSessionIDPtr(fgs.PDUSessionID(pduSessionID)))
 	setRequestType(msg, fgs.RequestTypeInitialRequest)
 
-	// SST=2 is outside the UE's allowed NSSAI.
 	msg.SNSSAI = &fgs.SNSSAI{SST: 2, SD: &[3]byte{4, 5, 6}}
 	msg.DNN = new(fgs.DNN("internet"))
 
@@ -307,9 +306,7 @@ func TestTransport5GSMMessage_InitialRequest_NotAllowedNssai_NotForwarded(t *tes
 	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgDLNASTransport))
 }
 
-// TS 24.501 §5.4.5.2.5 case 13 names "initial request" or "modification request",
-// so a modification request for an existing session is checked against the
-// allowed NSSAI too, and on the S-NSSAI this message carries.
+// TS 24.501 §5.4.5.2.5 case 13.
 func TestTransport5GSMMessage_ModificationRequest_NotAllowedNssai_NotForwarded(t *testing.T) {
 	ue, ngapSender, err := buildUeAndRadio()
 	if err != nil {
@@ -321,7 +318,6 @@ func TestTransport5GSMMessage_ModificationRequest_NotAllowedNssai_NotForwarded(t
 
 	var pduSessionID uint8 = 5
 
-	// The session's own S-NSSAI is allowed; the one the message requests is not.
 	_ = ue.CreateSmContext(pduSessionID, "testref", &models.Snssai{Sst: 1, Sd: "010203"})
 
 	smPayload := []byte{0x2E, 0x01, 0x00, 0xC1, 0x00}

--- a/internal/amf/nas/handle_ul_nas_transport_test.go
+++ b/internal/amf/nas/handle_ul_nas_transport_test.go
@@ -306,7 +306,6 @@ func TestTransport5GSMMessage_InitialRequest_NotAllowedNssai_NotForwarded(t *tes
 	assertPlainGmm(t, ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgDLNASTransport))
 }
 
-// TS 24.501 §5.4.5.2.5 case 13.
 func TestTransport5GSMMessage_ModificationRequest_NotAllowedNssai_NotForwarded(t *testing.T) {
 	ue, ngapSender, err := buildUeAndRadio()
 	if err != nil {

--- a/internal/amf/nas/nas_gate_test.go
+++ b/internal/amf/nas/nas_gate_test.go
@@ -135,7 +135,7 @@ func TestHandleGmmMessage_UnimplementedType_ReturnsStatus97(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d := HandleGmmMessage(context.Background(), amf.New(nil, nil, nil), ue, uint8(fgs.MsgRegistrationReject), reject, true)
+	d := HandleGmmMessage(context.Background(), amf.New(nil, nil, nil), ue, uint8(fgs.MsgRegistrationReject), reject, true, false)
 
 	if d.Action != nasreply.ActionStatus || d.Domain != nasreply.DomainMM || d.Cause != nasreply.CauseMessageTypeNotImplemented {
 		t.Errorf("disposition = %+v, want a 5GMM STATUS #97 (message type non-existent or not implemented)", d)

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -106,7 +106,7 @@ func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn
 		logger.SUPI(ue.UeContext().Supi().String()),
 	)
 
-	return HandleGmmMessage(ctx, amfInstance, ue.UeContext(), result.MessageType, result.Plain, integrityVerified)
+	return HandleGmmMessage(ctx, amfInstance, ue.UeContext(), result.MessageType, result.Plain, integrityVerified, result.ArrivedPlain)
 }
 
 // dispositionForUnresolved classifies a fresh-connection NAS PDU that established or resolved

--- a/internal/amf/nas_ciphering_test.go
+++ b/internal/amf/nas_ciphering_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
-// TS 24.501 §4.4.5.
 func TestDecodeNASMessageDiscardsAnUncipheredMessageAfterCiphering(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
 
-	// The first message establishes secure exchange on the connection.
 	if _, err := DecodeNASMessage(ue, wrapProtected(t, ue, encodePlainULNasTransport(t), 0)); err != nil {
 		t.Fatalf("first message not accepted: %v", err)
 	}
@@ -30,9 +28,6 @@ func TestDecodeNASMessageDiscardsAnUncipheredMessageAfterCiphering(t *testing.T)
 	}
 }
 
-// TS 24.501 §4.4.6 has the UE send an initial NAS message integrity protected
-// but not ciphered, with its non-cleartext IEs in the NAS message container, so
-// the guard must not discard one.
 func TestDecodeNASMessageAcceptsAnUncipheredInitialNASMessage(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
@@ -46,8 +41,6 @@ func TestDecodeNASMessageAcceptsAnUncipheredInitialNASMessage(t *testing.T) {
 	}
 }
 
-// The initial NAS message of a new connection precedes secure exchange on it, so
-// nothing is held to ciphering there whatever its type.
 func TestDecodeNASMessageAcceptsAnUncipheredFirstMessage(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)

--- a/internal/amf/nas_ciphering_test.go
+++ b/internal/amf/nas_ciphering_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+//
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+// TS 24.501 §4.4.5.
+func TestDecodeNASMessageDiscardsAnUncipheredMessageAfterCiphering(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	// The first message establishes secure exchange on the connection.
+	if _, err := DecodeNASMessage(ue, wrapProtected(t, ue, encodePlainULNasTransport(t), 0)); err != nil {
+		t.Fatalf("first message not accepted: %v", err)
+	}
+
+	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 1))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered UL NAS TRANSPORT) = %+v, nil, want it discarded", res)
+	}
+
+	if ue.ULCount() != 1 {
+		t.Errorf("uplink NAS COUNT = %d, want 1; a discarded message advanced it", ue.ULCount())
+	}
+}
+
+// TS 24.501 §4.4.6 has the UE send an initial NAS message integrity protected
+// but not ciphered, with its non-cleartext IEs in the NAS message container, so
+// the guard must not discard one.
+func TestDecodeNASMessageAcceptsAnUncipheredInitialNASMessage(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapProtected(t, ue, encodePlainULNasTransport(t), 0)); err != nil {
+		t.Fatalf("first message not accepted: %v", err)
+	}
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 1)); err != nil {
+		t.Fatalf("DecodeNASMessage(unciphered REGISTRATION REQUEST) = %v, want it accepted", err)
+	}
+}
+
+// The initial NAS message of a new connection precedes secure exchange on it, so
+// nothing is held to ciphering there whatever its type.
+func TestDecodeNASMessageAcceptsAnUncipheredFirstMessage(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 0)); err != nil {
+		t.Fatalf("DecodeNASMessage(first message, unciphered) = %v, want it accepted", err)
+	}
+}
+
+func TestCipheringRequired(t *testing.T) {
+	exempt := []fgs.MessageType{
+		fgs.MsgRegistrationRequest,
+		fgs.MsgDeregistrationRequestUEOrig,
+		fgs.MsgServiceRequest,
+		fgs.MsgControlPlaneServiceRequest,
+	}
+
+	for _, mt := range exempt {
+		if cipheringRequired(mt) {
+			t.Errorf("cipheringRequired(%s) = true, want false: it can be an initial NAS message", mt)
+		}
+	}
+
+	held := []fgs.MessageType{
+		fgs.MsgRegistrationComplete,
+		fgs.MsgIdentityResponse,
+		fgs.MsgULNASTransport,
+		fgs.MsgGMMStatus,
+	}
+
+	for _, mt := range held {
+		if !cipheringRequired(mt) {
+			t.Errorf("cipheringRequired(%s) = false, want true", mt)
+		}
+	}
+}

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -27,6 +27,32 @@ type DecodeResult struct {
 	Plain []byte
 }
 
+// A standalone 5GSM message, or one whose type will not peek, lands on the
+// required-ciphered default.
+func cipheringRequiredFor(plain []byte) bool {
+	mt, err := fgs.PeekMessageType(plain)
+	if err != nil {
+		return true
+	}
+
+	return cipheringRequired(mt)
+}
+
+// TS 24.501 §4.4.6 has the UE set the security header type of an initial NAS
+// message to "integrity protected" and carry its non-cleartext IEs in the
+// ciphered NAS message container, so these four are unciphered by design.
+func cipheringRequired(mt fgs.MessageType) bool {
+	switch mt {
+	case fgs.MsgRegistrationRequest,
+		fgs.MsgDeregistrationRequestUEOrig,
+		fgs.MsgServiceRequest,
+		fgs.MsgControlPlaneServiceRequest:
+		return false
+	}
+
+	return true
+}
+
 // plainNasAllowed reports whether a NAS message type may be processed without a verified
 // MAC before secure exchange (TS 24.501 §4.4.4.3, TS 33.501) — either sent as plain NAS,
 // or received integrity-protected with a failed MAC. SERVICE REQUEST is on the spec's

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -18,10 +18,8 @@ type DecodeResult struct {
 	// IsGMM reports whether Plain is a 5GMM message; false for a standalone 5GSM message on N1.
 	IsGMM             bool
 	IntegrityVerified bool
-	// ArrivedPlain reports that the PDU carried security header type "plain 5GS
-	// NAS message", which a UE sends when it holds no 5G NAS security context to
-	// protect with. It tells that case apart from a protected PDU whose MAC did
-	// not verify, which TS 24.501 §4.4.6 treats differently.
+	// Distinct from a protected PDU whose MAC failed: only a UE holding no
+	// security context sends plain.
 	ArrivedPlain bool
 	// Plain is the decoded plain 5GMM message (after any decipher), the input for the
 	// nas/fgs handlers. It starts with the extended protocol discriminator, and is

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -18,6 +18,11 @@ type DecodeResult struct {
 	// IsGMM reports whether Plain is a 5GMM message; false for a standalone 5GSM message on N1.
 	IsGMM             bool
 	IntegrityVerified bool
+	// ArrivedPlain reports that the PDU carried security header type "plain 5GS
+	// NAS message", which a UE sends when it holds no 5G NAS security context to
+	// protect with. It tells that case apart from a protected PDU whose MAC did
+	// not verify, which TS 24.501 §4.4.6 treats differently.
+	ArrivedPlain bool
 	// Plain is the decoded plain 5GMM message (after any decipher), the input for the
 	// nas/fgs handlers. It starts with the extended protocol discriminator, and is
 	// also the byte-for-byte duplicate-detection oracle (TS 24.501 §5.5.1.2.8).

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -18,17 +18,13 @@ type DecodeResult struct {
 	// IsGMM reports whether Plain is a 5GMM message; false for a standalone 5GSM message on N1.
 	IsGMM             bool
 	IntegrityVerified bool
-	// Distinct from a protected PDU whose MAC failed: only a UE holding no
-	// security context sends plain.
-	ArrivedPlain bool
+	ArrivedPlain      bool
 	// Plain is the decoded plain 5GMM message (after any decipher), the input for the
 	// nas/fgs handlers. It starts with the extended protocol discriminator, and is
 	// also the byte-for-byte duplicate-detection oracle (TS 24.501 §5.5.1.2.8).
 	Plain []byte
 }
 
-// A standalone 5GSM message, or one whose type will not peek, lands on the
-// required-ciphered default.
 func cipheringRequiredFor(plain []byte) bool {
 	mt, err := fgs.PeekMessageType(plain)
 	if err != nil {
@@ -38,9 +34,8 @@ func cipheringRequiredFor(plain []byte) bool {
 	return cipheringRequired(mt)
 }
 
-// TS 24.501 §4.4.6 has the UE set the security header type of an initial NAS
-// message to "integrity protected" and carry its non-cleartext IEs in the
-// ciphered NAS message container, so these four are unciphered by design.
+// TS 24.501 §4.4.6 has the UE set an initial NAS message to "integrity
+// protected" and cipher only its NAS message container.
 func cipheringRequired(mt fgs.MessageType) bool {
 	switch mt {
 	case fgs.MsgRegistrationRequest,

--- a/internal/amf/nas_integrity_verified_test.go
+++ b/internal/amf/nas_integrity_verified_test.go
@@ -29,6 +29,21 @@ func wrapIntegrityProtected(t *testing.T, ue *UeContext, inner []byte, sqn uint8
 	return pdu
 }
 
+// wrapProtected builds the security header a UE uses for everything after the
+// security mode procedure: integrity protected and ciphered.
+func wrapProtected(t *testing.T, ue *UeContext, inner []byte, sqn uint8) []byte {
+	t.Helper()
+
+	cnt, _ := ue.ulCount.Estimate(sqn)
+
+	pdu, err := fgs.Protect(inner, fgs.SHTIntegrityProtectedCiphered, cnt, nas.DirectionUplink, ue.sc)
+	if err != nil {
+		t.Fatalf("protect NAS: %v", err)
+	}
+
+	return pdu
+}
+
 func newSecuredUE(t *testing.T) *UeContext {
 	t.Helper()
 

--- a/internal/amf/nas_integrity_verified_test.go
+++ b/internal/amf/nas_integrity_verified_test.go
@@ -29,8 +29,6 @@ func wrapIntegrityProtected(t *testing.T, ue *UeContext, inner []byte, sqn uint8
 	return pdu
 }
 
-// wrapProtected builds the security header a UE uses for everything after the
-// security mode procedure: integrity protected and ciphered.
 func wrapProtected(t *testing.T, ue *UeContext, inner []byte, sqn uint8) []byte {
 	t.Helper()
 

--- a/internal/amf/nas_replay_test.go
+++ b/internal/amf/nas_replay_test.go
@@ -13,7 +13,7 @@ func TestNASUplinkReplayRejected(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
 
-	msg := wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 0)
+	msg := wrapProtected(t, ue, encodePlainULNasTransport(t), 0)
 
 	res, err := DecodeNASMessage(ue, msg)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestNASUplinkCountWrap(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(255)
 
-	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 255)); err != nil {
+	if _, err := DecodeNASMessage(ue, wrapProtected(t, ue, encodePlainULNasTransport(t), 255)); err != nil {
 		t.Fatalf("sequence 255 not accepted: %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestNASUplinkCountWrap(t *testing.T) {
 	}
 
 	// The UE's sequence wraps 255->0 and its overflow becomes 1.
-	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 0)); err != nil {
+	if _, err := DecodeNASMessage(ue, wrapProtected(t, ue, encodePlainULNasTransport(t), 0)); err != nil {
 		t.Fatalf("wrapped message not accepted: %v", err)
 	}
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -100,7 +100,11 @@ type UeConn struct {
 	RegistrationRequest *fgs.RegistrationRequest
 	// RegistrationRequestPlain is compared byte-for-byte for duplicate detection
 	// (TS 24.501 §5.5.1.2.8), immune to the decoder dropping IEs it does not model.
-	RegistrationRequestPlain        []byte
+	RegistrationRequestPlain []byte
+	// RegistrationRequestProtected records whether the stored request arrived
+	// integrity protected, which decides whether its non-cleartext IEs are
+	// authenticated (TS 24.501 §4.4.6).
+	RegistrationRequestProtected    bool
 	RegistrationType5GS             fgs.RegistrationType
 	IdentityTypeUsedForRegistration uint8
 	RetransmissionOfInitialNASMsg   bool

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -101,13 +101,13 @@ type UeConn struct {
 	// RegistrationRequestPlain is compared byte-for-byte for duplicate detection
 	// (TS 24.501 §5.5.1.2.8), immune to the decoder dropping IEs it does not model.
 	RegistrationRequestPlain []byte
-	// RegistrationRequestProtected records whether the stored request arrived
-	// integrity protected, which decides whether its non-cleartext IEs are
-	// authenticated (TS 24.501 §4.4.6).
-	RegistrationRequestProtected    bool
-	RegistrationType5GS             fgs.RegistrationType
-	IdentityTypeUsedForRegistration uint8
-	RetransmissionOfInitialNASMsg   bool
+	// RegistrationRequestReplayRequired records that the stored request arrived as
+	// a plain NAS message, so the UE has to repeat it in the NAS message container
+	// of the SECURITY MODE COMPLETE (TS 24.501 §4.4.6 case a).
+	RegistrationRequestReplayRequired bool
+	RegistrationType5GS               fgs.RegistrationType
+	IdentityTypeUsedForRegistration   uint8
+	RetransmissionOfInitialNASMsg     bool
 
 	// RegistrationAcceptPdu is the REGISTRATION ACCEPT last sent, kept to resend on a
 	// duplicate REGISTRATION REQUEST with identical IEs while awaiting REGISTRATION

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -101,9 +101,8 @@ type UeConn struct {
 	// RegistrationRequestPlain is compared byte-for-byte for duplicate detection
 	// (TS 24.501 §5.5.1.2.8), immune to the decoder dropping IEs it does not model.
 	RegistrationRequestPlain []byte
-	// RegistrationRequestReplayRequired records that the stored request arrived as
-	// a plain NAS message, so the UE has to repeat it in the NAS message container
-	// of the SECURITY MODE COMPLETE (TS 24.501 §4.4.6 case a).
+	// Plain arrival means the UE held no security context, so it must repeat the
+	// request in the SECURITY MODE COMPLETE (TS 24.501 §4.4.6 case a).
 	RegistrationRequestReplayRequired bool
 	RegistrationType5GS               fgs.RegistrationType
 	IdentityTypeUsedForRegistration   uint8

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -205,9 +205,8 @@ func SendRegistrationReject(ctx context.Context, ue *UeConn, cause5GMM fgs.GMMCa
 				return nil, err
 			}
 
-			// A UE that has established secure exchange discards an unprotected
-			// downlink (TS 24.501 §4.4.4.2); the plain form is for the rejects that
-			// precede security activation, which §4.4.4.2 admits.
+			// A secured UE discards an unprotected downlink; the plain form is for
+			// the rejects preceding security activation (TS 24.501 §4.4.4.2).
 			if !ue.SecureExchangeEstablished() {
 				return plain, nil
 			}

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -200,7 +200,19 @@ func SendRegistrationReject(ctx context.Context, ue *UeConn, cause5GMM fgs.GMMCa
 	sendGmm(ctx, ue, "nas/send_registration_reject",
 		[]attribute.KeyValue{attribute.Int("cause", int(cause5GMM))},
 		func(amfUe *UeContext) ([]byte, error) {
-			return BuildRegistrationReject(int(ue.amf.T3502Value.Seconds()), cause5GMM)
+			plain, err := BuildRegistrationReject(int(ue.amf.T3502Value.Seconds()), cause5GMM)
+			if err != nil {
+				return nil, err
+			}
+
+			// A UE that has established secure exchange discards an unprotected
+			// downlink (TS 24.501 §4.4.4.2); the plain form is for the rejects that
+			// precede security activation, which §4.4.4.2 admits.
+			if !ue.SecureExchangeEstablished() {
+				return plain, nil
+			}
+
+			return amfUe.EncodeNASMessagePlain(plain, uint8(fgs.SHTIntegrityProtectedCiphered))
 		})
 }
 

--- a/internal/mme/decode_nas_message.go
+++ b/internal/mme/decode_nas_message.go
@@ -108,8 +108,8 @@ func DecodeNASMessage(ue *UeContext, nas []byte) (*DecodeResult, error) {
 	// is dropped (TS 24.301).
 	p, count, err := ue.TryUnprotectUplink(nas)
 	if err == nil {
-		// connSecured is per connection, so the initial NAS message of a new one —
-		// legitimately unciphered — stays outside this guard (TS 24.301 §4.4.5).
+		// connSecured is per connection, leaving the initial NAS message of a new
+		// one outside this guard.
 		if connSecured && spm.SecurityHeaderType == eps.SHTIntegrityProtected && cipheringRequiredFor(p) {
 			logger.MmeLog.Warn("discarding unciphered NAS message received after ciphering started",
 				zap.String("imsi", ue.IMSI()))

--- a/internal/mme/decode_nas_message.go
+++ b/internal/mme/decode_nas_message.go
@@ -108,6 +108,18 @@ func DecodeNASMessage(ue *UeContext, nas []byte) (*DecodeResult, error) {
 	// is dropped (TS 24.301).
 	p, count, err := ue.TryUnprotectUplink(nas)
 	if err == nil {
+		// TS 24.301 §4.4.5: once ciphering has started the receiver discards an
+		// unciphered message that should have been ciphered. An integrity-only
+		// message carries its plaintext, so its type is readable here. Secure
+		// exchange is per connection, which leaves the initial NAS message of a new
+		// connection — legitimately unciphered — outside this guard.
+		if connSecured && spm.SecurityHeaderType == eps.SHTIntegrityProtected && cipheringRequiredFor(p) {
+			logger.MmeLog.Warn("discarding unciphered NAS message received after ciphering started",
+				zap.String("imsi", ue.IMSI()))
+
+			return nil, silentDecode(nasreply.ReasonIntegrityFail, "NAS discarded: unciphered after ciphering started (TS 24.301 §4.4.5)")
+		}
+
 		ue.CommitUplinkCount(count)
 
 		// First verified message establishes secure exchange on the connection (TS 24.301 §4.4.4.3).

--- a/internal/mme/decode_nas_message.go
+++ b/internal/mme/decode_nas_message.go
@@ -108,11 +108,8 @@ func DecodeNASMessage(ue *UeContext, nas []byte) (*DecodeResult, error) {
 	// is dropped (TS 24.301).
 	p, count, err := ue.TryUnprotectUplink(nas)
 	if err == nil {
-		// TS 24.301 §4.4.5: once ciphering has started the receiver discards an
-		// unciphered message that should have been ciphered. An integrity-only
-		// message carries its plaintext, so its type is readable here. Secure
-		// exchange is per connection, which leaves the initial NAS message of a new
-		// connection — legitimately unciphered — outside this guard.
+		// connSecured is per connection, so the initial NAS message of a new one —
+		// legitimately unciphered — stays outside this guard (TS 24.301 §4.4.5).
 		if connSecured && spm.SecurityHeaderType == eps.SHTIntegrityProtected && cipheringRequiredFor(p) {
 			logger.MmeLog.Warn("discarding unciphered NAS message received after ciphering started",
 				zap.String("imsi", ue.IMSI()))

--- a/internal/mme/kenb_freshness_test.go
+++ b/internal/mme/kenb_freshness_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import "testing"
+
+// TS 33.401 §7.2.5.2.2: with a NAS security mode control procedure before the AS
+// SMC, K_eNB derives from the uplink NAS COUNT of the SECURITY MODE COMPLETE. Any
+// uplink message the MME receives between it and the Initial Context Setup — an
+// ESM INFORMATION RESPONSE, say — advances the count but is not what the UE
+// derives from.
+func TestKeNBFreshnessSurvivesALaterUplinkMessage(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.SetULCountForTest(0)
+	ue.CommitUplinkCount(0)
+	ue.PinKeNBFreshness()
+
+	pinned, pinnedCount, err := ue.DeriveInitialKeNB()
+	if err != nil {
+		t.Fatalf("derive K_eNB at the Security Mode Complete: %v", err)
+	}
+
+	if pinnedCount != 0 {
+		t.Fatalf("pinned K_eNB NAS COUNT = %d, want 0", pinnedCount)
+	}
+
+	ue.CommitUplinkCount(1)
+
+	kenb, count, err := ue.DeriveInitialKeNB()
+	if err != nil {
+		t.Fatalf("derive K_eNB at the Initial Context Setup: %v", err)
+	}
+
+	if count != 0 {
+		t.Errorf("K_eNB NAS COUNT = %d, want the pinned 0; an intervening uplink message moved it", count)
+	}
+
+	if kenb != pinned {
+		t.Error("K_eNB changed after an intervening uplink message; the UE would derive a different key")
+	}
+}
+
+// A later procedure that triggers its own context setup re-pins, so a UE
+// returning from idle does not derive against the attach's count.
+func TestKeNBFreshnessRepinsForALaterTrigger(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.SetULCountForTest(0)
+	ue.CommitUplinkCount(0)
+	ue.PinKeNBFreshness()
+
+	attach, _, err := ue.DeriveInitialKeNB()
+	if err != nil {
+		t.Fatalf("derive K_eNB at attach: %v", err)
+	}
+
+	ue.CommitUplinkCount(1)
+	ue.PinKeNBFreshness()
+
+	resume, count, err := ue.DeriveInitialKeNB()
+	if err != nil {
+		t.Fatalf("derive K_eNB on resume: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("K_eNB NAS COUNT = %d, want 1", count)
+	}
+
+	if resume == attach {
+		t.Error("K_eNB unchanged across two triggers with different NAS COUNTs")
+	}
+}
+
+// A fresh security context restarts the counts, and zero is the freshness it
+// derives from (TS 33.401 §7.2.5.2.3).
+func TestKeNBFreshnessResetsWithTheSecurityContext(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.SetULCountForTest(0)
+	ue.CommitUplinkCount(4)
+	ue.PinKeNBFreshness()
+
+	if _, count, err := ue.DeriveInitialKeNB(); err != nil || count != 4 {
+		t.Fatalf("K_eNB NAS COUNT = %d (err %v), want 4", count, err)
+	}
+
+	if err := ue.InstallNASSecurityContext(2, 2, MintAuthProofForSecurityMode()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, count, err := ue.DeriveInitialKeNB(); err != nil || count != 0 {
+		t.Fatalf("K_eNB NAS COUNT after a fresh context = %d (err %v), want 0", count, err)
+	}
+}

--- a/internal/mme/kenb_freshness_test.go
+++ b/internal/mme/kenb_freshness_test.go
@@ -5,11 +5,6 @@ package mme
 
 import "testing"
 
-// TS 33.401 §7.2.5.2.2: with a NAS security mode control procedure before the AS
-// SMC, K_eNB derives from the uplink NAS COUNT of the SECURITY MODE COMPLETE. Any
-// uplink message the MME receives between it and the Initial Context Setup — an
-// ESM INFORMATION RESPONSE, say — advances the count but is not what the UE
-// derives from.
 func TestKeNBFreshnessSurvivesALaterUplinkMessage(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -43,8 +38,6 @@ func TestKeNBFreshnessSurvivesALaterUplinkMessage(t *testing.T) {
 	}
 }
 
-// A later procedure that triggers its own context setup re-pins, so a UE
-// returning from idle does not derive against the attach's count.
 func TestKeNBFreshnessRepinsForALaterTrigger(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -75,8 +68,6 @@ func TestKeNBFreshnessRepinsForALaterTrigger(t *testing.T) {
 	}
 }
 
-// A fresh security context restarts the counts, and zero is the freshness it
-// derives from (TS 33.401 §7.2.5.2.3).
 func TestKeNBFreshnessResetsWithTheSecurityContext(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -192,8 +192,7 @@ const (
 	defaultNASGuardMaxRetransmit = 4
 )
 
-// TS 24.301 §6.6.1.2.6 a) aborts on the third expiry, so two retransmissions
-// follow the initial request (table 10.2.2).
+// TS 24.301 §6.6.1.2.6 a) aborts on the third expiry.
 const (
 	defaultT3489Timeout       = 4 * time.Second
 	defaultT3489MaxRetransmit = 2

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -151,6 +151,7 @@ type MME struct {
 	// Retransmitting supervision guards, held as guard.TimerValue.
 	nasGuardCfg guard.TimerValue // NAS common-procedure guard (TS 24.301: T3450/T3460/T3470)
 	esmGuardCfg guard.TimerValue // ESM bearer-procedure guard (TS 24.301: T3486/T3495), 4G-only (no AMF peer)
+	t3489Cfg    guard.TimerValue // ESM information request guard (TS 24.301: T3489)
 	pagingCfg   guard.TimerValue // paging supervision (T3413, TS 24.301 §5.6.2)
 
 	// handoverGuardTimeout bounds the whole S1 handover (HANDOVER REQUIRED → NOTIFY)
@@ -189,6 +190,14 @@ const (
 const (
 	defaultNASGuardTimeout       = 6 * time.Second
 	defaultNASGuardMaxRetransmit = 4
+)
+
+// T3489 supervises the ESM information request procedure. Its third expiry
+// aborts the procedure, so the initial request is followed by two
+// retransmissions (TS 24.301 §6.6.1.2.6 a, table 10.2.1).
+const (
+	defaultT3489Timeout       = 4 * time.Second
+	defaultT3489MaxRetransmit = 2
 )
 
 // defaultESMGuardTimeout is the retransmission interval for the ESM bearer
@@ -235,6 +244,7 @@ func New(cred credentialProvider, bearer bearerStore, session epsSessionManager)
 
 		nasGuardCfg: guard.TimerValue{Enable: true, ExpireTime: defaultNASGuardTimeout, MaxRetryTimes: int32(defaultNASGuardMaxRetransmit)},
 		esmGuardCfg: guard.TimerValue{Enable: true, ExpireTime: defaultESMGuardTimeout, MaxRetryTimes: int32(defaultNASGuardMaxRetransmit)},
+		t3489Cfg:    guard.TimerValue{Enable: true, ExpireTime: defaultT3489Timeout, MaxRetryTimes: int32(defaultT3489MaxRetransmit)},
 		pagingCfg:   guard.TimerValue{Enable: true, ExpireTime: defaultPagingTimeout, MaxRetryTimes: int32(defaultPagingMaxRetransmit)},
 
 		handoverGuardTimeout: defaultHandoverGuardTimeout,

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -192,9 +192,8 @@ const (
 	defaultNASGuardMaxRetransmit = 4
 )
 
-// T3489 supervises the ESM information request procedure. Its third expiry
-// aborts the procedure, so the initial request is followed by two
-// retransmissions (TS 24.301 §6.6.1.2.6 a, table 10.2.1).
+// TS 24.301 §6.6.1.2.6 a) aborts on the third expiry, so two retransmissions
+// follow the initial request (table 10.2.2).
 const (
 	defaultT3489Timeout       = 4 * time.Second
 	defaultT3489MaxRetransmit = 2

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -738,6 +738,12 @@ func (m *MME) detachConnLocked(ue *UeContext) *UeConn {
 	// fire on a detached connection.
 	m.clearHandoverLocked(ue)
 	m.stopNASGuardLocked(ue)
+	// The ESM information request procedure is bounded by the connection it runs
+	// on: its response can only arrive over that connection, and the reject its
+	// abort would emit could not be delivered. Dropping the wait keeps a later
+	// response on a fresh connection from resuming a procedure that is over.
+	old.esmInfoGuard.Stop()
+	ue.esmInfoWait.Store(nil)
 	// Detaching the connection ends any in-flight key-changing procedure on it
 	// (e.g. a security mode whose Complete never arrived), so the {NH, NCC} chain
 	// claim must not outlive it and block a later procedure (TS 33.401 §7.2.8).

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -154,6 +154,9 @@ type UeContext struct {
 	// Request the ATTACH REQUEST carried, replayed in the default bearer's
 	// ACTIVATE DEFAULT EPS BEARER CONTEXT REQUEST (TS 24.301 §6.4.1).
 	RequestedPTI nas.ProcedureTransactionIdentity
+	// kenbCount is the uplink NAS COUNT the K_eNB derivation uses, pinned when the
+	// message that names it is accepted (TS 33.401 §7.2.5.2.2, §7.2.6.2).
+	kenbCount uint32
 	// Swapped whole from the NAS goroutine and the T3489 timer goroutine, so it
 	// needs no ordering against ue.mu.
 	esmInfoWait atomic.Pointer[ESMInfoWait]

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -113,6 +113,22 @@ type PdnConnection struct {
 	guard guard.Guard
 }
 
+// ESMInfoWait is an outstanding ESM information request procedure
+// (TS 24.301 §6.6.1.2). PTI is the transaction it belongs to, so a response
+// naming another one is refused without ending it (§7.3.1 e). Standalone is nil
+// when the procedure runs inside an attach.
+type ESMInfoWait struct {
+	PTI        uint8
+	Standalone *PendingPDNConnectivity
+}
+
+// PendingPDNConnectivity is the standalone PDN CONNECTIVITY REQUEST waiting on
+// the ESM information the UE deferred (TS 24.301 §6.5.1.2).
+type PendingPDNConnectivity struct {
+	PTI     uint8
+	PDNType uint8
+}
+
 // UeContext is the MME's persistent per-UE EMM context: subscriber identity, the
 // EPS NAS security context, and the bearer state.
 type UeContext struct {
@@ -142,7 +158,12 @@ type UeContext struct {
 	// RequestedPTI is the procedure transaction identity of the PDN Connectivity
 	// Request the ATTACH REQUEST carried, replayed in the default bearer's
 	// ACTIVATE DEFAULT EPS BEARER CONTEXT REQUEST (TS 24.301 §6.4.1).
-	RequestedPTI   nas.ProcedureTransactionIdentity
+	RequestedPTI nas.ProcedureTransactionIdentity
+	// esmInfoWait is the outstanding ESM information request, nil when none. It is
+	// swapped whole from the NAS goroutine and from the T3489 timer goroutine, so
+	// it is an atomic pointer and needs no ordering against ue.mu.
+	esmInfoWait atomic.Pointer[ESMInfoWait]
+
 	CombinedAttach bool // UE requested combined EPS/IMSI attach (TS 24.301)
 	// HashmmeInput is the plain Attach Request to hash into the SECURITY MODE
 	// COMMAND HashMME IE, set when the Attach arrived without integrity protection;
@@ -513,6 +534,40 @@ func (m *MME) FindPDNByAPN(ue *UeContext, apn string) *PdnConnection {
 	defer ue.mu.Unlock()
 
 	return ue.PdnForAPN(apn)
+}
+
+// AwaitESMInformation records that an ESM information request is outstanding for
+// transaction pti. standalone is nil when the procedure runs inside an attach.
+func (ue *UeContext) AwaitESMInformation(pti uint8, standalone *PendingPDNConnectivity) {
+	ue.esmInfoWait.Store(&ESMInfoWait{PTI: pti, Standalone: standalone})
+}
+
+// PendingESMInfo returns the outstanding ESM information request without ending
+// it, or nil when none is running.
+func (ue *UeContext) PendingESMInfo() *ESMInfoWait {
+	return ue.esmInfoWait.Load()
+}
+
+// TakeESMInfoWait ends the ESM information procedure and returns what it was
+// running for, so exactly one caller concludes it.
+func (ue *UeContext) TakeESMInfoWait() *ESMInfoWait {
+	return ue.esmInfoWait.Swap(nil)
+}
+
+// TakeESMInfoWaitFor ends the ESM information procedure only if pti names it,
+// returning nil otherwise so a response for another transaction leaves the
+// procedure running (TS 24.301 §7.3.1 e).
+func (ue *UeContext) TakeESMInfoWaitFor(pti uint8) *ESMInfoWait {
+	w := ue.esmInfoWait.Load()
+	if w == nil || w.PTI != pti {
+		return nil
+	}
+
+	if ue.esmInfoWait.CompareAndSwap(w, nil) {
+		return w
+	}
+
+	return nil
 }
 
 // DropPDN removes a PDN connection from the UE without releasing a session, for

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -113,7 +113,6 @@ type PdnConnection struct {
 	guard guard.Guard
 }
 
-// Standalone is nil when the procedure runs inside an attach.
 type ESMInfoWait struct {
 	PTI        uint8
 	Standalone *PendingPDNConnectivity
@@ -157,8 +156,7 @@ type UeContext struct {
 	// kenbCount is the uplink NAS COUNT the K_eNB derivation uses, pinned when the
 	// message that names it is accepted (TS 33.401 §7.2.5.2.2, §7.2.6.2).
 	kenbCount uint32
-	// Swapped whole from the NAS goroutine and the T3489 timer goroutine, so it
-	// needs no ordering against ue.mu.
+	// Swapped from the NAS goroutine and the T3489 timer goroutine.
 	esmInfoWait atomic.Pointer[ESMInfoWait]
 
 	CombinedAttach bool // UE requested combined EPS/IMSI attach (TS 24.301)
@@ -541,13 +539,10 @@ func (ue *UeContext) PendingESMInfo() *ESMInfoWait {
 	return ue.esmInfoWait.Load()
 }
 
-// Swap so exactly one of the response and the T3489 abort concludes the procedure.
 func (ue *UeContext) TakeESMInfoWait() *ESMInfoWait {
 	return ue.esmInfoWait.Swap(nil)
 }
 
-// Nil unless pti names the running procedure, so a response for another
-// transaction leaves it running (TS 24.301 §7.3.1 e).
 func (ue *UeContext) TakeESMInfoWaitFor(pti uint8) *ESMInfoWait {
 	w := ue.esmInfoWait.Load()
 	if w == nil || w.PTI != pti {

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -113,17 +113,12 @@ type PdnConnection struct {
 	guard guard.Guard
 }
 
-// ESMInfoWait is an outstanding ESM information request procedure
-// (TS 24.301 §6.6.1.2). PTI is the transaction it belongs to, so a response
-// naming another one is refused without ending it (§7.3.1 e). Standalone is nil
-// when the procedure runs inside an attach.
+// Standalone is nil when the procedure runs inside an attach.
 type ESMInfoWait struct {
 	PTI        uint8
 	Standalone *PendingPDNConnectivity
 }
 
-// PendingPDNConnectivity is the standalone PDN CONNECTIVITY REQUEST waiting on
-// the ESM information the UE deferred (TS 24.301 §6.5.1.2).
 type PendingPDNConnectivity struct {
 	PTI     uint8
 	PDNType uint8
@@ -159,9 +154,8 @@ type UeContext struct {
 	// Request the ATTACH REQUEST carried, replayed in the default bearer's
 	// ACTIVATE DEFAULT EPS BEARER CONTEXT REQUEST (TS 24.301 §6.4.1).
 	RequestedPTI nas.ProcedureTransactionIdentity
-	// esmInfoWait is the outstanding ESM information request, nil when none. It is
-	// swapped whole from the NAS goroutine and from the T3489 timer goroutine, so
-	// it is an atomic pointer and needs no ordering against ue.mu.
+	// Swapped whole from the NAS goroutine and the T3489 timer goroutine, so it
+	// needs no ordering against ue.mu.
 	esmInfoWait atomic.Pointer[ESMInfoWait]
 
 	CombinedAttach bool // UE requested combined EPS/IMSI attach (TS 24.301)
@@ -536,27 +530,21 @@ func (m *MME) FindPDNByAPN(ue *UeContext, apn string) *PdnConnection {
 	return ue.PdnForAPN(apn)
 }
 
-// AwaitESMInformation records that an ESM information request is outstanding for
-// transaction pti. standalone is nil when the procedure runs inside an attach.
 func (ue *UeContext) AwaitESMInformation(pti uint8, standalone *PendingPDNConnectivity) {
 	ue.esmInfoWait.Store(&ESMInfoWait{PTI: pti, Standalone: standalone})
 }
 
-// PendingESMInfo returns the outstanding ESM information request without ending
-// it, or nil when none is running.
 func (ue *UeContext) PendingESMInfo() *ESMInfoWait {
 	return ue.esmInfoWait.Load()
 }
 
-// TakeESMInfoWait ends the ESM information procedure and returns what it was
-// running for, so exactly one caller concludes it.
+// Swap so exactly one of the response and the T3489 abort concludes the procedure.
 func (ue *UeContext) TakeESMInfoWait() *ESMInfoWait {
 	return ue.esmInfoWait.Swap(nil)
 }
 
-// TakeESMInfoWaitFor ends the ESM information procedure only if pti names it,
-// returning nil otherwise so a response for another transaction leaves the
-// procedure running (TS 24.301 §7.3.1 e).
+// Nil unless pti names the running procedure, so a response for another
+// transaction leaves it running (TS 24.301 §7.3.1 e).
 func (ue *UeContext) TakeESMInfoWaitFor(pti uint8) *ESMInfoWait {
 	w := ue.esmInfoWait.Load()
 	if w == nil || w.PTI != pti {
@@ -738,10 +726,8 @@ func (m *MME) detachConnLocked(ue *UeContext) *UeConn {
 	// fire on a detached connection.
 	m.clearHandoverLocked(ue)
 	m.stopNASGuardLocked(ue)
-	// The ESM information request procedure is bounded by the connection it runs
-	// on: its response can only arrive over that connection, and the reject its
-	// abort would emit could not be delivered. Dropping the wait keeps a later
-	// response on a fresh connection from resuming a procedure that is over.
+	// The response can only arrive over this connection, so a surviving wait could
+	// only be concluded by an unrelated one.
 	old.esmInfoGuard.Stop()
 	ue.esmInfoWait.Store(nil)
 	// Detaching the connection ends any in-flight key-changing procedure on it

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -48,7 +48,7 @@ func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext) {
 		// (TS 24.301 §6.5.1.4, ESM cause #27).
 		logger.From(ctx, logger.MmeLog).Info("attach rejected: requested APN not in subscriber profile",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", ue.RequestedAPN))
-		rejectAttach(ctx, m, ue, eps.EMMCauseESMFailure)
+		rejectAttachESMFailure(ctx, m, ue, eps.ESMCauseMissingOrUnknownAPN)
 
 		return
 	}
@@ -86,7 +86,7 @@ func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext) {
 		// IPv4-only data network); reject with EMM cause #19 "ESM failure" (TS 24.301).
 		logger.From(ctx, logger.MmeLog).Info("attach rejected: default bearer setup failed",
 			zap.String("imsi", ue.IMSI()), zap.Error(err))
-		rejectAttach(ctx, m, ue, eps.EMMCauseESMFailure)
+		rejectAttachESMFailure(ctx, m, ue, eps.ESMCauseRequestRejectedUnspecified)
 
 		return
 	}

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -42,9 +42,8 @@ func registrationAreaTAIList(area []models.Tai) (eps.TAIList, error) {
 }
 
 func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext) {
-	// The security context is up by the time the attach reaches here, which is what
-	// the ESM information request procedure waits for (TS 24.301 §6.6.1.2.2). The
-	// response re-enters this function with the deferred APN in hand.
+	// Both callers reach here with the security context up (TS 24.301 §6.6.1.2.2).
+	// The response re-enters this function.
 	if requestESMInformation(ctx, ue, func(pti uint8) {
 		// T3489's final expiry outlives the request's context.
 		rejectAttachESM(context.Background(), m, ue, pti, eps.ESMCauseESMInformationNotReceived)

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -42,13 +42,23 @@ func registrationAreaTAIList(area []models.Tai) (eps.TAIList, error) {
 }
 
 func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext) {
+	// The security context is up by the time the attach reaches here, which is what
+	// the ESM information request procedure waits for (TS 24.301 §6.6.1.2.2). The
+	// response re-enters this function with the deferred APN in hand.
+	if requestESMInformation(ctx, ue, func(pti uint8) {
+		// T3489's final expiry outlives the request's context.
+		rejectAttachESM(context.Background(), m, ue, pti, eps.ESMCauseESMInformationNotReceived)
+	}) {
+		return
+	}
+
 	qos, err := mme.ResolveAttachQoS(ctx, m, ue)
 	if errors.Is(err, mme.ErrUnknownAPN) {
 		// The requested APN is not bound to any policy in the subscriber's profile
 		// (TS 24.301 §6.5.1.4, ESM cause #27).
 		logger.From(ctx, logger.MmeLog).Info("attach rejected: requested APN not in subscriber profile",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", ue.RequestedAPN))
-		rejectAttachESMFailure(ctx, m, ue, eps.ESMCauseMissingOrUnknownAPN)
+		rejectAttachESM(ctx, m, ue, uint8(ue.RequestedPTI), eps.ESMCauseMissingOrUnknownAPN)
 
 		return
 	}
@@ -86,7 +96,7 @@ func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext) {
 		// IPv4-only data network); reject with EMM cause #19 "ESM failure" (TS 24.301).
 		logger.From(ctx, logger.MmeLog).Info("attach rejected: default bearer setup failed",
 			zap.String("imsi", ue.IMSI()), zap.Error(err))
-		rejectAttachESMFailure(ctx, m, ue, eps.ESMCauseRequestRejectedUnspecified)
+		rejectAttachESM(ctx, m, ue, uint8(ue.RequestedPTI), eps.ESMCauseRequestRejectedUnspecified)
 
 		return
 	}

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -42,8 +42,6 @@ func registrationAreaTAIList(area []models.Tai) (eps.TAIList, error) {
 }
 
 func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext) {
-	// Both callers reach here with the security context up (TS 24.301 §6.6.1.2.2).
-	// The response re-enters this function.
 	if requestESMInformation(ctx, ue, func(pti uint8) {
 		// T3489's final expiry outlives the request's context.
 		rejectAttachESM(context.Background(), m, ue, pti, eps.ESMCauseESMInformationNotReceived)

--- a/internal/mme/nas/egress.go
+++ b/internal/mme/nas/egress.go
@@ -33,8 +33,6 @@ func (e egress) SendSMStatus(ctx context.Context, cause uint8) {
 	e.emit(ctx, &eps.ESMStatus{Cause: eps.ESMCause(cause)})
 }
 
-// SendSMStatusFor reports an ESM protocol error naming the transaction it
-// refuses, so the UE can correlate it (TS 24.301 §8.3.15).
 func (e egress) SendSMStatusFor(ctx context.Context, cause, pti, ebi uint8) {
 	e.emit(ctx, &eps.ESMStatus{
 		EPSBearerIdentity: eps.EPSBearerIdentity(ebi),

--- a/internal/mme/nas/egress.go
+++ b/internal/mme/nas/egress.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/nasreply"
+	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
 	"go.uber.org/zap"
 )
@@ -30,6 +31,16 @@ func (e egress) SendMMStatus(ctx context.Context, cause uint8) {
 
 func (e egress) SendSMStatus(ctx context.Context, cause uint8) {
 	e.emit(ctx, &eps.ESMStatus{Cause: eps.ESMCause(cause)})
+}
+
+// SendSMStatusFor reports an ESM protocol error naming the transaction it
+// refuses, so the UE can correlate it (TS 24.301 §8.3.15).
+func (e egress) SendSMStatusFor(ctx context.Context, cause, pti, ebi uint8) {
+	e.emit(ctx, &eps.ESMStatus{
+		EPSBearerIdentity: eps.EPSBearerIdentity(ebi),
+		PTI:               nas.ProcedureTransactionIdentity(pti),
+		Cause:             eps.ESMCause(cause),
+	})
 }
 
 func (e egress) emit(ctx context.Context, msg nasMarshaler) {

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -65,8 +65,6 @@ func decodeDownlinkNAS(t *testing.T, pdu []byte) []byte {
 	return []byte(dl.NASPDU)
 }
 
-// decodeProtectedDownlink returns the plaintext of a security-protected downlink
-// NAS message sent to a secured UE.
 func decodeProtectedDownlink(t *testing.T, ue *mme.UeContext, pdu []byte) []byte {
 	t.Helper()
 

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -65,6 +65,22 @@ func decodeDownlinkNAS(t *testing.T, pdu []byte) []byte {
 	return []byte(dl.NASPDU)
 }
 
+// decodeProtectedDownlink returns the plaintext of a security-protected downlink
+// NAS message sent to a secured UE.
+func decodeProtectedDownlink(t *testing.T, ue *mme.UeContext, pdu []byte) []byte {
+	t.Helper()
+
+	dl := decodeDownlinkNAS(t, pdu)
+
+	plain, err := unprotected(eps.Unprotect(dl, nas.MakeCount(0, dl[5]), nas.DirectionDownlink,
+		mustSecurityContext(t, ue.EIA(), ue.EEA(), ue.KnasIntForTest(), ue.KnasEncForTest())))
+	if err != nil {
+		t.Fatalf("unprotect downlink: %v", err)
+	}
+
+	return plain
+}
+
 // TestAttachAuthenticationAndSecurityMode drives the EMM engine through the
 // Attach → EPS-AKA → Security Mode exchange, with the test playing the UE.
 // TestAttachRecoveryAfterMMERestart reproduces the field case: after the MME

--- a/internal/mme/nas/esm.go
+++ b/internal/mme/nas/esm.go
@@ -41,6 +41,8 @@ func handleESMMessage(ctx context.Context, m *mme.MME, ue *mme.UeContext, msg ep
 		return handleModifyBearerAccept(m, ue, msg)
 	case *eps.ModifyEPSBearerContextReject:
 		return handleModifyBearerReject(m, ue, msg)
+	case *eps.ESMInformationResponse:
+		return handleESMInformationResponse(ctx, m, ue, msg)
 	case *eps.ESMStatus:
 		return handleESMStatus(ctx, m, ue, msg)
 	case eps.ESMMessage:

--- a/internal/mme/nas/esm_information.go
+++ b/internal/mme/nas/esm_information.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// Reports whether the procedure now waits for the response.
 func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(pti uint8)) bool {
 	wait := ue.PendingESMInfo()
 	if wait == nil {
@@ -32,7 +31,6 @@ func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(
 		onAbort(w.PTI)
 	}
 
-	// TS 24.301 §6.6.1.2.2 leaves the EPS bearer identity unassigned.
 	esm, err := (&eps.ESMInformationRequest{PTI: nas.ProcedureTransactionIdentity(wait.PTI)}).MarshalBinary()
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build ESM Information Request", zap.Error(err))
@@ -45,8 +43,7 @@ func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(
 	if err != nil {
 		mme.ReportProtectFailure(ctx, ue.Conn(), "ESM Information Request", err)
 
-		// The connection is gone, so the abort's reject could not be protected
-		// either; drop the wait without one.
+		// The connection is gone, so the abort's reject could not be protected.
 		if errors.Is(err, nas.ErrCountExhausted) {
 			ue.TakeESMInfoWait()
 
@@ -71,10 +68,7 @@ func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(
 	return true
 }
 
-// TS 24.301 §6.6.1.2.4 also has the response's PCO replace any received earlier
-// in the attach; the MME reads no uplink PCO, so there is nothing to replace.
 func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeContext, req *eps.ESMInformationResponse) nasreply.Disposition {
-	// TS 24.301 §7.3.2 e).
 	if req.EPSBearerIdentity != 0 {
 		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response with an assigned EPS bearer identity, ignoring",
 			zap.String("imsi", ue.IMSI()), zap.Uint8("ebi", uint8(req.EPSBearerIdentity)))
@@ -82,7 +76,6 @@ func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		return nasreply.Handled()
 	}
 
-	// TS 24.301 §7.3.1 e).
 	pti := uint8(req.PTI)
 	if pti == 0 || pti == 255 {
 		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response with an unassigned or reserved PTI, ignoring",

--- a/internal/mme/nas/esm_information.go
+++ b/internal/mme/nas/esm_information.go
@@ -81,7 +81,9 @@ func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(
 
 // handleESMInformationResponse takes the APN the UE deferred and resumes the
 // procedure that deferred it — the attach or a standalone PDN CONNECTIVITY
-// REQUEST (TS 24.301 §6.6.1.2.4).
+// REQUEST (TS 24.301 §6.6.1.2.4). §6.6.1.2.4 also has the response's protocol
+// configuration options replace any received earlier in the attach; the MME
+// reads no uplink PCO on any path, so there is nothing to replace.
 func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeContext, req *eps.ESMInformationResponse) nasreply.Disposition {
 	// TS 24.301 §7.3.2 e): a response naming an assigned or reserved EPS bearer
 	// identity is ignored. §6.6.1.2.3 has the UE set "no EPS bearer identity

--- a/internal/mme/nas/esm_information.go
+++ b/internal/mme/nas/esm_information.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/nasreply"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"go.uber.org/zap"
+)
+
+// requestESMInformation asks the UE for the ESM information it deferred and
+// reports whether the procedure now waits for it (TS 24.301 §6.6.1.2.2). Every
+// abort path ends the wait and the T3489 supervision before running onAbort,
+// which receives the transaction identity the wait recorded, so nothing the abort
+// needs is read from the UE off the NAS goroutine.
+func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(pti uint8)) bool {
+	wait := ue.PendingESMInfo()
+	if wait == nil {
+		return false
+	}
+
+	abort := func() {
+		w := ue.TakeESMInfoWait()
+		if w == nil {
+			return
+		}
+
+		ue.Conn().StopESMInfoGuard()
+		onAbort(w.PTI)
+	}
+
+	// TS 24.301 §6.6.1.2.2: the EPS bearer identity is "no EPS bearer identity
+	// assigned" and the PTI is the one the PDN CONNECTIVITY REQUEST carried.
+	esm, err := (&eps.ESMInformationRequest{PTI: nas.ProcedureTransactionIdentity(wait.PTI)}).MarshalBinary()
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to build ESM Information Request", zap.Error(err))
+		abort()
+
+		return true
+	}
+
+	naspdu, err := ue.ProtectDownlink(esm, eps.SHTIntegrityProtectedCiphered)
+	if err != nil {
+		mme.ReportProtectFailure(ctx, ue.Conn(), "ESM Information Request", err)
+
+		// An exhausted downlink COUNT has already released the connection, and the
+		// abort's reject would fail to protect for the same reason. Clear the wait
+		// so no late response resumes a procedure that is over.
+		if errors.Is(err, nas.ErrCountExhausted) {
+			ue.TakeESMInfoWait()
+
+			return true
+		}
+
+		// Returning with no request sent and no T3489 armed would leave the attach
+		// waiting on ESM information the UE was never asked for.
+		abort()
+
+		return true
+	}
+
+	logger.From(ctx, logger.MmeLog).Info("requesting deferred ESM information",
+		zap.String("imsi", ue.IMSI()), zap.Uint8("pti", wait.PTI))
+
+	ue.Conn().ArmT3489("ESM Information Request", naspdu, func() {
+		logger.MmeLog.Info("ESM information not received", zap.String("imsi", ue.IMSI()))
+		abort()
+	})
+
+	ue.Conn().SendDownlinkNASTransport(ctx, naspdu)
+
+	return true
+}
+
+// handleESMInformationResponse takes the APN the UE deferred and resumes the
+// procedure that deferred it — the attach or a standalone PDN CONNECTIVITY
+// REQUEST (TS 24.301 §6.6.1.2.4).
+func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeContext, req *eps.ESMInformationResponse) nasreply.Disposition {
+	// TS 24.301 §7.3.2 e): a response naming an assigned or reserved EPS bearer
+	// identity is ignored. §6.6.1.2.3 has the UE set "no EPS bearer identity
+	// assigned".
+	if req.EPSBearerIdentity != 0 {
+		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response with an assigned EPS bearer identity, ignoring",
+			zap.String("imsi", ue.IMSI()), zap.Uint8("ebi", uint8(req.EPSBearerIdentity)))
+
+		return nasreply.Handled()
+	}
+
+	// TS 24.301 §7.3.1 e): an unassigned or reserved PTI is ignored, and an
+	// assigned one matching no ongoing transaction draws ESM STATUS #81.
+	pti := uint8(req.PTI)
+	if pti == 0 || pti == 255 {
+		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response with an unassigned or reserved PTI, ignoring",
+			zap.String("imsi", ue.IMSI()), zap.Uint8("pti", pti))
+
+		return nasreply.Handled()
+	}
+
+	// The transaction is ended only by a response that names it, so one naming
+	// another assigned PTI draws #81 and leaves the ongoing procedure running.
+	wait := ue.TakeESMInfoWaitFor(pti)
+	if wait == nil {
+		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response for no ongoing transaction",
+			zap.String("imsi", ue.IMSI()), zap.Uint8("pti", pti))
+		egress{conn: ue.Conn()}.SendSMStatusFor(ctx, uint8(eps.ESMCauseInvalidPTIValue), pti, uint8(req.EPSBearerIdentity))
+
+		return nasreply.Handled()
+	}
+
+	ue.Conn().StopESMInfoGuard()
+
+	if req.AccessPointName != nil {
+		ue.RequestedAPN = string(*req.AccessPointName)
+	}
+
+	logger.From(ctx, logger.MmeLog).Info("received deferred ESM information",
+		zap.String("imsi", ue.IMSI()), zap.String("apn", ue.RequestedAPN))
+
+	if wait.Standalone != nil {
+		resumePDNConnectivity(ctx, m, ue, wait.Standalone)
+
+		return nasreply.Handled()
+	}
+
+	activateDefaultBearer(ctx, m, ue)
+
+	return nasreply.Handled()
+}

--- a/internal/mme/nas/esm_information.go
+++ b/internal/mme/nas/esm_information.go
@@ -15,11 +15,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// requestESMInformation asks the UE for the ESM information it deferred and
-// reports whether the procedure now waits for it (TS 24.301 §6.6.1.2.2). Every
-// abort path ends the wait and the T3489 supervision before running onAbort,
-// which receives the transaction identity the wait recorded, so nothing the abort
-// needs is read from the UE off the NAS goroutine.
+// Reports whether the procedure now waits for the response.
 func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(pti uint8)) bool {
 	wait := ue.PendingESMInfo()
 	if wait == nil {
@@ -36,8 +32,7 @@ func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(
 		onAbort(w.PTI)
 	}
 
-	// TS 24.301 §6.6.1.2.2: the EPS bearer identity is "no EPS bearer identity
-	// assigned" and the PTI is the one the PDN CONNECTIVITY REQUEST carried.
+	// TS 24.301 §6.6.1.2.2 leaves the EPS bearer identity unassigned.
 	esm, err := (&eps.ESMInformationRequest{PTI: nas.ProcedureTransactionIdentity(wait.PTI)}).MarshalBinary()
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build ESM Information Request", zap.Error(err))
@@ -50,17 +45,14 @@ func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(
 	if err != nil {
 		mme.ReportProtectFailure(ctx, ue.Conn(), "ESM Information Request", err)
 
-		// An exhausted downlink COUNT has already released the connection, and the
-		// abort's reject would fail to protect for the same reason. Clear the wait
-		// so no late response resumes a procedure that is over.
+		// The connection is gone, so the abort's reject could not be protected
+		// either; drop the wait without one.
 		if errors.Is(err, nas.ErrCountExhausted) {
 			ue.TakeESMInfoWait()
 
 			return true
 		}
 
-		// Returning with no request sent and no T3489 armed would leave the attach
-		// waiting on ESM information the UE was never asked for.
 		abort()
 
 		return true
@@ -79,15 +71,10 @@ func requestESMInformation(ctx context.Context, ue *mme.UeContext, onAbort func(
 	return true
 }
 
-// handleESMInformationResponse takes the APN the UE deferred and resumes the
-// procedure that deferred it — the attach or a standalone PDN CONNECTIVITY
-// REQUEST (TS 24.301 §6.6.1.2.4). §6.6.1.2.4 also has the response's protocol
-// configuration options replace any received earlier in the attach; the MME
-// reads no uplink PCO on any path, so there is nothing to replace.
+// TS 24.301 §6.6.1.2.4 also has the response's PCO replace any received earlier
+// in the attach; the MME reads no uplink PCO, so there is nothing to replace.
 func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeContext, req *eps.ESMInformationResponse) nasreply.Disposition {
-	// TS 24.301 §7.3.2 e): a response naming an assigned or reserved EPS bearer
-	// identity is ignored. §6.6.1.2.3 has the UE set "no EPS bearer identity
-	// assigned".
+	// TS 24.301 §7.3.2 e).
 	if req.EPSBearerIdentity != 0 {
 		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response with an assigned EPS bearer identity, ignoring",
 			zap.String("imsi", ue.IMSI()), zap.Uint8("ebi", uint8(req.EPSBearerIdentity)))
@@ -95,8 +82,7 @@ func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		return nasreply.Handled()
 	}
 
-	// TS 24.301 §7.3.1 e): an unassigned or reserved PTI is ignored, and an
-	// assigned one matching no ongoing transaction draws ESM STATUS #81.
+	// TS 24.301 §7.3.1 e).
 	pti := uint8(req.PTI)
 	if pti == 0 || pti == 255 {
 		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response with an unassigned or reserved PTI, ignoring",
@@ -105,8 +91,6 @@ func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		return nasreply.Handled()
 	}
 
-	// The transaction is ended only by a response that names it, so one naming
-	// another assigned PTI draws #81 and leaves the ongoing procedure running.
 	wait := ue.TakeESMInfoWaitFor(pti)
 	if wait == nil {
 		logger.From(ctx, logger.MmeLog).Warn("ESM Information Response for no ongoing transaction",

--- a/internal/mme/nas/esm_information_guard_test.go
+++ b/internal/mme/nas/esm_information_guard_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// waitFor polls until cond holds or the deadline passes, so a timer-driven
-// assertion does not depend on a fixed sleep.
 func waitFor(t *testing.T, what string, cond func() bool) {
 	t.Helper()
 
@@ -28,8 +26,7 @@ func waitFor(t *testing.T, what string, cond func() bool) {
 	t.Fatalf("timed out waiting for %s", what)
 }
 
-// TS 24.301 §6.6.1.2.6 a): the first two expiries of T3489 resend the ESM
-// INFORMATION REQUEST; the third aborts the procedure and rejects the attach.
+// TS 24.301 §6.6.1.2.6 a).
 func TestT3489RetransmitsTwiceThenRejects(t *testing.T) {
 	m := esmInfoTestMME()
 	m.SetT3489ConfigForTest(5*time.Millisecond, 2)
@@ -38,7 +35,6 @@ func TestT3489RetransmitsTwiceThenRejects(t *testing.T) {
 
 	activateDefaultBearer(context.Background(), m, ue)
 
-	// Initial request, two retransmissions, the Attach Reject and the release.
 	waitFor(t, "T3489 to exhaust its retransmissions", func() bool { return cc.count() >= 5 })
 
 	if got := cc.count(); got != 5 {
@@ -75,7 +71,6 @@ func TestT3489RetransmitsTwiceThenRejects(t *testing.T) {
 	}
 }
 
-// The response stops T3489, so no retransmission follows a resumed attach.
 func TestESMInformationResponseStopsT3489(t *testing.T) {
 	m := esmInfoTestMME()
 	m.SetT3489ConfigForTest(5*time.Millisecond, 2)
@@ -103,9 +98,8 @@ func TestESMInformationResponseStopsT3489(t *testing.T) {
 	}
 }
 
-// The ESM INFORMATION RESPONSE and T3489's final expiry race for the same
-// transaction. Exactly one concludes it, so the attach is never both resumed and
-// rejected.
+// Exactly one of the response and the final expiry may conclude the transaction,
+// or the attach would be both resumed and rejected.
 func TestESMInformationResponseRacesTheTimeout(t *testing.T) {
 	for range 200 {
 		m := esmInfoTestMME()
@@ -138,8 +132,6 @@ func TestESMInformationResponseRacesTheTimeout(t *testing.T) {
 	}
 }
 
-// The procedure is bounded by the connection it runs on: releasing that
-// connection drops the wait, so a later response cannot resume it.
 func TestS1ReleaseDropsTheESMInformationWait(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, _ := esmInfoAttachUe(t, m, 3)

--- a/internal/mme/nas/esm_information_guard_test.go
+++ b/internal/mme/nas/esm_information_guard_test.go
@@ -137,3 +137,22 @@ func TestESMInformationResponseRacesTheTimeout(t *testing.T) {
 		}
 	}
 }
+
+// The procedure is bounded by the connection it runs on: releasing that
+// connection drops the wait, so a later response cannot resume it.
+func TestS1ReleaseDropsTheESMInformationWait(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, _ := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	if ue.PendingESMInfo() == nil {
+		t.Fatal("the ESM information procedure is not outstanding before the release")
+	}
+
+	m.FreeUeConn(ue)
+
+	if ue.PendingESMInfo() != nil {
+		t.Error("the ESM information wait survived the S1 release")
+	}
+}

--- a/internal/mme/nas/esm_information_guard_test.go
+++ b/internal/mme/nas/esm_information_guard_test.go
@@ -26,7 +26,6 @@ func waitFor(t *testing.T, what string, cond func() bool) {
 	t.Fatalf("timed out waiting for %s", what)
 }
 
-// TS 24.301 §6.6.1.2.6 a).
 func TestT3489RetransmitsTwiceThenRejects(t *testing.T) {
 	m := esmInfoTestMME()
 	m.SetT3489ConfigForTest(5*time.Millisecond, 2)
@@ -98,8 +97,6 @@ func TestESMInformationResponseStopsT3489(t *testing.T) {
 	}
 }
 
-// Exactly one of the response and the final expiry may conclude the transaction,
-// or the attach would be both resumed and rejected.
 func TestESMInformationResponseRacesTheTimeout(t *testing.T) {
 	for range 200 {
 		m := esmInfoTestMME()

--- a/internal/mme/nas/esm_information_guard_test.go
+++ b/internal/mme/nas/esm_information_guard_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// waitFor polls until cond holds or the deadline passes, so a timer-driven
+// assertion does not depend on a fixed sleep.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TS 24.301 §6.6.1.2.6 a): the first two expiries of T3489 resend the ESM
+// INFORMATION REQUEST; the third aborts the procedure and rejects the attach.
+func TestT3489RetransmitsTwiceThenRejects(t *testing.T) {
+	m := esmInfoTestMME()
+	m.SetT3489ConfigForTest(5*time.Millisecond, 2)
+
+	ue, cc := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	// Initial request, two retransmissions, the Attach Reject and the release.
+	waitFor(t, "T3489 to exhaust its retransmissions", func() bool { return cc.count() >= 5 })
+
+	if got := cc.count(); got != 5 {
+		t.Fatalf("message count is %d, want 5 (request, 2 retransmissions, Attach Reject, UE Context Release Command)", got)
+	}
+
+	for i := range 3 {
+		req := parseESMInformationRequest(t, ue, cc.sent[i])
+		if req.PTI != 3 {
+			t.Errorf("attempt %d PTI = %d, want 3", i, req.PTI)
+		}
+	}
+
+	rej, err := eps.ParseAttachReject(decodeProtectedDownlink(t, ue, cc.sent[3]))
+	if err != nil {
+		t.Fatalf("not an Attach Reject: %v", err)
+	}
+
+	if rej.Cause != eps.EMMCauseESMFailure {
+		t.Fatalf("Attach Reject EMM cause = %d, want %d", rej.Cause, eps.EMMCauseESMFailure)
+	}
+
+	esm, err := eps.ParsePDNConnectivityReject(rej.ESMMessageContainer)
+	if err != nil {
+		t.Fatalf("ESM message container is not a PDN Connectivity Reject: %v", err)
+	}
+
+	if esm.Cause != eps.ESMCauseESMInformationNotReceived {
+		t.Errorf("carried ESM cause = %d, want %d", esm.Cause, eps.ESMCauseESMInformationNotReceived)
+	}
+
+	if ue.PendingESMInfo() != nil {
+		t.Error("the ESM information procedure is still outstanding after its final expiry")
+	}
+}
+
+// The response stops T3489, so no retransmission follows a resumed attach.
+func TestESMInformationResponseStopsT3489(t *testing.T) {
+	m := esmInfoTestMME()
+	m.SetT3489ConfigForTest(5*time.Millisecond, 2)
+
+	ue, cc := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	apn := eps.APN("internet")
+	handleESMInformationResponse(context.Background(), m, ue, &eps.ESMInformationResponse{
+		PTI:             3,
+		AccessPointName: &apn,
+	})
+
+	if ue.Conn().T3489ActiveForTest() {
+		t.Fatal("T3489 is still armed after the ESM Information Response")
+	}
+
+	settled := cc.count()
+
+	time.Sleep(30 * time.Millisecond)
+
+	if got := cc.count(); got != settled {
+		t.Errorf("message count grew from %d to %d after the response; T3489 kept firing", settled, got)
+	}
+}
+
+// The ESM INFORMATION RESPONSE and T3489's final expiry race for the same
+// transaction. Exactly one concludes it, so the attach is never both resumed and
+// rejected.
+func TestESMInformationResponseRacesTheTimeout(t *testing.T) {
+	for range 200 {
+		m := esmInfoTestMME()
+		ue, _ := esmInfoAttachUe(t, m, 3)
+
+		activateDefaultBearer(context.Background(), m, ue)
+
+		var (
+			concluded = make(chan bool, 2)
+			start     = make(chan struct{})
+		)
+
+		go func() {
+			<-start
+
+			concluded <- ue.TakeESMInfoWaitFor(3) != nil
+		}()
+
+		go func() {
+			<-start
+
+			concluded <- ue.TakeESMInfoWait() != nil
+		}()
+
+		close(start)
+
+		if won := <-concluded; won == (<-concluded) {
+			t.Fatalf("both racers concluded the transaction (won=%v); exactly one must", won)
+		}
+	}
+}

--- a/internal/mme/nas/esm_information_test.go
+++ b/internal/mme/nas/esm_information_test.go
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/udm"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// esmInfoAttachUe returns a secured UE whose attach carried a PDN CONNECTIVITY
+// REQUEST with the ESM information transfer flag set on transaction pti, so the
+// APN and PCO are withheld (TS 24.301 §6.5.1.2).
+func esmInfoAttachUe(t *testing.T, m *mme.MME, pti uint8) (*mme.UeContext, *captureConn) { //nolint:unparam // the transaction identity is part of the helper's shape
+	t.Helper()
+
+	ue, cc := securedUE(t, m)
+	ue.RequestedPTI = nas.ProcedureTransactionIdentity(pti)
+	ue.AwaitESMInformation(pti, nil)
+
+	return ue, cc
+}
+
+func esmInfoTestMME() *mme.MME {
+	return mme.New(udm.New(newFakeCredStore(), noopKeyResolver), fakeBearerStore{}, &fakeSessionManager{})
+}
+
+// parseESMInformationRequest asserts the downlink is a protected ESM INFORMATION
+// REQUEST and returns it.
+func parseESMInformationRequest(t *testing.T, ue *mme.UeContext, pdu []byte) *eps.ESMInformationRequest {
+	t.Helper()
+
+	req, err := eps.ParseESMInformationRequest(decodeProtectedDownlink(t, ue, pdu))
+	if err != nil {
+		t.Fatalf("not an ESM Information Request: %v", err)
+	}
+
+	return req
+}
+
+// TS 24.301 §6.6.1.2.2: with the flag set, the attach does not activate the
+// default bearer but asks the UE for the ESM information it withheld. The request
+// names the PDN CONNECTIVITY REQUEST's transaction and no EPS bearer identity.
+func TestAttachWithESMInformationTransferFlagRequestsIt(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, cc := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("downlink count is %d, want 1 (the ESM Information Request)", len(cc.sent))
+	}
+
+	req := parseESMInformationRequest(t, ue, cc.sent[0])
+
+	if req.PTI != 3 {
+		t.Errorf("ESM Information Request PTI = %d, want 3", req.PTI)
+	}
+
+	if req.EPSBearerIdentity != 0 {
+		t.Errorf("ESM Information Request EPS bearer identity = %d, want 0 (no EPS bearer identity assigned)", req.EPSBearerIdentity)
+	}
+
+	if ue.PendingESMInfo() == nil {
+		t.Error("the ESM information procedure is not recorded as outstanding")
+	}
+}
+
+// TS 24.301 §6.6.1.2.4: the response's APN is taken and the deferred attach
+// resumes, activating the default bearer against that APN.
+func TestESMInformationResponseResumesTheAttach(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, cc := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	apn := eps.APN("ims")
+	handleESMInformationResponse(context.Background(), m, ue, &eps.ESMInformationResponse{
+		PTI:             3,
+		AccessPointName: &apn,
+	})
+
+	if ue.RequestedAPN != "ims" {
+		t.Errorf("requested APN = %q, want %q", ue.RequestedAPN, "ims")
+	}
+
+	if ue.PendingESMInfo() != nil {
+		t.Error("the ESM information procedure is still outstanding after its response")
+	}
+
+	if ue.EMMState() == mme.EMMDeregistered {
+		t.Fatal("the attach was aborted rather than resumed")
+	}
+
+	// The Attach Accept rides the Initial Context Setup, so the resumed attach adds
+	// an S1AP message rather than a further downlink NAS transport.
+	if len(cc.sent) != 2 {
+		t.Fatalf("message count is %d, want 2 (ESM Information Request, Initial Context Setup)", len(cc.sent))
+	}
+
+	if ue.DefaultEBI == 0 {
+		t.Error("no default bearer was activated after the ESM information arrived")
+	}
+}
+
+// TS 24.301 §6.5.1.6 c): with no ESM information before T3489's final expiry the
+// attach is rejected, EMM cause #19 combined with a PDN CONNECTIVITY REJECT
+// carrying ESM cause #53.
+func TestESMInformationTimeoutRejectsTheAttach(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, cc := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	// Drive the abort directly: T3489's schedule is the guard's contract, tested
+	// where the guard is.
+	rejectAttachESM(context.Background(), m, ue, 3, eps.ESMCauseESMInformationNotReceived)
+
+	if len(cc.sent) != 3 {
+		t.Fatalf("message count is %d, want 3 (ESM Information Request, Attach Reject, UE Context Release Command)", len(cc.sent))
+	}
+
+	rej, err := eps.ParseAttachReject(decodeProtectedDownlink(t, ue, cc.sent[1]))
+	if err != nil {
+		t.Fatalf("not an Attach Reject: %v", err)
+	}
+
+	if rej.Cause != eps.EMMCauseESMFailure {
+		t.Fatalf("Attach Reject EMM cause = %d, want %d", rej.Cause, eps.EMMCauseESMFailure)
+	}
+
+	esm, err := eps.ParsePDNConnectivityReject(rej.ESMMessageContainer)
+	if err != nil {
+		t.Fatalf("ESM message container is not a PDN Connectivity Reject: %v", err)
+	}
+
+	if esm.Cause != eps.ESMCauseESMInformationNotReceived {
+		t.Errorf("carried ESM cause = %d, want %d", esm.Cause, eps.ESMCauseESMInformationNotReceived)
+	}
+
+	if esm.PTI != 3 {
+		t.Errorf("carried PTI = %d, want 3", esm.PTI)
+	}
+
+	parseUEContextReleaseCommand(t, cc.sent[2])
+}
+
+// TS 24.301 §7.3.1 e): a response naming another assigned transaction draws ESM
+// STATUS #81 and leaves the procedure running.
+func TestESMInformationResponseForAnotherTransactionIsRefused(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, cc := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	handleESMInformationResponse(context.Background(), m, ue, &eps.ESMInformationResponse{PTI: 9})
+
+	if ue.PendingESMInfo() == nil {
+		t.Error("a response for another transaction ended the ongoing procedure")
+	}
+
+	if len(cc.sent) != 2 {
+		t.Fatalf("downlink count is %d, want 2 (ESM Information Request, ESM Status)", len(cc.sent))
+	}
+
+	status, err := eps.ParseESMStatus(decodeProtectedDownlink(t, ue, cc.sent[1]))
+	if err != nil {
+		t.Fatalf("not an ESM Status: %v", err)
+	}
+
+	if status.Cause != eps.ESMCauseInvalidPTIValue {
+		t.Errorf("ESM Status cause = %d, want %d", status.Cause, eps.ESMCauseInvalidPTIValue)
+	}
+
+	if status.PTI != 9 {
+		t.Errorf("ESM Status PTI = %d, want the refused 9", status.PTI)
+	}
+}
+
+// TS 24.301 §7.3.1 e): an unassigned or reserved PTI is ignored outright — no
+// ESM STATUS, and the ongoing procedure keeps running.
+func TestESMInformationResponseWithUnassignedPTIIsIgnored(t *testing.T) {
+	for _, pti := range []uint8{0, 255} {
+		m := esmInfoTestMME()
+		ue, cc := esmInfoAttachUe(t, m, 3)
+
+		activateDefaultBearer(context.Background(), m, ue)
+
+		handleESMInformationResponse(context.Background(), m, ue, &eps.ESMInformationResponse{
+			PTI: nas.ProcedureTransactionIdentity(pti),
+		})
+
+		if ue.PendingESMInfo() == nil {
+			t.Errorf("PTI %d ended the ongoing procedure", pti)
+		}
+
+		if len(cc.sent) != 1 {
+			t.Errorf("PTI %d: downlink count is %d, want 1 (the ESM Information Request alone)", pti, len(cc.sent))
+		}
+	}
+}
+
+// TS 24.301 §7.3.2 e), §6.6.1.2.3: the UE sets "no EPS bearer identity assigned",
+// so a response naming one is ignored.
+func TestESMInformationResponseWithAnEPSBearerIdentityIsIgnored(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, cc := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	handleESMInformationResponse(context.Background(), m, ue, &eps.ESMInformationResponse{
+		EPSBearerIdentity: 5,
+		PTI:               3,
+	})
+
+	if ue.PendingESMInfo() == nil {
+		t.Error("a response naming an EPS bearer identity ended the ongoing procedure")
+	}
+
+	if len(cc.sent) != 1 {
+		t.Errorf("downlink count is %d, want 1 (the ESM Information Request alone)", len(cc.sent))
+	}
+}
+
+// Without the flag the attach proceeds straight to the default bearer, so the
+// procedure costs nothing for a UE that does not defer.
+func TestAttachWithoutESMInformationTransferFlagDoesNotRequestIt(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, cc := securedUE(t, m)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	if ue.PendingESMInfo() != nil {
+		t.Error("an ESM information procedure was started for a UE that did not defer")
+	}
+
+	if ue.DefaultEBI == 0 {
+		t.Error("no default bearer was activated")
+	}
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("message count is %d, want 1 (Initial Context Setup)", len(cc.sent))
+	}
+}
+
+// A second attach on the same connection clears the earlier deferral, so its
+// abandoned abort cannot fire against the new attach (TS 24.301 §5.5.1.2.6).
+func TestAttachClearsAnAbandonedESMInformationWait(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, _ := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue)
+
+	ingestAttachRequest(context.Background(), ue, &eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		EPSMobileIdentity:   eps.IMSIIdentity(eps.IMSI(testSubscriber.IMSI)),
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70},
+		ESMMessageContainer: mustPDNConnectivityRequest(t, 4, false),
+	})
+
+	if ue.PendingESMInfo() != nil {
+		t.Error("the earlier deferral survived a new attach")
+	}
+}
+
+// The flag on a new attach re-arms the procedure for that attach's transaction.
+func TestAttachIngestRecordsTheDeferral(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, _ := securedUE(t, m)
+
+	ingestAttachRequest(context.Background(), ue, &eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		EPSMobileIdentity:   eps.IMSIIdentity(eps.IMSI(testSubscriber.IMSI)),
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70},
+		ESMMessageContainer: mustPDNConnectivityRequest(t, 7, true),
+	})
+
+	wait := ue.PendingESMInfo()
+	if wait == nil {
+		t.Fatal("the ESM information transfer flag did not record a deferral")
+	}
+
+	if wait.PTI != 7 {
+		t.Errorf("deferral PTI = %d, want 7", wait.PTI)
+	}
+
+	if wait.Standalone != nil {
+		t.Error("an attach deferral is marked as standalone")
+	}
+}
+
+// mustPDNConnectivityRequest encodes the PDN CONNECTIVITY REQUEST an ATTACH
+// REQUEST carries, with the ESM information transfer flag set to eit.
+func mustPDNConnectivityRequest(t *testing.T, pti uint8, eit bool) []byte {
+	t.Helper()
+
+	req := &eps.PDNConnectivityRequest{
+		PTI:         nas.ProcedureTransactionIdentity(pti),
+		RequestType: eps.RequestTypeInitialRequest,
+		PDNType:     eps.PDNTypeIPv4,
+	}
+
+	if eit {
+		req.ESMInformationTransferFlag = &eit
+	}
+
+	b, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode PDN Connectivity Request: %v", err)
+	}
+
+	return b
+}

--- a/internal/mme/nas/esm_information_test.go
+++ b/internal/mme/nas/esm_information_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// esmInfoAttachUe returns a secured UE whose attach carried a PDN CONNECTIVITY
-// REQUEST with the ESM information transfer flag set on transaction pti, so the
-// APN and PCO are withheld (TS 24.301 §6.5.1.2).
 func esmInfoAttachUe(t *testing.T, m *mme.MME, pti uint8) (*mme.UeContext, *captureConn) { //nolint:unparam // the transaction identity is part of the helper's shape
 	t.Helper()
 
@@ -30,8 +27,6 @@ func esmInfoTestMME() *mme.MME {
 	return mme.New(udm.New(newFakeCredStore(), noopKeyResolver), fakeBearerStore{}, &fakeSessionManager{})
 }
 
-// parseESMInformationRequest asserts the downlink is a protected ESM INFORMATION
-// REQUEST and returns it.
 func parseESMInformationRequest(t *testing.T, ue *mme.UeContext, pdu []byte) *eps.ESMInformationRequest {
 	t.Helper()
 
@@ -43,9 +38,7 @@ func parseESMInformationRequest(t *testing.T, ue *mme.UeContext, pdu []byte) *ep
 	return req
 }
 
-// TS 24.301 §6.6.1.2.2: with the flag set, the attach does not activate the
-// default bearer but asks the UE for the ESM information it withheld. The request
-// names the PDN CONNECTIVITY REQUEST's transaction and no EPS bearer identity.
+// TS 24.301 §6.6.1.2.2.
 func TestAttachWithESMInformationTransferFlagRequestsIt(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
@@ -71,8 +64,7 @@ func TestAttachWithESMInformationTransferFlagRequestsIt(t *testing.T) {
 	}
 }
 
-// TS 24.301 §6.6.1.2.4: the response's APN is taken and the deferred attach
-// resumes, activating the default bearer against that APN.
+// TS 24.301 §6.6.1.2.4.
 func TestESMInformationResponseResumesTheAttach(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
@@ -97,8 +89,6 @@ func TestESMInformationResponseResumesTheAttach(t *testing.T) {
 		t.Fatal("the attach was aborted rather than resumed")
 	}
 
-	// The Attach Accept rides the Initial Context Setup, so the resumed attach adds
-	// an S1AP message rather than a further downlink NAS transport.
 	if len(cc.sent) != 2 {
 		t.Fatalf("message count is %d, want 2 (ESM Information Request, Initial Context Setup)", len(cc.sent))
 	}
@@ -108,17 +98,14 @@ func TestESMInformationResponseResumesTheAttach(t *testing.T) {
 	}
 }
 
-// TS 24.301 §6.5.1.6 c): with no ESM information before T3489's final expiry the
-// attach is rejected, EMM cause #19 combined with a PDN CONNECTIVITY REJECT
-// carrying ESM cause #53.
+// TS 24.301 §6.5.1.6 c).
 func TestESMInformationTimeoutRejectsTheAttach(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
 
 	activateDefaultBearer(context.Background(), m, ue)
 
-	// Drive the abort directly: T3489's schedule is the guard's contract, tested
-	// where the guard is.
+	// The schedule that reaches this abort is covered by the T3489 tests.
 	rejectAttachESM(context.Background(), m, ue, 3, eps.ESMCauseESMInformationNotReceived)
 
 	if len(cc.sent) != 3 {
@@ -150,8 +137,7 @@ func TestESMInformationTimeoutRejectsTheAttach(t *testing.T) {
 	parseUEContextReleaseCommand(t, cc.sent[2])
 }
 
-// TS 24.301 §7.3.1 e): a response naming another assigned transaction draws ESM
-// STATUS #81 and leaves the procedure running.
+// TS 24.301 §7.3.1 e).
 func TestESMInformationResponseForAnotherTransactionIsRefused(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
@@ -182,8 +168,7 @@ func TestESMInformationResponseForAnotherTransactionIsRefused(t *testing.T) {
 	}
 }
 
-// TS 24.301 §7.3.1 e): an unassigned or reserved PTI is ignored outright — no
-// ESM STATUS, and the ongoing procedure keeps running.
+// TS 24.301 §7.3.1 e): ignored outright, with no ESM STATUS.
 func TestESMInformationResponseWithUnassignedPTIIsIgnored(t *testing.T) {
 	for _, pti := range []uint8{0, 255} {
 		m := esmInfoTestMME()
@@ -205,8 +190,7 @@ func TestESMInformationResponseWithUnassignedPTIIsIgnored(t *testing.T) {
 	}
 }
 
-// TS 24.301 §7.3.2 e), §6.6.1.2.3: the UE sets "no EPS bearer identity assigned",
-// so a response naming one is ignored.
+// TS 24.301 §7.3.2 e).
 func TestESMInformationResponseWithAnEPSBearerIdentityIsIgnored(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
@@ -227,8 +211,6 @@ func TestESMInformationResponseWithAnEPSBearerIdentityIsIgnored(t *testing.T) {
 	}
 }
 
-// Without the flag the attach proceeds straight to the default bearer, so the
-// procedure costs nothing for a UE that does not defer.
 func TestAttachWithoutESMInformationTransferFlagDoesNotRequestIt(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := securedUE(t, m)
@@ -248,8 +230,6 @@ func TestAttachWithoutESMInformationTransferFlagDoesNotRequestIt(t *testing.T) {
 	}
 }
 
-// A second attach on the same connection clears the earlier deferral, so its
-// abandoned abort cannot fire against the new attach (TS 24.301 §5.5.1.2.6).
 func TestAttachClearsAnAbandonedESMInformationWait(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, _ := esmInfoAttachUe(t, m, 3)
@@ -268,7 +248,6 @@ func TestAttachClearsAnAbandonedESMInformationWait(t *testing.T) {
 	}
 }
 
-// The flag on a new attach re-arms the procedure for that attach's transaction.
 func TestAttachIngestRecordsTheDeferral(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, _ := securedUE(t, m)
@@ -294,8 +273,6 @@ func TestAttachIngestRecordsTheDeferral(t *testing.T) {
 	}
 }
 
-// mustPDNConnectivityRequest encodes the PDN CONNECTIVITY REQUEST an ATTACH
-// REQUEST carries, with the ESM information transfer flag set to eit.
 func mustPDNConnectivityRequest(t *testing.T, pti uint8, eit bool) []byte {
 	t.Helper()
 

--- a/internal/mme/nas/esm_information_test.go
+++ b/internal/mme/nas/esm_information_test.go
@@ -38,7 +38,6 @@ func parseESMInformationRequest(t *testing.T, ue *mme.UeContext, pdu []byte) *ep
 	return req
 }
 
-// TS 24.301 §6.6.1.2.2.
 func TestAttachWithESMInformationTransferFlagRequestsIt(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
@@ -64,7 +63,6 @@ func TestAttachWithESMInformationTransferFlagRequestsIt(t *testing.T) {
 	}
 }
 
-// TS 24.301 §6.6.1.2.4.
 func TestESMInformationResponseResumesTheAttach(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
@@ -98,14 +96,12 @@ func TestESMInformationResponseResumesTheAttach(t *testing.T) {
 	}
 }
 
-// TS 24.301 §6.5.1.6 c).
 func TestESMInformationTimeoutRejectsTheAttach(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
 
 	activateDefaultBearer(context.Background(), m, ue)
 
-	// The schedule that reaches this abort is covered by the T3489 tests.
 	rejectAttachESM(context.Background(), m, ue, 3, eps.ESMCauseESMInformationNotReceived)
 
 	if len(cc.sent) != 3 {
@@ -137,7 +133,6 @@ func TestESMInformationTimeoutRejectsTheAttach(t *testing.T) {
 	parseUEContextReleaseCommand(t, cc.sent[2])
 }
 
-// TS 24.301 §7.3.1 e).
 func TestESMInformationResponseForAnotherTransactionIsRefused(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)
@@ -168,7 +163,6 @@ func TestESMInformationResponseForAnotherTransactionIsRefused(t *testing.T) {
 	}
 }
 
-// TS 24.301 §7.3.1 e): ignored outright, with no ESM STATUS.
 func TestESMInformationResponseWithUnassignedPTIIsIgnored(t *testing.T) {
 	for _, pti := range []uint8{0, 255} {
 		m := esmInfoTestMME()
@@ -190,7 +184,6 @@ func TestESMInformationResponseWithUnassignedPTIIsIgnored(t *testing.T) {
 	}
 }
 
-// TS 24.301 §7.3.2 e).
 func TestESMInformationResponseWithAnEPSBearerIdentityIsIgnored(t *testing.T) {
 	m := esmInfoTestMME()
 	ue, cc := esmInfoAttachUe(t, m, 3)

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -217,10 +217,28 @@ func resolveAttachContext(ctx context.Context, m *mme.MME, ue *mme.UeContext, na
 // rejectAttach sends ATTACH REJECT (TS 24.301) with the given EMM
 // cause, then releases the UE's S1 context.
 func rejectAttach(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause eps.EMMCause) {
+	sendAttachReject(ctx, m, ue, cause, nil)
+}
+
+// rejectAttachESMFailure refuses an attach whose PDN CONNECTIVITY REQUEST the ESM
+// sublayer rejected. EMM cause #19 "ESM failure" is combined with the PDN
+// CONNECTIVITY REJECT carrying esmCause, which the UE needs to learn why the PDN
+// connection was refused (TS 24.301 §5.5.1.2.5).
+func rejectAttachESMFailure(ctx context.Context, m *mme.MME, ue *mme.UeContext, esmCause eps.ESMCause) {
+	esm, err := (&eps.PDNConnectivityReject{PTI: ue.RequestedPTI, Cause: esmCause}).MarshalBinary()
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to build the PDN Connectivity Reject carried by an Attach Reject",
+			zap.String("imsi", ue.IMSI()), zap.Error(err))
+	}
+
+	sendAttachReject(ctx, m, ue, eps.EMMCauseESMFailure, esm)
+}
+
+func sendAttachReject(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause eps.EMMCause, esm []byte) {
 	metrics.RegistrationAttempt(metrics.RAT4G, attachTypeName(ue), metrics.ResultReject)
 	ue.Conn().StopNASGuard()
 
-	reject := &eps.AttachReject{Cause: cause}
+	reject := &eps.AttachReject{Cause: cause, ESMMessageContainer: esm}
 
 	if timer, err := nas.GPRSTimer2FromDuration(mme.T3402Backoff); err == nil {
 		reject.T3402 = &timer

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -122,6 +122,10 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, req *eps.Attach
 	ue.RequestedPDNType = uint8(eps.PDNTypeIPv4)
 	ue.RequestedAPN = ""
 	ue.RequestedPTI = 0
+	// The abort of an abandoned deferral would otherwise fire against this attach,
+	// clearing its wait and emitting a reject with the earlier transaction's PTI.
+	ue.Conn().StopESMInfoGuard()
+	ue.TakeESMInfoWait()
 
 	// A syntactically incorrect optional element leaves the rest of the message
 	// usable (TS 24.301 §7.7.1), so only a hard failure falls back to the
@@ -135,6 +139,12 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, req *eps.Attach
 
 		if pc.AccessPointName != nil {
 			ue.RequestedAPN = string(*pc.AccessPointName)
+		}
+
+		// The UE holds the APN and PCO back until the ESM information exchange, which
+		// runs once the security context is up (TS 24.301 §6.5.1.2, §6.6.1.2.2).
+		if pc.ESMInformationTransferFlag != nil && *pc.ESMInformationTransferFlag {
+			ue.AwaitESMInformation(uint8(pc.PTI), nil)
 		}
 	}
 }
@@ -220,15 +230,17 @@ func rejectAttach(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause eps.
 	sendAttachReject(ctx, m, ue, cause, nil)
 }
 
-// rejectAttachESMFailure refuses an attach whose PDN CONNECTIVITY REQUEST the ESM
+// rejectAttachESM refuses an attach whose PDN CONNECTIVITY REQUEST the ESM
 // sublayer rejected. EMM cause #19 "ESM failure" is combined with the PDN
-// CONNECTIVITY REJECT carrying esmCause, which the UE needs to learn why the PDN
-// connection was refused (TS 24.301 §5.5.1.2.5).
-func rejectAttachESMFailure(ctx context.Context, m *mme.MME, ue *mme.UeContext, esmCause eps.ESMCause) {
-	esm, err := (&eps.PDNConnectivityReject{PTI: ue.RequestedPTI, Cause: esmCause}).MarshalBinary()
+// CONNECTIVITY REJECT carrying esmCause on transaction pti, which the UE needs
+// to learn why the PDN connection was refused (TS 24.301 §5.5.1.2.5).
+func rejectAttachESM(ctx context.Context, m *mme.MME, ue *mme.UeContext, pti uint8, esmCause eps.ESMCause) {
+	esm, err := (&eps.PDNConnectivityReject{PTI: nas.ProcedureTransactionIdentity(pti), Cause: esmCause}).MarshalBinary()
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build the PDN Connectivity Reject carried by an Attach Reject",
 			zap.String("imsi", ue.IMSI()), zap.Error(err))
+
+		esm = nil
 	}
 
 	sendAttachReject(ctx, m, ue, eps.EMMCauseESMFailure, esm)
@@ -244,7 +256,15 @@ func sendAttachReject(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause 
 		reject.T3402 = &timer
 	}
 
-	ue.Conn().SendDownlinkMessage(ctx, reject)
+	// A UE that has established secure exchange discards an unprotected downlink
+	// (TS 24.301 §4.4.4.2). The plain form is for the rejects that precede
+	// security activation.
+	if ue.Secured() {
+		ue.Conn().SendDownlinkProtected(ctx, reject)
+	} else {
+		ue.Conn().SendDownlinkMessage(ctx, reject)
+	}
+
 	m.ReleaseUEContext(ctx, ue, mme.CauseNASUnspecified)
 }
 

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -229,7 +229,6 @@ func rejectAttach(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause eps.
 	sendAttachReject(ctx, m, ue, cause, nil)
 }
 
-// TS 24.301 §5.5.1.2.5 pairs EMM cause #19 with the ESM reject that explains it.
 func rejectAttachESM(ctx context.Context, m *mme.MME, ue *mme.UeContext, pti uint8, esmCause eps.ESMCause) {
 	esm, err := (&eps.PDNConnectivityReject{PTI: nas.ProcedureTransactionIdentity(pti), Cause: esmCause}).MarshalBinary()
 	if err != nil {

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -141,8 +141,9 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, req *eps.Attach
 			ue.RequestedAPN = string(*pc.AccessPointName)
 		}
 
-		// The UE holds the APN and PCO back until the ESM information exchange, which
-		// runs once the security context is up (TS 24.301 §6.5.1.2, §6.6.1.2.2).
+		// The UE withholds its ESM information until the exchange that runs once the
+		// security context is up (TS 24.301 §6.5.1.2, §6.6.1.2.2). Of what it then
+		// sends, the MME reads the APN; it acts on no uplink PCO anywhere.
 		if pc.ESMInformationTransferFlag != nil && *pc.ESMInformationTransferFlag {
 			ue.AwaitESMInformation(uint8(pc.PTI), nil)
 		}

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -122,8 +122,8 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, req *eps.Attach
 	ue.RequestedPDNType = uint8(eps.PDNTypeIPv4)
 	ue.RequestedAPN = ""
 	ue.RequestedPTI = 0
-	// The abort of an abandoned deferral would otherwise fire against this attach,
-	// clearing its wait and emitting a reject with the earlier transaction's PTI.
+	// An abandoned deferral's abort would otherwise emit a reject naming the
+	// earlier transaction.
 	ue.Conn().StopESMInfoGuard()
 	ue.TakeESMInfoWait()
 
@@ -141,9 +141,6 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, req *eps.Attach
 			ue.RequestedAPN = string(*pc.AccessPointName)
 		}
 
-		// The UE withholds its ESM information until the exchange that runs once the
-		// security context is up (TS 24.301 §6.5.1.2, §6.6.1.2.2). Of what it then
-		// sends, the MME reads the APN; it acts on no uplink PCO anywhere.
 		if pc.ESMInformationTransferFlag != nil && *pc.ESMInformationTransferFlag {
 			ue.AwaitESMInformation(uint8(pc.PTI), nil)
 		}
@@ -231,10 +228,7 @@ func rejectAttach(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause eps.
 	sendAttachReject(ctx, m, ue, cause, nil)
 }
 
-// rejectAttachESM refuses an attach whose PDN CONNECTIVITY REQUEST the ESM
-// sublayer rejected. EMM cause #19 "ESM failure" is combined with the PDN
-// CONNECTIVITY REJECT carrying esmCause on transaction pti, which the UE needs
-// to learn why the PDN connection was refused (TS 24.301 §5.5.1.2.5).
+// TS 24.301 §5.5.1.2.5 pairs EMM cause #19 with the ESM reject that explains it.
 func rejectAttachESM(ctx context.Context, m *mme.MME, ue *mme.UeContext, pti uint8, esmCause eps.ESMCause) {
 	esm, err := (&eps.PDNConnectivityReject{PTI: nas.ProcedureTransactionIdentity(pti), Cause: esmCause}).MarshalBinary()
 	if err != nil {
@@ -257,9 +251,8 @@ func sendAttachReject(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause 
 		reject.T3402 = &timer
 	}
 
-	// A UE that has established secure exchange discards an unprotected downlink
-	// (TS 24.301 §4.4.4.2). The plain form is for the rejects that precede
-	// security activation.
+	// A secured UE discards an unprotected downlink (TS 24.301 §4.4.4.2); the
+	// plain form is for the rejects preceding security activation.
 	if ue.Secured() {
 		ue.Conn().SendDownlinkProtected(ctx, reject)
 	} else {

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -87,6 +87,7 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, req
 	// §5.4.3.3). Its old EPS bearers are deleted (§5.5.1.2.4 case f) before the new
 	// default bearer is activated.
 	if ue.Secured() && integrityVerified {
+		ue.PinKeNBFreshness()
 		m.ReleaseAllSessions(ctx, ue)
 		activateDefaultBearer(ctx, m, ue)
 

--- a/internal/mme/nas/handle_security_mode_complete.go
+++ b/internal/mme/nas/handle_security_mode_complete.go
@@ -42,6 +42,7 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 	}
 
 	ue.MarkSecured(pei)
+	ue.PinKeNBFreshness()
 
 	// Anti-tamper recovery: on a HASHMME mismatch the UE returns the complete plain
 	// ATTACH REQUEST in the Replayed NAS message container. Re-ingest it so a tampered

--- a/internal/mme/nas/handle_security_mode_complete.go
+++ b/internal/mme/nas/handle_security_mode_complete.go
@@ -60,8 +60,6 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 		logger.From(ctx, logger.MmeLog).Info("recovered genuine Attach Request from replayed NAS message container", zap.String("imsi", ue.IMSI()))
 
 		ingestAttachRequest(ctx, ue, req)
-		// The container carries the genuine message, so it becomes the oracle a
-		// later retransmission is compared against (TS 24.301 §5.5.1.2.7 case d).
 		ue.Conn().AttachRequestPlain = slices.Clone(smc.ReplayedNASMessageContainer)
 	}
 

--- a/internal/mme/nas/handle_security_mode_complete.go
+++ b/internal/mme/nas/handle_security_mode_complete.go
@@ -5,6 +5,7 @@ package nas
 
 import (
 	"context"
+	"slices"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/logger"
@@ -51,12 +52,17 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 		req, err := eps.ParseAttachRequest(smc.ReplayedNASMessageContainer)
 		if !decoded(ctx, "AttachRequest", err) {
 			logger.From(ctx, logger.MmeLog).Warn("failed to decode replayed NAS message container in Security Mode Complete", zap.Error(err))
+			rejectAttach(ctx, m, ue, eps.EMMCauseInvalidMandatoryInformation)
+
 			return nasreply.Handled()
 		}
 
 		logger.From(ctx, logger.MmeLog).Info("recovered genuine Attach Request from replayed NAS message container", zap.String("imsi", ue.IMSI()))
 
 		ingestAttachRequest(ctx, ue, req)
+		// The container carries the genuine message, so it becomes the oracle a
+		// later retransmission is compared against (TS 24.301 §5.5.1.2.7 case d).
+		ue.Conn().AttachRequestPlain = slices.Clone(smc.ReplayedNASMessageContainer)
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("NAS security context established",

--- a/internal/mme/nas/handle_service_request.go
+++ b/internal/mme/nas/handle_service_request.go
@@ -77,6 +77,7 @@ func HandleServiceRequest(ctx context.Context, m *mme.MME, conn mme.S1APWriter, 
 	}
 
 	ue.AdvanceULCount()
+	ue.PinKeNBFreshness()
 
 	logger.From(ctx, logger.MmeLog).Info("Service Request accepted",
 		zap.Uint32("enb-ue-id", uint32(ue.Conn().ENBUES1APID)),

--- a/internal/mme/nas/pdn_address_test.go
+++ b/internal/mme/nas/pdn_address_test.go
@@ -138,7 +138,7 @@ func TestActivateDefaultBearerRejectsWhen4GNotAllowed(t *testing.T) {
 		t.Fatalf("expected Attach Reject + UE Context Release Command, got %d", len(cc.sent))
 	}
 
-	rej, err := eps.ParseAttachReject(decodeDownlinkNAS(t, cc.sent[0]))
+	rej, err := eps.ParseAttachReject(decodeProtectedDownlink(t, ue, cc.sent[0]))
 	if err != nil {
 		t.Fatalf("not an Attach Reject: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestActivateDefaultBearerRejectsOnSessionFailure(t *testing.T) {
 		t.Fatalf("expected Attach Reject + UE Context Release Command, got %d", len(cc.sent))
 	}
 
-	rej, err := eps.ParseAttachReject(decodeDownlinkNAS(t, cc.sent[0]))
+	rej, err := eps.ParseAttachReject(decodeProtectedDownlink(t, ue, cc.sent[0]))
 	if err != nil {
 		t.Fatalf("not an Attach Reject: %v", err)
 	}

--- a/internal/mme/nas/pdn_address_test.go
+++ b/internal/mme/nas/pdn_address_test.go
@@ -172,7 +172,6 @@ func TestActivateDefaultBearerRejectsOnSessionFailure(t *testing.T) {
 		t.Fatalf("Attach Reject cause = %d, want %d (ESM failure)", rej.Cause, eps.EMMCauseESMFailure)
 	}
 
-	// TS 24.301 §5.5.1.2.5.
 	if len(rej.ESMMessageContainer) == 0 {
 		t.Fatal("Attach Reject with EMM cause #19 carries no ESM message container")
 	}

--- a/internal/mme/nas/pdn_address_test.go
+++ b/internal/mme/nas/pdn_address_test.go
@@ -172,8 +172,7 @@ func TestActivateDefaultBearerRejectsOnSessionFailure(t *testing.T) {
 		t.Fatalf("Attach Reject cause = %d, want %d (ESM failure)", rej.Cause, eps.EMMCauseESMFailure)
 	}
 
-	// EMM cause #19 is combined with the ESM reject that explains it
-	// (TS 24.301 §5.5.1.2.5).
+	// TS 24.301 §5.5.1.2.5.
 	if len(rej.ESMMessageContainer) == 0 {
 		t.Fatal("Attach Reject with EMM cause #19 carries no ESM message container")
 	}

--- a/internal/mme/nas/pdn_address_test.go
+++ b/internal/mme/nas/pdn_address_test.go
@@ -172,6 +172,25 @@ func TestActivateDefaultBearerRejectsOnSessionFailure(t *testing.T) {
 		t.Fatalf("Attach Reject cause = %d, want %d (ESM failure)", rej.Cause, eps.EMMCauseESMFailure)
 	}
 
+	// EMM cause #19 is combined with the ESM reject that explains it
+	// (TS 24.301 §5.5.1.2.5).
+	if len(rej.ESMMessageContainer) == 0 {
+		t.Fatal("Attach Reject with EMM cause #19 carries no ESM message container")
+	}
+
+	esm, err := eps.ParsePDNConnectivityReject(rej.ESMMessageContainer)
+	if err != nil {
+		t.Fatalf("ESM message container is not a PDN Connectivity Reject: %v", err)
+	}
+
+	if esm.Cause != eps.ESMCauseRequestRejectedUnspecified {
+		t.Errorf("carried ESM cause = %d, want %d", esm.Cause, eps.ESMCauseRequestRejectedUnspecified)
+	}
+
+	if esm.PTI != ue.RequestedPTI {
+		t.Errorf("carried PTI = %d, want the requested %d", esm.PTI, ue.RequestedPTI)
+	}
+
 	parseUEContextReleaseCommand(t, cc.sent[1])
 }
 

--- a/internal/mme/nas/pdn_connectivity.go
+++ b/internal/mme/nas/pdn_connectivity.go
@@ -60,8 +60,8 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		apn = string(*req.AccessPointName)
 	}
 
-	// The UE may hold the APN back until the ESM information exchange
-	// (TS 24.301 §6.5.1.2); #53 follows only once T3489 has expired (§6.5.1.6 c).
+	// The APN may be withheld until the ESM information exchange; #53 follows only
+	// once T3489 has expired (TS 24.301 §6.5.1.2, §6.5.1.6 c).
 	if req.ESMInformationTransferFlag != nil && *req.ESMInformationTransferFlag {
 		ue.RequestedAPN = apn
 		ue.AwaitESMInformation(uint8(pti), &mme.PendingPDNConnectivity{
@@ -69,8 +69,7 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 			PDNType: uint8(req.PDNType),
 		})
 
-		// The abort runs on a build or protect failure and on T3489's final expiry,
-		// the last of which outlives this request's context.
+		// T3489's final expiry outlives this request's context.
 		requestESMInformation(ctx, ue, func(abortedPTI uint8) {
 			rejectPDNConnectivity(context.Background(), ue, abortedPTI, eps.ESMCauseESMInformationNotReceived)
 		})
@@ -86,15 +85,11 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 	return openPDNConnection(ctx, m, ue, apn, uint8(pti), req.PDNType)
 }
 
-// openPDNConnection commits a PDN connection whose parameters are already
-// resolved, so a request resumed after the ESM information exchange re-enters
-// here with the APN the UE deferred.
 func openPDNConnection(ctx context.Context, m *mme.MME, ue *mme.UeContext, apn string, ptiValue uint8, pdnType eps.PDNType) nasreply.Disposition {
 	pti := nas.ProcedureTransactionIdentity(ptiValue)
 
-	// A resumed request re-enters here from the ESM information response, which can
-	// arrive after a detach or an S1 release has ended the procedure (TS 24.301
-	// §6.5.1.1: the UE must be EMM-REGISTERED to request a PDN connection).
+	// Re-checked: a resumed request arrives after a detach or S1 release may have
+	// intervened (TS 24.301 §6.5.1.1).
 	if ue.EMMState() != mme.EMMRegistered || !ue.Connected() {
 		rejectPDNConnectivity(ctx, ue, ptiValue, eps.ESMCauseRequestRejectedUnspecified)
 		return nasreply.Handled()
@@ -185,8 +180,6 @@ func openPDNConnection(ctx context.Context, m *mme.MME, ue *mme.UeContext, apn s
 	return nasreply.Handled()
 }
 
-// resumePDNConnectivity re-runs the standalone request with the APN the UE
-// deferred (TS 24.301 §6.6.1.2.4).
 func resumePDNConnectivity(ctx context.Context, m *mme.MME, ue *mme.UeContext, pending *mme.PendingPDNConnectivity) {
 	openPDNConnection(ctx, m, ue, ue.RequestedAPN, pending.PTI, eps.PDNType(pending.PDNType))
 }

--- a/internal/mme/nas/pdn_connectivity.go
+++ b/internal/mme/nas/pdn_connectivity.go
@@ -60,8 +60,48 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		apn = string(*req.AccessPointName)
 	}
 
+	// The UE may hold the APN back until the ESM information exchange
+	// (TS 24.301 §6.5.1.2); #53 follows only once T3489 has expired (§6.5.1.6 c).
+	if req.ESMInformationTransferFlag != nil && *req.ESMInformationTransferFlag {
+		ue.RequestedAPN = apn
+		ue.AwaitESMInformation(uint8(pti), &mme.PendingPDNConnectivity{
+			PTI:     uint8(pti),
+			PDNType: uint8(req.PDNType),
+		})
+
+		// The abort runs on a build or protect failure and on T3489's final expiry,
+		// the last of which outlives this request's context.
+		requestESMInformation(ctx, ue, func(abortedPTI uint8) {
+			rejectPDNConnectivity(context.Background(), ue, abortedPTI, eps.ESMCauseESMInformationNotReceived)
+		})
+
+		return nasreply.Handled()
+	}
+
 	if apn == "" {
 		rejectPDNConnectivity(ctx, ue, uint8(pti), eps.ESMCauseMissingOrUnknownAPN)
+		return nasreply.Handled()
+	}
+
+	return openPDNConnection(ctx, m, ue, apn, uint8(pti), req.PDNType)
+}
+
+// openPDNConnection commits a PDN connection whose parameters are already
+// resolved, so a request resumed after the ESM information exchange re-enters
+// here with the APN the UE deferred.
+func openPDNConnection(ctx context.Context, m *mme.MME, ue *mme.UeContext, apn string, ptiValue uint8, pdnType eps.PDNType) nasreply.Disposition {
+	pti := nas.ProcedureTransactionIdentity(ptiValue)
+
+	// A resumed request re-enters here from the ESM information response, which can
+	// arrive after a detach or an S1 release has ended the procedure (TS 24.301
+	// §6.5.1.1: the UE must be EMM-REGISTERED to request a PDN connection).
+	if ue.EMMState() != mme.EMMRegistered || !ue.Connected() {
+		rejectPDNConnectivity(ctx, ue, ptiValue, eps.ESMCauseRequestRejectedUnspecified)
+		return nasreply.Handled()
+	}
+
+	if apn == "" {
+		rejectPDNConnectivity(ctx, ue, ptiValue, eps.ESMCauseMissingOrUnknownAPN)
 		return nasreply.Handled()
 	}
 
@@ -109,7 +149,7 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		IPv6Pool:          qos.IPv6Pool,
 		DNS:               qos.DNS,
 		MTU:               qos.MTU,
-		RequestedPDNType:  uint8(req.PDNType),
+		RequestedPDNType:  uint8(pdnType),
 	})
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Info("PDN connectivity rejected: session setup failed",
@@ -143,6 +183,12 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 	sendERABSetup(ctx, m, ue, p, qos, naspdu)
 
 	return nasreply.Handled()
+}
+
+// resumePDNConnectivity re-runs the standalone request with the APN the UE
+// deferred (TS 24.301 §6.6.1.2.4).
+func resumePDNConnectivity(ctx context.Context, m *mme.MME, ue *mme.UeContext, pending *mme.PendingPDNConnectivity) {
+	openPDNConnection(ctx, m, ue, ue.RequestedAPN, pending.PTI, eps.PDNType(pending.PDNType))
 }
 
 // sendERABSetup asks the eNB to set up the radio leg of a new PDN connection,

--- a/internal/mme/nas/pdn_connectivity.go
+++ b/internal/mme/nas/pdn_connectivity.go
@@ -60,8 +60,6 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		apn = string(*req.AccessPointName)
 	}
 
-	// The APN may be withheld until the ESM information exchange; #53 follows only
-	// once T3489 has expired (TS 24.301 §6.5.1.2, §6.5.1.6 c).
 	if req.ESMInformationTransferFlag != nil && *req.ESMInformationTransferFlag {
 		ue.RequestedAPN = apn
 		ue.AwaitESMInformation(uint8(pti), &mme.PendingPDNConnectivity{
@@ -89,7 +87,7 @@ func openPDNConnection(ctx context.Context, m *mme.MME, ue *mme.UeContext, apn s
 	pti := nas.ProcedureTransactionIdentity(ptiValue)
 
 	// Re-checked: a resumed request arrives after a detach or S1 release may have
-	// intervened (TS 24.301 §6.5.1.1).
+	// intervened.
 	if ue.EMMState() != mme.EMMRegistered || !ue.Connected() {
 		rejectPDNConnectivity(ctx, ue, ptiValue, eps.ESMCauseRequestRejectedUnspecified)
 		return nasreply.Handled()

--- a/internal/mme/nas/pdn_connectivity_test.go
+++ b/internal/mme/nas/pdn_connectivity_test.go
@@ -443,7 +443,6 @@ func TestLastPDNDisconnectRejected(t *testing.T) {
 	}
 }
 
-// TS 24.301 §6.5.1.2: the withheld APN must not be mistaken for #27.
 func TestStandalonePDNConnectivityDefersToESMInformation(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
@@ -482,7 +481,6 @@ func TestStandalonePDNConnectivityDefersToESMInformation(t *testing.T) {
 	}
 }
 
-// TS 24.301 §6.5.1.6 c).
 func TestStandalonePDNConnectivityRejectsWhenESMInformationNeverArrives(t *testing.T) {
 	m := newTestMME(t)
 	m.SetT3489ConfigForTest(5*time.Millisecond, 1)

--- a/internal/mme/nas/pdn_connectivity_test.go
+++ b/internal/mme/nas/pdn_connectivity_test.go
@@ -442,3 +442,80 @@ func TestLastPDNDisconnectRejected(t *testing.T) {
 		t.Fatalf("ESM cause = %d, want %d (last PDN disconnect not allowed)", reject.Cause, eps.ESMCauseLastPDNDisconnectionNotAllow)
 	}
 }
+
+// TS 24.301 §6.5.1.2: a standalone PDN CONNECTIVITY REQUEST may defer its APN to
+// the ESM information exchange, so no connection opens until the response
+// arrives — and the missing APN is not mistaken for #27.
+func TestStandalonePDNConnectivityDefersToESMInformation(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	testPDN(ue).Apn = "internet"
+
+	eit := true
+	handlePDNConnectivityRequest(context.Background(), m, ue, &eps.PDNConnectivityRequest{
+		PTI: 2, RequestType: 1, PDNType: eps.PDNTypeIPv4, ESMInformationTransferFlag: &eit,
+	})
+
+	wait := ue.PendingESMInfo()
+	if wait == nil {
+		t.Fatal("the ESM information transfer flag did not defer the request")
+	}
+
+	if wait.Standalone == nil || wait.Standalone.PTI != 2 {
+		t.Fatalf("deferral is not recorded as the standalone request on PTI 2: %+v", wait.Standalone)
+	}
+
+	if ue.PdnForAPN("ims") != nil {
+		t.Error("a PDN connection was opened before the deferred APN arrived")
+	}
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("downlink count is %d, want 1 (the ESM Information Request)", len(cc.sent))
+	}
+
+	apn := eps.APN("ims")
+	handleESMInformationResponse(context.Background(), m, ue, &eps.ESMInformationResponse{
+		PTI: 2, AccessPointName: &apn,
+	})
+
+	if ue.PdnForAPN("ims") == nil {
+		t.Fatal("the resumed request did not open the PDN connection for the deferred APN")
+	}
+}
+
+// The final expiry of T3489 rejects the standalone request with ESM cause #53
+// and leaves the UE connected (TS 24.301 §6.5.1.6 c).
+func TestStandalonePDNConnectivityRejectsWhenESMInformationNeverArrives(t *testing.T) {
+	m := newTestMME(t)
+	m.SetT3489ConfigForTest(5*time.Millisecond, 1)
+
+	ue, cc := securedUE(t, m)
+
+	testPDN(ue).Apn = "internet"
+
+	eit := true
+	handlePDNConnectivityRequest(context.Background(), m, ue, &eps.PDNConnectivityRequest{
+		PTI: 2, RequestType: 1, PDNType: eps.PDNTypeIPv4, ESMInformationTransferFlag: &eit,
+	})
+
+	// The request, one retransmission, then the reject.
+	waitFor(t, "T3489 to exhaust its retransmissions", func() bool { return cc.count() >= 3 })
+
+	rej, err := eps.ParsePDNConnectivityReject(decodeProtectedDownlink(t, ue, cc.sent[2]))
+	if err != nil {
+		t.Fatalf("not a PDN Connectivity Reject: %v", err)
+	}
+
+	if rej.Cause != eps.ESMCauseESMInformationNotReceived {
+		t.Errorf("ESM cause = %d, want %d", rej.Cause, eps.ESMCauseESMInformationNotReceived)
+	}
+
+	if rej.PTI != 2 {
+		t.Errorf("PDN Connectivity Reject PTI = %d, want 2", rej.PTI)
+	}
+
+	if !ue.Connected() {
+		t.Error("the UE was released; a failed standalone PDN connectivity leaves it connected")
+	}
+}

--- a/internal/mme/nas/pdn_connectivity_test.go
+++ b/internal/mme/nas/pdn_connectivity_test.go
@@ -443,9 +443,7 @@ func TestLastPDNDisconnectRejected(t *testing.T) {
 	}
 }
 
-// TS 24.301 §6.5.1.2: a standalone PDN CONNECTIVITY REQUEST may defer its APN to
-// the ESM information exchange, so no connection opens until the response
-// arrives — and the missing APN is not mistaken for #27.
+// TS 24.301 §6.5.1.2: the withheld APN must not be mistaken for #27.
 func TestStandalonePDNConnectivityDefersToESMInformation(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
@@ -484,8 +482,7 @@ func TestStandalonePDNConnectivityDefersToESMInformation(t *testing.T) {
 	}
 }
 
-// The final expiry of T3489 rejects the standalone request with ESM cause #53
-// and leaves the UE connected (TS 24.301 §6.5.1.6 c).
+// TS 24.301 §6.5.1.6 c).
 func TestStandalonePDNConnectivityRejectsWhenESMInformationNeverArrives(t *testing.T) {
 	m := newTestMME(t)
 	m.SetT3489ConfigForTest(5*time.Millisecond, 1)
@@ -499,7 +496,6 @@ func TestStandalonePDNConnectivityRejectsWhenESMInformationNeverArrives(t *testi
 		PTI: 2, RequestType: 1, PDNType: eps.PDNTypeIPv4, ESMInformationTransferFlag: &eit,
 	})
 
-	// The request, one retransmission, then the reject.
 	waitFor(t, "T3489 to exhaust its retransmissions", func() bool { return cc.count() >= 3 })
 
 	rej, err := eps.ParsePDNConnectivityReject(decodeProtectedDownlink(t, ue, cc.sent[2]))

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -138,7 +138,16 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 func rejectTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext, cause eps.EMMCause) {
 	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
 	ue.Conn().StopNASGuard()
-	ue.Conn().SendDownlinkMessage(ctx, &eps.TrackingAreaUpdateReject{Cause: cause})
+
+	// A secured UE discards an unprotected downlink (TS 24.301 §4.4.4.2); the
+	// plain form is for the rejects preceding security activation.
+	reject := &eps.TrackingAreaUpdateReject{Cause: cause}
+	if ue.Secured() {
+		ue.Conn().SendDownlinkProtected(ctx, reject)
+	} else {
+		ue.Conn().SendDownlinkMessage(ctx, reject)
+	}
+
 	m.ReleaseUEContext(ctx, ue, mme.CauseNASUnspecified)
 }
 

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -63,8 +63,6 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	// TS 24.301 §5.5.3.2.4: either capability or both. Stored after the accept is
-	// built, so a TAU that is never accepted leaves the held one alone.
 	if req.UENetworkCapability != nil || req.MSNetworkCapability != nil {
 		ueNetCap := ue.UeNetCap()
 		if req.UENetworkCapability != nil {
@@ -103,8 +101,6 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	}
 
 	if req.ActiveFlag {
-		// The TAU REQUEST triggers the context setup, so it names the K_eNB
-		// freshness (TS 33.401 §7.2.6.2).
 		ue.PinKeNBFreshness()
 
 		qos, err := mme.ResolveQoS(ctx, m, ue.IMSI())

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -67,15 +67,22 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	// it carries is as authenticated as the attach-time one (TS 24.301 §5.5.3.2.4).
 	// It is stored only once the accept is built, so a TAU that is never accepted
 	// leaves the held capability alone.
-	if req.UENetworkCapability != nil {
-		// TS 24.301 §5.5.3.2.4: the UE may replay the UE network capability, the MS
-		// network capability, or both. An absent MS capability keeps the held one.
+	//
+	// TS 24.301 §5.5.3.2.4: the UE may replay the UE network capability, the MS
+	// network capability, or both, and the MME stores what arrives. An absent one
+	// keeps the held value.
+	if req.UENetworkCapability != nil || req.MSNetworkCapability != nil {
+		ueNetCap := ue.UeNetCap()
+		if req.UENetworkCapability != nil {
+			ueNetCap = *req.UENetworkCapability
+		}
+
 		msNetCap := req.MSNetworkCapability
 		if msNetCap == nil {
 			msNetCap = ue.MsNetCap()
 		}
 
-		ue.SetUESecurityCapability(*req.UENetworkCapability, msNetCap, mme.MintAuthProofForTrackingAreaUpdate())
+		ue.SetUESecurityCapability(ueNetCap, msNetCap, mme.MintAuthProofForTrackingAreaUpdate())
 	}
 
 	// The accept reallocates the GUTI, so it is guarded by T3450 and retransmitted

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -63,6 +63,21 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
+	// The TAU is integrity protected against the stored context, so the capability
+	// it carries is as authenticated as the attach-time one (TS 24.301 §5.5.3.2.4).
+	// It is stored only once the accept is built, so a TAU that is never accepted
+	// leaves the held capability alone.
+	if req.UENetworkCapability != nil {
+		// TS 24.301 §5.5.3.2.4: the UE may replay the UE network capability, the MS
+		// network capability, or both. An absent MS capability keeps the held one.
+		msNetCap := req.MSNetworkCapability
+		if msNetCap == nil {
+			msNetCap = ue.MsNetCap()
+		}
+
+		ue.SetUESecurityCapability(*req.UENetworkCapability, msNetCap, mme.MintAuthProofForTrackingAreaUpdate())
+	}
+
 	// The accept reallocates the GUTI, so it is guarded by T3450 and retransmitted
 	// until TRACKING AREA UPDATE COMPLETE commits the new GUTI (TS 24.301).
 	naspdu, err := ue.ProtectDownlinkMessage(accept)

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -63,14 +63,8 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	// The TAU is integrity protected against the stored context, so the capability
-	// it carries is as authenticated as the attach-time one (TS 24.301 §5.5.3.2.4).
-	// It is stored only once the accept is built, so a TAU that is never accepted
-	// leaves the held capability alone.
-	//
-	// TS 24.301 §5.5.3.2.4: the UE may replay the UE network capability, the MS
-	// network capability, or both, and the MME stores what arrives. An absent one
-	// keeps the held value.
+	// TS 24.301 §5.5.3.2.4: either capability or both. Stored after the accept is
+	// built, so a TAU that is never accepted leaves the held one alone.
 	if req.UENetworkCapability != nil || req.MSNetworkCapability != nil {
 		ueNetCap := ue.UeNetCap()
 		if req.UENetworkCapability != nil {

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -103,6 +103,10 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	}
 
 	if req.ActiveFlag {
+		// The TAU REQUEST triggers the context setup, so it names the K_eNB
+		// freshness (TS 33.401 §7.2.6.2).
+		ue.PinKeNBFreshness()
+
 		qos, err := mme.ResolveQoS(ctx, m, ue.IMSI())
 		if err != nil {
 			logger.From(ctx, logger.MmeLog).Error("failed to resolve subscriber QoS", zap.String("imsi", ue.IMSI()), zap.Error(err))

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -31,7 +31,7 @@ func TestTrackingAreaUpdateTrackingAreaNotAllowed(t *testing.T) {
 		t.Fatal("expected a TAU Reject, got no downlink")
 	}
 
-	rej, err := eps.ParseTrackingAreaUpdateReject(decodeDownlinkNAS(t, cc.sent[0]))
+	rej, err := eps.ParseTrackingAreaUpdateReject(decodeProtectedDownlink(t, ue, cc.sent[0]))
 	if err != nil {
 		t.Fatalf("not a TAU Reject: %v", err)
 	}

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -422,7 +422,6 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 	}
 }
 
-// TS 24.301 §5.5.3.2.4.
 func TestTrackingAreaUpdateStoresReplayedCapabilities(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -422,8 +422,7 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 	}
 }
 
-// TS 24.301 §5.5.3.2.4: the MME stores the UE network capability and the MS
-// network capability the UE replays in an accepted TRACKING AREA UPDATE REQUEST.
+// TS 24.301 §5.5.3.2.4.
 func TestTrackingAreaUpdateStoresReplayedCapabilities(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -452,8 +451,6 @@ func TestTrackingAreaUpdateStoresReplayedCapabilities(t *testing.T) {
 	}
 }
 
-// TS 24.301 §5.5.3.2.4: the UE may replay either capability or both, so a TAU
-// carrying only the UE network capability keeps the held MS network capability.
 func TestTrackingAreaUpdateKeepsHeldMSCapability(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -476,7 +473,6 @@ func TestTrackingAreaUpdateKeepsHeldMSCapability(t *testing.T) {
 	}
 }
 
-// A TAU that omits the UE network capability leaves the held capability alone.
 func TestTrackingAreaUpdateWithoutCapabilityKeepsStored(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -492,9 +488,6 @@ func TestTrackingAreaUpdateWithoutCapabilityKeepsStored(t *testing.T) {
 	}
 }
 
-// TS 24.301 §5.5.3.2.4 stores what the UE replays whether that is the UE network
-// capability, the MS network capability, or both, so a TAU carrying only the MS
-// capability is stored and the held UE capability kept.
 func TestTrackingAreaUpdateStoresAnMSCapabilityOnlyReplay(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -421,3 +421,73 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 		t.Fatalf("bare connection not released after the TAU Reject: %d remain", m.ConnCountForTest())
 	}
 }
+
+// TS 24.301 §5.5.3.2.4: the MME stores the UE network capability and the MS
+// network capability the UE replays in an accepted TRACKING AREA UPDATE REQUEST.
+func TestTrackingAreaUpdateStoresReplayedCapabilities(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	replayed := eps.UENetworkCapability{EEA: 0xe0, EIA: 0x60, HasUMTS: true, UEA: 0xc0, UIA: 0x40, Rest: []byte{0x00, 0x80, 0x20}}
+	msNetCap := eps.MSNetworkCapability{Rest: []byte{0xe5, 0xe0, 0x00}}
+
+	req := tauRequest(eps.EPSUpdateTypeTA)
+	req.UENetworkCapability = &replayed
+	req.MSNetworkCapability = &msNetCap
+
+	handleTAU(t, m, ue, req)
+
+	if got := ue.UeNetCap(); got.EEA != replayed.EEA || got.EIA != replayed.EIA {
+		t.Errorf("stored UE network capability = EEA %#08b EIA %#08b, want EEA %#08b EIA %#08b",
+			uint8(got.EEA), uint8(got.EIA), uint8(replayed.EEA), uint8(replayed.EIA))
+	}
+
+	stored := ue.MsNetCap()
+	if stored == nil {
+		t.Fatal("MS network capability not stored, want the replayed one")
+	}
+
+	if !bytes.Equal(stored.Rest, msNetCap.Rest) {
+		t.Errorf("stored MS network capability = %x, want %x", stored.Rest, msNetCap.Rest)
+	}
+}
+
+// TS 24.301 §5.5.3.2.4: the UE may replay either capability or both, so a TAU
+// carrying only the UE network capability keeps the held MS network capability.
+func TestTrackingAreaUpdateKeepsHeldMSCapability(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	held := eps.MSNetworkCapability{Rest: []byte{0xe5, 0xe0, 0x00}}
+	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}, &held, mme.MintAuthProofForAttachRequest())
+
+	req := tauRequest(eps.EPSUpdateTypeTA)
+	req.UENetworkCapability = &eps.UENetworkCapability{EEA: 0xe0, EIA: 0x60}
+
+	handleTAU(t, m, ue, req)
+
+	stored := ue.MsNetCap()
+	if stored == nil {
+		t.Fatal("held MS network capability dropped, want it kept")
+	}
+
+	if !bytes.Equal(stored.Rest, held.Rest) {
+		t.Errorf("stored MS network capability = %x, want the held %x", stored.Rest, held.Rest)
+	}
+}
+
+// A TAU that omits the UE network capability leaves the held capability alone.
+func TestTrackingAreaUpdateWithoutCapabilityKeepsStored(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	held := eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}
+	ue.SetUESecurityCapability(held, nil, mme.MintAuthProofForAttachRequest())
+
+	handleTAU(t, m, ue, tauRequest(eps.EPSUpdateTypeTA))
+
+	if got := ue.UeNetCap(); got.EEA != held.EEA || got.EIA != held.EIA {
+		t.Errorf("stored UE network capability = EEA %#08b EIA %#08b, want the held EEA %#08b EIA %#08b",
+			uint8(got.EEA), uint8(got.EIA), uint8(held.EEA), uint8(held.EIA))
+	}
+}

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -491,3 +491,35 @@ func TestTrackingAreaUpdateWithoutCapabilityKeepsStored(t *testing.T) {
 			uint8(got.EEA), uint8(got.EIA), uint8(held.EEA), uint8(held.EIA))
 	}
 }
+
+// TS 24.301 §5.5.3.2.4 stores what the UE replays whether that is the UE network
+// capability, the MS network capability, or both, so a TAU carrying only the MS
+// capability is stored and the held UE capability kept.
+func TestTrackingAreaUpdateStoresAnMSCapabilityOnlyReplay(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	held := eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}
+	ue.SetUESecurityCapability(held, nil, mme.MintAuthProofForAttachRequest())
+
+	replayed := eps.MSNetworkCapability{Rest: []byte{0xe5, 0xe0, 0x00}}
+
+	req := tauRequest(eps.EPSUpdateTypeTA)
+	req.MSNetworkCapability = &replayed
+
+	handleTAU(t, m, ue, req)
+
+	stored := ue.MsNetCap()
+	if stored == nil {
+		t.Fatal("MS network capability not stored, want the replayed one")
+	}
+
+	if !bytes.Equal(stored.Rest, replayed.Rest) {
+		t.Errorf("stored MS network capability = %x, want %x", stored.Rest, replayed.Rest)
+	}
+
+	if got := ue.UeNetCap(); got.EEA != held.EEA || got.EIA != held.EIA {
+		t.Errorf("stored UE network capability = EEA %#08b EIA %#08b, want the held EEA %#08b EIA %#08b",
+			uint8(got.EEA), uint8(got.EIA), uint8(held.EEA), uint8(held.EIA))
+	}
+}

--- a/internal/mme/nas_classify.go
+++ b/internal/mme/nas_classify.go
@@ -5,8 +5,6 @@ package mme
 
 import "github.com/ellanetworks/core/nas/eps"
 
-// An ESM message fails the EMM protocol-discriminator check, so it lands on the
-// required-ciphered default.
 func cipheringRequiredFor(plain []byte) bool {
 	mt, err := eps.PeekMessageType(plain)
 	if err != nil {
@@ -16,13 +14,8 @@ func cipheringRequiredFor(plain []byte) bool {
 	return cipheringRequired(mt)
 }
 
-// TS 24.301 §4.4.5 has the UE send ATTACH REQUEST and TRACKING AREA UPDATE
-// REQUEST always unciphered, and the initial NAS message of a new NAS signalling
-// connection unciphered whatever it is. An initial NAS message is one that can
-// trigger the establishment of that connection (§3.1), so for the types below
-// whether ciphering was owed depends on a UE-side decision the receiver cannot
-// observe; only the types that can never be initial are held to it. SERVICE
-// REQUEST carries its own security header type and never reaches here.
+// Each of these can be the initial NAS message of a new connection, which the UE
+// sends unciphered; the receiver cannot tell whether it was (TS 24.301 §4.4.5).
 func cipheringRequired(mt eps.MessageType) bool {
 	switch mt {
 	case eps.MsgAttachRequest,

--- a/internal/mme/nas_classify.go
+++ b/internal/mme/nas_classify.go
@@ -16,10 +16,20 @@ func cipheringRequiredFor(plain []byte) bool {
 	return cipheringRequired(mt)
 }
 
-// TS 24.301 §4.4.5 has the UE send these two always unciphered.
+// TS 24.301 §4.4.5 has the UE send ATTACH REQUEST and TRACKING AREA UPDATE
+// REQUEST always unciphered, and the initial NAS message of a new NAS signalling
+// connection unciphered whatever it is. An initial NAS message is one that can
+// trigger the establishment of that connection (§3.1), so for the types below
+// whether ciphering was owed depends on a UE-side decision the receiver cannot
+// observe; only the types that can never be initial are held to it. SERVICE
+// REQUEST carries its own security header type and never reaches here.
 func cipheringRequired(mt eps.MessageType) bool {
 	switch mt {
-	case eps.MsgAttachRequest, eps.MsgTrackingAreaUpdateRequest:
+	case eps.MsgAttachRequest,
+		eps.MsgDetachRequest,
+		eps.MsgTrackingAreaUpdateRequest,
+		eps.MsgExtendedServiceRequest,
+		eps.MsgControlPlaneServiceRequest:
 		return false
 	}
 

--- a/internal/mme/nas_classify.go
+++ b/internal/mme/nas_classify.go
@@ -5,11 +5,8 @@ package mme
 
 import "github.com/ellanetworks/core/nas/eps"
 
-// cipheringRequiredFor reports whether a plain uplink NAS message has to arrive
-// ciphered once ciphering has started (TS 24.301 §4.4.5). Only two EMM messages
-// are exempt, so anything that does not decode as one of those — every ESM
-// message included, since its protocol discriminator fails the EMM peek —
-// requires ciphering.
+// An ESM message fails the EMM protocol-discriminator check, so it lands on the
+// required-ciphered default.
 func cipheringRequiredFor(plain []byte) bool {
 	mt, err := eps.PeekMessageType(plain)
 	if err != nil {
@@ -19,9 +16,7 @@ func cipheringRequiredFor(plain []byte) bool {
 	return cipheringRequired(mt)
 }
 
-// cipheringRequired reports whether a security-protected uplink message of this
-// type has to arrive ciphered once ciphering has started. TS 24.301 §4.4.5 has
-// the UE send ATTACH REQUEST and TRACKING AREA UPDATE REQUEST always unciphered.
+// TS 24.301 §4.4.5 has the UE send these two always unciphered.
 func cipheringRequired(mt eps.MessageType) bool {
 	switch mt {
 	case eps.MsgAttachRequest, eps.MsgTrackingAreaUpdateRequest:

--- a/internal/mme/nas_classify.go
+++ b/internal/mme/nas_classify.go
@@ -5,6 +5,32 @@ package mme
 
 import "github.com/ellanetworks/core/nas/eps"
 
+// cipheringRequiredFor reports whether a plain uplink NAS message has to arrive
+// ciphered once ciphering has started (TS 24.301 §4.4.5). Only two EMM messages
+// are exempt, so anything that does not decode as one of those — every ESM
+// message included, since its protocol discriminator fails the EMM peek —
+// requires ciphering.
+func cipheringRequiredFor(plain []byte) bool {
+	mt, err := eps.PeekMessageType(plain)
+	if err != nil {
+		return true
+	}
+
+	return cipheringRequired(mt)
+}
+
+// cipheringRequired reports whether a security-protected uplink message of this
+// type has to arrive ciphered once ciphering has started. TS 24.301 §4.4.5 has
+// the UE send ATTACH REQUEST and TRACKING AREA UPDATE REQUEST always unciphered.
+func cipheringRequired(mt eps.MessageType) bool {
+	switch mt {
+	case eps.MsgAttachRequest, eps.MsgTrackingAreaUpdateRequest:
+		return false
+	}
+
+	return true
+}
+
 // plainNasAllowed reports whether an EMM message may be processed without a verified
 // MAC before secure exchange is established (TS 24.301 §4.4.4.3) — either sent as plain
 // NAS, or received integrity-protected with a failed MAC. The spec's plain and

--- a/internal/mme/nas_guard.go
+++ b/internal/mme/nas_guard.go
@@ -52,8 +52,6 @@ func (c *UeConn) ArmNASGuardAbortOnly(name string, nas []byte, onAbort func()) {
 	c.armNASGuardMode(name, nas, onAbort)
 }
 
-// ArmT3489 arms the ESM information request guard: two retransmissions, then
-// onAbort on the third expiry (TS 24.301 §6.6.1.2.6 a).
 func (c *UeConn) ArmT3489(name string, nas []byte, onAbort func()) {
 	if c == nil || c.ue == nil {
 		return
@@ -72,7 +70,6 @@ func (c *UeConn) ArmT3489(name string, nas []byte, onAbort func()) {
 	)
 }
 
-// StopESMInfoGuard cancels the ESM information request guard.
 func (c *UeConn) StopESMInfoGuard() {
 	if c == nil {
 		return

--- a/internal/mme/nas_guard.go
+++ b/internal/mme/nas_guard.go
@@ -52,6 +52,38 @@ func (c *UeConn) ArmNASGuardAbortOnly(name string, nas []byte, onAbort func()) {
 	c.armNASGuardMode(name, nas, onAbort)
 }
 
+// ArmT3489 arms the ESM information request guard: two retransmissions, then
+// onAbort on the third expiry (TS 24.301 §6.6.1.2.6 a).
+func (c *UeConn) ArmT3489(name string, nas []byte, onAbort func()) {
+	if c == nil || c.ue == nil {
+		return
+	}
+
+	m := c.m
+	ue := c.ue
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c.esmInfoGuard.ArmWith(
+		m.t3489Cfg,
+		func(attempt int32) { c.retransmitNASGuard(ue, name, nas, attempt) },
+		func() { c.expireNASGuard(ue, name, onAbort) },
+	)
+}
+
+// StopESMInfoGuard cancels the ESM information request guard.
+func (c *UeConn) StopESMInfoGuard() {
+	if c == nil {
+		return
+	}
+
+	c.m.mu.Lock()
+	defer c.m.mu.Unlock()
+
+	c.esmInfoGuard.Stop()
+}
+
 func (c *UeConn) armNASGuardMode(name string, nas []byte, onAbort func()) {
 	if c == nil || c.ue == nil {
 		return

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -105,8 +105,8 @@ type UeConn struct {
 	// nasGuardName is the EMM procedure the guard currently supervises, for the status
 	// export. Set at arm and cleared at stop under m.mu, so a plain string suffices.
 	nasGuardName string
-	// T3489. Separate from nasGuard because the procedure runs inside the attach,
-	// whose own guard is already armed.
+	// T3489. Separate from nasGuard because it runs inside the attach, whose own
+	// guard is already armed.
 	esmInfoGuard guard.Guard
 	// releaseGuard supervises a sent UE Context Release Command: armed when the command
 	// is sent, stopped on the Release Complete; a lost Complete fires it once and runs

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -105,9 +105,8 @@ type UeConn struct {
 	// nasGuardName is the EMM procedure the guard currently supervises, for the status
 	// export. Set at arm and cleared at stop under m.mu, so a plain string suffices.
 	nasGuardName string
-	// esmInfoGuard supervises the ESM information request procedure (T3489,
-	// TS 24.301 §6.6.1.2.6 a). It is separate from nasGuard because the procedure
-	// runs inside the attach, whose own guard is already armed.
+	// T3489. Separate from nasGuard because the procedure runs inside the attach,
+	// whose own guard is already armed.
 	esmInfoGuard guard.Guard
 	// releaseGuard supervises a sent UE Context Release Command: armed when the command
 	// is sent, stopped on the Release Complete; a lost Complete fires it once and runs

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -105,6 +105,10 @@ type UeConn struct {
 	// nasGuardName is the EMM procedure the guard currently supervises, for the status
 	// export. Set at arm and cleared at stop under m.mu, so a plain string suffices.
 	nasGuardName string
+	// esmInfoGuard supervises the ESM information request procedure (T3489,
+	// TS 24.301 §6.6.1.2.6 a). It is separate from nasGuard because the procedure
+	// runs inside the attach, whose own guard is already armed.
+	esmInfoGuard guard.Guard
 	// releaseGuard supervises a sent UE Context Release Command: armed when the command
 	// is sent, stopped on the Release Complete; a lost Complete fires it once and runs
 	// the EMMState-keyed local cleanup so the UeConn + M-TMSI cannot leak.

--- a/internal/mme/security_state.go
+++ b/internal/mme/security_state.go
@@ -7,7 +7,7 @@ package mme
 // AuthProof is an unforgeable witness that the caller is entitled to mutate
 // security-critical state on a UeContext: installing the NAS security context or
 // committing the UE identity. It has no exported constructor and is minted only
-// by the two functions below.
+// by the functions below.
 type AuthProof struct {
 	_ struct{} // unexported field forbids struct-literal construction outside this package
 }
@@ -32,6 +32,14 @@ func MintAuthProofForAttachCommit() AuthProof {
 // one audited path. Downgrade protection itself is the HashMME replay check
 // (TS 24.301 §5.4.3.2).
 func MintAuthProofForAttachRequest() AuthProof {
+	return AuthProof{}
+}
+
+// MintAuthProofForTrackingAreaUpdate returns an AuthProof gating the store of UE
+// security capabilities replayed in a TRACKING AREA UPDATE REQUEST
+// (TS 24.301 §5.5.3.2.4). It must only be called for a request that passed its
+// integrity check, which is the downgrade protection on this path (§4.4.4.3).
+func MintAuthProofForTrackingAreaUpdate() AuthProof {
 	return AuthProof{}
 }
 

--- a/internal/mme/security_state.go
+++ b/internal/mme/security_state.go
@@ -35,8 +35,6 @@ func MintAuthProofForAttachRequest() AuthProof {
 	return AuthProof{}
 }
 
-// Only for a TRACKING AREA UPDATE REQUEST that passed its integrity check: that
-// check is the downgrade protection on this path (TS 24.301 §4.4.4.3).
 func MintAuthProofForTrackingAreaUpdate() AuthProof {
 	return AuthProof{}
 }

--- a/internal/mme/security_state.go
+++ b/internal/mme/security_state.go
@@ -35,10 +35,8 @@ func MintAuthProofForAttachRequest() AuthProof {
 	return AuthProof{}
 }
 
-// MintAuthProofForTrackingAreaUpdate returns an AuthProof gating the store of UE
-// security capabilities replayed in a TRACKING AREA UPDATE REQUEST
-// (TS 24.301 §5.5.3.2.4). It must only be called for a request that passed its
-// integrity check, which is the downgrade protection on this path (§4.4.4.3).
+// Only for a TRACKING AREA UPDATE REQUEST that passed its integrity check: that
+// check is the downgrade protection on this path (TS 24.301 §4.4.4.3).
 func MintAuthProofForTrackingAreaUpdate() AuthProof {
 	return AuthProof{}
 }

--- a/internal/mme/ue_accessors.go
+++ b/internal/mme/ue_accessors.go
@@ -210,9 +210,11 @@ func (ue *UeContext) InstallNASSecurityContext(eea nas.CipheringAlgorithm, eia n
 	}
 
 	// A new EPS security context starts both NAS COUNTs at zero, so the initial
-	// SECURITY MODE COMMAND rides downlink COUNT 0 (TS 24.301 §4.4.3.1).
+	// SECURITY MODE COMMAND rides downlink COUNT 0 (TS 24.301 §4.4.3.1). Zero is
+	// also the K_eNB freshness a fresh context derives from (TS 33.401 §7.2.5.2.3).
 	ue.ulCount.Reset()
 	ue.dlCount.Reset()
+	ue.kenbCount = 0
 
 	return nil
 }
@@ -311,7 +313,20 @@ func (ue *UeContext) VerifyServiceRequest(sr *eps.ServiceRequest) (expSeq uint8,
 	return expSeq, ul, nil
 }
 
-// DeriveInitialKeNB derives K_eNB from K_ASME and the last uplink NAS COUNT and
+// PinKeNBFreshness records the uplink NAS COUNT of the message just accepted as
+// the K_eNB derivation input. TS 33.401 §7.2.6.2 names the message that triggers
+// the AS SMC, and §7.2.5.2.2 has a NAS SECURITY MODE COMPLETE supersede it, which
+// the later call does. Reading the count at Initial Context Setup instead would
+// pick up any message that arrived in between, such as an ESM INFORMATION
+// RESPONSE, which the UE does not count.
+func (ue *UeContext) PinKeNBFreshness() {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.kenbCount = ue.ulCount.LastAccepted().Value()
+}
+
+// DeriveInitialKeNB derives K_eNB from K_ASME and the pinned uplink NAS COUNT and
 // seeds the X2-handover key chain (NH for NCC=1) for the first path switch
 // (TS 33.401). It returns K_eNB for delivery to the eNB in the Initial Context
 // Setup, plus the NAS COUNT it used (for diagnostics). K_ASME never leaves the
@@ -320,10 +335,7 @@ func (ue *UeContext) DeriveInitialKeNB() (kenb [32]byte, kenbCount uint32, err e
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	// K_eNB is derived from the uplink NAS COUNT of the most recently accepted
-	// uplink NAS message: the Security Mode Complete on attach, the Service
-	// Request on reconnect (TS 33.401 §A.3).
-	kenbCount = ue.ulCount.LastAccepted().Value()
+	kenbCount = ue.kenbCount
 
 	kenb, err = DeriveKeNB(ue.kasme, kenbCount)
 	if err != nil {

--- a/internal/mme/ue_accessors.go
+++ b/internal/mme/ue_accessors.go
@@ -209,9 +209,6 @@ func (ue *UeContext) InstallNASSecurityContext(eea nas.CipheringAlgorithm, eia n
 		return err
 	}
 
-	// A new EPS security context starts both NAS COUNTs at zero, so the initial
-	// SECURITY MODE COMMAND rides downlink COUNT 0 (TS 24.301 §4.4.3.1). Zero is
-	// also the K_eNB freshness a fresh context derives from (TS 33.401 §7.2.5.2.3).
 	ue.ulCount.Reset()
 	ue.dlCount.Reset()
 	ue.kenbCount = 0
@@ -313,12 +310,8 @@ func (ue *UeContext) VerifyServiceRequest(sr *eps.ServiceRequest) (expSeq uint8,
 	return expSeq, ul, nil
 }
 
-// PinKeNBFreshness records the uplink NAS COUNT of the message just accepted as
-// the K_eNB derivation input. TS 33.401 §7.2.6.2 names the message that triggers
-// the AS SMC, and §7.2.5.2.2 has a NAS SECURITY MODE COMPLETE supersede it, which
-// the later call does. Reading the count at Initial Context Setup instead would
-// pick up any message that arrived in between, such as an ESM INFORMATION
-// RESPONSE, which the UE does not count.
+// Reading the count at Initial Context Setup instead would pick up any message
+// that arrived in between, which the UE does not count (TS 33.401 §7.2.6.2).
 func (ue *UeContext) PinKeNBFreshness() {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
@@ -326,11 +319,6 @@ func (ue *UeContext) PinKeNBFreshness() {
 	ue.kenbCount = ue.ulCount.LastAccepted().Value()
 }
 
-// DeriveInitialKeNB derives K_eNB from K_ASME and the pinned uplink NAS COUNT and
-// seeds the X2-handover key chain (NH for NCC=1) for the first path switch
-// (TS 33.401). It returns K_eNB for delivery to the eNB in the Initial Context
-// Setup, plus the NAS COUNT it used (for diagnostics). K_ASME never leaves the
-// kernel.
 func (ue *UeContext) DeriveInitialKeNB() (kenb [32]byte, kenbCount uint32, err error) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/mme/ue_test_support.go
+++ b/internal/mme/ue_test_support.go
@@ -221,6 +221,17 @@ func (m *MME) SetESMGuardConfigForTest(expire time.Duration, maxRetry int32) {
 	m.esmGuardCfg.MaxRetryTimes = maxRetry
 }
 
+// SetT3489ConfigForTest overrides the ESM information request guard's interval
+// and retry budget so a test can drive its expiry quickly.
+func (m *MME) SetT3489ConfigForTest(expire time.Duration, maxRetry int32) {
+	m.t3489Cfg.ExpireTime = expire
+	m.t3489Cfg.MaxRetryTimes = maxRetry
+}
+
+// T3489ActiveForTest reports whether the connection's ESM information request
+// guard is currently armed.
+func (c *UeConn) T3489ActiveForTest() bool { return c.esmInfoGuard.Active() }
+
 func (m *MME) FireHandoverGuardForTest(ue *UeContext) { m.abandonHandover(ue) }
 
 func (m *MME) ReclaimUEsOnConnLossForTest(conn S1APWriter) { m.reclaimUEsOnConnLoss(conn) }

--- a/internal/mme/ue_test_support.go
+++ b/internal/mme/ue_test_support.go
@@ -221,15 +221,11 @@ func (m *MME) SetESMGuardConfigForTest(expire time.Duration, maxRetry int32) {
 	m.esmGuardCfg.MaxRetryTimes = maxRetry
 }
 
-// SetT3489ConfigForTest overrides the ESM information request guard's interval
-// and retry budget so a test can drive its expiry quickly.
 func (m *MME) SetT3489ConfigForTest(expire time.Duration, maxRetry int32) {
 	m.t3489Cfg.ExpireTime = expire
 	m.t3489Cfg.MaxRetryTimes = maxRetry
 }
 
-// T3489ActiveForTest reports whether the connection's ESM information request
-// guard is currently armed.
 func (c *UeConn) T3489ActiveForTest() bool { return c.esmInfoGuard.Active() }
 
 func (m *MME) FireHandoverGuardForTest(ue *UeContext) { m.abandonHandover(ue) }

--- a/internal/mme/unciphered_esm_test.go
+++ b/internal/mme/unciphered_esm_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// TS 24.301 §4.4.5.
 func TestDecodeNASMessageDiscardsAnUncipheredESMMessage(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -37,7 +36,6 @@ func TestDecodeNASMessageDiscardsAnUncipheredESMMessage(t *testing.T) {
 	}
 }
 
-// Pins the discard above to the ciphering requirement, not the message itself.
 func TestDecodeNASMessageAcceptsTheSameESMMessageCiphered(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -59,9 +57,6 @@ func TestDecodeNASMessageAcceptsTheSameESMMessageCiphered(t *testing.T) {
 	}
 }
 
-// TS 24.301 §3.1, §4.4.5: a message that can be the initial NAS message of a new
-// connection is legitimately unciphered, and the receiver cannot tell whether the
-// UE sent it as one. srsUE relies on this for the switch-off DETACH REQUEST.
 func TestDecodeNASMessageAcceptsTheUncipheredExemptMessages(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/mme/unciphered_esm_test.go
+++ b/internal/mme/unciphered_esm_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// TS 24.301 §4.4.5: once ciphering has started the receiver discards a message
+// that should have been ciphered. Only two EMM messages are exempt, so every ESM
+// message arriving integrity-protected only is discarded.
+func TestDecodeNASMessageDiscardsAnUncipheredESMMessage(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	esm, err := (&eps.PDNConnectivityRequest{PTI: 1, RequestType: 1, PDNType: 1}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal PDN CONNECTIVITY REQUEST: %v", err)
+	}
+
+	sc := mustSecurityContext(t, ue.EIA(), ue.EEA(), ue.KnasIntForTest(), ue.KnasEncForTest())
+
+	wire, err := eps.Protect(esm, eps.SHTIntegrityProtected, nas.MakeCount(0, 0), nas.DirectionUplink, sc)
+	if err != nil {
+		t.Fatalf("protect: %v", err)
+	}
+
+	res, err := DecodeNASMessage(ue, wire)
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered ESM) = %+v, nil, want it discarded", res)
+	}
+
+	if res != nil {
+		t.Errorf("DecodeNASMessage returned %+v alongside the error, want no message", res)
+	}
+}
+
+// The same message ciphered is accepted, so the discard above is the ciphering
+// requirement and not a rejection of the message itself.
+func TestDecodeNASMessageAcceptsTheSameESMMessageCiphered(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	esm, err := (&eps.PDNConnectivityRequest{PTI: 1, RequestType: 1, PDNType: 1}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal PDN CONNECTIVITY REQUEST: %v", err)
+	}
+
+	sc := mustSecurityContext(t, ue.EIA(), ue.EEA(), ue.KnasIntForTest(), ue.KnasEncForTest())
+
+	wire, err := eps.Protect(esm, eps.SHTIntegrityProtectedCiphered, nas.MakeCount(0, 0), nas.DirectionUplink, sc)
+	if err != nil {
+		t.Fatalf("protect: %v", err)
+	}
+
+	if _, err := DecodeNASMessage(ue, wire); err != nil {
+		t.Fatalf("DecodeNASMessage(ciphered ESM) = %v, want it accepted", err)
+	}
+}
+
+// TS 24.301 §4.4.5 has the UE send ATTACH REQUEST and TRACKING AREA UPDATE
+// REQUEST always unciphered, so neither is discarded by the ciphering guard.
+func TestDecodeNASMessageAcceptsTheUncipheredExemptMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  interface{ MarshalBinary() ([]byte, error) }
+	}{
+		{"ATTACH REQUEST", &eps.AttachRequest{
+			EPSAttachType:       eps.AttachTypeEPS,
+			NASKeySetIdentifier: nas.KeySetIdentifier{Value: 7},
+			EPSMobileIdentity:   eps.IMSIIdentity(eps.IMSI(testSubscriber.IMSI)),
+			UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70},
+			ESMMessageContainer: []byte{0x02, 0x00, 0xc1},
+		}},
+		{"TRACKING AREA UPDATE REQUEST", &eps.TrackingAreaUpdateRequest{
+			NASKeySetIdentifier: nas.KeySetIdentifier{Value: 7},
+			OldGUTI:             eps.IMSIIdentity(eps.IMSI(testSubscriber.IMSI)),
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMME(t)
+			ue, _ := securedUE(t, m)
+
+			plain, err := tc.msg.MarshalBinary()
+			if err != nil {
+				t.Fatalf("marshal %s: %v", tc.name, err)
+			}
+
+			sc := mustSecurityContext(t, ue.EIA(), ue.EEA(), ue.KnasIntForTest(), ue.KnasEncForTest())
+
+			wire, err := eps.Protect(plain, eps.SHTIntegrityProtected, nas.MakeCount(0, 0), nas.DirectionUplink, sc)
+			if err != nil {
+				t.Fatalf("protect: %v", err)
+			}
+
+			if _, err := DecodeNASMessage(ue, wire); err != nil {
+				t.Fatalf("DecodeNASMessage(unciphered %s) = %v, want it accepted", tc.name, err)
+			}
+		})
+	}
+}

--- a/internal/mme/unciphered_esm_test.go
+++ b/internal/mme/unciphered_esm_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// TS 24.301 §4.4.5: once ciphering has started the receiver discards a message
-// that should have been ciphered. Only two EMM messages are exempt, so every ESM
-// message arriving integrity-protected only is discarded.
+// TS 24.301 §4.4.5.
 func TestDecodeNASMessageDiscardsAnUncipheredESMMessage(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -39,8 +37,7 @@ func TestDecodeNASMessageDiscardsAnUncipheredESMMessage(t *testing.T) {
 	}
 }
 
-// The same message ciphered is accepted, so the discard above is the ciphering
-// requirement and not a rejection of the message itself.
+// Pins the discard above to the ciphering requirement, not the message itself.
 func TestDecodeNASMessageAcceptsTheSameESMMessageCiphered(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -62,8 +59,7 @@ func TestDecodeNASMessageAcceptsTheSameESMMessageCiphered(t *testing.T) {
 	}
 }
 
-// TS 24.301 §4.4.5 has the UE send ATTACH REQUEST and TRACKING AREA UPDATE
-// REQUEST always unciphered, so neither is discarded by the ciphering guard.
+// The two TS 24.301 §4.4.5 exempts.
 func TestDecodeNASMessageAcceptsTheUncipheredExemptMessages(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/mme/unciphered_esm_test.go
+++ b/internal/mme/unciphered_esm_test.go
@@ -59,12 +59,20 @@ func TestDecodeNASMessageAcceptsTheSameESMMessageCiphered(t *testing.T) {
 	}
 }
 
-// The two TS 24.301 §4.4.5 exempts.
+// TS 24.301 §3.1, §4.4.5: a message that can be the initial NAS message of a new
+// connection is legitimately unciphered, and the receiver cannot tell whether the
+// UE sent it as one. srsUE relies on this for the switch-off DETACH REQUEST.
 func TestDecodeNASMessageAcceptsTheUncipheredExemptMessages(t *testing.T) {
 	tests := []struct {
 		name string
 		msg  interface{ MarshalBinary() ([]byte, error) }
 	}{
+		{"DETACH REQUEST", &eps.DetachRequestUE{
+			SwitchOff:           true,
+			TypeOfDetach:        eps.DetachTypeEPS,
+			NASKeySetIdentifier: nas.KeySetIdentifier{Value: 0},
+			EPSMobileIdentity:   eps.IMSIIdentity(eps.IMSI(testSubscriber.IMSI)),
+		}},
 		{"ATTACH REQUEST", &eps.AttachRequest{
 			EPSAttachType:       eps.AttachTypeEPS,
 			NASKeySetIdentifier: nas.KeySetIdentifier{Value: 7},

--- a/nas/eps/canonical_cases_test.go
+++ b/nas/eps/canonical_cases_test.go
@@ -63,6 +63,9 @@ func canonicalCases(t *testing.T) []canonicalCase {
 	// EPS reuses 0x5B for the T3442 value in EMM and the new EPS QoS in ESM.
 	qos := map[uint8][]byte{ieiNewEPSQoS: {0x09}}
 	imeisv := map[uint8][]byte{ieiIMEISV: {0x33, 0x21, 0x43, 0x65, 0x87, 0x09, 0x21, 0x43, 0xf5}}
+	// EPS reuses 0x58 for the UE network capability in TAU REQUEST and the ESM
+	// cause in ESM messages.
+	ueNetCap := map[uint8][]byte{ieiUENetworkCapability: {0xf0, 0x70}}
 
 	return []canonicalCase{
 		{
@@ -163,7 +166,12 @@ func canonicalCases(t *testing.T) []canonicalCase {
 				NASKeySetIdentifier: nas.NoKeySet,
 				OldGUTI:             GUTIIdentity(GUTI{PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 1, MMECode: 1, TMSI: [4]byte{0, 0, 0, 1}}),
 			},
-			order: []canonicalIE{{ieiEPSBearerContextStatus, nas.IETLV}},
+			order: []canonicalIE{
+				{ieiUENetworkCapability, nas.IETLV},
+				{ieiEPSBearerContextStatus, nas.IETLV},
+				{ieiMSNetworkCapability, nas.IETLV},
+			},
+			values: ueNetCap,
 		},
 	}
 }

--- a/nas/eps/emm_attach_accept.go
+++ b/nas/eps/emm_attach_accept.go
@@ -327,8 +327,7 @@ func ParseAttachComplete(b []byte) (*AttachComplete, error) {
 // the back-off before the UE retries, mirroring the 5G T3502 in REGISTRATION
 // REJECT.
 type AttachReject struct {
-	Cause EMMCause
-	// Accompanies EMM cause #19 (TS 24.301 §5.5.1.2.5); empty omits the IE.
+	Cause               EMMCause
 	ESMMessageContainer []byte
 	// T3402 is the encoded one-octet GPRS timer value (§9.9.3.16A); 0 omits the IE.
 	T3402 *nas.GPRSTimer2
@@ -338,7 +337,6 @@ type AttachReject struct {
 	Unrecognized []nas.RawIE
 }
 
-// Table 8.2.3.1 order.
 var attachRejectIEs = []nas.OptionalIE{
 	{IEI: ieiESMMessageContainer, Format: nas.IETLVE, Name: "ESM message container"},
 	{IEI: ieiT3402Value, Format: nas.IETLV, Name: "T3402 value"},

--- a/nas/eps/emm_attach_accept.go
+++ b/nas/eps/emm_attach_accept.go
@@ -113,6 +113,15 @@ func (n NetworkFeatureSupport) AppendBinary(b []byte) ([]byte, error) {
 		return b, fmt.Errorf("nas/eps: EPS network feature support: octet 5 onwards requires octet 4")
 	}
 
+	// Octet 3, octet 4 and Rest are the whole value, which the element caps at
+	// maxNetworkFeatureSupportLen (TS 24.301 §9.9.3.12A).
+	if n.HasOctet4 {
+		if size := 2 + len(n.Rest); size > maxNetworkFeatureSupportLen {
+			return b, fmt.Errorf(
+				"nas/eps: EPS network feature support value is %d octets, want at most %d", size, maxNetworkFeatureSupportLen)
+		}
+	}
+
 	octet := boolBit(n.IMSVoPS, 0) | boolBit(n.EMCBS, 1) | boolBit(n.EPCLCS, 2) |
 		n.CSLCS&0x03<<3 | boolBit(n.ESRPS, 5) | boolBit(n.ERwoPDN, 6) | boolBit(n.CPCIoT, 7)
 
@@ -321,6 +330,9 @@ func ParseAttachComplete(b []byte) (*AttachComplete, error) {
 // REJECT.
 type AttachReject struct {
 	Cause EMMCause
+	// ESMMessageContainer carries the ESM reject that accompanies EMM cause #19
+	// "ESM failure" (TS 24.301 §5.5.1.2.5); empty omits the IE.
+	ESMMessageContainer []byte
 	// T3402 is the encoded one-octet GPRS timer value (§9.9.3.16A); 0 omits the IE.
 	T3402 *nas.GPRSTimer2
 
@@ -330,8 +342,10 @@ type AttachReject struct {
 }
 
 // attachRejectIEs are the optional IEs Ella Core emits in an ATTACH REJECT: the
-// T3402 value, a type-4 (TLV) "GPRS timer 2" IE with a one-octet value (§8.2.3.4).
+// ESM message container, a type-6 (TLV-E) IE, and the T3402 value, a type-4
+// (TLV) "GPRS timer 2" IE with a one-octet value (§8.2.3.2, §8.2.3.4).
 var attachRejectIEs = []nas.OptionalIE{
+	{IEI: ieiESMMessageContainer, Format: nas.IETLVE, Name: "ESM message container"},
 	{IEI: ieiT3402Value, Format: nas.IETLV, Name: "T3402 value"},
 }
 
@@ -344,6 +358,10 @@ func (m *AttachReject) AppendBinary(b []byte) ([]byte, error) {
 
 	writeEMMHeader(w, MsgAttachReject)
 	w.U8(uint8(m.Cause))
+
+	if len(m.ESMMessageContainer) > 0 {
+		o.TLVE(ieiESMMessageContainer, m.ESMMessageContainer)
+	}
 
 	if m.T3402 != nil {
 		raw, err := m.T3402.MarshalBinary()
@@ -379,18 +397,23 @@ func ParseAttachReject(b []byte) (*AttachReject, error) {
 	m := &AttachReject{Cause: EMMCause(cause)}
 
 	_unrec, err := walkOptionalIEs(r, attachRejectIEs, func(iei uint8, value []byte) (bool, error) {
-		if iei != ieiT3402Value {
-			return false, nil
+		switch iei {
+		case ieiESMMessageContainer:
+			m.ESMMessageContainer = value
+
+			return true, nil
+		case ieiT3402Value:
+			timer, err := nas.ParseGPRSTimer2(value)
+			if err != nil {
+				return false, err
+			}
+
+			m.T3402 = &timer
+
+			return true, nil
 		}
 
-		timer, err := nas.ParseGPRSTimer2(value)
-		if err != nil {
-			return false, err
-		}
-
-		m.T3402 = &timer
-
-		return true, nil
+		return false, nil
 	})
 	if err != nil && !nas.SoftOnly(err) {
 		return nil, err

--- a/nas/eps/emm_attach_accept.go
+++ b/nas/eps/emm_attach_accept.go
@@ -113,8 +113,6 @@ func (n NetworkFeatureSupport) AppendBinary(b []byte) ([]byte, error) {
 		return b, fmt.Errorf("nas/eps: EPS network feature support: octet 5 onwards requires octet 4")
 	}
 
-	// Octet 3, octet 4 and Rest are the whole value, which the element caps at
-	// maxNetworkFeatureSupportLen (TS 24.301 §9.9.3.12A).
 	if n.HasOctet4 {
 		if size := 2 + len(n.Rest); size > maxNetworkFeatureSupportLen {
 			return b, fmt.Errorf(
@@ -330,8 +328,7 @@ func ParseAttachComplete(b []byte) (*AttachComplete, error) {
 // REJECT.
 type AttachReject struct {
 	Cause EMMCause
-	// ESMMessageContainer carries the ESM reject that accompanies EMM cause #19
-	// "ESM failure" (TS 24.301 §5.5.1.2.5); empty omits the IE.
+	// Accompanies EMM cause #19 (TS 24.301 §5.5.1.2.5); empty omits the IE.
 	ESMMessageContainer []byte
 	// T3402 is the encoded one-octet GPRS timer value (§9.9.3.16A); 0 omits the IE.
 	T3402 *nas.GPRSTimer2
@@ -341,9 +338,7 @@ type AttachReject struct {
 	Unrecognized []nas.RawIE
 }
 
-// attachRejectIEs are the optional IEs Ella Core emits in an ATTACH REJECT: the
-// ESM message container, a type-6 (TLV-E) IE, and the T3402 value, a type-4
-// (TLV) "GPRS timer 2" IE with a one-octet value (§8.2.3.2, §8.2.3.4).
+// Table 8.2.3.1 order.
 var attachRejectIEs = []nas.OptionalIE{
 	{IEI: ieiESMMessageContainer, Format: nas.IETLVE, Name: "ESM message container"},
 	{IEI: ieiT3402Value, Format: nas.IETLV, Name: "T3402 value"},

--- a/nas/eps/emm_negotiation_test.go
+++ b/nas/eps/emm_negotiation_test.go
@@ -218,7 +218,6 @@ func TestAttachNetworkRoundTrips(t *testing.T) {
 	})
 }
 
-// The encoder must not emit what ParseNetworkFeatureSupport rejects.
 func TestNetworkFeatureSupportRejectsAnOverlongValue(t *testing.T) {
 	in := NetworkFeatureSupport{IMSVoPS: true, HasOctet4: true, Rest: []byte{0x00, 0x00}}
 

--- a/nas/eps/emm_negotiation_test.go
+++ b/nas/eps/emm_negotiation_test.go
@@ -175,6 +175,60 @@ func TestAttachNetworkRoundTrips(t *testing.T) {
 			t.Fatalf("ATTACH REJECT T3402 encoding = % x, want % x", b, want)
 		}
 	})
+
+	// EMM cause #19 "ESM failure" comes with the ESM reject in the ESM message
+	// container, a type-6 (TLV-E) IE (TS 24.301 §5.5.1.2.5, table 8.2.3.1).
+	t.Run("RejectWithESMMessageContainer", func(t *testing.T) {
+		esm, err := (&PDNConnectivityReject{PTI: 1, Cause: ESMCauseMissingOrUnknownAPN}).MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		in := &AttachReject{Cause: EMMCauseESMFailure, ESMMessageContainer: esm}
+
+		b, err := in.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantIE := append([]byte{0x78, byte(len(esm) >> 8), byte(len(esm))}, esm...)
+		if !bytes.Contains(b, wantIE) {
+			t.Fatalf("encoded %x does not contain the ESM message container IE %x", b, wantIE)
+		}
+
+		out, err := ParseAttachReject(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if out.Cause != EMMCauseESMFailure {
+			t.Errorf("EMM cause = %d, want %d", out.Cause, EMMCauseESMFailure)
+		}
+
+		if !bytes.Equal(out.ESMMessageContainer, esm) {
+			t.Fatalf("ESM message container = % x, want % x", out.ESMMessageContainer, esm)
+		}
+
+		inner, err := ParsePDNConnectivityReject(out.ESMMessageContainer)
+		if err != nil {
+			t.Fatalf("parse the carried PDN Connectivity Reject: %v", err)
+		}
+
+		if inner.Cause != ESMCauseMissingOrUnknownAPN {
+			t.Errorf("carried ESM cause = %d, want %d", inner.Cause, ESMCauseMissingOrUnknownAPN)
+		}
+	})
+}
+
+// The element caps its value at maxNetworkFeatureSupportLen (TS 24.301
+// §9.9.3.12A), so the encoder does not emit what ParseNetworkFeatureSupport
+// rejects.
+func TestNetworkFeatureSupportRejectsAnOverlongValue(t *testing.T) {
+	in := NetworkFeatureSupport{IMSVoPS: true, HasOctet4: true, Rest: []byte{0x00, 0x00}}
+
+	if b, err := in.MarshalBinary(); err == nil {
+		t.Fatalf("MarshalBinary = % x, nil, want an error for a %d-octet value", b, len(b))
+	}
 }
 
 // TestNetworkFeatureSupportRoundTrips checks the EPS network feature support

--- a/nas/eps/emm_negotiation_test.go
+++ b/nas/eps/emm_negotiation_test.go
@@ -176,8 +176,6 @@ func TestAttachNetworkRoundTrips(t *testing.T) {
 		}
 	})
 
-	// EMM cause #19 "ESM failure" comes with the ESM reject in the ESM message
-	// container, a type-6 (TLV-E) IE (TS 24.301 §5.5.1.2.5, table 8.2.3.1).
 	t.Run("RejectWithESMMessageContainer", func(t *testing.T) {
 		esm, err := (&PDNConnectivityReject{PTI: 1, Cause: ESMCauseMissingOrUnknownAPN}).MarshalBinary()
 		if err != nil {
@@ -220,9 +218,7 @@ func TestAttachNetworkRoundTrips(t *testing.T) {
 	})
 }
 
-// The element caps its value at maxNetworkFeatureSupportLen (TS 24.301
-// §9.9.3.12A), so the encoder does not emit what ParseNetworkFeatureSupport
-// rejects.
+// The encoder must not emit what ParseNetworkFeatureSupport rejects.
 func TestNetworkFeatureSupportRejectsAnOverlongValue(t *testing.T) {
 	in := NetworkFeatureSupport{IMSVoPS: true, HasOctet4: true, Rest: []byte{0x00, 0x00}}
 

--- a/nas/eps/emm_tau.go
+++ b/nas/eps/emm_tau.go
@@ -37,6 +37,12 @@ type TrackingAreaUpdateRequest struct {
 	OldGUTI EPSMobileIdentity
 	// EPSBearerContextStatus reports which EPS bearer contexts are active.
 	EPSBearerContextStatus *nas.EPSBearerContextStatus
+	// UENetworkCapability is the UE's supported algorithms and per-release
+	// feature bits (§9.9.3.34); nil when the element was absent.
+	UENetworkCapability *UENetworkCapability
+	// MSNetworkCapability carries the GERAN/UTRAN algorithms (§9.9.3.20). The UE
+	// may replay either capability or both (§5.5.3.2.4); nil when absent.
+	MSNetworkCapability *MSNetworkCapability
 
 	// Unrecognized carries the optional information elements this message does
 	// not model, so they survive decoding and re-encode unchanged.
@@ -100,6 +106,15 @@ func (m *TrackingAreaUpdateRequest) AppendBinary(b []byte) ([]byte, error) {
 
 	w.LV(oldGUTI)
 
+	if m.UENetworkCapability != nil {
+		raw, err := m.UENetworkCapability.MarshalBinary()
+		if err != nil {
+			return b, err
+		}
+
+		o.TLV(ieiUENetworkCapability, raw)
+	}
+
 	if m.EPSBearerContextStatus != nil {
 		raw, err := m.EPSBearerContextStatus.MarshalBinary()
 		if err != nil {
@@ -107,6 +122,15 @@ func (m *TrackingAreaUpdateRequest) AppendBinary(b []byte) ([]byte, error) {
 		}
 
 		o.TLV(ieiEPSBearerContextStatus, raw)
+	}
+
+	if m.MSNetworkCapability != nil {
+		raw, err := m.MSNetworkCapability.MarshalBinary()
+		if err != nil {
+			return b, err
+		}
+
+		o.TLV(ieiMSNetworkCapability, raw)
 	}
 
 	o.Raw(m.Unrecognized...)
@@ -151,18 +175,40 @@ func ParseTrackingAreaUpdateRequest(b []byte) (*TrackingAreaUpdateRequest, error
 	}
 
 	_unrec, err := walkOptionalIEs(r, tauRequestOptionalIEs, func(iei uint8, value []byte) (bool, error) {
-		if iei != ieiEPSBearerContextStatus {
-			return false, nil
+		switch iei {
+		case ieiEPSBearerContextStatus:
+			status, err := nas.ParseEPSBearerContextStatus(value)
+			if err != nil {
+				return false, err
+			}
+
+			m.EPSBearerContextStatus = &status
+
+			return true, nil
+		case ieiUENetworkCapability:
+			// A syntactically incorrect optional element leaves the rest of the
+			// message usable (TS 24.301 §7.7.1). Declining it keeps it among the
+			// preserved elements, so the re-encoded message still carries it.
+			parsed, err := ParseUENetworkCapability(value)
+			if err != nil {
+				return false, nil
+			}
+
+			m.UENetworkCapability = &parsed
+
+			return true, nil
+		case ieiMSNetworkCapability:
+			parsed, err := ParseMSNetworkCapability(value)
+			if err != nil {
+				return false, nil
+			}
+
+			m.MSNetworkCapability = &parsed
+
+			return true, nil
 		}
 
-		status, err := nas.ParseEPSBearerContextStatus(value)
-		if err != nil {
-			return false, err
-		}
-
-		m.EPSBearerContextStatus = &status
-
-		return true, nil
+		return false, nil
 	})
 	if err != nil && !nas.SoftOnly(err) {
 		return nil, err

--- a/nas/eps/emm_tau.go
+++ b/nas/eps/emm_tau.go
@@ -182,8 +182,8 @@ func ParseTrackingAreaUpdateRequest(b []byte) (*TrackingAreaUpdateRequest, error
 
 			return true, nil
 		case ieiUENetworkCapability:
-			// Both are Critical, so a malformed value fails the message rather than
-			// taking the §7.7.1 not-present default.
+			// Critical, so a malformed value fails the message rather than taking
+			// the §7.7.1 not-present default.
 			parsed, err := ParseUENetworkCapability(value)
 			if err != nil {
 				return false, err

--- a/nas/eps/emm_tau.go
+++ b/nas/eps/emm_tau.go
@@ -37,12 +37,8 @@ type TrackingAreaUpdateRequest struct {
 	OldGUTI EPSMobileIdentity
 	// EPSBearerContextStatus reports which EPS bearer contexts are active.
 	EPSBearerContextStatus *nas.EPSBearerContextStatus
-	// UENetworkCapability is the UE's supported algorithms and per-release
-	// feature bits (§9.9.3.34); nil when the element was absent.
-	UENetworkCapability *UENetworkCapability
-	// MSNetworkCapability carries the GERAN/UTRAN algorithms (§9.9.3.20). The UE
-	// may replay either capability or both (§5.5.3.2.4); nil when absent.
-	MSNetworkCapability *MSNetworkCapability
+	UENetworkCapability    *UENetworkCapability // §9.9.3.34
+	MSNetworkCapability    *MSNetworkCapability // §9.9.3.20
 
 	// Unrecognized carries the optional information elements this message does
 	// not model, so they survive decoding and re-encode unchanged.
@@ -186,9 +182,8 @@ func ParseTrackingAreaUpdateRequest(b []byte) (*TrackingAreaUpdateRequest, error
 
 			return true, nil
 		case ieiUENetworkCapability:
-			// Both capabilities are Critical: the MME stores what they replay
-			// (§5.5.3.2.4), so a malformed one fails the message rather than
-			// leaving the field silently absent.
+			// Both are Critical, so a malformed value fails the message rather than
+			// taking the §7.7.1 not-present default.
 			parsed, err := ParseUENetworkCapability(value)
 			if err != nil {
 				return false, err

--- a/nas/eps/emm_tau.go
+++ b/nas/eps/emm_tau.go
@@ -186,12 +186,12 @@ func ParseTrackingAreaUpdateRequest(b []byte) (*TrackingAreaUpdateRequest, error
 
 			return true, nil
 		case ieiUENetworkCapability:
-			// A syntactically incorrect optional element leaves the rest of the
-			// message usable (TS 24.301 §7.7.1). Declining it keeps it among the
-			// preserved elements, so the re-encoded message still carries it.
+			// Both capabilities are Critical: the MME stores what they replay
+			// (§5.5.3.2.4), so a malformed one fails the message rather than
+			// leaving the field silently absent.
 			parsed, err := ParseUENetworkCapability(value)
 			if err != nil {
-				return false, nil
+				return false, err
 			}
 
 			m.UENetworkCapability = &parsed
@@ -200,7 +200,7 @@ func ParseTrackingAreaUpdateRequest(b []byte) (*TrackingAreaUpdateRequest, error
 		case ieiMSNetworkCapability:
 			parsed, err := ParseMSNetworkCapability(value)
 			if err != nil {
-				return false, nil
+				return false, err
 			}
 
 			m.MSNetworkCapability = &parsed

--- a/nas/eps/emm_tau_test.go
+++ b/nas/eps/emm_tau_test.go
@@ -78,7 +78,7 @@ func TestTrackingAreaUpdateRequestBearerContextStatus(t *testing.T) {
 	preceded := []byte{0x07, byte(MsgTrackingAreaUpdateRequest), 0x1b}
 	preceded = append(preceded, 0x0b, 0xf2, 0x00, 0xf1, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01) // Old GUTI (LV, 11)
 	preceded = append(preceded, 0x52, 1, 2, 3, 4, 5)                                                    // Last visited TAI (TV3, 5)
-	preceded = append(preceded, 0x58, 0x03, 0xe0, 0xe0, 0x00)                                           // UE network capability (TLV, 3)
+	preceded = append(preceded, 0x58, 0x02, 0xe0, 0xe0)                                                 // UE network capability (TLV, 2)
 
 	statusRaw, err := status.MarshalBinary()
 	if err != nil {
@@ -275,5 +275,32 @@ func TestTrackingAreaUpdateRejectMarshal(t *testing.T) {
 
 	if parsed.Cause != 9 {
 		t.Fatalf("cause = %d, want 9", parsed.Cause)
+	}
+}
+
+// Both replayed capabilities are Critical (TS 24.301 §5.5.3.2.4 has the MME store
+// them), so a malformed value fails the message rather than leaving the field
+// silently absent.
+func TestTrackingAreaUpdateRequestRejectsMalformedCapabilities(t *testing.T) {
+	tests := []struct {
+		name string
+		ie   []byte
+	}{
+		// §9.9.3.34: the value is 2 octets, or 4 to 13.
+		{"UE network capability", []byte{0x58, 0x03, 0xe0, 0xe0, 0x00}},
+		// §9.9.3.20 / TS 24.008 §10.5.5.12: the value is at most 8 octets.
+		{"MS network capability", []byte{0x31, 0x09, 0xe5, 0xe0, 0, 0, 0, 0, 0, 0, 0}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := []byte{0x07, byte(MsgTrackingAreaUpdateRequest), 0x1b}
+			b = append(b, 0x0b, 0xf2, 0x00, 0xf1, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+			b = append(b, tc.ie...)
+
+			if out, err := ParseTrackingAreaUpdateRequest(b); err == nil {
+				t.Fatalf("ParseTrackingAreaUpdateRequest = %+v, nil, want an error for a malformed %s", out, tc.name)
+			}
+		})
 	}
 }

--- a/nas/eps/emm_tau_test.go
+++ b/nas/eps/emm_tau_test.go
@@ -278,9 +278,6 @@ func TestTrackingAreaUpdateRejectMarshal(t *testing.T) {
 	}
 }
 
-// Both replayed capabilities are Critical (TS 24.301 §5.5.3.2.4 has the MME store
-// them), so a malformed value fails the message rather than leaving the field
-// silently absent.
 func TestTrackingAreaUpdateRequestRejectsMalformedCapabilities(t *testing.T) {
 	tests := []struct {
 		name string

--- a/nas/eps/emm_tau_test.go
+++ b/nas/eps/emm_tau_test.go
@@ -283,9 +283,7 @@ func TestTrackingAreaUpdateRequestRejectsMalformedCapabilities(t *testing.T) {
 		name string
 		ie   []byte
 	}{
-		// §9.9.3.34: the value is 2 octets, or 4 to 13.
 		{"UE network capability", []byte{0x58, 0x03, 0xe0, 0xe0, 0x00}},
-		// §9.9.3.20 / TS 24.008 §10.5.5.12: the value is at most 8 octets.
 		{"MS network capability", []byte{0x31, 0x09, 0xe5, 0xe0, 0, 0, 0, 0, 0, 0, 0}},
 	}
 

--- a/nas/eps/iei.go
+++ b/nas/eps/iei.go
@@ -34,6 +34,7 @@ const (
 	ieiNetworkDaylightSavingTime      uint8 = 0x49 // EMM INFORMATION
 	ieiHashMME                        uint8 = 0x4F // SECURITY MODE COMMAND
 	ieiReplayedNASMessage             uint8 = 0x79 // SECURITY MODE COMPLETE (TS 24.301 table 8.2.21.1)
+	ieiESMMessageContainer            uint8 = 0x78 // ATTACH REJECT (TS 24.301 table 8.2.3.1)
 	ieiGUTI                           uint8 = 0x50 // ATTACH ACCEPT / TAU ACCEPT: assigned GUTI
 	ieiAdditionalGUTI                 uint8 = 0x50 // ATTACH REQUEST / TAU REQUEST (same octet as the assigned GUTI)
 	ieiLastVisitedRegisteredTAI       uint8 = 0x52

--- a/nas/fgs/gmm_registration.go
+++ b/nas/fgs/gmm_registration.go
@@ -829,6 +829,10 @@ func ParseNetworkFeatureSupport(b []byte) (NetworkFeatureSupport, error) {
 // AppendBinary encodes the network feature support IE value as two octets.
 // The encoding is appended to b.
 func (n NetworkFeatureSupport) AppendBinary(b []byte) ([]byte, error) {
+	if !n.HasOctet4 && (n.EMCN3 || n.MCSI || n.Octet4Spare != 0 || len(n.Rest) > 0) {
+		return b, fmt.Errorf("nas/fgs: network feature support: octet 4 content requires octet 4")
+	}
+
 	if n2 := 2 + len(n.Rest); n.HasOctet4 && n2 > maxNetworkFeatureSupportLen {
 		return b, fmt.Errorf(
 			"nas/fgs: network feature support is %d octets, want at most %d", n2, maxNetworkFeatureSupportLen)


### PR DESCRIPTION
# Description

Address a couple of edge-case 3gpp conformance gaps.
1. SECURITY MODE COMPLETE must replay a cleartext-only REGISTRATION REQUEST (TS 24.501 §4.4.6 case a)
2. Allowed-NSSAI check on PDU session establishment (TS 24.501 §5.4.5.2.5 case 13)
3. Discard unciphered NAS after ciphering starts (TS 24.301 §4.4.5)
4. Store UE/MS network capability replayed in TAU (TS 24.301 §5.5.3.2.4)
5. Network feature support bound, ESM container in ATTACH REJECT
6. Add ESM information request procedure (TS 24.301 §6.6.1.2)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
