### PR TITLE
fix: X2 and Xn handover edge-cases and conformance tests

### DIFF
--- a/internal/amf/handover.go
+++ b/internal/amf/handover.go
@@ -78,24 +78,12 @@ func (a *AMF) PrepareHandover(ctx context.Context, ue *UeContext, source *UeConn
 	return target, nh, ncc, true
 }
 
-// SuperviseHandover arms the guard bounding HANDOVER REQUIRED → NOTIFY. Arm it only after
-// the HANDOVER REQUEST is sent, so the guard timer cannot race the outbound request; on
-// expiry it abandons the handover and releases the target.
 func (a *AMF) SuperviseHandover(ue *UeContext, source, target *UeConn) {
 	ue.SuperviseKeyChainProc(procedure.N2Handover,
 		time.Now().Add(a.handoverGuardTimeout),
 		handoverGuardExpiry(a, source, target))
 }
 
-// stageHandover advances the AS key chain and installs the handover FSM at
-// hoPreparing (registry lock). It neither claims the procedure nor arms supervision.
-//
-// TS 33.501 §6.9.2.3.3: "Upon reception of the NGAP HANDOVER REQUIRED message ... the
-// source AMF shall increment its locally kept NCC value by one and compute a fresh NH."
-// The increment is unconditional and committed here, not on completion: the pair is
-// sent to the target in the HANDOVER REQUEST, so rolling it back would let a later
-// handover hand the same {NH, NCC} to a second gNB — §6.9.2.1.1 NOTE 3 requires the AMF
-// to "always compute a fresh {NH, NCC} pair".
 func (a *AMF) stageHandover(ue *UeContext, source, target *UeConn) (nh [32]uint8, ncc uint8, ok bool) {
 	ue.mu.Lock()
 

--- a/internal/amf/handover.go
+++ b/internal/amf/handover.go
@@ -124,6 +124,10 @@ func handoverGuardExpiry(a *AMF, sourceUe, targetUe *UeConn) func(context.Contex
 		amfUe := sourceUe.UeContext()
 
 		if !a.abandonHandover(amfUe) {
+			if amfUe != nil && !amfUe.BeginKeyChainProc(procedure.N2Handover) {
+				logger.WithTrace(cctx, sourceUe.Log).Error("could not re-claim the key chain for a committing handover")
+			}
+
 			return nil
 		}
 

--- a/internal/amf/handover.go
+++ b/internal/amf/handover.go
@@ -121,11 +121,14 @@ func (a *AMF) stageHandover(ue *UeContext, source, target *UeConn) (nh [32]uint8
 // aborted on the radio by its own TNGRELOCprep/Overall timers (TS 38.413).
 func handoverGuardExpiry(a *AMF, sourceUe, targetUe *UeConn) func(context.Context) error {
 	return func(cctx context.Context) error {
-		logger.WithTrace(cctx, sourceUe.Log).Warn("N2 handover abandoned: target gNB did not complete it in time, releasing target")
-
 		amfUe := sourceUe.UeContext()
 
-		a.ClearHandover(amfUe)
+		if !a.abandonHandover(amfUe) {
+			return nil
+		}
+
+		logger.WithTrace(cctx, sourceUe.Log).Warn("N2 handover abandoned: target gNB did not complete it in time, releasing target")
+
 		a.UnbindHandoverTarget(cctx, amfUe)
 
 		targetUe.ReleaseAction = UeContextReleaseHandover
@@ -135,6 +138,29 @@ func handoverGuardExpiry(a *AMF, sourceUe, targetUe *UeConn) func(context.Contex
 
 		return nil
 	}
+}
+
+func (a *AMF) abandonHandover(ue *UeContext) bool {
+	if ue == nil {
+		return false
+	}
+
+	a.mu.Lock()
+
+	ho := ue.handover
+	if ho == nil || ho.state == hoCommitting {
+		a.mu.Unlock()
+		return false
+	}
+
+	detachAbandonedTargetLocked(ue, ho)
+	ue.handover = nil
+
+	a.mu.Unlock()
+
+	ue.EndKeyChainProc(procedure.N2Handover)
+
+	return true
 }
 
 // SetHandoverForTest installs a preparing handover FSM for a source→target pair without
@@ -181,15 +207,6 @@ func (a *AMF) MarkHandoverCommitting(ue *UeContext, targetUe *UeConn) (admitted 
 
 	ho.state = hoCommitting
 
-	// Commit the staged AS key chain now that the UE has reached the target
-	// (TS 33.501 §6.9.2.1.1), under the per-UE lock. An abandoned handover clears the
-	// FSM without reaching here, so the live {NH, NCC} is never advanced for a
-	// handover that did not complete.
-	ue.mu.Lock()
-	ue.nh = ho.newNH
-	ue.ncc = ho.newNCC
-	ue.mu.Unlock()
-
 	return ho.admitted, true
 }
 
@@ -217,6 +234,11 @@ func (a *AMF) FinishHandoverCommit(ue *UeContext, targetUe *UeConn) bool {
 		a.mu.Unlock()
 		return false
 	}
+
+	ue.mu.Lock()
+	ue.nh = ue.handover.newNH
+	ue.ncc = ue.handover.newNCC
+	ue.mu.Unlock()
 
 	ue.handover = nil
 	// The source connection is managed by the handover flow, not released here.

--- a/internal/amf/handover.go
+++ b/internal/amf/handover.go
@@ -40,11 +40,6 @@ type handoverContext struct {
 	// ACKNOWLEDGE); the rest are released at HANDOVER NOTIFY, since a session the
 	// target did not accept cannot continue there (TS 23.501 §5.30.3.5).
 	admitted map[uint8]struct{}
-	// {NH, NCC} advanced for the target, staged at preparation and committed to the
-	// UE only at HANDOVER NOTIFY (TS 33.501 §6.9.2.1.1); discarded if the handover is
-	// abandoned, so a failed handover never advances the live AS key chain.
-	newNH  [32]uint8
-	newNCC uint8
 }
 
 // PrepareHandover begins N2 handover preparation for the source→target pair: it claims
@@ -92,12 +87,22 @@ func (a *AMF) SuperviseHandover(ue *UeContext, source, target *UeConn) {
 		handoverGuardExpiry(a, source, target))
 }
 
-// stageHandover derives the next {NH, NCC} of the AS key chain (per-UE lock, key material)
-// and installs the handover FSM at hoPreparing (registry lock). It neither claims the
-// procedure nor arms supervision.
+// stageHandover advances the AS key chain and installs the handover FSM at
+// hoPreparing (registry lock). It neither claims the procedure nor arms supervision.
+//
+// TS 33.501 §6.9.2.3.3: "Upon reception of the NGAP HANDOVER REQUIRED message ... the
+// source AMF shall increment its locally kept NCC value by one and compute a fresh NH."
+// The increment is unconditional and committed here, not on completion: the pair is
+// sent to the target in the HANDOVER REQUEST, so rolling it back would let a later
+// handover hand the same {NH, NCC} to a second gNB — §6.9.2.1.1 NOTE 3 requires the AMF
+// to "always compute a fresh {NH, NCC} pair".
 func (a *AMF) stageHandover(ue *UeContext, source, target *UeConn) (nh [32]uint8, ncc uint8, ok bool) {
 	ue.mu.Lock()
+
 	nh, ncc, err := ue.deriveNextNHLocked()
+	if err == nil {
+		ue.nh, ue.ncc = nh, ncc
+	}
 	ue.mu.Unlock()
 
 	if err != nil {
@@ -110,7 +115,7 @@ func (a *AMF) stageHandover(ue *UeContext, source, target *UeConn) (nh [32]uint8
 		target.ue.Store(ue)
 	}
 
-	ue.handover = &handoverContext{state: hoPreparing, source: source, target: target, newNH: nh, newNCC: ncc}
+	ue.handover = &handoverContext{state: hoPreparing, source: source, target: target}
 	a.mu.Unlock()
 
 	return nh, ncc, true
@@ -238,11 +243,6 @@ func (a *AMF) FinishHandoverCommit(ue *UeContext, targetUe *UeConn) bool {
 		a.mu.Unlock()
 		return false
 	}
-
-	ue.mu.Lock()
-	ue.nh = ue.handover.newNH
-	ue.ncc = ue.handover.newNCC
-	ue.mu.Unlock()
 
 	ue.handover = nil
 	// The source connection is managed by the handover flow, not released here.

--- a/internal/amf/handover_finish_test.go
+++ b/internal/amf/handover_finish_test.go
@@ -147,9 +147,52 @@ func TestCancelHandover(t *testing.T) {
 	})
 }
 
-// TestFinishHandoverCommit verifies the gated finalize: the UE moves onto the
-// target only from the committing stage and only while the target is still
-// present after the (unlocked) user-plane switch (TS 23.502).
+func TestHandoverGuardDoesNotAbandonCommitting(t *testing.T) {
+	t.Run("abandons a prepared handover", func(t *testing.T) {
+		a, ue, _, _ := newPreparingHandover(t)
+
+		if !a.MarkHandoverPrepared(ue, nil) {
+			t.Fatal("MarkHandoverPrepared")
+		}
+
+		if !a.FireHandoverGuardForTest(ue) {
+			t.Fatal("the guard must abandon a handover that has not reached the committing stage")
+		}
+
+		if a.HandoverInProgress(ue) {
+			t.Error("the FSM must be cleared after the guard fires")
+		}
+	})
+
+	t.Run("leaves a committing handover to finish", func(t *testing.T) {
+		a, ue, _, target := newPreparingHandover(t)
+
+		if !a.MarkHandoverPrepared(ue, nil) {
+			t.Fatal("MarkHandoverPrepared")
+		}
+
+		if _, ok := a.MarkHandoverCommitting(ue, target); !ok {
+			t.Fatal("MarkHandoverCommitting")
+		}
+
+		if a.FireHandoverGuardForTest(ue) {
+			t.Fatal("the guard must not abandon a committing handover")
+		}
+
+		if !a.HandoverInProgress(ue) {
+			t.Fatal("the guard cleared a committing handover")
+		}
+
+		if !a.FinishHandoverCommit(ue, target) {
+			t.Fatal("a committing handover must still finalize after the guard fires")
+		}
+
+		if ue.Conn() != target {
+			t.Error("the UE must be on the target after finalize")
+		}
+	})
+}
+
 func TestFinishHandoverCommit(t *testing.T) {
 	commit := func(t *testing.T, a *amf.AMF, ue *amf.UeContext, target *amf.UeConn) {
 		t.Helper()
@@ -177,6 +220,50 @@ func TestFinishHandoverCommit(t *testing.T) {
 
 		if a.HandoverInProgress(ue) {
 			t.Error("the FSM must be cleared after finalize")
+		}
+	})
+
+	t.Run("commits the staged NH chain only at finalize", func(t *testing.T) {
+		a, ue, _, target := newPreparingHandover(t)
+
+		nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
+
+		commit(t, a, ue, target)
+
+		if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
+			t.Fatal("the chain must not advance at the committing stage")
+		}
+
+		if !a.FinishHandoverCommit(ue, target) {
+			t.Fatal("FinishHandoverCommit")
+		}
+
+		if ue.NHForTest() == nh0 {
+			t.Error("finalize must advance the live NH")
+		}
+
+		if ue.NCCForTest() != (ncc0+1)%8 {
+			t.Errorf("live NCC = %d, want %d", ue.NCCForTest(), (ncc0+1)%8)
+		}
+	})
+
+	t.Run("a handover that fails to finalize does not advance the chain", func(t *testing.T) {
+		a, ue, _, target := newPreparingHandover(t)
+
+		nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
+
+		commit(t, a, ue, target)
+
+		if err := a.RemoveUeConn(context.Background(), target); err != nil {
+			t.Fatalf("RemoveUeConn: %v", err)
+		}
+
+		if a.FinishHandoverCommit(ue, target) {
+			t.Fatal("FinishHandoverCommit must fail for a released target")
+		}
+
+		if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
+			t.Error("a handover that did not finalize must not advance the live NH chain")
 		}
 	})
 

--- a/internal/amf/handover_finish_test.go
+++ b/internal/amf/handover_finish_test.go
@@ -223,34 +223,29 @@ func TestFinishHandoverCommit(t *testing.T) {
 		}
 	})
 
-	t.Run("commits the staged NH chain only at finalize", func(t *testing.T) {
+	// TS 33.501 §6.9.2.3.3: the chain is advanced at preparation, so finalize must not
+	// touch it, and a handover that fails to finalize leaves it advanced. Rolling back
+	// would re-issue a pair already given to a gNB — see TestHandover_NHAdvancedAtPreparation.
+	t.Run("finalize does not touch the key chain", func(t *testing.T) {
 		a, ue, _, target := newPreparingHandover(t)
 
-		nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
+		nh, ncc := ue.NHForTest(), ue.NCCForTest()
 
 		commit(t, a, ue, target)
-
-		if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
-			t.Fatal("the chain must not advance at the committing stage")
-		}
 
 		if !a.FinishHandoverCommit(ue, target) {
 			t.Fatal("FinishHandoverCommit")
 		}
 
-		if ue.NHForTest() == nh0 {
-			t.Error("finalize must advance the live NH")
-		}
-
-		if ue.NCCForTest() != (ncc0+1)%8 {
-			t.Errorf("live NCC = %d, want %d", ue.NCCForTest(), (ncc0+1)%8)
+		if ue.NHForTest() != nh || ue.NCCForTest() != ncc {
+			t.Error("finalize must leave the chain as preparation set it")
 		}
 	})
 
-	t.Run("a handover that fails to finalize does not advance the chain", func(t *testing.T) {
+	t.Run("a handover that fails to finalize leaves the chain advanced", func(t *testing.T) {
 		a, ue, _, target := newPreparingHandover(t)
 
-		nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
+		nh, ncc := ue.NHForTest(), ue.NCCForTest()
 
 		commit(t, a, ue, target)
 
@@ -262,8 +257,8 @@ func TestFinishHandoverCommit(t *testing.T) {
 			t.Fatal("FinishHandoverCommit must fail for a released target")
 		}
 
-		if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
-			t.Error("a handover that did not finalize must not advance the live NH chain")
+		if ue.NHForTest() != nh || ue.NCCForTest() != ncc {
+			t.Error("a failed finalize must not roll the chain back")
 		}
 	})
 

--- a/internal/amf/handover_test.go
+++ b/internal/amf/handover_test.go
@@ -76,7 +76,16 @@ func TestHandover_TargetRemovalAbortsHandover(t *testing.T) {
 	}
 }
 
-func TestHandover_NHCommittedOnlyOnCompletion(t *testing.T) {
+// TestHandover_NHAdvancedAtPreparation verifies the AS key chain advances when the
+// handover is prepared, and stays advanced however the handover ends.
+//
+// TS 33.501 §6.9.2.3.3: "Upon reception of the NGAP HANDOVER REQUIRED message ... the
+// source AMF shall increment its locally kept NCC value by one and compute a fresh NH."
+// The increment is unconditional. The pair is handed to the target gNB in the HANDOVER
+// REQUEST, so rolling it back on abandonment would let the next handover issue the same
+// {NH, NCC} to a different gNB — two gNBs each able to derive the other's KgNB, which
+// §6.9.2.1.1 NOTE 3 ("the AMF always computes a fresh {NH, NCC} pair") rules out.
+func TestHandover_NHAdvancedAtPreparation(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 
 	makeUE := func() *amf.UeContext {
@@ -88,7 +97,7 @@ func TestHandover_NHCommittedOnlyOnCompletion(t *testing.T) {
 		return ue
 	}
 
-	t.Run("abandoned handover does not advance the live NH chain", func(t *testing.T) {
+	t.Run("preparation advances the live chain", func(t *testing.T) {
 		ue := makeUE()
 		nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
 
@@ -98,38 +107,55 @@ func TestHandover_NHCommittedOnlyOnCompletion(t *testing.T) {
 		}
 
 		if staged == nh0 {
-			t.Fatal("staged NH should differ from the current NH")
+			t.Fatal("the derived NH should differ from the previous one")
 		}
 
 		if stagedNCC != (ncc0+1)%8 {
-			t.Fatalf("staged NCC = %d, want %d", stagedNCC, (ncc0+1)%8)
+			t.Fatalf("derived NCC = %d, want %d", stagedNCC, (ncc0+1)%8)
+		}
+
+		if ue.NHForTest() != staged || ue.NCCForTest() != stagedNCC {
+			t.Fatal("the pair sent to the target must be the UE's live chain")
+		}
+	})
+
+	t.Run("an abandoned handover leaves the chain advanced", func(t *testing.T) {
+		ue := makeUE()
+
+		staged, stagedNCC, ok := amfInstance.StageHandoverForTest(ue)
+		if !ok {
+			t.Fatal("StageHandoverForTest failed")
 		}
 
 		amfInstance.ClearHandover(ue)
 
-		if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
-			t.Fatal("abandoned handover must not advance the live NH chain")
+		// Rolling back here would re-issue this pair to the next target gNB.
+		if ue.NHForTest() != staged || ue.NCCForTest() != stagedNCC {
+			t.Fatal("an abandoned handover must not roll the chain back")
 		}
 	})
 
-	t.Run("reaching the committing stage does not advance the live NH chain", func(t *testing.T) {
+	t.Run("a second handover derives a different pair", func(t *testing.T) {
 		ue := makeUE()
-		nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
 
-		if _, _, ok := amfInstance.StageHandoverForTest(ue); !ok {
+		first, firstNCC, ok := amfInstance.StageHandoverForTest(ue)
+		if !ok {
 			t.Fatal("StageHandoverForTest failed")
 		}
 
-		if !amfInstance.MarkHandoverPrepared(ue, nil) {
-			t.Fatal("MarkHandoverPrepared returned false")
+		amfInstance.ClearHandover(ue)
+
+		second, secondNCC, ok := amfInstance.StageHandoverForTest(ue)
+		if !ok {
+			t.Fatal("StageHandoverForTest failed")
 		}
 
-		if _, ok := amfInstance.MarkHandoverCommitting(ue, nil); !ok {
-			t.Fatal("MarkHandoverCommitting returned false")
+		if second == first {
+			t.Error("a second handover reissued the NH already given to the first target")
 		}
 
-		if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
-			t.Fatal("the live NH chain must not advance before the handover is finalized")
+		if secondNCC != (firstNCC+1)%8 {
+			t.Errorf("second NCC = %d, want %d", secondNCC, (firstNCC+1)%8)
 		}
 	})
 }

--- a/internal/amf/handover_test.go
+++ b/internal/amf/handover_test.go
@@ -12,9 +12,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestHandoverFSM_Lifecycle asserts the handover FSM — the single source of truth
-// for the source/target UeConn pair — is installed by SetHandoverForTest and
-// torn down by ClearHandover.
 func TestHandoverFSM_Lifecycle(t *testing.T) {
 	amfUe := amf.NewUeContext()
 
@@ -52,9 +49,6 @@ func TestHandoverFSM_Lifecycle(t *testing.T) {
 	}
 }
 
-// TestHandover_TargetRemovalAbortsHandover verifies that removing the prepared
-// target UeConn (its gNB association reset or lost) clears the in-flight handover at
-// once, rather than leaving it dangling until the supervision guard fires.
 func TestHandover_TargetRemovalAbortsHandover(t *testing.T) {
 	amfUe := amf.NewUeContext()
 
@@ -82,9 +76,6 @@ func TestHandover_TargetRemovalAbortsHandover(t *testing.T) {
 	}
 }
 
-// TestHandover_NHCommittedOnlyOnCompletion verifies the staged AS key chain is
-// committed to the UE only when the handover completes (HANDOVER NOTIFY), and an
-// abandoned handover leaves the live {NH, NCC} untouched (TS 33.501 §6.9.2.1.1).
 func TestHandover_NHCommittedOnlyOnCompletion(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 
@@ -121,11 +112,11 @@ func TestHandover_NHCommittedOnlyOnCompletion(t *testing.T) {
 		}
 	})
 
-	t.Run("completed handover commits the staged NH chain", func(t *testing.T) {
+	t.Run("reaching the committing stage does not advance the live NH chain", func(t *testing.T) {
 		ue := makeUE()
+		nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
 
-		staged, stagedNCC, ok := amfInstance.StageHandoverForTest(ue)
-		if !ok {
+		if _, _, ok := amfInstance.StageHandoverForTest(ue); !ok {
 			t.Fatal("StageHandoverForTest failed")
 		}
 
@@ -137,8 +128,8 @@ func TestHandover_NHCommittedOnlyOnCompletion(t *testing.T) {
 			t.Fatal("MarkHandoverCommitting returned false")
 		}
 
-		if ue.NHForTest() != staged || ue.NCCForTest() != stagedNCC {
-			t.Fatal("completed handover must commit the staged NH chain")
+		if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
+			t.Fatal("the live NH chain must not advance before the handover is finalized")
 		}
 	})
 }

--- a/internal/amf/ngap/fixtures_test.go
+++ b/internal/amf/ngap/fixtures_test.go
@@ -62,6 +62,15 @@ type fakeSmfSbi struct {
 	N2HandoverCanceledCalls  []string
 	N2HandoverCompleteErr    error
 	ReleaseSmContextCalls    []string
+
+	// The N2 preparation calls record their refs and can be made to fail, so the
+	// per-session error branches of the handover handlers are reachable from a test.
+	N2HandoverPreparingCalls []string
+	N2HandoverPreparingErr   error
+	N2HandoverPreparedCalls  []string
+	N2HandoverPreparedErr    error
+	N2HandoverCanceledErr    error
+	ReleaseSmContextErr      error
 }
 
 func (f *fakeSmfSbi) ActivateSmContext(_ context.Context, smContextRef string) ([]byte, error) {
@@ -136,12 +145,16 @@ func (f *fakeSmfSbi) UpdateSmContextN2InfoPduResRelRsp(_ context.Context, smCont
 	return nil
 }
 
-func (f *fakeSmfSbi) UpdateSmContextN2HandoverPreparing(_ context.Context, _ string, _ []byte) ([]byte, error) {
-	return nil, nil
+func (f *fakeSmfSbi) UpdateSmContextN2HandoverPreparing(_ context.Context, smContextRef string, _ []byte) ([]byte, error) {
+	f.N2HandoverPreparingCalls = append(f.N2HandoverPreparingCalls, smContextRef)
+
+	return nil, f.N2HandoverPreparingErr
 }
 
-func (f *fakeSmfSbi) UpdateSmContextN2HandoverPrepared(_ context.Context, _ string, _ []byte) ([]byte, error) {
-	return nil, nil
+func (f *fakeSmfSbi) UpdateSmContextN2HandoverPrepared(_ context.Context, smContextRef string, _ []byte) ([]byte, error) {
+	f.N2HandoverPreparedCalls = append(f.N2HandoverPreparedCalls, smContextRef)
+
+	return nil, f.N2HandoverPreparedErr
 }
 
 func (f *fakeSmfSbi) UpdateSmContextN2HandoverComplete(_ context.Context, smContextRef string) error {

--- a/internal/amf/ngap/fixtures_test.go
+++ b/internal/amf/ngap/fixtures_test.go
@@ -62,9 +62,6 @@ type fakeSmfSbi struct {
 	N2HandoverCanceledCalls  []string
 	N2HandoverCompleteErr    error
 	ReleaseSmContextCalls    []string
-
-	// The N2 preparation calls record their refs and can be made to fail, so the
-	// per-session error branches of the handover handlers are reachable from a test.
 	N2HandoverPreparingCalls []string
 	N2HandoverPreparingErr   error
 	N2HandoverPreparedCalls  []string

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/ngap"
-	"go.uber.org/zap"
 )
 
 func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio, msg *ngap.HandoverNotify) {
@@ -46,30 +45,28 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	}
 
 	// Complete the sessions the target admitted (the SMF sends N4 Session Modification
-	// to the UPF with the new AN tunnel info, TS 23.502), and release those it did not:
-	// a session the target rejected cannot continue there, so its core context is freed
+	// to the UPF with the new AN tunnel info, TS 23.502) and release the rest. A
+	// completed handover is authoritative about what the target holds: a session it did
+	// not admit cannot continue there, so its core context is freed
 	// (TS 23.501 §5.30.3.5 / TS 23.401 §5.5.1.2.2).
+	var present []amf.RANSession
+
 	for _, sr := range amfUe.SmContextRefs() {
 		if sr.Ref == "" {
 			continue
 		}
 
 		if _, ok := admitted[sr.PduSessionID]; ok {
-			if err := amfInstance.Session.UpdateSmContextN2HandoverComplete(ctx, sr.Ref); err != nil {
-				logger.WithTrace(ctx, targetUe.Log).Error("failed to update SM context for handover completion",
-					zap.String("smContextRef", sr.Ref), zap.Error(err))
-			}
-
-			continue
+			present = append(present, amf.RANSession{PduSessionID: sr.PduSessionID})
 		}
-
-		if err := amfInstance.Session.ReleaseSmContext(ctx, sr.Ref); err != nil {
-			logger.WithTrace(ctx, targetUe.Log).Error("failed to release a target-rejected PDU session after handover",
-				zap.String("smContextRef", sr.Ref), zap.Uint8("PduSessionID", sr.PduSessionID), zap.Error(err))
-		}
-
-		amfUe.DeleteSmContext(sr.PduSessionID)
 	}
+
+	amfInstance.ReconcileSessionsToRAN(ctx, amfUe, amf.RANSessions{
+		Present:       present,
+		Authoritative: true,
+	}, func(ctx context.Context, ref string, _ []byte) ([]byte, error) {
+		return nil, amfInstance.Session.UpdateSmContextN2HandoverComplete(ctx, ref)
+	})
 
 	// Move the UE onto the target and clear the FSM, gated on the UE still being
 	// present after the unlocked user-plane switch; only then end the procedure and

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -19,10 +19,6 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	targetUe.TouchLastSeen()
 
-	if msg.UserLocationInformation != nil {
-		targetUe.UpdateLocation(ctx, *msg.UserLocationInformation)
-	}
-
 	amfUe := targetUe.UeContext()
 	if amfUe == nil {
 		logger.WithTrace(ctx, targetUe.Log).Error("UeContext is nil")
@@ -63,12 +59,16 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return nil, amfInstance.Session.UpdateSmContextN2HandoverComplete(ctx, ref)
 	})
 
-	// Move the UE onto the target and clear the FSM, gated on the UE still being
-	// present after the unlocked user-plane switch; only then end the procedure and
-	// release the source (TS 23.502).
 	if !amfInstance.FinishHandoverCommit(amfUe, targetUe) {
 		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Notify: UE released during the user-plane switch")
+
+		amfInstance.ClearHandover(amfUe)
+
 		return
+	}
+
+	if msg.UserLocationInformation != nil {
+		targetUe.UpdateLocation(ctx, *msg.UserLocationInformation)
 	}
 
 	logger.WithTrace(ctx, targetUe.Log).Info("Handle Handover notification Finished")

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -44,11 +44,6 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	// Complete the sessions the target admitted (the SMF sends N4 Session Modification
-	// to the UPF with the new AN tunnel info, TS 23.502) and release the rest. A
-	// completed handover is authoritative about what the target holds: a session it did
-	// not admit cannot continue there, so its core context is freed
-	// (TS 23.501 §5.30.3.5 / TS 23.401 §5.5.1.2.2).
 	var present []amf.RANSession
 
 	for _, sr := range amfUe.SmContextRefs() {

--- a/internal/amf/ngap/handle_handover_notify_test.go
+++ b/internal/amf/ngap/handle_handover_notify_test.go
@@ -163,7 +163,7 @@ func TestHandoverNotify_HappyPath(t *testing.T) {
 // the sessions the target admitted are completed while a session the target did not
 // admit is released, not left leaking in the core (TS 23.501 §5.30.3.5 / TS 23.401
 // §5.5.1.2.2), mirroring the MME.
-func TestHandoverNotify_ReleasesRejectedSessions(t *testing.T) {
+func TestHandoverNotify_DeactivatesRejectedSessions(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	fakeSmf := &fakeSmfSbi{}
 	amfInstance.Session = fakeSmf
@@ -195,12 +195,21 @@ func TestHandoverNotify_ReleasesRejectedSessions(t *testing.T) {
 		t.Fatalf("expected only the admitted session ref-1 completed, got %v", fakeSmf.N2HandoverCompleteCalls)
 	}
 
-	if len(fakeSmf.ReleaseSmContextCalls) != 1 || fakeSmf.ReleaseSmContextCalls[0] != "ref-2" {
-		t.Fatalf("expected the rejected session ref-2 released, got %v", fakeSmf.ReleaseSmContextCalls)
+	if len(fakeSmf.DeactivateSmContextCalls) != 1 || fakeSmf.DeactivateSmContextCalls[0] != "ref-2" {
+		t.Fatalf("expected the rejected session ref-2 deactivated, got %v", fakeSmf.DeactivateSmContextCalls)
 	}
 
-	if _, ok := amfUe.SmContextFindByPDUSessionID(2); ok {
-		t.Fatal("the rejected session's SM context must be dropped from the UE")
+	if len(fakeSmf.ReleaseSmContextCalls) != 0 {
+		t.Fatalf("a session the target did not accept must not be released: %v", fakeSmf.ReleaseSmContextCalls)
+	}
+
+	sc, ok := amfUe.SmContextFindByPDUSessionID(2)
+	if !ok {
+		t.Fatal("the rejected session must survive as an inactive session")
+	}
+
+	if !sc.PduSessionInactive {
+		t.Error("the rejected session must be marked user-plane inactive")
 	}
 
 	if _, ok := amfUe.SmContextFindByPDUSessionID(1); !ok {

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -63,10 +63,6 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	// The acknowledge must come from the radio the handover was prepared for, not
-	// merely from an association bound to this UE. UpdateSmContextN2HandoverPrepared
-	// below rebinds the downlink tunnel, so a spurious acknowledge would redirect the
-	// user plane and draw a HANDOVER COMMAND (TS 38.413 §8.4.2).
 	if amfInstance.HandoverTarget(amfUe) != targetUe {
 		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Request Acknowledge from a radio that is not the prepared target; dropping")
 		return
@@ -80,8 +76,6 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	// Only now that the acknowledge is known to come from the prepared target is the
-	// RAN-UE-NGAP-ID it assigned recorded: a rejected message must leave no state.
 	if msg.RANUENGAPID != nil {
 		amfInstance.UpdateUERanNgapID(targetUe, models.RanUeNgapID(*msg.RANUENGAPID))
 	}

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -48,10 +48,6 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	if msg.RANUENGAPID != nil {
-		amfInstance.UpdateUERanNgapID(targetUe, models.RanUeNgapID(*msg.RANUENGAPID))
-	}
-
 	targetUe.TouchLastSeen()
 	logger.WithTrace(ctx, targetUe.Log).Debug("Handle Handover Request Acknowledge", zap.Uint32("ran-ue-id", uint32(targetUe.RanUeNgapID)), zap.Uint64("amf-ue-id", uint64(targetUe.AmfUeNgapID)))
 
@@ -67,12 +63,27 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
+	// The acknowledge must come from the radio the handover was prepared for, not
+	// merely from an association bound to this UE. UpdateSmContextN2HandoverPrepared
+	// below rebinds the downlink tunnel, so a spurious acknowledge would redirect the
+	// user plane and draw a HANDOVER COMMAND (TS 38.413 §8.4.2).
+	if amfInstance.HandoverTarget(amfUe) != targetUe {
+		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Request Acknowledge from a radio that is not the prepared target; dropping")
+		return
+	}
+
 	// A duplicate or out-of-order HANDOVER REQUEST ACKNOWLEDGE: the staleness check
 	// precedes any per-session SMF side effect, since UpdateSmContextN2HandoverPrepared
 	// rebinds the downlink tunnel (TS 38.413 §10.4).
 	if !amfInstance.HandoverPreparing(amfUe) {
 		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Request Acknowledge for a handover past the preparing stage; dropping")
 		return
+	}
+
+	// Only now that the acknowledge is known to come from the prepared target is the
+	// RAN-UE-NGAP-ID it assigned recorded: a rejected message must leave no state.
+	if msg.RANUENGAPID != nil {
+		amfInstance.UpdateUERanNgapID(targetUe, models.RanUeNgapID(*msg.RANUENGAPID))
 	}
 
 	var (

--- a/internal/amf/ngap/handle_handover_request_acknowledge_test.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/ellanetworks/core/ngap"
 )
 
-// setupHandoverAckTestContext creates the AMF, source/target UEs, radios, and
-// SMF context needed for handover request acknowledge tests.
 func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *fakeNGAPSender, *amf.AMF) {
 	t.Helper()
 
@@ -27,8 +25,6 @@ func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *fakeNGAPSender, *am
 	return targetRan, sourceNGAPSender, amfInstance
 }
 
-// setupHandoverAckTestContextWithSource is setupHandoverAckTestContext, also handing
-// back the source radio for tests that must deliver a message on it.
 func setupHandoverAckTestContextWithSource(t *testing.T) (*amf.Radio, *amf.Radio, *fakeNGAPSender, *amf.AMF) {
 	t.Helper()
 
@@ -91,11 +87,6 @@ func setupHandoverAckTestContextWithSource(t *testing.T) (*amf.Radio, *amf.Radio
 	return sourceRan, targetRan, sourceNGAPSender, amfInstance
 }
 
-// TestHandoverRequestAcknowledge_NotFromPreparedTarget checks an acknowledge that
-// arrives on an association other than the prepared target is dropped. Accepting it
-// would rebind the downlink tunnel through UpdateSmContextN2HandoverPrepared and draw
-// a HANDOVER COMMAND for a target the handover was never prepared for
-// (TS 38.413 §8.4.2). The AMF already makes the equivalent check on HANDOVER FAILURE.
 func TestHandoverRequestAcknowledge_NotFromPreparedTarget(t *testing.T) {
 	sourceRan, _, sourceNGAPSender, amfInstance := setupHandoverAckTestContextWithSource(t)
 
@@ -220,10 +211,6 @@ func TestHandoverRequestAcknowledge_NoPDUSessionsAdmitted_SendsPreparationFailur
 	}
 }
 
-// TestHandoverRequestAcknowledge_NoPDUSessionsAdmitted_SourceUeContextDetached
-// verifies that when no PDU sessions are admitted and the source UE's AMF UE
-// context has been detached (e.g. due to a concurrent deregistration), the
-// handler does not panic.
 func TestHandoverRequestAcknowledge_NoPDUSessionsAdmitted_SourceUeContextDetached(t *testing.T) {
 	targetRan, sourceNGAPSender, amfInstance := setupHandoverAckTestContext(t)
 

--- a/internal/amf/ngap/handle_handover_request_acknowledge_test.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge_test.go
@@ -22,6 +22,16 @@ import (
 func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *fakeNGAPSender, *amf.AMF) {
 	t.Helper()
 
+	_, targetRan, sourceNGAPSender, amfInstance := setupHandoverAckTestContextWithSource(t)
+
+	return targetRan, sourceNGAPSender, amfInstance
+}
+
+// setupHandoverAckTestContextWithSource is setupHandoverAckTestContext, also handing
+// back the source radio for tests that must deliver a message on it.
+func setupHandoverAckTestContextWithSource(t *testing.T) (*amf.Radio, *amf.Radio, *fakeNGAPSender, *amf.AMF) {
+	t.Helper()
+
 	const (
 		pduSessionID = uint8(1)
 		supiStr      = "imsi-001010000000001"
@@ -78,7 +88,36 @@ func setupHandoverAckTestContext(t *testing.T) (*amf.Radio, *fakeNGAPSender, *am
 		t.Fatalf("failed to attach source/target: %v", err)
 	}
 
-	return targetRan, sourceNGAPSender, amfInstance
+	return sourceRan, targetRan, sourceNGAPSender, amfInstance
+}
+
+// TestHandoverRequestAcknowledge_NotFromPreparedTarget checks an acknowledge that
+// arrives on an association other than the prepared target is dropped. Accepting it
+// would rebind the downlink tunnel through UpdateSmContextN2HandoverPrepared and draw
+// a HANDOVER COMMAND for a target the handover was never prepared for
+// (TS 38.413 §8.4.2). The AMF already makes the equivalent check on HANDOVER FAILURE.
+func TestHandoverRequestAcknowledge_NotFromPreparedTarget(t *testing.T) {
+	sourceRan, _, sourceNGAPSender, amfInstance := setupHandoverAckTestContextWithSource(t)
+
+	smfSbi, ok := amfInstance.Session.(*fakeSmfSbi)
+	if !ok {
+		t.Fatalf("session is %T, want *fakeSmfSbi", amfInstance.Session)
+	}
+
+	// Address the source association (AMF-UE-NGAP-ID 100), not the prepared target.
+	msg := admittedAckMsg(t)
+	sourceAMFID := ngap.AMFUENGAPID(100)
+	msg.AMFUENGAPID = &sourceAMFID
+
+	HandleHandoverRequestAcknowledge(context.Background(), amfInstance, sourceRan, msg)
+
+	if len(sourceNGAPSender.SentHandoverCommands) != 0 {
+		t.Errorf("acknowledge from a non-target drew %d HandoverCommand(s)", len(sourceNGAPSender.SentHandoverCommands))
+	}
+
+	if len(smfSbi.N2HandoverPreparedCalls) != 0 {
+		t.Errorf("acknowledge from a non-target rebound the downlink: %v", smfSbi.N2HandoverPreparedCalls)
+	}
 }
 
 func TestHandoverRequestAcknowledge_UeNotFound(t *testing.T) {

--- a/internal/amf/ngap/handle_handover_request_acknowledge_test.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge_test.go
@@ -95,7 +95,6 @@ func TestHandoverRequestAcknowledge_NotFromPreparedTarget(t *testing.T) {
 		t.Fatalf("session is %T, want *fakeSmfSbi", amfInstance.Session)
 	}
 
-	// Address the source association (AMF-UE-NGAP-ID 100), not the prepared target.
 	msg := admittedAckMsg(t)
 	sourceAMFID := ngap.AMFUENGAPID(100)
 	msg.AMFUENGAPID = &sourceAMFID

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -85,8 +85,6 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 
 	defer amfUe.EndKeyChainProc(procedure.PathSwitch)
 
-	// Tell the SMF about the sessions the target could not set up before reconciling,
-	// so it sees the gNB's own failure cause rather than only a release.
 	for _, item := range msg.PDUSessionResourceFailedToSetup {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -95,42 +95,8 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 
 	defer amfUe.EndKeyChainProc(procedure.PathSwitch)
 
-	var (
-		switched ngap.PDUSessionResourceSwitchedList
-		released ngap.PDUSessionResourceReleasedListPSAck
-	)
-
-	for _, item := range msg.PDUSessionResourceToBeSwitchedDLList {
-		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
-		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
-			continue
-		}
-
-		transfer := item.Transfer
-
-		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
-		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
-			appendPathSwitchReleasedItem(ctx, ueConn, &released, pduSessionID, ngap.CauseRadioNetworkUnknownPDUSessionID)
-
-			continue
-		}
-
-		n2Rsp, err := amfInstance.Session.UpdateSmContextXnHandoverPathSwitchReq(ctx, smContext.Ref, transfer)
-		if err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextXnHandover[PathSwitchRequestTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
-			appendPathSwitchReleasedItem(ctx, ueConn, &released, pduSessionID, ngap.CauseRadioNetworkUnspecified)
-
-			continue
-		}
-
-		switched = append(switched, ngap.PDUSessionResourceSwitchedItem{
-			PDUSessionID: ngap.PDUSessionID(pduSessionID),
-			Transfer:     ngap.TransferContainer(n2Rsp),
-		})
-	}
-
+	// Tell the SMF about the sessions the target could not set up before reconciling,
+	// so it sees the gNB's own failure cause rather than only a release.
 	for _, item := range msg.PDUSessionResourceFailedToSetup {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
@@ -138,18 +104,42 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 			continue
 		}
 
-		transfer := item.Transfer
-
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
 			logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 			continue
 		}
 
-		err := amfInstance.Session.UpdateSmContextHandoverFailed(ctx, smContext.Ref, transfer)
-		if err != nil {
+		if err := amfInstance.Session.UpdateSmContextHandoverFailed(ctx, smContext.Ref, item.Transfer); err != nil {
 			logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextXnHandoverFailed[PathSwitchRequestSetupFailedTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 		}
+	}
+
+	// A PATH SWITCH REQUEST is authoritative: it names every PDU session the target
+	// gNB holds, so anything else in the UE context has been implicitly released
+	// (TS 38.413 §8.4.4.2). Same rule, same shape as the EPS path switch.
+	present, undecodable := pathSwitchSessions(ctx, ueConn, msg.PDUSessionResourceToBeSwitchedDLList)
+
+	result := amfInstance.ReconcileSessionsToRAN(ctx, amfUe, amf.RANSessions{
+		Present:       present,
+		Rejected:      pathSwitchFailedSessions(msg.PDUSessionResourceFailedToSetup),
+		Authoritative: true,
+	}, amfInstance.Session.UpdateSmContextXnHandoverPathSwitchReq)
+
+	var (
+		switched ngap.PDUSessionResourceSwitchedList
+		released ngap.PDUSessionResourceReleasedListPSAck
+	)
+
+	for _, a := range result.Applied {
+		switched = append(switched, ngap.PDUSessionResourceSwitchedItem{
+			PDUSessionID: ngap.PDUSessionID(a.PduSessionID),
+			Transfer:     ngap.TransferContainer(a.Transfer),
+		})
+	}
+
+	for _, id := range append(result.Failed, undecodable...) {
+		appendPathSwitchReleasedItem(ctx, ueConn, &released, id, ngap.CauseRadioNetworkUnspecified)
 	}
 
 	// TS 23.502: acknowledge to the target NG-RAN; if no session switched, fail the path switch.

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -76,16 +76,6 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 
 	verifyUESecurityCapabilitiesOnPathSwitch(ctx, ueConn, amfUe, msg.UESecurityCapabilities)
 
-	ueConn.RanUeNgapID = models.RanUeNgapID(msg.RANUENGAPID)
-
-	if msg.UserLocationInformation != nil {
-		ueConn.UpdateLocation(ctx, *msg.UserLocationInformation)
-	}
-
-	// Claim the {NH,NCC} key chain for the whole path switch: a concurrent N2 handover or
-	// NAS SMC (possibly on another gNB's dispatch goroutine) must not advance the same
-	// chain in parallel (TS 33.501 §6.9.5). Claimed before the SMF is touched so a rejected
-	// path switch changes nothing. Path switch is synchronous, so hold until return.
 	if !amfUe.BeginKeyChainProc(procedure.PathSwitch) {
 		logger.WithTrace(ctx, ueConn.Log).Warn("Path Switch rejected: a key-changing procedure is in progress")
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
@@ -115,15 +105,28 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 		}
 	}
 
-	// A PATH SWITCH REQUEST is authoritative: it names every PDU session the target
-	// gNB holds, so anything else in the UE context has been implicitly released
-	// (TS 38.413 §8.4.4.2). Same rule, same shape as the EPS path switch.
+	nh, ncc, err := amfUe.AdvancePathSwitchNH()
+	if err != nil {
+		logger.WithTrace(ctx, ueConn.Log).Error("error advancing NH", zap.Error(err))
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
+
+		return
+	}
+
+	snssaiList, err := amfInstance.ListOperatorSnssai(ctx)
+	if err != nil {
+		logger.WithTrace(ctx, ueConn.Log).Error("List Operator SNSSAI Error", zap.Error(err))
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
+
+		return
+	}
+
 	present, undecodable := pathSwitchSessions(ctx, ueConn, msg.PDUSessionResourceToBeSwitchedDLList)
 
 	result := amfInstance.ReconcileSessionsToRAN(ctx, amfUe, amf.RANSessions{
-		Present:       present,
-		Rejected:      pathSwitchFailedSessions(msg.PDUSessionResourceFailedToSetup),
-		Authoritative: true,
+		Present:             present,
+		Rejected:            pathSwitchFailedSessions(msg.PDUSessionResourceFailedToSetup),
+		ReleaseOnApplyError: true,
 	}, amfInstance.Session.UpdateSmContextXnHandoverPathSwitchReq)
 
 	var (
@@ -138,42 +141,39 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 		})
 	}
 
-	for _, id := range append(result.Failed, undecodable...) {
-		appendPathSwitchReleasedItem(ctx, ueConn, &released, id, ngap.CauseRadioNetworkUnspecified)
+	for _, id := range result.Failed {
+		appendPathSwitchReleasedItem(ctx, ueConn, &released, id, pathSwitchFailureCause(amfUe, id))
 	}
 
-	// TS 23.502: acknowledge to the target NG-RAN; if no session switched, fail the path switch.
-	if len(switched) > 0 {
-		// TS 33.501: derive fresh {NH, NCC} but commit them only once the switch is
-		// confirmed, so an abandoned path switch never advances the live AS key chain.
-		nh, ncc, err := amfUe.AdvancePathSwitchNH()
-		if err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("error advancing NH", zap.Error(err))
-			return
-		}
+	for _, id := range undecodable {
+		appendPathSwitchReleasedItem(ctx, ueConn, &released, id, ngap.CauseRadioNetworkUnknownPDUSessionID)
+	}
 
-		snssaiList, err := amfInstance.ListOperatorSnssai(ctx)
-		if err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("List Operator SNSSAI Error", zap.Error(err))
-			return
-		}
-
-		// Re-point the UE at the target radio and commit the chain atomically: a UE
-		// released during the user-plane switch fails the path switch with the chain
-		// left unadvanced.
-		if !amfInstance.CommitPathSwitch(amfUe, ueConn, ran, models.RanUeNgapID(msg.RANUENGAPID), nh, ncc) {
-			logger.WithTrace(ctx, ueConn.Log).Warn("Path Switch Request: UE released during the user-plane switch")
-			sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
-
-			return
-		}
-
-		ueConn.SendPathSwitchRequestAcknowledge(ctx, amfUe.UESecCap(), ncc, nh[:], switched, released, snssaiList)
-	} else {
-		// TS 38.413: no session switched, so the path switch fails and every requested
-		// session is released.
+	if len(switched) == 0 {
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
+		return
 	}
+
+	if !amfInstance.CommitPathSwitch(amfUe, ueConn, ran, models.RanUeNgapID(msg.RANUENGAPID), nh, ncc) {
+		logger.WithTrace(ctx, ueConn.Log).Warn("Path Switch Request: UE released during the user-plane switch")
+		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
+
+		return
+	}
+
+	if msg.UserLocationInformation != nil {
+		ueConn.UpdateLocation(ctx, *msg.UserLocationInformation)
+	}
+
+	ueConn.SendPathSwitchRequestAcknowledge(ctx, amfUe.UESecCap(), ncc, nh[:], switched, released, snssaiList)
+}
+
+func pathSwitchFailureCause(amfUe *amf.UeContext, pduSessionID uint8) int {
+	if _, known := amfUe.SmContextFindByPDUSessionID(pduSessionID); !known {
+		return ngap.CauseRadioNetworkUnknownPDUSessionID
+	}
+
+	return ngap.CauseRadioNetworkUnspecified
 }
 
 // verifyUESecurityCapabilitiesOnPathSwitch logs any mismatch between the UE 5G

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -122,9 +122,8 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	present, undecodable := pathSwitchSessions(ctx, ueConn, msg.PDUSessionResourceToBeSwitchedDLList)
 
 	result := amfInstance.ReconcileSessionsToRAN(ctx, amfUe, amf.RANSessions{
-		Present:             present,
-		Rejected:            pathSwitchFailedSessions(msg.PDUSessionResourceFailedToSetup),
-		ReleaseOnApplyError: true,
+		Present:  present,
+		Rejected: pathSwitchFailedSessions(msg.PDUSessionResourceFailedToSetup),
 	}, amfInstance.Session.UpdateSmContextXnHandoverPathSwitchReq)
 
 	var (

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -50,9 +50,6 @@ func smContextRefFor(pduSessionID uint8) string {
 	return "imsi-001010000000001-" + string(rune('0'+pduSessionID))
 }
 
-// switchedDLItem is the to-be-switched entry for PDU session 1, the session every
-// test in this file switches. Tests that need a different identity copy it and
-// overwrite PDUSessionID.
 func switchedDLItem(t *testing.T) ngap.PDUSessionResourceToBeSwitchedDLItem {
 	t.Helper()
 
@@ -135,8 +132,7 @@ func TestPathSwitchReportsUndecodablePDUSessionID(t *testing.T) {
 	}
 }
 
-// TS 38.413 §8.4.4.2 / TS 23.502 §4.9.1.2.2
-func TestPathSwitchFailedSessionReleasesCoreResources(t *testing.T) {
+func TestPathSwitchFailedSessionDeactivatesUserPlane(t *testing.T) {
 	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}, PathSwitchErr: errSmfRefused}
 	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
 
@@ -149,12 +145,21 @@ func TestPathSwitchFailedSessionReleasesCoreResources(t *testing.T) {
 
 	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
 
-	if !hasRef(fakeSmf.ReleaseSmContextCalls, smContextRefFor(1)) {
-		t.Errorf("a PDU session that failed to switch kept its core context; ReleaseSmContext calls = %v", fakeSmf.ReleaseSmContextCalls)
+	if !hasRef(fakeSmf.DeactivateSmContextCalls, smContextRefFor(1)) {
+		t.Errorf("user plane not deactivated; DeactivateSmContext calls = %v", fakeSmf.DeactivateSmContextCalls)
 	}
 
-	if _, still := amfUe.SmContextFindByPDUSessionID(1); still {
-		t.Error("a PDU session that failed to switch is still in the UE context")
+	if hasRef(fakeSmf.ReleaseSmContextCalls, smContextRefFor(1)) {
+		t.Errorf("session was released where 3GPP asks for UP deactivation: %v", fakeSmf.ReleaseSmContextCalls)
+	}
+
+	sc, still := amfUe.SmContextFindByPDUSessionID(1)
+	if !still {
+		t.Fatal("the PDU session must survive a failed switch")
+	}
+
+	if !sc.PduSessionInactive {
+		t.Error("the PDU session must be marked user-plane inactive")
 	}
 }
 

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/sctp"
+	"github.com/ellanetworks/core/ngap"
+)
+
+// Conformance tests for the Xn handover Path Switch procedure, mirroring the EPS
+// suite in internal/mme/s1ap/path_switch_conformance_test.go clause for clause. The
+// two stacks converge PDU sessions and EPS bearers with the same rules, so a
+// requirement proven on one is proven the same way on the other.
+
+var errSmfRefused = errors.New("SMF refused the path switch")
+
+// pathSwitchTestUE builds a secured UE with the given PDU sessions, its source
+// association, and an AMF wired to fakeSmf. It returns the UE and the target radio
+// the PATH SWITCH REQUEST arrives on.
+func pathSwitchTestUE(t *testing.T, fakeSmf *fakeSmfSbi, pduSessionIDs ...uint8) (*amf.AMF, *amf.UeContext, *amf.Radio) {
+	t.Helper()
+
+	const sourceAmfUeNgapID = int64(10)
+
+	sourceRan := &amf.Radio{Log: logger.AmfLog, Conn: &fakeNGAPSender{}}
+	targetRan := &amf.Radio{Log: logger.AmfLog, Conn: &fakeNGAPSender{}}
+
+	amfUe := newValidUeContext()
+
+	for _, id := range pduSessionIDs {
+		amfUe.SmContextList[id] = &amf.SmContext{
+			Ref:    smContextRefFor(id),
+			Snssai: &models.Snssai{Sst: 1},
+		}
+	}
+
+	sourceUe := amf.NewUeConnForTest(sourceRan, 1, models.AmfUeNgapID(sourceAmfUeNgapID), logger.AmfLog)
+	sourceUe.AMFForTest().AttachUeConn(amfUe, sourceUe)
+
+	amfInstance := newTestAMFWithSmf(fakeSmf)
+	amfInstance.SetRadioForTest(new(sctp.SCTPConn), sourceRan)
+	sourceRan.BindAMFForTest(amfInstance)
+	targetRan.BindAMFForTest(amfInstance)
+
+	return amfInstance, amfUe, targetRan
+}
+
+func smContextRefFor(pduSessionID uint8) string {
+	return "imsi-001010000000001-" + string(rune('0'+pduSessionID))
+}
+
+func switchedDLItem(t *testing.T, pduSessionID uint8, teid uint32) ngap.PDUSessionResourceToBeSwitchedDLItem {
+	t.Helper()
+
+	transfer, err := buildPathSwitchRequestTransfer(teid, []byte{10, 0, 0, 2})
+	if err != nil {
+		t.Fatalf("build transfer: %v", err)
+	}
+
+	return ngap.PDUSessionResourceToBeSwitchedDLItem{
+		PDUSessionID: ngap.PDUSessionID(pduSessionID),
+		Transfer:     transfer,
+	}
+}
+
+func hasRef(refs []string, want string) bool {
+	for _, r := range refs {
+		if r == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TS 38.413 §8.4.4.2: a PDU session in the UE context that the PATH SWITCH REQUEST
+// does not list has been implicitly released by the gNB. Leaving it in place strands
+// a session whose downlink still points at the source gNB. This is the same
+// requirement as TS 36.413 §8.4.4.2 on the EPS side.
+func TestPathSwitchImplicitlyReleasesOmittedSessions(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
+	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1, 2)
+
+	// The target gNB reports only session 1; session 2 is omitted.
+	msg := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000)},
+		nil, nil,
+	)
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+	if !hasRef(fakeSmf.ReleaseSmContextCalls, smContextRefFor(2)) {
+		t.Errorf("omitted PDU session 2 was not released; ReleaseSmContext calls = %v", fakeSmf.ReleaseSmContextCalls)
+	}
+
+	if _, still := amfUe.SmContextFindByPDUSessionID(2); still {
+		t.Error("omitted PDU session 2 is still in the UE context")
+	}
+
+	if _, kept := amfUe.SmContextFindByPDUSessionID(1); !kept {
+		t.Error("the switched PDU session must be kept")
+	}
+}
+
+// TS 38.413 §8.4.4.2 / TS 23.502 §4.9.1.2.2: a session the core could not switch is
+// reported to the gNB so it releases the radio resources — and its core context is
+// freed too, rather than left pointing at a gNB the UE has left.
+func TestPathSwitchFailedSessionReleasesCoreResources(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}, PathSwitchErr: errSmfRefused}
+	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
+
+	msg := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000)},
+		nil, nil,
+	)
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+	if !hasRef(fakeSmf.ReleaseSmContextCalls, smContextRefFor(1)) {
+		t.Errorf("a PDU session that failed to switch kept its core context; ReleaseSmContext calls = %v", fakeSmf.ReleaseSmContextCalls)
+	}
+
+	if _, still := amfUe.SmContextFindByPDUSessionID(1); still {
+		t.Error("a PDU session that failed to switch is still in the UE context")
+	}
+}
+
+// TS 38.413 §8.4.4.3: when no session could be switched the AMF answers with PATH
+// SWITCH REQUEST FAILURE. Unlike EPS, no detach follows — TS 23.502 §4.9.1.2 leaves
+// the UE's fate to the RAN, where TS 23.401 §5.5.1.1.2 step 6 mandates one.
+func TestPathSwitchNoSessionSwitchedSendsFailure(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchErr: errSmfRefused}
+	amfInstance, _, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
+
+	targetSender, ok := targetRan.Conn.(*fakeNGAPSender)
+	if !ok {
+		t.Fatalf("target conn is %T", targetRan.Conn)
+	}
+
+	msg := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000)},
+		nil, nil,
+	)
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+	if len(targetSender.SentPathSwitchRequestFailures) != 1 {
+		t.Fatalf("expected one PathSwitchRequestFailure, got %d", len(targetSender.SentPathSwitchRequestFailures))
+	}
+
+	if len(targetSender.SentPathSwitchRequestAcknowledges) != 0 {
+		t.Error("a path switch that switched nothing must not be acknowledged")
+	}
+}

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -18,9 +18,6 @@ import (
 // Conformance tests for the Xn handover Path Switch procedure.
 var errSmfRefused = errors.New("SMF refused the path switch")
 
-// pathSwitchTestUE builds a secured UE with the given PDU sessions, its source
-// association, and an AMF wired to fakeSmf. It returns the UE and the target radio
-// the PATH SWITCH REQUEST arrives on.
 func pathSwitchTestUE(t *testing.T, fakeSmf *fakeSmfSbi, pduSessionIDs ...uint8) (*amf.AMF, *amf.UeContext, *amf.Radio) {
 	t.Helper()
 
@@ -159,9 +156,7 @@ func TestPathSwitchFailedSessionReleasesCoreResources(t *testing.T) {
 	}
 }
 
-// TS 38.413 §8.4.4.3: when no session could be switched the AMF answers with PATH
-// SWITCH REQUEST FAILURE. Unlike EPS, no detach follows — TS 23.502 §4.9.1.2 leaves
-// the UE's fate to the RAN, where TS 23.401 §5.5.1.1.2 step 6 mandates one.
+// TS 38.413 §8.4.4.3
 func TestPathSwitchNoSessionSwitchedSendsFailure(t *testing.T) {
 	fakeSmf := &fakeSmfSbi{PathSwitchErr: errSmfRefused}
 	amfInstance, _, targetRan := pathSwitchTestUE(t, fakeSmf, 1)

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -81,7 +81,6 @@ func TestPathSwitchKeepsSessionsTheGNBDidNotList(t *testing.T) {
 	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
 	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1, 2)
 
-	// The target gNB reports only session 1; session 2 is omitted.
 	msg := buildPathSwitchRequest(
 		ngap.Ptr(ngap.AMFUENGAPID(10)),
 		ngap.Ptr(ngap.RANUENGAPID(2)),

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -50,16 +50,19 @@ func smContextRefFor(pduSessionID uint8) string {
 	return "imsi-001010000000001-" + string(rune('0'+pduSessionID))
 }
 
-func switchedDLItem(t *testing.T, pduSessionID uint8, teid uint32) ngap.PDUSessionResourceToBeSwitchedDLItem {
+// switchedDLItem is the to-be-switched entry for PDU session 1, the session every
+// test in this file switches. Tests that need a different identity copy it and
+// overwrite PDUSessionID.
+func switchedDLItem(t *testing.T) ngap.PDUSessionResourceToBeSwitchedDLItem {
 	t.Helper()
 
-	transfer, err := buildPathSwitchRequestTransfer(teid, []byte{10, 0, 0, 2})
+	transfer, err := buildPathSwitchRequestTransfer(5000, []byte{10, 0, 0, 2})
 	if err != nil {
 		t.Fatalf("build transfer: %v", err)
 	}
 
 	return ngap.PDUSessionResourceToBeSwitchedDLItem{
-		PDUSessionID: ngap.PDUSessionID(pduSessionID),
+		PDUSessionID: 1,
 		Transfer:     transfer,
 	}
 }
@@ -82,7 +85,7 @@ func TestPathSwitchKeepsSessionsTheGNBDidNotList(t *testing.T) {
 	msg := buildPathSwitchRequest(
 		ngap.Ptr(ngap.AMFUENGAPID(10)),
 		ngap.Ptr(ngap.RANUENGAPID(2)),
-		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000)},
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
 		nil, nil,
 	)
 
@@ -111,13 +114,13 @@ func TestPathSwitchReportsUndecodablePDUSessionID(t *testing.T) {
 		t.Fatalf("target conn is %T", targetRan.Conn)
 	}
 
-	bad := switchedDLItem(t, 1, 5000)
+	bad := switchedDLItem(t)
 	bad.PDUSessionID = 0 // outside the valid 1..15 range
 
 	msg := buildPathSwitchRequest(
 		ngap.Ptr(ngap.AMFUENGAPID(10)),
 		ngap.Ptr(ngap.RANUENGAPID(2)),
-		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000), bad},
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t), bad},
 		nil, nil,
 	)
 
@@ -141,7 +144,7 @@ func TestPathSwitchFailedSessionReleasesCoreResources(t *testing.T) {
 	msg := buildPathSwitchRequest(
 		ngap.Ptr(ngap.AMFUENGAPID(10)),
 		ngap.Ptr(ngap.RANUENGAPID(2)),
-		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000)},
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
 		nil, nil,
 	)
 
@@ -169,7 +172,7 @@ func TestPathSwitchNoSessionSwitchedSendsFailure(t *testing.T) {
 	msg := buildPathSwitchRequest(
 		ngap.Ptr(ngap.AMFUENGAPID(10)),
 		ngap.Ptr(ngap.RANUENGAPID(2)),
-		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000)},
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
 		nil, nil,
 	)
 

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -5,6 +5,7 @@ package ngap
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"testing"
 
@@ -188,5 +189,303 @@ func TestPathSwitchNoSessionSwitchedSendsFailure(t *testing.T) {
 
 	if len(targetSender.SentPathSwitchRequestAcknowledges) != 0 {
 		t.Error("a path switch that switched nothing must not be acknowledged")
+	}
+}
+
+// NGAP protocol IE identifiers, for stripping mandatory ignore-criticality IEs from an
+// encoded PATH SWITCH REQUEST (TS 38.413 §9.3.1.x).
+const (
+	ieIDUESecurityCapabilities  = 119
+	ieIDUserLocationInformation = 121
+)
+
+// dropNGAPIEs removes the named protocol IEs from an encoded NGAP message body: a
+// 1-byte extension preamble, a 2-byte IE count, then ID/criticality/length/value
+// tuples. It builds a message the encoder would refuse to produce, so the receiver's
+// handling of an absent mandatory ignore-criticality IE can be exercised
+// (TS 38.413 §10.3.5). Mirrors dropIEs on the S1AP side.
+func dropNGAPIEs(t *testing.T, value []byte, ids ...uint16) []byte {
+	t.Helper()
+
+	drop := make(map[uint16]bool, len(ids))
+	for _, id := range ids {
+		drop[id] = true
+	}
+
+	if len(value) < 3 {
+		t.Fatalf("message body too short: %d bytes", len(value))
+	}
+
+	preamble, count, pos := value[0], binary.BigEndian.Uint16(value[1:3]), 3
+
+	kept := make([]byte, 0, len(value))
+	keptCount := uint16(0)
+
+	for i := uint16(0); i < count; i++ {
+		start := pos
+		if pos+4 > len(value) {
+			t.Fatalf("truncated IE header at offset %d", pos)
+		}
+
+		id := binary.BigEndian.Uint16(value[pos : pos+2])
+		pos += 3
+
+		n := int(value[pos])
+
+		switch {
+		case n < 0x80:
+			pos++
+		case n < 0xC0:
+			n = (n&0x3F)<<8 | int(value[pos+1])
+			pos += 2
+		default:
+			t.Fatalf("fragmented IE length at offset %d is not supported", pos)
+		}
+
+		if pos+n > len(value) {
+			t.Fatalf("IE 0x%04x claims %d bytes, only %d remain", id, n, len(value)-pos)
+		}
+
+		pos += n
+
+		if drop[id] {
+			continue
+		}
+
+		kept = append(kept, value[start:pos]...)
+		keptCount++
+	}
+
+	out := make([]byte, 3, 3+len(kept))
+	out[0] = preamble
+	binary.BigEndian.PutUint16(out[1:3], keptCount)
+
+	return append(out, kept...)
+}
+
+// XNP-17/XNP-18. TS 38.413 §9.2.3.9: the PATH SWITCH REQUEST ACKNOWLEDGE carries AMF
+// UE NGAP ID and RAN UE NGAP ID (both M), Security Context (M, reject), Allowed NSSAI
+// (M, reject), and a PDU Session Resource Switched List whose Range is 1 — so it is
+// never empty.
+func TestPathSwitchAckCarriesMandatoryIEs(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
+	amfInstance, _, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
+
+	targetSender, ok := targetRan.Conn.(*fakeNGAPSender)
+	if !ok {
+		t.Fatalf("target conn is %T", targetRan.Conn)
+	}
+
+	msg := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
+		nil, nil,
+	)
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+	if len(targetSender.SentPathSwitchRequestAcknowledges) != 1 {
+		t.Fatalf("expected one acknowledge, got %d", len(targetSender.SentPathSwitchRequestAcknowledges))
+	}
+
+	ack := targetSender.SentPathSwitchRequestAcknowledges[0]
+
+	if ack.AMFUENGAPID == nil {
+		t.Error("acknowledge carries no AMF UE NGAP ID")
+	}
+
+	if ack.RANUENGAPID == nil {
+		t.Error("acknowledge carries no RAN UE NGAP ID")
+	}
+
+	if len(ack.AllowedNSSAI) == 0 {
+		t.Error("acknowledge carries no Allowed NSSAI (mandatory, reject criticality)")
+	}
+
+	if len(ack.PDUSessionResourceSwitchedList) == 0 {
+		t.Error("acknowledge carries an empty PDU Session Resource Switched List (Range 1)")
+	}
+}
+
+// XNP-20. TS 38.413 §9.2.3.10: the PATH SWITCH REQUEST FAILURE carries AMF UE NGAP ID
+// and RAN UE NGAP ID (both M) and a PDU Session Resource Released List whose Range is
+// 1 — the message has no Cause IE of its own, so the reason travels per session and
+// the list can never be empty (§8.4.4.3).
+func TestPathSwitchFailureCarriesMandatoryIEs(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		fakeSmf *fakeSmfSbi
+		sourceA int64
+	}{
+		{name: "no session switched", fakeSmf: &fakeSmfSbi{PathSwitchErr: errSmfRefused}, sourceA: 10},
+		{name: "unknown source AMF UE NGAP ID", fakeSmf: &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}, sourceA: 0x7ffffff0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			amfInstance, _, targetRan := pathSwitchTestUE(t, tt.fakeSmf, 1)
+
+			targetSender, ok := targetRan.Conn.(*fakeNGAPSender)
+			if !ok {
+				t.Fatalf("target conn is %T", targetRan.Conn)
+			}
+
+			msg := buildPathSwitchRequest(
+				ngap.Ptr(ngap.AMFUENGAPID(tt.sourceA)),
+				ngap.Ptr(ngap.RANUENGAPID(2)),
+				ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
+				nil, nil,
+			)
+
+			HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+			if len(targetSender.SentPathSwitchRequestFailures) != 1 {
+				t.Fatalf("expected one failure, got %d", len(targetSender.SentPathSwitchRequestFailures))
+			}
+
+			fail := targetSender.SentPathSwitchRequestFailures[0]
+
+			if fail.AMFUENGAPID == nil {
+				t.Error("failure carries no AMF UE NGAP ID")
+			}
+
+			if fail.RANUENGAPID == nil {
+				t.Error("failure carries no RAN UE NGAP ID")
+			}
+
+			if len(fail.PDUSessionResourceReleased) == 0 {
+				t.Error("failure carries an empty PDU Session Resource Released List (Range 1)")
+			}
+		})
+	}
+}
+
+// XNP-24. TS 33.501 §6.9.2.3.2: "Upon reception of the NGAP PATH SWITCH REQUEST, the
+// AMF shall increase its locally kept NCC value by one and compute a new fresh NH ...
+// The AMF shall then send the newly computed {NH, NCC} pair to the target gNB/ng-eNB in
+// the NGAP PATH SWITCH REQUEST ACKNOWLEDGE message."
+func TestPathSwitchAckCarriesFreshlyDerivedNH(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
+	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
+
+	targetSender, ok := targetRan.Conn.(*fakeNGAPSender)
+	if !ok {
+		t.Fatalf("target conn is %T", targetRan.Conn)
+	}
+
+	beforeNH, beforeNCC := amfUe.NHForTest(), amfUe.NCCForTest()
+
+	msg := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
+		nil, nil,
+	)
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+	if len(targetSender.SentPathSwitchRequestAcknowledges) != 1 {
+		t.Fatalf("expected one acknowledge, got %d", len(targetSender.SentPathSwitchRequestAcknowledges))
+	}
+
+	ack := targetSender.SentPathSwitchRequestAcknowledges[0]
+
+	if ack.SecurityContext.NextHopChainingCount != (beforeNCC+1)%8 {
+		t.Errorf("acknowledge NCC = %d, want %d", ack.SecurityContext.NextHopChainingCount, (beforeNCC+1)%8)
+	}
+
+	if ack.SecurityContext.NextHopNH == beforeNH {
+		t.Error("acknowledge replayed the current NH instead of a freshly derived one")
+	}
+
+	if amfUe.NHForTest() != ack.SecurityContext.NextHopNH {
+		t.Error("the pair sent to the target must be the UE's committed chain")
+	}
+}
+
+// XNP-25. NCC is a 3-bit chaining counter, so the increment wraps from 7 to 0.
+func TestPathSwitchNCCWrapsToZero(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
+	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
+
+	amfUe.SetNCCForTest(7)
+
+	targetSender, ok := targetRan.Conn.(*fakeNGAPSender)
+	if !ok {
+		t.Fatalf("target conn is %T", targetRan.Conn)
+	}
+
+	msg := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
+		nil, nil,
+	)
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+	if len(targetSender.SentPathSwitchRequestAcknowledges) != 1 {
+		t.Fatalf("expected one acknowledge, got %d", len(targetSender.SentPathSwitchRequestAcknowledges))
+	}
+
+	if got := targetSender.SentPathSwitchRequestAcknowledges[0].SecurityContext.NextHopChainingCount; got != 0 {
+		t.Errorf("NCC after 7 = %d, want 0", got)
+	}
+
+	if amfUe.NCCForTest() != 0 {
+		t.Errorf("stored NCC after 7 = %d, want 0", amfUe.NCCForTest())
+	}
+}
+
+// XNP-16. TS 38.413 §9.2.3.8 lists User Location Information and UE Security
+// Capabilities as mandatory with ignore criticality. Per §10.3.5 an absent
+// ignore-criticality IE does not stop delivery, so the path switch must still complete.
+func TestPathSwitchToleratesAbsentIgnoreCriticalityIEs(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
+	amfInstance, _, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
+
+	targetSender, ok := targetRan.Conn.(*fakeNGAPSender)
+	if !ok {
+		t.Fatalf("target conn is %T", targetRan.Conn)
+	}
+
+	full := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t)},
+		nil,
+		ngap.Ptr(ngap.UESecurityCapabilities{NREncryptionAlgorithms: 0xc000, NRIntegrityProtectionAlgorithms: 0xc000}),
+	)
+
+	encoded, err := full.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	pdu, err := ngap.Unmarshal(encoded)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	initiating, ok := pdu.(*ngap.InitiatingMessage)
+	if !ok {
+		t.Fatalf("expected InitiatingMessage, got %T", pdu)
+	}
+
+	stripped, err := ngap.ParsePathSwitchRequest(
+		dropNGAPIEs(t, initiating.Value, ieIDUserLocationInformation, ieIDUESecurityCapabilities))
+	if err != nil {
+		t.Fatalf("a message missing only ignore-criticality IEs must still parse: %v", err)
+	}
+
+	// Guard against a vacuous test: the IEs must really be gone.
+	if stripped.UserLocationInformation != nil || stripped.UESecurityCapabilities != nil {
+		t.Fatal("dropNGAPIEs did not strip the ignore-criticality IEs")
+	}
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, stripped)
+
+	if len(targetSender.SentPathSwitchRequestAcknowledges) != 1 {
+		t.Fatalf("path switch did not complete: %d acknowledges, %d failures",
+			len(targetSender.SentPathSwitchRequestAcknowledges), len(targetSender.SentPathSwitchRequestFailures))
 	}
 }

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -15,11 +15,7 @@ import (
 	"github.com/ellanetworks/core/ngap"
 )
 
-// Conformance tests for the Xn handover Path Switch procedure, mirroring the EPS
-// suite in internal/mme/s1ap/path_switch_conformance_test.go clause for clause. The
-// two stacks converge PDU sessions and EPS bearers with the same rules, so a
-// requirement proven on one is proven the same way on the other.
-
+// Conformance tests for the Xn handover Path Switch procedure.
 var errSmfRefused = errors.New("SMF refused the path switch")
 
 // pathSwitchTestUE builds a secured UE with the given PDU sessions, its source
@@ -81,11 +77,7 @@ func hasRef(refs []string, want string) bool {
 	return false
 }
 
-// TS 38.413 §8.4.4.2: a PDU session in the UE context that the PATH SWITCH REQUEST
-// does not list has been implicitly released by the gNB. Leaving it in place strands
-// a session whose downlink still points at the source gNB. This is the same
-// requirement as TS 36.413 §8.4.4.2 on the EPS side.
-func TestPathSwitchImplicitlyReleasesOmittedSessions(t *testing.T) {
+func TestPathSwitchKeepsSessionsTheGNBDidNotList(t *testing.T) {
 	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
 	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1, 2)
 
@@ -99,12 +91,12 @@ func TestPathSwitchImplicitlyReleasesOmittedSessions(t *testing.T) {
 
 	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
 
-	if !hasRef(fakeSmf.ReleaseSmContextCalls, smContextRefFor(2)) {
-		t.Errorf("omitted PDU session 2 was not released; ReleaseSmContext calls = %v", fakeSmf.ReleaseSmContextCalls)
+	if hasRef(fakeSmf.ReleaseSmContextCalls, smContextRefFor(2)) {
+		t.Errorf("PDU session the gNB did not list was released; ReleaseSmContext calls = %v", fakeSmf.ReleaseSmContextCalls)
 	}
 
-	if _, still := amfUe.SmContextFindByPDUSessionID(2); still {
-		t.Error("omitted PDU session 2 is still in the UE context")
+	if _, kept := amfUe.SmContextFindByPDUSessionID(2); !kept {
+		t.Error("PDU session the gNB did not list was dropped from the UE context")
 	}
 
 	if _, kept := amfUe.SmContextFindByPDUSessionID(1); !kept {
@@ -112,9 +104,39 @@ func TestPathSwitchImplicitlyReleasesOmittedSessions(t *testing.T) {
 	}
 }
 
-// TS 38.413 §8.4.4.2 / TS 23.502 §4.9.1.2.2: a session the core could not switch is
-// reported to the gNB so it releases the radio resources — and its core context is
-// freed too, rather than left pointing at a gNB the UE has left.
+// TS 38.413 §9.2.3.8
+func TestPathSwitchReportsUndecodablePDUSessionID(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}}
+	amfInstance, _, targetRan := pathSwitchTestUE(t, fakeSmf, 1)
+
+	targetSender, ok := targetRan.Conn.(*fakeNGAPSender)
+	if !ok {
+		t.Fatalf("target conn is %T", targetRan.Conn)
+	}
+
+	bad := switchedDLItem(t, 1, 5000)
+	bad.PDUSessionID = 0 // outside the valid 1..15 range
+
+	msg := buildPathSwitchRequest(
+		ngap.Ptr(ngap.AMFUENGAPID(10)),
+		ngap.Ptr(ngap.RANUENGAPID(2)),
+		ngap.PDUSessionResourceToBeSwitchedDLList{switchedDLItem(t, 1, 5000), bad},
+		nil, nil,
+	)
+
+	HandlePathSwitchRequest(context.Background(), amfInstance, targetRan, msg)
+
+	if len(targetSender.SentPathSwitchRequestAcknowledges) != 1 {
+		t.Fatalf("expected one acknowledge, got %d", len(targetSender.SentPathSwitchRequestAcknowledges))
+	}
+
+	ack := targetSender.SentPathSwitchRequestAcknowledges[0]
+	if len(ack.PDUSessionResourceReleased) != 1 {
+		t.Fatalf("released list = %+v, want the undecodable session reported", ack.PDUSessionResourceReleased)
+	}
+}
+
+// TS 38.413 §8.4.4.2 / TS 23.502 §4.9.1.2.2
 func TestPathSwitchFailedSessionReleasesCoreResources(t *testing.T) {
 	fakeSmf := &fakeSmfSbi{PathSwitchResponse: []byte{0xAA}, PathSwitchErr: errSmfRefused}
 	amfInstance, amfUe, targetRan := pathSwitchTestUE(t, fakeSmf, 1)

--- a/internal/amf/ngap/path_switch_failure.go
+++ b/internal/amf/ngap/path_switch_failure.go
@@ -13,6 +13,47 @@ import (
 	"go.uber.org/zap"
 )
 
+// pathSwitchSessions decodes the to-be-switched list into the RAN session set the
+// reconciliation primitive consumes. An item whose PDU session ID will not decode is
+// reported separately: it names nothing the core can act on. Mirrors
+// pathSwitchBearers on the EPS side.
+func pathSwitchSessions(ctx context.Context, ueConn *amf.UeConn, items ngap.PDUSessionResourceToBeSwitchedDLList) (present []amf.RANSession, undecodable []uint8) {
+	present = make([]amf.RANSession, 0, len(items))
+
+	for _, item := range items {
+		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
+		if !ok {
+			logger.WithTrace(ctx, ueConn.Log).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+			continue
+		}
+
+		present = append(present, amf.RANSession{PduSessionID: pduSessionID, Transfer: item.Transfer})
+	}
+
+	return present, undecodable
+}
+
+// pathSwitchFailedSessions renders the gNB's failed-to-setup list as the rejected
+// set. NGAP carries this list where S1AP has none (TS 38.413 §9.2.3.8).
+func pathSwitchFailedSessions(items ngap.PDUSessionResourceFailedToSetupListPSReq) []amf.RANSession {
+	if len(items) == 0 {
+		return nil
+	}
+
+	out := make([]amf.RANSession, 0, len(items))
+
+	for _, item := range items {
+		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
+		if !ok {
+			continue
+		}
+
+		out = append(out, amf.RANSession{PduSessionID: pduSessionID, Transfer: item.Transfer})
+	}
+
+	return out
+}
+
 // sendPathSwitchRequestFailure refuses a path switch. TS 38.413 §9.2.3.10 has
 // no Cause IE for the message as a whole — unlike TS 36.413 §9.1.5.10 — so the
 // reason is reported per session, once for every session the request named.

--- a/internal/amf/ngap/path_switch_failure.go
+++ b/internal/amf/ngap/path_switch_failure.go
@@ -23,7 +23,10 @@ func pathSwitchSessions(ctx context.Context, ueConn *amf.UeConn, items ngap.PDUS
 	for _, item := range items {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+			logger.WithTrace(ctx, ueConn.Log).Error("invalid PDU session ID from gNB, not switched", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+
+			undecodable = append(undecodable, uint8(item.PDUSessionID))
+
 			continue
 		}
 
@@ -35,12 +38,12 @@ func pathSwitchSessions(ctx context.Context, ueConn *amf.UeConn, items ngap.PDUS
 
 // pathSwitchFailedSessions renders the gNB's failed-to-setup list as the rejected
 // set. NGAP carries this list where S1AP has none (TS 38.413 §9.2.3.8).
-func pathSwitchFailedSessions(items ngap.PDUSessionResourceFailedToSetupListPSReq) []amf.RANSession {
+func pathSwitchFailedSessions(items ngap.PDUSessionResourceFailedToSetupListPSReq) []uint8 {
 	if len(items) == 0 {
 		return nil
 	}
 
-	out := make([]amf.RANSession, 0, len(items))
+	out := make([]uint8, 0, len(items))
 
 	for _, item := range items {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
@@ -48,7 +51,7 @@ func pathSwitchFailedSessions(items ngap.PDUSessionResourceFailedToSetupListPSRe
 			continue
 		}
 
-		out = append(out, amf.RANSession{PduSessionID: pduSessionID, Transfer: item.Transfer})
+		out = append(out, pduSessionID)
 	}
 
 	return out

--- a/internal/amf/ngap/path_switch_failure.go
+++ b/internal/amf/ngap/path_switch_failure.go
@@ -13,10 +13,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// pathSwitchSessions decodes the to-be-switched list into the RAN session set the
-// reconciliation primitive consumes. An item whose PDU session ID will not decode is
-// reported separately: it names nothing the core can act on. Mirrors
-// pathSwitchBearers on the EPS side.
 func pathSwitchSessions(ctx context.Context, ueConn *amf.UeConn, items ngap.PDUSessionResourceToBeSwitchedDLList) (present []amf.RANSession, undecodable []uint8) {
 	present = make([]amf.RANSession, 0, len(items))
 
@@ -36,8 +32,6 @@ func pathSwitchSessions(ctx context.Context, ueConn *amf.UeConn, items ngap.PDUS
 	return present, undecodable
 }
 
-// pathSwitchFailedSessions renders the gNB's failed-to-setup list as the rejected
-// set. NGAP carries this list where S1AP has none (TS 38.413 §9.2.3.8).
 func pathSwitchFailedSessions(items ngap.PDUSessionResourceFailedToSetupListPSReq) []uint8 {
 	if len(items) == 0 {
 		return nil

--- a/internal/amf/reconcile_sessions.go
+++ b/internal/amf/reconcile_sessions.go
@@ -18,18 +18,11 @@ type RANSession struct {
 	Transfer     []byte
 }
 
-// RANSessions is a gNB's view of a UE's PDU session set, as carried by one NGAP
-// message.
-//
-// Authoritative distinguishes the two kinds of message 3GPP defines, exactly as
-// RANBearers does for EPS. A PATH SWITCH REQUEST or a completed handover names
-// everything the gNB holds, so a session in the UE context that appears in neither
-// list has been implicitly released by the gNB (TS 38.413 §8.4.4.2). A message that
-// reports only its own procedure's sessions is not authoritative.
 type RANSessions struct {
-	Present       []RANSession
-	Rejected      []RANSession
-	Authoritative bool
+	Present             []RANSession
+	Rejected            []uint8
+	Authoritative       bool
+	ReleaseOnApplyError bool
 }
 
 // AppliedSession is a session whose downlink now points at the gNB, with the N2
@@ -47,23 +40,6 @@ type RANSessionResult struct {
 	Released []uint8
 }
 
-// ReconcileSessionsToRAN converges a UE's PDU sessions onto the set a gNB reports.
-// It is the 5G counterpart of MME.ReconcileBearersToRAN and follows the same rules:
-//
-//   - a session the gNB holds is applied at the SMF, and only a successful apply
-//     counts as switched;
-//   - a session the gNB rejected, or that the SMF could not converge, has its core
-//     context released rather than only being reported;
-//   - on an authoritative message, a session absent from both lists is released too.
-//
-// apply performs the procedure-specific SMF call — path switch and handover
-// completion drive different Nsmf operations — and returns the N2 response transfer,
-// if any. The caller keeps what is procedure-specific: rejecting duplicate PDU
-// session IDs, choosing the response message, and deciding what a total failure
-// means.
-//
-// There is no default-session re-election step: EPS has a default bearer to repair,
-// 5GS has no equivalent (TS 23.501 §5.6).
 func (a *AMF) ReconcileSessionsToRAN(
 	ctx context.Context,
 	ue *UeContext,
@@ -93,15 +69,16 @@ func (a *AMF) ReconcileSessionsToRAN(
 
 		n2Rsp, err := apply(ctx, smContext.Ref, s.Transfer)
 		if err != nil {
-			logger.From(ctx, logger.AmfLog).Error("failed to switch a PDU session to the RAN endpoint",
-				zap.String("smContextRef", smContext.Ref), zap.Uint8("pdu-session-id", s.PduSessionID), zap.Error(err))
-
-			// The session has no usable downlink: free its core context rather than
-			// leaving it pointed at a gNB the UE has left.
-			a.releaseSession(ctx, ue, smContext.Ref, s.PduSessionID)
+			logger.From(ctx, logger.AmfLog).Error("failed to converge a PDU session onto the RAN endpoint",
+				logger.SUPI(ue.Supi().String()), zap.String("smContextRef", smContext.Ref),
+				zap.Uint8("pdu-session-id", s.PduSessionID), zap.Error(err))
 
 			result.Failed = append(result.Failed, s.PduSessionID)
-			result.Released = append(result.Released, s.PduSessionID)
+
+			if want.ReleaseOnApplyError {
+				a.releaseSession(ctx, ue, smContext.Ref, s.PduSessionID)
+				result.Released = append(result.Released, s.PduSessionID)
+			}
 
 			continue
 		}
@@ -109,16 +86,16 @@ func (a *AMF) ReconcileSessionsToRAN(
 		result.Applied = append(result.Applied, AppliedSession{PduSessionID: s.PduSessionID, Transfer: n2Rsp})
 	}
 
-	for _, s := range want.Rejected {
-		named[s.PduSessionID] = struct{}{}
+	for _, id := range want.Rejected {
+		named[id] = struct{}{}
 
-		smContext, ok := ue.SmContextFindByPDUSessionID(s.PduSessionID)
+		smContext, ok := ue.SmContextFindByPDUSessionID(id)
 		if !ok {
 			continue
 		}
 
-		a.releaseSession(ctx, ue, smContext.Ref, s.PduSessionID)
-		result.Released = append(result.Released, s.PduSessionID)
+		a.releaseSession(ctx, ue, smContext.Ref, id)
+		result.Released = append(result.Released, id)
 	}
 
 	if want.Authoritative {
@@ -131,8 +108,12 @@ func (a *AMF) ReconcileSessionsToRAN(
 				continue
 			}
 
-			logger.From(ctx, logger.AmfLog).Info("releasing a PDU session the RAN did not report; implicitly released",
-				zap.Uint8("pdu-session-id", sr.PduSessionID))
+			if sr.Inactive {
+				continue
+			}
+
+			logger.From(ctx, logger.AmfLog).Info("releasing a PDU session the RAN did not report",
+				logger.SUPI(ue.Supi().String()), zap.Uint8("pdu-session-id", sr.PduSessionID))
 
 			a.releaseSession(ctx, ue, sr.Ref, sr.PduSessionID)
 			result.Released = append(result.Released, sr.PduSessionID)
@@ -150,22 +131,4 @@ func (a *AMF) releaseSession(ctx context.Context, ue *UeContext, ref string, pdu
 	}
 
 	ue.DeleteSmContext(pduSessionID)
-}
-
-// DuplicatePDUSessionID reports the first PDU session identity that appears more
-// than once. Several NGAP procedures make a repeated ID an abnormal condition but
-// answer it differently, so detection is shared and the response stays with the
-// caller (TS 38.413 §8.4.4.4). Mirrors mme.DuplicateEBI.
-func DuplicatePDUSessionID(ids []uint8) (uint8, bool) {
-	seen := make(map[uint8]struct{}, len(ids))
-
-	for _, id := range ids {
-		if _, ok := seen[id]; ok {
-			return id, true
-		}
-
-		seen[id] = struct{}{}
-	}
-
-	return 0, false
 }

--- a/internal/amf/reconcile_sessions.go
+++ b/internal/amf/reconcile_sessions.go
@@ -10,34 +10,26 @@ import (
 	"go.uber.org/zap"
 )
 
-// RANSession is one PDU session a gNB reports it holds, with the opaque N2 transfer
-// the SMF consumes. Unlike EPS, where the MME carries the eNB S1-U endpoint itself,
-// the downlink endpoint stays inside the transfer (TS 38.413 §9.3.4).
 type RANSession struct {
 	PduSessionID uint8
 	Transfer     []byte
 }
 
 type RANSessions struct {
-	Present             []RANSession
-	Rejected            []uint8
-	Authoritative       bool
-	ReleaseOnApplyError bool
+	Present       []RANSession
+	Rejected      []uint8
+	Authoritative bool
 }
 
-// AppliedSession is a session whose downlink now points at the gNB, with the N2
-// response transfer to echo back.
 type AppliedSession struct {
 	PduSessionID uint8
 	Transfer     []byte
 }
 
-// RANSessionResult reports the outcome per PDU session. Failed is what the caller
-// reports back to the gNB so it releases the matching radio resources.
 type RANSessionResult struct {
-	Applied  []AppliedSession
-	Failed   []uint8
-	Released []uint8
+	Applied     []AppliedSession
+	Failed      []uint8
+	Deactivated []uint8
 }
 
 func (a *AMF) ReconcileSessionsToRAN(
@@ -75,10 +67,8 @@ func (a *AMF) ReconcileSessionsToRAN(
 
 			result.Failed = append(result.Failed, s.PduSessionID)
 
-			if want.ReleaseOnApplyError {
-				a.releaseSession(ctx, ue, smContext.Ref, s.PduSessionID)
-				result.Released = append(result.Released, s.PduSessionID)
-			}
+			a.deactivateSession(ctx, ue, smContext.Ref, s.PduSessionID)
+			result.Deactivated = append(result.Deactivated, s.PduSessionID)
 
 			continue
 		}
@@ -94,8 +84,8 @@ func (a *AMF) ReconcileSessionsToRAN(
 			continue
 		}
 
-		a.releaseSession(ctx, ue, smContext.Ref, id)
-		result.Released = append(result.Released, id)
+		a.deactivateSession(ctx, ue, smContext.Ref, id)
+		result.Deactivated = append(result.Deactivated, id)
 	}
 
 	if want.Authoritative {
@@ -112,23 +102,24 @@ func (a *AMF) ReconcileSessionsToRAN(
 				continue
 			}
 
-			logger.From(ctx, logger.AmfLog).Info("releasing a PDU session the RAN did not report",
+			logger.From(ctx, logger.AmfLog).Info("deactivating a PDU session the RAN did not report",
 				logger.SUPI(ue.Supi().String()), zap.Uint8("pdu-session-id", sr.PduSessionID))
 
-			a.releaseSession(ctx, ue, sr.Ref, sr.PduSessionID)
-			result.Released = append(result.Released, sr.PduSessionID)
+			a.deactivateSession(ctx, ue, sr.Ref, sr.PduSessionID)
+			result.Deactivated = append(result.Deactivated, sr.PduSessionID)
 		}
 	}
 
 	return result
 }
 
-// releaseSession frees a PDU session's core context and drops it from the UE.
-func (a *AMF) releaseSession(ctx context.Context, ue *UeContext, ref string, pduSessionID uint8) {
-	if err := a.Session.ReleaseSmContext(ctx, ref); err != nil {
-		logger.From(ctx, logger.AmfLog).Error("failed to release a PDU session",
+func (a *AMF) deactivateSession(ctx context.Context, ue *UeContext, ref string, pduSessionID uint8) {
+	if err := a.Session.DeactivateSmContext(ctx, ref); err != nil {
+		logger.From(ctx, logger.AmfLog).Error("failed to deactivate a PDU session",
 			zap.String("smContextRef", ref), zap.Uint8("pdu-session-id", pduSessionID), zap.Error(err))
+
+		return
 	}
 
-	ue.DeleteSmContext(pduSessionID)
+	ue.SetSmContextInactive(pduSessionID)
 }

--- a/internal/amf/reconcile_sessions.go
+++ b/internal/amf/reconcile_sessions.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"go.uber.org/zap"
+)
+
+// RANSession is one PDU session a gNB reports it holds, with the opaque N2 transfer
+// the SMF consumes. Unlike EPS, where the MME carries the eNB S1-U endpoint itself,
+// the downlink endpoint stays inside the transfer (TS 38.413 §9.3.4).
+type RANSession struct {
+	PduSessionID uint8
+	Transfer     []byte
+}
+
+// RANSessions is a gNB's view of a UE's PDU session set, as carried by one NGAP
+// message.
+//
+// Authoritative distinguishes the two kinds of message 3GPP defines, exactly as
+// RANBearers does for EPS. A PATH SWITCH REQUEST or a completed handover names
+// everything the gNB holds, so a session in the UE context that appears in neither
+// list has been implicitly released by the gNB (TS 38.413 §8.4.4.2). A message that
+// reports only its own procedure's sessions is not authoritative.
+type RANSessions struct {
+	Present       []RANSession
+	Rejected      []RANSession
+	Authoritative bool
+}
+
+// AppliedSession is a session whose downlink now points at the gNB, with the N2
+// response transfer to echo back.
+type AppliedSession struct {
+	PduSessionID uint8
+	Transfer     []byte
+}
+
+// RANSessionResult reports the outcome per PDU session. Failed is what the caller
+// reports back to the gNB so it releases the matching radio resources.
+type RANSessionResult struct {
+	Applied  []AppliedSession
+	Failed   []uint8
+	Released []uint8
+}
+
+// ReconcileSessionsToRAN converges a UE's PDU sessions onto the set a gNB reports.
+// It is the 5G counterpart of MME.ReconcileBearersToRAN and follows the same rules:
+//
+//   - a session the gNB holds is applied at the SMF, and only a successful apply
+//     counts as switched;
+//   - a session the gNB rejected, or that the SMF could not converge, has its core
+//     context released rather than only being reported;
+//   - on an authoritative message, a session absent from both lists is released too.
+//
+// apply performs the procedure-specific SMF call — path switch and handover
+// completion drive different Nsmf operations — and returns the N2 response transfer,
+// if any. The caller keeps what is procedure-specific: rejecting duplicate PDU
+// session IDs, choosing the response message, and deciding what a total failure
+// means.
+//
+// There is no default-session re-election step: EPS has a default bearer to repair,
+// 5GS has no equivalent (TS 23.501 §5.6).
+func (a *AMF) ReconcileSessionsToRAN(
+	ctx context.Context,
+	ue *UeContext,
+	want RANSessions,
+	apply func(ctx context.Context, ref string, transfer []byte) ([]byte, error),
+) RANSessionResult {
+	var result RANSessionResult
+
+	if ue == nil {
+		return result
+	}
+
+	named := make(map[uint8]struct{}, len(want.Present)+len(want.Rejected))
+
+	for _, s := range want.Present {
+		named[s.PduSessionID] = struct{}{}
+
+		smContext, ok := ue.SmContextFindByPDUSessionID(s.PduSessionID)
+		if !ok {
+			logger.From(ctx, logger.AmfLog).Warn("RAN reports a PDU session the core does not know; not switched",
+				zap.Uint8("pdu-session-id", s.PduSessionID))
+
+			result.Failed = append(result.Failed, s.PduSessionID)
+
+			continue
+		}
+
+		n2Rsp, err := apply(ctx, smContext.Ref, s.Transfer)
+		if err != nil {
+			logger.From(ctx, logger.AmfLog).Error("failed to switch a PDU session to the RAN endpoint",
+				zap.String("smContextRef", smContext.Ref), zap.Uint8("pdu-session-id", s.PduSessionID), zap.Error(err))
+
+			// The session has no usable downlink: free its core context rather than
+			// leaving it pointed at a gNB the UE has left.
+			a.releaseSession(ctx, ue, smContext.Ref, s.PduSessionID)
+
+			result.Failed = append(result.Failed, s.PduSessionID)
+			result.Released = append(result.Released, s.PduSessionID)
+
+			continue
+		}
+
+		result.Applied = append(result.Applied, AppliedSession{PduSessionID: s.PduSessionID, Transfer: n2Rsp})
+	}
+
+	for _, s := range want.Rejected {
+		named[s.PduSessionID] = struct{}{}
+
+		smContext, ok := ue.SmContextFindByPDUSessionID(s.PduSessionID)
+		if !ok {
+			continue
+		}
+
+		a.releaseSession(ctx, ue, smContext.Ref, s.PduSessionID)
+		result.Released = append(result.Released, s.PduSessionID)
+	}
+
+	if want.Authoritative {
+		for _, sr := range ue.SmContextRefs() {
+			if sr.Ref == "" {
+				continue
+			}
+
+			if _, ok := named[sr.PduSessionID]; ok {
+				continue
+			}
+
+			logger.From(ctx, logger.AmfLog).Info("releasing a PDU session the RAN did not report; implicitly released",
+				zap.Uint8("pdu-session-id", sr.PduSessionID))
+
+			a.releaseSession(ctx, ue, sr.Ref, sr.PduSessionID)
+			result.Released = append(result.Released, sr.PduSessionID)
+		}
+	}
+
+	return result
+}
+
+// releaseSession frees a PDU session's core context and drops it from the UE.
+func (a *AMF) releaseSession(ctx context.Context, ue *UeContext, ref string, pduSessionID uint8) {
+	if err := a.Session.ReleaseSmContext(ctx, ref); err != nil {
+		logger.From(ctx, logger.AmfLog).Error("failed to release a PDU session",
+			zap.String("smContextRef", ref), zap.Uint8("pdu-session-id", pduSessionID), zap.Error(err))
+	}
+
+	ue.DeleteSmContext(pduSessionID)
+}
+
+// DuplicatePDUSessionID reports the first PDU session identity that appears more
+// than once. Several NGAP procedures make a repeated ID an abnormal condition but
+// answer it differently, so detection is shared and the response stays with the
+// caller (TS 38.413 §8.4.4.4). Mirrors mme.DuplicateEBI.
+func DuplicatePDUSessionID(ids []uint8) (uint8, bool) {
+	seen := make(map[uint8]struct{}, len(ids))
+
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			return id, true
+		}
+
+		seen[id] = struct{}{}
+	}
+
+	return 0, false
+}

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -100,6 +100,11 @@ func (r *Radio) NumUEsForTest() int {
 
 func (a *AMF) SetHandoverGuardTimeoutForTest(d time.Duration) { a.handoverGuardTimeout = d }
 
+// FireHandoverGuardForTest runs the handover guard's abandon action synchronously,
+// so a test can drive guard expiry without waiting on the timer. It reports whether
+// the handover was abandoned. Mirrors MME.FireHandoverGuardForTest.
+func (a *AMF) FireHandoverGuardForTest(ue *UeContext) bool { return a.abandonHandover(ue) }
+
 func (ue *UeContext) ArmPagingForTest(d time.Duration, maxRetransmit int32) {
 	ue.pagingTimer.Arm(d, maxRetransmit, func(int32) {}, func() {})
 }

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -100,9 +100,6 @@ func (r *Radio) NumUEsForTest() int {
 
 func (a *AMF) SetHandoverGuardTimeoutForTest(d time.Duration) { a.handoverGuardTimeout = d }
 
-// FireHandoverGuardForTest runs the handover guard's abandon action synchronously,
-// so a test can drive guard expiry without waiting on the timer. It reports whether
-// the handover was abandoned. Mirrors MME.FireHandoverGuardForTest.
 func (a *AMF) FireHandoverGuardForTest(ue *UeContext) bool { return a.abandonHandover(ue) }
 
 func (ue *UeContext) ArmPagingForTest(d time.Duration, maxRetransmit int32) {

--- a/internal/mme/bearer_support.go
+++ b/internal/mme/bearer_support.go
@@ -95,14 +95,11 @@ func (ue *UeContext) ClearPendingModify(p *PdnConnection) {
 	ClearPendingModifyLocked(p)
 }
 
-// BearerReleaseOnly reports whether deactivating p releases only that PDN
-// connection (an additional PDN, or a disconnect) without detaching the UE
-// (TS 24.301 §6.4.4.2/§6.5.2).
 func (ue *UeContext) BearerReleaseOnly(p *PdnConnection) bool {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	return p.Ebi != ue.DefaultEBI || p.Disconnecting
+	return len(ue.Pdns) > 1 || p.Disconnecting
 }
 
 func (ue *UeContext) BearerDeactivating(p *PdnConnection) bool {

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -11,6 +11,27 @@ import (
 	"go.uber.org/zap"
 )
 
+// DetachUEAfterPathSwitchFailure performs the explicit detach TS 23.401 §5.5.1.1.2
+// step 6 requires when no default EPS bearer could be switched during an X2 path
+// switch. The UE has already moved to the target cell over the radio and now has no
+// usable path there, so no association can carry a NAS DETACH REQUEST: the detach is
+// local, and the UE re-attaches (TS 24.301 §5.5.2.3.1).
+//
+// There is no 5G counterpart: TS 23.502 §4.9.1.2 requires only the PATH SWITCH
+// REQUEST FAILURE, leaving the UE's fate to the RAN.
+func (m *MME) DetachUEAfterPathSwitchFailure(ctx context.Context, ue *UeContext) {
+	if ue == nil {
+		return
+	}
+
+	logger.From(ctx, logger.MmeLog).Warn("detaching UE: no EPS bearer could be switched during path switch",
+		zap.String("imsi", ue.IMSI()))
+
+	ue.TransitionTo(EMMDeregistered)
+	m.ReleaseAllSessions(ctx, ue)
+	m.RemoveUe(ue)
+}
+
 // DetachSubscriber sends a network-initiated DETACH REQUEST (TS 24.301)
 // to the attached UE for imsi, if any, when a subscriber is deleted. The
 // request is guarded by T3422: if the UE does not reply with Detach Accept it

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -8,14 +8,23 @@ import (
 
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
 )
 
-// DetachUEAfterPathSwitchFailure performs the explicit detach TS 23.401 §5.5.1.1.2
-// step 6 requires when no default EPS bearer could be switched during an X2 path
-// switch. The UE has already moved to the target cell over the radio and now has no
-// usable path there, so no association can carry a NAS DETACH REQUEST: the detach is
-// local, and the UE re-attaches (TS 24.301 §5.5.2.3.1).
+// DetachUEAfterPathSwitchFailure performs the detach TS 23.401 §5.5.1.1.2 step 6
+// requires when no default EPS bearer could be switched during an X2 path switch.
+//
+// No NAS DETACH REQUEST is sent: the UE has already left the source cell over the
+// radio, and the target has no path for it, so the message would not arrive. The
+// detach is therefore local to the MME, which TS 24.301 §5.5.2.3.1 recognises — the UE
+// is denied with EMM cause #10 "implicitly detached" at its next contact.
+//
+// The source eNB's UE-associated S1 connection is still up and must be commanded to
+// release: the UE's MME-UE-S1AP-ID is recycled, so leaving it would have the eNB
+// addressing a context the MME has deleted. Deregistering first makes that release a
+// teardown rather than a drop to ECM-IDLE; the Release Complete frees the sessions and
+// the context, and the release guard covers a Complete that never arrives.
 //
 // There is no 5G counterpart: TS 23.502 §4.9.1.2 requires only the PATH SWITCH
 // REQUEST FAILURE, leaving the UE's fate to the RAN.
@@ -28,8 +37,7 @@ func (m *MME) DetachUEAfterPathSwitchFailure(ctx context.Context, ue *UeContext)
 		zap.String("imsi", ue.IMSI()))
 
 	ue.TransitionTo(EMMDeregistered)
-	m.ReleaseAllSessions(ctx, ue)
-	m.RemoveUe(ue)
+	m.ReleaseUEContext(ctx, ue, s1ap.Cause{Group: s1ap.CauseGroupNAS, Value: s1ap.CauseNASDetach})
 }
 
 // DetachSubscriber sends a network-initiated DETACH REQUEST (TS 24.301)

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -12,22 +12,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// DetachUEAfterPathSwitchFailure performs the detach TS 23.401 §5.5.1.1.2 step 6
-// requires when no default EPS bearer could be switched during an X2 path switch.
-//
-// No NAS DETACH REQUEST is sent: the UE has already left the source cell over the
-// radio, and the target has no path for it, so the message would not arrive. The
-// detach is therefore local to the MME, which TS 24.301 §5.5.2.3.1 recognises — the UE
-// is denied with EMM cause #10 "implicitly detached" at its next contact.
-//
-// The source eNB's UE-associated S1 connection is still up and must be commanded to
-// release: the UE's MME-UE-S1AP-ID is recycled, so leaving it would have the eNB
-// addressing a context the MME has deleted. Deregistering first makes that release a
-// teardown rather than a drop to ECM-IDLE; the Release Complete frees the sessions and
-// the context, and the release guard covers a Complete that never arrives.
-//
-// There is no 5G counterpart: TS 23.502 §4.9.1.2 requires only the PATH SWITCH
-// REQUEST FAILURE, leaving the UE's fate to the RAN.
 func (m *MME) DetachUEAfterPathSwitchFailure(ctx context.Context, ue *UeContext) {
 	if ue == nil {
 		return
@@ -40,22 +24,12 @@ func (m *MME) DetachUEAfterPathSwitchFailure(ctx context.Context, ue *UeContext)
 	m.ReleaseUEContext(ctx, ue, s1ap.Cause{Group: s1ap.CauseGroupNAS, Value: s1ap.CauseNASDetach})
 }
 
-// DetachSubscriber sends a network-initiated DETACH REQUEST (TS 24.301)
-// to the attached UE for imsi, if any, when a subscriber is deleted. The
-// request is guarded by T3422: if the UE does not reply with Detach Accept it
-// is retransmitted, and on exhaustion the UE context is released regardless, so
-// a silent UE cannot leak the context.
 func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 	ue, ok := m.LookupUeByIMSI(imsi)
 	if !ok {
 		return
 	}
 
-	// An idle UE (ECM-IDLE) holds no S1 connection to carry the DETACH REQUEST, so
-	// release its sessions and context locally. The deleted subscriber fails
-	// authentication at its next contact. The connection is snapshotted, not
-	// re-read: this runs on the API goroutine, so a concurrent release could nil
-	// ue.Conn() between the unlocked calls below.
 	ueConn := ue.Conn()
 	if ueConn == nil || !m.UeConnected(ue) {
 		ue.TransitionTo(EMMDeregistered)
@@ -66,10 +40,6 @@ func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 		return
 	}
 
-	// A connected UE with no security context cannot be sent a protected DETACH
-	// REQUEST, so perform a local detach. Local detach is spec-recognised
-	// (TS 24.301 §5.5.2.3.1): the UE is denied with EMM cause #10 "implicitly
-	// detached" at its next contact.
 	if !ue.Secured() {
 		logger.From(ctx, logger.MmeLog).Info("local detach of connected-but-unsecured UE on subscriber deletion",
 			zap.String("imsi", imsi))
@@ -78,8 +48,6 @@ func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 		return
 	}
 
-	// The connected UE is asked to detach; T3422 guards the DETACH REQUEST and the
-	// UE stays EMM-DEREGISTERED-INITIATED until it accepts or the guard exhausts.
 	ue.TransitionTo(EMMDeregistrationInitiated)
 
 	logger.From(ctx, ueConn.Log).Info("network-initiated detach (subscriber deleted)",

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -40,9 +40,6 @@ type handoverContext struct {
 	target      *UeConn // its ENBUES1APID is learned from the acknowledge
 	admitted    []AdmittedERAB
 	releaseEBIs []uint8 // bearers the target rejected, released at notify (TS 23.401 §5.5.1.2.2 step 15)
-	// {NH, NCC} for the target, advanced at preparation, committed at notify (TS 33.401 §7.2.8).
-	newNH  [32]byte
-	newNCC uint8
 }
 
 // PrepareHandover allocates a target association, advances the {NH, NCC} chain, and
@@ -60,9 +57,19 @@ func (m *MME) PrepareHandover(ue *UeContext, target S1APWriter, reqMMEID s1ap.MM
 		return 0, [32]byte{}, 0, false
 	}
 
+	// TS 33.401 §7.2.8.4.3: "Upon reception of the HANDOVER REQUIRED message the source
+	// MME shall increase its locally kept NCC value by one and compute a fresh NH from
+	// its stored data." The increment is unconditional and is committed here, not on
+	// completion: the pair goes to the target in the HANDOVER REQUEST, so rolling it
+	// back would let a later handover hand the same {NH, NCC} to a second eNB.
 	ue.mu.Lock()
+
 	newNH, err := deriveNH(ue.kasme, ue.nh[:])
-	newNCC = (ue.ncc + 1) & 0x07
+	if err == nil {
+		ue.nh = newNH
+		ue.ncc = (ue.ncc + 1) & 0x07
+		newNCC = ue.ncc
+	}
 	ue.mu.Unlock()
 
 	if err != nil {
@@ -90,8 +97,6 @@ func (m *MME) PrepareHandover(ue *UeContext, target S1APWriter, reqMMEID s1ap.MM
 		state:  hoPreparing,
 		source: ue.Conn(),
 		target: targetConn,
-		newNH:  newNH,
-		newNCC: newNCC,
 	}
 	ue.handover = ho
 
@@ -190,9 +195,9 @@ func (m *MME) MarkHandoverCommitting(ue *UeContext, conn S1APWriter, notifyENBID
 	return ho.admitted, ho.releaseEBIs, true
 }
 
-// FinishHandoverCommit commits the {NH, NCC} chain, switches the UE's active S1
-// connection to the target, detaches the source, and clears the handover
-// (TS 36.413 §8.4.3, TS 33.401 §7.2.8). It returns the source association to
+// FinishHandoverCommit switches the UE's active S1 connection to the target, detaches
+// the source, and clears the handover (TS 36.413 §8.4.3). The {NH, NCC} chain was
+// already advanced at preparation. It returns the source association to
 // release. ok is false if a concurrent release tore the UE down during the switch.
 func (m *MME) FinishHandoverCommit(ue *UeContext, conn S1APWriter, notifyENBID s1ap.ENBUES1APID) (sourceConn S1APWriter, sourceMMEID s1ap.MMEUES1APID, sourceENBID s1ap.ENBUES1APID, targetMMEID s1ap.MMEUES1APID, ok bool) {
 	m.mu.Lock()
@@ -204,11 +209,6 @@ func (m *MME) FinishHandoverCommit(ue *UeContext, conn S1APWriter, notifyENBID s
 	}
 
 	source := ho.source
-
-	ue.mu.Lock()
-	ue.nh = ho.newNH
-	ue.ncc = ho.newNCC
-	ue.mu.Unlock()
 
 	ue.active.Store(ho.target)
 	source.ue = nil // its Release Complete removes the connection

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -57,11 +57,6 @@ func (m *MME) PrepareHandover(ue *UeContext, target S1APWriter, reqMMEID s1ap.MM
 		return 0, [32]byte{}, 0, false
 	}
 
-	// TS 33.401 §7.2.8.4.3: "Upon reception of the HANDOVER REQUIRED message the source
-	// MME shall increase its locally kept NCC value by one and compute a fresh NH from
-	// its stored data." The increment is unconditional and is committed here, not on
-	// completion: the pair goes to the target in the HANDOVER REQUEST, so rolling it
-	// back would let a later handover hand the same {NH, NCC} to a second eNB.
 	ue.mu.Lock()
 
 	newNH, err := deriveNH(ue.kasme, ue.nh[:])

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -190,10 +190,6 @@ func (m *MME) MarkHandoverCommitting(ue *UeContext, conn S1APWriter, notifyENBID
 	return ho.admitted, ho.releaseEBIs, true
 }
 
-// FinishHandoverCommit switches the UE's active S1 connection to the target, detaches
-// the source, and clears the handover (TS 36.413 §8.4.3). The {NH, NCC} chain was
-// already advanced at preparation. It returns the source association to
-// release. ok is false if a concurrent release tore the UE down during the switch.
 func (m *MME) FinishHandoverCommit(ue *UeContext, conn S1APWriter, notifyENBID s1ap.ENBUES1APID) (sourceConn S1APWriter, sourceMMEID s1ap.MMEUES1APID, sourceENBID s1ap.ENBUES1APID, targetMMEID s1ap.MMEUES1APID, ok bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/mme/handover_bearers.go
+++ b/internal/mme/handover_bearers.go
@@ -10,34 +10,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// EnsureDefaultPDN promotes the lowest surviving admitted PDN to the UE's default
-// when a partial-admission handover released the attach-default PDN, so a registered
-// UE keeps EPS last-resort connectivity (TS 23.401).
-func EnsureDefaultPDN(ue *UeContext, admitted []AdmittedERAB) {
-	ue.mu.Lock()
-	defer ue.mu.Unlock()
-
-	if ue.DefaultEBI != 0 {
-		return
-	}
-
-	lowest := uint8(0)
-
-	for _, a := range admitted {
-		if _, ok := ue.Pdns[a.Ebi]; !ok {
-			continue
-		}
-
-		if lowest == 0 || a.Ebi < lowest {
-			lowest = a.Ebi
-		}
-	}
-
-	if lowest != 0 {
-		ue.DefaultEBI = lowest
-	}
-}
-
 // HandoverBearers snapshots the UE's PDN connections into the E-RABs To Be Setup
 // list of a HANDOVER REQUEST (TS 36.413 §9.1.5.4), reporting false when the UE has
 // no usable bearer.

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -55,8 +55,7 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	}
 
 	accept, err := trackingAreaUpdateAccept(ctx, m, ue, tauAcceptOptions{
-		combined:            isCombinedUpdate(uint8(req.EPSUpdateType)),
-		includeBearerStatus: req.EPSBearerContextStatus != nil,
+		combined: isCombinedUpdate(uint8(req.EPSUpdateType)),
 	})
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build Tracking Area Update Accept", zap.String("imsi", ue.IMSI()), zap.Error(err))
@@ -190,12 +189,8 @@ func isCombinedUpdate(updateType uint8) bool {
 	return updateType == 1 || updateType == 2
 }
 
-// tauAcceptOptions selects the optional parts of a TRACKING AREA UPDATE ACCEPT:
-// combined for a combined EPS/IMSI update, includeBearerStatus to echo the UE's
-// EPS bearer context status (TS 24.301).
 type tauAcceptOptions struct {
-	combined            bool
-	includeBearerStatus bool
+	combined bool
 }
 
 // trackingAreaUpdateAccept builds a TRACKING AREA UPDATE ACCEPT with the operator's
@@ -243,10 +238,8 @@ func trackingAreaUpdateAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		accept.Cause = &cause
 	}
 
-	if opts.includeBearerStatus {
-		status := bearerContextStatus(m, ue)
-		accept.EPSBearerContextStatus = &status
-	}
+	status := bearerContextStatus(m, ue)
+	accept.EPSBearerContextStatus = &status
 
 	return accept, nil
 }

--- a/internal/mme/reconcile_bearers.go
+++ b/internal/mme/reconcile_bearers.go
@@ -11,8 +11,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// RANBearer is one E-RAB the eNB reports it holds, with the downlink endpoint the
-// core must forward to.
 type RANBearer struct {
 	Ebi      uint8
 	EnbFTEID models.FTEID
@@ -37,8 +35,6 @@ func (m *MME) ReconcileBearersToRAN(ctx context.Context, ue *UeContext, want RAN
 		return result
 	}
 
-	// Everything the eNB named, so an authoritative message can tell which of the
-	// UE's remaining bearers it left out.
 	named := make(map[uint8]struct{}, len(want.Present)+len(want.Rejected))
 
 	for _, b := range want.Present {
@@ -46,7 +42,6 @@ func (m *MME) ReconcileBearersToRAN(ctx context.Context, ue *UeContext, want RAN
 
 		p := m.LookupPDN(ue, b.Ebi)
 		if p == nil {
-			// The eNB holds a bearer the core has no context for; it must drop it.
 			logger.From(ctx, logger.MmeLog).Warn("RAN reports an E-RAB the core does not know; not switched",
 				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", b.Ebi))
 
@@ -59,8 +54,6 @@ func (m *MME) ReconcileBearersToRAN(ctx context.Context, ue *UeContext, want RAN
 			logger.From(ctx, logger.MmeLog).Error("failed to switch an EPS session downlink to the RAN endpoint",
 				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", b.Ebi), zap.Error(err))
 
-			// The bearer has no usable downlink: free its core resources rather than
-			// leaving a session pointed at an eNB the UE has left.
 			m.ReleasePDN(ctx, ue, p)
 
 			result.Failed = append(result.Failed, b.Ebi)
@@ -98,28 +91,5 @@ func (m *MME) ReconcileBearersToRAN(ctx context.Context, ue *UeContext, want RAN
 		}
 	}
 
-	m.ensureDefaultBearer(ue)
-
 	return result
-}
-
-// ensureDefaultBearer re-elects the default EPS bearer when the previous one is
-// gone, promoting the lowest surviving EBI. Without it a UE can hold bearers with
-// DefaultEBI zeroed, which silently makes every bearer look releasable on its own
-// and stops a last-bearer release from ever detaching the UE (TS 24.301).
-func (m *MME) ensureDefaultBearer(ue *UeContext) {
-	ue.mu.Lock()
-	defer ue.mu.Unlock()
-
-	if _, ok := ue.Pdns[ue.DefaultEBI]; ok && ue.DefaultEBI != 0 {
-		return
-	}
-
-	ue.DefaultEBI = 0
-
-	for ebi := range ue.Pdns {
-		if ue.DefaultEBI == 0 || ebi < ue.DefaultEBI {
-			ue.DefaultEBI = ebi
-		}
-	}
 }

--- a/internal/mme/reconcile_bearers.go
+++ b/internal/mme/reconcile_bearers.go
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"go.uber.org/zap"
+)
+
+// RANBearer is one E-RAB the eNB reports it holds, with the downlink endpoint the
+// core must forward to.
+type RANBearer struct {
+	Ebi      uint8
+	EnbFTEID models.FTEID
+}
+
+// RANBearers is an eNB's view of a UE's bearer set, as carried by one S1AP message.
+//
+// Authoritative distinguishes the two kinds of message 3GPP defines. A PATH SWITCH
+// REQUEST or a completed handover names *everything* the eNB holds, so an E-RAB in
+// the UE context that appears in neither list has been implicitly released by the
+// eNB (TS 36.413 §8.4.4.2, TS 23.401 §5.5.1.1.2 step 2). An E-RAB SETUP RESPONSE
+// names only the bearers its own procedure set up and says nothing about the rest.
+// Treating the first kind as if it were the second silently strands bearers whose
+// downlink still points at the source eNB.
+type RANBearers struct {
+	Present       []RANBearer
+	Rejected      []uint8
+	Authoritative bool
+}
+
+// RANBearerResult reports the outcome per E-RAB. Failed is what the caller reports
+// back to the eNB — in the PATH SWITCH REQUEST ACKNOWLEDGE E-RAB To Be Released
+// List, for instance — so it releases the matching data radio bearers.
+type RANBearerResult struct {
+	Applied  []uint8
+	Failed   []uint8
+	Released []uint8
+}
+
+// ReconcileBearersToRAN converges a UE's PDN connections onto the bearer set an eNB
+// reports, and is the single place that does so: every S1AP message that carries a
+// bearer set drives this, so the ordering, locking and cleanup rules below hold once
+// rather than per handler.
+//
+//   - a bearer the eNB holds has its anchor downlink switched first and its stored
+//     endpoint written second, under the UE lock, only on success — so the context
+//     never claims a path the anchor does not have;
+//   - a bearer the eNB rejected, or that the core could not converge, has its
+//     core-network resources released (TS 23.401 §5.5.1.1.2 step 6) rather than only
+//     being reported;
+//   - on an authoritative message, a bearer absent from both lists is released too;
+//   - the default bearer is re-elected over the survivors, so a UE never keeps
+//     bearers with no default among them.
+//
+// The caller keeps what is procedure-specific: rejecting duplicate E-RAB IDs with
+// the right cause, choosing the response message, and deciding what a total failure
+// means.
+func (m *MME) ReconcileBearersToRAN(ctx context.Context, ue *UeContext, want RANBearers) RANBearerResult {
+	var result RANBearerResult
+
+	if ue == nil {
+		return result
+	}
+
+	// Everything the eNB named, so an authoritative message can tell which of the
+	// UE's remaining bearers it left out.
+	named := make(map[uint8]struct{}, len(want.Present)+len(want.Rejected))
+
+	for _, b := range want.Present {
+		named[b.Ebi] = struct{}{}
+
+		p := m.LookupPDN(ue, b.Ebi)
+		if p == nil {
+			// The eNB holds a bearer the core has no context for; it must drop it.
+			logger.From(ctx, logger.MmeLog).Warn("RAN reports an E-RAB the core does not know; not switched",
+				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", b.Ebi))
+
+			result.Failed = append(result.Failed, b.Ebi)
+
+			continue
+		}
+
+		if err := m.Session.ModifyEPSSession(ctx, ue.IMSI(), b.Ebi, b.EnbFTEID); err != nil {
+			logger.From(ctx, logger.MmeLog).Error("failed to switch an EPS session downlink to the RAN endpoint",
+				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", b.Ebi), zap.Error(err))
+
+			// The bearer has no usable downlink: free its core resources rather than
+			// leaving a session pointed at an eNB the UE has left.
+			m.ReleasePDN(ctx, ue, p)
+
+			result.Failed = append(result.Failed, b.Ebi)
+			result.Released = append(result.Released, b.Ebi)
+
+			continue
+		}
+
+		m.SetPDNEnbFTEID(ue, p, b.EnbFTEID)
+
+		result.Applied = append(result.Applied, b.Ebi)
+	}
+
+	for _, ebi := range want.Rejected {
+		named[ebi] = struct{}{}
+
+		if p := m.LookupPDN(ue, ebi); p != nil {
+			m.ReleasePDN(ctx, ue, p)
+
+			result.Released = append(result.Released, ebi)
+		}
+	}
+
+	if want.Authoritative {
+		for _, p := range m.SnapshotPDNs(ue) {
+			if _, ok := named[p.Ebi]; ok {
+				continue
+			}
+
+			logger.From(ctx, logger.MmeLog).Info("releasing an E-RAB the RAN did not report; implicitly released",
+				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", p.Ebi))
+
+			m.ReleasePDN(ctx, ue, p)
+			result.Released = append(result.Released, p.Ebi)
+		}
+	}
+
+	m.ensureDefaultBearer(ue)
+
+	return result
+}
+
+// ensureDefaultBearer re-elects the default EPS bearer when the previous one is
+// gone, promoting the lowest surviving EBI. Without it a UE can hold bearers with
+// DefaultEBI zeroed, which silently makes every bearer look releasable on its own
+// and stops a last-bearer release from ever detaching the UE (TS 24.301).
+func (m *MME) ensureDefaultBearer(ue *UeContext) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if _, ok := ue.Pdns[ue.DefaultEBI]; ok && ue.DefaultEBI != 0 {
+		return
+	}
+
+	ue.DefaultEBI = 0
+
+	for ebi := range ue.Pdns {
+		if ue.DefaultEBI == 0 || ebi < ue.DefaultEBI {
+			ue.DefaultEBI = ebi
+		}
+	}
+}
+
+// DuplicateEBI reports the first EPS bearer identity that appears more than once.
+// Several S1AP procedures make a repeated E-RAB ID an abnormal condition but answer
+// it differently, so detection is shared and the response stays with the caller
+// (TS 36.413 §8.4.4.4, §8.2.4.4).
+func DuplicateEBI(ebis []uint8) (uint8, bool) {
+	seen := make(map[uint8]struct{}, len(ebis))
+
+	for _, ebi := range ebis {
+		if _, ok := seen[ebi]; ok {
+			return ebi, true
+		}
+
+		seen[ebi] = struct{}{}
+	}
+
+	return 0, false
+}

--- a/internal/mme/reconcile_bearers.go
+++ b/internal/mme/reconcile_bearers.go
@@ -18,48 +18,18 @@ type RANBearer struct {
 	EnbFTEID models.FTEID
 }
 
-// RANBearers is an eNB's view of a UE's bearer set, as carried by one S1AP message.
-//
-// Authoritative distinguishes the two kinds of message 3GPP defines. A PATH SWITCH
-// REQUEST or a completed handover names *everything* the eNB holds, so an E-RAB in
-// the UE context that appears in neither list has been implicitly released by the
-// eNB (TS 36.413 §8.4.4.2, TS 23.401 §5.5.1.1.2 step 2). An E-RAB SETUP RESPONSE
-// names only the bearers its own procedure set up and says nothing about the rest.
-// Treating the first kind as if it were the second silently strands bearers whose
-// downlink still points at the source eNB.
 type RANBearers struct {
 	Present       []RANBearer
 	Rejected      []uint8
 	Authoritative bool
 }
 
-// RANBearerResult reports the outcome per E-RAB. Failed is what the caller reports
-// back to the eNB — in the PATH SWITCH REQUEST ACKNOWLEDGE E-RAB To Be Released
-// List, for instance — so it releases the matching data radio bearers.
 type RANBearerResult struct {
 	Applied  []uint8
 	Failed   []uint8
 	Released []uint8
 }
 
-// ReconcileBearersToRAN converges a UE's PDN connections onto the bearer set an eNB
-// reports, and is the single place that does so: every S1AP message that carries a
-// bearer set drives this, so the ordering, locking and cleanup rules below hold once
-// rather than per handler.
-//
-//   - a bearer the eNB holds has its anchor downlink switched first and its stored
-//     endpoint written second, under the UE lock, only on success — so the context
-//     never claims a path the anchor does not have;
-//   - a bearer the eNB rejected, or that the core could not converge, has its
-//     core-network resources released (TS 23.401 §5.5.1.1.2 step 6) rather than only
-//     being reported;
-//   - on an authoritative message, a bearer absent from both lists is released too;
-//   - the default bearer is re-elected over the survivors, so a UE never keeps
-//     bearers with no default among them.
-//
-// The caller keeps what is procedure-specific: rejecting duplicate E-RAB IDs with
-// the right cause, choosing the response message, and deciding what a total failure
-// means.
 func (m *MME) ReconcileBearersToRAN(ctx context.Context, ue *UeContext, want RANBearers) RANBearerResult {
 	var result RANBearerResult
 

--- a/internal/mme/reconcile_bearers.go
+++ b/internal/mme/reconcile_bearers.go
@@ -153,21 +153,3 @@ func (m *MME) ensureDefaultBearer(ue *UeContext) {
 		}
 	}
 }
-
-// DuplicateEBI reports the first EPS bearer identity that appears more than once.
-// Several S1AP procedures make a repeated E-RAB ID an abnormal condition but answer
-// it differently, so detection is shared and the response stays with the caller
-// (TS 36.413 §8.4.4.4, §8.2.4.4).
-func DuplicateEBI(ebis []uint8) (uint8, bool) {
-	seen := make(map[uint8]struct{}, len(ebis))
-
-	for _, ebi := range ebis {
-		if _, ok := seen[ebi]; ok {
-			return ebi, true
-		}
-
-		seen[ebi] = struct{}{}
-	}
-
-	return 0, false
-}

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -103,12 +103,22 @@ func parseUEContextReleaseCommand(t *testing.T, pdu []byte) *s1ap.UEContextRelea
 	return cmd
 }
 
-// fakeSessionManager stands in for the SMF+PGW-C anchor.
 type fakeSessionManager struct {
-	lastRequest models.EPSBearerRequest
-	modifiedENB models.FTEID
-	released    bool
-	deactivated bool
+	lastRequest  models.EPSBearerRequest
+	modifiedENB  models.FTEID
+	released     bool
+	deactivated  bool
+	modifyErr    map[uint8]error
+	modifiedEBIs []uint8
+	releasedRefs []string
+}
+
+func (f *fakeSessionManager) failModify(ebi uint8, err error) {
+	if f.modifyErr == nil {
+		f.modifyErr = make(map[uint8]error)
+	}
+
+	f.modifyErr[ebi] = err
 }
 
 func (f *fakeSessionManager) CreateEPSSession(_ context.Context, req models.EPSBearerRequest) (models.EPSBearer, error) {
@@ -127,8 +137,13 @@ func (f *fakeSessionManager) CreateEPSSession(_ context.Context, req models.EPSB
 	return bearer, nil
 }
 
-func (f *fakeSessionManager) ModifyEPSSession(_ context.Context, _ string, _ uint8, enb models.FTEID) error {
+func (f *fakeSessionManager) ModifyEPSSession(_ context.Context, _ string, ebi uint8, enb models.FTEID) error {
+	if err, ok := f.modifyErr[ebi]; ok {
+		return err
+	}
+
 	f.modifiedENB = enb
+	f.modifiedEBIs = append(f.modifiedEBIs, ebi)
 
 	return nil
 }
@@ -151,8 +166,9 @@ func (f *fakeSessionManager) ClearEPSPagingSuppression(_ context.Context, _ stri
 	return nil
 }
 
-func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) error {
+func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, ref string) error {
 	f.released = true
+	f.releasedRefs = append(f.releasedRefs, ref)
 
 	return nil
 }

--- a/internal/mme/s1ap/handle_erab_modification_indication.go
+++ b/internal/mme/s1ap/handle_erab_modification_indication.go
@@ -80,21 +80,10 @@ func handleERABModificationIndication(m *mme.MME, ctx context.Context, radio *mm
 	m.SendToRadio(ctx, radio.Conn, mme.S1APProcedureERABModificationConfirm, b)
 }
 
-// modifyBearerDownlinks relocates each listed E-RAB's downlink to the eNB S1-U
-// endpoint it names, returning the E-RABs successfully relocated. Reuses the same
-// user-plane path as a Path Switch (TS 36.413 §8.2.4.2).
 func modifyBearerDownlinks(m *mme.MME, ctx context.Context, ue *mme.UeContext, items []s1ap.ERABToBeModifiedItemBearerModInd) []s1ap.ERABID {
-	var modified []s1ap.ERABID
+	present := make([]mme.RANBearer, 0, len(items))
 
 	for _, erab := range items {
-		p := m.LookupPDN(ue, uint8(erab.ERABID))
-		if p == nil {
-			logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication lists an unknown E-RAB; skipped",
-				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
-
-			continue
-		}
-
 		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
 		if !ok {
 			logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication has an invalid eNB transport address; skipped",
@@ -103,21 +92,17 @@ func modifyBearerDownlinks(m *mme.MME, ctx context.Context, ue *mme.UeContext, i
 			continue
 		}
 
-		fteid := models.FTEID{TEID: uint32(erab.DLGTPTEID), Addr: addr}
+		present = append(present, mme.RANBearer{
+			Ebi:      uint8(erab.ERABID),
+			EnbFTEID: models.FTEID{TEID: uint32(erab.DLGTPTEID), Addr: addr},
+		})
+	}
 
-		if err := m.Session.ModifyEPSSession(ctx, ue.IMSI(), p.Ebi, fteid); err != nil {
-			logger.From(ctx, logger.MmeLog).Error("failed to relocate an E-RAB downlink",
-				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)), zap.Error(err))
+	result := m.ReconcileBearersToRAN(ctx, ue, mme.RANBearers{Present: present})
 
-			continue
-		}
-
-		p.EnbFTEID = fteid
-
-		modified = append(modified, erab.ERABID)
-
-		logger.From(ctx, logger.MmeLog).Debug("E-RAB downlink relocated",
-			zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)), zap.String("enb-s1u", addr.String()))
+	modified := make([]s1ap.ERABID, 0, len(result.Applied))
+	for _, ebi := range result.Applied {
+		modified = append(modified, s1ap.ERABID(ebi))
 	}
 
 	return modified

--- a/internal/mme/s1ap/handle_erab_setup_response.go
+++ b/internal/mme/s1ap/handle_erab_setup_response.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/mme"
-	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
 )
@@ -33,42 +32,23 @@ func HandleERABSetupResponse(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	ue.TouchLastSeen()
 	captureUserLocation(ueConn, msg.UserLocationInformation)
 
-	for _, erab := range msg.ERABSetup {
-		p := m.LookupPDN(ue, uint8(erab.ERABID))
-		if p == nil {
-			ueConn.Log.Warn("E-RAB Setup Response for an unknown E-RAB",
-				zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+	result := m.ReconcileBearersToRAN(ctx, ue, mme.RANBearers{
+		Present:  setupBearers(ctx, ueConn.MMEUES1APID, bearerSetupBearers(msg.ERABSetup)),
+		Rejected: failedERABIDs(msg.ERABFailedToSetup),
+	})
 
-			continue
-		}
+	logger.MmeLog.Info("additional PDN connection radio legs reconciled",
+		zap.String("imsi", ue.IMSI()),
+		zap.Int("e-rabs-setup", len(result.Applied)),
+		zap.Int("e-rabs-released", len(result.Released)))
+}
 
-		enbAddr, ok := enbTransportAddress(erab.TransportLayerAddress)
-		if !ok {
-			ueConn.Log.Warn("E-RAB Setup Response with an invalid eNB transport address",
-				zap.Uint8("e-rab-id", uint8(erab.ERABID)))
-
-			continue
-		}
-
-		p.EnbFTEID = models.FTEID{TEID: uint32(erab.GTPTEID), Addr: enbAddr}
-
-		if err := m.Session.ModifyEPSSession(ctx, ue.IMSI(), p.Ebi, p.EnbFTEID); err != nil {
-			logger.MmeLog.Error("failed to set the eNB F-TEID on the additional EPS session",
-				zap.String("imsi", ue.IMSI()), zap.Uint8("ebi", p.Ebi), zap.Error(err))
-
-			continue
-		}
-
-		logger.MmeLog.Info("additional PDN connection radio leg established",
-			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn), zap.Uint8("ebi", p.Ebi),
-			zap.String("enb-s1u", enbAddr.String()))
+// bearerSetupBearers projects an E-RAB SETUP RESPONSE setup list.
+func bearerSetupBearers(items []s1ap.ERABSetupItemBearerSURes) []setupBearer {
+	out := make([]setupBearer, 0, len(items))
+	for _, e := range items {
+		out = append(out, setupBearer{ERABID: e.ERABID, TransportLayerAddress: e.TransportLayerAddress, GTPTEID: e.GTPTEID})
 	}
 
-	for _, erab := range msg.ERABFailedToSetup {
-		if p := m.LookupPDN(ue, uint8(erab.ERABID)); p != nil {
-			logger.MmeLog.Warn("eNB failed to set up an additional E-RAB; releasing the PDN connection",
-				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
-			m.ReleasePDN(ctx, ue, p)
-		}
-	}
+	return out
 }

--- a/internal/mme/s1ap/handle_handover_notify.go
+++ b/internal/mme/s1ap/handle_handover_notify.go
@@ -41,35 +41,16 @@ func handleHandoverNotify(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 		return
 	}
 
-	// Switch the downlink only at notify (TS 23.401 §5.5.1.2.2 step 15).
+	present := make([]mme.RANBearer, 0, len(admitted))
 	for _, a := range admitted {
-		p := m.LookupPDN(ue, a.Ebi)
-		if p == nil {
-			continue
-		}
-
-		if err := m.Session.ModifyEPSSession(ctx, ue.IMSI(), a.Ebi, a.EnbFTEID); err != nil {
-			logger.From(ctx, logger.MmeLog).Error("failed to switch an EPS session downlink to the target eNB",
-				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", a.Ebi), zap.Error(err))
-
-			continue
-		}
-
-		m.SetPDNEnbFTEID(ue, p, a.EnbFTEID)
+		present = append(present, mme.RANBearer(a))
 	}
 
-	for _, ebi := range releaseEBIs {
-		if p := m.LookupPDN(ue, ebi); p != nil {
-			if err := m.Session.ReleaseEPSSession(ctx, p.SessionRef); err != nil {
-				logger.From(ctx, logger.MmeLog).Error("failed to release a rejected PDN connection after handover",
-					zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", ebi), zap.Error(err))
-			}
-		}
-
-		m.DropPDN(ue, ebi)
-	}
-
-	mme.EnsureDefaultPDN(ue, admitted)
+	m.ReconcileBearersToRAN(ctx, ue, mme.RANBearers{
+		Present:       present,
+		Rejected:      releaseEBIs,
+		Authoritative: true,
+	})
 
 	sourceConn, sourceMMEID, sourceENBID, targetMMEID, ok := m.FinishHandoverCommit(ue, radio.Conn, notify.ENBUES1APID)
 	if !ok {

--- a/internal/mme/s1ap/handle_initial_context_setup_response.go
+++ b/internal/mme/s1ap/handle_initial_context_setup_response.go
@@ -51,60 +51,19 @@ func handleInitialContextSetupResponse(m *mme.MME, ctx context.Context, radio *m
 
 	ue.TouchLastSeen()
 
-	// Tear down bearers the eNB failed to set up (TS 36.413 §8.3.1.2).
-	for _, erab := range msg.ERABFailedToSetup {
-		if p := m.LookupPDN(ue, uint8(erab.ERABID)); p != nil {
-			logger.From(ctx, logger.MmeLog).Warn("eNB failed to set up an E-RAB in Initial Context Setup; releasing the PDN connection",
-				zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
-			m.ReleasePDN(ctx, ue, p)
-		}
-	}
+	// Not authoritative: an INITIAL CONTEXT SETUP RESPONSE reports the E-RABs this
+	// procedure set up and says nothing about any other bearer (TS 36.413 §8.3.1.2).
+	result := m.ReconcileBearersToRAN(ctx, ue, mme.RANBearers{
+		Present:  setupBearers(ctx, mmeUEID, ctxtSetupBearers(msg.ERABSetup)),
+		Rejected: failedERABIDs(msg.ERABFailedToSetup),
+	})
 
-	if len(msg.ERABSetup) == 0 {
-		logger.From(ctx, logger.MmeLog).Warn("Initial Context Setup Response without an E-RAB",
-			zap.Uint32("mme-ue-id", uint32(mmeUEID)))
+	setup := len(result.Applied)
 
-		return
-	}
-
-	// Record the eNB S1-U F-TEID for every confirmed E-RAB (TS 36.413). A bad or
-	// unknown E-RAB is skipped, not fatal to the rest.
-	setup := 0
-
-	for _, erab := range msg.ERABSetup {
-		enbAddr, ok := enbTransportAddress(erab.TransportLayerAddress)
-		if !ok {
-			logger.From(ctx, logger.MmeLog).Warn("Initial Context Setup Response with an invalid eNB transport address",
-				zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.Int("erab-id", int(erab.ERABID)))
-
-			continue
-		}
-
-		p := m.LookupPDN(ue, uint8(erab.ERABID))
-		if p == nil {
-			logger.From(ctx, logger.MmeLog).Warn("Initial Context Setup Response for an unknown E-RAB",
-				zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.Int("erab-id", int(erab.ERABID)))
-
-			continue
-		}
-
-		p.EnbFTEID = models.FTEID{TEID: uint32(erab.GTPTEID), Addr: enbAddr}
-
-		if err := m.Session.ModifyEPSSession(ctx, ue.IMSI(), p.Ebi, p.EnbFTEID); err != nil {
-			logger.From(ctx, logger.MmeLog).Error("failed to set the eNB F-TEID on the EPS session",
-				zap.String("imsi", ue.IMSI()), zap.Int("erab-id", int(erab.ERABID)), zap.Error(err))
-
-			continue
-		}
-
-		setup++
-
-		logger.From(ctx, logger.MmeLog).Info("Initial Context Setup Response",
-			zap.Uint32("mme-ue-id", uint32(mmeUEID)),
-			zap.Int("erab-id", int(erab.ERABID)),
-			zap.String("enb-s1u", p.EnbFTEID.Addr.String()),
-		)
-	}
+	logger.From(ctx, logger.MmeLog).Info("Initial Context Setup Response",
+		zap.Uint32("mme-ue-id", uint32(mmeUEID)),
+		zap.Int("e-rabs-setup", setup),
+		zap.Int("e-rabs-released", len(result.Released)))
 
 	if setup == 0 {
 		return
@@ -117,4 +76,61 @@ func handleInitialContextSetupResponse(m *mme.MME, ctx context.Context, radio *m
 	// With the radio bearers up, a pending data-network change becomes deliverable.
 	// ReconcileUE returns early for a UE not yet EMM-REGISTERED (attach).
 	m.ReconcileUE(ctx, ue)
+}
+
+// setupBearer is the part of an E-RAB setup item the core needs. S1AP spells the item
+// differently per message (ERABSetupItemCtxtSURes, ERABSetupItemBearerSURes) with the
+// same three fields, so each caller projects onto this.
+type setupBearer struct {
+	ERABID                s1ap.ERABID
+	TransportLayerAddress s1ap.TransportLayerAddress
+	GTPTEID               s1ap.GTPTEID
+}
+
+// setupBearers decodes an E-RAB setup list into the RAN bearer set the reconciliation
+// primitive consumes. An item whose transport address will not decode names no usable
+// downlink and is dropped; it is absent from the applied set the caller reports.
+func setupBearers(ctx context.Context, mmeUEID s1ap.MMEUES1APID, items []setupBearer) []mme.RANBearer {
+	present := make([]mme.RANBearer, 0, len(items))
+
+	for _, erab := range items {
+		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
+		if !ok {
+			logger.From(ctx, logger.MmeLog).Warn("E-RAB setup item with an invalid eNB transport address",
+				zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+
+			continue
+		}
+
+		present = append(present, mme.RANBearer{
+			Ebi:      uint8(erab.ERABID),
+			EnbFTEID: models.FTEID{TEID: uint32(erab.GTPTEID), Addr: addr},
+		})
+	}
+
+	return present
+}
+
+// failedERABIDs is the EPS bearer identities of an E-RAB failed-to-setup list.
+func failedERABIDs(items []s1ap.ERABItem) []uint8 {
+	if len(items) == 0 {
+		return nil
+	}
+
+	out := make([]uint8, 0, len(items))
+	for _, erab := range items {
+		out = append(out, uint8(erab.ERABID))
+	}
+
+	return out
+}
+
+// ctxtSetupBearers projects an INITIAL CONTEXT SETUP RESPONSE setup list.
+func ctxtSetupBearers(items []s1ap.ERABSetupItemCtxtSURes) []setupBearer {
+	out := make([]setupBearer, 0, len(items))
+	for _, e := range items {
+		out = append(out, setupBearer{ERABID: e.ERABID, TransportLayerAddress: e.TransportLayerAddress, GTPTEID: e.GTPTEID})
+	}
+
+	return out
 }

--- a/internal/mme/s1ap/handle_path_switch_request.go
+++ b/internal/mme/s1ap/handle_path_switch_request.go
@@ -144,11 +144,15 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 		ueConn.UpdateLocation(*req.EUTRANCGI, *req.TAI)
 	}
 
-	ambr := handoverUEAMBR(ue)
+	var ambr *s1ap.UEAggregateMaximumBitRate
+
+	if ul, dl := ue.AmbrRates(); ul.Bps() != 0 || dl.Bps() != 0 {
+		ambr = new(handoverUEAMBR(ue))
+	}
 
 	ack := &s1ap.PathSwitchRequestAcknowledge{
 		SecurityContext:           s1ap.SecurityContext{NextHopChainingCount: ncc, NextHopParameter: s1ap.SecurityKey(newNH)},
-		UEAggregateMaximumBitRate: &ambr,
+		UEAggregateMaximumBitRate: ambr,
 		UESecurityCapabilities:    replayCaps,
 		ERABToBeReleased:          released,
 	}

--- a/internal/mme/s1ap/handle_path_switch_request.go
+++ b/internal/mme/s1ap/handle_path_switch_request.go
@@ -100,7 +100,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 		return
 	}
 
-	present, undecodable := pathSwitchBearers(ctx, ue, mmeID, req.ERABToBeSwitchedDL)
+	present, undecodable := pathSwitchBearers(ctx, mmeID, req.ERABToBeSwitchedDL)
 
 	result := m.ReconcileBearersToRAN(ctx, ue, mme.RANBearers{
 		Present:       present,
@@ -169,7 +169,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	}
 }
 
-func pathSwitchBearers(ctx context.Context, ue *mme.UeContext, mmeID s1ap.MMEUES1APID, items []s1ap.ERABToBeSwitchedDLItem) (present []mme.RANBearer, undecodable []uint8) {
+func pathSwitchBearers(ctx context.Context, mmeID s1ap.MMEUES1APID, items []s1ap.ERABToBeSwitchedDLItem) (present []mme.RANBearer, undecodable []uint8) {
 	present = make([]mme.RANBearer, 0, len(items))
 
 	for _, erab := range items {

--- a/internal/mme/s1ap/handle_path_switch_request.go
+++ b/internal/mme/s1ap/handle_path_switch_request.go
@@ -100,10 +100,22 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 		return
 	}
 
-	switched, released := switchPathBearers(m, ctx, ue, mmeID, req.ERABToBeSwitchedDL)
-	if switched == 0 {
+	present, undecodable := pathSwitchBearers(ctx, ue, mmeID, req.ERABToBeSwitchedDL)
+
+	result := m.ReconcileBearersToRAN(ctx, ue, mme.RANBearers{
+		Present:       present,
+		Rejected:      undecodable,
+		Authoritative: true,
+	})
+
+	released := releasedERABItems(append(result.Failed, undecodable...))
+
+	if len(result.Applied) == 0 {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request switched no E-RAB",
 			zap.Uint32("mme-ue-id", uint32(mmeID)))
+
+		m.DetachUEAfterPathSwitchFailure(ctx, ue)
+
 		sendPathSwitchFailure(m, radio.Conn, req, causePathSwitchUPFailure)
 
 		return
@@ -111,9 +123,6 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 
 	replayCaps := pathSwitchSecurityCapabilities(ue, ueLog, req.UESecurityCapabilities)
 
-	// The UE may have been released during the unlocked switch above, so the commit is
-	// gated on the connection still being present. NCC is a 3-bit chaining counter
-	// (TS 33.401).
 	ncc, ok := m.CommitPathSwitch(ue, radio.Conn, req.ENBUES1APID, newNH, curNCC)
 	if !ok {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request: UE released during the user-plane switch",
@@ -123,8 +132,6 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 		return
 	}
 
-	// The commit rebound the UE to the target association; a release can still
-	// have beaten us to it.
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request: UE released immediately after the path switch",
@@ -137,16 +144,20 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 		ueConn.UpdateLocation(*req.EUTRANCGI, *req.TAI)
 	}
 
+	ambr := handoverUEAMBR(ue)
+
 	ack := &s1ap.PathSwitchRequestAcknowledge{
-		SecurityContext:        s1ap.SecurityContext{NextHopChainingCount: ncc, NextHopParameter: s1ap.SecurityKey(newNH)},
-		UESecurityCapabilities: replayCaps,
-		ERABToBeReleased:       released,
+		SecurityContext:           s1ap.SecurityContext{NextHopChainingCount: ncc, NextHopParameter: s1ap.SecurityKey(newNH)},
+		UEAggregateMaximumBitRate: &ambr,
+		UESecurityCapabilities:    replayCaps,
+		ERABToBeReleased:          released,
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Path Switch Request",
 		zap.Uint32("mme-ue-id", uint32(mmeID)),
 		zap.Uint32("enb-ue-id", uint32(req.ENBUES1APID)),
-		zap.Int("e-rabs-switched", switched),
+		zap.Int("e-rabs-switched", len(result.Applied)),
+		zap.Int("e-rabs-released", len(result.Released)),
 		zap.Uint8("ncc", ncc))
 
 	if err := ueConn.SendPathSwitchAcknowledge(ctx, ack); err != nil {
@@ -154,60 +165,42 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	}
 }
 
-// switchPathBearers switches the downlink of each listed E-RAB to the target eNB.
-// It returns the number switched and the E-RABs whose UP path it could not switch —
-// these must be reported in the PATH SWITCH REQUEST ACKNOWLEDGE E-RAB To Be Released
-// List so the eNB releases their data radio bearers (TS 36.413 §8.4.4.2); otherwise
-// the eNB keeps a radio bearer for an E-RAB with no downlink path (black-holed DL).
-func switchPathBearers(m *mme.MME, ctx context.Context, ue *mme.UeContext, mmeID s1ap.MMEUES1APID, items []s1ap.ERABToBeSwitchedDLItem) (int, []s1ap.ERABItem) {
-	switched := 0
-
-	relCause := s1ap.Cause{Group: s1ap.CauseGroupTransport, Value: s1ap.CauseTransportResourceUnavailable}
-
-	var released []s1ap.ERABItem
+func pathSwitchBearers(ctx context.Context, ue *mme.UeContext, mmeID s1ap.MMEUES1APID, items []s1ap.ERABToBeSwitchedDLItem) (present []mme.RANBearer, undecodable []uint8) {
+	present = make([]mme.RANBearer, 0, len(items))
 
 	for _, erab := range items {
-		p := m.LookupPDN(ue, uint8(erab.ERABID))
-		if p == nil {
-			logger.From(ctx, logger.MmeLog).Warn("Path Switch Request lists an unknown E-RAB; not switched",
-				zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
-
-			released = append(released, s1ap.ERABItem{ERABID: erab.ERABID, Cause: relCause})
-
-			continue
-		}
-
 		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
 		if !ok {
 			logger.From(ctx, logger.MmeLog).Warn("Path Switch Request E-RAB has an invalid eNB transport address; not switched",
 				zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
-			released = append(released, s1ap.ERABItem{ERABID: erab.ERABID, Cause: relCause})
+			undecodable = append(undecodable, uint8(erab.ERABID))
 
 			continue
 		}
 
-		fteid := models.FTEID{TEID: uint32(erab.GTPTEID), Addr: addr}
-
-		if err := m.Session.ModifyEPSSession(ctx, ue.IMSI(), p.Ebi, fteid); err != nil {
-			logger.From(ctx, logger.MmeLog).Error("failed to switch an EPS session downlink to the target eNB",
-				zap.String("imsi", ue.IMSI()), zap.Uint8("e-rab-id", uint8(erab.ERABID)), zap.Error(err))
-
-			released = append(released, s1ap.ERABItem{ERABID: erab.ERABID, Cause: relCause})
-
-			continue
-		}
-
-		p.EnbFTEID = fteid
-		switched++
-
-		logger.From(ctx, logger.MmeLog).Debug("Path Switch: E-RAB downlink switched",
-			zap.Uint32("mme-ue-id", uint32(mmeID)),
-			zap.Uint8("e-rab-id", uint8(erab.ERABID)),
-			zap.String("enb-s1u", addr.String()))
+		present = append(present, mme.RANBearer{
+			Ebi:      uint8(erab.ERABID),
+			EnbFTEID: models.FTEID{TEID: uint32(erab.GTPTEID), Addr: addr},
+		})
 	}
 
-	return switched, released
+	return present, undecodable
+}
+
+func releasedERABItems(failed []uint8) []s1ap.ERABItem {
+	if len(failed) == 0 {
+		return nil
+	}
+
+	cause := s1ap.Cause{Group: s1ap.CauseGroupTransport, Value: s1ap.CauseTransportResourceUnavailable}
+
+	items := make([]s1ap.ERABItem, 0, len(failed))
+	for _, ebi := range failed {
+		items = append(items, s1ap.ERABItem{ERABID: s1ap.ERABID(ebi), Cause: cause})
+	}
+
+	return items
 }
 
 // sendPathSwitchFailure sends a PATH SWITCH REQUEST FAILURE on the association the

--- a/internal/mme/s1ap/handover_test.go
+++ b/internal/mme/s1ap/handover_test.go
@@ -1135,14 +1135,6 @@ func TestHandoverRequestAcknowledge_NoMatchingPreparation_DoesNotReleaseLiveUE(t
 	}
 }
 
-// TestHandoverNHAdvancedAtPreparation is the EPS counterpart of
-// TestHandover_NHAdvancedAtPreparation on the 5G side.
-//
-// TS 33.401 §7.2.8.4.3: "Upon reception of the HANDOVER REQUIRED message the source
-// MME shall increase its locally kept NCC value by one and compute a fresh NH from its
-// stored data." The increment is unconditional, and the pair is sent to the target in
-// the HANDOVER REQUEST — so an abandoned handover must not roll it back, or the next
-// handover would hand the same {NH, NCC} to a second eNB.
 func TestHandoverNHAdvancedAtPreparation(t *testing.T) {
 	m := newTestMME(t)
 	ue, source, target := handoverUE(t, m)

--- a/internal/mme/s1ap/handover_test.go
+++ b/internal/mme/s1ap/handover_test.go
@@ -801,7 +801,7 @@ func TestHandoverGuardTimerAbandons(t *testing.T) {
 // TestHandoverPartialAdmissionPromotesDefault checks that when the target rejects
 // the UE's attach-default PDN but admits a secondary, the surviving PDN is promoted
 // to the default so the UE retains a default PDN connection (TS 23.401 §5.5.1.2.2).
-func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
+func TestHandoverPartialAdmissionKeepsSurvivingPDN(t *testing.T) {
 	m := newTestMME(t)
 	ue, source, target := handoverUE(t, m)
 
@@ -842,10 +842,17 @@ func TestHandoverPartialAdmissionPromotesDefault(t *testing.T) {
 		t.Fatal("rejected attach-default PDN not dropped")
 	}
 
-	defaultEBI := ue.DefaultEBI
+	survivor := m.LookupPDN(ue, 6)
+	if survivor == nil {
+		t.Fatal("the admitted PDN connection must survive the handover")
+	}
 
-	if defaultEBI != 6 {
-		t.Fatalf("default EBI = %d, want 6 (promoted survivor)", defaultEBI)
+	if survivor.EnbFTEID.TEID != 0x99 {
+		t.Errorf("survivor downlink not switched to the target: %+v", survivor.EnbFTEID)
+	}
+
+	if ue.BearerReleaseOnly(survivor) {
+		t.Error("releasing the last remaining PDN connection must not be treated as bearer-only")
 	}
 }
 

--- a/internal/mme/s1ap/handover_test.go
+++ b/internal/mme/s1ap/handover_test.go
@@ -1134,3 +1134,42 @@ func TestHandoverRequestAcknowledge_NoMatchingPreparation_DoesNotReleaseLiveUE(t
 		t.Fatalf("a stale acknowledge with no matching preparation must be dropped, but %d PDU(s) were sent (a UE Context Release would drop a live UE)", len(source.sent)-before)
 	}
 }
+
+// TestHandoverNHAdvancedAtPreparation is the EPS counterpart of
+// TestHandover_NHAdvancedAtPreparation on the 5G side.
+//
+// TS 33.401 §7.2.8.4.3: "Upon reception of the HANDOVER REQUIRED message the source
+// MME shall increase its locally kept NCC value by one and compute a fresh NH from its
+// stored data." The increment is unconditional, and the pair is sent to the target in
+// the HANDOVER REQUEST — so an abandoned handover must not roll it back, or the next
+// handover would hand the same {NH, NCC} to a second eNB.
+func TestHandoverNHAdvancedAtPreparation(t *testing.T) {
+	m := newTestMME(t)
+	ue, source, target := handoverUE(t, m)
+
+	nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
+
+	handleHandoverRequired(m, context.Background(), mme.NewRadioForTest(source),
+		initiatingValue(t, mustMarshal(t, sampleHandoverRequired(ue).Marshal)))
+
+	if target.count() != 1 {
+		t.Fatalf("expected a HANDOVER REQUEST to the target, got %d messages", target.count())
+	}
+
+	afterPrepare, afterPrepareNCC := ue.NHForTest(), ue.NCCForTest()
+
+	if afterPrepare == nh0 {
+		t.Fatal("preparation must advance the live NH")
+	}
+
+	if afterPrepareNCC != (ncc0+1)&0x07 {
+		t.Fatalf("NCC after preparation = %d, want %d", afterPrepareNCC, (ncc0+1)&0x07)
+	}
+
+	// Abandon it; the chain must stay where preparation left it.
+	m.FireHandoverGuardForTest(ue)
+
+	if ue.NHForTest() != afterPrepare || ue.NCCForTest() != afterPrepareNCC {
+		t.Error("an abandoned handover must not roll the key chain back")
+	}
+}

--- a/internal/mme/s1ap/path_switch_conformance_test.go
+++ b/internal/mme/s1ap/path_switch_conformance_test.go
@@ -15,9 +15,7 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// Conformance tests for the X2 handover Path Switch procedure, derived clause by
-// clause from TS 36.413 §8.4.4 and §9.1.5.8-10, TS 23.401 §5.5.1.1.2 and
-// TS 33.401 §7.2.8.4.2.
+// Conformance tests for the X2 handover Path Switch procedure.
 
 const (
 	ieIDTAI                    = 67

--- a/internal/mme/s1ap/path_switch_conformance_test.go
+++ b/internal/mme/s1ap/path_switch_conformance_test.go
@@ -1,0 +1,474 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// Conformance tests for the X2 handover Path Switch procedure, derived clause by
+// clause from TS 36.413 §8.4.4 and §9.1.5.8-10, TS 23.401 §5.5.1.1.2 and
+// TS 33.401 §7.2.8.4.2.
+
+const (
+	ieIDTAI                    = 67
+	ieIDEUTRANCGI              = 100
+	ieIDUESecurityCapabilities = 107
+)
+
+var errAnchorRefused = errors.New("anchor refused the downlink switch")
+
+func dropIEs(t *testing.T, value []byte, ids ...uint16) []byte {
+	t.Helper()
+
+	drop := make(map[uint16]bool, len(ids))
+	for _, id := range ids {
+		drop[id] = true
+	}
+
+	if len(value) < 3 {
+		t.Fatalf("message body too short: %d bytes", len(value))
+	}
+
+	preamble, count, pos := value[0], binary.BigEndian.Uint16(value[1:3]), 3
+
+	kept := make([]byte, 0, len(value))
+	keptCount := uint16(0)
+
+	for i := uint16(0); i < count; i++ {
+		start := pos
+		if pos+4 > len(value) {
+			t.Fatalf("truncated IE header at offset %d", pos)
+		}
+
+		id := binary.BigEndian.Uint16(value[pos : pos+2])
+		pos += 3 // ID (2) + criticality (1)
+
+		n := int(value[pos])
+		if n < 0x80 {
+			pos++
+		} else if n < 0xC0 {
+			if pos+2 > len(value) {
+				t.Fatalf("truncated length determinant at offset %d", pos)
+			}
+
+			n = (n&0x3F)<<8 | int(value[pos+1])
+			pos += 2
+		} else {
+			t.Fatalf("fragmented IE length at offset %d is not supported", pos)
+		}
+
+		if pos+n > len(value) {
+			t.Fatalf("IE 0x%04x claims %d bytes, only %d remain", id, n, len(value)-pos)
+		}
+
+		pos += n
+
+		if drop[id] {
+			continue
+		}
+
+		kept = append(kept, value[start:pos]...)
+		keptCount++
+	}
+
+	out := make([]byte, 3, 3+len(kept))
+	out[0] = preamble
+	binary.BigEndian.PutUint16(out[1:3], keptCount)
+
+	return append(out, kept...)
+}
+
+func pathSwitchUEWithSecondPDN(t *testing.T, m *mme.MME) (*mme.UeContext, *mme.PdnConnection, *mme.PdnConnection) {
+	t.Helper()
+
+	ue := pathSwitchUE(t, m)
+
+	first := testPDN(ue)
+	first.SessionRef = "session-ebi-5"
+
+	second := ue.EnsurePDN(6)
+	second.Apn = "internet2"
+	second.SessionRef = "session-ebi-6"
+
+	return ue, first, second
+}
+
+func switchedDLItemFor(ebi uint8, teid uint32) s1ap.ERABToBeSwitchedDLItem {
+	return s1ap.ERABToBeSwitchedDLItem{
+		ERABID:                s1ap.ERABID(ebi),
+		TransportLayerAddress: s1ap.TransportLayerAddress{10, 4, 0, 2},
+		GTPTEID:               s1ap.GTPTEID(teid),
+	}
+}
+
+func sessionManager(t *testing.T, m *mme.MME) *fakeSessionManager {
+	t.Helper()
+
+	fsm, ok := m.Session.(*fakeSessionManager)
+	if !ok {
+		t.Fatalf("session manager is %T, want *fakeSessionManager", m.Session)
+	}
+
+	return fsm
+}
+
+func releasedRef(fsm *fakeSessionManager, ref string) bool {
+	for _, r := range fsm.releasedRefs {
+		if r == ref {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestPathSwitchImplicitlyReleasesOmittedERABs(t *testing.T) {
+	m := newTestMME(t)
+	ue, _, second := pathSwitchUEWithSecondPDN(t, m)
+	fsm := sessionManager(t, m)
+
+	req := samplePathSwitchRequest(ue)
+	req.ERABToBeSwitchedDL = []s1ap.ERABToBeSwitchedDLItem{switchedDLItemFor(mme.DefaultERABID, 0x99)}
+
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(&captureConn{}), pathSwitchValue(t, req))
+
+	if !releasedRef(fsm, second.SessionRef) {
+		t.Errorf("omitted E-RAB 6 was not released at the anchor; released refs = %v", fsm.releasedRefs)
+	}
+
+	for _, p := range m.SnapshotPDNs(ue) {
+		if p.Ebi == 6 {
+			t.Errorf("omitted E-RAB 6 is still in the UE context with eNB F-TEID %+v", p.EnbFTEID)
+		}
+	}
+}
+
+func TestPathSwitchOmittedDefaultBearerReleasesPDNConnection(t *testing.T) {
+	m := newTestMME(t)
+	ue, first, _ := pathSwitchUEWithSecondPDN(t, m)
+	fsm := sessionManager(t, m)
+
+	req := samplePathSwitchRequest(ue)
+	req.ERABToBeSwitchedDL = []s1ap.ERABToBeSwitchedDLItem{switchedDLItemFor(6, 0xaa)}
+
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(&captureConn{}), pathSwitchValue(t, req))
+
+	if !releasedRef(fsm, first.SessionRef) {
+		t.Errorf("PDN connection whose default bearer was not accepted was not released; released refs = %v", fsm.releasedRefs)
+	}
+}
+
+func TestPathSwitchAllUPSwitchesFailSendsFailure(t *testing.T) {
+	m := newTestMME(t)
+	ue, _, _ := pathSwitchUEWithSecondPDN(t, m)
+	fsm := sessionManager(t, m)
+
+	fsm.failModify(mme.DefaultERABID, errAnchorRefused)
+	fsm.failModify(6, errAnchorRefused)
+
+	req := samplePathSwitchRequest(ue)
+	req.ERABToBeSwitchedDL = []s1ap.ERABToBeSwitchedDLItem{
+		switchedDLItemFor(mme.DefaultERABID, 0x99),
+		switchedDLItemFor(6, 0xaa),
+	}
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, req))
+
+	if target.count() != 1 {
+		t.Fatalf("sent %d messages, want exactly one Path Switch Request Failure", target.count())
+	}
+
+	fail := parsePathSwitchFailure(t, target.sent[0])
+	if fail.Cause == nil {
+		t.Fatal("Path Switch Request Failure carries no Cause")
+	}
+}
+
+func TestPathSwitchPartialUPFailureReportsReleasedERAB(t *testing.T) {
+	m := newTestMME(t)
+	ue, _, _ := pathSwitchUEWithSecondPDN(t, m)
+	fsm := sessionManager(t, m)
+
+	fsm.failModify(6, errAnchorRefused)
+
+	req := samplePathSwitchRequest(ue)
+	req.ERABToBeSwitchedDL = []s1ap.ERABToBeSwitchedDLItem{
+		switchedDLItemFor(mme.DefaultERABID, 0x99),
+		switchedDLItemFor(6, 0xaa),
+	}
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, req))
+
+	if target.count() != 1 {
+		t.Fatalf("sent %d messages, want exactly one Path Switch Request Acknowledge", target.count())
+	}
+
+	ack := parsePathSwitchAck(t, target.sent[0])
+
+	if len(ack.ERABToBeReleased) != 1 || ack.ERABToBeReleased[0].ERABID != 6 {
+		t.Fatalf("E-RAB To Be Released List = %+v, want exactly E-RAB 6", ack.ERABToBeReleased)
+	}
+
+	// TS 36.413 §9.1.5.9: an E-RAB ID shall be present only once across the
+	// switched-uplink and to-be-released lists.
+	seen := map[s1ap.ERABID]bool{}
+	for _, item := range ack.ERABToBeReleased {
+		if seen[item.ERABID] {
+			t.Errorf("E-RAB ID %d appears more than once in the To Be Released List", item.ERABID)
+		}
+
+		seen[item.ERABID] = true
+	}
+}
+
+func TestPathSwitchFailedERABReleasesCoreNetworkResources(t *testing.T) {
+	m := newTestMME(t)
+	ue, _, second := pathSwitchUEWithSecondPDN(t, m)
+	fsm := sessionManager(t, m)
+
+	fsm.failModify(6, errAnchorRefused)
+
+	req := samplePathSwitchRequest(ue)
+	req.ERABToBeSwitchedDL = []s1ap.ERABToBeSwitchedDLItem{
+		switchedDLItemFor(mme.DefaultERABID, 0x99),
+		switchedDLItemFor(6, 0xaa),
+	}
+
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(&captureConn{}), pathSwitchValue(t, req))
+
+	if !releasedRef(fsm, second.SessionRef) {
+		t.Errorf("core-network resources of the failed E-RAB 6 were not released; released refs = %v", fsm.releasedRefs)
+	}
+}
+
+func TestPathSwitchTotalFailureDetachesUE(t *testing.T) {
+	m := newTestMME(t)
+	ue := pathSwitchUE(t, m)
+	testPDN(ue).SessionRef = "session-ebi-5"
+
+	fsm := sessionManager(t, m)
+	fsm.failModify(mme.DefaultERABID, errAnchorRefused)
+
+	// Captured before the handler runs: an explicit detach tears the association down.
+	mmeID := ue.Conn().MMEUES1APID
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, samplePathSwitchRequest(ue)))
+
+	if !releasedRef(fsm, "session-ebi-5") {
+		t.Errorf("UE was not detached after a total path-switch failure; released refs = %v", fsm.releasedRefs)
+	}
+
+	if _, stillKnown := m.LookupUe(mmeID); stillKnown {
+		t.Error("UE is still registered after a total path-switch failure; no explicit detach was performed")
+	}
+}
+
+func TestPathSwitchAckCarriesUEAMBR(t *testing.T) {
+	m := newTestMME(t)
+	ue, _, _ := pathSwitchUEWithSecondPDN(t, m)
+
+	ue.Ambr = &models.Ambr{
+		Uplink:   models.MustParseBitRate("100 Mbps"),
+		Downlink: models.MustParseBitRate("200 Mbps"),
+	}
+
+	fsm := sessionManager(t, m)
+	fsm.failModify(6, errAnchorRefused)
+
+	req := samplePathSwitchRequest(ue)
+	req.ERABToBeSwitchedDL = []s1ap.ERABToBeSwitchedDLItem{
+		switchedDLItemFor(mme.DefaultERABID, 0x99),
+		switchedDLItemFor(6, 0xaa),
+	}
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, req))
+
+	if target.count() != 1 {
+		t.Fatalf("sent %d messages, want exactly one Path Switch Request Acknowledge", target.count())
+	}
+
+	ack := parsePathSwitchAck(t, target.sent[0])
+	if ack.UEAggregateMaximumBitRate == nil {
+		t.Fatal("Path Switch Request Acknowledge carries no UE Aggregate Maximum Bit Rate")
+	}
+}
+
+func TestPathSwitchNCCWrapsToZero(t *testing.T) {
+	m := newTestMME(t)
+	ue := pathSwitchUE(t, m)
+	ue.SetNCCForTest(7)
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, samplePathSwitchRequest(ue)))
+
+	if target.count() != 1 {
+		t.Fatalf("sent %d messages, want exactly one Path Switch Request Acknowledge", target.count())
+	}
+
+	ack := parsePathSwitchAck(t, target.sent[0])
+	if ack.SecurityContext.NextHopChainingCount != 0 {
+		t.Errorf("NCC after 7 = %d, want 0", ack.SecurityContext.NextHopChainingCount)
+	}
+
+	if ue.NCCForTest() != 0 {
+		t.Errorf("stored NCC after 7 = %d, want 0", ue.NCCForTest())
+	}
+}
+
+func TestPathSwitchAckCarriesFreshlyDerivedNH(t *testing.T) {
+	m := newTestMME(t)
+	ue := pathSwitchUE(t, m)
+
+	beforeNH, beforeNCC := ue.NHForTest(), ue.NCCForTest()
+
+	wantNH, err := ue.DeriveNextNHForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, samplePathSwitchRequest(ue)))
+
+	ack := parsePathSwitchAck(t, target.sent[0])
+
+	if ack.SecurityContext.NextHopParameter == s1ap.SecurityKey(beforeNH) {
+		t.Error("acknowledge replayed the current NH instead of a freshly derived one")
+	}
+
+	if ack.SecurityContext.NextHopParameter != s1ap.SecurityKey(wantNH) {
+		t.Error("acknowledge NH is not KDF(KASME, previous NH)")
+	}
+
+	if ack.SecurityContext.NextHopChainingCount != (beforeNCC+1)&0x07 {
+		t.Errorf("acknowledge NCC = %d, want %d", ack.SecurityContext.NextHopChainingCount, (beforeNCC+1)&0x07)
+	}
+}
+
+func TestPathSwitchFailureCarriesMandatoryIEs(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		prepare func(t *testing.T, m *mme.MME) *s1ap.PathSwitchRequest
+	}{
+		{
+			name: "duplicate E-RAB ID",
+			prepare: func(t *testing.T, m *mme.MME) *s1ap.PathSwitchRequest {
+				ue := pathSwitchUE(t, m)
+				req := samplePathSwitchRequest(ue)
+				req.ERABToBeSwitchedDL = []s1ap.ERABToBeSwitchedDLItem{switchedDLItem(), switchedDLItem()}
+
+				return req
+			},
+		},
+		{
+			name: "unknown source MME UE S1AP ID",
+			prepare: func(t *testing.T, m *mme.MME) *s1ap.PathSwitchRequest {
+				ue := pathSwitchUE(t, m)
+				req := samplePathSwitchRequest(ue)
+				req.SourceMMEUES1APID = 0x7ffffff0
+
+				return req
+			},
+		},
+		{
+			name: "no E-RAB switched",
+			prepare: func(t *testing.T, m *mme.MME) *s1ap.PathSwitchRequest {
+				ue := pathSwitchUE(t, m)
+				sessionManager(t, m).failModify(mme.DefaultERABID, errAnchorRefused)
+
+				return samplePathSwitchRequest(ue)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMME(t)
+			req := tt.prepare(t, m)
+
+			target := &captureConn{}
+			handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, req))
+
+			if target.count() != 1 {
+				t.Fatalf("sent %d messages, want exactly one Path Switch Request Failure", target.count())
+			}
+
+			fail := parsePathSwitchFailure(t, target.sent[0])
+
+			if fail.MMEUES1APID == nil {
+				t.Error("failure carries no MME UE S1AP ID")
+			}
+
+			if fail.ENBUES1APID == nil {
+				t.Error("failure carries no eNB UE S1AP ID")
+			}
+
+			if fail.Cause == nil {
+				t.Error("failure carries no Cause")
+			}
+		})
+	}
+}
+
+func TestPathSwitchToleratesAbsentIgnoreCriticalityIEs(t *testing.T) {
+	m := newTestMME(t)
+	ue := pathSwitchUE(t, m)
+
+	value := dropIEs(t, pathSwitchValue(t, samplePathSwitchRequest(ue)),
+		ieIDEUTRANCGI, ieIDTAI, ieIDUESecurityCapabilities)
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), value)
+
+	if target.count() != 1 {
+		t.Fatalf("sent %d messages, want exactly one Path Switch Request Acknowledge", target.count())
+	}
+
+	if _, err := s1ap.Unmarshal(target.sent[0]); err != nil {
+		t.Fatalf("unmarshal reply: %v", err)
+	}
+
+	ack := parsePathSwitchAck(t, target.sent[0])
+	if ack.SecurityContext.NextHopChainingCount != 2 {
+		t.Errorf("NCC = %d, want 2: the path switch did not complete", ack.SecurityContext.NextHopChainingCount)
+	}
+}
+
+func TestPathSwitchDuringNASSecurityModeStillAcknowledges(t *testing.T) {
+	m := newTestMME(t)
+	ue := pathSwitchUE(t, m)
+
+	oldNH, oldNCC := ue.NHForTest(), ue.NCCForTest()
+
+	wantNH, err := ue.DeriveNextNHForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !m.TryClaimKeyChain(ue) {
+		t.Fatal("could not claim the key chain for the NAS security mode procedure")
+	}
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, samplePathSwitchRequest(ue)))
+
+	if target.count() != 1 {
+		t.Fatalf("sent %d messages, want exactly one Path Switch Request Acknowledge", target.count())
+	}
+
+	ack := parsePathSwitchAck(t, target.sent[0])
+
+	if ack.SecurityContext.NextHopParameter != s1ap.SecurityKey(wantNH) {
+		t.Errorf("acknowledge NH is not derived from the old KASME chain (previous NH %x, NCC %d)", oldNH[:4], oldNCC)
+	}
+}

--- a/internal/mme/s1ap/path_switch_conformance_test.go
+++ b/internal/mme/s1ap/path_switch_conformance_test.go
@@ -422,24 +422,6 @@ func TestPathSwitchToleratesAbsentIgnoreCriticalityIEs(t *testing.T) {
 	}
 }
 
-// TestPathSwitchDuringNASSecurityModeIsRefused pins a deliberate design decision on a
-// point TS 33.401 does not settle.
-//
-// §7.2.10 rule 3 is conditional: while a NAS SMC is taking a new KASME into use, the
-// MME "shall continue to include AS security context parameters based on the old KASME
-// in the HANDOVER REQUEST or PATH SWITCH REQUEST ACKNOWLEDGE message". It governs the
-// contents of an acknowledge that is sent. Refusing never reaches that condition, so
-// the rule is not violated — whether refusing is permitted at all is not addressed.
-//
-// Ella Core refuses, because the two procedures would otherwise advance the same
-// {NH, NCC} chain concurrently. The UE has already moved to the target cell over the
-// radio, so it is stranded and re-attaches — recoverable, where a key desync is not.
-// Answering per rule 3 would mean keeping the pre-SMC chain usable alongside the new
-// one: two live key chains in the most security-sensitive path, for a rare race.
-//
-// Recorded as F-7 in handover_review_plan.md, with the reasoning in
-// handover_design.md §7. Revisit if a clearer clause turns up or the rejection is
-// observed in a real deployment.
 func TestPathSwitchDuringNASSecurityModeIsRefused(t *testing.T) {
 	m := newTestMME(t)
 	ue := pathSwitchUE(t, m)
@@ -462,19 +444,11 @@ func TestPathSwitchDuringNASSecurityModeIsRefused(t *testing.T) {
 		t.Error("Path Switch Request Failure carries no Cause")
 	}
 
-	// Whatever the answer, the refusal must leave the AS key chain exactly as it was:
-	// the NAS SMC owns it for the duration.
 	if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
 		t.Error("a refused path switch must not advance the AS key chain")
 	}
-} // TS 23.401 §5.5.1.1.2 step 6: "If none of the default EPS bearers have been
-// switched successfully in the core network ... the MME shall send a Path Switch
-// Request Failure message ... The MME performs explicit detach of the UE."
-//
-// No NAS DETACH REQUEST can reach a UE that has left the source cell, so the detach is
-// local (TS 24.301 §5.5.2.3.1). What must still happen is the deregistration and the
-// UE CONTEXT RELEASE COMMAND to the source eNB — without it the eNB keeps a UE-
-// associated S1 connection whose MME-UE-S1AP-ID the MME will hand to another UE.
+}
+
 func TestPathSwitchTotalFailureDetachesUE(t *testing.T) {
 	m := newTestMME(t)
 

--- a/internal/mme/s1ap/path_switch_conformance_test.go
+++ b/internal/mme/s1ap/path_switch_conformance_test.go
@@ -444,23 +444,23 @@ func TestPathSwitchToleratesAbsentIgnoreCriticalityIEs(t *testing.T) {
 	}
 }
 
-// TestPathSwitchDuringNASSecurityModeIsRefused pins a known, deliberate divergence
-// from TS 33.401 §7.2.10 rule 3.
+// TestPathSwitchDuringNASSecurityModeIsRefused pins a deliberate design decision on a
+// point TS 33.401 does not settle.
 //
-// The clause says that while a NAS SMC is taking a new KASME into use, the MME "shall
-// continue to include AS security context parameters based on the old KASME in the
-// HANDOVER REQUEST or PATH SWITCH REQUEST ACKNOWLEDGE message" — which presumes the
-// acknowledge is still sent. Rules 1-2, which enumerate the procedures the MME must
-// not run during a NAS SMC, do not list Path Switch.
+// §7.2.10 rule 3 is conditional: while a NAS SMC is taking a new KASME into use, the
+// MME "shall continue to include AS security context parameters based on the old KASME
+// in the HANDOVER REQUEST or PATH SWITCH REQUEST ACKNOWLEDGE message". It governs the
+// contents of an acknowledge that is sent. Refusing never reaches that condition, so
+// the rule is not violated — whether refusing is permitted at all is not addressed.
 //
-// Ella Core instead refuses the path switch, because the two procedures would
-// otherwise advance the same {NH, NCC} chain concurrently. The UE has already moved to
-// the target cell over the radio, so it is stranded and re-attaches. The clause never
-// literally forbids rejecting, and answering it properly would mean keeping the
-// pre-SMC chain usable alongside the new one — two live key chains in the most
-// security-sensitive path, to serve a narrow race whose failure mode is recoverable.
+// Ella Core refuses, because the two procedures would otherwise advance the same
+// {NH, NCC} chain concurrently. The UE has already moved to the target cell over the
+// radio, so it is stranded and re-attaches — recoverable, where a key desync is not.
+// Answering per rule 3 would mean keeping the pre-SMC chain usable alongside the new
+// one: two live key chains in the most security-sensitive path, for a rare race.
 //
-// Recorded as F-7 in handover_review_plan.md. Revisit if this rejection is ever
+// Recorded as F-7 in handover_review_plan.md, with the reasoning in
+// handover_design.md §7. Revisit if a clearer clause turns up or the rejection is
 // observed in a real deployment.
 func TestPathSwitchDuringNASSecurityModeIsRefused(t *testing.T) {
 	m := newTestMME(t)

--- a/internal/mme/s1ap/path_switch_conformance_test.go
+++ b/internal/mme/s1ap/path_switch_conformance_test.go
@@ -444,16 +444,29 @@ func TestPathSwitchToleratesAbsentIgnoreCriticalityIEs(t *testing.T) {
 	}
 }
 
-func TestPathSwitchDuringNASSecurityModeStillAcknowledges(t *testing.T) {
+// TestPathSwitchDuringNASSecurityModeIsRefused pins a known, deliberate divergence
+// from TS 33.401 §7.2.10 rule 3.
+//
+// The clause says that while a NAS SMC is taking a new KASME into use, the MME "shall
+// continue to include AS security context parameters based on the old KASME in the
+// HANDOVER REQUEST or PATH SWITCH REQUEST ACKNOWLEDGE message" — which presumes the
+// acknowledge is still sent. Rules 1-2, which enumerate the procedures the MME must
+// not run during a NAS SMC, do not list Path Switch.
+//
+// Ella Core instead refuses the path switch, because the two procedures would
+// otherwise advance the same {NH, NCC} chain concurrently. The UE has already moved to
+// the target cell over the radio, so it is stranded and re-attaches. The clause never
+// literally forbids rejecting, and answering it properly would mean keeping the
+// pre-SMC chain usable alongside the new one — two live key chains in the most
+// security-sensitive path, to serve a narrow race whose failure mode is recoverable.
+//
+// Recorded as F-7 in handover_review_plan.md. Revisit if this rejection is ever
+// observed in a real deployment.
+func TestPathSwitchDuringNASSecurityModeIsRefused(t *testing.T) {
 	m := newTestMME(t)
 	ue := pathSwitchUE(t, m)
 
-	oldNH, oldNCC := ue.NHForTest(), ue.NCCForTest()
-
-	wantNH, err := ue.DeriveNextNHForTest()
-	if err != nil {
-		t.Fatal(err)
-	}
+	nh0, ncc0 := ue.NHForTest(), ue.NCCForTest()
 
 	if !m.TryClaimKeyChain(ue) {
 		t.Fatal("could not claim the key chain for the NAS security mode procedure")
@@ -463,12 +476,17 @@ func TestPathSwitchDuringNASSecurityModeStillAcknowledges(t *testing.T) {
 	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, samplePathSwitchRequest(ue)))
 
 	if target.count() != 1 {
-		t.Fatalf("sent %d messages, want exactly one Path Switch Request Acknowledge", target.count())
+		t.Fatalf("sent %d messages, want exactly one Path Switch Request Failure", target.count())
 	}
 
-	ack := parsePathSwitchAck(t, target.sent[0])
+	fail := parsePathSwitchFailure(t, target.sent[0])
+	if fail.Cause == nil {
+		t.Error("Path Switch Request Failure carries no Cause")
+	}
 
-	if ack.SecurityContext.NextHopParameter != s1ap.SecurityKey(wantNH) {
-		t.Errorf("acknowledge NH is not derived from the old KASME chain (previous NH %x, NCC %d)", oldNH[:4], oldNCC)
+	// Whatever the answer, the refusal must leave the AS key chain exactly as it was:
+	// the NAS SMC owns it for the duration.
+	if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
+		t.Error("a refused path switch must not advance the AS key chain")
 	}
 }

--- a/internal/mme/s1ap/path_switch_conformance_test.go
+++ b/internal/mme/s1ap/path_switch_conformance_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 )
 
@@ -252,29 +253,6 @@ func TestPathSwitchFailedERABReleasesCoreNetworkResources(t *testing.T) {
 	}
 }
 
-func TestPathSwitchTotalFailureDetachesUE(t *testing.T) {
-	m := newTestMME(t)
-	ue := pathSwitchUE(t, m)
-	testPDN(ue).SessionRef = "session-ebi-5"
-
-	fsm := sessionManager(t, m)
-	fsm.failModify(mme.DefaultERABID, errAnchorRefused)
-
-	// Captured before the handler runs: an explicit detach tears the association down.
-	mmeID := ue.Conn().MMEUES1APID
-
-	target := &captureConn{}
-	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, samplePathSwitchRequest(ue)))
-
-	if !releasedRef(fsm, "session-ebi-5") {
-		t.Errorf("UE was not detached after a total path-switch failure; released refs = %v", fsm.releasedRefs)
-	}
-
-	if _, stillKnown := m.LookupUe(mmeID); stillKnown {
-		t.Error("UE is still registered after a total path-switch failure; no explicit detach was performed")
-	}
-}
-
 func TestPathSwitchAckCarriesUEAMBR(t *testing.T) {
 	m := newTestMME(t)
 	ue, _, _ := pathSwitchUEWithSecondPDN(t, m)
@@ -488,5 +466,50 @@ func TestPathSwitchDuringNASSecurityModeIsRefused(t *testing.T) {
 	// the NAS SMC owns it for the duration.
 	if ue.NHForTest() != nh0 || ue.NCCForTest() != ncc0 {
 		t.Error("a refused path switch must not advance the AS key chain")
+	}
+} // TS 23.401 §5.5.1.1.2 step 6: "If none of the default EPS bearers have been
+// switched successfully in the core network ... the MME shall send a Path Switch
+// Request Failure message ... The MME performs explicit detach of the UE."
+//
+// No NAS DETACH REQUEST can reach a UE that has left the source cell, so the detach is
+// local (TS 24.301 §5.5.2.3.1). What must still happen is the deregistration and the
+// UE CONTEXT RELEASE COMMAND to the source eNB — without it the eNB keeps a UE-
+// associated S1 connection whose MME-UE-S1AP-ID the MME will hand to another UE.
+func TestPathSwitchTotalFailureDetachesUE(t *testing.T) {
+	m := newTestMME(t)
+
+	ue, source := securedUE(t, m)
+	testPDN(ue).Apn = "internet"
+	testPDN(ue).SessionRef = "session-ebi-5"
+	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xe0, EIA: 0xe0}, nil, mme.MintAuthProofForAttachRequest())
+	ue.SetNCCForTest(1)
+	ue.SetNHForTest([32]byte{})
+
+	fsm := sessionManager(t, m)
+	fsm.failModify(mme.DefaultERABID, errAnchorRefused)
+
+	target := &captureConn{}
+	handlePathSwitchRequest(m, context.Background(), mme.NewRadioForTest(target), pathSwitchValue(t, samplePathSwitchRequest(ue)))
+
+	if ue.EMMState() == mme.EMMRegistered {
+		t.Error("UE is still registered after a total path-switch failure")
+	}
+
+	if source.count() != 1 {
+		t.Fatalf("source eNB got %d messages, want one UE Context Release Command", source.count())
+	}
+
+	cmd := parseUEContextReleaseCommand(t, source.sent[0])
+	if cmd == nil {
+		t.Fatal("source eNB was not commanded to release the UE context")
+	}
+
+	// The target still gets its failure.
+	if target.count() != 1 {
+		t.Fatalf("target eNB got %d messages, want one Path Switch Request Failure", target.count())
+	}
+
+	if fail := parsePathSwitchFailure(t, target.sent[0]); fail.Cause == nil {
+		t.Error("Path Switch Request Failure carries no Cause")
 	}
 }


### PR DESCRIPTION
# Description

Fixes X2 and Xn handover edge cases by introducing a shared bearer/session reconciliation primitive on both the MME and AMF.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
