### PR TITLE
fix: set the SECURITY MODE COMMAND HDP only when the AMF derives K'AMF

### DIFF
--- a/etsi/supi.go
+++ b/etsi/supi.go
@@ -27,7 +27,13 @@ var InvalidSUPI SUPI = SUPI{}
 
 const imsiPrefix = "imsi-"
 
-// NewSUPIFromIMSI creates a SUPI from a bare 15-digit numeric IMSI.
+const (
+	MinIMSIDigits = 6
+	MaxIMSIDigits = 15
+)
+
+// NewSUPIFromIMSI creates a SUPI from a bare numeric IMSI of MinIMSIDigits to
+// MaxIMSIDigits digits.
 func NewSUPIFromIMSI(imsi string) (SUPI, error) {
 	if err := validateIMSI(imsi); err != nil {
 		return InvalidSUPI, err
@@ -86,10 +92,11 @@ func (s SUPI) IsNAI() bool {
 	return s.supiType == supiTypeNAI
 }
 
-// validateIMSI checks that s is a valid IMSI: 15 digits, all numeric.
+// validateIMSI checks that s is a valid IMSI: MinIMSIDigits to MaxIMSIDigits
+// digits, all numeric.
 func validateIMSI(s string) error {
-	if len(s) != 15 {
-		return fmt.Errorf("invalid IMSI length: %d (must be 15 digits)", len(s))
+	if len(s) < MinIMSIDigits || len(s) > MaxIMSIDigits {
+		return fmt.Errorf("invalid IMSI length: %d (must be %d to %d digits)", len(s), MinIMSIDigits, MaxIMSIDigits)
 	}
 
 	if !isAllDigits(s) {

--- a/etsi/supi_test.go
+++ b/etsi/supi_test.go
@@ -20,6 +20,9 @@ func TestNewSUPIFromIMSI(t *testing.T) {
 		{"FifteenDigits", "001019756139935", "imsi-001019756139935"},
 		{"AllZeros", "000000000000000", "imsi-000000000000000"},
 		{"AllNines", "999999999999999", "imsi-999999999999999"},
+		{"SixDigits", "001011", "imsi-001011"},
+		{"TenDigits", "0010112345", "imsi-0010112345"},
+		{"FourteenDigits", "00101975613993", "imsi-00101975613993"},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -47,9 +50,10 @@ func TestNewSUPIFromIMSIInvalid(t *testing.T) {
 	}
 
 	testcases := []Testcase{
-		{"Empty", "", "invalid IMSI length: 0 (must be 15 digits)"},
-		{"TooShort", "0010", "invalid IMSI length: 4 (must be 15 digits)"},
-		{"TooLong", "0010197561399350", "invalid IMSI length: 16 (must be 15 digits)"},
+		{"Empty", "", "invalid IMSI length: 0 (must be 6 to 15 digits)"},
+		{"TooShort", "0010", "invalid IMSI length: 4 (must be 6 to 15 digits)"},
+		{"FiveDigits", "00101", "invalid IMSI length: 5 (must be 6 to 15 digits)"},
+		{"TooLong", "0010197561399350", "invalid IMSI length: 16 (must be 6 to 15 digits)"},
 		{"ContainsLetters", "0010a9756130000", "invalid IMSI: contains non-digit characters: 0010a9756130000"},
 		{"ContainsHyphen", "001-01-97560000", "invalid IMSI: contains non-digit characters: 001-01-97560000"},
 		{"ContainsSpace", "00101 975610000", "invalid IMSI: contains non-digit characters: 00101 975610000"},
@@ -103,11 +107,11 @@ func TestNewSUPIFromPrefixedInvalid(t *testing.T) {
 
 	testcases := []Testcase{
 		{"NaiPrefix", "nai-user@realm1", "invalid IMSI: contains non-digit characters: nai-user@realm1"},
-		{"SuciPrefix", "suci-0-001-01-0000-0-0-001019756139935", "invalid IMSI length: 38 (must be 15 digits)"},
+		{"SuciPrefix", "suci-0-001-01-0000-0-0-001019756139935", "invalid IMSI length: 38 (must be 6 to 15 digits)"},
 		{"Garbage", "not-a-supi-str-", "invalid IMSI: contains non-digit characters: not-a-supi-str-"},
-		{"ImsiPrefixNoDigits", "imsi-", "invalid IMSI length: 0 (must be 15 digits)"},
-		{"ImsiPrefixTooShort", "imsi-001", "invalid IMSI length: 3 (must be 15 digits)"},
-		{"EmptyString", "", "invalid IMSI length: 0 (must be 15 digits)"},
+		{"ImsiPrefixNoDigits", "imsi-", "invalid IMSI length: 0 (must be 6 to 15 digits)"},
+		{"ImsiPrefixTooShort", "imsi-001", "invalid IMSI length: 3 (must be 6 to 15 digits)"},
+		{"EmptyString", "", "invalid IMSI length: 0 (must be 6 to 15 digits)"},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -67,6 +67,7 @@ type UeContext struct {
 	procedures *procedure.Registry
 
 	secured              bool
+	keyOrigin            KeyOrigin
 	ueSecurityCapability *fgs.UESecurityCapability // TS 24.501 §9.11.3.54
 
 	gmmCapability         *fgs.GMMCapability
@@ -335,6 +336,7 @@ func (ue *UeContext) InstallNASSecurityContext(nea nas.CipheringAlgorithm, nia n
 
 	if err == nil {
 		ue.ulCount.Reset()
+		ue.keyOrigin = KeyOriginPrimaryAuth
 	}
 	ue.mu.Unlock()
 

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -162,19 +162,21 @@ func BuildSecurityModeCommand(ue *UeContext) ([]byte, error) {
 
 	addInfo := fgs.AdditionalSecurityInformation{
 		RINMR: conn.RetransmissionOfInitialNASMsg,
-		HDP: conn.RegistrationType5GS == fgs.RegistrationTypePeriodicUpdating ||
-			conn.RegistrationType5GS == fgs.RegistrationTypeMobilityUpdating,
+		HDP:   ue.KeyOrigin() == KeyOriginHorizontalDerivation,
 	}
 
 	ngksi := ue.NgKsi()
 
 	smc := &fgs.SecurityModeCommand{
-		CipheringAlgorithm:            ue.NEA(),
-		IntegrityAlgorithm:            ue.NIA(),
-		NgKSI:                         ngKsi(ngksi),
-		ReplayedUESecurityCapability:  *ueSecCap,
-		IMEISVRequested:               &imeisv,
-		AdditionalSecurityInformation: &addInfo,
+		CipheringAlgorithm:           ue.NEA(),
+		IntegrityAlgorithm:           ue.NIA(),
+		NgKSI:                        ngKsi(ngksi),
+		ReplayedUESecurityCapability: *ueSecCap,
+		IMEISVRequested:              &imeisv,
+	}
+
+	if addInfo.RINMR || addInfo.HDP {
+		smc.AdditionalSecurityInformation = &addInfo
 	}
 
 	addEPSNASSecurityAlgorithms(ue, smc)

--- a/internal/amf/eps_security.go
+++ b/internal/amf/eps_security.go
@@ -188,10 +188,12 @@ func (ue *UeContext) InstallMappedSecurityContextFromEPS(mapped interworking.Map
 	ue.ncc = mapped.NCC
 
 	ue.secured = true
+	ue.keyOrigin = KeyOriginMappedFromEPS
 
 	err := ue.installSecurityContextLocked()
 	if err != nil {
 		ue.secured = false
+		ue.keyOrigin = KeyOriginUnknown
 	}
 
 	sc := ue.sc

--- a/internal/amf/security_mode_command_test.go
+++ b/internal/amf/security_mode_command_test.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf_test
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func securityModeCommandForTest(t *testing.T, ue *amf.UeContext) *fgs.SecurityModeCommand {
+	t.Helper()
+
+	raw, err := amf.BuildSecurityModeCommand(ue)
+	if err != nil {
+		t.Fatalf("BuildSecurityModeCommand: %v", err)
+	}
+
+	smc, err := fgs.ParseSecurityModeCommand(raw)
+	if err != nil {
+		t.Fatalf("parse SecurityModeCommand: %v", err)
+	}
+
+	return smc
+}
+
+func horizontalDerivationRequired(smc *fgs.SecurityModeCommand) bool {
+	return smc.AdditionalSecurityInformation != nil && smc.AdditionalSecurityInformation.HDP
+}
+
+func securityModeCommandUE(t *testing.T, origin amf.KeyOrigin, regType fgs.RegistrationType) *amf.UeContext {
+	t.Helper()
+
+	ue := buildTestUE(t)
+	ue.SetUESecurityCapabilityForTest(amf.UESecCapForTest([]uint8{2}, []uint8{2}))
+	attachTestConn(t, ue)
+	ue.SetKeyOriginForTest(origin)
+
+	conn := ue.Conn()
+	if conn == nil {
+		t.Fatal("no NAS connection")
+	}
+
+	conn.SetRegistrationType5GS(uint8(regType))
+
+	return ue
+}
+
+func TestSecurityModeCommandDoesNotClaimHorizontalDerivationAfterPrimaryAuth(t *testing.T) {
+	for _, regType := range []fgs.RegistrationType{
+		fgs.RegistrationTypeInitial,
+		fgs.RegistrationTypeMobilityUpdating,
+		fgs.RegistrationTypePeriodicUpdating,
+		fgs.RegistrationTypeEmergency,
+	} {
+		ue := securityModeCommandUE(t, amf.KeyOriginPrimaryAuth, regType)
+
+		if horizontalDerivationRequired(securityModeCommandForTest(t, ue)) {
+			t.Errorf("registration type %v: HDP is set, but the KAMF comes from primary authentication, not from a KAMF to K'AMF derivation", regType)
+		}
+	}
+}
+
+func TestSecurityModeCommandDoesNotClaimHorizontalDerivationForAMappedContext(t *testing.T) {
+	ue := securityModeCommandUE(t, amf.KeyOriginMappedFromEPS, fgs.RegistrationTypeMobilityUpdating)
+
+	if horizontalDerivationRequired(securityModeCommandForTest(t, ue)) {
+		t.Error("HDP is set, but a mapped KAMF' is derived from the KASME, not horizontally")
+	}
+}
+
+func TestSecurityModeCommandSignalsHorizontalDerivation(t *testing.T) {
+	ue := securityModeCommandUE(t, amf.KeyOriginHorizontalDerivation, fgs.RegistrationTypeMobilityUpdating)
+
+	if !horizontalDerivationRequired(securityModeCommandForTest(t, ue)) {
+		t.Error("HDP is not set for a horizontally derived KAMF")
+	}
+}
+
+func TestSecurityModeCommandOmitsAdditionalSecurityInformationWhenNothingToSignal(t *testing.T) {
+	ue := securityModeCommandUE(t, amf.KeyOriginPrimaryAuth, fgs.RegistrationTypeMobilityUpdating)
+
+	smc := securityModeCommandForTest(t, ue)
+	if smc.AdditionalSecurityInformation != nil {
+		t.Fatalf("Additional 5G security information = %+v, want the IE omitted", *smc.AdditionalSecurityInformation)
+	}
+}
+
+func TestSecurityModeCommandRequestsRetransmissionWithoutHorizontalDerivation(t *testing.T) {
+	ue := securityModeCommandUE(t, amf.KeyOriginPrimaryAuth, fgs.RegistrationTypeMobilityUpdating)
+
+	conn := ue.Conn()
+	conn.RetransmissionOfInitialNASMsg = true
+
+	smc := securityModeCommandForTest(t, ue)
+	if smc.AdditionalSecurityInformation == nil {
+		t.Fatal("the Additional 5G security information IE is missing")
+	}
+
+	if !smc.AdditionalSecurityInformation.RINMR || smc.AdditionalSecurityInformation.HDP {
+		t.Fatalf("Additional 5G security information = %+v, want RINMR alone", *smc.AdditionalSecurityInformation)
+	}
+}

--- a/internal/amf/security_state.go
+++ b/internal/amf/security_state.go
@@ -76,6 +76,22 @@ func MintAuthProofForInterworking() AuthProof {
 	return AuthProof{}
 }
 
+type KeyOrigin uint8
+
+const (
+	KeyOriginUnknown KeyOrigin = iota
+	KeyOriginPrimaryAuth
+	KeyOriginHorizontalDerivation
+	KeyOriginMappedFromEPS
+)
+
+func (ue *UeContext) KeyOrigin() KeyOrigin {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return ue.keyOrigin
+}
+
 // VerifyResult reports the outcome of comparing a peer-reported value
 // against the AMF's locally stored value.
 type VerifyResult int

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -186,6 +186,8 @@ func (ue *UeContext) SetKnasEncForTest(k [16]uint8) {
 }
 func (ue *UeContext) KnasEncForTest() [16]uint8 { return ue.knasEnc }
 
+func (ue *UeContext) SetKeyOriginForTest(o KeyOrigin) { ue.keyOrigin = o }
+
 func (ue *UeContext) SetNgKsiForTest(n models.NgKsi) { ue.ngKsi = n }
 func (ue *UeContext) NgKsiForTest() models.NgKsi     { return ue.ngKsi }
 

--- a/internal/api/server/api_subscriber_usage.go
+++ b/internal/api/server/api_subscriber_usage.go
@@ -59,7 +59,7 @@ func GetSubscriberUsage(dbInstance *db.Database) http.Handler {
 		subscriber := q.Get("subscriber")
 		if subscriber != "" {
 			if _, err := etsi.NewSUPIFromIMSI(subscriber); err != nil {
-				writeError(r.Context(), w, http.StatusBadRequest, "invalid subscriber: must be a valid 15-digit IMSI", nil, logger.APILog)
+				writeError(r.Context(), w, http.StatusBadRequest, "invalid subscriber: must be a valid IMSI of 6 to 15 digits", nil, logger.APILog)
 				return
 			}
 		}

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -134,7 +134,7 @@ func isImsiValid(ctx context.Context, imsi string, dbInstance *db.Database) bool
 		return false
 	}
 
-	return true
+	return len(imsi) > 3+mncLength
 }
 
 func isHexOfLength(input string, byteLength int) bool {
@@ -529,7 +529,7 @@ func CreateSubscriber(dbInstance *db.Database) http.Handler {
 		}
 
 		if !isImsiValid(r.Context(), params.Imsi, dbInstance) {
-			writeError(r.Context(), w, http.StatusBadRequest, "Invalid IMSI format. Must be a 15-digit string starting with `<mcc><mnc>`.", errors.New("validation error"), logger.APILog)
+			writeError(r.Context(), w, http.StatusBadRequest, "Invalid IMSI format. Must be a string of 6 to 15 digits starting with `<mcc><mnc>`.", errors.New("validation error"), logger.APILog)
 			return
 		}
 

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -986,25 +986,25 @@ func TestCreateSubscriberInvalidInput(t *testing.T) {
 			imsi:           "12345",
 			key:            Key,
 			sequenceNumber: SequenceNumber,
-			error:          "Invalid IMSI format. Must be a 15-digit string starting with `<mcc><mnc>`.",
+			error:          "Invalid IMSI format. Must be a string of 6 to 15 digits starting with `<mcc><mnc>`.",
 		},
 		{
 			imsi:           "00101010000748812",
 			key:            Key,
 			sequenceNumber: SequenceNumber,
-			error:          "Invalid IMSI format. Must be a 15-digit string starting with `<mcc><mnc>`.",
+			error:          "Invalid IMSI format. Must be a string of 6 to 15 digits starting with `<mcc><mnc>`.",
 		},
 		{
 			imsi:           "002010100007488",
 			key:            Key,
 			sequenceNumber: SequenceNumber,
-			error:          "Invalid IMSI format. Must be a 15-digit string starting with `<mcc><mnc>`.",
+			error:          "Invalid IMSI format. Must be a string of 6 to 15 digits starting with `<mcc><mnc>`.",
 		},
 		{
 			imsi:           "00101",
 			key:            Key,
 			sequenceNumber: SequenceNumber,
-			error:          "Invalid IMSI format. Must be a 15-digit string starting with `<mcc><mnc>`.",
+			error:          "Invalid IMSI format. Must be a string of 6 to 15 digits starting with `<mcc><mnc>`.",
 		},
 		{
 			imsi:           Imsi,
@@ -1088,6 +1088,21 @@ func TestCreateSubscriberValidInput(t *testing.T) {
 			mnc:  "001",
 			imsi: "001001975613993",
 		},
+		{
+			mcc:  "001",
+			mnc:  "01",
+			imsi: "001011",
+		},
+		{
+			mcc:  "001",
+			mnc:  "01",
+			imsi: "0010112345",
+		},
+		{
+			mcc:  "001",
+			mnc:  "001",
+			imsi: "0010017",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.imsi, func(t *testing.T) {
@@ -1130,6 +1145,52 @@ func TestCreateSubscriberValidInput(t *testing.T) {
 				t.Fatalf("expected status %d, got %d", http.StatusOK, statusCode)
 			}
 		})
+	}
+}
+
+func TestCreateSubscriberRejectsEmptyMSIN(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "db.sqlite3")
+
+	env, err := setupServer(dbPath)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer env.Server.Close()
+
+	client := newTestClient(env.Server)
+
+	token, err := initializeAndRefresh(env.Server.URL, client)
+	if err != nil {
+		t.Fatalf("couldn't create first user and login: %s", err)
+	}
+
+	statusCode, _, err := updateOperatorID(env.Server.URL, client, token, &UpdateOperatorIDParams{Mcc: "001", Mnc: "001"})
+	if err != nil {
+		t.Fatalf("couldn't update operator ID: %s", err)
+	}
+
+	if statusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+	}
+
+	statusCode, response, err := createSubscriber(env.Server.URL, client, token, &CreateSubscriberParams{
+		Imsi:           "001001",
+		Key:            Key,
+		SequenceNumber: SequenceNumber,
+		ProfileName:    "default",
+	})
+	if err != nil {
+		t.Fatalf("couldn't create subscriber: %s", err)
+	}
+
+	if statusCode != http.StatusBadRequest {
+		t.Fatalf("an IMSI that is only MCC+MNC was accepted: status %d", statusCode)
+	}
+
+	want := "Invalid IMSI format. Must be a string of 6 to 15 digits starting with `<mcc><mnc>`."
+	if response.Error != want {
+		t.Errorf("error = %q, want %q", response.Error, want)
 	}
 }
 

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3360,8 +3360,8 @@ components:
       required: true
       schema:
         type: string
-        pattern: "^[0-9]{15}$"
-      description: "15-digit IMSI (International Mobile Subscriber Identity)."
+        pattern: "^[0-9]{6,15}$"
+      description: "IMSI (International Mobile Subscriber Identity), 6 to 15 digits."
     PolicyNamePath:
       name: name
       in: path
@@ -3821,7 +3821,7 @@ components:
       properties:
         imsi:
           type: string
-          description: "15-digit International Mobile Subscriber Identity."
+          description: "International Mobile Subscriber Identity, 6 to 15 digits."
         profile_name:
           type: string
           description: Name of the assigned profile.
@@ -3981,8 +3981,8 @@ components:
       properties:
         imsi:
           type: string
-          pattern: "^[0-9]{15}$"
-          description: "15-digit IMSI. Must start with the operator's MCC+MNC."
+          pattern: "^[0-9]{6,15}$"
+          description: "IMSI of 6 to 15 digits. Must start with the operator's MCC+MNC."
         key:
           type: string
           pattern: "^[0-9a-fA-F]{32}$"
@@ -4770,7 +4770,7 @@ components:
       properties:
         imsi:
           type: string
-          description: "15-digit IMSI of the subscriber to pin."
+          description: "IMSI of the subscriber to pin, 6 to 15 digits."
         address:
           type: string
           description: "IPv4 address or /64-aligned IPv6 prefix within the data network pool."
@@ -4828,7 +4828,7 @@ components:
       properties:
         imsi:
           type: string
-          description: "15-digit IMSI of the subscriber."
+          description: "IMSI of the subscriber, 6 to 15 digits."
         ipv4:
           type: array
           items:

--- a/internal/tester/scenarios/enb/connectivity.go
+++ b/internal/tester/scenarios/enb/connectivity.go
@@ -49,7 +49,7 @@ func buildEnbSubscribers(numSubscribers int, startIMSI string) ([]enbSubscriber,
 		}
 
 		newIMSI := intBaseIMSI + i
-		imsi := fmt.Sprintf("%015d", newIMSI)
+		imsi := fmt.Sprintf("%0*d", len(startIMSI), newIMSI)
 
 		subs = append(subs, enbSubscriber{
 			IMSI:           imsi,

--- a/internal/tester/scenarios/gnb/common.go
+++ b/internal/tester/scenarios/gnb/common.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
 	"github.com/ellanetworks/core/internal/tester/testutil"
@@ -29,8 +30,8 @@ type subscriber struct {
 }
 
 func incrementIMSI(base string, offset int) string {
-	if len(base) != 15 {
-		panic("incrementIMSI: base must be 15 digits")
+	if len(base) < etsi.MinIMSIDigits || len(base) > etsi.MaxIMSIDigits {
+		panic(fmt.Sprintf("incrementIMSI: base must be %d to %d digits", etsi.MinIMSIDigits, etsi.MaxIMSIDigits))
 	}
 
 	var n uint64
@@ -45,8 +46,8 @@ func incrementIMSI(base string, offset int) string {
 
 	n += uint64(offset)
 
-	out := make([]byte, 15)
-	for i := 14; i >= 0; i-- {
+	out := make([]byte, len(base))
+	for i := len(base) - 1; i >= 0; i-- {
 		out[i] = byte('0' + n%10)
 		n /= 10
 	}
@@ -64,7 +65,7 @@ func buildSubscribers(numSubscribers int, startIMSI string) ([]subscriber, error
 		}
 
 		newIMSI := intBaseIMSI + i
-		imsi := fmt.Sprintf("%015d", newIMSI)
+		imsi := fmt.Sprintf("%0*d", len(startIMSI), newIMSI)
 
 		subs = append(subs, subscriber{
 			IMSI:           imsi,

--- a/internal/tester/scenarios/multi/cluster_traffic_5g.go
+++ b/internal/tester/scenarios/multi/cluster_traffic_5g.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/logger"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
@@ -33,7 +34,7 @@ func init() {
 		BindFlags: func(fs *pflag.FlagSet) any {
 			p := &clusterTrafficParams{}
 			fs.IntVar(&p.UECount, "ue-count", 5, "number of UEs to drive on this gNB")
-			fs.StringVar(&p.IMSIBase, "imsi-base", "", "IMSI of the first UE; subsequent UEs increment the last digit (required, 15 digits)")
+			fs.StringVar(&p.IMSIBase, "imsi-base", "", "IMSI of the first UE; subsequent UEs increment the last digit (required, 6 to 15 digits)")
 			fs.StringVar(&p.GnbID, "gnb-id", scenarios.DefaultGNBID, "gNB-ID for this scenario")
 
 			return p
@@ -57,8 +58,8 @@ func runClusterTraffic(ctx context.Context, env scenarios.Env, p *clusterTraffic
 		return fmt.Errorf("--ue-count must be >= 1, got %d", p.UECount)
 	}
 
-	if len(p.IMSIBase) != 15 {
-		return fmt.Errorf("--imsi-base must be 15 digits, got %q", p.IMSIBase)
+	if _, err := etsi.NewSUPIFromIMSI(p.IMSIBase); err != nil {
+		return fmt.Errorf("--imsi-base %q: %w", p.IMSIBase, err)
 	}
 
 	g := env.FirstGNB()

--- a/internal/tester/ue/sidf/suci_concealment.go
+++ b/internal/tester/ue/sidf/suci_concealment.go
@@ -11,6 +11,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
 )
 
 type HomeNetworkPublicKey struct {
@@ -110,8 +112,8 @@ func profileBEncrypt(msin string, hnPubkey *ecdh.PublicKey) (string, error) {
 }
 
 func CipherSuci(msin, mcc, mnc string, routingIndicator string, profile HomeNetworkPublicKey) (*Suci, error) {
-	if len(msin)+len(mcc)+len(mnc) < 14 {
-		return nil, errors.New("supi length must be 15")
+	if n := len(msin) + len(mcc) + len(mnc); n < etsi.MinIMSIDigits || n > etsi.MaxIMSIDigits {
+		return nil, fmt.Errorf("supi length must be %d to %d digits, got %d", etsi.MinIMSIDigits, etsi.MaxIMSIDigits, n)
 	}
 
 	var schemeOutput string

--- a/internal/upf/ebpf/flow_test.go
+++ b/internal/upf/ebpf/flow_test.go
@@ -37,10 +37,10 @@ func TestFlowReportUplink(t *testing.T) {
 		t.Fatalf("no flow_stats entry recorded (iterate err=%v)", it.Err())
 	}
 
-	const wantIMSI = 1010000000001 // "001010000000001"
+	const wantIMSI = "001010000000001"
 
-	if key.Imsi != wantIMSI {
-		t.Errorf("flow IMSI = %d, want %d", key.Imsi, uint64(wantIMSI))
+	if got := DecodeIMSITag(key.Imsi); got != wantIMSI {
+		t.Errorf("flow IMSI = %q, want %q", got, wantIMSI)
 	}
 
 	if key.Proto != 17 {
@@ -154,10 +154,10 @@ func TestFlowReportDownlink(t *testing.T) {
 		t.Fatalf("no flow_stats entry recorded (iterate err=%v)", it.Err())
 	}
 
-	const wantIMSI = 1010000000001 // "001010000000001"
+	const wantIMSI = "001010000000001"
 
-	if key.Imsi != wantIMSI {
-		t.Errorf("flow IMSI = %d, want %d", key.Imsi, uint64(wantIMSI))
+	if got := DecodeIMSITag(key.Imsi); got != wantIMSI {
+		t.Errorf("flow IMSI = %q, want %q", got, wantIMSI)
 	}
 
 	if key.Proto != 17 {

--- a/internal/upf/ebpf/imsi_tag.go
+++ b/internal/upf/ebpf/imsi_tag.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ebpf
+
+import "fmt"
+
+const (
+	imsiTagValueBits = 50
+	imsiTagValueMask = uint64(1)<<imsiTagValueBits - 1
+	imsiTagMaxDigits = 15
+)
+
+func EncodeIMSITag(imsi string) (uint64, error) {
+	if len(imsi) == 0 || len(imsi) > imsiTagMaxDigits {
+		return 0, fmt.Errorf("imsi %q: length %d out of range 1..%d", imsi, len(imsi), imsiTagMaxDigits)
+	}
+
+	var value uint64
+
+	for i := 0; i < len(imsi); i++ {
+		if imsi[i] < '0' || imsi[i] > '9' {
+			return 0, fmt.Errorf("imsi %q: contains non-digit characters", imsi)
+		}
+
+		value = value*10 + uint64(imsi[i]-'0')
+	}
+
+	return uint64(len(imsi))<<imsiTagValueBits | value, nil
+}
+
+func DecodeIMSITag(tag uint64) string {
+	digits := int(tag >> imsiTagValueBits)
+	if digits <= 0 || digits > imsiTagMaxDigits {
+		return ""
+	}
+
+	return fmt.Sprintf("%0*d", digits, tag&imsiTagValueMask)
+}

--- a/internal/upf/ebpf/imsi_tag_test.go
+++ b/internal/upf/ebpf/imsi_tag_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ebpf
+
+import "testing"
+
+func TestIMSITagRoundTrip(t *testing.T) {
+	for _, imsi := range []string{
+		"001011",
+		"0010112345",
+		"00101123456789",
+		"001019756139935",
+		"999999999999999",
+		"000000000000001",
+		"001010000000001",
+	} {
+		tag, err := EncodeIMSITag(imsi)
+		if err != nil {
+			t.Fatalf("EncodeIMSITag(%q): %v", imsi, err)
+		}
+
+		if got := DecodeIMSITag(tag); got != imsi {
+			t.Errorf("round trip of %q gave %q", imsi, got)
+		}
+	}
+}
+
+func TestIMSITagDistinguishesLeadingZeros(t *testing.T) {
+	short, err := EncodeIMSITag("0010112345")
+	if err != nil {
+		t.Fatalf("EncodeIMSITag: %v", err)
+	}
+
+	long, err := EncodeIMSITag("000000010112345")
+	if err != nil {
+		t.Fatalf("EncodeIMSITag: %v", err)
+	}
+
+	if short == long {
+		t.Fatalf("IMSIs of different lengths share tag %d", short)
+	}
+}
+
+func TestEncodeIMSITagRejectsMalformed(t *testing.T) {
+	for _, imsi := range []string{"", "0001011234567890", "00101a"} {
+		if _, err := EncodeIMSITag(imsi); err == nil {
+			t.Errorf("EncodeIMSITag(%q): encoded without error, want a rejection", imsi)
+		}
+	}
+}
+
+func TestDecodeIMSITagZeroIsEmpty(t *testing.T) {
+	if got := DecodeIMSITag(0); got != "" {
+		t.Errorf("DecodeIMSITag(0) = %q, want the empty string", got)
+	}
+}

--- a/internal/upf/ebpf/pdr.go
+++ b/internal/upf/ebpf/pdr.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/netip"
 	"runtime"
-	"strconv"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -340,12 +339,12 @@ func ToN3N6EntrypointPdrInfo(defaultPdr PdrInfo) (N3N6EntrypointPdrInfo, error) 
 	pdrToStore.UrrId = defaultPdr.UrrID
 	pdrToStore.QerId = defaultPdr.QerID
 
-	imsiUint64, err := strconv.ParseUint(defaultPdr.IMSI, 10, 64)
+	imsiTag, err := EncodeIMSITag(defaultPdr.IMSI)
 	if err != nil {
 		return N3N6EntrypointPdrInfo{}, fmt.Errorf("parse IMSI %q: %w", defaultPdr.IMSI, err)
 	}
 
-	pdrToStore.Imsi = imsiUint64
+	pdrToStore.Imsi = imsiTag
 
 	pdrToStore.Far.Action = defaultPdr.Far.Action
 	pdrToStore.Far.OuterHeaderCreation = defaultPdr.Far.OuterHeaderCreation

--- a/internal/upf/ebpf/pdr_test.go
+++ b/internal/upf/ebpf/pdr_test.go
@@ -96,8 +96,8 @@ func TestToN3N6EntrypointPdrInfoCarriesFARAndQER(t *testing.T) {
 		t.Fatalf("ToN3N6EntrypointPdrInfo: %v", err)
 	}
 
-	if got.Imsi != 1010000000001 {
-		t.Errorf("Imsi = %d, want 1010000000001", got.Imsi)
+	if DecodeIMSITag(got.Imsi) != "001010000000001" {
+		t.Errorf("Imsi = %q, want %q", DecodeIMSITag(got.Imsi), "001010000000001")
 	}
 
 	if got.Far.Action != 2 || got.Far.Teid != 0x1234 {

--- a/internal/upf/engine/flow_reporter.go
+++ b/internal/upf/engine/flow_reporter.go
@@ -5,7 +5,6 @@ package engine
 
 import (
 	"encoding/binary"
-	"fmt"
 	"net/netip"
 	"time"
 
@@ -75,7 +74,7 @@ func BuildFlowReportRequest(flow ebpf.N3N6EntrypointFlow, stats ebpf.N3N6Entrypo
 	}
 
 	return &models.FlowReportRequest{
-		IMSI:            fmt.Sprintf("%015d", flow.Imsi),
+		IMSI:            ebpf.DecodeIMSITag(flow.Imsi),
 		SourceIP:        saddr.String(),
 		DestinationIP:   daddr.String(),
 		SourcePort:      sport,

--- a/internal/upf/engine/flow_reporter_test.go
+++ b/internal/upf/engine/flow_reporter_test.go
@@ -41,9 +41,18 @@ func makePortUint16(port uint16) uint16 {
 	return (port >> 8) | (port << 8)
 }
 
+var testIMSITag = func() uint64 {
+	tag, err := ebpf.EncodeIMSITag("001019756139935")
+	if err != nil {
+		panic(err)
+	}
+
+	return tag
+}()
+
 func TestBuildFlowReportRequestBasic(t *testing.T) {
 	flow := ebpf.N3N6EntrypointFlow{
-		Imsi:  1019756139935,
+		Imsi:  testIMSITag,
 		Saddr: makeIPV4Mapped(192, 168, 1, 100),
 		Daddr: makeIPV4Mapped(8, 8, 8, 8),
 		Sport: makePortUint16(12345),
@@ -103,7 +112,7 @@ func TestBuildFlowReportRequestDifferentProtocols(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			flow := ebpf.N3N6EntrypointFlow{
-				Imsi:  1019756139935,
+				Imsi:  testIMSITag,
 				Saddr: makeIPV4Mapped(192, 168, 1, 100),
 				Daddr: makeIPV4Mapped(8, 8, 8, 8),
 				Sport: makePortUint16(12345),
@@ -133,7 +142,7 @@ func TestBuildFlowReportRequestDifferentProtocols(t *testing.T) {
 
 func TestBuildFlowReportRequestTimestampFormatting(t *testing.T) {
 	flow := ebpf.N3N6EntrypointFlow{
-		Imsi:  1019756139935,
+		Imsi:  testIMSITag,
 		Saddr: makeIPV4Mapped(192, 168, 1, 100),
 		Daddr: makeIPV4Mapped(8, 8, 8, 8),
 		Sport: makePortUint16(12345),
@@ -173,7 +182,7 @@ func TestBuildFlowReportRequestTimestampAccuracy(t *testing.T) {
 	now := time.Now()
 
 	flow := ebpf.N3N6EntrypointFlow{
-		Imsi:  1019756139935,
+		Imsi:  testIMSITag,
 		Saddr: makeIPV4Mapped(192, 168, 1, 100),
 		Daddr: makeIPV4Mapped(8, 8, 8, 8),
 		Sport: makePortUint16(12345),
@@ -257,7 +266,7 @@ func TestBuildFlowReportRequestIPAddressConversion(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			flow := ebpf.N3N6EntrypointFlow{
-				Imsi:  1019756139935,
+				Imsi:  testIMSITag,
 				Saddr: tc.saddr,
 				Daddr: tc.daddr,
 				Sport: makePortUint16(12345),
@@ -287,7 +296,7 @@ func TestBuildFlowReportRequestIPAddressConversion(t *testing.T) {
 
 func TestBuildFlowReportRequestImsiFormatting(t *testing.T) {
 	flow := ebpf.N3N6EntrypointFlow{
-		Imsi:  1019756139935,
+		Imsi:  testIMSITag,
 		Saddr: makeIPV4Mapped(192, 168, 1, 100),
 		Daddr: makeIPV4Mapped(8, 8, 8, 8),
 		Sport: makePortUint16(12345),
@@ -312,7 +321,7 @@ func TestBuildFlowReportRequestImsiFormatting(t *testing.T) {
 func TestBuildFlowReportRequestIPv6Addresses(t *testing.T) {
 	// Test that IPv6 addresses are correctly converted without the IPv4-mapped prefix
 	flow := ebpf.N3N6EntrypointFlow{
-		Imsi:  1019756139935,
+		Imsi:  testIMSITag,
 		Saddr: makeIPV6(0x20, 0x01, 0x0d, 0xb8, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01),
 		Daddr: makeIPV6(0x20, 0x01, 0x0d, 0xb8, 0xab, 0xcd, 0xef, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01),
 		Sport: makePortUint16(54321),
@@ -353,7 +362,7 @@ func TestBuildFlowReportRequestIPv6Addresses(t *testing.T) {
 func TestBuildFlowReportRequestMixedIPv4IPv6(t *testing.T) {
 	// Test that IPv4 addresses are correctly identified as IPv4-mapped
 	flow := ebpf.N3N6EntrypointFlow{
-		Imsi:  1019756139935,
+		Imsi:  testIMSITag,
 		Saddr: makeIPV4Mapped(10, 0, 0, 1),
 		Daddr: makeIPV4Mapped(172, 16, 0, 1),
 		Sport: makePortUint16(8080),

--- a/internal/upf/engine/modify_session_imsi_test.go
+++ b/internal/upf/engine/modify_session_imsi_test.go
@@ -92,8 +92,8 @@ func TestModifySessionCreatePDRCarriesSessionIMSI(t *testing.T) {
 		t.Fatalf("created PDR is absent from pdrs_downlink_ip4: %v", err)
 	}
 
-	if v.Imsi != 1010000000001 {
-		t.Errorf("datapath IMSI = %d, want %d (from the establish request %q)", v.Imsi, 1010000000001, imsi)
+	if got := upfebpf.DecodeIMSITag(v.Imsi); got != imsi {
+		t.Errorf("datapath IMSI = %q, want %q (from the establish request)", got, imsi)
 	}
 
 	if v.LocalSeid != seid {
@@ -127,8 +127,8 @@ func TestModifySessionUpdateWithoutPredecessorCarriesSessionIMSI(t *testing.T) {
 		t.Fatalf("updated PDR is absent from pdrs_downlink_ip4: %v", err)
 	}
 
-	if v.Imsi != 1010000000002 {
-		t.Errorf("datapath IMSI = %d, want %d (from the establish request %q)", v.Imsi, 1010000000002, imsi)
+	if got := upfebpf.DecodeIMSITag(v.Imsi); got != imsi {
+		t.Errorf("datapath IMSI = %q, want %q (from the establish request)", got, imsi)
 	}
 
 	if v.LocalSeid != seid {

--- a/nas/eps/ie_identity.go
+++ b/nas/eps/ie_identity.go
@@ -240,9 +240,6 @@ type IMSI string
 
 func (i IMSI) String() string { return "imsi-" + string(i) }
 
-// Valid reports whether the identity has a length TS 23.003 §2.2 permits.
-func (i IMSI) Valid() bool { return len(i) >= 6 && len(i) <= 15 }
-
 // AppendBinary encodes the IMSI as an EPS mobile identity value onto b.
 func (i IMSI) AppendBinary(b []byte) ([]byte, error) {
 	return appendPackedDigits(b, uint8(IdentityIMSI), IdentityIMSI, string(i))

--- a/nas/eps/ie_identity_imsi_length_test.go
+++ b/nas/eps/ie_identity_imsi_length_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package eps
+
+import "testing"
+
+func TestIMSIWireRoundTripAcrossLengths(t *testing.T) {
+	for _, imsi := range []string{
+		"001011",
+		"0010112",
+		"0010112345",
+		"00101123456",
+		"00101975613993",
+		"001019756139935",
+	} {
+		b, err := IMSI(imsi).MarshalBinary()
+		if err != nil {
+			t.Fatalf("IMSI(%q).MarshalBinary: %v", imsi, err)
+		}
+
+		got, err := ParseEPSMobileIdentity(b)
+		if err != nil {
+			t.Fatalf("ParseEPSMobileIdentity(%q): %v", imsi, err)
+		}
+
+		if got.IMSI == nil || string(*got.IMSI) != imsi {
+			t.Errorf("round trip of %q gave %+v", imsi, got)
+		}
+	}
+}
+
+func TestIMSIWireOddEvenIndicator(t *testing.T) {
+	odd, err := IMSI("0010112345678").MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+
+	if odd[0]&0x08 == 0 {
+		t.Errorf("13-digit IMSI: odd/even indicator clear, want set")
+	}
+
+	even, err := IMSI("001011234567").MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+
+	if even[0]&0x08 != 0 {
+		t.Errorf("12-digit IMSI: odd/even indicator set, want clear")
+	}
+
+	if even[len(even)-1]&0xF0 != 0xF0 {
+		t.Errorf("12-digit IMSI: last octet high nibble = %#x, want the 0xF end mark", even[len(even)-1]>>4)
+	}
+}

--- a/nas/fgs/ie_identity_msin_length_test.go
+++ b/nas/fgs/ie_identity_msin_length_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fgs
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+)
+
+func TestSUCIMSINRoundTripAcrossLengths(t *testing.T) {
+	cases := []struct {
+		plmn nas.PLMN
+		msin string
+		supi string
+	}{
+		{nas.PLMN{MCC: "001", MNC: "01"}, "1", "imsi-001011"},
+		{nas.PLMN{MCC: "001", MNC: "01"}, "12", "imsi-0010112"},
+		{nas.PLMN{MCC: "001", MNC: "01"}, "12345", "imsi-0010112345"},
+		{nas.PLMN{MCC: "001", MNC: "01"}, "0000000001", "imsi-001010000000001"},
+		{nas.PLMN{MCC: "001", MNC: "001"}, "123", "imsi-001001123"},
+		{nas.PLMN{MCC: "001", MNC: "001"}, "975613993", "imsi-001001975613993"},
+	}
+
+	for _, tc := range cases {
+		scheme, err := nas.EncodeTBCD(tc.msin)
+		if err != nil {
+			t.Fatalf("EncodeTBCD(%q): %v", tc.msin, err)
+		}
+
+		buf, err := SUCI{
+			PLMN:             tc.plmn,
+			RoutingIndicator: "0000",
+			ProtectionScheme: ProtectionSchemeNull,
+			SchemeOutput:     scheme,
+		}.MarshalBinary()
+		if err != nil {
+			t.Fatalf("MarshalBinary(%q): %v", tc.msin, err)
+		}
+
+		got, err := ParseSUCI(buf)
+		if err != nil {
+			t.Fatalf("ParseSUCI(%q): %v", tc.msin, err)
+		}
+
+		if msin, ok := got.MSIN(); !ok || msin != tc.msin {
+			t.Errorf("MSIN of %q = %q (revealed %v)", tc.msin, msin, ok)
+		}
+
+		if supi, ok := got.SUPI(); !ok || supi != tc.supi {
+			t.Errorf("SUPI for MSIN %q = %q, want %q", tc.msin, supi, tc.supi)
+		}
+	}
+}
+
+func TestSUCIOddMSINCarriesFiller(t *testing.T) {
+	odd, err := nas.EncodeTBCD("12345")
+	if err != nil {
+		t.Fatalf("EncodeTBCD: %v", err)
+	}
+
+	if odd[len(odd)-1]&0xF0 != 0xF0 {
+		t.Errorf("odd MSIN: last octet high nibble = %#x, want the 0xF filler", odd[len(odd)-1]>>4)
+	}
+
+	even, err := nas.EncodeTBCD("123456")
+	if err != nil {
+		t.Fatalf("EncodeTBCD: %v", err)
+	}
+
+	if even[len(even)-1]&0xF0 == 0xF0 {
+		t.Errorf("even MSIN: last octet carries a filler it should not")
+	}
+}

--- a/ui/src/components/CreateSubscriberModal.tsx
+++ b/ui/src/components/CreateSubscriberModal.tsx
@@ -54,7 +54,17 @@ type Operator = {
   };
 };
 
-const getMSINLength = (mnc: string) => (mnc?.length === 3 ? 9 : 10);
+const MCC_DIGITS = 3;
+const IMSI_MIN_DIGITS = 6;
+const IMSI_MAX_DIGITS = 15;
+
+const getMSINBounds = (mncLength: number) => {
+  const prefixLength = MCC_DIGITS + mncLength;
+  return {
+    min: Math.max(1, IMSI_MIN_DIGITS - prefixLength),
+    max: Math.max(1, IMSI_MAX_DIGITS - prefixLength),
+  };
+};
 
 const schema = yup.object().shape({
   msin: yup
@@ -62,12 +72,15 @@ const schema = yup.object().shape({
     .matches(/^\d+$/, "MSIN must be numeric.")
     .test("msin-len", function (value) {
       const mncLength = this.options?.context?.mncLength ?? 2;
-      const len = mncLength === 3 ? 9 : 10;
+      const { min, max } = getMSINBounds(mncLength);
       if (!value) return this.createError({ message: "MSIN is required." });
       return (
-        value.length === len ||
+        (value.length >= min && value.length <= max) ||
         this.createError({
-          message: `MSIN must be exactly ${len} digits long.`,
+          message:
+            min === max
+              ? `MSIN must be exactly ${min} digits long.`
+              : `MSIN must be between ${min} and ${max} digits long.`,
         })
       );
     })
@@ -257,25 +270,23 @@ const CreateSubscriberModal: React.FC<CreateSubscriberModalProps> = ({
   ) => {
     const digits = sanitizeDigits(raw);
     const prefix = `${operatorMcc}${operatorMnc}`;
-    const msinLen = 15 - (operatorMcc.length + operatorMnc.length);
-    const fullLen = prefix.length + msinLen;
+    const { max } = getMSINBounds(operatorMnc.length);
 
-    if (digits.length <= msinLen) {
+    if (digits.length <= max) {
       return { msin: digits, mismatchMsg: null };
     }
 
-    if (digits.length >= fullLen) {
-      if (digits.startsWith(prefix)) {
-        const msin = digits.slice(prefix.length, prefix.length + msinLen);
-        return { msin, mismatchMsg: null };
-      }
+    if (digits.startsWith(prefix)) {
       return {
-        msin: null,
-        mismatchMsg: `IMSI prefix does not match MCC ${operatorMcc} / MNC ${operatorMnc}.`,
+        msin: digits.slice(prefix.length, prefix.length + max),
+        mismatchMsg: null,
       };
     }
 
-    return { msin: digits.slice(-msinLen), mismatchMsg: null };
+    return {
+      msin: null,
+      mismatchMsg: `IMSI prefix does not match MCC ${operatorMcc} / MNC ${operatorMnc}.`,
+    };
   };
 
   const handleIMSIishInput = (raw: string) => {
@@ -293,8 +304,8 @@ const CreateSubscriberModal: React.FC<CreateSubscriberModalProps> = ({
     Array.from({ length: len }, () => Math.floor(Math.random() * 10)).join("");
 
   const generateRandomMSIN = () => {
-    const len = getMSINLength(mnc);
-    const randomMSIN = randomDigits(len);
+    const { max } = getMSINBounds(mnc.length);
+    const randomMSIN = randomDigits(max);
     handleChange("msin", randomMSIN);
   };
 


### PR DESCRIPTION
# Description

Set the SECURITY MODE COMMAND HDP only when the AMF derives K'AMF.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
