### PR TITLE
feat: Idle-mode 4G/5G interworking

### DIFF
--- a/etsi/interworking.go
+++ b/etsi/interworking.go
@@ -17,8 +17,6 @@ func MapGUTI5GToEPS(g fgs.GUTI) eps.GUTI {
 	}
 }
 
-// MappedEPSGUTI is the 4G-GUTI a UE derives from this 5G-GUTI to address the
-// peer MME on an inter-system change (TS 23.003 §2.10.2.1.3).
 func (g GUTI5G) MappedEPSGUTI() (eps.GUTI, error) {
 	id, err := g.MobileIdentity()
 	if err != nil {

--- a/etsi/interworking.go
+++ b/etsi/interworking.go
@@ -17,6 +17,17 @@ func MapGUTI5GToEPS(g fgs.GUTI) eps.GUTI {
 	}
 }
 
+// MappedEPSGUTI is the 4G-GUTI a UE derives from this 5G-GUTI to address the
+// peer MME on an inter-system change (TS 23.003 §2.10.2.1.3).
+func (g GUTI5G) MappedEPSGUTI() (eps.GUTI, error) {
+	id, err := g.MobileIdentity()
+	if err != nil {
+		return eps.GUTI{}, err
+	}
+
+	return MapGUTI5GToEPS(*id.GUTI), nil
+}
+
 func MapGUTIEPSTo5G(g eps.GUTI) fgs.GUTI {
 	return fgs.GUTI{
 		PLMN:        g.PLMN,

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -72,6 +72,7 @@ var scenarioFollowsDeploymentIPFamily = map[string]bool{
 	"interworking/handover_5gs_to_eps_target_refuses": true,
 	"interworking/handover_eps_to_5gs":                true,
 	"interworking/handover_eps_to_5gs_target_refuses": true,
+	"interworking/idle_5gs_to_eps":                    true,
 }
 
 // scenarioIPFamilyExclusions returns a map of scenario name → set of IP

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -73,6 +73,7 @@ var scenarioFollowsDeploymentIPFamily = map[string]bool{
 	"interworking/handover_eps_to_5gs":                true,
 	"interworking/handover_eps_to_5gs_target_refuses": true,
 	"interworking/idle_5gs_to_eps":                    true,
+	"interworking/idle_5gs_to_eps_returning_to_idle":  true,
 	"interworking/idle_eps_to_5gs":                    true,
 }
 

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -73,6 +73,7 @@ var scenarioFollowsDeploymentIPFamily = map[string]bool{
 	"interworking/handover_eps_to_5gs":                true,
 	"interworking/handover_eps_to_5gs_target_refuses": true,
 	"interworking/idle_5gs_to_eps":                    true,
+	"interworking/idle_eps_to_5gs":                    true,
 }
 
 // scenarioIPFamilyExclusions returns a map of scenario name → set of IP

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -266,6 +266,7 @@ func (amf *AMF) DeregisterAndRemoveUeContext(ctx context.Context, ue *UeContext)
 
 	amf.mu.Lock()
 	amf.releaseTmsisLocked(ue)
+	amf.endRelocationFromEPSLocked(ue.supi, ue)
 
 	// Only delete the SUPI index if it still points to this context: an authenticated
 	// re-registration indexes the new context under the same SUPI before this superseded

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -76,6 +76,7 @@ type SmfSbi interface {
 	UpdateSmContextN2InfoPduResRelRsp(ctx context.Context, smContextRef string) error
 	UpdateSmContextCauseDuplicatePDUSessionID(ctx context.Context, smContextRef string) ([]byte, error)
 	PrepareSmContextFromEPS(ctx context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (string, []byte, error)
+	TransferIdleTo5GS(ctx context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (string, error)
 	UpdateSmContextN2HandoverPreparing(ctx context.Context, smContextRef string, n2Data []byte) ([]byte, error)
 	UpdateSmContextN2HandoverPrepared(ctx context.Context, smContextRef string, n2Data []byte) ([]byte, error)
 	UpdateSmContextN2HandoverComplete(ctx context.Context, smContextRef string) error

--- a/internal/amf/amf_test.go
+++ b/internal/amf/amf_test.go
@@ -14,6 +14,10 @@ import (
 	"go.uber.org/zap"
 )
 
+func testGuami() *models.Guami {
+	return &models.Guami{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, AmfID: "cafe00"}
+}
+
 func newSUPI(t *testing.T, imsi string) etsi.SUPI {
 	t.Helper()
 
@@ -124,13 +128,50 @@ func TestLookupUeByGuti(t *testing.T) {
 	ue := addTestUE(t, amfInstance, "001010000000009", func(ue *amf.UeContext) {})
 	amfInstance.AssignGutiForTest(ue, guti)
 
-	found, ok := amfInstance.LookupUeByGuti(guti)
+	found, ok := amfInstance.LookupUeByGuti(testGuami(), guti)
 	if !ok {
 		t.Fatal("expected to find UE by GUTI")
 	}
 
 	if found.TmsiForTest() != guti.Tmsi {
 		t.Fatalf("5G-TMSI mismatch: got %v, want %v", found.TmsiForTest(), guti.Tmsi)
+	}
+}
+
+// TS 23.003 §2.10.2.2.3
+func TestLookupUeByGutiRefusesAGutiNamingAnotherNode(t *testing.T) {
+	amfInstance := amf.New(nil, nil, nil)
+
+	tmsi, err := etsi.NewTMSI(42)
+	if err != nil {
+		t.Fatalf("NewTMSI: %v", err)
+	}
+
+	native, err := etsi.NewGUTI5G("001", "01", "cafe00", tmsi)
+	if err != nil {
+		t.Fatalf("NewGUTI: %v", err)
+	}
+
+	ue := addTestUE(t, amfInstance, "001010000000012", func(ue *amf.UeContext) {})
+	amfInstance.AssignGutiForTest(ue, native)
+
+	for _, tc := range []struct {
+		name            string
+		mcc, mnc, amfID string
+	}{
+		{"another AMF", "001", "01", "cafe01"},
+		{"another PLMN", "002", "01", "cafe00"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			foreign, err := etsi.NewGUTI5G(tc.mcc, tc.mnc, tc.amfID, tmsi)
+			if err != nil {
+				t.Fatalf("NewGUTI: %v", err)
+			}
+
+			if found, ok := amfInstance.LookupUeByGuti(testGuami(), foreign); ok {
+				t.Fatalf("GUTI %s resolved to the holder of 5G-TMSI %s", foreign.String(), found.TmsiForTest())
+			}
+		})
 	}
 }
 
@@ -145,14 +186,11 @@ func TestGutiIndexLifecycle(t *testing.T) {
 		t.Fatalf("ReallocateGUTI: %v", err)
 	}
 
-	// The AMF stores only the 5G-TMSI and resolves an inbound GUTI by its TMSI part, so
-	// a lookup GUTI need only carry the UE's current TMSI.
 	guti1, _ := etsi.NewGUTI5G("001", "01", "cafe00", ue.TmsiForTest())
-	if found, ok := amfInstance.LookupUeByGuti(guti1); !ok || found != ue {
+	if found, ok := amfInstance.LookupUeByGuti(testGuami(), guti1); !ok || found != ue {
 		t.Fatal("UE not resolvable by its GUTI after allocation")
 	}
 
-	// Reallocation: both the new and the in-flight old 5G-TMSI resolve to the UE.
 	if err := amfInstance.ReallocateGUTI(context.Background(), ue); err != nil {
 		t.Fatalf("ReallocateGUTI (realloc): %v", err)
 	}
@@ -162,29 +200,28 @@ func TestGutiIndexLifecycle(t *testing.T) {
 		t.Fatal("reallocation should produce a new GUTI")
 	}
 
-	if found, ok := amfInstance.LookupUeByGuti(guti2); !ok || found != ue {
+	if found, ok := amfInstance.LookupUeByGuti(testGuami(), guti2); !ok || found != ue {
 		t.Fatal("UE not resolvable by its new GUTI")
 	}
 
-	if found, ok := amfInstance.LookupUeByGuti(guti1); !ok || found != ue {
+	if found, ok := amfInstance.LookupUeByGuti(testGuami(), guti1); !ok || found != ue {
 		t.Fatal("UE not resolvable by its old GUTI during the reallocation window")
 	}
 
-	// CommitGUTIRealloc: the old GUTI stops resolving; the current one still resolves.
 	amfInstance.CommitGUTIRealloc(ue)
 
-	if _, ok := amfInstance.LookupUeByGuti(guti1); ok {
+	if _, ok := amfInstance.LookupUeByGuti(testGuami(), guti1); ok {
 		t.Fatal("old GUTI must not resolve after CommitGUTIRealloc")
 	}
 
-	if _, ok := amfInstance.LookupUeByGuti(guti2); !ok {
+	if _, ok := amfInstance.LookupUeByGuti(testGuami(), guti2); !ok {
 		t.Fatal("current GUTI must still resolve after CommitGUTIRealloc")
 	}
 
 	// Removal: no GUTI resolves to the removed UE.
 	amfInstance.DeregisterAndRemoveUeContext(context.Background(), ue)
 
-	if _, ok := amfInstance.LookupUeByGuti(guti2); ok {
+	if _, ok := amfInstance.LookupUeByGuti(testGuami(), guti2); ok {
 		t.Fatal("removed UE must not resolve by GUTI")
 	}
 }
@@ -276,7 +313,7 @@ func TestFindUeContextByGuti_InvalidGUTI(t *testing.T) {
 
 	addTestUE(t, amfInstance, "001010000000010", func(ue *amf.UeContext) {})
 
-	_, ok := amfInstance.LookupUeByGuti(etsi.InvalidGUTI5G)
+	_, ok := amfInstance.LookupUeByGuti(testGuami(), etsi.InvalidGUTI5G)
 	if ok {
 		t.Fatal("should not find UE with InvalidGUTI")
 	}

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -463,6 +463,7 @@ func (ue *UeContext) ClearRegistrationRequestData() {
 	conn.resyncTried = false
 	conn.RetransmissionOfInitialNASMsg = false
 	conn.RegistrationAcceptPlain = nil
+	conn.ArrivedFromEPS = false
 
 	if r := ue.active.Load(); r != nil {
 		r.UeContextRequest = false

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -67,7 +67,6 @@ type UeContext struct {
 	procedures *procedure.Registry
 
 	secured              bool
-	keyOrigin            KeyOrigin
 	ueSecurityCapability *fgs.UESecurityCapability // TS 24.501 §9.11.3.54
 
 	gmmCapability         *fgs.GMMCapability
@@ -336,7 +335,6 @@ func (ue *UeContext) InstallNASSecurityContext(nea nas.CipheringAlgorithm, nia n
 
 	if err == nil {
 		ue.ulCount.Reset()
-		ue.keyOrigin = KeyOriginPrimaryAuth
 	}
 	ue.mu.Unlock()
 

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -46,6 +46,7 @@ type UeContext struct {
 	regStep RegStep
 
 	arrivedFromEPSHandover bool
+	exportableToEPSUntil   time.Time
 
 	PlmnID  models.PlmnID
 	Suci    string

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -92,6 +92,10 @@ func (s *deregisterTestSmf) UpdateSmContextCauseDuplicatePDUSessionID(context.Co
 	return nil, nil
 }
 
+func (s *deregisterTestSmf) TransferIdleTo5GS(context.Context, etsi.SUPI, uint8, uint8, string, *models.Snssai) (string, error) {
+	return "", nil
+}
+
 func (s *deregisterTestSmf) PrepareSmContextFromEPS(context.Context, etsi.SUPI, uint8, uint8, string, *models.Snssai) (string, []byte, error) {
 	return "", nil, nil
 }

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -160,9 +160,11 @@ func BuildSecurityModeCommand(ue *UeContext) ([]byte, error) {
 		imeisv = fgs.IMEISVRequested
 	}
 
+	// HDP stays clear: horizontal K_AMF derivation (TS 33.501 Annex A.13, FC 0x72)
+	// is not performed by this AMF, so TS 24.501 §5.4.2.2 never has it signalled.
 	addInfo := fgs.AdditionalSecurityInformation{
 		RINMR: conn.RetransmissionOfInitialNASMsg,
-		HDP:   ue.KeyOrigin() == KeyOriginHorizontalDerivation,
+		HDP:   false,
 	}
 
 	ngksi := ue.NgKsi()

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -160,8 +160,6 @@ func BuildSecurityModeCommand(ue *UeContext) ([]byte, error) {
 		imeisv = fgs.IMEISVRequested
 	}
 
-	// HDP stays clear: horizontal K_AMF derivation (TS 33.501 Annex A.13, FC 0x72)
-	// is not performed by this AMF, so TS 24.501 §5.4.2.2 never has it signalled.
 	addInfo := fgs.AdditionalSecurityInformation{
 		RINMR: conn.RetransmissionOfInitialNASMsg,
 		HDP:   false,

--- a/internal/amf/build_test.go
+++ b/internal/amf/build_test.go
@@ -167,3 +167,56 @@ func TestBuildRegistrationAccept_EmptyAllowedNSSAI(t *testing.T) {
 		t.Fatal("expected AllowedNSSAI to be absent when list is empty")
 	}
 }
+
+// The EPS bearer context status IE belongs to an actual S1→N1 change
+// (TS 24.501 §8.2.7.31, TS 23.502 §4.11.1.3.3 steps 17-18), so the flag that
+// records one must not outlive the registration that set it: a later mobility or
+// periodic registration on the same connection would otherwise claim the IE and
+// run the EPS bearer release with it.
+func TestRegistrationAcceptDropsTheEPSBearerStatusOnceTheRegistrationIsDone(t *testing.T) {
+	ue := buildTestUE(t)
+	attachTestConn(t, ue)
+
+	if err := ue.CreateSmContext(3, "ref-3", &models.Snssai{Sst: 1, Sd: "010203"}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	ue.SetEPSBearerIdentity(3, 6)
+
+	amfInstance := amf.New(nil, nil, nil)
+	amfInstance.EPS = &fakeEPSPeer{}
+
+	conn := ue.Conn()
+	if conn == nil {
+		t.Fatal("no NAS connection")
+	}
+
+	conn.ArrivedFromEPS = true
+
+	if status := epsBearerStatusOf(t, amfInstance, ue); status == nil || !status.Active[6] {
+		t.Fatalf("EPS bearer context status = %+v, want EBI 6 active while the arrival is being registered", status)
+	}
+
+	ue.ClearRegistrationRequestData()
+
+	if status := epsBearerStatusOf(t, amfInstance, ue); status != nil {
+		t.Errorf("EPS bearer context status = %+v, want the IE omitted: the arrival flag outlived its registration", status)
+	}
+}
+
+func epsBearerStatusOf(t *testing.T, amfInstance *amf.AMF, ue *amf.UeContext) *nas.EPSBearerContextStatus {
+	t.Helper()
+
+	raw, err := amf.BuildRegistrationAccept(amfInstance, ue, etsi.InvalidGUTI5G, nil, nil, nil, nil,
+		models.PlmnID{Mcc: "001", Mnc: "01"})
+	if err != nil {
+		t.Fatalf("BuildRegistrationAccept: %v", err)
+	}
+
+	ra, err := fgs.ParseRegistrationAccept(raw)
+	if err != nil {
+		t.Fatalf("parse RegistrationAccept: %v", err)
+	}
+
+	return ra.EPSBearerContextStatus
+}

--- a/internal/amf/build_test.go
+++ b/internal/amf/build_test.go
@@ -168,11 +168,7 @@ func TestBuildRegistrationAccept_EmptyAllowedNSSAI(t *testing.T) {
 	}
 }
 
-// The EPS bearer context status IE belongs to an actual S1→N1 change
-// (TS 24.501 §8.2.7.31, TS 23.502 §4.11.1.3.3 steps 17-18), so the flag that
-// records one must not outlive the registration that set it: a later mobility or
-// periodic registration on the same connection would otherwise claim the IE and
-// run the EPS bearer release with it.
+// TS 24.501 §8.2.7.31, TS 23.502 §4.11.1.3.3 steps 17-18
 func TestRegistrationAcceptDropsTheEPSBearerStatusOnceTheRegistrationIsDone(t *testing.T) {
 	ue := buildTestUE(t)
 	attachTestConn(t, ue)

--- a/internal/amf/config.go
+++ b/internal/amf/config.go
@@ -45,7 +45,7 @@ func (amf *AMF) operatorInfoFrom(operator *db.Operator) (*OperatorInfo, error) {
 	}
 
 	amfID := util.AMFIDToModels(
-		ngap.AMFRegionID(operator.AMFRegionID()),
+		ngap.AMFRegionID(operator.GUAMIRegionID()),
 		ngap.AMFSetID(operator.AmfSetID),
 		ngap.AMFPointer(amf.DBInstance.NodeID()),
 	)

--- a/internal/amf/config.go
+++ b/internal/amf/config.go
@@ -45,7 +45,7 @@ func (amf *AMF) operatorInfoFrom(operator *db.Operator) (*OperatorInfo, error) {
 	}
 
 	amfID := util.AMFIDToModels(
-		ngap.AMFRegionID(operator.AmfRegionID),
+		ngap.AMFRegionID(operator.AMFRegionID()),
 		ngap.AMFSetID(operator.AmfSetID),
 		ngap.AMFPointer(amf.DBInstance.NodeID()),
 	)

--- a/internal/amf/config_test.go
+++ b/internal/amf/config_test.go
@@ -321,9 +321,9 @@ func TestGetOperatorInfo_AmfID(t *testing.T) {
 		setID    int
 		wantAmf  string
 	}{
-		{"defaults", 1, 1, "010040"},
+		{"defaults", 1, 1, "810040"},
 		{"region_255_set_1023_pointer_0", 255, 1023, "ffffc0"},
-		{"region_0_set_0_pointer_0", 0, 0, "000000"},
+		{"region_0_set_0_pointer_0", 0, 0, "800000"},
 	}
 
 	for _, tt := range tests {

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -141,6 +141,27 @@ func (ue *UeContext) ReuseForInboundNAS(payload []byte) bool {
 
 var ErrNoUplinkNASCount = errors.New("amf: no uplink NAS COUNT admits the message")
 
+// CitesCurrentSecurityContext reports whether the enclosed EPS NAS message names
+// the UE's current 5G NAS security context. The UE carries the ngKSI value of
+// that context in the eKSI of the update it sends over S1 (TS 24.301 §4.4.2.3,
+// TS 33.501 §8.5.2 step 1), and the AMF identifies the context by that value
+// field before verifying the message with it (TS 33.501 §8.5.2 step 4). Only the
+// value is compared: the type flag describes the context in EPS terms, not the
+// 5G one the value names.
+func (ue *UeContext) CitesCurrentSecurityContext(plain []byte) error {
+	cited, err := eps.PeekKeySetIdentifier(plain)
+	if err != nil {
+		return err
+	}
+
+	if held := ue.NgKsi(); cited.Value != uint8(held.Ksi) {
+		return fmt.Errorf("amf: the enclosed message cites eKSI %d, the UE's current 5G NAS security context is ngKSI %d",
+			cited.Value, held.Ksi)
+	}
+
+	return nil
+}
+
 func (ue *UeContext) VerifyEnclosedEPSNAS(payload []byte) (nas.Count, error) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -141,13 +141,6 @@ func (ue *UeContext) ReuseForInboundNAS(payload []byte) bool {
 
 var ErrNoUplinkNASCount = errors.New("amf: no uplink NAS COUNT admits the message")
 
-// CitesCurrentSecurityContext reports whether the enclosed EPS NAS message names
-// the UE's current 5G NAS security context. The UE carries the ngKSI value of
-// that context in the eKSI of the update it sends over S1 (TS 24.301 §4.4.2.3,
-// TS 33.501 §8.5.2 step 1), and the AMF identifies the context by that value
-// field before verifying the message with it (TS 33.501 §8.5.2 step 4). Only the
-// value is compared: the type flag describes the context in EPS terms, not the
-// 5G one the value names.
 func (ue *UeContext) CitesCurrentSecurityContext(plain []byte) error {
 	cited, err := eps.PeekKeySetIdentifier(plain)
 	if err != nil {

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -139,18 +139,8 @@ func (ue *UeContext) ReuseForInboundNAS(payload []byte) bool {
 	return ue.NasIntegrityVerified(payload)
 }
 
-// ErrNoUplinkNASCount reports an EPS-framed NAS message the UE's uplink count
-// cannot cover.
 var ErrNoUplinkNASCount = errors.New("amf: no uplink NAS COUNT admits the message")
 
-// VerifyEnclosedEPSNAS verifies an EPS-framed NAS message — the TRACKING AREA
-// UPDATE REQUEST a UE changing system to EPS sends — against this UE's current
-// 5G NAS security context, and returns the uplink NAS COUNT it was accepted at
-// (TS 33.501 §8.5.2 step 4).
-//
-// Unlike NasIntegrityVerified the count is committed here: it is the P0 of the
-// K'ASME derivation (Annex A.14.1), so a replay has to fail before it can
-// re-derive the key the peer then holds.
 func (ue *UeContext) VerifyEnclosedEPSNAS(payload []byte) (nas.Count, error) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
@@ -136,6 +137,48 @@ func (ue *UeContext) NasIntegrityVerified(payload []byte) bool {
 // security context and PDU sessions untouched (TS 24.501).
 func (ue *UeContext) ReuseForInboundNAS(payload []byte) bool {
 	return ue.NasIntegrityVerified(payload)
+}
+
+// ErrNoUplinkNASCount reports an EPS-framed NAS message the UE's uplink count
+// cannot cover.
+var ErrNoUplinkNASCount = errors.New("amf: no uplink NAS COUNT admits the message")
+
+// VerifyEnclosedEPSNAS verifies an EPS-framed NAS message — the TRACKING AREA
+// UPDATE REQUEST a UE changing system to EPS sends — against this UE's current
+// 5G NAS security context, and returns the uplink NAS COUNT it was accepted at
+// (TS 33.501 §8.5.2 step 4).
+//
+// Unlike NasIntegrityVerified the count is committed here: it is the P0 of the
+// K'ASME derivation (Annex A.14.1), so a replay has to fail before it can
+// re-derive the key the peer then holds.
+func (ue *UeContext) VerifyEnclosedEPSNAS(payload []byte) (nas.Count, error) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if !ue.secured || ue.sc == nil {
+		return 0, ErrNo5GSecurityContext
+	}
+
+	spm, err := eps.ParseSecurityProtectedMessage(payload)
+	if err != nil {
+		return 0, err
+	}
+
+	counter := ue.ulCount
+
+	cnt, err := counter.Estimate(spm.SequenceNumber)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", ErrNoUplinkNASCount, err)
+	}
+
+	if _, err := eps.VerifyWith5GContext(payload, cnt, nas.DirectionUplink, ue.sc); err != nil {
+		return 0, err
+	}
+
+	_ = counter.Commit(cnt)
+	ue.ulCount = counter
+
+	return cnt, nil
 }
 
 // GmmDecodeFailureCause maps a plain-NAS decode failure to the 5GMM STATUS cause

--- a/internal/amf/eps_idle_mobility.go
+++ b/internal/amf/eps_idle_mobility.go
@@ -35,6 +35,10 @@ func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworki
 		return fmt.Errorf("amf: resolve the NAS security algorithms: %w", err)
 	}
 
+	if attested := ue.UESecCap(); attested != nil {
+		resp.Security.UE5GSecurityCapability = attested
+	}
+
 	mapped, err := interworking.MapTo5GSOnIdleMobility(resp.Security, intOrder, encOrder)
 	if err != nil {
 		return err

--- a/internal/amf/eps_idle_mobility.go
+++ b/internal/amf/eps_idle_mobility.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/models"
+)
+
+// FetchMMContext asks the MME for the UE's EPS context on an idle-mode
+// inter-system change, presenting the 4G-GUTI the UE's 5G-GUTI maps to and the
+// TRACKING AREA UPDATE REQUEST it enclosed (TS 23.502 §4.11.1.3.3 step 5a).
+//
+// The MME verifies the enclosed message against the EPS security context, so a
+// context comes back only for a UE that holds the keys: this is what
+// authenticates the move (TS 33.501 §8.2).
+func (a *AMF) FetchMMContext(ctx context.Context, presented etsi.GUTI5G, epsNAS []byte) (interworking.MMContextResponse, error) {
+	if a.EPS == nil {
+		return interworking.MMContextResponse{}, ErrNoEPSPeer
+	}
+
+	if len(epsNAS) == 0 {
+		return interworking.MMContextResponse{}, fmt.Errorf("%w: the registration carried no EPS NAS message container", interworking.ErrIntegrityCheckFailed)
+	}
+
+	mapped, err := presented.MappedEPSGUTI()
+	if err != nil {
+		return interworking.MMContextResponse{}, fmt.Errorf("%w: %w", interworking.ErrUnknownUEContext, err)
+	}
+
+	return a.EPS.MMContext(ctx, interworking.MMContextRequest{MappedEPSGUTI: mapped, EPSNAS: epsNAS})
+}
+
+// AdoptMMContext takes the EPS context the MME returned onto ue: the identity it
+// verified, the UE's subscribed AMBR, and a 5G security context mapped from the
+// EPS one (TS 33.501 §8.6.2). The mapped context is activated by the NAS SMC
+// that follows, which is why it is installed before the authentication decision
+// rather than after (§8.2).
+func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworking.MMContextResponse) error {
+	intOrder, encOrder, err := a.SecurityAlgorithms(ctx)
+	if err != nil {
+		return fmt.Errorf("amf: resolve the NAS security algorithms: %w", err)
+	}
+
+	mapped, err := interworking.MapTo5GSOnIdleMobility(resp.Security, intOrder, encOrder)
+	if err != nil {
+		return err
+	}
+
+	ue.SetSupi(resp.SUPI)
+	ue.Ambr = &models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink}
+
+	// A UE that omitted the S1 UE network capability still has to be able to
+	// return to EPS, and the MME's copy is the one it registered under
+	// (TS 24.301 §9.9.3.34).
+	if _, ok := ue.EPSNetworkCapability(); !ok {
+		if raw, err := resp.UENetworkCapability.MarshalBinary(); err == nil {
+			ue.SetUECapabilities(nil, raw)
+		}
+	}
+
+	return ue.InstallMappedSecurityContextFromEPS(mapped, MintAuthProofForInterworking())
+}
+
+// AckMMContext tells the MME which PDU sessions 5GS adopted, releasing the UE
+// from EPS (TS 23.502 §4.11.1.3.3 step 8). It is sent only once the AMF has
+// committed to serving the UE, so an abandoned move leaves the EPS registration
+// intact.
+func (a *AMF) AckMMContext(ctx context.Context, supi etsi.SUPI, transferred []uint8) error {
+	if a.EPS == nil {
+		return ErrNoEPSPeer
+	}
+
+	return a.EPS.MMContextAck(ctx, supi, transferred)
+}

--- a/internal/amf/eps_idle_mobility.go
+++ b/internal/amf/eps_idle_mobility.go
@@ -12,13 +12,6 @@ import (
 	"github.com/ellanetworks/core/internal/models"
 )
 
-// FetchMMContext asks the MME for the UE's EPS context on an idle-mode
-// inter-system change, presenting the 4G-GUTI the UE's 5G-GUTI maps to and the
-// TRACKING AREA UPDATE REQUEST it enclosed (TS 23.502 §4.11.1.3.3 step 5a).
-//
-// The MME verifies the enclosed message against the EPS security context, so a
-// context comes back only for a UE that holds the keys: this is what
-// authenticates the move (TS 33.501 §8.2).
 func (a *AMF) FetchMMContext(ctx context.Context, presented etsi.GUTI5G, epsNAS []byte) (interworking.MMContextResponse, error) {
 	if a.EPS == nil {
 		return interworking.MMContextResponse{}, ErrNoEPSPeer
@@ -36,11 +29,6 @@ func (a *AMF) FetchMMContext(ctx context.Context, presented etsi.GUTI5G, epsNAS 
 	return a.EPS.MMContext(ctx, interworking.MMContextRequest{MappedEPSGUTI: mapped, EPSNAS: epsNAS})
 }
 
-// AdoptMMContext takes the EPS context the MME returned onto ue: the identity it
-// verified, the UE's subscribed AMBR, and a 5G security context mapped from the
-// EPS one (TS 33.501 §8.6.2). The mapped context is activated by the NAS SMC
-// that follows, which is why it is installed before the authentication decision
-// rather than after (§8.2).
 func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworking.MMContextResponse) error {
 	intOrder, encOrder, err := a.SecurityAlgorithms(ctx)
 	if err != nil {
@@ -55,9 +43,6 @@ func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworki
 	ue.SetSupi(resp.SUPI)
 	ue.Ambr = &models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink}
 
-	// A UE that omitted the S1 UE network capability still has to be able to
-	// return to EPS, and the MME's copy is the one it registered under
-	// (TS 24.301 §9.9.3.34).
 	if _, ok := ue.EPSNetworkCapability(); !ok {
 		if raw, err := resp.UENetworkCapability.MarshalBinary(); err == nil {
 			ue.SetUECapabilities(nil, raw)
@@ -67,10 +52,6 @@ func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworki
 	return ue.InstallMappedSecurityContextFromEPS(mapped, MintAuthProofForInterworking())
 }
 
-// AckMMContext tells the MME which PDU sessions 5GS adopted, releasing the UE
-// from EPS (TS 23.502 §4.11.1.3.3 step 8). It is sent only once the AMF has
-// committed to serving the UE, so an abandoned move leaves the EPS registration
-// intact.
 func (a *AMF) AckMMContext(ctx context.Context, supi etsi.SUPI, transferred []uint8) error {
 	if a.EPS == nil {
 		return ErrNoEPSPeer

--- a/internal/amf/eps_idle_mobility.go
+++ b/internal/amf/eps_idle_mobility.go
@@ -45,7 +45,7 @@ func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworki
 	}
 
 	ue.SetSupi(resp.SUPI)
-	ue.Ambr = &models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink}
+	ue.SetAmbr(&models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink})
 
 	if _, ok := ue.EPSNetworkCapability(); !ok {
 		if raw, err := resp.UENetworkCapability.MarshalBinary(); err == nil {

--- a/internal/amf/eps_relocation.go
+++ b/internal/amf/eps_relocation.go
@@ -12,7 +12,31 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
+// TransferableEPSSessions is the subset of requested the UE can take to EPS.
+// requested is an allow-list, so it selects nothing when empty; the handover
+// call site names the sessions the target admitted.
 func (ue *UeContext) TransferableEPSSessions(requested []uint8) []interworking.PDNConnection {
+	asked := make(map[uint8]struct{}, len(requested))
+	for _, pduSessionID := range requested {
+		asked[pduSessionID] = struct{}{}
+	}
+
+	return ue.transferableEPSSessions(func(pduSessionID uint8) bool {
+		_, ok := asked[pduSessionID]
+
+		return ok
+	})
+}
+
+// AllTransferableEPSSessions is every session the UE can take to EPS. An idle
+// move transfers the lot: the AMF chooses what to hand over, and the UE reports
+// what it kept in the EPS bearer context status of the TAU
+// (TS 23.502 §4.11.1.3.2 step 5a).
+func (ue *UeContext) AllTransferableEPSSessions() []interworking.PDNConnection {
+	return ue.transferableEPSSessions(func(uint8) bool { return true })
+}
+
+func (ue *UeContext) transferableEPSSessions(include func(pduSessionID uint8) bool) []interworking.PDNConnection {
 	if !ue.TransfersToEPS() {
 		return nil
 	}
@@ -20,15 +44,10 @@ func (ue *UeContext) TransferableEPSSessions(requested []uint8) []interworking.P
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	asked := make(map[uint8]struct{}, len(requested))
-	for _, pduSessionID := range requested {
-		asked[pduSessionID] = struct{}{}
-	}
-
-	out := make([]interworking.PDNConnection, 0, len(requested))
+	out := make([]interworking.PDNConnection, 0, len(ue.SmContextList))
 
 	for pduSessionID, sc := range ue.SmContextList {
-		if _, ok := asked[pduSessionID]; !ok {
+		if !include(pduSessionID) {
 			continue
 		}
 

--- a/internal/amf/eps_relocation.go
+++ b/internal/amf/eps_relocation.go
@@ -12,9 +12,6 @@ import (
 	"github.com/ellanetworks/core/s1ap"
 )
 
-// TransferableEPSSessions is the subset of requested the UE can take to EPS.
-// requested is an allow-list, so it selects nothing when empty; the handover
-// call site names the sessions the target admitted.
 func (ue *UeContext) TransferableEPSSessions(requested []uint8) []interworking.PDNConnection {
 	asked := make(map[uint8]struct{}, len(requested))
 	for _, pduSessionID := range requested {
@@ -28,10 +25,6 @@ func (ue *UeContext) TransferableEPSSessions(requested []uint8) []interworking.P
 	})
 }
 
-// AllTransferableEPSSessions is every session the UE can take to EPS. An idle
-// move transfers the lot: the AMF chooses what to hand over, and the UE reports
-// what it kept in the EPS bearer context status of the TAU
-// (TS 23.502 §4.11.1.3.2 step 5a).
 func (ue *UeContext) AllTransferableEPSSessions() []interworking.PDNConnection {
 	return ue.transferableEPSSessions(func(uint8) bool { return true })
 }

--- a/internal/amf/eps_relocation_test.go
+++ b/internal/amf/eps_relocation_test.go
@@ -82,8 +82,7 @@ func TestTransferableEPSSessionsSkipsASessionWithNoBearerIdentity(t *testing.T) 
 	}
 }
 
-// TS 23.502 §4.11.1.3.2 step 5a: an idle move is not answering a target's
-// admission list, so every session holding an EBI goes.
+// TS 23.502 §4.11.1.3.2 step 5a
 func TestAllTransferableEPSSessions(t *testing.T) {
 	ue := relocatableUE(t)
 
@@ -100,8 +99,6 @@ func TestAllTransferableEPSSessions(t *testing.T) {
 		t.Fatalf("got %d transferable sessions, want both", len(got))
 	}
 
-	// The allow-list form selects nothing from the same UE when asked for nothing,
-	// which is why the idle path needs its own entry point.
 	if asked := ue.TransferableEPSSessions(nil); len(asked) != 0 {
 		t.Fatalf("got %d sessions for an empty allow-list, want none", len(asked))
 	}
@@ -110,7 +107,6 @@ func TestAllTransferableEPSSessions(t *testing.T) {
 func TestAllTransferableEPSSessionsAppliesTheSameFilters(t *testing.T) {
 	ue := relocatableUE(t)
 
-	// No EBI, so it cannot become a PDN connection.
 	if err := ue.CreateSmContext(2, "ref-2", &models.Snssai{Sst: 2}, "ims"); err != nil {
 		t.Fatalf("CreateSmContext: %v", err)
 	}
@@ -164,7 +160,6 @@ func TestBuildForwardRelocationRequest(t *testing.T) {
 		t.Fatal("the NAS transparent container must accompany the request")
 	}
 
-	// TS 33.501 §8.3.2 step 2, §8.6.1
 	if got, want := mapped.Container.SequenceNumber, consumed.SQN(); got != want {
 		t.Fatalf("container sequence number = %d, want the consumed count's %d", got, want)
 	}
@@ -218,8 +213,6 @@ func TestENBIdentityFromNGAP(t *testing.T) {
 		t.Fatalf("PLMN = %+v, want 001/01", got.PlmnID)
 	}
 
-	// TS 23.502 §4.11.1.2.1: the selected PLMN travels in the TAI, and on a shared
-	// RAN it is not the eNB's own.
 	if got.SelectedEPSTAI.PlmnID.Mcc != "002" || got.SelectedEPSTAI.PlmnID.Mnc != "01" {
 		t.Fatalf("selected TAI PLMN = %+v, want the 002/01 the source chose", got.SelectedEPSTAI.PlmnID)
 	}

--- a/internal/amf/eps_relocation_test.go
+++ b/internal/amf/eps_relocation_test.go
@@ -82,6 +82,50 @@ func TestTransferableEPSSessionsSkipsASessionWithNoBearerIdentity(t *testing.T) 
 	}
 }
 
+// TS 23.502 §4.11.1.3.2 step 5a: an idle move is not answering a target's
+// admission list, so every session holding an EBI goes.
+func TestAllTransferableEPSSessions(t *testing.T) {
+	ue := relocatableUE(t)
+
+	if err := ue.CreateSmContext(2, "ref-2", &models.Snssai{Sst: 2}, "ims"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if err := assignEBI(t, ue, 2); err != nil {
+		t.Fatalf("assign an EPS bearer identity: %v", err)
+	}
+
+	got := ue.AllTransferableEPSSessions()
+	if len(got) != 2 {
+		t.Fatalf("got %d transferable sessions, want both", len(got))
+	}
+
+	// The allow-list form selects nothing from the same UE when asked for nothing,
+	// which is why the idle path needs its own entry point.
+	if asked := ue.TransferableEPSSessions(nil); len(asked) != 0 {
+		t.Fatalf("got %d sessions for an empty allow-list, want none", len(asked))
+	}
+}
+
+func TestAllTransferableEPSSessionsAppliesTheSameFilters(t *testing.T) {
+	ue := relocatableUE(t)
+
+	// No EBI, so it cannot become a PDN connection.
+	if err := ue.CreateSmContext(2, "ref-2", &models.Snssai{Sst: 2}, "ims"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if got := ue.AllTransferableEPSSessions(); len(got) != 1 || got[0].PDUSessionID != 1 {
+		t.Fatalf("transferable sessions = %+v, want PDU session 1 alone", got)
+	}
+
+	ue.SetAllow4G(false)
+
+	if got := ue.AllTransferableEPSSessions(); len(got) != 0 {
+		t.Fatalf("got %d transferable sessions for a UE barred from 4G, want none", len(got))
+	}
+}
+
 func TestBuildForwardRelocationRequest(t *testing.T) {
 	ue := relocatableUE(t)
 

--- a/internal/amf/eps_security.go
+++ b/internal/amf/eps_security.go
@@ -165,6 +165,35 @@ func (ue *UeContext) MapSecurityContextToEPS() (interworking.FiveGToEPSHandover,
 	return interworking.MapToEPSOnHandover(in)
 }
 
+func (ue *UeContext) MapSecurityContextToEPSOnIdleMobility() (interworking.EPSSecurityContext, error) {
+	dl := ue.dl.Next()
+
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if !ue.secured || ue.sc == nil {
+		return interworking.EPSSecurityContext{}, ErrNo5GSecurityContext
+	}
+
+	if ue.epsNASAlgorithms == nil {
+		return interworking.EPSSecurityContext{}, ErrNoEPSNASAlgorithms
+	}
+
+	if ue.epsSecurityCapability == nil {
+		return interworking.EPSSecurityContext{}, ErrNoEPSSecurityCapability
+	}
+
+	return interworking.MapToEPSOnIdleMobility(interworking.FiveGToEPSInput{
+		KAMF:                   ue.kamf,
+		NgKSI:                  ngKsi(ue.ngKsi),
+		ULNASCount:             ue.ulCount.LastAccepted(),
+		DLNASCount:             dl,
+		Algorithms:             *ue.epsNASAlgorithms,
+		UESecurityCapability:   *ue.epsSecurityCapability,
+		UE5GSecurityCapability: ue.ueSecurityCapability,
+	})
+}
+
 func (ue *UeContext) InstallMappedSecurityContextFromEPS(mapped interworking.Mapped5GSecurityContext, _ AuthProof) error {
 	ue.mu.Lock()
 

--- a/internal/amf/eps_security.go
+++ b/internal/amf/eps_security.go
@@ -217,12 +217,10 @@ func (ue *UeContext) InstallMappedSecurityContextFromEPS(mapped interworking.Map
 	ue.ncc = mapped.NCC
 
 	ue.secured = true
-	ue.keyOrigin = KeyOriginMappedFromEPS
 
 	err := ue.installSecurityContextLocked()
 	if err != nil {
 		ue.secured = false
-		ue.keyOrigin = KeyOriginUnknown
 	}
 
 	sc := ue.sc

--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -33,11 +33,6 @@ func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest
 		return none, fmt.Errorf("%w: no context for 5G-GUTI %s", interworking.ErrUnknownUEContext, presented.String())
 	}
 
-	// Only a registered, secured context is the UE's current one to hand over, and
-	// the peer's mirror-image handler guards the same way. The AMF keeps a
-	// deregistered context resolvable by its 5G-GUTI so a return from EPS can resume
-	// on native keys (TS 23.502 §4.11.1.3.2 step 15c), which is not a context to
-	// export again.
 	if ue.State() != Registered || !ue.Secured() {
 		return none, fmt.Errorf("%w: the context for 5G-GUTI %s is not a registered, secured one",
 			interworking.ErrUnknownUEContext, presented.String())

--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/nas/fgs"
 	"go.uber.org/zap"
 )
@@ -32,6 +33,35 @@ func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest
 		return none, fmt.Errorf("%w: no context for 5G-GUTI %s", interworking.ErrUnknownUEContext, presented.String())
 	}
 
+	// Only a registered, secured context is the UE's current one to hand over, and
+	// the peer's mirror-image handler guards the same way. The AMF keeps a
+	// deregistered context resolvable by its 5G-GUTI so a return from EPS can resume
+	// on native keys (TS 23.502 §4.11.1.3.2 step 15c), which is not a context to
+	// export again.
+	if ue.State() != Registered || !ue.Secured() {
+		return none, fmt.Errorf("%w: the context for 5G-GUTI %s is not a registered, secured one",
+			interworking.ErrUnknownUEContext, presented.String())
+	}
+
+	ambrUplink, ambrDownlink, ok := ue.AmbrRates()
+	if !ok {
+		return none, fmt.Errorf("amf: UE has no AMBR")
+	}
+
+	spm, err := eps.ParseSecurityProtectedMessage(req.EPSNAS)
+	if err != nil {
+		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
+	}
+
+	// TS 33.501 §8.5.2 steps 3-4
+	if mt, err := eps.PeekMessageType(spm.UnverifiedPayload); err != nil || mt != eps.MsgTrackingAreaUpdateRequest {
+		return none, fmt.Errorf("%w: the container holds no TRACKING AREA UPDATE REQUEST", interworking.ErrIntegrityCheckFailed)
+	}
+
+	if err := ue.CitesCurrentSecurityContext(spm.UnverifiedPayload); err != nil {
+		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
+	}
+
 	if _, err := ue.VerifyEnclosedEPSNAS(req.EPSNAS); err != nil {
 		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
 	}
@@ -39,11 +69,6 @@ func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest
 	security, err := ue.MapSecurityContextToEPSOnIdleMobility()
 	if err != nil {
 		return none, err
-	}
-
-	ambr := ue.Ambr
-	if ambr == nil {
-		return none, fmt.Errorf("amf: UE has no AMBR")
 	}
 
 	sessions := ue.AllTransferableEPSSessions()
@@ -55,8 +80,8 @@ func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest
 		SUPI:           ue.Supi(),
 		Security:       security,
 		PDNConnections: sessions,
-		AMBRUplink:     ambr.Uplink,
-		AMBRDownlink:   ambr.Downlink,
+		AMBRUplink:     ambrUplink,
+		AMBRDownlink:   ambrDownlink,
 	}, nil
 }
 

--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -6,6 +6,7 @@ package amf
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/interworking"
@@ -14,6 +15,8 @@ import (
 	"github.com/ellanetworks/core/nas/fgs"
 	"go.uber.org/zap"
 )
+
+const epsContextRetention = 75 * time.Second
 
 func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
 	none := interworking.EPSContextResponse{}
@@ -33,7 +36,7 @@ func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest
 		return none, fmt.Errorf("%w: no context for 5G-GUTI %s", interworking.ErrUnknownUEContext, presented.String())
 	}
 
-	if ue.State() != Registered || !ue.Secured() {
+	if !ue.ExportableToEPS() || !ue.Secured() {
 		return none, fmt.Errorf("%w: the context for 5G-GUTI %s is not a registered, secured one",
 			interworking.ErrUnknownUEContext, presented.String())
 	}
@@ -90,6 +93,7 @@ func (a *AMF) EPSContextAck(ctx context.Context, supi etsi.SUPI, transferred []u
 		ue.DeleteSmContext(pduSessionID)
 	}
 
+	ue.RetainForEPS(epsContextRetention)
 	ue.Deregister(ctx)
 
 	logger.From(ctx, logger.AmfLog).Info("UE moved to EPS in idle mode; keeping its 5G security context for a return",

--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/nas/fgs"
+	"go.uber.org/zap"
+)
+
+func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
+	none := interworking.EPSContextResponse{}
+
+	operatorInfo, err := a.OperatorInfo(ctx)
+	if err != nil {
+		return none, fmt.Errorf("amf: get operator info: %w", err)
+	}
+
+	presented, err := etsi.NewGUTI5GFromNAS(fgs.GUTIIdentity(req.Mapped5GGUTI))
+	if err != nil {
+		return none, fmt.Errorf("%w: %w", interworking.ErrUnknownUEContext, err)
+	}
+
+	ue, ok := a.LookupUeByGuti(operatorInfo.Guami, presented)
+	if !ok {
+		return none, fmt.Errorf("%w: no context for 5G-GUTI %s", interworking.ErrUnknownUEContext, presented.String())
+	}
+
+	if _, err := ue.VerifyEnclosedEPSNAS(req.EPSNAS); err != nil {
+		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
+	}
+
+	security, err := ue.MapSecurityContextToEPSOnIdleMobility()
+	if err != nil {
+		return none, err
+	}
+
+	ambr := ue.Ambr
+	if ambr == nil {
+		return none, fmt.Errorf("amf: UE has no AMBR")
+	}
+
+	sessions := ue.AllTransferableEPSSessions()
+
+	logger.From(ctx, logger.AmfLog).Info("handing the UE's context to EPS for an idle-mode change",
+		logger.SUPI(ue.Supi().String()), zap.Int("pdu-sessions", len(sessions)))
+
+	return interworking.EPSContextResponse{
+		SUPI:           ue.Supi(),
+		Security:       security,
+		PDNConnections: sessions,
+		AMBRUplink:     ambr.Uplink,
+		AMBRDownlink:   ambr.Downlink,
+	}, nil
+}
+
+func (a *AMF) EPSContextAck(ctx context.Context, supi etsi.SUPI, transferred []uint8) error {
+	ue, ok := a.LookupUeBySupi(supi)
+	if !ok {
+		return fmt.Errorf("%w: %s", interworking.ErrUnknownUEContext, supi)
+	}
+
+	for _, pduSessionID := range transferred {
+		ue.DeleteSmContext(pduSessionID)
+	}
+
+	ue.Deregister(ctx)
+
+	logger.From(ctx, logger.AmfLog).Info("UE moved to EPS in idle mode; keeping its 5G security context for a return",
+		logger.SUPI(supi.String()), zap.Int("adopted", len(transferred)))
+
+	return nil
+}

--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -16,19 +16,22 @@ import (
 	"go.uber.org/zap"
 )
 
-const epsContextRetention = 75 * time.Second
+// epsContextRetention keeps the 5G context exportable for the UE's own tracking
+// area updating budget — five T3430 expiries — so a repeated update still finds a
+// context to map (TS 24.301 §5.5.3.2.7 d).
+const epsContextRetention = 5 * 15 * time.Second
 
 func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
 	none := interworking.EPSContextResponse{}
 
-	operatorInfo, err := a.OperatorInfo(ctx)
-	if err != nil {
-		return none, fmt.Errorf("amf: get operator info: %w", err)
-	}
-
 	presented, err := etsi.NewGUTI5GFromNAS(fgs.GUTIIdentity(req.Mapped5GGUTI))
 	if err != nil {
 		return none, fmt.Errorf("%w: %w", interworking.ErrUnknownUEContext, err)
+	}
+
+	operatorInfo, err := a.OperatorInfo(ctx)
+	if err != nil {
+		return none, fmt.Errorf("amf: get operator info: %w", err)
 	}
 
 	ue, ok := a.LookupUeByGuti(operatorInfo.Guami, presented)
@@ -95,6 +98,11 @@ func (a *AMF) EPSContextAck(ctx context.Context, supi etsi.SUPI, transferred []u
 
 	ue.RetainForEPS(epsContextRetention)
 	ue.Deregister(ctx)
+
+	// Supervision is still running against the deadline set when the UE went idle on
+	// NR, which can be moments away. Restart it from the transfer so the escalation
+	// cannot remove the context this ack just chose to retain.
+	a.StartMobileReachable(ue)
 
 	logger.From(ctx, logger.AmfLog).Info("UE moved to EPS in idle mode; keeping its 5G security context for a return",
 		logger.SUPI(supi.String()), zap.Int("adopted", len(transferred)))

--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -16,9 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// epsContextRetention keeps the 5G context exportable for the UE's own tracking
-// area updating budget — five T3430 expiries — so a repeated update still finds a
-// context to map (TS 24.301 §5.5.3.2.7 d).
+// TS 24.301 §5.5.3.2.7 d)
 const epsContextRetention = 5 * 15 * time.Second
 
 func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
@@ -99,9 +97,6 @@ func (a *AMF) EPSContextAck(ctx context.Context, supi etsi.SUPI, transferred []u
 	ue.RetainForEPS(epsContextRetention)
 	ue.Deregister(ctx)
 
-	// Supervision is still running against the deadline set when the UE went idle on
-	// NR, which can be moments away. Restart it from the transfer so the escalation
-	// cannot remove the context this ack just chose to retain.
 	a.StartMobileReachable(ue)
 
 	logger.From(ctx, logger.AmfLog).Info("UE moved to EPS in idle mode; keeping its 5G security context for a return",

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/ellanetworks/core/etsi"
@@ -65,6 +66,7 @@ func leavingUE(t *testing.T, a *AMF, guti etsi.GUTI5G) *UeContext {
 	}
 
 	ue.SetSupiForTest(supi)
+	ue.ForceStateForTest(Registered)
 	ue.SetAllow4G(true)
 	ue.Ambr = &models.Ambr{
 		Uplink:   models.MustParseBitRate("50 Mbps"),
@@ -216,6 +218,121 @@ func TestEPSContextRefusals(t *testing.T) {
 		}
 	})
 
+	// The peer's mirror-image handler refuses a context that is not a registered,
+	// secured one; this one must too, and before it reads the enclosed message.
+	t.Run("a context that is not registered", func(t *testing.T) {
+		a := idleMobilityAMF()
+		guti := idleMobilityGUTI(t)
+		ue := leavingUE(t, a, guti)
+
+		count, err := ue.ulCount.Estimate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := mappedRequest(t, ue, guti, count)
+		ue.ForceStateForTest(Deregistered)
+
+		if _, err := a.EPSContext(context.Background(), req); !errors.Is(err, interworking.ErrUnknownUEContext) {
+			t.Fatalf("error = %v, want an unknown context", err)
+		}
+	})
+
+	t.Run("a context with no security context installed", func(t *testing.T) {
+		a := idleMobilityAMF()
+		guti := idleMobilityGUTI(t)
+		ue := leavingUE(t, a, guti)
+
+		count, err := ue.ulCount.Estimate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := mappedRequest(t, ue, guti, count)
+		ue.SetSecuredForTest(false)
+
+		if _, err := a.EPSContext(context.Background(), req); !errors.Is(err, interworking.ErrUnknownUEContext) {
+			t.Fatalf("error = %v, want an unknown context", err)
+		}
+	})
+
+	// TS 23.502 §4.11.1.3.2 step 15c leaves a deregistered context resolvable by its
+	// 5G-GUTI so a return from EPS resumes on native keys. A second context request
+	// for a UE already handed over must not export it again.
+	t.Run("a context already handed over to EPS", func(t *testing.T) {
+		a := idleMobilityAMF()
+		guti := idleMobilityGUTI(t)
+		ue := leavingUE(t, a, guti)
+
+		count, err := ue.ulCount.Estimate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count)); err != nil {
+			t.Fatalf("EPSContext: %v", err)
+		}
+
+		if err := a.EPSContextAck(context.Background(), ue.Supi(), []uint8{3}); err != nil {
+			t.Fatalf("EPSContextAck: %v", err)
+		}
+
+		next, err := ue.ulCount.Estimate(uint8(count) + 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, next)); !errors.Is(err, interworking.ErrUnknownUEContext) {
+			t.Fatalf("error = %v, want an unknown context", err)
+		}
+	})
+
+	// TS 33.501 §8.5.2 steps 3-4
+	t.Run("a container holding no TAU REQUEST", func(t *testing.T) {
+		a := idleMobilityAMF()
+		guti := idleMobilityGUTI(t)
+		ue := leavingUE(t, a, guti)
+
+		count, err := ue.ulCount.Estimate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := mappedRequest(t, ue, guti, count)
+		req.EPSNAS = epsFramedEMM(t, ue, count, nas.Bearer3GPP, eps.MsgDetachRequest, 0x01)
+
+		if _, err := a.EPSContext(context.Background(), req); !errors.Is(err, interworking.ErrIntegrityCheckFailed) {
+			t.Fatalf("error = %v, want an integrity failure", err)
+		}
+
+		if _, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count)); err != nil {
+			t.Fatalf("EPSContext after a refused container: %v: the refusal spent the uplink NAS COUNT the real update needs", err)
+		}
+	})
+
+	// TS 33.501 §8.5.2 step 4
+	t.Run("a TAU citing another 5G NAS security context", func(t *testing.T) {
+		a := idleMobilityAMF()
+		guti := idleMobilityGUTI(t)
+		ue := leavingUE(t, a, guti)
+
+		count, err := ue.ulCount.Estimate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := mappedRequest(t, ue, guti, count)
+		req.EPSNAS = epsFramedTAUCitingKSI(t, ue, count, nas.Bearer3GPP, uint8(ue.NgKsi().Ksi)+1)
+
+		if _, err := a.EPSContext(context.Background(), req); !errors.Is(err, interworking.ErrIntegrityCheckFailed) {
+			t.Fatalf("error = %v, want an integrity failure", err)
+		}
+
+		if _, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count)); err != nil {
+			t.Fatalf("EPSContext after a refused eKSI: %v: the refusal spent the uplink NAS COUNT the real update needs", err)
+		}
+	})
+
 	t.Run("a TAU MAC'd over the EPS bearer", func(t *testing.T) {
 		a := idleMobilityAMF()
 		guti := idleMobilityGUTI(t)
@@ -235,16 +352,11 @@ func TestEPSContextRefusals(t *testing.T) {
 	})
 }
 
-// TS 23.502 §4.11.1.3.2 step 8
-// TS 23.401 §5.3.3.1 step 7, which TS 23.502 §4.11.1.3.2 steps 7-14 performs: an
-// inter-system change the peer abandons leaves this AMF serving the UE exactly as
-// before, so the UE that stays on NR keeps its sessions. Nothing is released until
-// the acknowledgement says what moved.
+// TS 23.401 §5.3.3.1 step 7, which TS 23.502 §4.11.1.3.2 steps 7-14 performs
 func TestEPSContextHandedOverButNeverAcknowledgedKeepsServingTheUE(t *testing.T) {
 	a := idleMobilityAMF()
 	guti := idleMobilityGUTI(t)
 	ue := leavingUE(t, a, guti)
-	ue.ForceStateForTest(Registered)
 
 	count, err := ue.ulCount.Estimate(0)
 	if err != nil {
@@ -268,6 +380,7 @@ func TestEPSContextHandedOverButNeverAcknowledgedKeepsServingTheUE(t *testing.T)
 	}
 }
 
+// TS 23.502 §4.11.1.3.2 step 8
 func TestEPSContextAckReleasesWhatDidNotTransferAndKeepsTheContext(t *testing.T) {
 	a := idleMobilityAMF()
 	guti := idleMobilityGUTI(t)
@@ -307,4 +420,50 @@ func TestEPSContextAckForAnUnknownSubscriber(t *testing.T) {
 	if err := a.EPSContextAck(context.Background(), supi, nil); !errors.Is(err, interworking.ErrUnknownUEContext) {
 		t.Fatalf("error = %v, want an unknown context", err)
 	}
+}
+
+// The subscribed UE-AMBR is written on the NAS dispatch goroutine while the peer's
+// context request reads it on its own, so both sides take ue.mu.
+func TestEPSContextReadsTheAmbrUnderTheLock(t *testing.T) {
+	const rounds = 64
+
+	a := idleMobilityAMF()
+	guti := idleMobilityGUTI(t)
+	ue := leavingUE(t, a, guti)
+
+	// Built up front: the request builder reads the security context and estimates
+	// uplink NAS COUNTs, which EPSContext then commits.
+	reqs := make([]interworking.EPSContextRequest, 0, rounds)
+
+	for i := range rounds {
+		count, err := ue.ulCount.Estimate(uint8(i))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		reqs = append(reqs, mappedRequest(t, ue, guti, count))
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range rounds {
+			ue.SetAmbr(&models.Ambr{
+				Uplink:   models.MustParseBitRate("50 Mbps"),
+				Downlink: models.MustParseBitRate("100 Mbps"),
+			})
+		}
+	}()
+
+	for _, req := range reqs {
+		if _, err := a.EPSContext(context.Background(), req); err != nil {
+			t.Fatalf("EPSContext: %v", err)
+		}
+	}
+
+	wg.Wait()
 }

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -447,6 +447,10 @@ func TestEPSContextAckReleasesWhatDidNotTransferAndKeepsTheContext(t *testing.T)
 		t.Error("the native 5G security context was discarded, so a return from EPS could not resume on native keys")
 	}
 
+	if !ue.MobileReachableActiveForTest() {
+		t.Error("idle supervision was not restarted at the transfer, so the escalation left running from before it can remove the retained context at any moment")
+	}
+
 	if found, ok := a.LookupUeByGuti(idleMobilityGuami(), guti); !ok || found != ue {
 		t.Error("the UE context is no longer resolvable by its 5G-GUTI, so the Additional GUTI of a later registration names nothing")
 	}

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -236,6 +236,38 @@ func TestEPSContextRefusals(t *testing.T) {
 }
 
 // TS 23.502 §4.11.1.3.2 step 8
+// TS 23.401 §5.3.3.1 step 7, which TS 23.502 §4.11.1.3.2 steps 7-14 performs: an
+// inter-system change the peer abandons leaves this AMF serving the UE exactly as
+// before, so the UE that stays on NR keeps its sessions. Nothing is released until
+// the acknowledgement says what moved.
+func TestEPSContextHandedOverButNeverAcknowledgedKeepsServingTheUE(t *testing.T) {
+	a := idleMobilityAMF()
+	guti := idleMobilityGUTI(t)
+	ue := leavingUE(t, a, guti)
+	ue.ForceStateForTest(Registered)
+
+	count, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count)); err != nil {
+		t.Fatalf("EPSContext: %v", err)
+	}
+
+	if _, ok := ue.SmContextFindByPDUSessionID(3); !ok {
+		t.Error("the PDU session was released before EPS said it took the context")
+	}
+
+	if ue.State() == Deregistered {
+		t.Error("the UE was deregistered before EPS said it took the context")
+	}
+
+	if found, ok := a.LookupUeByGuti(idleMobilityGuami(), guti); !ok || found != ue {
+		t.Error("the UE context is no longer resolvable by its 5G-GUTI, so a retry would re-authenticate")
+	}
+}
+
 func TestEPSContextAckReleasesWhatDidNotTransferAndKeepsTheContext(t *testing.T) {
 	a := idleMobilityAMF()
 	guti := idleMobilityGUTI(t)

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"testing"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func idleMobilityGuami() *models.Guami {
+	return &models.Guami{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, AmfID: "010040"}
+}
+
+func idleMobilityAMF() *AMF {
+	return New(operatorOnlyDB{operator: &db.Operator{
+		Mcc: "001", Mnc: "01", AmfRegionID: 1, AmfSetID: 1,
+		Ciphering: `["AES"]`, Integrity: `["AES"]`,
+	}}, nil, nil)
+}
+
+func idleMobilityGUTI(t *testing.T) etsi.GUTI5G {
+	t.Helper()
+
+	tmsi, err := etsi.NewTMSI(0x0000dead)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	guti, err := etsi.NewGUTI5G("001", "01", idleMobilityGuami().AmfID, tmsi)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return guti
+}
+
+func leavingUE(t *testing.T, a *AMF, guti etsi.GUTI5G) *UeContext {
+	t.Helper()
+
+	ue := newSecuredUE(t)
+
+	kamf := make([]byte, 32)
+	for i := range kamf {
+		kamf[i] = byte(i + 1)
+	}
+
+	ue.kamf = kamf
+
+	supi, err := etsi.NewSUPIFromIMSI("001010000000001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ue.SetSupiForTest(supi)
+	ue.SetAllow4G(true)
+	ue.Ambr = &models.Ambr{
+		Uplink:   models.MustParseBitRate("50 Mbps"),
+		Downlink: models.MustParseBitRate("100 Mbps"),
+	}
+	ue.SetUESecurityCapability(&fgs.UESecurityCapability{EA: 0xe0, IA: 0xe0}, MintAuthProofForSecurityMode())
+	ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: true}, mustEncodeNetworkCapability(t))
+
+	if _, ok := ue.SelectEPSNASAlgorithms([]nas.IntegrityAlgorithm{nas.IntegrityAES}, []nas.CipheringAlgorithm{nas.CipheringAES}); !ok {
+		t.Fatal("could not select the EPS NAS algorithms")
+	}
+
+	ue.MarkEPSNASAlgorithmsDelivered()
+
+	if err := a.CommitUEIdentity(context.Background(), ue, MintAuthProofForRegistrationCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	a.AssignGutiForTest(ue, guti)
+
+	if err := ue.CreateSmContext(3, "ref-3", &models.Snssai{Sst: 1, Sd: "010203"}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	ue.SetEPSBearerIdentity(3, 6)
+
+	return ue
+}
+
+func mustEncodeNetworkCapability(t *testing.T) []byte {
+	t.Helper()
+
+	raw, err := (eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return raw
+}
+
+func kdfFor(t *testing.T, key []byte, fc byte, p0 []byte) []byte {
+	t.Helper()
+
+	s := append([]byte{fc}, p0...)
+	s = append(s, byte(len(p0)>>8), byte(len(p0)))
+
+	mac := hmac.New(sha256.New, key)
+	if _, err := mac.Write(s); err != nil {
+		t.Fatal(err)
+	}
+
+	return mac.Sum(nil)
+}
+
+func mappedRequest(t *testing.T, ue *UeContext, guti etsi.GUTI5G, count nas.Count) interworking.EPSContextRequest {
+	t.Helper()
+
+	id, err := guti.MobileIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return interworking.EPSContextRequest{
+		Mapped5GGUTI: *id.GUTI,
+		EPSNAS:       epsFramedTAU(t, ue, count, nas.Bearer3GPP),
+	}
+}
+
+// TS 33.501 §8.5.2 steps 4-5
+func TestEPSContextReturnsTheMappedContext(t *testing.T) {
+	a := idleMobilityAMF()
+	guti := idleMobilityGUTI(t)
+	ue := leavingUE(t, a, guti)
+
+	count, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count))
+	if err != nil {
+		t.Fatalf("EPSContext: %v", err)
+	}
+
+	if resp.SUPI != ue.Supi() {
+		t.Errorf("SUPI = %s, want %s", resp.SUPI, ue.Supi())
+	}
+
+	want := kdfFor(t, ue.kamf, 0x73, []byte{0, 0, 0, uint8(count)})
+	if !bytes.Equal(resp.Security.KASME[:], want) {
+		t.Errorf("K'ASME = %x, want the FC 0x73 derivation over the TAU's count %x", resp.Security.KASME, want)
+	}
+
+	if !resp.Security.EKSI.Mapped {
+		t.Errorf("eKSI = %+v, want a mapped one", resp.Security.EKSI)
+	}
+
+	if resp.Security.Algorithms != (interworking.EPSNASAlgorithms{Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES}) {
+		t.Errorf("EPS algorithms = %+v, want the pair signalled to the UE", resp.Security.Algorithms)
+	}
+
+	if len(resp.PDNConnections) != 1 || resp.PDNConnections[0].EPSBearerIdentity != 6 {
+		t.Errorf("PDN connections = %+v, want the session holding EBI 6", resp.PDNConnections)
+	}
+
+	if resp.AMBRUplink != ue.Ambr.Uplink || resp.AMBRDownlink != ue.Ambr.Downlink {
+		t.Errorf("AMBR = %v/%v, want the subscribed one", resp.AMBRUplink, resp.AMBRDownlink)
+	}
+}
+
+// TS 33.501 §8.5.2 step 1
+func TestEPSContextCommitsTheCountItVerifiedAt(t *testing.T) {
+	a := idleMobilityAMF()
+	guti := idleMobilityGUTI(t)
+	ue := leavingUE(t, a, guti)
+
+	count, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := mappedRequest(t, ue, guti, count)
+
+	if _, err := a.EPSContext(context.Background(), req); err != nil {
+		t.Fatalf("EPSContext: %v", err)
+	}
+
+	if _, err := a.EPSContext(context.Background(), req); !errors.Is(err, interworking.ErrIntegrityCheckFailed) {
+		t.Fatalf("replayed request returned %v, want an integrity failure", err)
+	}
+}
+
+func TestEPSContextRefusals(t *testing.T) {
+	t.Run("a 5G-GUTI this AMF did not issue", func(t *testing.T) {
+		a := idleMobilityAMF()
+		guti := idleMobilityGUTI(t)
+		ue := leavingUE(t, a, guti)
+
+		count, err := ue.ulCount.Estimate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := mappedRequest(t, ue, guti, count)
+		req.Mapped5GGUTI.AMFPointer++
+
+		if _, err := a.EPSContext(context.Background(), req); !errors.Is(err, interworking.ErrUnknownUEContext) {
+			t.Fatalf("error = %v, want an unknown context", err)
+		}
+	})
+
+	t.Run("a TAU MAC'd over the EPS bearer", func(t *testing.T) {
+		a := idleMobilityAMF()
+		guti := idleMobilityGUTI(t)
+		ue := leavingUE(t, a, guti)
+
+		count, err := ue.ulCount.Estimate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := mappedRequest(t, ue, guti, count)
+		req.EPSNAS = epsFramedTAU(t, ue, count, nas.BearerEPS)
+
+		if _, err := a.EPSContext(context.Background(), req); !errors.Is(err, interworking.ErrIntegrityCheckFailed) {
+			t.Fatalf("error = %v, want an integrity failure", err)
+		}
+	})
+}
+
+// TS 23.502 §4.11.1.3.2 step 8
+func TestEPSContextAckReleasesWhatDidNotTransferAndKeepsTheContext(t *testing.T) {
+	a := idleMobilityAMF()
+	guti := idleMobilityGUTI(t)
+	ue := leavingUE(t, a, guti)
+
+	kamf := bytes.Clone(ue.kamf)
+
+	if err := a.EPSContextAck(context.Background(), ue.Supi(), nil); err != nil {
+		t.Fatalf("EPSContextAck: %v", err)
+	}
+
+	if _, ok := ue.SmContextFindByPDUSessionID(3); ok {
+		t.Error("a PDU session EPS did not adopt is still held on 5GS")
+	}
+
+	if ue.State() != Deregistered {
+		t.Errorf("state = %v, want deregistered", ue.State())
+	}
+
+	if !bytes.Equal(ue.kamf, kamf) {
+		t.Error("the native 5G security context was discarded, so a return from EPS could not resume on native keys")
+	}
+
+	if found, ok := a.LookupUeByGuti(idleMobilityGuami(), guti); !ok || found != ue {
+		t.Error("the UE context is no longer resolvable by its 5G-GUTI, so the Additional GUTI of a later registration names nothing")
+	}
+}
+
+func TestEPSContextAckForAnUnknownSubscriber(t *testing.T) {
+	a := idleMobilityAMF()
+
+	supi, err := etsi.NewSUPIFromIMSI("001010000000999")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := a.EPSContextAck(context.Background(), supi, nil); !errors.Is(err, interworking.ErrUnknownUEContext) {
+		t.Fatalf("error = %v, want an unknown context", err)
+	}
+}

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/db"
@@ -22,7 +23,7 @@ import (
 )
 
 func idleMobilityGuami() *models.Guami {
-	return &models.Guami{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, AmfID: "010040"}
+	return &models.Guami{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, AmfID: "810040"}
 }
 
 func idleMobilityAMF() *AMF {
@@ -199,6 +200,50 @@ func TestEPSContextCommitsTheCountItVerifiedAt(t *testing.T) {
 	}
 }
 
+// TS 24.301 §5.5.3.2.7 d), TS 33.501 §8.6.1
+func TestEPSContextRemapsARepeatedTrackingAreaUpdate(t *testing.T) {
+	a := idleMobilityAMF()
+	guti := idleMobilityGUTI(t)
+	ue := leavingUE(t, a, guti)
+
+	count, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count))
+	if err != nil {
+		t.Fatalf("EPSContext: %v", err)
+	}
+
+	if err := a.EPSContextAck(context.Background(), ue.Supi(), []uint8{3}); err != nil {
+		t.Fatalf("EPSContextAck: %v", err)
+	}
+
+	next, err := ue.ulCount.Estimate(uint8(count) + 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repeat, err := a.EPSContext(context.Background(), mappedRequest(t, ue, guti, next))
+	if err != nil {
+		t.Fatalf("the repeated update was refused, so the MME can only reject it: %v", err)
+	}
+
+	want := kdfFor(t, ue.kamf, 0x73, []byte{0, 0, 0, uint8(next)})
+	if !bytes.Equal(repeat.Security.KASME[:], want) {
+		t.Errorf("K'ASME = %x, want the FC 0x73 derivation over the repeated TAU's count %x", repeat.Security.KASME, want)
+	}
+
+	if bytes.Equal(repeat.Security.KASME[:], first.Security.KASME[:]) {
+		t.Error("the repeated update returned the first mapped context, so the MME would protect the accept under a key the UE has replaced")
+	}
+
+	if repeat.Security.ULNASCount != next {
+		t.Errorf("mapped uplink NAS COUNT = %d, want the repeated TAU's %d", repeat.Security.ULNASCount, next)
+	}
+}
+
 func TestEPSContextRefusals(t *testing.T) {
 	t.Run("a 5G-GUTI this AMF did not issue", func(t *testing.T) {
 		a := idleMobilityAMF()
@@ -254,7 +299,8 @@ func TestEPSContextRefusals(t *testing.T) {
 		}
 	})
 
-	t.Run("a context already handed over to EPS", func(t *testing.T) {
+	// TS 23.502 §4.11.1.3.2 step 6
+	t.Run("a context whose EPS retention has run out", func(t *testing.T) {
 		a := idleMobilityAMF()
 		guti := idleMobilityGUTI(t)
 		ue := leavingUE(t, a, guti)
@@ -271,6 +317,8 @@ func TestEPSContextRefusals(t *testing.T) {
 		if err := a.EPSContextAck(context.Background(), ue.Supi(), []uint8{3}); err != nil {
 			t.Fatalf("EPSContextAck: %v", err)
 		}
+
+		ue.exportableToEPSUntil = time.Now().Add(-time.Second)
 
 		next, err := ue.ulCount.Estimate(uint8(count) + 1)
 		if err != nil {

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -218,8 +218,6 @@ func TestEPSContextRefusals(t *testing.T) {
 		}
 	})
 
-	// The peer's mirror-image handler refuses a context that is not a registered,
-	// secured one; this one must too, and before it reads the enclosed message.
 	t.Run("a context that is not registered", func(t *testing.T) {
 		a := idleMobilityAMF()
 		guti := idleMobilityGUTI(t)
@@ -256,9 +254,6 @@ func TestEPSContextRefusals(t *testing.T) {
 		}
 	})
 
-	// TS 23.502 §4.11.1.3.2 step 15c leaves a deregistered context resolvable by its
-	// 5G-GUTI so a return from EPS resumes on native keys. A second context request
-	// for a UE already handed over must not export it again.
 	t.Run("a context already handed over to EPS", func(t *testing.T) {
 		a := idleMobilityAMF()
 		guti := idleMobilityGUTI(t)
@@ -422,8 +417,6 @@ func TestEPSContextAckForAnUnknownSubscriber(t *testing.T) {
 	}
 }
 
-// The subscribed UE-AMBR is written on the NAS dispatch goroutine while the peer's
-// context request reads it on its own, so both sides take ue.mu.
 func TestEPSContextReadsTheAmbrUnderTheLock(t *testing.T) {
 	const rounds = 64
 
@@ -431,8 +424,6 @@ func TestEPSContextReadsTheAmbrUnderTheLock(t *testing.T) {
 	guti := idleMobilityGUTI(t)
 	ue := leavingUE(t, a, guti)
 
-	// Built up front: the request builder reads the security context and estimates
-	// uplink NAS COUNTs, which EPSContext then commits.
 	reqs := make([]interworking.EPSContextRequest, 0, rounds)
 
 	for i := range rounds {

--- a/internal/amf/fivegs_relocation.go
+++ b/internal/amf/fivegs_relocation.go
@@ -126,7 +126,7 @@ func (a *AMF) ForwardRelocation(ctx context.Context, req interworking.FiveGSRelo
 
 	ue := NewUeContext()
 	ue.SetSupi(req.SUPI)
-	ue.Ambr = &models.Ambr{Uplink: req.UEAMBRUplink, Downlink: req.UEAMBRDownlink}
+	ue.SetAmbr(&models.Ambr{Uplink: req.UEAMBRUplink, Downlink: req.UEAMBRDownlink})
 	ue.AllowedNssai = snssaiList
 	ue.SetAllow4G(subscriberProfile.Allow4G)
 	ue.smf = a.Session
@@ -460,6 +460,11 @@ func (a *AMF) endRelocationFromEPS(supi etsi.SUPI, ue *UeContext) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	a.endRelocationFromEPSLocked(supi, ue)
+}
+
+// The caller holds a.mu.
+func (a *AMF) endRelocationFromEPSLocked(supi etsi.SUPI, ue *UeContext) {
 	if held, ok := a.relocatingFromEPS[supi]; ok && held.ue == ue {
 		delete(a.relocatingFromEPS, supi)
 	}

--- a/internal/amf/guti.go
+++ b/internal/amf/guti.go
@@ -33,18 +33,19 @@ func (amf *AMF) freeTmsiLocked(t etsi.TMSI) {
 	amf.tmsi.Free(t)
 }
 
-func (amf *AMF) LookupUeByGuti(guti etsi.GUTI5G) (*UeContext, bool) {
+func (amf *AMF) LookupUeByGuti(guami *models.Guami, guti etsi.GUTI5G) (*UeContext, bool) {
 	if guti == etsi.InvalidGUTI5G {
+		return nil, false
+	}
+
+	native, err := gutiFor(guami, guti.Tmsi)
+	if err != nil || native != guti {
 		return nil, false
 	}
 
 	amf.mu.RLock()
 	defer amf.mu.RUnlock()
 
-	// uesByTmsi indexes both the current and the in-flight old 5G-TMSI of every UE,
-	// so an inbound GUTI/5G-S-TMSI resolves in O(1) without scanning every UE. The
-	// 5G-TMSI is the unpredictable, per-UE part of the GUTI; the GUAMI is invariant,
-	// so the TMSI alone disambiguates.
 	ue, ok := amf.uesByTmsi[guti.Tmsi]
 
 	return ue, ok

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -127,6 +127,10 @@ func (f *fakeSmf) UpdateSmContextCauseDuplicatePDUSessionID(context.Context, str
 	return nil, nil
 }
 
+func (f *fakeSmf) TransferIdleTo5GS(context.Context, etsi.SUPI, uint8, uint8, string, *models.Snssai) (string, error) {
+	return "", nil
+}
+
 func (f *fakeSmf) PrepareSmContextFromEPS(context.Context, etsi.SUPI, uint8, uint8, string, *models.Snssai) (string, []byte, error) {
 	return "", nil, nil
 }

--- a/internal/amf/nas/context_setup.go
+++ b/internal/amf/nas/context_setup.go
@@ -41,8 +41,10 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, 
 	case fgs.RegistrationTypeInitial:
 		HandleInitialRegistration(ctx, amfInstance, ue)
 	case fgs.RegistrationTypeMobilityUpdating:
+		arrivedByHandover := ue.TakeArrivedFromEPSHandover()
+
 		if movingFromEPC(msg) {
-			if conn.ArrivingFromEPS == nil && !ue.TakeArrivedFromEPSHandover() {
+			if conn.ArrivingFromEPS == nil && !arrivedByHandover {
 				HandleInitialRegistration(ctx, amfInstance, ue)
 				return
 			}

--- a/internal/amf/nas/context_setup.go
+++ b/internal/amf/nas/context_setup.go
@@ -42,7 +42,11 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, 
 		HandleInitialRegistration(ctx, amfInstance, ue)
 	case fgs.RegistrationTypeMobilityUpdating:
 		if movingFromEPC(msg) {
-			if !ue.TakeArrivedFromEPSHandover() {
+			// An idle-mode change whose context the MME handed over is served as a
+			// mobility update: the UE keeps its PDU sessions and its addresses
+			// (TS 23.502 §4.11.1.3.3). Without one there is nothing to update, so
+			// the UE registers afresh (TS 24.501 §5.5.1.3.5 b).
+			if conn.ArrivingFromEPS == nil && !ue.TakeArrivedFromEPSHandover() {
 				HandleInitialRegistration(ctx, amfInstance, ue)
 				return
 			}

--- a/internal/amf/nas/context_setup.go
+++ b/internal/amf/nas/context_setup.go
@@ -42,10 +42,6 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, 
 		HandleInitialRegistration(ctx, amfInstance, ue)
 	case fgs.RegistrationTypeMobilityUpdating:
 		if movingFromEPC(msg) {
-			// An idle-mode change whose context the MME handed over is served as a
-			// mobility update: the UE keeps its PDU sessions and its addresses
-			// (TS 23.502 §4.11.1.3.3). Without one there is nothing to update, so
-			// the UE registers afresh (TS 24.501 §5.5.1.3.5 b).
 			if conn.ArrivingFromEPS == nil && !ue.TakeArrivedFromEPSHandover() {
 				HandleInitialRegistration(ctx, amfInstance, ue)
 				return

--- a/internal/amf/nas/fixtures_test.go
+++ b/internal/amf/nas/fixtures_test.go
@@ -210,37 +210,25 @@ type SmfReleaseSmContextCall struct {
 }
 
 type fakeSmf struct {
-	Error             error
-	ReleasedSmContext []string
-
-	// TransferIdleTo5GS fields
-	IdleTransfers   []idleTransfer
-	IdleTransferErr error
-
-	// ActivateSmContext fields
+	Error                     error
+	ReleasedSmContext         []string
+	IdleTransfers             []idleTransfer
+	IdleTransferErr           error
 	ActivateSmContextResponse []byte
 	ActivateSmContextError    error
 	ActivateSmContextCalls    []SmfActivateSmContextCall
-
-	// ReleaseSmContext fields
-	ReleaseSmContextError error
-	ReleaseSmContextCalls []SmfReleaseSmContextCall
-
-	// UpdateSmContextN1Msg fields
-	UpdateN1MsgResponse *smf.UpdateResult
-	UpdateN1MsgError    error
-	UpdateN1MsgCalls    []SmfUpdateN1MsgCall
-
-	// CreateSmContext fields
-	CreateSmContextRef     string
-	CreateSmContextErrResp []byte
-	CreateSmContextError   error
-	CreateSmContextCalls   []SmfCreateSmContextCall
-
-	// UpdateSmContextCauseDuplicatePDUSessionID fields
-	DuplicatePDUResponse []byte
-	DuplicatePDUError    error
-	DuplicatePDUCalls    []SmfDuplicatePDUCall
+	ReleaseSmContextError     error
+	ReleaseSmContextCalls     []SmfReleaseSmContextCall
+	UpdateN1MsgResponse       *smf.UpdateResult
+	UpdateN1MsgError          error
+	UpdateN1MsgCalls          []SmfUpdateN1MsgCall
+	CreateSmContextRef        string
+	CreateSmContextErrResp    []byte
+	CreateSmContextError      error
+	CreateSmContextCalls      []SmfCreateSmContextCall
+	DuplicatePDUResponse      []byte
+	DuplicatePDUError         error
+	DuplicatePDUCalls         []SmfDuplicatePDUCall
 }
 
 type SmfUpdateN1MsgCall struct {

--- a/internal/amf/nas/fixtures_test.go
+++ b/internal/amf/nas/fixtures_test.go
@@ -213,6 +213,10 @@ type fakeSmf struct {
 	Error             error
 	ReleasedSmContext []string
 
+	// TransferIdleTo5GS fields
+	IdleTransfers   []idleTransfer
+	IdleTransferErr error
+
 	// ActivateSmContext fields
 	ActivateSmContextResponse []byte
 	ActivateSmContextError    error
@@ -368,6 +372,30 @@ func (s *fakeSmf) UpdateSmContextN2InfoPduResRelRsp(_ context.Context, _ string)
 
 func (s *fakeSmf) PrepareSmContextFromEPS(_ context.Context, _ etsi.SUPI, _, _ uint8, _ string, _ *models.Snssai) (string, []byte, error) {
 	return "", nil, nil
+}
+
+type idleTransfer struct {
+	Supi              etsi.SUPI
+	PDUSessionID      uint8
+	EPSBearerIdentity uint8
+	Dnn               string
+	Snssai            *models.Snssai
+}
+
+func (s *fakeSmf) TransferIdleTo5GS(_ context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (string, error) {
+	s.IdleTransfers = append(s.IdleTransfers, idleTransfer{
+		Supi:              supi,
+		PDUSessionID:      pduSessionID,
+		EPSBearerIdentity: epsBearerIdentity,
+		Dnn:               dnn,
+		Snssai:            snssai,
+	})
+
+	if s.IdleTransferErr != nil {
+		return "", s.IdleTransferErr
+	}
+
+	return fmt.Sprintf("idle-ref-%d", pduSessionID), nil
 }
 
 func (s *fakeSmf) UpdateSmContextN2HandoverPreparing(_ context.Context, _ string, _ []byte) ([]byte, error) {

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -281,9 +281,6 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 	switch {
 	case state == amf.Deregistered, state == amf.Registered, step == amf.RegStepAuthenticating:
 		if err := handleRegistrationRequestMessage(ctx, amfInstance, ue, req, plain, integrityVerified, arrivedPlain); err != nil {
-			// Release the half-registered UE at the point of failure; a failed
-			// handleRegistrationRequestMessage (which may already have sent a REGISTRATION
-			// REJECT) releases nothing, leaking its open RAN connection under no supervision.
 			abortRegistration(ctx, amfInstance, ue, "handle registration request message", err)
 
 			return nasreply.Handled()
@@ -291,10 +288,6 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 		ue.TransitionTo(amf.RegistrationInitiated)
 
-		// Before the authentication decision: a context recovered from the MME is
-		// what makes authenticationProcedure skip primary authentication and the
-		// security mode procedure activate the mapped context instead
-		// (TS 33.501 §8.2).
 		if movingFromEPCInIdleMode(ue.Conn(), req) {
 			recoverContextFromEPS(ctx, amfInstance, ue, req)
 		}

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -291,6 +291,14 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 		ue.TransitionTo(amf.RegistrationInitiated)
 
+		// Before the authentication decision: a context recovered from the MME is
+		// what makes authenticationProcedure skip primary authentication and the
+		// security mode procedure activate the mapped context instead
+		// (TS 33.501 §8.2).
+		if movingFromEPCInIdleMode(ue.Conn(), req) {
+			recoverContextFromEPS(ctx, amfInstance, ue, req)
+		}
+
 		pass, err := authenticationProcedure(ctx, amfInstance, ue)
 		if err != nil {
 			logger.From(ctx, logger.AmfLog).Warn("authentication procedure failed, rejecting registration", zap.Error(err))

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/nas/fgs"
 	"go.uber.org/zap"
@@ -44,7 +45,7 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		logger.From(ctx, logger.AmfLog).Info("inter-system change resumed on the UE's native 5G security context",
 			logger.SUPI(resp.SUPI.String()))
 
-		conn.ArrivingFromEPS = &resp
+		conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
 
 		return
 	}
@@ -55,7 +56,7 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
-	conn.ArrivingFromEPS = &resp
+	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
 
 	logger.From(ctx, logger.AmfLog).Info("mapped the UE's EPS security context onto 5GS for an idle-mode change",
 		logger.SUPI(resp.SUPI.String()), zap.Int("pdn-connections", len(resp.PDNConnections)))
@@ -76,9 +77,9 @@ func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
-	transferred := make([]uint8, 0, len(arriving.PDNConnections))
+	transferred := make([]uint8, 0, len(arriving.PDN))
 
-	for _, c := range arriving.PDNConnections {
+	for _, c := range arriving.PDN {
 		snssai := c.Snssai
 
 		ref, err := amfInstance.Session.TransferIdleTo5GS(ctx, supi, c.PDUSessionID, c.EPSBearerIdentity, c.APN, &snssai)
@@ -108,5 +109,5 @@ func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 
 	logger.From(ctx, logger.AmfLog).Info("adopted the PDN connections of a UE arriving from EPS in idle mode",
 		logger.SUPI(supi.String()), zap.Int("adopted", len(transferred)),
-		zap.Int("offered", len(arriving.PDNConnections)))
+		zap.Int("offered", len(arriving.PDN)))
 }

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -62,9 +62,6 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		logger.SUPI(resp.SUPI.String()), zap.Int("pdn-connections", len(resp.PDNConnections)))
 }
 
-// adoptArrivingSessions reports whether the registration may proceed. Nothing has
-// moved when the identity commit fails, so the MME still holds the UE's context and
-// PDN connections and aborting returns the UE to EPS (TS 23.502 §4.11.1.3.3).
 func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, conn *amf.UeConn) bool {
 	arriving := conn.ArrivingFromEPS
 	if arriving == nil {

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -62,10 +62,13 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		logger.SUPI(resp.SUPI.String()), zap.Int("pdn-connections", len(resp.PDNConnections)))
 }
 
-func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, conn *amf.UeConn) {
+// adoptArrivingSessions reports whether the registration may proceed. Nothing has
+// moved when the identity commit fails, so the MME still holds the UE's context and
+// PDN connections and aborting returns the UE to EPS (TS 23.502 §4.11.1.3.3).
+func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, conn *amf.UeConn) bool {
 	arriving := conn.ArrivingFromEPS
 	if arriving == nil {
-		return
+		return true
 	}
 
 	conn.ArrivingFromEPS = nil
@@ -73,8 +76,9 @@ func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 	supi := ue.Supi()
 
 	if err := amfInstance.CommitUEIdentity(ctx, ue, amf.MintAuthProofForInterworking()); err != nil {
-		logger.From(ctx, logger.AmfLog).Error("failed to commit the identity of a UE arriving from EPS", zap.Error(err))
-		return
+		abortRegistration(ctx, amfInstance, ue, "commit the identity of a UE arriving from EPS", err)
+
+		return false
 	}
 
 	transferred := make([]uint8, 0, len(arriving.PDN))
@@ -91,8 +95,13 @@ func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		}
 
 		if err := ue.CreateSmContext(c.PDUSessionID, ref, &snssai, c.APN); err != nil {
-			logger.From(ctx, logger.AmfLog).Warn("failed to open the SM context of an arriving PDN connection",
+			logger.From(ctx, logger.AmfLog).Warn("failed to open the SM context of an arriving PDN connection; releasing the session it moved",
 				zap.Error(err), zap.Uint8("pdu_session_id", c.PDUSessionID))
+
+			if err := amfInstance.Session.ReleaseSmContext(ctx, ref); err != nil {
+				logger.From(ctx, logger.AmfLog).Warn("failed to release the session of a PDN connection the AMF could not adopt",
+					zap.Error(err), zap.Uint8("pdu_session_id", c.PDUSessionID))
+			}
 
 			continue
 		}
@@ -110,4 +119,6 @@ func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 	logger.From(ctx, logger.AmfLog).Info("adopted the PDN connections of a UE arriving from EPS in idle mode",
 		logger.SUPI(supi.String()), zap.Int("adopted", len(transferred)),
 		zap.Int("offered", len(arriving.PDN)))
+
+	return true
 }

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/nas/fgs"
+	"go.uber.org/zap"
+)
+
+// movingFromEPCInIdleMode reports whether this registration is an inter-system
+// change performed in 5GMM-IDLE mode: a mobility registration update reporting
+// EMM-REGISTERED, carrying the TRACKING AREA UPDATE REQUEST the UE would have
+// sent in S1 mode. A UE that changed system in connected mode sends no such
+// container (TS 24.501 §5.5.1.3.2 c), so its arrival is the handover path.
+func movingFromEPCInIdleMode(conn *amf.UeConn, req *fgs.RegistrationRequest) bool {
+	return conn != nil &&
+		conn.RegistrationType5GS == fgs.RegistrationTypeMobilityUpdating &&
+		movingFromEPC(req) &&
+		len(req.EPSNASMessageContainer) > 0
+}
+
+// recoverContextFromEPS fetches the UE's context from the MME and takes it onto
+// ue, so the registration proceeds on a context the MME authenticated rather
+// than on primary authentication (TS 23.502 §4.11.1.3.3 steps 5a-6,
+// TS 33.501 §8.2).
+//
+// A failure is not fatal: the caller carries on to primary authentication and
+// the registration is served as an initial one (TS 24.501 §5.5.1.3.5 b), which
+// costs the UE its PDU sessions but not its service.
+func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest) {
+	conn := ue.Conn()
+	if conn == nil {
+		return
+	}
+
+	presented, err := etsi.NewGUTI5GFromNAS(req.MobileIdentity)
+	if err != nil {
+		logger.From(ctx, logger.AmfLog).Info("inter-system change presents no 5G-GUTI to map back to a 4G one", zap.Error(err))
+		return
+	}
+
+	resp, err := amfInstance.FetchMMContext(ctx, presented, req.EPSNASMessageContainer)
+	if err != nil {
+		logger.From(ctx, logger.AmfLog).Info("the MME returned no context for an inter-system change; authenticating the UE instead",
+			zap.Error(err))
+
+		return
+	}
+
+	// TS 24.501 §5.5.1.3.4 case a: a native 5G context that already verified this
+	// request stays current, and the EPS security parameters are discarded. Only
+	// the PDN connections are taken from the MME.
+	if ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI {
+		logger.From(ctx, logger.AmfLog).Info("inter-system change resumed on the UE's native 5G security context",
+			logger.SUPI(resp.SUPI.String()))
+
+		conn.ArrivingFromEPS = &resp
+
+		return
+	}
+
+	if err := amfInstance.AdoptMMContext(ctx, ue, resp); err != nil {
+		logger.From(ctx, logger.AmfLog).Warn("failed to map the EPS context onto 5GS; authenticating the UE instead", zap.Error(err))
+
+		return
+	}
+
+	conn.ArrivingFromEPS = &resp
+
+	logger.From(ctx, logger.AmfLog).Info("mapped the UE's EPS security context onto 5GS for an idle-mode change",
+		logger.SUPI(resp.SUPI.String()), zap.Int("pdn-connections", len(resp.PDNConnections)))
+}
+
+// adoptArrivingSessions takes the PDN connections the MME handed over onto 5GS
+// and releases the UE from EPS.
+//
+// Each session moves with its address and EPS bearer identity but with no user
+// plane on the target: an idle move establishes none unless the UE asks for one
+// in the Uplink data status IE (TS 23.502 §4.11.1.3.3 step 14). The MME is
+// acknowledged once the moves are done, which releases whatever 5GS did not take
+// (step 8).
+func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, conn *amf.UeConn) {
+	arriving := conn.ArrivingFromEPS
+	if arriving == nil {
+		return
+	}
+
+	conn.ArrivingFromEPS = nil
+
+	supi := ue.Supi()
+
+	// The MME verified the enclosed TRACKING AREA UPDATE REQUEST against the EPS
+	// security context, so this identity is an authenticated one (TS 33.501 §8.2).
+	if err := amfInstance.CommitUEIdentity(ctx, ue, amf.MintAuthProofForInterworking()); err != nil {
+		logger.From(ctx, logger.AmfLog).Error("failed to commit the identity of a UE arriving from EPS", zap.Error(err))
+		return
+	}
+
+	transferred := make([]uint8, 0, len(arriving.PDNConnections))
+
+	for _, c := range arriving.PDNConnections {
+		snssai := c.Snssai
+
+		ref, err := amfInstance.Session.TransferIdleTo5GS(ctx, supi, c.PDUSessionID, c.EPSBearerIdentity, c.APN, &snssai)
+		if err != nil {
+			logger.From(ctx, logger.AmfLog).Warn("a PDN connection could not move onto 5GS; leaving it behind",
+				zap.Error(err), zap.Uint8("pdu_session_id", c.PDUSessionID), zap.String("apn", c.APN))
+
+			continue
+		}
+
+		if err := ue.CreateSmContext(c.PDUSessionID, ref, &snssai, c.APN); err != nil {
+			logger.From(ctx, logger.AmfLog).Warn("failed to open the SM context of an arriving PDN connection",
+				zap.Error(err), zap.Uint8("pdu_session_id", c.PDUSessionID))
+
+			continue
+		}
+
+		ue.SetEPSBearerIdentity(c.PDUSessionID, c.EPSBearerIdentity)
+
+		transferred = append(transferred, c.PDUSessionID)
+	}
+
+	if err := amfInstance.AckMMContext(ctx, supi, transferred); err != nil {
+		logger.From(ctx, logger.AmfLog).Warn("the MME refused the context acknowledgement for an idle-mode change",
+			zap.Error(err), logger.SUPI(supi.String()))
+	}
+
+	logger.From(ctx, logger.AmfLog).Info("adopted the PDN connections of a UE arriving from EPS in idle mode",
+		logger.SUPI(supi.String()), zap.Int("adopted", len(transferred)),
+		zap.Int("offered", len(arriving.PDNConnections)))
+}

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -13,11 +13,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// movingFromEPCInIdleMode reports whether this registration is an inter-system
-// change performed in 5GMM-IDLE mode: a mobility registration update reporting
-// EMM-REGISTERED, carrying the TRACKING AREA UPDATE REQUEST the UE would have
-// sent in S1 mode. A UE that changed system in connected mode sends no such
-// container (TS 24.501 §5.5.1.3.2 c), so its arrival is the handover path.
 func movingFromEPCInIdleMode(conn *amf.UeConn, req *fgs.RegistrationRequest) bool {
 	return conn != nil &&
 		conn.RegistrationType5GS == fgs.RegistrationTypeMobilityUpdating &&
@@ -25,14 +20,6 @@ func movingFromEPCInIdleMode(conn *amf.UeConn, req *fgs.RegistrationRequest) boo
 		len(req.EPSNASMessageContainer) > 0
 }
 
-// recoverContextFromEPS fetches the UE's context from the MME and takes it onto
-// ue, so the registration proceeds on a context the MME authenticated rather
-// than on primary authentication (TS 23.502 §4.11.1.3.3 steps 5a-6,
-// TS 33.501 §8.2).
-//
-// A failure is not fatal: the caller carries on to primary authentication and
-// the registration is served as an initial one (TS 24.501 §5.5.1.3.5 b), which
-// costs the UE its PDU sessions but not its service.
 func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest) {
 	conn := ue.Conn()
 	if conn == nil {
@@ -53,9 +40,6 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
-	// TS 24.501 §5.5.1.3.4 case a: a native 5G context that already verified this
-	// request stays current, and the EPS security parameters are discarded. Only
-	// the PDN connections are taken from the MME.
 	if ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI {
 		logger.From(ctx, logger.AmfLog).Info("inter-system change resumed on the UE's native 5G security context",
 			logger.SUPI(resp.SUPI.String()))
@@ -77,14 +61,6 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		logger.SUPI(resp.SUPI.String()), zap.Int("pdn-connections", len(resp.PDNConnections)))
 }
 
-// adoptArrivingSessions takes the PDN connections the MME handed over onto 5GS
-// and releases the UE from EPS.
-//
-// Each session moves with its address and EPS bearer identity but with no user
-// plane on the target: an idle move establishes none unless the UE asks for one
-// in the Uplink data status IE (TS 23.502 §4.11.1.3.3 step 14). The MME is
-// acknowledged once the moves are done, which releases whatever 5GS did not take
-// (step 8).
 func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, conn *amf.UeConn) {
 	arriving := conn.ArrivingFromEPS
 	if arriving == nil {
@@ -95,8 +71,6 @@ func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 
 	supi := ue.Supi()
 
-	// The MME verified the enclosed TRACKING AREA UPDATE REQUEST against the EPS
-	// security context, so this identity is an authenticated one (TS 33.501 §8.2).
 	if err := amfInstance.CommitUEIdentity(ctx, ue, amf.MintAuthProofForInterworking()); err != nil {
 		logger.From(ctx, logger.AmfLog).Error("failed to commit the identity of a UE arriving from EPS", zap.Error(err))
 		return

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -455,3 +455,44 @@ func TestIdleArrivalFromEPSAlwaysRunsTheSecurityModeProcedure(t *testing.T) {
 		t.Errorf("security mode command ngKSI = %+v, want the mapped context's", smc.NgKSI)
 	}
 }
+
+// TS 24.501 §5.5.1.3.4, TS 23.502 §4.11.1.3.3 step 14
+func TestAnArrivalThatMovesNothingIsStillAccepted(t *testing.T) {
+	ue, amfInstance, peer, smf := idleArrivalUE(t)
+	smf.IdleTransferErr = context.DeadlineExceeded
+
+	conn := ue.Conn()
+	conn.ArrivedFromEPS = true
+
+	resp := arrivingMMContext(ue.Supi())
+	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+
+	if !adoptArrivingSessions(context.Background(), amfInstance, ue, conn) {
+		t.Fatal("the registration was abandoned, so the UE gets no 5GS service until it retries")
+	}
+
+	if !peer.Acked {
+		t.Error("the MME was not acknowledged, so it keeps serving a UE that has left EPS")
+	}
+
+	plain, err := amf.BuildRegistrationAccept(amfInstance, ue, etsi.InvalidGUTI5G, nil, nil, nil, nil,
+		models.PlmnID{Mcc: "001", Mnc: "01"})
+	if err != nil {
+		t.Fatalf("BuildRegistrationAccept: %v", err)
+	}
+
+	accept, err := fgs.ParseRegistrationAccept(plain)
+	if err != nil {
+		t.Fatalf("parse the registration accept: %v", err)
+	}
+
+	if accept.EPSBearerContextStatus == nil {
+		t.Fatal("the accept carries no EPS bearer context status, so the UE keeps QoS rules for bearers that no longer exist")
+	}
+
+	for ebi, active := range accept.EPSBearerContextStatus.Active {
+		if active {
+			t.Errorf("EPS bearer %d reported active though no PDN connection moved onto 5GS", ebi)
+		}
+	}
+}

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -18,9 +18,6 @@ import (
 
 const idleEKSI uint8 = 4
 
-// arrivingMMContext is the context an MME returns for a UE changing system in
-// idle mode: an EPS security context whose uplink count is the one the TAU
-// verified at, and one PDN connection.
 func arrivingMMContext(supi etsi.SUPI) interworking.MMContextResponse {
 	var kasme [32]byte
 	for i := range kasme {
@@ -46,8 +43,6 @@ func arrivingMMContext(supi etsi.SUPI) interworking.MMContextResponse {
 	}
 }
 
-// idleArrivalRequest is the REGISTRATION REQUEST of an inter-system change
-// performed in 5GMM-IDLE mode (TS 24.501 §5.5.1.3.2 a, c).
 func idleArrivalRequest() *fgs.RegistrationRequest {
 	return &fgs.RegistrationRequest{
 		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,
@@ -72,9 +67,7 @@ func idleArrivalUE(t *testing.T) (*amf.UeContext, *amf.AMF, *fakeEPSPeer, *fakeS
 	return ue, amfInstance, peer, smf
 }
 
-// A registration in connected mode carries no EPS NAS message container
-// (TS 24.501 §5.5.1.3.2 c), which is what separates the idle path from the
-// arrival of a handover.
+// TS 24.501 §5.5.1.3.2 c
 func TestMovingFromEPCInIdleModeNeedsTheContainer(t *testing.T) {
 	ue, _, err := buildUeAndRadio()
 	if err != nil {
@@ -102,9 +95,7 @@ func TestMovingFromEPCInIdleModeNeedsTheContainer(t *testing.T) {
 	}
 }
 
-// TS 33.501 §8.2: the mapped context is installed before the authentication
-// decision, so the security mode command activates it — carrying the mapped
-// ngKSI and the EPS NAS algorithms already in use.
+// TS 33.501 §8.2
 func TestRecoverContextFromEPSInstallsTheMappedContext(t *testing.T) {
 	ue, amfInstance, peer, _ := idleArrivalUE(t)
 
@@ -136,8 +127,6 @@ func TestRecoverContextFromEPSInstallsTheMappedContext(t *testing.T) {
 		t.Errorf("security mode command ngKSI = %+v, want the mapped %d", smc.NgKSI, idleEKSI)
 	}
 
-	// TS 33.501 §8.6.1: the EPS algorithms the AMF signals now are the ones a
-	// later move back to EPS maps the context under.
 	if smc.SelectedEPSNASSecurityAlgorithms == nil {
 		t.Fatal("no selected EPS NAS security algorithms: the UE could not derive the same mapped EPS context on its way back")
 	}
@@ -152,8 +141,7 @@ func TestRecoverContextFromEPSInstallsTheMappedContext(t *testing.T) {
 	}
 }
 
-// TS 24.501 §5.5.1.3.5 b: with no context to recover the UE is authenticated,
-// and the registration proceeds as an initial one.
+// TS 24.501 §5.5.1.3.5 b
 func TestRecoverContextFromEPSFallsBackWhenTheMMEHasNoContext(t *testing.T) {
 	ue, amfInstance, peer, _ := idleArrivalUE(t)
 	peer.MMContextErr = interworking.ErrUnknownUEContext
@@ -180,8 +168,7 @@ func TestRecoverContextFromEPSFallsBackOnAFailedIntegrityCheck(t *testing.T) {
 	}
 }
 
-// TS 24.501 §5.5.1.3.4 case a: a native 5G context that already verified the
-// request stays current, and the EPS security parameters are discarded.
+// TS 24.501 §5.5.1.3.4 case a
 func TestRecoverContextFromEPSKeepsANativeContext(t *testing.T) {
 	ue, amfInstance, peer, _ := idleArrivalUE(t)
 
@@ -247,8 +234,7 @@ func TestAdoptArrivingSessionsMovesThemAndAcksTheMME(t *testing.T) {
 	}
 }
 
-// A session the SMF refuses is left behind rather than reported as adopted, so
-// the MME releases it (TS 23.502 §4.11.1.3.3 step 8).
+// TS 23.502 §4.11.1.3.3 step 8
 func TestAdoptArrivingSessionsLeavesBehindWhatCannotMove(t *testing.T) {
 	ue, amfInstance, peer, smf := idleArrivalUE(t)
 	smf.IdleTransferErr = context.DeadlineExceeded
@@ -271,8 +257,7 @@ func TestAdoptArrivingSessionsLeavesBehindWhatCannotMove(t *testing.T) {
 	}
 }
 
-// TS 23.502 §4.11.1.3.3 step 17: the accept reports the adopted sessions to the
-// UE, both as PDU sessions and as the EPS bearers they map to.
+// TS 23.502 §4.11.1.3.3 step 17
 func TestIdleArrivalAcceptReportsTheAdoptedSessions(t *testing.T) {
 	ue, ngapSender, smf, amfInstance := buildMobilityRegUeAndAMF(t)
 

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -343,9 +343,7 @@ func TestIdleArrivalAcceptReportsTheAdoptedSessions(t *testing.T) {
 	}
 }
 
-// TS 33.501 §8.2: the mapped context is taken into use by a NAS SMC. Skipping it
-// leaves the UE on keys it never activated, and leaves the AMF without the
-// non-cleartext IEs the UE replays in SECURITY MODE COMPLETE.
+// TS 33.501 §8.2
 func TestIdleArrivalFromEPSAlwaysRunsTheSecurityModeProcedure(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas"
@@ -138,6 +139,47 @@ func TestRecoverContextFromEPSInstallsTheMappedContext(t *testing.T) {
 
 	if ue.Ambr == nil || ue.Ambr.Uplink != models.MustParseBitRate("50 Mbps") {
 		t.Errorf("AMBR = %+v, want the subscribed one the MME returned", ue.Ambr)
+	}
+}
+
+// TS 33.501 §6.7.2 step 2a, §8.2
+func TestIdleArrivalReplaysTheUEsOwn5GSecurityCapability(t *testing.T) {
+	ue, amfInstance, _, _ := idleArrivalUE(t)
+
+	amfInstance.DBInstance = &fakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: `["000001"]`,
+			Ciphering:     `["NULL","AES"]`,
+			Integrity:     `["AES"]`,
+		},
+	}
+
+	req := idleArrivalRequest()
+	req.UESecurityCapability = &fgs.UESecurityCapability{EA: 0x20, IA: 0x20}
+
+	ue.SetUESecurityCapabilityForTest(req.UESecurityCapability)
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, req)
+
+	raw, err := amf.BuildSecurityModeCommand(ue)
+	if err != nil {
+		t.Fatalf("BuildSecurityModeCommand: %v", err)
+	}
+
+	smc, err := fgs.ParseSecurityModeCommand(raw)
+	if err != nil {
+		t.Fatalf("parse SecurityModeCommand: %v", err)
+	}
+
+	if !smc.ReplayedUESecurityCapability.Equal(*req.UESecurityCapability) {
+		t.Errorf("replayed UE security capability = %+v, want the %+v the UE sent: the UE answers SECURITY MODE REJECT on a mismatch",
+			smc.ReplayedUESecurityCapability, *req.UESecurityCapability)
+	}
+
+	if smc.CipheringAlgorithm == nas.CipheringNull {
+		t.Error("the AMF selected NEA0 for a UE that advertised NEA2, so it negotiated against a capability set the UE never sent")
 	}
 }
 

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -299,6 +299,74 @@ func TestAdoptArrivingSessionsLeavesBehindWhatCannotMove(t *testing.T) {
 	}
 }
 
+// TS 23.502 §4.11.1.3.3 step 8
+func TestAdoptArrivingSessionsReleasesASessionItCannotAddress(t *testing.T) {
+	ue, amfInstance, peer, smf := idleArrivalUE(t)
+
+	resp := arrivingMMContext(ue.Supi())
+	resp.PDNConnections[0].PDUSessionID = 16
+	ue.Conn().ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+
+	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
+
+	if len(smf.IdleTransfers) != 1 {
+		t.Fatalf("idle transfers = %d, want the session to have moved before the SM context failed", len(smf.IdleTransfers))
+	}
+
+	if len(smf.ReleaseSmContextCalls) != 1 {
+		t.Fatalf("released sessions = %d, want 1: the MME dropped its PDN connection when the session moved, so nobody else releases it",
+			len(smf.ReleaseSmContextCalls))
+	}
+
+	if got := smf.ReleaseSmContextCalls[0].SmContextRef; got != "idle-ref-16" {
+		t.Errorf("released SM context ref = %q, want the moved session's", got)
+	}
+
+	if len(peer.Transferred) != 0 {
+		t.Errorf("acknowledged sessions = %v, want none", peer.Transferred)
+	}
+}
+
+// TS 23.502 §4.11.1.3.3 step 14
+func TestIdleArrivalIsAbortedWhenTheIdentityCannotBeCommitted(t *testing.T) {
+	ue, ngapSender, smf, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	peer := &fakeEPSPeer{MMContextResponse: arrivingMMContext(ue.Supi())}
+	amfInstance.EPS = peer
+
+	resp := arrivingMMContext(ue.Supi())
+	conn := ue.Conn()
+	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+	conn.ArrivedFromEPS = true
+	conn.RegistrationRequest = &fgs.RegistrationRequest{
+		RegistrationType: fgs.RegistrationTypeMobilityUpdating,
+		UEStatus:         &fgs.UEStatus{S1ModeReg: true},
+	}
+	conn.MarkICSCompleted()
+
+	ue.SetSupiForTest(etsi.SUPI{})
+
+	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	if len(smf.IdleTransfers) != 0 {
+		t.Errorf("idle transfers = %d, want none: the AMF moved sessions for a UE it could not index", len(smf.IdleTransfers))
+	}
+
+	if peer.Acked {
+		t.Error("the MME was acknowledged, so it released PDN connections the AMF never adopted")
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 0 {
+		t.Errorf("downlink NAS messages = %d, want none: the UE was accepted on 5GS with no session while the MME still holds them all",
+			len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	if len(ngapSender.SentUEContextReleaseCommand) != 1 {
+		t.Errorf("UE context release commands = %d, want 1: the half-built registration was left in place",
+			len(ngapSender.SentUEContextReleaseCommand))
+	}
+}
+
 // TS 23.502 §4.11.1.3.3 step 17
 func TestIdleArrivalAcceptReportsTheAdoptedSessions(t *testing.T) {
 	ue, ngapSender, smf, amfInstance := buildMobilityRegUeAndAMF(t)

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -300,3 +300,50 @@ func TestIdleArrivalAcceptReportsTheAdoptedSessions(t *testing.T) {
 		t.Errorf("EPS bearer context status = %+v, want EBI 6 active", accept.EPSBearerContextStatus)
 	}
 }
+
+// TS 33.501 §8.2: the mapped context is taken into use by a NAS SMC. Skipping it
+// leaves the UE on keys it never activated, and leaves the AMF without the
+// non-cleartext IEs the UE replays in SECURITY MODE COMPLETE.
+func TestIdleArrivalFromEPSAlwaysRunsTheSecurityModeProcedure(t *testing.T) {
+	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	amfInstance.EPS = &fakeEPSPeer{MMContextResponse: arrivingMMContext(ue.Supi())}
+
+	ue.SetSecuredForTest(false)
+	ue.ForceStateForTest(amf.RegistrationInitiated)
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+
+	if !ue.SecurityContextIsValid() {
+		t.Fatal("no mapped context was installed")
+	}
+
+	conn := ue.Conn()
+	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
+	conn.RegistrationRequest = idleArrivalRequest()
+
+	securityMode(context.Background(), amfInstance, ue)
+
+	if ue.RegStep() != amf.RegStepSecurityMode {
+		t.Fatalf("registration step = %v, want the security mode sub-phase: the AMF skipped the command that activates the mapped context",
+			ue.RegStep())
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlink NAS messages = %d, want the SECURITY MODE COMMAND", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	wire := ngapSender.SentDownlinkNASTransport[0].NASPDU
+	if len(wire) < 7 {
+		t.Fatalf("downlink NAS PDU is %d octets, too short to carry a SECURITY MODE COMMAND", len(wire))
+	}
+
+	smc, err := fgs.ParseSecurityModeCommand(wire[7:])
+	if err != nil {
+		t.Fatalf("the AMF sent something other than a SECURITY MODE COMMAND: %v", err)
+	}
+
+	if !smc.NgKSI.Mapped {
+		t.Errorf("security mode command ngKSI = %+v, want the mapped context's", smc.NgKSI)
+	}
+}

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+const idleEKSI uint8 = 4
+
+// arrivingMMContext is the context an MME returns for a UE changing system in
+// idle mode: an EPS security context whose uplink count is the one the TAU
+// verified at, and one PDN connection.
+func arrivingMMContext(supi etsi.SUPI) interworking.MMContextResponse {
+	var kasme [32]byte
+	for i := range kasme {
+		kasme[i] = byte(i + 1)
+	}
+
+	return interworking.MMContextResponse{
+		SUPI: supi,
+		Security: interworking.EPSSecurityContext{
+			KASME:                kasme,
+			EKSI:                 nas.KeySetIdentifier{Value: idleEKSI},
+			ULNASCount:           nas.MakeCount(0, 7),
+			DLNASCount:           nas.MakeCount(0, 2),
+			Algorithms:           interworking.EPSNASAlgorithms{Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES},
+			UESecurityCapability: eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70},
+		},
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70},
+		PDNConnections: []interworking.PDNConnection{
+			{PDUSessionID: 3, EPSBearerIdentity: 6, APN: "internet", Snssai: models.Snssai{Sst: 1, Sd: "010203"}},
+		},
+		AMBRUplink:   models.MustParseBitRate("50 Mbps"),
+		AMBRDownlink: models.MustParseBitRate("100 Mbps"),
+	}
+}
+
+// idleArrivalRequest is the REGISTRATION REQUEST of an inter-system change
+// performed in 5GMM-IDLE mode (TS 24.501 §5.5.1.3.2 a, c).
+func idleArrivalRequest() *fgs.RegistrationRequest {
+	return &fgs.RegistrationRequest{
+		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,
+		NgKSI:                  nas.KeySetIdentifier{Value: idleEKSI, Mapped: true},
+		MobileIdentity:         mappedGUTIIdentity(),
+		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
+		EPSNASMessageContainer: []byte{uint8(eps.PDEMM), 0x01, 0xde, 0xad, 0xbe, 0xef, 0x00},
+		UESecurityCapability:   &fgs.UESecurityCapability{EA: 0xe0, IA: 0xe0},
+	}
+}
+
+func idleArrivalUE(t *testing.T) (*amf.UeContext, *amf.AMF, *fakeEPSPeer, *fakeSmf) {
+	t.Helper()
+
+	ue, _, smf, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	peer := &fakeEPSPeer{MMContextResponse: arrivingMMContext(ue.Supi())}
+	amfInstance.EPS = peer
+
+	ue.SetSecuredForTest(false)
+
+	return ue, amfInstance, peer, smf
+}
+
+// A registration in connected mode carries no EPS NAS message container
+// (TS 24.501 §5.5.1.3.2 c), which is what separates the idle path from the
+// arrival of a handover.
+func TestMovingFromEPCInIdleModeNeedsTheContainer(t *testing.T) {
+	ue, _, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	conn := ue.Conn()
+	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
+
+	req := idleArrivalRequest()
+	if !movingFromEPCInIdleMode(conn, req) {
+		t.Error("a mobility update reporting EMM-REGISTERED with a container is not taken as an idle-mode change")
+	}
+
+	req.EPSNASMessageContainer = nil
+	if movingFromEPCInIdleMode(conn, req) {
+		t.Error("a mobility update with no container is taken as an idle-mode change")
+	}
+
+	req = idleArrivalRequest()
+	req.UEStatus = nil
+
+	if movingFromEPCInIdleMode(conn, req) {
+		t.Error("a mobility update that does not report EMM-REGISTERED is taken as an inter-system change")
+	}
+}
+
+// TS 33.501 §8.2: the mapped context is installed before the authentication
+// decision, so the security mode command activates it — carrying the mapped
+// ngKSI and the EPS NAS algorithms already in use.
+func TestRecoverContextFromEPSInstallsTheMappedContext(t *testing.T) {
+	ue, amfInstance, peer, _ := idleArrivalUE(t)
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+
+	if len(peer.MMContextRequests) != 1 {
+		t.Fatalf("MME context requests = %d, want 1", len(peer.MMContextRequests))
+	}
+
+	if !ue.SecurityContextIsValid() {
+		t.Fatal("no security context was installed, so the AMF would authenticate a UE the MME already vouched for")
+	}
+
+	if got := ue.NgKsi(); got.Tsc != models.ScTypeMapped || got.Ksi != int32(idleEKSI) {
+		t.Errorf("ngKSI = %+v, want the eKSI %d of a mapped context", got, idleEKSI)
+	}
+
+	raw, err := amf.BuildSecurityModeCommand(ue)
+	if err != nil {
+		t.Fatalf("BuildSecurityModeCommand: %v", err)
+	}
+
+	smc, err := fgs.ParseSecurityModeCommand(raw)
+	if err != nil {
+		t.Fatalf("parse SecurityModeCommand: %v", err)
+	}
+
+	if smc.NgKSI.Value != idleEKSI || !smc.NgKSI.Mapped {
+		t.Errorf("security mode command ngKSI = %+v, want the mapped %d", smc.NgKSI, idleEKSI)
+	}
+
+	// TS 33.501 §8.6.1: the EPS algorithms the AMF signals now are the ones a
+	// later move back to EPS maps the context under.
+	if smc.SelectedEPSNASSecurityAlgorithms == nil {
+		t.Fatal("no selected EPS NAS security algorithms: the UE could not derive the same mapped EPS context on its way back")
+	}
+
+	if smc.SelectedEPSNASSecurityAlgorithms.Integrity != nas.IntegrityAES ||
+		smc.SelectedEPSNASSecurityAlgorithms.Ciphering != nas.CipheringAES {
+		t.Errorf("selected EPS NAS algorithms = %+v, want the AES pair already in use", smc.SelectedEPSNASSecurityAlgorithms)
+	}
+
+	if ue.Ambr == nil || ue.Ambr.Uplink != models.MustParseBitRate("50 Mbps") {
+		t.Errorf("AMBR = %+v, want the subscribed one the MME returned", ue.Ambr)
+	}
+}
+
+// TS 24.501 §5.5.1.3.5 b: with no context to recover the UE is authenticated,
+// and the registration proceeds as an initial one.
+func TestRecoverContextFromEPSFallsBackWhenTheMMEHasNoContext(t *testing.T) {
+	ue, amfInstance, peer, _ := idleArrivalUE(t)
+	peer.MMContextErr = interworking.ErrUnknownUEContext
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+
+	if ue.SecurityContextIsValid() {
+		t.Error("a security context was installed though the MME returned none")
+	}
+
+	if ue.Conn().ArrivingFromEPS != nil {
+		t.Error("the connection holds an arriving context the MME never returned")
+	}
+}
+
+func TestRecoverContextFromEPSFallsBackOnAFailedIntegrityCheck(t *testing.T) {
+	ue, amfInstance, peer, _ := idleArrivalUE(t)
+	peer.MMContextErr = interworking.ErrIntegrityCheckFailed
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+
+	if ue.SecurityContextIsValid() {
+		t.Error("a security context was installed though the MME could not verify the TAU")
+	}
+}
+
+// TS 24.501 §5.5.1.3.4 case a: a native 5G context that already verified the
+// request stays current, and the EPS security parameters are discarded.
+func TestRecoverContextFromEPSKeepsANativeContext(t *testing.T) {
+	ue, amfInstance, peer, _ := idleArrivalUE(t)
+
+	ue.SetSecuredForTest(true)
+
+	native := ue.NgKsi()
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+
+	if got := ue.NgKsi(); got != native {
+		t.Errorf("ngKSI = %+v, want the native %+v: the UE holds no mapped context to answer under", got, native)
+	}
+
+	if ue.Conn().ArrivingFromEPS == nil {
+		t.Fatal("the PDN connections were discarded with the EPS security parameters")
+	}
+
+	if len(peer.MMContextRequests) != 1 {
+		t.Error("the MME was not asked for the UE's PDN connections")
+	}
+}
+
+// TS 23.502 §4.11.1.3.3 steps 8 and 14
+func TestAdoptArrivingSessionsMovesThemAndAcksTheMME(t *testing.T) {
+	ue, amfInstance, peer, smf := idleArrivalUE(t)
+
+	resp := arrivingMMContext(ue.Supi())
+	ue.Conn().ArrivingFromEPS = &resp
+
+	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
+
+	if len(smf.IdleTransfers) != 1 {
+		t.Fatalf("idle transfers = %d, want 1", len(smf.IdleTransfers))
+	}
+
+	if got := smf.IdleTransfers[0]; got.PDUSessionID != 3 || got.EPSBearerIdentity != 6 || got.Dnn != "internet" {
+		t.Errorf("idle transfer = %+v, want PDU session 3 as EBI 6 on internet", got)
+	}
+
+	sm, ok := ue.SmContextFindByPDUSessionID(3)
+	if !ok {
+		t.Fatal("the arriving PDN connection opened no SM context")
+	}
+
+	if sm.Ref != "idle-ref-3" {
+		t.Errorf("SM context ref = %q, want the moved session's", sm.Ref)
+	}
+
+	if ebi := ue.EPSBearerIdentities()[3]; ebi != 6 {
+		t.Errorf("EPS bearer identity = %d, want the 6 it keeps on 5GS", ebi)
+	}
+
+	if !peer.Acked {
+		t.Fatal("the MME was never acknowledged, so it keeps serving a UE that has left")
+	}
+
+	if len(peer.Transferred) != 1 || peer.Transferred[0] != 3 {
+		t.Errorf("acknowledged sessions = %v, want the adopted PDU session 3", peer.Transferred)
+	}
+
+	if ue.Conn().ArrivingFromEPS != nil {
+		t.Error("the arriving context outlived the adoption, so a later registration would move it again")
+	}
+}
+
+// A session the SMF refuses is left behind rather than reported as adopted, so
+// the MME releases it (TS 23.502 §4.11.1.3.3 step 8).
+func TestAdoptArrivingSessionsLeavesBehindWhatCannotMove(t *testing.T) {
+	ue, amfInstance, peer, smf := idleArrivalUE(t)
+	smf.IdleTransferErr = context.DeadlineExceeded
+
+	resp := arrivingMMContext(ue.Supi())
+	ue.Conn().ArrivingFromEPS = &resp
+
+	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
+
+	if _, ok := ue.SmContextFindByPDUSessionID(3); ok {
+		t.Error("an SM context was opened for a session that never moved")
+	}
+
+	if !peer.Acked {
+		t.Fatal("the MME was never acknowledged")
+	}
+
+	if len(peer.Transferred) != 0 {
+		t.Errorf("acknowledged sessions = %v, want none", peer.Transferred)
+	}
+}
+
+// TS 23.502 §4.11.1.3.3 step 17: the accept reports the adopted sessions to the
+// UE, both as PDU sessions and as the EPS bearers they map to.
+func TestIdleArrivalAcceptReportsTheAdoptedSessions(t *testing.T) {
+	ue, ngapSender, smf, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	peer := &fakeEPSPeer{MMContextResponse: arrivingMMContext(ue.Supi())}
+	amfInstance.EPS = peer
+
+	resp := arrivingMMContext(ue.Supi())
+	conn := ue.Conn()
+	conn.ArrivingFromEPS = &resp
+	conn.ArrivedFromEPS = true
+	conn.RegistrationRequest = &fgs.RegistrationRequest{
+		RegistrationType: fgs.RegistrationTypeMobilityUpdating,
+		UEStatus:         &fgs.UEStatus{S1ModeReg: true},
+		PDUSessionStatus: &fgs.PSIBitmap{PSI: [16]bool{3: true}},
+	}
+	conn.MarkICSCompleted()
+
+	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	if len(smf.IdleTransfers) != 1 {
+		t.Fatalf("idle transfers = %d, want the arriving PDN connection to have moved", len(smf.IdleTransfers))
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlink NAS transports = %d, want 1", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	plain := decryptAndDecodeNasPdu(t, ue, ngapSender.SentDownlinkNASTransport[0].NASPDU, 0)
+
+	accept, err := fgs.ParseRegistrationAccept(plain)
+	if err != nil {
+		t.Fatalf("could not parse RegistrationAccept: %v", err)
+	}
+
+	if accept.PDUSessionStatus == nil || !accept.PDUSessionStatus.PSI[3] {
+		t.Errorf("PDU session status = %+v, want PDU session 3 active", accept.PDUSessionStatus)
+	}
+
+	if accept.EPSBearerContextStatus == nil || !accept.EPSBearerContextStatus.Active[6] {
+		t.Errorf("EPS bearer context status = %+v, want EBI 6 active", accept.EPSBearerContextStatus)
+	}
+}

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -238,7 +238,7 @@ func TestAdoptArrivingSessionsMovesThemAndAcksTheMME(t *testing.T) {
 	ue, amfInstance, peer, smf := idleArrivalUE(t)
 
 	resp := arrivingMMContext(ue.Supi())
-	ue.Conn().ArrivingFromEPS = &resp
+	ue.Conn().ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
 
 	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
 
@@ -282,7 +282,7 @@ func TestAdoptArrivingSessionsLeavesBehindWhatCannotMove(t *testing.T) {
 	smf.IdleTransferErr = context.DeadlineExceeded
 
 	resp := arrivingMMContext(ue.Supi())
-	ue.Conn().ArrivingFromEPS = &resp
+	ue.Conn().ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
 
 	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
 
@@ -308,7 +308,7 @@ func TestIdleArrivalAcceptReportsTheAdoptedSessions(t *testing.T) {
 
 	resp := arrivingMMContext(ue.Supi())
 	conn := ue.Conn()
-	conn.ArrivingFromEPS = &resp
+	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
 	conn.ArrivedFromEPS = true
 	conn.RegistrationRequest = &fgs.RegistrationRequest{
 		RegistrationType: fgs.RegistrationTypeMobilityUpdating,

--- a/internal/amf/nas/interworking_conformance_test.go
+++ b/internal/amf/nas/interworking_conformance_test.go
@@ -160,8 +160,7 @@ func TestRegistrationAfterAnEPSHandoverKeepsTheMovedSessions(t *testing.T) {
 	}
 }
 
-// TS 23.502 §4.11.2.3: the mark stands for the one mobility update that follows a
-// completed handover, so any mobility update spends it.
+// TS 23.502 §4.11.2.3
 func TestIdleArrivalSpendsALeftoverHandoverMark(t *testing.T) {
 	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
 

--- a/internal/amf/nas/interworking_conformance_test.go
+++ b/internal/amf/nas/interworking_conformance_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/fgs"
 )
@@ -156,5 +157,28 @@ func TestRegistrationAfterAnEPSHandoverKeepsTheMovedSessions(t *testing.T) {
 
 	if _, ok := ue.SmContextFindByPDUSessionID(1); !ok {
 		t.Error("the AMF dropped the PDU session the handover moved")
+	}
+}
+
+// TS 23.502 §4.11.2.3: the mark stands for the one mobility update that follows a
+// completed handover, so any mobility update spends it.
+func TestIdleArrivalSpendsALeftoverHandoverMark(t *testing.T) {
+	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	ue.MarkArrivedFromEPSHandover()
+
+	conn := ue.Conn()
+	conn.RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
+	conn.ArrivingFromEPS = &interworking.ArrivingSessions{}
+
+	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)
+
+	conn.ArrivingFromEPS = nil
+	conn.ArrivedFromEPS = false
+
+	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)
+
+	if conn.ArrivedFromEPS {
+		t.Error("an update the AMF holds no EPS arrival for was taken as one: the handover mark outlived the idle arrival that short-circuited it")
 	}
 }

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -290,6 +290,12 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 
 	additional := etsi.InvalidGUTI5G
 
+	// On an inter-system change from S1 mode the 5GS mobile identity carries a
+	// 5G-GUTI mapped from the UE's 4G-GUTI, which names the MME rather than any
+	// context here; the UE's own 5G-GUTI is the native one in the Additional GUTI IE
+	// (TS 24.501 §5.5.1.3.2 a) NOTE 6, §5.5.1.3.4 a) and c)).
+	nativeIsAdditional := false
+
 	switch msgType {
 	case fgs.MsgRegistrationRequest:
 		req, err := fgs.ParseRegistrationRequest(body)
@@ -300,6 +306,8 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 		if req.AdditionalGUTI != nil {
 			additional, _ = etsi.NewGUTI5GFromNAS(*req.AdditionalGUTI)
 		}
+
+		nativeIsAdditional = movingFromEPC(req)
 
 		switch {
 		case req.MobileIdentity.GUTI != nil:
@@ -351,23 +359,30 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 		return nil, nil
 	}
 
-	ue, _ := amfInstance.LookupUeByGuti(operatorInfo.Guami, guti)
-	if ue == nil {
-		guti = additional
-		ue, _ = amfInstance.LookupUeByGuti(operatorInfo.Guami, additional)
+	candidates := [2]etsi.GUTI5G{guti, additional}
+	if nativeIsAdditional {
+		candidates = [2]etsi.GUTI5G{additional, guti}
 	}
 
-	if ue == nil {
-		logger.WithTrace(ctx, logger.AmfLog).Warn("UE Context not found", logger.GUTI(guti.String()))
-		return nil, nil
+	for _, candidate := range candidates {
+		ue, _ := amfInstance.LookupUeByGuti(operatorInfo.Guami, candidate)
+		if ue == nil {
+			continue
+		}
+
+		// A pure check, so an identity that resolves the wrong context costs nothing
+		// but the attempt and the next candidate still gets its turn.
+		if !ue.ReuseForInboundNAS(payload) {
+			logger.WithTrace(ctx, logger.AmfLog).Info("NAS message cites a known GUTI but is not authenticated for that context; using a fresh context", logger.GUTI(candidate.String()))
+			continue
+		}
+
+		logger.From(ctx, logger.AmfLog).Info("UE Context derived from Guti", logger.GUTI(candidate.String()))
+
+		return ue, nil
 	}
 
-	if !ue.ReuseForInboundNAS(payload) {
-		logger.WithTrace(ctx, logger.AmfLog).Info("NAS message cites a known GUTI but is not authenticated for that context; using a fresh context", logger.GUTI(guti.String()))
-		return nil, nil
-	}
+	logger.WithTrace(ctx, logger.AmfLog).Warn("UE Context not found", logger.GUTI(candidates[0].String()))
 
-	logger.From(ctx, logger.AmfLog).Info("UE Context derived from Guti", logger.GUTI(guti.String()))
-
-	return ue, nil
+	return nil, nil
 }

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -290,10 +290,6 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 
 	additional := etsi.InvalidGUTI5G
 
-	// On an inter-system change from S1 mode the 5GS mobile identity carries a
-	// 5G-GUTI mapped from the UE's 4G-GUTI, which names the MME rather than any
-	// context here; the UE's own 5G-GUTI is the native one in the Additional GUTI IE
-	// (TS 24.501 §5.5.1.3.2 a) NOTE 6, §5.5.1.3.4 a) and c)).
 	nativeIsAdditional := false
 
 	switch msgType {
@@ -370,8 +366,6 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 			continue
 		}
 
-		// A pure check, so an identity that resolves the wrong context costs nothing
-		// but the attempt and the next candidate still gets its turn.
 		if !ue.ReuseForInboundNAS(payload) {
 			logger.WithTrace(ctx, logger.AmfLog).Info("NAS message cites a known GUTI but is not authenticated for that context; using a fresh context", logger.GUTI(candidate.String()))
 			continue

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -288,9 +288,6 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 
 	guti := etsi.InvalidGUTI5G
 
-	// additional is the native 5G-GUTI a UE changing system from S1 mode carries
-	// alongside the mapped one in its 5GS mobile identity IE (TS 24.501
-	// §8.2.6.12 a). Only this one can name a context this AMF holds.
 	additional := etsi.InvalidGUTI5G
 
 	switch msgType {
@@ -309,10 +306,6 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 			guti, _ = etsi.NewGUTI5GFromNAS(req.MobileIdentity)
 			logger.WithTrace(ctx, logger.AmfLog).Debug("Guti received in Registration Request Message", logger.GUTI(guti.String()))
 		case req.MobileIdentity.SUCI != nil:
-			// A SUCI is a one-time concealed identity, not a handle to an existing
-			// context. Always register on a fresh context; any prior context for
-			// the same subscriber is superseded only once this registration is
-			// authenticated (TS 24.501, reconciled by SUPI on accept).
 			logger.WithTrace(ctx, logger.AmfLog).Debug("Suci received in Registration Request Message; using a fresh context",
 				zap.Stringer("suci", req.MobileIdentity.SUCI))
 
@@ -358,9 +351,6 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 		return nil, nil
 	}
 
-	// The 5GS mobile identity of a UE arriving from EPS is a 5G-GUTI mapped from
-	// its 4G one, which names the MME; the native 5G-GUTI it may still hold is in
-	// the Additional GUTI IE (TS 24.501 §5.5.1.3.2 case e).
 	ue, _ := amfInstance.LookupUeByGuti(operatorInfo.Guami, guti)
 	if ue == nil {
 		guti = additional

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -288,11 +288,20 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 
 	guti := etsi.InvalidGUTI5G
 
+	// additional is the native 5G-GUTI a UE changing system from S1 mode carries
+	// alongside the mapped one in its 5GS mobile identity IE (TS 24.501
+	// §8.2.6.12 a). Only this one can name a context this AMF holds.
+	additional := etsi.InvalidGUTI5G
+
 	switch msgType {
 	case fgs.MsgRegistrationRequest:
 		req, err := fgs.ParseRegistrationRequest(body)
 		if !decoded(ctx, "RegistrationRequest", err) {
 			return nil, fmt.Errorf("error decoding plain nas: %w", err)
+		}
+
+		if req.AdditionalGUTI != nil {
+			additional, _ = etsi.NewGUTI5GFromNAS(*req.AdditionalGUTI)
 		}
 
 		switch {
@@ -339,7 +348,7 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 		}
 	}
 
-	if guti == etsi.InvalidGUTI5G {
+	if guti == etsi.InvalidGUTI5G && additional == etsi.InvalidGUTI5G {
 		return nil, nil
 	}
 
@@ -349,7 +358,15 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 		return nil, nil
 	}
 
+	// The 5GS mobile identity of a UE arriving from EPS is a 5G-GUTI mapped from
+	// its 4G one, which names the MME; the native 5G-GUTI it may still hold is in
+	// the Additional GUTI IE (TS 24.501 §5.5.1.3.2 case e).
 	ue, _ := amfInstance.LookupUeByGuti(operatorInfo.Guami, guti)
+	if ue == nil {
+		guti = additional
+		ue, _ = amfInstance.LookupUeByGuti(operatorInfo.Guami, additional)
+	}
+
 	if ue == nil {
 		logger.WithTrace(ctx, logger.AmfLog).Warn("UE Context not found", logger.GUTI(guti.String()))
 		return nil, nil

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -343,16 +343,19 @@ func fetchUeContextWithMobileIdentity(ctx context.Context, amfInstance *amf.AMF,
 		return nil, nil
 	}
 
-	ue, _ := amfInstance.LookupUeByGuti(guti)
+	operatorInfo, err := amfInstance.OperatorInfo(ctx)
+	if err != nil {
+		logger.WithTrace(ctx, logger.AmfLog).Error("could not get operator info; resolving no context by GUTI", zap.Error(err))
+		return nil, nil
+	}
+
+	ue, _ := amfInstance.LookupUeByGuti(operatorInfo.Guami, guti)
 	if ue == nil {
 		logger.WithTrace(ctx, logger.AmfLog).Warn("UE Context not found", logger.GUTI(guti.String()))
 		return nil, nil
 	}
 
 	if !ue.ReuseForInboundNAS(payload) {
-		// TS 24.501: this message cites an existing context but is not
-		// integrity-verified for it. Register on a fresh context; the committed
-		// context (its NAS security context and PDU sessions) is left unchanged.
 		logger.WithTrace(ctx, logger.AmfLog).Info("NAS message cites a known GUTI but is not authenticated for that context; using a fresh context", logger.GUTI(guti.String()))
 		return nil, nil
 	}

--- a/internal/amf/nas/reg_initial.go
+++ b/internal/amf/nas/reg_initial.go
@@ -103,7 +103,7 @@ func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *am
 	}
 
 	ue.AllowedNssai = subscriberProfile.AllowedNssai
-	ue.Ambr = subscriberProfile.Ambr
+	ue.SetAmbr(subscriberProfile.Ambr)
 	ue.SetAllow4G(subscriberProfile.Allow4G)
 
 	if conn.RegistrationRequest.MICOIndication != nil {

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -90,9 +90,6 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	ue.Ambr = subscriberProfile.Ambr
 	ue.SetAllow4G(subscriberProfile.Allow4G)
 
-	// After the subscription checks above and before the session work below: the
-	// UE is released from EPS only once this AMF has accepted to serve it
-	// (TS 23.502 §4.11.1.3.3 step 8).
 	adoptArrivingSessions(ctx, amfInstance, ue, conn)
 
 	releaseLocallyDeactivatedEPSBearers(ctx, amfInstance, ue, conn)

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -90,7 +90,9 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	ue.SetAmbr(subscriberProfile.Ambr)
 	ue.SetAllow4G(subscriberProfile.Allow4G)
 
-	adoptArrivingSessions(ctx, amfInstance, ue, conn)
+	if !adoptArrivingSessions(ctx, amfInstance, ue, conn) {
+		return
+	}
 
 	releaseLocallyDeactivatedEPSBearers(ctx, amfInstance, ue, conn)
 

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -87,7 +87,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		ue.DRXParameter = drx
 	}
 
-	ue.Ambr = subscriberProfile.Ambr
+	ue.SetAmbr(subscriberProfile.Ambr)
 	ue.SetAllow4G(subscriberProfile.Allow4G)
 
 	adoptArrivingSessions(ctx, amfInstance, ue, conn)

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -90,6 +90,11 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	ue.Ambr = subscriberProfile.Ambr
 	ue.SetAllow4G(subscriberProfile.Allow4G)
 
+	// After the subscription checks above and before the session work below: the
+	// UE is released from EPS only once this AMF has accepted to serve it
+	// (TS 23.502 §4.11.1.3.3 step 8).
+	adoptArrivingSessions(ctx, amfInstance, ue, conn)
+
 	releaseLocallyDeactivatedEPSBearers(ctx, amfInstance, ue, conn)
 
 	var (

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -984,15 +984,12 @@ func TestMobilityReg_OmitsTheEPSBearerContextStatusWithoutAnArrivalFromEPS(t *te
 }
 
 type fakeEPSPeer struct {
-	// MMContext fields
 	MMContextRequests []interworking.MMContextRequest
 	MMContextResponse interworking.MMContextResponse
 	MMContextErr      error
-
-	// MMContextAck fields
-	Acked       bool
-	AckedSupi   etsi.SUPI
-	Transferred []uint8
+	Acked             bool
+	AckedSupi         etsi.SUPI
+	Transferred       []uint8
 }
 
 func (*fakeEPSPeer) ForwardRelocation(context.Context, interworking.ForwardRelocationRequest) (interworking.ForwardRelocationResponse, error) {

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -100,6 +100,8 @@ func buildMobilityRegUeAndAMF(t *testing.T) (*amf.UeContext, *fakeNGAPSender, *f
 				Mcc:           "001",
 				Mnc:           "01",
 				SupportedTACs: "[\"000001\"]",
+				Ciphering:     `["AES"]`,
+				Integrity:     `["AES"]`,
 			},
 		},
 		nil,
@@ -981,17 +983,43 @@ func TestMobilityReg_OmitsTheEPSBearerContextStatusWithoutAnArrivalFromEPS(t *te
 	}
 }
 
-type fakeEPSPeer struct{}
+type fakeEPSPeer struct {
+	// MMContext fields
+	MMContextRequests []interworking.MMContextRequest
+	MMContextResponse interworking.MMContextResponse
+	MMContextErr      error
 
-func (fakeEPSPeer) ForwardRelocation(context.Context, interworking.ForwardRelocationRequest) (interworking.ForwardRelocationResponse, error) {
+	// MMContextAck fields
+	Acked       bool
+	AckedSupi   etsi.SUPI
+	Transferred []uint8
+}
+
+func (*fakeEPSPeer) ForwardRelocation(context.Context, interworking.ForwardRelocationRequest) (interworking.ForwardRelocationResponse, error) {
 	return interworking.ForwardRelocationResponse{}, nil
 }
 
-func (fakeEPSPeer) RelocationCancel(context.Context, etsi.SUPI, interworking.RelocationID) error {
+func (*fakeEPSPeer) RelocationCancel(context.Context, etsi.SUPI, interworking.RelocationID) error {
 	return nil
 }
 
-func (fakeEPSPeer) RelocationComplete(context.Context, etsi.SUPI, interworking.RelocationID) error {
+func (*fakeEPSPeer) RelocationComplete(context.Context, etsi.SUPI, interworking.RelocationID) error {
+	return nil
+}
+
+func (p *fakeEPSPeer) MMContext(_ context.Context, req interworking.MMContextRequest) (interworking.MMContextResponse, error) {
+	p.MMContextRequests = append(p.MMContextRequests, req)
+
+	if p.MMContextErr != nil {
+		return interworking.MMContextResponse{}, p.MMContextErr
+	}
+
+	return p.MMContextResponse, nil
+}
+
+func (p *fakeEPSPeer) MMContextAck(_ context.Context, supi etsi.SUPI, transferred []uint8) error {
+	p.Acked, p.AckedSupi, p.Transferred = true, supi, transferred
+
 	return nil
 }
 

--- a/internal/amf/nas/reuse_bind_test.go
+++ b/internal/amf/nas/reuse_bind_test.go
@@ -162,11 +162,7 @@ func securedUeForTest(t *testing.T, amfInstance *amf.AMF, imsi string, guti etsi
 	return ue
 }
 
-// TestFetchUeContext_InterSystemChangeResolvesTheAdditionalGUTI covers the
-// 5G-GUTI mapped from a 4G-GUTI carrying this deployment's own GUAMI, so it
-// resolves in the AMF's own 5G-TMSI index even though it names the MME. The
-// native context lives behind the Additional GUTI IE and must still be found
-// (TS 24.501 §5.5.1.3.2 a) NOTE 6, §5.5.1.3.4 a) and c)).
+// TS 24.501 §5.5.1.3.2 a) NOTE 6, §5.5.1.3.4 a) and c)
 func TestFetchUeContext_InterSystemChangeResolvesTheAdditionalGUTI(t *testing.T) {
 	amfInstance := reuseTestAMF()
 
@@ -206,11 +202,7 @@ func TestFetchUeContext_InterSystemChangeResolvesTheAdditionalGUTI(t *testing.T)
 	}
 }
 
-// TestFetchUeContext_PlainRegistrationDoesNotReuseRegisteredVictim is the
-// end-to-end regression for the GUTI-spoof DoS: a plain (unauthenticated)
-// initial REGISTRATION REQUEST that resolves by GUTI to a registered UE must be
-// routed to a fresh context, leaving the victim's committed context untouched
-// (TS 24.501).
+// TS 24.501
 func TestFetchUeContext_PlainRegistrationDoesNotReuseRegisteredVictim(t *testing.T) {
 	gutiID := fgs.GUTIIdentity(fgs.GUTI{
 		PLMN: nas.PLMN{MCC: "001", MNC: "01"}, AMFRegionID: 0xca, AMFSetID: 0x3f, AMFPointer: 0x00,

--- a/internal/amf/nas/reuse_bind_test.go
+++ b/internal/amf/nas/reuse_bind_test.go
@@ -126,6 +126,86 @@ func TestFetchUeContext_DeregistrationResolvesExistingContextByGuti(t *testing.T
 	}
 }
 
+func gutiWithTMSI(t *testing.T, tmsi [4]byte) (fgs.MobileIdentity, etsi.GUTI5G) {
+	t.Helper()
+
+	id := fgs.GUTIIdentity(fgs.GUTI{
+		PLMN: nas.PLMN{MCC: "001", MNC: "01"}, AMFRegionID: 0xca, AMFSetID: 0x3f, AMFPointer: 0x00,
+		TMSI: tmsi,
+	})
+
+	guti, err := etsi.NewGUTI5GFromNAS(id)
+	if err != nil {
+		t.Fatalf("NewGUTI5GFromNAS: %v", err)
+	}
+
+	return id, guti
+}
+
+func securedUeForTest(t *testing.T, amfInstance *amf.AMF, imsi string, guti etsi.GUTI5G, knasInt [16]uint8) *amf.UeContext {
+	t.Helper()
+
+	supi, err := etsi.NewSUPIFromPrefixed(imsi)
+	if err != nil {
+		t.Fatalf("NewSUPIFromPrefixed: %v", err)
+	}
+
+	ue := amf.NewUeContext()
+	ue.SetSupiForTest(supi)
+	ue.SetSecuredForTest(true)
+	ue.SetIntegrityAlgForTest(nas.IntegrityAES)
+	ue.SetKnasIntForTest(knasInt)
+	ue.ForceStateForTest(amf.Registered)
+
+	amfInstance.AssignGutiForTest(ue, guti)
+
+	return ue
+}
+
+// TestFetchUeContext_InterSystemChangeResolvesTheAdditionalGUTI covers the
+// 5G-GUTI mapped from a 4G-GUTI carrying this deployment's own GUAMI, so it
+// resolves in the AMF's own 5G-TMSI index even though it names the MME. The
+// native context lives behind the Additional GUTI IE and must still be found
+// (TS 24.501 §5.5.1.3.2 a) NOTE 6, §5.5.1.3.4 a) and c)).
+func TestFetchUeContext_InterSystemChangeResolvesTheAdditionalGUTI(t *testing.T) {
+	amfInstance := reuseTestAMF()
+
+	collidingID, collidingGuti := gutiWithTMSI(t, [4]byte{0x00, 0x00, 0x00, 0x01})
+	nativeID, nativeGuti := gutiWithTMSI(t, [4]byte{0x00, 0x00, 0x00, 0x02})
+
+	stranger := securedUeForTest(t, amfInstance, "imsi-001010000000001", collidingGuti,
+		[16]uint8{9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9})
+	mover := securedUeForTest(t, amfInstance, "imsi-001010000000002", nativeGuti,
+		[16]uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	inner, err := (&fgs.RegistrationRequest{
+		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,
+		FOR:                    true,
+		MobileIdentity:         collidingID,
+		AdditionalGUTI:         &nativeID,
+		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
+		UESecurityCapability:   &fgs.UESecurityCapability{},
+		EPSNASMessageContainer: []byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x07, 0x48},
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode RegistrationRequest: %v", err)
+	}
+
+	got, err := fetchUeContextWithMobileIdentity(context.Background(), amfInstance,
+		wrapIntegrityProtected(t, mover, inner, 0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got == stranger {
+		t.Fatal("the mapped 5G-GUTI resolved another subscriber's context")
+	}
+
+	if got != mover {
+		t.Fatal("the UE's native 5G context was not found behind the Additional GUTI, so the AMF re-authenticates a UE it can already verify")
+	}
+}
+
 // TestFetchUeContext_PlainRegistrationDoesNotReuseRegisteredVictim is the
 // end-to-end regression for the GUTI-spoof DoS: a plain (unauthenticated)
 // initial REGISTRATION REQUEST that resolves by GUTI to a registered UE must be

--- a/internal/amf/nas/reuse_bind_test.go
+++ b/internal/amf/nas/reuse_bind_test.go
@@ -9,9 +9,16 @@ import (
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/fgs"
 )
+
+func reuseTestAMF() *amf.AMF {
+	return amf.New(&fakeDBInstance{Operator: &db.Operator{
+		Mcc: "001", Mnc: "01", AmfRegionID: 0xca, AmfSetID: 0x3f,
+	}}, nil, nil)
+}
 
 func plainRegistrationWithGuti(t *testing.T, guti fgs.MobileIdentity) []byte {
 	t.Helper()
@@ -92,7 +99,7 @@ func TestFetchUeContext_DeregistrationResolvesExistingContextByGuti(t *testing.T
 		t.Fatalf("NewSUPIFromPrefixed: %v", err)
 	}
 
-	amfInstance := amf.New(nil, nil, nil)
+	amfInstance := reuseTestAMF()
 
 	ue := amf.NewUeContext()
 	ue.SetSupiForTest(supi)
@@ -140,7 +147,7 @@ func TestFetchUeContext_PlainRegistrationDoesNotReuseRegisteredVictim(t *testing
 		t.Fatalf("NewSUPIFromPrefixed: %v", err)
 	}
 
-	amfInstance := amf.New(nil, nil, nil)
+	amfInstance := reuseTestAMF()
 
 	victim := amf.NewUeContext()
 	victim.SetSupiForTest(supi)

--- a/internal/amf/nas/security_mode.go
+++ b/internal/amf/nas/security_mode.go
@@ -41,7 +41,7 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) 
 		return
 	}
 
-	if ue.SecurityContextIsValid() {
+	if ue.SecurityContextIsValid() && conn.ArrivingFromEPS == nil {
 		if ue.NeedsEPSNASAlgorithms() && provideEPSNASAlgorithms(ctx, amfInstance, ue, conn) {
 			return
 		}

--- a/internal/amf/ngap/fixtures_test.go
+++ b/internal/amf/ngap/fixtures_test.go
@@ -88,6 +88,10 @@ type SmfPrepareFromEPSCall struct {
 	Snssai            *models.Snssai
 }
 
+func (f *fakeSmfSbi) TransferIdleTo5GS(context.Context, etsi.SUPI, uint8, uint8, string, *models.Snssai) (string, error) {
+	return "", nil
+}
+
 func (f *fakeSmfSbi) PrepareSmContextFromEPS(_ context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (string, []byte, error) {
 	f.PrepareFromEPSCalls = append(f.PrepareFromEPSCalls, &SmfPrepareFromEPSCall{
 		Supi:              supi,

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -107,7 +107,7 @@ func resumeExistingContext(ctx context.Context, amfInstance *amf.AMF, ueConn *am
 		logger.WithTrace(ctx, ueConn.Log).Warn("invalid guti", zap.Error(err))
 	}
 
-	amfUe, ok := amfInstance.LookupUeByGuti(guti)
+	amfUe, ok := amfInstance.LookupUeByGuti(operatorInfo.Guami, guti)
 	if !ok {
 		logger.WithTrace(ctx, ueConn.Log).Warn("Unknown UE", logger.GUTI(guti.String()))
 		return

--- a/internal/amf/ngap/handover_to_eps_test.go
+++ b/internal/amf/ngap/handover_to_eps_test.go
@@ -41,6 +41,12 @@ type epsPeerStub struct {
 	gate      chan struct{}
 }
 
+func (p *epsPeerStub) MMContext(context.Context, interworking.MMContextRequest) (interworking.MMContextResponse, error) {
+	return interworking.MMContextResponse{}, interworking.ErrUnknownUEContext
+}
+
+func (p *epsPeerStub) MMContextAck(context.Context, etsi.SUPI, []uint8) error { return nil }
+
 func (p *epsPeerStub) ForwardRelocation(_ context.Context, req interworking.ForwardRelocationRequest) (interworking.ForwardRelocationResponse, error) {
 	p.mu.Lock()
 	p.request = &req

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/guard"
+	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/fgs"
@@ -111,6 +112,12 @@ type UeConn struct {
 	RetransmissionOfInitialNASMsg     bool
 
 	ArrivedFromEPS bool
+
+	// ArrivingFromEPS is the MM context the MME handed over for an idle-mode
+	// inter-system change, held from the context request until the PDN
+	// connections it names have been adopted (TS 23.502 §4.11.1.3.3 steps 5a-14).
+	// Nil on every other registration.
+	ArrivingFromEPS *interworking.MMContextResponse
 
 	RegistrationAcceptPlain []byte
 }

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -111,12 +111,7 @@ type UeConn struct {
 	IdentityTypeUsedForRegistration   uint8
 	RetransmissionOfInitialNASMsg     bool
 
-	ArrivedFromEPS bool
-
-	// ArrivingFromEPS is the MM context the MME handed over for an idle-mode
-	// inter-system change, held from the context request until the PDN
-	// connections it names have been adopted (TS 23.502 §4.11.1.3.3 steps 5a-14).
-	// Nil on every other registration.
+	ArrivedFromEPS  bool
 	ArrivingFromEPS *interworking.MMContextResponse
 
 	RegistrationAcceptPlain []byte

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -112,7 +112,7 @@ type UeConn struct {
 	RetransmissionOfInitialNASMsg     bool
 
 	ArrivedFromEPS  bool
-	ArrivingFromEPS *interworking.MMContextResponse
+	ArrivingFromEPS *interworking.ArrivingSessions
 
 	RegistrationAcceptPlain []byte
 }

--- a/internal/amf/relocation_cancel_window_test.go
+++ b/internal/amf/relocation_cancel_window_test.go
@@ -62,3 +62,41 @@ func TestRelocationCancelRejectsAnUnknownRelocation(t *testing.T) {
 		t.Fatal("a cancel naming another relocation was accepted")
 	}
 }
+
+// The relocation registry admits one handover from EPS per subscriber, so an entry
+// that outlives the context naming it locks that subscriber out for good. The MME
+// clears the mirror registry from removeContextLocked; the AMF must clear this one
+// from its own removal path, which is reached even when the connection has already
+// passed to a fresh re-registration.
+func TestRemovingAUeContextEndsItsRelocationFromEPS(t *testing.T) {
+	a, ue, _, supi := cancelWindowUE(t)
+
+	if !a.beginRelocationFromEPS(supi, 7, ue) {
+		t.Fatal("beginRelocationFromEPS refused a fresh relocation")
+	}
+
+	a.DeregisterAndRemoveUeContext(context.Background(), ue)
+
+	if !a.beginRelocationFromEPS(supi, 8, NewUeContext()) {
+		t.Fatal("the subscriber is still marked as relocating from EPS, so every later handover for it is refused")
+	}
+}
+
+// A removal must not clear an entry another context holds: a superseded husk is torn
+// down after a fresh context has taken over the subscriber.
+func TestRemovingASupersededContextKeepsTheLiveRelocation(t *testing.T) {
+	a, husk, _, supi := cancelWindowUE(t)
+
+	live := NewUeContext()
+	live.SetSupi(supi)
+
+	if !a.beginRelocationFromEPS(supi, 7, live) {
+		t.Fatal("beginRelocationFromEPS refused a fresh relocation")
+	}
+
+	a.DeregisterAndRemoveUeContext(context.Background(), husk)
+
+	if a.beginRelocationFromEPS(supi, 8, NewUeContext()) {
+		t.Fatal("tearing down a superseded context dropped the live relocation another context holds")
+	}
+}

--- a/internal/amf/relocation_cancel_window_test.go
+++ b/internal/amf/relocation_cancel_window_test.go
@@ -63,11 +63,6 @@ func TestRelocationCancelRejectsAnUnknownRelocation(t *testing.T) {
 	}
 }
 
-// The relocation registry admits one handover from EPS per subscriber, so an entry
-// that outlives the context naming it locks that subscriber out for good. The MME
-// clears the mirror registry from removeContextLocked; the AMF must clear this one
-// from its own removal path, which is reached even when the connection has already
-// passed to a fresh re-registration.
 func TestRemovingAUeContextEndsItsRelocationFromEPS(t *testing.T) {
 	a, ue, _, supi := cancelWindowUE(t)
 
@@ -82,8 +77,6 @@ func TestRemovingAUeContextEndsItsRelocationFromEPS(t *testing.T) {
 	}
 }
 
-// A removal must not clear an entry another context holds: a superseded husk is torn
-// down after a fresh context has taken over the subscriber.
 func TestRemovingASupersededContextKeepsTheLiveRelocation(t *testing.T) {
 	a, husk, _, supi := cancelWindowUE(t)
 

--- a/internal/amf/relocation_test.go
+++ b/internal/amf/relocation_test.go
@@ -33,6 +33,12 @@ type fakeEPSPeer struct {
 	block        chan struct{}
 }
 
+func (f *fakeEPSPeer) MMContext(context.Context, interworking.MMContextRequest) (interworking.MMContextResponse, error) {
+	return interworking.MMContextResponse{}, interworking.ErrUnknownUEContext
+}
+
+func (f *fakeEPSPeer) MMContextAck(context.Context, etsi.SUPI, []uint8) error { return nil }
+
 func (f *fakeEPSPeer) ForwardRelocation(ctx context.Context, req interworking.ForwardRelocationRequest) (interworking.ForwardRelocationResponse, error) {
 	f.mu.Lock()
 	f.request = req

--- a/internal/amf/security_mode_command_test.go
+++ b/internal/amf/security_mode_command_test.go
@@ -30,13 +30,12 @@ func horizontalDerivationRequired(smc *fgs.SecurityModeCommand) bool {
 	return smc.AdditionalSecurityInformation != nil && smc.AdditionalSecurityInformation.HDP
 }
 
-func securityModeCommandUE(t *testing.T, origin amf.KeyOrigin, regType fgs.RegistrationType) *amf.UeContext {
+func securityModeCommandUE(t *testing.T, regType fgs.RegistrationType) *amf.UeContext {
 	t.Helper()
 
 	ue := buildTestUE(t)
 	ue.SetUESecurityCapabilityForTest(amf.UESecCapForTest([]uint8{2}, []uint8{2}))
 	attachTestConn(t, ue)
-	ue.SetKeyOriginForTest(origin)
 
 	conn := ue.Conn()
 	if conn == nil {
@@ -48,39 +47,26 @@ func securityModeCommandUE(t *testing.T, origin amf.KeyOrigin, regType fgs.Regis
 	return ue
 }
 
-func TestSecurityModeCommandDoesNotClaimHorizontalDerivationAfterPrimaryAuth(t *testing.T) {
+// TS 33.501 Annex A.13, TS 24.501 §5.4.2.2: the horizontal derivation parameter
+// tells the UE to derive a new KAMF and zero its NAS COUNTs. This AMF derives no
+// KAMF horizontally, so no registration type may claim that it did.
+func TestSecurityModeCommandNeverClaimsHorizontalDerivation(t *testing.T) {
 	for _, regType := range []fgs.RegistrationType{
 		fgs.RegistrationTypeInitial,
 		fgs.RegistrationTypeMobilityUpdating,
 		fgs.RegistrationTypePeriodicUpdating,
 		fgs.RegistrationTypeEmergency,
 	} {
-		ue := securityModeCommandUE(t, amf.KeyOriginPrimaryAuth, regType)
+		ue := securityModeCommandUE(t, regType)
 
 		if horizontalDerivationRequired(securityModeCommandForTest(t, ue)) {
-			t.Errorf("registration type %v: HDP is set, but the KAMF comes from primary authentication, not from a KAMF to K'AMF derivation", regType)
+			t.Errorf("registration type %v: HDP is set, so the UE would derive a KAMF this AMF never derived", regType)
 		}
 	}
 }
 
-func TestSecurityModeCommandDoesNotClaimHorizontalDerivationForAMappedContext(t *testing.T) {
-	ue := securityModeCommandUE(t, amf.KeyOriginMappedFromEPS, fgs.RegistrationTypeMobilityUpdating)
-
-	if horizontalDerivationRequired(securityModeCommandForTest(t, ue)) {
-		t.Error("HDP is set, but a mapped KAMF' is derived from the KASME, not horizontally")
-	}
-}
-
-func TestSecurityModeCommandSignalsHorizontalDerivation(t *testing.T) {
-	ue := securityModeCommandUE(t, amf.KeyOriginHorizontalDerivation, fgs.RegistrationTypeMobilityUpdating)
-
-	if !horizontalDerivationRequired(securityModeCommandForTest(t, ue)) {
-		t.Error("HDP is not set for a horizontally derived KAMF")
-	}
-}
-
 func TestSecurityModeCommandOmitsAdditionalSecurityInformationWhenNothingToSignal(t *testing.T) {
-	ue := securityModeCommandUE(t, amf.KeyOriginPrimaryAuth, fgs.RegistrationTypeMobilityUpdating)
+	ue := securityModeCommandUE(t, fgs.RegistrationTypeMobilityUpdating)
 
 	smc := securityModeCommandForTest(t, ue)
 	if smc.AdditionalSecurityInformation != nil {
@@ -89,7 +75,7 @@ func TestSecurityModeCommandOmitsAdditionalSecurityInformationWhenNothingToSigna
 }
 
 func TestSecurityModeCommandRequestsRetransmissionWithoutHorizontalDerivation(t *testing.T) {
-	ue := securityModeCommandUE(t, amf.KeyOriginPrimaryAuth, fgs.RegistrationTypeMobilityUpdating)
+	ue := securityModeCommandUE(t, fgs.RegistrationTypeMobilityUpdating)
 
 	conn := ue.Conn()
 	conn.RetransmissionOfInitialNASMsg = true

--- a/internal/amf/security_mode_command_test.go
+++ b/internal/amf/security_mode_command_test.go
@@ -47,9 +47,7 @@ func securityModeCommandUE(t *testing.T, regType fgs.RegistrationType) *amf.UeCo
 	return ue
 }
 
-// TS 33.501 Annex A.13, TS 24.501 §5.4.2.2: the horizontal derivation parameter
-// tells the UE to derive a new KAMF and zero its NAS COUNTs. This AMF derives no
-// KAMF horizontally, so no registration type may claim that it did.
+// TS 33.501 Annex A.13, TS 24.501 §5.4.2.2
 func TestSecurityModeCommandNeverClaimsHorizontalDerivation(t *testing.T) {
 	for _, regType := range []fgs.RegistrationType{
 		fgs.RegistrationTypeInitial,

--- a/internal/amf/security_state.go
+++ b/internal/amf/security_state.go
@@ -76,22 +76,6 @@ func MintAuthProofForInterworking() AuthProof {
 	return AuthProof{}
 }
 
-type KeyOrigin uint8
-
-const (
-	KeyOriginUnknown KeyOrigin = iota
-	KeyOriginPrimaryAuth
-	KeyOriginHorizontalDerivation
-	KeyOriginMappedFromEPS
-)
-
-func (ue *UeContext) KeyOrigin() KeyOrigin {
-	ue.mu.Lock()
-	defer ue.mu.Unlock()
-
-	return ue.keyOrigin
-}
-
 // VerifyResult reports the outcome of comparing a peer-reported value
 // against the AMF's locally stored value.
 type VerifyResult int

--- a/internal/amf/ue_accessors.go
+++ b/internal/amf/ue_accessors.go
@@ -37,6 +37,27 @@ func (ue *UeContext) SmContextRefs() []SmContextRef {
 	return refs
 }
 
+// SetAmbr and AmbrRates are the audited pair for the subscribed UE-AMBR: it is
+// written on the NAS dispatch goroutine and read from the status export and from
+// the peer's inter-system context request, which run on their own.
+func (ue *UeContext) SetAmbr(ambr *models.Ambr) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.Ambr = ambr
+}
+
+func (ue *UeContext) AmbrRates() (uplink, downlink models.BitRate, ok bool) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if ue.Ambr == nil {
+		return models.BitRate{}, models.BitRate{}, false
+	}
+
+	return ue.Ambr.Uplink, ue.Ambr.Downlink, true
+}
+
 func (ue *UeContext) Secured() bool {
 	if ue == nil {
 		return false

--- a/internal/amf/ue_accessors.go
+++ b/internal/amf/ue_accessors.go
@@ -4,6 +4,8 @@
 package amf
 
 import (
+	"time"
+
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas"
@@ -53,6 +55,20 @@ func (ue *UeContext) AmbrRates() (uplink, downlink models.BitRate, ok bool) {
 	}
 
 	return ue.Ambr.Uplink, ue.Ambr.Downlink, true
+}
+
+func (ue *UeContext) RetainForEPS(d time.Duration) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.exportableToEPSUntil = time.Now().Add(d)
+}
+
+func (ue *UeContext) ExportableToEPS() bool {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return ue.state == Registered || time.Now().Before(ue.exportableToEPSUntil)
 }
 
 func (ue *UeContext) Secured() bool {

--- a/internal/amf/ue_accessors.go
+++ b/internal/amf/ue_accessors.go
@@ -37,9 +37,6 @@ func (ue *UeContext) SmContextRefs() []SmContextRef {
 	return refs
 }
 
-// SetAmbr and AmbrRates are the audited pair for the subscribed UE-AMBR: it is
-// written on the NAS dispatch goroutine and read from the status export and from
-// the peer's inter-system context request, which run on their own.
 func (ue *UeContext) SetAmbr(ambr *models.Ambr) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -186,8 +186,6 @@ func (ue *UeContext) SetKnasEncForTest(k [16]uint8) {
 }
 func (ue *UeContext) KnasEncForTest() [16]uint8 { return ue.knasEnc }
 
-func (ue *UeContext) SetKeyOriginForTest(o KeyOrigin) { ue.keyOrigin = o }
-
 func (ue *UeContext) SetNgKsiForTest(n models.NgKsi) { ue.ngKsi = n }
 func (ue *UeContext) NgKsiForTest() models.NgKsi     { return ue.ngKsi }
 

--- a/internal/amf/verify_enclosed_eps_nas_test.go
+++ b/internal/amf/verify_enclosed_eps_nas_test.go
@@ -15,7 +15,23 @@ import (
 func epsFramedTAU(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer) []byte {
 	t.Helper()
 
-	plain := []byte{uint8(eps.PDEMM), uint8(eps.MsgTrackingAreaUpdateRequest), 0x0b}
+	return epsFramedTAUCitingKSI(t, ue, count, bearer, 0)
+}
+
+// epsFramedTAUCitingKSI frames a TRACKING AREA UPDATE REQUEST whose NAS key set
+// identifier half-octet names eksi (TS 24.301 §8.2.29.1).
+func epsFramedTAUCitingKSI(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer, eksi uint8) []byte {
+	t.Helper()
+
+	return epsFramedEMM(t, ue, count, bearer, eps.MsgTrackingAreaUpdateRequest, eksi<<4|0x0b)
+}
+
+// epsFramedEMM frames a plain EMM message of type mt whose octet 3 is octet3,
+// integrity protected as a 5G NAS message over 3GPP access (TS 33.501 §8.5.2).
+func epsFramedEMM(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer, mt eps.MessageType, octet3 byte) []byte {
+	t.Helper()
+
+	plain := []byte{uint8(eps.PDEMM), uint8(mt), octet3}
 
 	mac, err := ue.sc.MAC(append([]byte{count.SQN()}, plain...), count, bearer, nas.DirectionUplink)
 	if err != nil {

--- a/internal/amf/verify_enclosed_eps_nas_test.go
+++ b/internal/amf/verify_enclosed_eps_nas_test.go
@@ -11,8 +11,7 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// A TRACKING AREA UPDATE REQUEST as the UE frames it for an idle change to EPS:
-// EPS framing, MAC'd as a 5G NAS message over a 3GPP access (TS 33.501 §8.5.2).
+// TS 33.501 §8.5.2
 func epsFramedTAU(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer) []byte {
 	t.Helper()
 
@@ -36,9 +35,7 @@ func epsFramedTAU(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Beare
 	return raw
 }
 
-// TS 33.501 §8.5.2 step 4: the AMF verifies the enclosed TAU REQUEST as if it
-// were a 5G NAS message received over 3GPP access, and the count it verified at
-// is the K'ASME input.
+// TS 33.501 §8.5.2 step 4
 func TestVerifyEnclosedEPSNASReturnsTheCountItVerifiedAt(t *testing.T) {
 	ue := newSecuredUE(t)
 
@@ -57,9 +54,7 @@ func TestVerifyEnclosedEPSNASReturnsTheCountItVerifiedAt(t *testing.T) {
 	}
 }
 
-// The count is committed, so the same message cannot verify again and re-derive
-// the key the MME already holds (TS 33.501 §8.5.2 step 1: the UE's own stored
-// count increases when it sends the TAU).
+// TS 33.501 §8.5.2 step 1
 func TestVerifyEnclosedEPSNASCommitsTheCount(t *testing.T) {
 	ue := newSecuredUE(t)
 
@@ -83,8 +78,6 @@ func TestVerifyEnclosedEPSNASCommitsTheCount(t *testing.T) {
 	}
 }
 
-// A message MAC'd over the EPS bearer is one protected with an EPS context, not
-// the 5G one this path verifies against.
 func TestVerifyEnclosedEPSNASRefusesTheEPSBearer(t *testing.T) {
 	ue := newSecuredUE(t)
 

--- a/internal/amf/verify_enclosed_eps_nas_test.go
+++ b/internal/amf/verify_enclosed_eps_nas_test.go
@@ -11,23 +11,18 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// TS 33.501 §8.5.2
 func epsFramedTAU(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer) []byte {
 	t.Helper()
 
 	return epsFramedTAUCitingKSI(t, ue, count, bearer, 0)
 }
 
-// epsFramedTAUCitingKSI frames a TRACKING AREA UPDATE REQUEST whose NAS key set
-// identifier half-octet names eksi (TS 24.301 §8.2.29.1).
 func epsFramedTAUCitingKSI(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer, eksi uint8) []byte {
 	t.Helper()
 
 	return epsFramedEMM(t, ue, count, bearer, eps.MsgTrackingAreaUpdateRequest, eksi<<4|0x0b)
 }
 
-// epsFramedEMM frames a plain EMM message of type mt whose octet 3 is octet3,
-// integrity protected as a 5G NAS message over 3GPP access (TS 33.501 §8.5.2).
 func epsFramedEMM(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer, mt eps.MessageType, octet3 byte) []byte {
 	t.Helper()
 

--- a/internal/amf/verify_enclosed_eps_nas_test.go
+++ b/internal/amf/verify_enclosed_eps_nas_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// A TRACKING AREA UPDATE REQUEST as the UE frames it for an idle change to EPS:
+// EPS framing, MAC'd as a 5G NAS message over a 3GPP access (TS 33.501 §8.5.2).
+func epsFramedTAU(t *testing.T, ue *UeContext, count nas.Count, bearer nas.Bearer) []byte {
+	t.Helper()
+
+	plain := []byte{uint8(eps.PDEMM), uint8(eps.MsgTrackingAreaUpdateRequest), 0x0b}
+
+	mac, err := ue.sc.MAC(append([]byte{count.SQN()}, plain...), count, bearer, nas.DirectionUplink)
+	if err != nil {
+		t.Fatalf("MAC: %v", err)
+	}
+
+	raw, err := (&eps.SecurityProtectedMessage{
+		SecurityHeaderType: eps.SHTIntegrityProtected,
+		MAC:                mac,
+		SequenceNumber:     count.SQN(),
+		UnverifiedPayload:  plain,
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+
+	return raw
+}
+
+// TS 33.501 §8.5.2 step 4: the AMF verifies the enclosed TAU REQUEST as if it
+// were a 5G NAS message received over 3GPP access, and the count it verified at
+// is the K'ASME input.
+func TestVerifyEnclosedEPSNASReturnsTheCountItVerifiedAt(t *testing.T) {
+	ue := newSecuredUE(t)
+
+	cnt, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+
+	got, err := ue.VerifyEnclosedEPSNAS(epsFramedTAU(t, ue, cnt, nas.Bearer3GPP))
+	if err != nil {
+		t.Fatalf("VerifyEnclosedEPSNAS: %v", err)
+	}
+
+	if got != cnt {
+		t.Errorf("count = %d, want %d", got, cnt)
+	}
+}
+
+// The count is committed, so the same message cannot verify again and re-derive
+// the key the MME already holds (TS 33.501 §8.5.2 step 1: the UE's own stored
+// count increases when it sends the TAU).
+func TestVerifyEnclosedEPSNASCommitsTheCount(t *testing.T) {
+	ue := newSecuredUE(t)
+
+	cnt, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+
+	tau := epsFramedTAU(t, ue, cnt, nas.Bearer3GPP)
+
+	if _, err := ue.VerifyEnclosedEPSNAS(tau); err != nil {
+		t.Fatalf("VerifyEnclosedEPSNAS: %v", err)
+	}
+
+	if _, err := ue.VerifyEnclosedEPSNAS(tau); err == nil {
+		t.Fatal("a replayed TAU REQUEST verified a second time")
+	}
+
+	if ue.ulCount.LastAccepted() != cnt {
+		t.Errorf("uplink NAS COUNT = %d, want the %d the TAU was accepted at", ue.ulCount.LastAccepted(), cnt)
+	}
+}
+
+// A message MAC'd over the EPS bearer is one protected with an EPS context, not
+// the 5G one this path verifies against.
+func TestVerifyEnclosedEPSNASRefusesTheEPSBearer(t *testing.T) {
+	ue := newSecuredUE(t)
+
+	cnt, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+
+	if _, err := ue.VerifyEnclosedEPSNAS(epsFramedTAU(t, ue, cnt, nas.BearerEPS)); !errors.Is(err, nas.ErrMACMismatch) {
+		t.Errorf("error = %v, want a MAC mismatch", err)
+	}
+
+	if ue.ulCount.Accepted() {
+		t.Error("a refused message advanced the uplink NAS COUNT")
+	}
+}
+
+func TestVerifyEnclosedEPSNASWithoutASecurityContext(t *testing.T) {
+	ue := newSecuredUE(t)
+
+	cnt, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatalf("estimate: %v", err)
+	}
+
+	tau := epsFramedTAU(t, ue, cnt, nas.Bearer3GPP)
+
+	ue.secured = false
+
+	if _, err := ue.VerifyEnclosedEPSNAS(tau); !errors.Is(err, ErrNo5GSecurityContext) {
+		t.Errorf("error = %v, want no 5G security context", err)
+	}
+}

--- a/internal/db/operator.go
+++ b/internal/db/operator.go
@@ -49,8 +49,15 @@ type Operator struct {
 	ClusterID     string `db:"clusterID"`
 }
 
-func (operator *Operator) AMFRegionID() uint8 {
-	return uint8(operator.AmfRegionID) | 0x80
+const guamiRegionIDNodeType = 0x80
+
+const (
+	maxAmfRegionID = 0x7f
+	maxAmfSetID    = 1023
+)
+
+func (operator *Operator) GUAMIRegionID() uint8 {
+	return uint8(operator.AmfRegionID) | guamiRegionIDNodeType
 }
 
 func (operator *Operator) GetSupportedTacs() ([]string, error) {
@@ -481,6 +488,14 @@ func (db *Database) UpdateOperatorSPN(ctx context.Context, spnFullName, spnShort
 // UpdateOperatorAMFIdentity updates the AMF Region ID and Set ID used to
 // compute the 24-bit AMF ID (3GPP TS 23.003 §2.10.1).
 func (db *Database) UpdateOperatorAMFIdentity(ctx context.Context, regionID, setID int) error {
+	if regionID < 0 || regionID > maxAmfRegionID {
+		return fmt.Errorf("amfRegionID must be between 0 and %d (the node-type bit is reserved), got %d", maxAmfRegionID, regionID)
+	}
+
+	if setID < 0 || setID > maxAmfSetID {
+		return fmt.Errorf("amfSetID must be between 0 and %d (constrained by the 10-bit AMF Set ID field), got %d", maxAmfSetID, setID)
+	}
+
 	_, span := tracer.Start(
 		ctx,
 		fmt.Sprintf("%s %s (amf identity)", "UPDATE", OperatorTableName),

--- a/internal/db/operator.go
+++ b/internal/db/operator.go
@@ -49,10 +49,6 @@ type Operator struct {
 	ClusterID     string `db:"clusterID"`
 }
 
-// AMFRegionID is the AMF Region ID of the GUAMI, carrying the node-type bit. It
-// maps verbatim into the high octet of the MME Group ID derived for E-UTRAN
-// (TS 23.003 §2.10.2.1.2), whose most significant bit shall be one so a peer can
-// tell an MME Group ID from a LAC (TS 23.003 §2.8.2.2.2).
 func (operator *Operator) AMFRegionID() uint8 {
 	return uint8(operator.AmfRegionID) | 0x80
 }

--- a/internal/db/operator.go
+++ b/internal/db/operator.go
@@ -49,6 +49,14 @@ type Operator struct {
 	ClusterID     string `db:"clusterID"`
 }
 
+// AMFRegionID is the AMF Region ID of the GUAMI, carrying the node-type bit. It
+// maps verbatim into the high octet of the MME Group ID derived for E-UTRAN
+// (TS 23.003 §2.10.2.1.2), whose most significant bit shall be one so a peer can
+// tell an MME Group ID from a LAC (TS 23.003 §2.8.2.2.2).
+func (operator *Operator) AMFRegionID() uint8 {
+	return uint8(operator.AmfRegionID) | 0x80
+}
+
 func (operator *Operator) GetSupportedTacs() ([]string, error) {
 	if operator.SupportedTACs == "" {
 		return nil, nil

--- a/internal/interworking/context_transfer.go
+++ b/internal/interworking/context_transfer.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package interworking
+
+import (
+	"errors"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+var (
+	// ErrUnknownUEContext reports a peer that holds no context for the presented
+	// identity, so the UE has to be recovered by authenticating it afresh.
+	ErrUnknownUEContext = errors.New("interworking: the peer holds no context for this identity")
+
+	// ErrIntegrityCheckFailed reports a peer that holds the context but could not
+	// verify the enclosed NAS message against it (TS 33.501 §8.2, §8.5.2 step 4).
+	ErrIntegrityCheckFailed = errors.New("interworking: the peer could not verify the enclosed NAS message")
+)
+
+// MMContextRequest asks the MME for the UE's EPS context on an idle-mode change
+// to 5GS: the Context Request of TS 23.502 §4.11.1.3.3 step 5a.
+type MMContextRequest struct {
+	// MappedEPSGUTI is the 4G-GUTI the presented 5G-GUTI reverse-maps to, which
+	// the MME compares against its stored values (TS 23.003 §2.10.2.1.3).
+	MappedEPSGUTI eps.GUTI
+
+	// EPSNAS is the complete TRACKING AREA UPDATE REQUEST the UE enclosed in the
+	// EPS NAS message container IE, integrity protected with the EPS security
+	// context only the MME holds (TS 24.501 §8.2.6.16).
+	EPSNAS []byte
+}
+
+// MMContextResponse is the MME's answer, returned only for a request whose
+// enclosed TAU REQUEST verified.
+type MMContextResponse struct {
+	SUPI etsi.SUPI
+
+	// Security carries the EPS context whose ULNASCount is the count the TAU
+	// verified at — the K'AMF input (TS 33.501 Annex A.15.1).
+	Security EPSSecurityContext
+
+	UENetworkCapability eps.UENetworkCapability
+	PDNConnections      []PDNConnection
+	AMBRUplink          models.BitRate
+	AMBRDownlink        models.BitRate
+}
+
+// EPSContextRequest asks the AMF for the UE's context on an idle-mode change to
+// EPS: the Context Request of TS 23.502 §4.11.1.3.2 step 3.
+type EPSContextRequest struct {
+	// Mapped5GGUTI is the 5G-GUTI the presented 4G-GUTI reverse-maps to
+	// (TS 23.003 §2.10.2.2.3).
+	Mapped5GGUTI fgs.GUTI
+
+	// EPSNAS is the complete TRACKING AREA UPDATE REQUEST as it arrived at the
+	// MME, integrity protected with the 5G security context the AMF holds
+	// (TS 33.501 §8.5.2 step 3).
+	EPSNAS []byte
+}
+
+// EPSContextResponse is the AMF's answer, returned only for a request whose TAU
+// REQUEST verified.
+type EPSContextResponse struct {
+	SUPI etsi.SUPI
+
+	// Security is the mapped EPS context alone: TS 33.501 §8.5.2 step 5 — "The
+	// AMF shall never transfer 5G security parameters to an entity outside the
+	// 5G system."
+	Security EPSSecurityContext
+
+	PDNConnections []PDNConnection
+	AMBRUplink     models.BitRate
+	AMBRDownlink   models.BitRate
+}

--- a/internal/interworking/context_transfer.go
+++ b/internal/interworking/context_transfer.go
@@ -13,66 +13,32 @@ import (
 )
 
 var (
-	// ErrUnknownUEContext reports a peer that holds no context for the presented
-	// identity, so the UE has to be recovered by authenticating it afresh.
-	ErrUnknownUEContext = errors.New("interworking: the peer holds no context for this identity")
-
-	// ErrIntegrityCheckFailed reports a peer that holds the context but could not
-	// verify the enclosed NAS message against it (TS 33.501 §8.2, §8.5.2 step 4).
+	ErrUnknownUEContext     = errors.New("interworking: the peer holds no context for this identity")
 	ErrIntegrityCheckFailed = errors.New("interworking: the peer could not verify the enclosed NAS message")
 )
 
-// MMContextRequest asks the MME for the UE's EPS context on an idle-mode change
-// to 5GS: the Context Request of TS 23.502 §4.11.1.3.3 step 5a.
 type MMContextRequest struct {
-	// MappedEPSGUTI is the 4G-GUTI the presented 5G-GUTI reverse-maps to, which
-	// the MME compares against its stored values (TS 23.003 §2.10.2.1.3).
 	MappedEPSGUTI eps.GUTI
-
-	// EPSNAS is the complete TRACKING AREA UPDATE REQUEST the UE enclosed in the
-	// EPS NAS message container IE, integrity protected with the EPS security
-	// context only the MME holds (TS 24.501 §8.2.6.16).
-	EPSNAS []byte
+	EPSNAS        []byte
 }
 
-// MMContextResponse is the MME's answer, returned only for a request whose
-// enclosed TAU REQUEST verified.
 type MMContextResponse struct {
-	SUPI etsi.SUPI
-
-	// Security carries the EPS context whose ULNASCount is the count the TAU
-	// verified at — the K'AMF input (TS 33.501 Annex A.15.1).
-	Security EPSSecurityContext
-
+	SUPI                etsi.SUPI
+	Security            EPSSecurityContext
 	UENetworkCapability eps.UENetworkCapability
 	PDNConnections      []PDNConnection
 	AMBRUplink          models.BitRate
 	AMBRDownlink        models.BitRate
 }
 
-// EPSContextRequest asks the AMF for the UE's context on an idle-mode change to
-// EPS: the Context Request of TS 23.502 §4.11.1.3.2 step 3.
 type EPSContextRequest struct {
-	// Mapped5GGUTI is the 5G-GUTI the presented 4G-GUTI reverse-maps to
-	// (TS 23.003 §2.10.2.2.3).
 	Mapped5GGUTI fgs.GUTI
-
-	// EPSNAS is the complete TRACKING AREA UPDATE REQUEST as it arrived at the
-	// MME, integrity protected with the 5G security context the AMF holds
-	// (TS 33.501 §8.5.2 step 3).
-	EPSNAS []byte
+	EPSNAS       []byte
 }
 
-// EPSContextResponse is the AMF's answer, returned only for a request whose TAU
-// REQUEST verified.
 type EPSContextResponse struct {
-	SUPI etsi.SUPI
-
-	// Security is the mapped EPS context alone: TS 33.501 §8.5.2 step 5 — "The
-	// AMF shall never transfer 5G security parameters to an entity outside the
-	// 5G system."
-	Security EPSSecurityContext
-
+	SUPI           etsi.SUPI
+	Security       EPSSecurityContext
 	PDNConnections []PDNConnection
 	AMBRUplink     models.BitRate
 	AMBRDownlink   models.BitRate

--- a/internal/interworking/context_transfer.go
+++ b/internal/interworking/context_transfer.go
@@ -43,3 +43,7 @@ type EPSContextResponse struct {
 	AMBRUplink     models.BitRate
 	AMBRDownlink   models.BitRate
 }
+
+type ArrivingSessions struct {
+	PDN []PDNConnection
+}

--- a/internal/interworking/forward_relocation.go
+++ b/internal/interworking/forward_relocation.go
@@ -109,6 +109,11 @@ type EPSPeer interface {
 	ForwardRelocation(ctx context.Context, req ForwardRelocationRequest) (ForwardRelocationResponse, error)
 	RelocationCancel(ctx context.Context, supi etsi.SUPI, id RelocationID) error
 	RelocationComplete(ctx context.Context, supi etsi.SUPI, id RelocationID) error
+
+	// MMContext and MMContextAck carry an idle-mode change to 5GS
+	// (TS 23.502 §4.11.1.3.3 steps 5a and 8).
+	MMContext(ctx context.Context, req MMContextRequest) (MMContextResponse, error)
+	MMContextAck(ctx context.Context, supi etsi.SUPI, transferred []uint8) error
 }
 
 type FiveGSPeer interface {

--- a/internal/interworking/forward_relocation.go
+++ b/internal/interworking/forward_relocation.go
@@ -27,7 +27,6 @@ type ENBIdentity struct {
 	SelectedEPSTAI EPSTAI
 }
 
-// EPSTAI is an E-UTRAN Tracking Area Identity: a PLMN and a TAC (TS 23.003).
 type EPSTAI struct {
 	PlmnID models.PlmnID
 	TAC    uint16
@@ -109,9 +108,6 @@ type EPSPeer interface {
 	ForwardRelocation(ctx context.Context, req ForwardRelocationRequest) (ForwardRelocationResponse, error)
 	RelocationCancel(ctx context.Context, supi etsi.SUPI, id RelocationID) error
 	RelocationComplete(ctx context.Context, supi etsi.SUPI, id RelocationID) error
-
-	// MMContext and MMContextAck carry an idle-mode change to 5GS
-	// (TS 23.502 §4.11.1.3.3 steps 5a and 8).
 	MMContext(ctx context.Context, req MMContextRequest) (MMContextResponse, error)
 	MMContextAck(ctx context.Context, supi etsi.SUPI, transferred []uint8) error
 }
@@ -120,4 +116,6 @@ type FiveGSPeer interface {
 	ForwardRelocation(ctx context.Context, req FiveGSRelocationRequest) (FiveGSRelocationResponse, error)
 	RelocationCancel(ctx context.Context, supi etsi.SUPI, id RelocationID) error
 	RelocationComplete(ctx context.Context, supi etsi.SUPI, id RelocationID) error
+	EPSContext(ctx context.Context, req EPSContextRequest) (EPSContextResponse, error)
+	EPSContextAck(ctx context.Context, supi etsi.SUPI, transferred []uint8) error
 }

--- a/internal/interworking/security.go
+++ b/internal/interworking/security.go
@@ -19,7 +19,9 @@ import (
 
 // TS 33.501 Annex A.14, A.15
 const (
+	fcKASMEPrimeIdle     = "73" // A.14.1: K_AMF → K'ASME, P0 = uplink 5G NAS COUNT
 	fcKASMEPrimeHandover = "74" // A.14.2: K_AMF → K'ASME, P0 = downlink 5G NAS COUNT
+	fcKAMFPrimeIdle      = "75" // A.15.1: K_ASME → K'AMF, P0 = uplink EPS NAS COUNT of the TAU
 	fcKAMFPrimeHandover  = "76" // A.15.2: K_ASME → K'AMF, P0 = NH
 )
 
@@ -130,14 +132,7 @@ func MapTo5GSOnHandover(in EPSSecurityContext, intOrder []nas.IntegrityAlgorithm
 		return EPSTo5GSHandover{}, fmt.Errorf("derive K'AMF: %w", err)
 	}
 
-	capability := DefaultUE5GSecurityCapability
-	if in.UE5GSecurityCapability != nil {
-		capability = *in.UE5GSecurityCapability
-	} else {
-		capability.HasEPS = true
-		capability.EEA = in.UESecurityCapability.EEA
-		capability.EIA = in.UESecurityCapability.EIA &^ 1
-	}
+	capability := mapped5GSecurityCapability(in)
 
 	nea, nia, ok := fgs.SelectNASAlgorithms(capability, intOrder, encOrder)
 	if !ok {
@@ -222,6 +217,23 @@ func macForContainer(c fgs.S1ModeToN1ModeNASTransparentContainer, knasInt nas.In
 	}
 
 	return mac, nil
+}
+
+// mapped5GSecurityCapability is the UE's 5G security capability for a context
+// mapped from EPS: the one the AMF holds when the UE has been on 5GS before,
+// else the EPS capability carried across, with EIA0 masked off since the UE
+// signals it only in the EPS form (TS 33.501 §8.6.2).
+func mapped5GSecurityCapability(in EPSSecurityContext) fgs.UESecurityCapability {
+	if in.UE5GSecurityCapability != nil {
+		return *in.UE5GSecurityCapability
+	}
+
+	capability := DefaultUE5GSecurityCapability
+	capability.HasEPS = true
+	capability.EEA = in.UESecurityCapability.EEA
+	capability.EIA = in.UESecurityCapability.EIA &^ 1
+
+	return capability
 }
 
 func mappedKSI(k nas.KeySetIdentifier) nas.KeySetIdentifier {

--- a/internal/interworking/security.go
+++ b/internal/interworking/security.go
@@ -219,10 +219,6 @@ func macForContainer(c fgs.S1ModeToN1ModeNASTransparentContainer, knasInt nas.In
 	return mac, nil
 }
 
-// mapped5GSecurityCapability is the UE's 5G security capability for a context
-// mapped from EPS: the one the AMF holds when the UE has been on 5GS before,
-// else the EPS capability carried across, with EIA0 masked off since the UE
-// signals it only in the EPS form (TS 33.501 §8.6.2).
 func mapped5GSecurityCapability(in EPSSecurityContext) fgs.UESecurityCapability {
 	if in.UE5GSecurityCapability != nil {
 		return *in.UE5GSecurityCapability

--- a/internal/interworking/security_idle.go
+++ b/internal/interworking/security_idle.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package interworking
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/fivegskeys"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+// MapToEPSOnIdleMobility maps the UE's 5G security context to the EPS one the
+// MME adopts on an idle-mode inter-system change (TS 33.501 §8.6.1). K'ASME
+// comes from K_AMF and the uplink 5G NAS COUNT of the verified TRACKING AREA
+// UPDATE REQUEST (Annex A.14.1), and both EPS NAS COUNTs are the 5G ones.
+//
+// No NH is derived: nothing carries one to the UE on this path, and the MME
+// derives K_eNB from K'ASME and the same uplink count if the active flag brings
+// up S1-U (TS 33.401 §7.2.6.2).
+func MapToEPSOnIdleMobility(in FiveGToEPSInput) (EPSSecurityContext, error) {
+	if len(in.KAMF) != keyLen {
+		return EPSSecurityContext{}, fmt.Errorf("interworking: K_AMF is %d octets, want %d", len(in.KAMF), keyLen)
+	}
+
+	kasme, err := deriveKey(in.KAMF, fcKASMEPrimeIdle, count32(in.ULNASCount.Value()))
+	if err != nil {
+		return EPSSecurityContext{}, fmt.Errorf("derive K'ASME: %w", err)
+	}
+
+	return EPSSecurityContext{
+		KASME:                  kasme,
+		EKSI:                   mappedKSI(in.NgKSI),
+		ULNASCount:             in.ULNASCount,
+		DLNASCount:             in.DLNASCount,
+		Algorithms:             in.Algorithms,
+		UESecurityCapability:   in.UESecurityCapability,
+		UE5GSecurityCapability: in.UE5GSecurityCapability,
+	}, nil
+}
+
+// MapTo5GSOnIdleMobility maps an EPS security context to the 5G one the AMF
+// adopts on an idle-mode inter-system change (TS 33.501 §8.6.2). K'AMF comes
+// from K_ASME and the uplink EPS NAS COUNT of the TRACKING AREA UPDATE REQUEST
+// enclosed in the REGISTRATION REQUEST (Annex A.15.1), and both 5G NAS COUNTs
+// are 0.
+//
+// The selected 5G algorithms reach the UE in a NAS SMC rather than a transparent
+// container (§8.2), so no container MAC is computed here and no K_gNB is
+// derived: the security mode procedure settles the context, and the AN key
+// follows from it.
+func MapTo5GSOnIdleMobility(in EPSSecurityContext, intOrder []nas.IntegrityAlgorithm, encOrder []nas.CipheringAlgorithm) (Mapped5GSecurityContext, error) {
+	kamf, err := deriveKey(in.KASME[:], fcKAMFPrimeIdle, count32(in.ULNASCount.Value()))
+	if err != nil {
+		return Mapped5GSecurityContext{}, fmt.Errorf("derive K'AMF: %w", err)
+	}
+
+	capability := mapped5GSecurityCapability(in)
+
+	nea, nia, ok := fgs.SelectNASAlgorithms(capability, intOrder, encOrder)
+	if !ok {
+		return Mapped5GSecurityContext{}, fmt.Errorf("interworking: no 5G NAS algorithm common to the UE and the operator policy")
+	}
+
+	knasEnc, err := fivegskeys.DeriveKNASEnc(kamf[:], nea)
+	if err != nil {
+		return Mapped5GSecurityContext{}, fmt.Errorf("derive K_NASenc: %w", err)
+	}
+
+	knasInt, err := fivegskeys.DeriveKNASInt(kamf[:], nia)
+	if err != nil {
+		return Mapped5GSecurityContext{}, fmt.Errorf("derive K_NASint: %w", err)
+	}
+
+	return Mapped5GSecurityContext{
+		KAMF:                  kamf,
+		NgKSI:                 mappedKSI(in.EKSI),
+		DLNASCount:            0,
+		Ciphering:             nea,
+		Integrity:             nia,
+		KNASEnc:               knasEnc,
+		KNASInt:               knasInt,
+		UESecurityCapability:  capability,
+		EPSAlgorithms:         in.Algorithms,
+		EPSSecurityCapability: in.UESecurityCapability,
+	}, nil
+}

--- a/internal/interworking/security_idle.go
+++ b/internal/interworking/security_idle.go
@@ -11,14 +11,6 @@ import (
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
-// MapToEPSOnIdleMobility maps the UE's 5G security context to the EPS one the
-// MME adopts on an idle-mode inter-system change (TS 33.501 §8.6.1). K'ASME
-// comes from K_AMF and the uplink 5G NAS COUNT of the verified TRACKING AREA
-// UPDATE REQUEST (Annex A.14.1), and both EPS NAS COUNTs are the 5G ones.
-//
-// No NH is derived: nothing carries one to the UE on this path, and the MME
-// derives K_eNB from K'ASME and the same uplink count if the active flag brings
-// up S1-U (TS 33.401 §7.2.6.2).
 func MapToEPSOnIdleMobility(in FiveGToEPSInput) (EPSSecurityContext, error) {
 	if len(in.KAMF) != keyLen {
 		return EPSSecurityContext{}, fmt.Errorf("interworking: K_AMF is %d octets, want %d", len(in.KAMF), keyLen)
@@ -40,16 +32,6 @@ func MapToEPSOnIdleMobility(in FiveGToEPSInput) (EPSSecurityContext, error) {
 	}, nil
 }
 
-// MapTo5GSOnIdleMobility maps an EPS security context to the 5G one the AMF
-// adopts on an idle-mode inter-system change (TS 33.501 §8.6.2). K'AMF comes
-// from K_ASME and the uplink EPS NAS COUNT of the TRACKING AREA UPDATE REQUEST
-// enclosed in the REGISTRATION REQUEST (Annex A.15.1), and both 5G NAS COUNTs
-// are 0.
-//
-// The selected 5G algorithms reach the UE in a NAS SMC rather than a transparent
-// container (§8.2), so no container MAC is computed here and no K_gNB is
-// derived: the security mode procedure settles the context, and the AN key
-// follows from it.
 func MapTo5GSOnIdleMobility(in EPSSecurityContext, intOrder []nas.IntegrityAlgorithm, encOrder []nas.CipheringAlgorithm) (Mapped5GSecurityContext, error) {
 	kamf, err := deriveKey(in.KASME[:], fcKAMFPrimeIdle, count32(in.ULNASCount.Value()))
 	if err != nil {

--- a/internal/interworking/security_idle_test.go
+++ b/internal/interworking/security_idle_test.go
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package interworking_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// TS 33.501 Annex A.14.1: idle-mode mobility derives K'ASME with FC 0x73 over
+// the uplink NAS COUNT, where the handover variant uses FC 0x74 over the
+// downlink one.
+func TestMapToEPSOnIdleMobilityDerivesKASMEFromTheUplinkCount(t *testing.T) {
+	kamf := mustHex(t, testKAMF)
+	ul := nas.MakeCount(0x0102, 0x03)
+	dl := nas.MakeCount(0x0044, 0x05)
+
+	got, err := interworking.MapToEPSOnIdleMobility(interworking.FiveGToEPSInput{
+		KAMF:       kamf,
+		NgKSI:      nas.KeySetIdentifier{Value: 5},
+		ULNASCount: ul,
+		DLNASCount: dl,
+		Algorithms: interworking.EPSNASAlgorithms{Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES},
+	})
+	if err != nil {
+		t.Fatalf("MapToEPSOnIdleMobility: %v", err)
+	}
+
+	want := kdf(t, kamf, 0x73, u32(ul.Value()))
+	if !bytes.Equal(got.KASME[:], want) {
+		t.Fatalf("K'ASME = %x, want %x", got.KASME, want)
+	}
+
+	if handover := kdf(t, kamf, 0x74, u32(dl.Value())); bytes.Equal(got.KASME[:], handover) {
+		t.Fatal("K'ASME is the handover derivation, so the UE's idle-mode key would not match")
+	}
+
+	if got.EKSI != (nas.KeySetIdentifier{Value: 5, Mapped: true}) {
+		t.Fatalf("eKSI = %+v, want value 5 of a mapped context", got.EKSI)
+	}
+}
+
+// TS 33.501 §8.6.1: the EPS NAS COUNTs are the 5G ones. Nothing consumes a
+// downlink count on this path — no transparent container is built — so the
+// downlink count is carried across untouched and stays available to the AMF.
+func TestMapToEPSOnIdleMobilityCarriesBothCounts(t *testing.T) {
+	ul := nas.MakeCount(7, 8)
+	dl := nas.MakeCount(9, 10)
+
+	got, err := interworking.MapToEPSOnIdleMobility(interworking.FiveGToEPSInput{
+		KAMF:       mustHex(t, testKAMF),
+		ULNASCount: ul,
+		DLNASCount: dl,
+	})
+	if err != nil {
+		t.Fatalf("MapToEPSOnIdleMobility: %v", err)
+	}
+
+	if got.ULNASCount != ul {
+		t.Errorf("EPS uplink NAS COUNT = %d, want the 5G context's %d", got.ULNASCount, ul)
+	}
+
+	if got.DLNASCount != dl {
+		t.Errorf("EPS downlink NAS COUNT = %d, want the 5G context's %d unconsumed", got.DLNASCount, dl)
+	}
+}
+
+// The MME derives K_eNB from K'ASME and the TAU's uplink count when the active
+// flag brings up S1-U (TS 33.401 §7.2.6.2); no NH reaches the UE on this path.
+func TestMapToEPSOnIdleMobilityCarriesNoNextHop(t *testing.T) {
+	got, err := interworking.MapToEPSOnIdleMobility(interworking.FiveGToEPSInput{
+		KAMF:       mustHex(t, testKAMF),
+		ULNASCount: nas.MakeCount(1, 2),
+	})
+	if err != nil {
+		t.Fatalf("MapToEPSOnIdleMobility: %v", err)
+	}
+
+	if got.NH != ([32]byte{}) || got.NCC != 0 {
+		t.Errorf("NH/NCC = %x/%d, want them unset", got.NH, got.NCC)
+	}
+}
+
+// TS 33.501 Annex A.15.1: K'AMF comes from K_ASME and the uplink EPS NAS COUNT
+// of the TAU REQUEST the REGISTRATION REQUEST enclosed, with FC 0x75 where the
+// handover variant uses 0x76 over the NH.
+func TestMapTo5GSOnIdleMobilityDerivesKAMFFromTheUplinkCount(t *testing.T) {
+	kasme := mustHex(t, testKASME)
+	ul := nas.MakeCount(0x0011, 0x22)
+
+	var key [32]byte
+
+	copy(key[:], kasme)
+
+	in := interworking.EPSSecurityContext{
+		KASME:                key,
+		EKSI:                 nas.KeySetIdentifier{Value: 3},
+		ULNASCount:           ul,
+		DLNASCount:           nas.MakeCount(4, 5),
+		Algorithms:           interworking.EPSNASAlgorithms{Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES},
+		UESecurityCapability: eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70},
+		NH:                   [32]byte{1, 2, 3},
+		NCC:                  2,
+	}
+
+	got, err := interworking.MapTo5GSOnIdleMobility(in,
+		[]nas.IntegrityAlgorithm{nas.IntegrityAES}, []nas.CipheringAlgorithm{nas.CipheringAES})
+	if err != nil {
+		t.Fatalf("MapTo5GSOnIdleMobility: %v", err)
+	}
+
+	want := kdf(t, kasme, 0x75, u32(ul.Value()))
+	if !bytes.Equal(got.KAMF[:], want) {
+		t.Fatalf("K'AMF = %x, want %x", got.KAMF, want)
+	}
+
+	if handover := kdf(t, kasme, 0x76, in.NH[:]); bytes.Equal(got.KAMF[:], handover) {
+		t.Fatal("K'AMF is the handover derivation, so the UE's idle-mode key would not match")
+	}
+
+	if got.NgKSI != (nas.KeySetIdentifier{Value: 3, Mapped: true}) {
+		t.Fatalf("ngKSI = %+v, want value 3 of a mapped context", got.NgKSI)
+	}
+
+	if got.EPSAlgorithms != in.Algorithms {
+		t.Errorf("EPS algorithms = %+v, want the ones already in use %+v", got.EPSAlgorithms, in.Algorithms)
+	}
+}
+
+// TS 33.501 §8.6.2: the 5G NAS COUNTs of the mapped context are 0.
+func TestMapTo5GSOnIdleMobilityStartsBothCountsAtZero(t *testing.T) {
+	var key [32]byte
+
+	copy(key[:], mustHex(t, testKASME))
+
+	got, err := interworking.MapTo5GSOnIdleMobility(interworking.EPSSecurityContext{
+		KASME:                key,
+		ULNASCount:           nas.MakeCount(3, 4),
+		DLNASCount:           nas.MakeCount(5, 6),
+		UESecurityCapability: eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70},
+	}, []nas.IntegrityAlgorithm{nas.IntegrityAES}, []nas.CipheringAlgorithm{nas.CipheringAES})
+	if err != nil {
+		t.Fatalf("MapTo5GSOnIdleMobility: %v", err)
+	}
+
+	if got.DLNASCount != 0 {
+		t.Errorf("5G downlink NAS COUNT = %d, want 0", got.DLNASCount)
+	}
+
+	// The AMF signals the mapped context in a NAS SMC (§8.2), not in a
+	// transparent container, so nothing is MAC'd here and no AN key is derived.
+	if got.TemporaryKgNB != ([32]byte{}) || got.NH != ([32]byte{}) || got.NCC != 0 {
+		t.Errorf("AN key material = %x/%x/%d, want it unset", got.TemporaryKgNB, got.NH, got.NCC)
+	}
+}
+
+// TS 33.501 §8.6.2: the algorithms are the AMF's own selection over the UE's 5G
+// capability, and K_NASenc/K_NASint follow from K'AMF and that selection.
+func TestMapTo5GSOnIdleMobilitySelectsAndKeysThe5GAlgorithms(t *testing.T) {
+	kasme := mustHex(t, testKASME)
+
+	var key [32]byte
+
+	copy(key[:], kasme)
+
+	ul := nas.MakeCount(0, 1)
+
+	got, err := interworking.MapTo5GSOnIdleMobility(interworking.EPSSecurityContext{
+		KASME:                key,
+		ULNASCount:           ul,
+		UESecurityCapability: eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70},
+	}, []nas.IntegrityAlgorithm{nas.IntegrityAES}, []nas.CipheringAlgorithm{nas.CipheringAES})
+	if err != nil {
+		t.Fatalf("MapTo5GSOnIdleMobility: %v", err)
+	}
+
+	if got.Ciphering != nas.CipheringAES || got.Integrity != nas.IntegrityAES {
+		t.Fatalf("algorithms = %v/%v, want AES/AES", got.Ciphering, got.Integrity)
+	}
+
+	kamf := kdf(t, kasme, 0x75, u32(ul.Value()))
+	wantEnc := kdf(t, kamf, 0x69, []byte{0x01}, []byte{uint8(nas.CipheringAES)})
+	wantInt := kdf(t, kamf, 0x69, []byte{0x02}, []byte{uint8(nas.IntegrityAES)})
+
+	if !bytes.Equal(got.KNASEnc[:], wantEnc[len(wantEnc)-16:]) {
+		t.Errorf("K_NASenc = %x, want %x", got.KNASEnc, wantEnc[len(wantEnc)-16:])
+	}
+
+	if !bytes.Equal(got.KNASInt[:], wantInt[len(wantInt)-16:]) {
+		t.Errorf("K_NASint = %x, want %x", got.KNASInt, wantInt[len(wantInt)-16:])
+	}
+}
+
+// A context is never mapped under an algorithm the operator policy does not
+// name: the AMF has nothing to put in the NAS SMC that follows.
+func TestMapTo5GSOnIdleMobilityRefusesWithNoCommonAlgorithm(t *testing.T) {
+	var key [32]byte
+
+	copy(key[:], mustHex(t, testKASME))
+
+	_, err := interworking.MapTo5GSOnIdleMobility(interworking.EPSSecurityContext{
+		KASME:                key,
+		UESecurityCapability: eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70},
+	}, nil, nil)
+	if err == nil {
+		t.Fatal("a context mapped under an empty operator policy, want a refusal")
+	}
+}

--- a/internal/interworking/security_idle_test.go
+++ b/internal/interworking/security_idle_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// TS 33.501 Annex A.14.1: idle-mode mobility derives K'ASME with FC 0x73 over
-// the uplink NAS COUNT, where the handover variant uses FC 0x74 over the
-// downlink one.
+// TS 33.501 Annex A.14.1
 func TestMapToEPSOnIdleMobilityDerivesKASMEFromTheUplinkCount(t *testing.T) {
 	kamf := mustHex(t, testKAMF)
 	ul := nas.MakeCount(0x0102, 0x03)
@@ -45,9 +43,7 @@ func TestMapToEPSOnIdleMobilityDerivesKASMEFromTheUplinkCount(t *testing.T) {
 	}
 }
 
-// TS 33.501 §8.6.1: the EPS NAS COUNTs are the 5G ones. Nothing consumes a
-// downlink count on this path — no transparent container is built — so the
-// downlink count is carried across untouched and stays available to the AMF.
+// TS 33.501 §8.6.1
 func TestMapToEPSOnIdleMobilityCarriesBothCounts(t *testing.T) {
 	ul := nas.MakeCount(7, 8)
 	dl := nas.MakeCount(9, 10)
@@ -70,8 +66,7 @@ func TestMapToEPSOnIdleMobilityCarriesBothCounts(t *testing.T) {
 	}
 }
 
-// The MME derives K_eNB from K'ASME and the TAU's uplink count when the active
-// flag brings up S1-U (TS 33.401 §7.2.6.2); no NH reaches the UE on this path.
+// TS 33.401 §7.2.6.2
 func TestMapToEPSOnIdleMobilityCarriesNoNextHop(t *testing.T) {
 	got, err := interworking.MapToEPSOnIdleMobility(interworking.FiveGToEPSInput{
 		KAMF:       mustHex(t, testKAMF),
@@ -86,9 +81,7 @@ func TestMapToEPSOnIdleMobilityCarriesNoNextHop(t *testing.T) {
 	}
 }
 
-// TS 33.501 Annex A.15.1: K'AMF comes from K_ASME and the uplink EPS NAS COUNT
-// of the TAU REQUEST the REGISTRATION REQUEST enclosed, with FC 0x75 where the
-// handover variant uses 0x76 over the NH.
+// TS 33.501 Annex A.15.1
 func TestMapTo5GSOnIdleMobilityDerivesKAMFFromTheUplinkCount(t *testing.T) {
 	kasme := mustHex(t, testKASME)
 	ul := nas.MakeCount(0x0011, 0x22)
@@ -132,7 +125,7 @@ func TestMapTo5GSOnIdleMobilityDerivesKAMFFromTheUplinkCount(t *testing.T) {
 	}
 }
 
-// TS 33.501 §8.6.2: the 5G NAS COUNTs of the mapped context are 0.
+// TS 33.501 §8.6.2
 func TestMapTo5GSOnIdleMobilityStartsBothCountsAtZero(t *testing.T) {
 	var key [32]byte
 
@@ -152,15 +145,12 @@ func TestMapTo5GSOnIdleMobilityStartsBothCountsAtZero(t *testing.T) {
 		t.Errorf("5G downlink NAS COUNT = %d, want 0", got.DLNASCount)
 	}
 
-	// The AMF signals the mapped context in a NAS SMC (§8.2), not in a
-	// transparent container, so nothing is MAC'd here and no AN key is derived.
 	if got.TemporaryKgNB != ([32]byte{}) || got.NH != ([32]byte{}) || got.NCC != 0 {
 		t.Errorf("AN key material = %x/%x/%d, want it unset", got.TemporaryKgNB, got.NH, got.NCC)
 	}
 }
 
-// TS 33.501 §8.6.2: the algorithms are the AMF's own selection over the UE's 5G
-// capability, and K_NASenc/K_NASint follow from K'AMF and that selection.
+// TS 33.501 §8.6.2
 func TestMapTo5GSOnIdleMobilitySelectsAndKeysThe5GAlgorithms(t *testing.T) {
 	kasme := mustHex(t, testKASME)
 
@@ -196,8 +186,6 @@ func TestMapTo5GSOnIdleMobilitySelectsAndKeysThe5GAlgorithms(t *testing.T) {
 	}
 }
 
-// A context is never mapped under an algorithm the operator policy does not
-// name: the AMF has nothing to put in the NAS SMC that follows.
 func TestMapTo5GSOnIdleMobilityRefusesWithNoCommonAlgorithm(t *testing.T) {
 	var key [32]byte
 

--- a/internal/interworking/security_test.go
+++ b/internal/interworking/security_test.go
@@ -126,7 +126,6 @@ func TestMapToEPSDerivesTheNHChainTwice(t *testing.T) {
 		t.Fatalf("NCC = %d, want 2", got.Context.NCC)
 	}
 
-	// The first hop must not be what is sent: a UE deriving twice would not match.
 	if bytes.Equal(got.Context.NH[:], nh1) {
 		t.Fatal("NH is the first hop, so the chain was walked only once")
 	}
@@ -144,7 +143,6 @@ func TestMapToEPSInitialKeNBUsesTheOutOfRangeCount(t *testing.T) {
 
 	kasme := kdf(t, kamf, 0x74, u32(dl.Value()))
 
-	// The same chain seeded from the 24-bit truncation of 2³²−1 must differ.
 	truncated := kdf(t, kasme, 0x11, u32(0x00FFFFFF))
 	nh1 := kdf(t, kasme, 0x12, truncated)
 
@@ -181,7 +179,6 @@ func TestMapToEPSCarriesTheEPSParameters(t *testing.T) {
 	}
 }
 
-// aesOnly is an operator policy of 128-NEA2 / 128-NIA2.
 var (
 	aesInt = []nas.IntegrityAlgorithm{nas.IntegrityAES}
 	aesEnc = []nas.CipheringAlgorithm{nas.CipheringAES}
@@ -206,8 +203,7 @@ func epsContext(t *testing.T) interworking.EPSSecurityContext {
 	return in
 }
 
-// K'AMF is KDF(K_ASME, FC=0x76, P0 = the NH of the EPS context) — the NH, not the
-// EPS NAS COUNTs (TS 33.501 Annex A.15.2, §8.6.2).
+// TS 33.501 Annex A.15.2, §8.6.2
 func TestMapTo5GSDerivesKAMFFromTheNH(t *testing.T) {
 	in := epsContext(t)
 
@@ -226,8 +222,7 @@ func TestMapTo5GSDerivesKAMFFromTheNH(t *testing.T) {
 	}
 }
 
-// The 5G NAS COUNTs start at zero, and the downlink one is already past zero
-// because building the container consumed it (TS 33.501 §8.6.2, §8.4.2 step 3).
+// TS 33.501 §8.6.2, §8.4.2 step 3
 func TestMapTo5GSResetsTheNASCounts(t *testing.T) {
 	got, err := interworking.MapTo5GSOnHandover(epsContext(t), aesInt, aesEnc)
 	if err != nil {
@@ -239,8 +234,7 @@ func TestMapTo5GSResetsTheNASCounts(t *testing.T) {
 	}
 }
 
-// The gNB is handed {NCC=0, NH=temporary K_gNB} derived from K'AMF at 2³²−1, and
-// the AMF keeps the chain advanced once to {NCC=1, NH} (§8.4.2 steps 3 and 4).
+// §8.4.2 steps 3 and 4
 func TestMapTo5GSDerivesTheASKeyChain(t *testing.T) {
 	in := epsContext(t)
 

--- a/internal/mme/common.go
+++ b/internal/mme/common.go
@@ -1,4 +1,0 @@
-// SPDX-FileCopyrightText: Ella Networks Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
-package mme

--- a/internal/mme/config.go
+++ b/internal/mme/config.go
@@ -150,7 +150,7 @@ func (m *MME) OperatorTAC(ctx context.Context) (uint16, error) {
 
 func (o OperatorConfig) GUMMEI() (uint16, uint8) {
 	mapped := etsi.MapGUTI5GToEPS(fgs.GUTI{
-		AMFRegionID: uint8(o.op.AmfRegionID),
+		AMFRegionID: o.op.AMFRegionID(),
 		AMFSetID:    uint16(o.op.AmfSetID),
 		AMFPointer:  uint8(o.nodeID),
 	})

--- a/internal/mme/config.go
+++ b/internal/mme/config.go
@@ -10,15 +10,18 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/fgs"
 	"github.com/ellanetworks/core/s1ap"
 )
 
 // OperatorConfig is a point-in-time view of the operator row: a handler needing
 // several derived values reads the row once and derives from this snapshot.
 type OperatorConfig struct {
-	op *db.Operator
+	op     *db.Operator
+	nodeID int
 }
 
 func (m *MME) Operator(ctx context.Context) (OperatorConfig, error) {
@@ -27,7 +30,7 @@ func (m *MME) Operator(ctx context.Context) (OperatorConfig, error) {
 		return OperatorConfig{}, fmt.Errorf("get operator: %w", err)
 	}
 
-	return OperatorConfig{op: op}, nil
+	return OperatorConfig{op: op, nodeID: m.Bearer.NodeID()}, nil
 }
 
 // PLMN returns the operator's serving PLMN (TS 23.003), the network's
@@ -145,16 +148,23 @@ func (m *MME) OperatorTAC(ctx context.Context) (uint16, error) {
 	return tacs[0], nil
 }
 
-// defaultMMEGroupID is the fixed MME Group ID of the GUMMEI (TS 23.003).
-// Ella Core is a single MME pool, so the group is constant; per-node identity
-// comes from the MME Code.
-const defaultMMEGroupID uint16 = 1
+func (o OperatorConfig) GUMMEI() (uint16, uint8) {
+	mapped := etsi.MapGUTI5GToEPS(fgs.GUTI{
+		AMFRegionID: uint8(o.op.AmfRegionID),
+		AMFSetID:    uint16(o.op.AmfSetID),
+		AMFPointer:  uint8(o.nodeID),
+	})
 
-// MmeIdentity returns the GUMMEI components (TS 23.003): a fixed MME Group
-// ID, and an MME Code derived from the cluster node ID so each HA node advertises
-// a distinct GUMMEI and a UE's GUTI routes back to its owning node.
-// The MME Code is 8 bits, so distinct codes hold for clusters up to 256 nodes;
-// beyond that the low 8 bits could collide.
-func (m *MME) MmeIdentity() (uint16, uint8) {
-	return defaultMMEGroupID, uint8(m.Bearer.NodeID() & 0xFF)
+	return mapped.MMEGroupID, mapped.MMECode
+}
+
+func (m *MME) MmeIdentity(ctx context.Context) (uint16, uint8, error) {
+	o, err := m.Operator(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	group, code := o.GUMMEI()
+
+	return group, code, nil
 }

--- a/internal/mme/config.go
+++ b/internal/mme/config.go
@@ -150,7 +150,7 @@ func (m *MME) OperatorTAC(ctx context.Context) (uint16, error) {
 
 func (o OperatorConfig) GUMMEI() (uint16, uint8) {
 	mapped := etsi.MapGUTI5GToEPS(fgs.GUTI{
-		AMFRegionID: o.op.AMFRegionID(),
+		AMFRegionID: o.op.GUAMIRegionID(),
 		AMFSetID:    uint16(o.op.AmfSetID),
 		AMFPointer:  uint8(o.nodeID),
 	})

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -26,7 +26,12 @@ func idleRegisteredUE(t *testing.T, m *MME) *UeContext {
 	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70}, nil, MintAuthProofForAttachRequest())
 	testPDN(ue).SgwFTEID = testSGWFTEID
 
-	if _, err := m.ReallocateGUTI(t.Context(), ue, models.PlmnID{Mcc: "001", Mnc: "01"}, 1, 1); err != nil {
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := m.ReallocateGUTI(t.Context(), ue, models.PlmnID{Mcc: "001", Mnc: "01"}, group, code); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -184,6 +184,8 @@ func (fakeBearerStore) GetOperator(_ context.Context) (*db.Operator, error) {
 		SupportedTACs: `["1"]`,
 		Ciphering:     `["AES"]`,
 		Integrity:     `["AES"]`,
+		AmfRegionID:   1,
+		AmfSetID:      1,
 	}, nil
 }
 

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -59,6 +59,8 @@ var (
 // fakeSessionManager stands in for the SMF+PGW-C anchor. CreateEPSSession honors
 // the requested PDN type so tests can drive IPv4/IPv6/IPv4v6.
 type fakeSessionManager struct {
+	idleTransfers   []idleEPSTransfer
+	idleTransferErr error
 	lastRequest     models.EPSBearerRequest
 	modifiedENB     models.FTEID // records the eNB F-TEID from the last ModifyEPSSession
 	released        bool
@@ -74,6 +76,37 @@ type fakeSessionManager struct {
 
 	suppressCalls         int // counts HandleEPSPagingFailure calls
 	clearSuppressionCalls int // counts ClearEPSPagingSuppression calls
+}
+
+type idleEPSTransfer struct {
+	Supi              etsi.SUPI
+	PDUSessionID      uint8
+	EPSBearerIdentity uint8
+	Dnn               string
+	Snssai            *models.Snssai
+}
+
+func (f *fakeSessionManager) TransferIdleToEPS(_ context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (models.EPSBearer, error) {
+	f.idleTransfers = append(f.idleTransfers, idleEPSTransfer{
+		Supi:              supi,
+		PDUSessionID:      pduSessionID,
+		EPSBearerIdentity: epsBearerIdentity,
+		Dnn:               dnn,
+		Snssai:            snssai,
+	})
+
+	if f.idleTransferErr != nil {
+		return models.EPSBearer{}, f.idleTransferErr
+	}
+
+	return models.EPSBearer{
+		Ref:          fmt.Sprintf("idle-ref-%d", pduSessionID),
+		PDNType:      eps.PDNTypeIPv4,
+		IPv4:         testUEIP,
+		SGW:          testSGWFTEID,
+		PDUSessionID: pduSessionID,
+		Snssai:       snssai,
+	}, nil
 }
 
 func (f *fakeSessionManager) CreateEPSSession(_ context.Context, req models.EPSBearerRequest) (models.EPSBearer, error) {

--- a/internal/mme/eps_security.go
+++ b/internal/mme/eps_security.go
@@ -65,6 +65,35 @@ func (ue *UeContext) installRelocatedKeys(in interworking.EPSSecurityContext) (*
 	return sc, nil
 }
 
+func (ue *UeContext) BeginIdleMobilityFrom5GS() {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.idleMobilityFrom5GS = true
+}
+
+func (ue *UeContext) EndIdleMobilityFrom5GS() {
+	if ue == nil {
+		return
+	}
+
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.idleMobilityFrom5GS = false
+}
+
+func (ue *UeContext) IdleMobilityFrom5GSPending() bool {
+	if ue == nil {
+		return false
+	}
+
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return ue.idleMobilityFrom5GS
+}
+
 var ErrNoEPSSecurityContext = errors.New("mme: UE has no current EPS NAS security context")
 
 func (ue *UeContext) EPSSecurityContextForRelocation() (interworking.EPSSecurityContext, error) {

--- a/internal/mme/eps_security_test.go
+++ b/internal/mme/eps_security_test.go
@@ -117,3 +117,22 @@ func TestInstallRelocatedSecurityContextCapability(t *testing.T) {
 		t.Fatal("a security capability carries no feature bits")
 	}
 }
+
+// TS 24.301 §5.5.3.2.4
+func TestIdleMobilityFrom5GSEndsWithTheRegistration(t *testing.T) {
+	ue := mme.NewUeContext()
+	ue.TransitionTo(mme.EMMRegistrationInitiated)
+	ue.BeginIdleMobilityFrom5GS()
+
+	ue.TransitionTo(mme.EMMRegistered)
+
+	if !ue.IdleMobilityFrom5GSPending() {
+		t.Fatal("the inter-system change ended before the UE confirmed the update, so a repeated update builds a second context")
+	}
+
+	ue.TransitionTo(mme.EMMDeregistered)
+
+	if ue.IdleMobilityFrom5GSPending() {
+		t.Error("a deregistered context still reports an inter-system change in progress, so a later arrival resumes it and adopts no session")
+	}
+}

--- a/internal/mme/fivegs_idle_mobility.go
+++ b/internal/mme/fivegs_idle_mobility.go
@@ -74,18 +74,20 @@ func (m *MME) AdoptIdlePDNs(ctx context.Context, ue *UeContext, conns []interwor
 	return transferred
 }
 
-func (m *MME) NASAlgorithmsForMappedContext(ctx context.Context, in interworking.EPSSecurityContext) (algorithms interworking.EPSNASAlgorithms, changed bool, err error) {
+// The selection reads netCap so that it matches the one the security mode
+// command would negotiate and replay (TS 33.401 §7.2.4.3.2, §7.2.4.4).
+func (m *MME) NASAlgorithmsForMappedContext(ctx context.Context, netCap eps.UENetworkCapability, current interworking.EPSNASAlgorithms) (algorithms interworking.EPSNASAlgorithms, changed bool, err error) {
 	intOrder, encOrder, err := m.SecurityAlgorithms(ctx)
 	if err != nil {
 		return interworking.EPSNASAlgorithms{}, false, fmt.Errorf("mme: resolve operator security policy: %w", err)
 	}
 
-	eea, eia, ok := eps.SelectNASAlgorithms(relocatedNetworkCapability(in.UESecurityCapability), intOrder, encOrder)
+	eea, eia, ok := eps.SelectNASAlgorithms(netCap, intOrder, encOrder)
 	if !ok {
 		return interworking.EPSNASAlgorithms{}, false, fmt.Errorf("mme: no NAS security algorithm common to the UE and the operator policy")
 	}
 
 	selected := interworking.EPSNASAlgorithms{Ciphering: eea, Integrity: eia}
 
-	return selected, selected != in.Algorithms, nil
+	return selected, selected != current, nil
 }

--- a/internal/mme/fivegs_idle_mobility.go
+++ b/internal/mme/fivegs_idle_mobility.go
@@ -74,8 +74,6 @@ func (m *MME) AdoptIdlePDNs(ctx context.Context, ue *UeContext, conns []interwor
 	return transferred
 }
 
-// The selection reads netCap so that it matches the one the security mode
-// command would negotiate and replay (TS 33.401 §7.2.4.3.2, §7.2.4.4).
 func (m *MME) NASAlgorithmsForMappedContext(ctx context.Context, netCap eps.UENetworkCapability, current interworking.EPSNASAlgorithms) (algorithms interworking.EPSNASAlgorithms, changed bool, err error) {
 	intOrder, encOrder, err := m.SecurityAlgorithms(ctx)
 	if err != nil {

--- a/internal/mme/fivegs_idle_mobility.go
+++ b/internal/mme/fivegs_idle_mobility.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/nas/eps"
+	"go.uber.org/zap"
+)
+
+func (m *MME) FetchEPSContext(ctx context.Context, oldGUTI eps.GUTI, tau []byte) (interworking.EPSContextResponse, error) {
+	if m.FiveGS == nil {
+		return interworking.EPSContextResponse{}, ErrNoFiveGSPeer
+	}
+
+	if len(tau) == 0 {
+		return interworking.EPSContextResponse{}, fmt.Errorf("%w: no message to verify", interworking.ErrIntegrityCheckFailed)
+	}
+
+	return m.FiveGS.EPSContext(ctx, interworking.EPSContextRequest{
+		Mapped5GGUTI: etsi.MapGUTIEPSTo5G(oldGUTI),
+		EPSNAS:       tau,
+	})
+}
+
+func (m *MME) AckEPSContext(ctx context.Context, supi etsi.SUPI, transferred []uint8) error {
+	if m.FiveGS == nil {
+		return ErrNoFiveGSPeer
+	}
+
+	return m.FiveGS.EPSContextAck(ctx, supi, transferred)
+}
+
+func (m *MME) AdoptIdlePDNs(ctx context.Context, ue *UeContext, conns []interworking.PDNConnection) []uint8 {
+	transferred := make([]uint8, 0, len(conns))
+
+	for _, c := range conns {
+		qos, err := ResolveQoSByAPN(ctx, m, ue.IMSI(), c.APN)
+		if err != nil {
+			logger.From(ctx, logger.MmeLog).Warn("arriving PDU session has no QoS in the subscriber profile; leaving it behind",
+				zap.String("imsi", ue.IMSI()), zap.String("apn", c.APN), zap.Error(err))
+
+			continue
+		}
+
+		if !qos.Allow4G {
+			logger.From(ctx, logger.MmeLog).Warn("arriving PDU session is not allowed on 4G; leaving it behind",
+				zap.String("imsi", ue.IMSI()), zap.String("apn", c.APN))
+
+			continue
+		}
+
+		snssai := c.Snssai
+
+		bearer, err := m.Session.TransferIdleToEPS(ctx, ue.Supi(), c.PDUSessionID, c.EPSBearerIdentity, c.APN, &snssai)
+		if err != nil {
+			logger.From(ctx, logger.MmeLog).Warn("a PDU session could not move onto EPS; leaving it behind",
+				zap.Error(err), zap.Uint8("pdu-session-id", c.PDUSessionID), zap.String("apn", c.APN))
+
+			continue
+		}
+
+		m.publishRelocatedPDN(ue, c.EPSBearerIdentity, qos, bearer)
+
+		transferred = append(transferred, c.PDUSessionID)
+	}
+
+	return transferred
+}
+
+func (m *MME) NASAlgorithmsForMappedContext(ctx context.Context, in interworking.EPSSecurityContext) (algorithms interworking.EPSNASAlgorithms, changed bool, err error) {
+	intOrder, encOrder, err := m.SecurityAlgorithms(ctx)
+	if err != nil {
+		return interworking.EPSNASAlgorithms{}, false, fmt.Errorf("mme: resolve operator security policy: %w", err)
+	}
+
+	eea, eia, ok := eps.SelectNASAlgorithms(relocatedNetworkCapability(in.UESecurityCapability), intOrder, encOrder)
+	if !ok {
+		return interworking.EPSNASAlgorithms{}, false, fmt.Errorf("mme: no NAS security algorithm common to the UE and the operator policy")
+	}
+
+	selected := interworking.EPSNASAlgorithms{Ciphering: eea, Integrity: eia}
+
+	return selected, selected != in.Algorithms, nil
+}

--- a/internal/mme/guti.go
+++ b/internal/mme/guti.go
@@ -16,9 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// SendGUTIReallocationCommand runs the standalone GUTI reallocation procedure, arming
-// T3450 to retransmit the GUTI REALLOCATION COMMAND until the UE acknowledges; the UE
-// keeps the old GUTI until then (TS 24.301 §5.4.1, §5.4.1.4).
 func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
 	plmn, err := m.OperatorPLMN(ctx)
 	if err != nil {
@@ -26,7 +23,11 @@ func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
 		return
 	}
 
-	mmeGroupID, mmeCode := m.MmeIdentity()
+	mmeGroupID, mmeCode, err := m.MmeIdentity(ctx)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("GUTI reallocation: get GUMMEI", zap.Error(err))
+		return
+	}
 
 	guti, err := m.ReallocateGUTI(ctx, ue, plmn, mmeGroupID, mmeCode)
 	if err != nil {
@@ -34,8 +35,6 @@ func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
 		return
 	}
 
-	// Snapshotted, not re-read: this runs off the dispatch goroutine and the
-	// unlocked calls below let a concurrent release nil ue.Conn().
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		logger.From(ctx, logger.MmeLog).Warn("GUTI reallocation: UE released before the command could be sent")
@@ -54,17 +53,12 @@ func (m *MME) SendGUTIReallocationCommand(ctx context.Context, ue *UeContext) {
 		return
 	}
 
-	// On T3450 exhaustion the reallocation is abort-only, not a UE release: the UE stays
-	// connected with both old and new GUTI valid, and a later Service Request re-initiates
-	// with the staged M-TMSI (TS 24.301 §5.4.1.6 a).
 	ueConn.ArmNASGuardAbortOnly("GUTI Reallocation Command", plain, eps.SHTIntegrityProtectedCiphered, func() {
 		logger.From(ctx, logger.MmeLog).Warn("GUTI reallocation aborted: no GUTI Reallocation Complete after T3450 retransmissions",
 			zap.String("imsi", ue.IMSI()))
 	})
 }
 
-// releaseMTMSIsLocked unindexes and frees both the UE's current M-TMSI and any
-// pending old one from an in-flight GUTI reallocation. The caller holds m.mu.
 func (m *MME) releaseMTMSIsLocked(ue *UeContext) {
 	if ue.tmsi != etsi.InvalidTMSI {
 		delete(m.uesByTmsi, ue.tmsi)
@@ -77,18 +71,10 @@ func (m *MME) releaseMTMSIsLocked(ue *UeContext) {
 	}
 }
 
-// freeMTMSILocked returns an M-TMSI to the allocator for reuse. The caller holds
-// m.mu.
 func (m *MME) freeMTMSILocked(t etsi.TMSI) {
 	m.tmsi.Free(t)
 }
 
-// ReallocateGUTI stages a new GUTI without dropping the old one: both M-TMSIs
-// stay indexed (and the UE keeps being paged with the old one) until the UE
-// acknowledges — ATTACH COMPLETE or TRACKING AREA UPDATE COMPLETE — which
-// commits the new GUTI (TS 24.301 §5.5.1.2.7, §5.5.3.2.4: the old GUTI stays
-// valid until completion). A reallocation already in flight (e.g. on a
-// retransmitted attach or TAU) reuses the staged M-TMSI.
 func (m *MME) ReallocateGUTI(ctx context.Context, ue *UeContext, plmn models.PlmnID, mmeGroupID uint16, mmeCode uint8) (eps.EPSMobileIdentity, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -99,8 +85,6 @@ func (m *MME) ReallocateGUTI(ctx context.Context, ue *UeContext, plmn models.Plm
 			return eps.EPSMobileIdentity{}, fmt.Errorf("allocate M-TMSI: %w", err)
 		}
 
-		// Also read through Tmsi()/OldTmsi() by callers holding no registry lock,
-		// so writes take ue.mu too. Order m.mu → ue.mu.
 		ue.mu.Lock()
 		ue.oldTmsi = ue.tmsi
 		ue.tmsi = tmsi
@@ -117,8 +101,6 @@ func (m *MME) ReallocateGUTI(ctx context.Context, ue *UeContext, plmn models.Plm
 	}), nil
 }
 
-// CommitGUTIRealloc finalises a GUTI reallocation once the UE acknowledges it:
-// the old M-TMSI is unindexed and freed, leaving only the new GUTI valid.
 func (m *MME) CommitGUTIRealloc(ue *UeContext) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/mme/idle_mobility_to_5gs.go
+++ b/internal/mme/idle_mobility_to_5gs.go
@@ -32,13 +32,13 @@ func (m *MME) ServesGUTI(ctx context.Context, id eps.GUTI) bool {
 func (m *MME) MMContext(ctx context.Context, req interworking.MMContextRequest) (interworking.MMContextResponse, error) {
 	none := interworking.MMContextResponse{}
 
-	if !m.ServesGUTI(ctx, req.MappedEPSGUTI) {
-		return none, fmt.Errorf("%w: GUTI %s was not assigned by this MME", interworking.ErrUnknownUEContext, req.MappedEPSGUTI)
-	}
-
 	ue, ok := m.LookupUeByMTMSI(binary.BigEndian.Uint32(req.MappedEPSGUTI.TMSI[:]))
 	if !ok {
 		return none, fmt.Errorf("%w: no context for M-TMSI %x", interworking.ErrUnknownUEContext, req.MappedEPSGUTI.TMSI)
+	}
+
+	if !m.ServesGUTI(ctx, req.MappedEPSGUTI) {
+		return none, fmt.Errorf("%w: GUTI %s was not assigned by this MME", interworking.ErrUnknownUEContext, req.MappedEPSGUTI)
 	}
 
 	if ue.EMMState() != EMMRegistered || !ue.Secured() {

--- a/internal/mme/idle_mobility_to_5gs.go
+++ b/internal/mme/idle_mobility_to_5gs.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"slices"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/nas/eps"
+	"go.uber.org/zap"
+)
+
+// ServesGUTI reports whether a 4G-GUTI was assigned by this node: its serving
+// PLMN and its GUMMEI (TS 23.003). A foreign GUTI would require S10, which Ella
+// Core does not implement.
+func (m *MME) ServesGUTI(ctx context.Context, id eps.GUTI) bool {
+	operator, err := m.Operator(ctx)
+	if err != nil {
+		return false
+	}
+
+	plmn := operator.PLMN()
+	group, code := operator.GUMMEI()
+
+	return id.PLMN.MCC == plmn.Mcc && id.PLMN.MNC == plmn.Mnc &&
+		id.MMEGroupID == group && id.MMECode == code
+}
+
+// MMContext answers the AMF's request for the UE's EPS context on an idle-mode
+// inter-system change to 5GS (TS 23.502 §4.11.1.3.3 step 5a).
+//
+// The MME is the only node holding the EPS security context the UE protected
+// its TRACKING AREA UPDATE REQUEST with, so verifying that message here is what
+// authenticates the whole move: the AMF acts on the SUPI this returns
+// (TS 33.501 §8.2). The count it verified at is committed before the context
+// goes out, so a replayed REGISTRATION REQUEST carrying the same container
+// cannot re-derive K'AMF.
+func (m *MME) MMContext(ctx context.Context, req interworking.MMContextRequest) (interworking.MMContextResponse, error) {
+	none := interworking.MMContextResponse{}
+
+	if !m.ServesGUTI(ctx, req.MappedEPSGUTI) {
+		return none, fmt.Errorf("%w: GUTI %s was not assigned by this MME", interworking.ErrUnknownUEContext, req.MappedEPSGUTI)
+	}
+
+	ue, ok := m.LookupUeByMTMSI(binary.BigEndian.Uint32(req.MappedEPSGUTI.TMSI[:]))
+	if !ok {
+		return none, fmt.Errorf("%w: no context for M-TMSI %x", interworking.ErrUnknownUEContext, req.MappedEPSGUTI.TMSI)
+	}
+
+	if ue.EMMState() != EMMRegistered || !ue.Secured() {
+		return none, fmt.Errorf("%w: the context for M-TMSI %x is not a registered, secured one",
+			interworking.ErrUnknownUEContext, req.MappedEPSGUTI.TMSI)
+	}
+
+	plain, count, err := ue.TryUnprotectUplink(req.EPSNAS)
+	if err != nil {
+		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
+	}
+
+	// The container of a mobility registration update carries a TRACKING AREA
+	// UPDATE REQUEST (TS 24.501 §8.2.6.16); an ATTACH REQUEST belongs to the
+	// initial-registration case, which this path does not serve.
+	if mt, err := eps.PeekMessageType(plain); err != nil || mt != eps.MsgTrackingAreaUpdateRequest {
+		return none, fmt.Errorf("%w: the container holds no TRACKING AREA UPDATE REQUEST", interworking.ErrIntegrityCheckFailed)
+	}
+
+	ue.CommitUplinkCount(count)
+
+	security, err := ue.EPSSecurityContextForRelocation()
+	if err != nil {
+		return none, err
+	}
+
+	connections, _ := TransferablePDNConnections(ue)
+
+	ambrUL, ambrDL := ue.AmbrRates()
+
+	logger.From(ctx, logger.MmeLog).Info("handing the UE's EPS context to 5GS for an idle-mode change",
+		zap.String("imsi", ue.IMSI()), zap.Int("pdn-connections", len(connections)))
+
+	return interworking.MMContextResponse{
+		SUPI:                ue.Supi(),
+		Security:            security,
+		UENetworkCapability: ue.UeNetCap(),
+		PDNConnections:      connections,
+		AMBRUplink:          ambrUL,
+		AMBRDownlink:        ambrDL,
+	}, nil
+}
+
+// MMContextAck is the AMF's Context Acknowledge: the UE is served from 5GS from
+// here on (TS 23.502 §4.11.1.3.3 step 8, TS 23.401 §5.3.3.1 step 7). transferred
+// names the PDU sessions 5GS adopted; every PDN connection left behind is
+// released, and the EMM context goes with them.
+//
+// Withholding the acknowledgement leaves this context untouched, so a move the
+// AMF abandons costs the UE nothing on EPS.
+func (m *MME) MMContextAck(ctx context.Context, supi etsi.SUPI, transferred []uint8) error {
+	ue, ok := m.LookupUeBySupi(supi)
+	if !ok {
+		return fmt.Errorf("%w: %s", interworking.ErrUnknownUEContext, supi)
+	}
+
+	for _, p := range m.SnapshotPDNs(ue) {
+		if slices.Contains(transferred, p.PDUSessionID) {
+			continue
+		}
+
+		logger.From(ctx, logger.MmeLog).Info("releasing a PDN connection 5GS did not adopt",
+			zap.String("imsi", ue.IMSI()), zap.Uint8("ebi", p.Ebi), zap.String("apn", p.Apn))
+		m.ReleasePDN(ctx, ue, p)
+	}
+
+	m.DeregisterEmptyUE(ctx, ue)
+
+	return nil
+}

--- a/internal/mme/idle_mobility_to_5gs.go
+++ b/internal/mme/idle_mobility_to_5gs.go
@@ -16,9 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// ServesGUTI reports whether a 4G-GUTI was assigned by this node: its serving
-// PLMN and its GUMMEI (TS 23.003). A foreign GUTI would require S10, which Ella
-// Core does not implement.
 func (m *MME) ServesGUTI(ctx context.Context, id eps.GUTI) bool {
 	operator, err := m.Operator(ctx)
 	if err != nil {
@@ -32,15 +29,6 @@ func (m *MME) ServesGUTI(ctx context.Context, id eps.GUTI) bool {
 		id.MMEGroupID == group && id.MMECode == code
 }
 
-// MMContext answers the AMF's request for the UE's EPS context on an idle-mode
-// inter-system change to 5GS (TS 23.502 §4.11.1.3.3 step 5a).
-//
-// The MME is the only node holding the EPS security context the UE protected
-// its TRACKING AREA UPDATE REQUEST with, so verifying that message here is what
-// authenticates the whole move: the AMF acts on the SUPI this returns
-// (TS 33.501 §8.2). The count it verified at is committed before the context
-// goes out, so a replayed REGISTRATION REQUEST carrying the same container
-// cannot re-derive K'AMF.
 func (m *MME) MMContext(ctx context.Context, req interworking.MMContextRequest) (interworking.MMContextResponse, error) {
 	none := interworking.MMContextResponse{}
 
@@ -63,9 +51,6 @@ func (m *MME) MMContext(ctx context.Context, req interworking.MMContextRequest) 
 		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
 	}
 
-	// The container of a mobility registration update carries a TRACKING AREA
-	// UPDATE REQUEST (TS 24.501 §8.2.6.16); an ATTACH REQUEST belongs to the
-	// initial-registration case, which this path does not serve.
 	if mt, err := eps.PeekMessageType(plain); err != nil || mt != eps.MsgTrackingAreaUpdateRequest {
 		return none, fmt.Errorf("%w: the container holds no TRACKING AREA UPDATE REQUEST", interworking.ErrIntegrityCheckFailed)
 	}
@@ -94,13 +79,6 @@ func (m *MME) MMContext(ctx context.Context, req interworking.MMContextRequest) 
 	}, nil
 }
 
-// MMContextAck is the AMF's Context Acknowledge: the UE is served from 5GS from
-// here on (TS 23.502 §4.11.1.3.3 step 8, TS 23.401 §5.3.3.1 step 7). transferred
-// names the PDU sessions 5GS adopted; every PDN connection left behind is
-// released, and the EMM context goes with them.
-//
-// Withholding the acknowledgement leaves this context untouched, so a move the
-// AMF abandons costs the UE nothing on EPS.
 func (m *MME) MMContextAck(ctx context.Context, supi etsi.SUPI, transferred []uint8) error {
 	ue, ok := m.LookupUeBySupi(supi)
 	if !ok {

--- a/internal/mme/idle_mobility_to_5gs_test.go
+++ b/internal/mme/idle_mobility_to_5gs_test.go
@@ -192,9 +192,7 @@ func TestMMContextRefusals(t *testing.T) {
 	})
 }
 
-// TS 23.401 §5.3.3.1 step 7: an inter-system change the peer abandons leaves this
-// MME serving the UE exactly as before, so the UE that falls back to E-UTRAN finds
-// its context. Nothing is released until the acknowledgement says what moved.
+// TS 23.401 §5.3.3.1 step 7
 func TestMMContextHandedOverButNeverAcknowledgedKeepsServingTheUE(t *testing.T) {
 	m := newTestMME(t)
 	ue, guti := idleMobilityUE(t, m)

--- a/internal/mme/idle_mobility_to_5gs_test.go
+++ b/internal/mme/idle_mobility_to_5gs_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// idleMobilityUE is a registered UE with a PDN connection, as it sits in
-// ECM-IDLE when it moves to 5GS.
 func idleMobilityUE(t *testing.T, m *MME) (*UeContext, eps.GUTI) {
 	t.Helper()
 
@@ -44,9 +42,6 @@ func idleMobilityUE(t *testing.T, m *MME) (*UeContext, eps.GUTI) {
 	}
 }
 
-// enclosedTAU is the TRACKING AREA UPDATE REQUEST the UE puts in the EPS NAS
-// message container: protected with the EPS security context, which is the
-// MME's alone (TS 24.501 §8.2.6.16).
 func enclosedTAU(t *testing.T, ue *UeContext, count nas.Count) []byte {
 	t.Helper()
 
@@ -78,9 +73,7 @@ func testGUTIIdentity(t *testing.T, ue *UeContext) eps.EPSMobileIdentity {
 	})
 }
 
-// TS 23.502 §4.11.1.3.3 step 5a, TS 33.501 §8.2: the MME hands the UE's context
-// to the AMF only for a request whose enclosed TAU REQUEST verifies against the
-// EPS security context.
+// TS 23.502 §4.11.1.3.3 step 5a, TS 33.501 §8.2
 func TestMMContextReturnsTheContextForAVerifiedTAU(t *testing.T) {
 	m := newTestMME(t)
 	ue, guti := idleMobilityUE(t, m)
@@ -106,14 +99,12 @@ func TestMMContextReturnsTheContextForAVerifiedTAU(t *testing.T) {
 			resp.AMBRUplink, resp.AMBRDownlink, ue.Ambr.Uplink, ue.Ambr.Downlink)
 	}
 
-	// The count the TAU verified at is the K'AMF input (TS 33.501 A.15.1).
 	if resp.Security.ULNASCount != nas.MakeCount(0, 0) {
 		t.Errorf("uplink NAS COUNT = %d, want the TAU's 0", resp.Security.ULNASCount)
 	}
 }
 
-// The count is committed before the context goes out, so the same container
-// cannot be replayed to derive K'AMF a second time (TS 33.501 §8.2).
+// TS 33.501 §8.2
 func TestMMContextCommitsTheCountItVerifiedAt(t *testing.T) {
 	m := newTestMME(t)
 	ue, guti := idleMobilityUE(t, m)
@@ -184,8 +175,6 @@ func TestMMContextRefusals(t *testing.T) {
 		sc := ue.sc
 		ue.mu.Unlock()
 
-		// A DETACH REQUEST verifies against the same context, but the container of
-		// a mobility registration update carries a TAU (TS 24.501 §8.2.6.16).
 		plain, err := (&eps.DetachRequestUE{TypeOfDetach: 1, EPSMobileIdentity: testGUTIIdentity(t, ue)}).MarshalBinary()
 		if err != nil {
 			t.Fatal(err)
@@ -203,8 +192,7 @@ func TestMMContextRefusals(t *testing.T) {
 	})
 }
 
-// TS 23.502 §4.11.1.3.3 step 8: the acknowledgement releases the UE from EPS —
-// the PDN connections 5GS did not take go with it.
+// TS 23.502 §4.11.1.3.3 step 8
 func TestMMContextAckReleasesWhatDidNotTransfer(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := idleMobilityUE(t, m)

--- a/internal/mme/idle_mobility_to_5gs_test.go
+++ b/internal/mme/idle_mobility_to_5gs_test.go
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// idleMobilityUE is a registered UE with a PDN connection, as it sits in
+// ECM-IDLE when it moves to 5GS.
+func idleMobilityUE(t *testing.T, m *MME) (*UeContext, eps.GUTI) {
+	t.Helper()
+
+	ue := idleRegisteredUE(t, m)
+
+	p := testPDN(ue)
+	p.PDUSessionID = 3
+	p.Apn = "internet"
+	p.Snssai = &models.Snssai{Sst: 1, Sd: "010203"}
+
+	ue.Ambr = &models.Ambr{
+		Uplink:   models.MustParseBitRate("50 Mbps"),
+		Downlink: models.MustParseBitRate("100 Mbps"),
+	}
+
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ue, eps.GUTI{
+		PLMN:       nas.PLMN{MCC: "001", MNC: "01"},
+		MMEGroupID: group,
+		MMECode:    code,
+		TMSI:       tmsiOctets(ue.Tmsi()),
+	}
+}
+
+// enclosedTAU is the TRACKING AREA UPDATE REQUEST the UE puts in the EPS NAS
+// message container: protected with the EPS security context, which is the
+// MME's alone (TS 24.501 §8.2.6.16).
+func enclosedTAU(t *testing.T, ue *UeContext, count nas.Count) []byte {
+	t.Helper()
+
+	plain, err := (&eps.TrackingAreaUpdateRequest{
+		EPSUpdateType: 0,
+		OldGUTI:       testGUTIIdentity(t, ue),
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode TAU: %v", err)
+	}
+
+	ue.mu.Lock()
+	sc := ue.sc
+	ue.mu.Unlock()
+
+	wire, err := eps.Protect(plain, eps.SHTIntegrityProtected, count, nas.DirectionUplink, sc)
+	if err != nil {
+		t.Fatalf("protect TAU: %v", err)
+	}
+
+	return wire
+}
+
+func testGUTIIdentity(t *testing.T, ue *UeContext) eps.EPSMobileIdentity {
+	t.Helper()
+
+	return eps.GUTIIdentity(eps.GUTI{
+		PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 1, MMECode: 1, TMSI: tmsiOctets(ue.Tmsi()),
+	})
+}
+
+// TS 23.502 §4.11.1.3.3 step 5a, TS 33.501 §8.2: the MME hands the UE's context
+// to the AMF only for a request whose enclosed TAU REQUEST verifies against the
+// EPS security context.
+func TestMMContextReturnsTheContextForAVerifiedTAU(t *testing.T) {
+	m := newTestMME(t)
+	ue, guti := idleMobilityUE(t, m)
+
+	resp, err := m.MMContext(t.Context(), interworking.MMContextRequest{
+		MappedEPSGUTI: guti,
+		EPSNAS:        enclosedTAU(t, ue, nas.MakeCount(0, 0)),
+	})
+	if err != nil {
+		t.Fatalf("MMContext: %v", err)
+	}
+
+	if resp.SUPI != ue.Supi() {
+		t.Errorf("SUPI = %s, want %s", resp.SUPI, ue.Supi())
+	}
+
+	if len(resp.PDNConnections) != 1 || resp.PDNConnections[0].PDUSessionID != 3 {
+		t.Fatalf("PDN connections = %+v, want the UE's one on PDU session 3", resp.PDNConnections)
+	}
+
+	if resp.AMBRUplink != ue.Ambr.Uplink || resp.AMBRDownlink != ue.Ambr.Downlink {
+		t.Errorf("AMBR = %v/%v, want the subscribed %v/%v",
+			resp.AMBRUplink, resp.AMBRDownlink, ue.Ambr.Uplink, ue.Ambr.Downlink)
+	}
+
+	// The count the TAU verified at is the K'AMF input (TS 33.501 A.15.1).
+	if resp.Security.ULNASCount != nas.MakeCount(0, 0) {
+		t.Errorf("uplink NAS COUNT = %d, want the TAU's 0", resp.Security.ULNASCount)
+	}
+}
+
+// The count is committed before the context goes out, so the same container
+// cannot be replayed to derive K'AMF a second time (TS 33.501 §8.2).
+func TestMMContextCommitsTheCountItVerifiedAt(t *testing.T) {
+	m := newTestMME(t)
+	ue, guti := idleMobilityUE(t, m)
+
+	req := interworking.MMContextRequest{
+		MappedEPSGUTI: guti,
+		EPSNAS:        enclosedTAU(t, ue, nas.MakeCount(0, 0)),
+	}
+
+	if _, err := m.MMContext(t.Context(), req); err != nil {
+		t.Fatalf("MMContext: %v", err)
+	}
+
+	if _, err := m.MMContext(t.Context(), req); !errors.Is(err, interworking.ErrIntegrityCheckFailed) {
+		t.Fatalf("replayed request returned %v, want an integrity failure", err)
+	}
+}
+
+func TestMMContextRefusals(t *testing.T) {
+	t.Run("a GUTI this MME did not assign", func(t *testing.T) {
+		m := newTestMME(t)
+		ue, guti := idleMobilityUE(t, m)
+
+		guti.MMECode++
+
+		_, err := m.MMContext(t.Context(), interworking.MMContextRequest{
+			MappedEPSGUTI: guti,
+			EPSNAS:        enclosedTAU(t, ue, nas.MakeCount(0, 0)),
+		})
+		if !errors.Is(err, interworking.ErrUnknownUEContext) {
+			t.Fatalf("error = %v, want an unknown context", err)
+		}
+	})
+
+	t.Run("no context for the M-TMSI", func(t *testing.T) {
+		m := newTestMME(t)
+		ue, guti := idleMobilityUE(t, m)
+
+		guti.TMSI = [4]byte{0xde, 0xad, 0xbe, 0xef}
+
+		_, err := m.MMContext(t.Context(), interworking.MMContextRequest{
+			MappedEPSGUTI: guti,
+			EPSNAS:        enclosedTAU(t, ue, nas.MakeCount(0, 0)),
+		})
+		if !errors.Is(err, interworking.ErrUnknownUEContext) {
+			t.Fatalf("error = %v, want an unknown context", err)
+		}
+	})
+
+	t.Run("a TAU that does not verify", func(t *testing.T) {
+		m := newTestMME(t)
+		ue, guti := idleMobilityUE(t, m)
+
+		tau := enclosedTAU(t, ue, nas.MakeCount(0, 0))
+		tau[2] ^= 0xff // corrupt the MAC
+
+		_, err := m.MMContext(t.Context(), interworking.MMContextRequest{MappedEPSGUTI: guti, EPSNAS: tau})
+		if !errors.Is(err, interworking.ErrIntegrityCheckFailed) {
+			t.Fatalf("error = %v, want an integrity failure", err)
+		}
+	})
+
+	t.Run("a container holding no TAU REQUEST", func(t *testing.T) {
+		m := newTestMME(t)
+		ue, guti := idleMobilityUE(t, m)
+
+		ue.mu.Lock()
+		sc := ue.sc
+		ue.mu.Unlock()
+
+		// A DETACH REQUEST verifies against the same context, but the container of
+		// a mobility registration update carries a TAU (TS 24.501 §8.2.6.16).
+		plain, err := (&eps.DetachRequestUE{TypeOfDetach: 1, EPSMobileIdentity: testGUTIIdentity(t, ue)}).MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wire, err := eps.Protect(plain, eps.SHTIntegrityProtected, nas.MakeCount(0, 0), nas.DirectionUplink, sc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = m.MMContext(t.Context(), interworking.MMContextRequest{MappedEPSGUTI: guti, EPSNAS: wire})
+		if !errors.Is(err, interworking.ErrIntegrityCheckFailed) {
+			t.Fatalf("error = %v, want an integrity failure", err)
+		}
+	})
+}
+
+// TS 23.502 §4.11.1.3.3 step 8: the acknowledgement releases the UE from EPS —
+// the PDN connections 5GS did not take go with it.
+func TestMMContextAckReleasesWhatDidNotTransfer(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := idleMobilityUE(t, m)
+
+	if err := m.MMContextAck(t.Context(), ue.Supi(), nil); err != nil {
+		t.Fatalf("MMContextAck: %v", err)
+	}
+
+	if ue.PDNCount() != 0 {
+		t.Errorf("PDN connections = %d, want none: 5GS adopted nothing", ue.PDNCount())
+	}
+
+	if ue.EMMState() != EMMDeregistered {
+		t.Errorf("EMM state = %v, want deregistered", ue.EMMState())
+	}
+}
+
+func TestMMContextAckKeepsNothingForAnUnknownSubscriber(t *testing.T) {
+	m := newTestMME(t)
+
+	supi, err := etsi.NewSUPIFromIMSI("001010000000999")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.MMContextAck(t.Context(), supi, nil); !errors.Is(err, interworking.ErrUnknownUEContext) {
+		t.Fatalf("error = %v, want an unknown context", err)
+	}
+}

--- a/internal/mme/idle_mobility_to_5gs_test.go
+++ b/internal/mme/idle_mobility_to_5gs_test.go
@@ -192,6 +192,34 @@ func TestMMContextRefusals(t *testing.T) {
 	})
 }
 
+// TS 23.401 §5.3.3.1 step 7: an inter-system change the peer abandons leaves this
+// MME serving the UE exactly as before, so the UE that falls back to E-UTRAN finds
+// its context. Nothing is released until the acknowledgement says what moved.
+func TestMMContextHandedOverButNeverAcknowledgedKeepsServingTheUE(t *testing.T) {
+	m := newTestMME(t)
+	ue, guti := idleMobilityUE(t, m)
+
+	if _, err := m.MMContext(t.Context(), interworking.MMContextRequest{
+		MappedEPSGUTI: guti,
+		EPSNAS:        enclosedTAU(t, ue, nas.MakeCount(0, 0)),
+	}); err != nil {
+		t.Fatalf("MMContext: %v", err)
+	}
+
+	if ue.EMMState() != EMMRegistered {
+		t.Errorf("EMM state = %v, want registered: the UE was released before 5GS said it took the context", ue.EMMState())
+	}
+
+	if ue.PDNCount() != 1 {
+		t.Errorf("PDN connections = %d, want the one the UE still has on E-UTRAN", ue.PDNCount())
+	}
+
+	held, ok := m.LookupUeBySupi(ue.Supi())
+	if !ok || held != ue {
+		t.Error("the subscriber no longer resolves to its context, so a fallback to E-UTRAN would re-attach from scratch")
+	}
+}
+
 // TS 23.502 §4.11.1.3.3 step 8
 func TestMMContextAckReleasesWhatDidNotTransfer(t *testing.T) {
 	m := newTestMME(t)

--- a/internal/mme/interworking_test.go
+++ b/internal/mme/interworking_test.go
@@ -19,7 +19,7 @@ func TestDerivedMMEGroupIDCarriesTheNodeTypeBit(t *testing.T) {
 	for _, regionID := range []int{0, 1, 0x7f, 0x80, 0xff} {
 		op := &db.Operator{AmfRegionID: regionID}
 
-		mapped := etsi.MapGUTI5GToEPS(fgs.GUTI{AMFRegionID: op.AMFRegionID()})
+		mapped := etsi.MapGUTI5GToEPS(fgs.GUTI{AMFRegionID: op.GUAMIRegionID()})
 		if mapped.MMEGroupID&0x8000 == 0 {
 			t.Errorf("AMF Region ID %#x derives MME Group ID %#04x, whose most significant bit is zero: a peer reads it as a LAC",
 				regionID, mapped.MMEGroupID)
@@ -42,7 +42,7 @@ func TestGUMMEIIsTheNodeGUAMIMapped(t *testing.T) {
 	}
 
 	amfID := util.AMFIDToModels(
-		ngap.AMFRegionID(op.AMFRegionID()),
+		ngap.AMFRegionID(op.GUAMIRegionID()),
 		ngap.AMFSetID(op.AmfSetID),
 		ngap.AMFPointer(fakeBearerStore{}.NodeID()),
 	)

--- a/internal/mme/interworking_test.go
+++ b/internal/mme/interworking_test.go
@@ -6,8 +6,49 @@ package mme
 import (
 	"testing"
 
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/amf/util"
 	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/nas/fgs"
+	"github.com/ellanetworks/core/ngap"
 )
+
+// TS 23.003 §2.10.2.1.3, TS 23.501 Annex B NOTE 2
+func TestGUMMEIIsTheNodeGUAMIMapped(t *testing.T) {
+	m := newTestMME(t)
+
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	op, err := fakeBearerStore{}.GetOperator(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	amfID := util.AMFIDToModels(
+		ngap.AMFRegionID(op.AmfRegionID),
+		ngap.AMFSetID(op.AmfSetID),
+		ngap.AMFPointer(fakeBearerStore{}.NodeID()),
+	)
+
+	region, set, pointer, err := util.AMFIDToNGAP(amfID)
+	if err != nil {
+		t.Fatalf("AMFIDToNGAP(%q): %v", amfID, err)
+	}
+
+	mapped := etsi.MapGUTI5GToEPS(fgs.GUTI{
+		AMFRegionID: uint8(region),
+		AMFSetID:    uint16(set),
+		AMFPointer:  uint8(pointer),
+	})
+
+	if mapped.MMEGroupID != group || mapped.MMECode != code {
+		t.Errorf("GUAMI %s maps to GUMMEI %d/%d, but the MME serves %d/%d: a UE's mapped identity would address no node",
+			amfID, mapped.MMEGroupID, mapped.MMECode, group, code)
+	}
+}
 
 // TS 24.301 §5.5.1.2.4, §9.9.3.12A
 func TestNetworkFeatureSupportNeverAdvertisesInterworkingWithoutN26(t *testing.T) {

--- a/internal/mme/interworking_test.go
+++ b/internal/mme/interworking_test.go
@@ -8,10 +8,24 @@ import (
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf/util"
+	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/nas/fgs"
 	"github.com/ellanetworks/core/ngap"
 )
+
+// TS 23.003 §2.8.2.2.2
+func TestDerivedMMEGroupIDCarriesTheNodeTypeBit(t *testing.T) {
+	for _, regionID := range []int{0, 1, 0x7f, 0x80, 0xff} {
+		op := &db.Operator{AmfRegionID: regionID}
+
+		mapped := etsi.MapGUTI5GToEPS(fgs.GUTI{AMFRegionID: op.AMFRegionID()})
+		if mapped.MMEGroupID&0x8000 == 0 {
+			t.Errorf("AMF Region ID %#x derives MME Group ID %#04x, whose most significant bit is zero: a peer reads it as a LAC",
+				regionID, mapped.MMEGroupID)
+		}
+	}
+}
 
 // TS 23.003 §2.10.2.1.3, TS 23.501 Annex B NOTE 2
 func TestGUMMEIIsTheNodeGUAMIMapped(t *testing.T) {
@@ -28,7 +42,7 @@ func TestGUMMEIIsTheNodeGUAMIMapped(t *testing.T) {
 	}
 
 	amfID := util.AMFIDToModels(
-		ngap.AMFRegionID(op.AmfRegionID),
+		ngap.AMFRegionID(op.AMFRegionID()),
 		ngap.AMFSetID(op.AmfSetID),
 		ngap.AMFPointer(fakeBearerStore{}.NodeID()),
 	)

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -31,6 +31,7 @@ type NASHandler interface {
 
 type epsSessionManager interface {
 	CreateEPSSession(ctx context.Context, req models.EPSBearerRequest) (models.EPSBearer, error)
+	TransferIdleToEPS(ctx context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (models.EPSBearer, error)
 	ModifyEPSSession(ctx context.Context, ref string, ebi uint8, enb models.FTEID) error
 	UpdateEPSSessionAMBR(ctx context.Context, ref string, ambrUplink, ambrDownlink models.BitRate) error
 	DeactivateEPSSession(ctx context.Context, ref string) error

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -178,9 +178,6 @@ type UeContext struct {
 
 	idleMobilityFrom5GS bool
 
-	// localBearerDeactivation is set when the MME drops a PDN connection without
-	// peer-to-peer signalling, and cleared once a TRACKING AREA UPDATE ACCEPT has
-	// reported the surviving set (TS 24.301 §5.5.3.2.4).
 	localBearerDeactivation bool
 
 	releasing bool

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -178,6 +178,11 @@ type UeContext struct {
 
 	idleMobilityFrom5GS bool
 
+	// localBearerDeactivation is set when the MME drops a PDN connection without
+	// peer-to-peer signalling, and cleared once a TRACKING AREA UPDATE ACCEPT has
+	// reported the surviving set (TS 24.301 §5.5.3.2.4).
+	localBearerDeactivation bool
+
 	releasing bool
 
 	regStep RegStep

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -176,6 +176,8 @@ type UeContext struct {
 
 	emmState EMMState
 
+	idleMobilityFrom5GS bool
+
 	releasing bool
 
 	regStep RegStep

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -288,7 +288,7 @@ func buildAttachAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext, qos *
 		return nil, err
 	}
 
-	mmeGroupID, mmeCode := m.MmeIdentity()
+	mmeGroupID, mmeCode := operator.GUMMEI()
 
 	guti, err := m.ReallocateGUTI(ctx, ue, plmn, mmeGroupID, mmeCode)
 	if err != nil {

--- a/internal/mme/nas/emm.go
+++ b/internal/mme/nas/emm.go
@@ -28,21 +28,27 @@ func HandleNAS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pdu []byte) {
 func dispositionForNAS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pdu []byte) nasreply.Disposition {
 	ue := conn.UeContext()
 	if ue == nil {
-		// A bare connection binds a persistent context only for an ATTACH REQUEST —
-		// the only message warranting one (TS 24.301) — so an unauthenticated peer
-		// cannot exhaust UE contexts. A connection left bare here is released by the
-		// S1AP layer.
-		if !isAttachRequest(pdu) {
+		switch peekEMMMessageType(pdu) {
+		case eps.MsgAttachRequest:
+			ue = mme.NewUeContext()
+			m.AttachUeConn(ue, conn)
+		case eps.MsgTrackingAreaUpdateRequest:
+			resolved, plain := recoverContextFrom5GS(ctx, m, conn, pdu)
+			if resolved == nil {
+				return nasreply.Silent(nasreply.ReasonNoContext)
+			}
+
+			ueConn := resolved.Conn()
+			if ueConn == nil {
+				return nasreply.Silent(nasreply.ReasonNoContext)
+			}
+
+			return HandleEmmMessage(ctx, m, resolved, ueConn, plain, true)
+		default:
 			return nasreply.Silent(nasreply.ReasonNoContext)
 		}
-
-		ue = mme.NewUeContext()
-		m.AttachUeConn(ue, conn)
 	}
 
-	// Resolve-first: for an as-yet-unsecured context (a fresh Attach), a native GUTI
-	// that verifies against a held EPS security context adopts it before decode, so
-	// everything below runs on the right context.
 	if !ue.Secured() {
 		resolved, drop := resolveAttachContext(ctx, m, ue, conn, pdu)
 		if drop {
@@ -52,9 +58,6 @@ func dispositionForNAS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pdu []
 		ue = resolved
 	}
 
-	// Snapshotted once: the handlers below make unlocked calls, and a concurrent
-	// detach nils ue.Conn() at any point. A nil dereference here panics the
-	// dispatch goroutine, which aborts the whole S1 association.
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		return nasreply.Silent(nasreply.ReasonNoContext)
@@ -127,9 +130,6 @@ func HandleEmmMessage(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn
 	case *eps.EMMStatus:
 		return handleEMMStatus(msg)
 	case *eps.UnknownEMMMessage:
-		// TS 24.301 §7.4: a message type the receiver does not implement draws a
-		// STATUS in its own protocol. The ESM counterpart reaches
-		// handleESMMessage through the default arm below.
 		logger.From(ctx, logger.MmeLog).Warn("unimplemented NAS message type", zap.Stringer("message", msg))
 
 		return nasreply.StatusMM(nasreply.CauseMessageTypeNotImplemented)
@@ -169,32 +169,21 @@ func rejectUndecodable(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 	return nasreply.StatusMM(nasreply.CauseInvalidMandatoryInfo)
 }
 
-func isAttachRequest(pdu []byte) bool {
+func peekEMMMessageType(pdu []byte) eps.MessageType {
 	pd, err := eps.PeekProtocolDiscriminator(pdu)
 	if err != nil || pd != eps.PDEMM {
-		return false
+		return 0
 	}
 
-	sht, err := eps.PeekSecurityHeaderType(pdu)
-	if err != nil {
-		return false
-	}
-
-	body := pdu
-
-	switch sht {
-	case eps.SHTPlain:
-	case eps.SHTIntegrityProtected, eps.SHTIntegrityProtectedNewContext:
-		if len(pdu) < 6 {
-			return false
-		}
-
-		body = pdu[6:]
-	default:
-		return false
+	body, ok := unprotectedBody(pdu)
+	if !ok {
+		return 0
 	}
 
 	mt, err := eps.PeekMessageType(body)
+	if err != nil {
+		return 0
+	}
 
-	return err == nil && mt == eps.MsgAttachRequest
+	return mt
 }

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -175,7 +175,10 @@ func nativeGUTIAttach(t *testing.T, m *mme.MME, ue *mme.UeContext) []byte {
 		t.Fatal(err)
 	}
 
-	group, code := m.MmeIdentity()
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	guti, err := m.ReallocateGUTI(t.Context(), ue, plmn, group, code)
 	if err != nil {
@@ -573,10 +576,14 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 
 	gutiID := *accept.GUTI.GUTI
 
-	// GUMMEI sourced from the operator config (fakeBearerStore returns group/code 1).
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if gutiID.PLMN.MCC != "001" || gutiID.PLMN.MNC != "01" ||
-		gutiID.MMEGroupID != 1 || gutiID.MMECode != 1 {
-		t.Fatalf("unexpected GUTI: %+v", gutiID)
+		gutiID.MMEGroupID != group || gutiID.MMECode != code {
+		t.Fatalf("GUTI = %+v, want the node's GUMMEI %d/%d on PLMN 001-01", gutiID, group, code)
 	}
 
 	if _, ok := m.LookupUeByMTMSI(binary.BigEndian.Uint32(gutiID.TMSI[:])); !ok {

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/models"
@@ -82,10 +83,43 @@ func initiatingValue(t *testing.T, b []byte) []byte {
 
 // fakeSessionManager stands in for the SMF+PGW-C anchor.
 type fakeSessionManager struct {
-	lastRequest models.EPSBearerRequest
-	modifiedENB models.FTEID
-	released    bool
-	deactivated bool
+	lastRequest     models.EPSBearerRequest
+	modifiedENB     models.FTEID
+	released        bool
+	deactivated     bool
+	idleTransfers   []idleEPSTransfer
+	idleTransferErr error
+}
+
+type idleEPSTransfer struct {
+	Supi              etsi.SUPI
+	PDUSessionID      uint8
+	EPSBearerIdentity uint8
+	Dnn               string
+	Snssai            *models.Snssai
+}
+
+func (f *fakeSessionManager) TransferIdleToEPS(_ context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (models.EPSBearer, error) {
+	f.idleTransfers = append(f.idleTransfers, idleEPSTransfer{
+		Supi:              supi,
+		PDUSessionID:      pduSessionID,
+		EPSBearerIdentity: epsBearerIdentity,
+		Dnn:               dnn,
+		Snssai:            snssai,
+	})
+
+	if f.idleTransferErr != nil {
+		return models.EPSBearer{}, f.idleTransferErr
+	}
+
+	return models.EPSBearer{
+		Ref:          fmt.Sprintf("idle-ref-%d", pduSessionID),
+		PDNType:      eps.PDNTypeIPv4,
+		IPv4:         testUEIP,
+		SGW:          testSGWFTEID,
+		PDUSessionID: pduSessionID,
+		Snssai:       snssai,
+	}, nil
 }
 
 func (f *fakeSessionManager) CreateEPSSession(_ context.Context, req models.EPSBearerRequest) (models.EPSBearer, error) {

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -190,7 +190,7 @@ func (fakeBearerStore) GetNetworkSliceByID(_ context.Context, id string) (*db.Ne
 }
 
 func (fakeBearerStore) GetOperator(_ context.Context) (*db.Operator, error) {
-	return &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: `["1"]`, Ciphering: `["AES"]`, Integrity: `["AES"]`}, nil
+	return &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: `["1"]`, Ciphering: `["AES"]`, Integrity: `["AES"]`, AmfRegionID: 1, AmfSetID: 1}, nil
 }
 
 func (fakeBearerStore) NodeID() int { return 1 }

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -157,22 +157,6 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, ueConn *mme.UeC
 	}
 }
 
-// isNativeGUTI reports whether a GUTI was assigned by this MME (its serving PLMN
-// and GUMMEI), so its M-TMSI can be resolved against the local context index
-// (TS 23.401). A foreign GUTI would require S10, which Ella Core (a
-// single MME) does not implement.
-func isNativeGUTI(ctx context.Context, m *mme.MME, id eps.GUTI) bool {
-	operator, err := m.Operator(ctx)
-	if err != nil {
-		return false
-	}
-
-	plmn := operator.PLMN()
-	group, code := operator.GUMMEI()
-
-	return id.PLMN.MCC == plmn.Mcc && id.PLMN.MNC == plmn.Mnc && id.MMEGroupID == group && id.MMECode == code
-}
-
 // resolveAttachContext resolves the UE context an ATTACH REQUEST runs on BEFORE the
 // message is decoded, so the decode verifies against the right keys and integrity is
 // settled once. A native GUTI whose MAC verifies against a held EPS security
@@ -196,7 +180,7 @@ func resolveAttachContext(ctx context.Context, m *mme.MME, ue *mme.UeContext, ue
 	}
 
 	guti := req.EPSMobileIdentity.GUTI
-	if guti == nil || !isNativeGUTI(ctx, m, *guti) {
+	if guti == nil || !m.ServesGUTI(ctx, *guti) {
 		return ue, false
 	}
 

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -162,12 +162,13 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, ueConn *mme.UeC
 // (TS 23.401). A foreign GUTI would require S10, which Ella Core (a
 // single MME) does not implement.
 func isNativeGUTI(ctx context.Context, m *mme.MME, id eps.GUTI) bool {
-	plmn, err := m.OperatorPLMN(ctx)
+	operator, err := m.Operator(ctx)
 	if err != nil {
 		return false
 	}
 
-	group, code := m.MmeIdentity()
+	plmn := operator.PLMN()
+	group, code := operator.GUMMEI()
 
 	return id.PLMN.MCC == plmn.Mcc && id.PLMN.MNC == plmn.Mnc && id.MMEGroupID == group && id.MMECode == code
 }

--- a/internal/mme/nas/handle_authentication_response.go
+++ b/internal/mme/nas/handle_authentication_response.go
@@ -41,7 +41,7 @@ func handleAuthenticationResponse(ctx context.Context, m *mme.MME, ue *mme.UeCon
 	c.SetResyncTried(false)
 
 	logger.From(ctx, logger.MmeLog).Info("authentication succeeded")
-	startSecurityMode(ctx, m, ue, ueConn)
+	startSecurityMode(ctx, m, ue, ueConn, freshKeys)
 
 	return nasreply.Handled()
 }

--- a/internal/mme/nas/handle_authentication_response.go
+++ b/internal/mme/nas/handle_authentication_response.go
@@ -41,7 +41,10 @@ func handleAuthenticationResponse(ctx context.Context, m *mme.MME, ue *mme.UeCon
 	c.SetResyncTried(false)
 
 	logger.From(ctx, logger.MmeLog).Info("authentication succeeded")
-	startSecurityMode(ctx, m, ue, ueConn, freshKeys)
+
+	if startSecurityMode(ctx, m, ue, ueConn, freshKeys) == securityModeNoCommonAlgorithm {
+		rejectAttach(ctx, m, ue, ueConn, eps.EMMCauseUESecurityCapabilitiesMismatch)
+	}
 
 	return nasreply.Handled()
 }

--- a/internal/mme/nas/handle_guti_reallocation_test.go
+++ b/internal/mme/nas/handle_guti_reallocation_test.go
@@ -21,7 +21,10 @@ func TestGUTIReallocationCommitsOnComplete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gid, code := m.MmeIdentity()
+	gid, code, err := m.MmeIdentity(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	first, err := m.ReallocateGUTI(context.Background(), ue, plmn, gid, code)
 	if err != nil {

--- a/internal/mme/nas/handle_security_mode_complete.go
+++ b/internal/mme/nas/handle_security_mode_complete.go
@@ -16,9 +16,6 @@ import (
 )
 
 func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, smc *eps.SecurityModeComplete) nasreply.Disposition {
-	// A SECURITY MODE COMPLETE is valid only during the security mode sub-phase;
-	// out of order, ignore it. A genuine one is integrity-protected against the
-	// context installed at command send, so this is defence in depth.
 	if ue.RegStep() != mme.RegStepSecurityMode {
 		logger.From(ctx, logger.MmeLog).Warn("ignoring Security Mode Complete outside the security mode sub-phase")
 
@@ -26,12 +23,9 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 	}
 
 	ueConn.StopNASGuard()
-	// Release the key-chain claim so a subsequent handover or Path Switch can
-	// proceed (TS 33.401 §7.2.8).
+
 	m.ClearKeyChainBusy(ue)
 
-	// The Security Mode Command requested the IMEISV (TS 24.301); parse it into the
-	// shared equipment-identity type for the status API.
 	var pei etsi.IMEI
 
 	if smc.IMEISV != nil && smc.IMEISV.IMEISV != nil {
@@ -45,9 +39,6 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 	ue.MarkSecured(pei)
 	ue.PinKeNBFreshness()
 
-	// Anti-tamper recovery: on a HASHMME mismatch the UE returns the complete plain
-	// ATTACH REQUEST in the Replayed NAS message container. Re-ingest it so a tampered
-	// initial Attach cannot alter the completed attach (TS 24.301 §5.4.3.4).
 	if len(smc.ReplayedNASMessageContainer) > 0 {
 		req, err := eps.ParseAttachRequest(smc.ReplayedNASMessageContainer)
 		if !decoded(ctx, "AttachRequest", err) {
@@ -66,6 +57,13 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 	logger.From(ctx, logger.MmeLog).Info("NAS security context established",
 		zap.String("imsi", ue.IMSI()),
 	)
+
+	if deferred := ueConn.DeferredTAU; deferred != nil {
+		plain := ueConn.DeferredTAUPlain
+		ueConn.DeferredTAU, ueConn.DeferredTAUPlain = nil, nil
+
+		return handleTrackingAreaUpdate(ctx, m, ue, ueConn, deferred, plain)
+	}
 
 	activateDefaultBearer(ctx, m, ue, ueConn)
 

--- a/internal/mme/nas/handle_security_mode_complete.go
+++ b/internal/mme/nas/handle_security_mode_complete.go
@@ -58,11 +58,15 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 		zap.String("imsi", ue.IMSI()),
 	)
 
-	if deferred := ueConn.DeferredTAU; deferred != nil {
-		plain := ueConn.DeferredTAUPlain
-		ueConn.DeferredTAU, ueConn.DeferredTAUPlain = nil, nil
+	if plain := ueConn.DeferredTAUPlain; len(plain) > 0 {
+		ueConn.DeferredTAUPlain = nil
 
-		return handleTrackingAreaUpdate(ctx, m, ue, ueConn, deferred, plain)
+		req, err := eps.ParseTrackingAreaUpdateRequest(plain)
+		if !decoded(ctx, "TrackingAreaUpdateRequest", err) || req == nil {
+			return rejectUndecodable(ctx, m, ue, ueConn, plain, err)
+		}
+
+		return handleTrackingAreaUpdate(ctx, m, ue, ueConn, req, plain)
 	}
 
 	activateDefaultBearer(ctx, m, ue, ueConn)

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -83,8 +83,6 @@ func unprotectedBody(pdu []byte) ([]byte, bool) {
 	}
 }
 
-// answered reports that the update was replied to here, either by the reject an
-// empty transfer draws or by the security mode command a re-key defers it behind.
 func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 	req *eps.TrackingAreaUpdateRequest, plain []byte,
 ) (answered bool) {
@@ -95,24 +93,15 @@ func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeCont
 
 	ueConn.ArrivingFrom5GS = nil
 
-	// Before the sessions move, so a prior context for the same subscriber gives up
-	// its M-TMSI and EPS bearers first and the transfer cannot be undone by
-	// superseding it afterwards. The 5GS peer verified the update, which is what
-	// entitles this context to the subscriber's identity (TS 24.301 §4.4.4.3).
 	m.CommitUEIdentity(ctx, ue, mme.MintAuthProofForInterworking())
 
 	transferred := m.AdoptIdlePDNs(ctx, ue, arriving.PDNConnections)
 
-	// TS 23.401 §5.3.3.1 step 8, which TS 23.502 §4.11.1.3.2 step 7-14 performs:
-	// with no bearer context at all the update is rejected. Cause #10 sends the UE
-	// to EMM-DEREGISTERED.NORMAL-SERVICE to attach afresh (TS 24.301 §5.5.3.2.5,
-	// §5.5.3.3.5). The 5GS peer is left unacknowledged so it keeps the sessions
-	// this MME could not take (TS 23.401 §5.3.3.1 step 7).
 	if len(transferred) == 0 {
 		logger.From(ctx, logger.MmeLog).Info("no PDU session of a UE arriving from 5GS could become a PDN connection; rejecting the update",
 			zap.String("imsi", ue.IMSI()), zap.Int("offered", len(arriving.PDNConnections)))
 
-		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseImplicitlyDetached)
+		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseNoEPSBearerContextActivated)
 
 		return true
 	}

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/eps"
+	"go.uber.org/zap"
+)
+
+func movingFrom5GSInIdleMode(req *eps.TrackingAreaUpdateRequest) bool {
+	if req == nil || req.OldGUTI.GUTI == nil || req.UEStatus == nil || !req.UEStatus.N1ModeReg {
+		return false
+	}
+
+	return req.OldGUTIType != nil && *req.OldGUTIType == eps.GUTITypeNative
+}
+
+func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pdu []byte) (*mme.UeContext, []byte) {
+	plain, ok := unprotectedBody(pdu)
+	if !ok {
+		return nil, nil
+	}
+
+	req, err := eps.ParseTrackingAreaUpdateRequest(plain)
+	if !decoded(ctx, "TrackingAreaUpdateRequest", err) || !movingFrom5GSInIdleMode(req) {
+		return nil, nil
+	}
+
+	resp, err := m.FetchEPSContext(ctx, *req.OldGUTI.GUTI, pdu)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Info("the 5GS peer returned no context for an inter-system change; the update is rejected",
+			zap.Error(err))
+
+		return nil, nil
+	}
+
+	ue := mme.NewUeContext()
+	ue.SetSupi(resp.SUPI)
+
+	if err := ue.InstallRelocatedSecurityContext(resp.Security, mme.MintAuthProofForInterworking()); err != nil {
+		logger.From(ctx, logger.MmeLog).Warn("failed to install the EPS context mapped from 5GS", zap.Error(err))
+
+		return nil, nil
+	}
+
+	ue.Ambr = &models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink}
+	ue.TransitionTo(mme.EMMRegistrationInitiated)
+
+	m.AttachUeConn(ue, conn)
+
+	conn.ArrivingFrom5GS = &resp
+
+	logger.From(ctx, logger.MmeLog).Info("recovered the UE's context from 5GS for an idle-mode change",
+		zap.String("imsi", ue.IMSI()), zap.Int("pdu-sessions", len(resp.PDNConnections)))
+
+	return ue, plain
+}
+
+func unprotectedBody(pdu []byte) ([]byte, bool) {
+	sht, err := eps.PeekSecurityHeaderType(pdu)
+	if err != nil {
+		return nil, false
+	}
+
+	switch sht {
+	case eps.SHTPlain:
+		return pdu, true
+	case eps.SHTIntegrityProtected, eps.SHTIntegrityProtectedNewContext:
+		if len(pdu) < 6 {
+			return nil, false
+		}
+
+		return pdu[6:], true
+	default:
+		return nil, false
+	}
+}
+
+func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
+	req *eps.TrackingAreaUpdateRequest, plain []byte,
+) (deferred bool) {
+	arriving := ueConn.ArrivingFrom5GS
+	if arriving == nil {
+		return false
+	}
+
+	ueConn.ArrivingFrom5GS = nil
+
+	transferred := m.AdoptIdlePDNs(ctx, ue, arriving.PDNConnections)
+
+	if err := m.AckEPSContext(ctx, ue.Supi(), transferred); err != nil {
+		logger.From(ctx, logger.MmeLog).Warn("the 5GS peer refused the context acknowledgement for an idle-mode change",
+			zap.Error(err), zap.String("imsi", ue.IMSI()))
+	}
+
+	logger.From(ctx, logger.MmeLog).Info("adopted the PDU sessions of a UE arriving from 5GS in idle mode",
+		zap.String("imsi", ue.IMSI()), zap.Int("adopted", len(transferred)),
+		zap.Int("offered", len(arriving.PDNConnections)))
+
+	return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, req, plain, arriving.Security)
+}
+
+func changeNASAlgorithmsForMappedContext(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
+	req *eps.TrackingAreaUpdateRequest, plain []byte, security interworking.EPSSecurityContext,
+) bool {
+	_, changed, err := m.NASAlgorithmsForMappedContext(ctx, security)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Warn("could not compare the mapped context's NAS algorithms with the operator policy",
+			zap.Error(err), zap.String("imsi", ue.IMSI()))
+
+		return false
+	}
+
+	if !changed {
+		return false
+	}
+
+	logger.From(ctx, logger.MmeLog).Info("the mapped EPS context uses algorithms this MME does not select; re-keying before the update",
+		zap.String("imsi", ue.IMSI()))
+
+	ueConn.DeferredTAU = req
+	ueConn.DeferredTAUPlain = plain
+
+	startSecurityMode(ctx, m, ue, ueConn)
+
+	return true
+}

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -55,7 +55,7 @@ func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pd
 
 	m.AttachUeConn(ue, conn)
 
-	conn.ArrivingFrom5GS = &resp
+	conn.ArrivingFrom5GS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
 
 	logger.From(ctx, logger.MmeLog).Info("recovered the UE's context from 5GS for an idle-mode change",
 		zap.String("imsi", ue.IMSI()), zap.Int("pdu-sessions", len(resp.PDNConnections)))
@@ -84,7 +84,7 @@ func unprotectedBody(pdu []byte) ([]byte, bool) {
 }
 
 func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
-	req *eps.TrackingAreaUpdateRequest, plain []byte,
+	plain []byte,
 ) (answered bool) {
 	arriving := ueConn.ArrivingFrom5GS
 	if arriving == nil {
@@ -95,11 +95,11 @@ func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeCont
 
 	m.CommitUEIdentity(ctx, ue, mme.MintAuthProofForInterworking())
 
-	transferred := m.AdoptIdlePDNs(ctx, ue, arriving.PDNConnections)
+	transferred := m.AdoptIdlePDNs(ctx, ue, arriving.PDN)
 
 	if len(transferred) == 0 {
 		logger.From(ctx, logger.MmeLog).Info("no PDU session of a UE arriving from 5GS could become a PDN connection; rejecting the update",
-			zap.String("imsi", ue.IMSI()), zap.Int("offered", len(arriving.PDNConnections)))
+			zap.String("imsi", ue.IMSI()), zap.Int("offered", len(arriving.PDN)))
 
 		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseNoEPSBearerContextActivated)
 
@@ -113,13 +113,14 @@ func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeCont
 
 	logger.From(ctx, logger.MmeLog).Info("adopted the PDU sessions of a UE arriving from 5GS in idle mode",
 		zap.String("imsi", ue.IMSI()), zap.Int("adopted", len(transferred)),
-		zap.Int("offered", len(arriving.PDNConnections)))
+		zap.Int("offered", len(arriving.PDN)))
 
-	return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, req, plain, arriving.Security.Algorithms)
+	return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, plain,
+		interworking.EPSNASAlgorithms{Ciphering: ue.EEA(), Integrity: ue.EIA()})
 }
 
 func changeNASAlgorithmsForMappedContext(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
-	req *eps.TrackingAreaUpdateRequest, plain []byte, current interworking.EPSNASAlgorithms,
+	plain []byte, current interworking.EPSNASAlgorithms,
 ) bool {
 	_, changed, err := m.NASAlgorithmsForMappedContext(ctx, ue.UeNetCap(), current)
 	if err != nil {
@@ -136,7 +137,6 @@ func changeNASAlgorithmsForMappedContext(ctx context.Context, m *mme.MME, ue *mm
 	logger.From(ctx, logger.MmeLog).Info("the mapped EPS context uses algorithms this MME does not select; re-keying before the update",
 		zap.String("imsi", ue.IMSI()))
 
-	ueConn.DeferredTAU = req
 	ueConn.DeferredTAUPlain = plain
 
 	startSecurityMode(ctx, m, ue, ueConn, rekeyedKeys)

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -41,6 +41,10 @@ func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pd
 		return nil, nil
 	}
 
+	if held, ok := m.LookupUeBySupi(resp.SUPI); ok && held.IdleMobilityFrom5GSPending() {
+		return remapHeldContext(ctx, m, held, conn, resp, plain)
+	}
+
 	ue := mme.NewUeContext()
 	ue.SetSupi(resp.SUPI)
 
@@ -52,6 +56,7 @@ func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pd
 
 	ue.Ambr = &models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink}
 	ue.TransitionTo(mme.EMMRegistrationInitiated)
+	ue.BeginIdleMobilityFrom5GS()
 
 	m.AttachUeConn(ue, conn)
 
@@ -61,6 +66,30 @@ func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pd
 		zap.String("imsi", ue.IMSI()), zap.Int("pdu-sessions", len(resp.PDNConnections)))
 
 	return ue, plain
+}
+
+// remapHeldContext resumes an inter-system update the UE repeated before it completed:
+// the AMF re-ran the integrity check and derived the mapped context from the new uplink
+// NAS COUNT (TS 33.501 §8.6.1), and the PDN connections of the first pass already moved,
+// so only the security context is taken over (TS 24.301 §5.5.3.2.7 d).
+func remapHeldContext(ctx context.Context, m *mme.MME, held *mme.UeContext, conn *mme.UeConn,
+	resp interworking.EPSContextResponse, plain []byte,
+) (*mme.UeContext, []byte) {
+	if err := held.InstallRelocatedSecurityContext(resp.Security, mme.MintAuthProofForInterworking()); err != nil {
+		logger.From(ctx, logger.MmeLog).Warn("failed to install the EPS context remapped for a repeated inter-system change",
+			zap.Error(err))
+
+		return nil, nil
+	}
+
+	m.AttachUeConn(held, conn)
+
+	conn.RemappedFrom5GS = true
+
+	logger.From(ctx, logger.MmeLog).Info("re-keyed a held context for an inter-system change the UE repeated",
+		zap.String("imsi", held.IMSI()))
+
+	return held, plain
 }
 
 func unprotectedBody(pdu []byte) ([]byte, bool) {
@@ -86,6 +115,13 @@ func unprotectedBody(pdu []byte) ([]byte, bool) {
 func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 	plain []byte,
 ) (answered bool) {
+	if ueConn.RemappedFrom5GS {
+		ueConn.RemappedFrom5GS = false
+
+		return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, plain,
+			interworking.EPSNASAlgorithms{Ciphering: ue.EEA(), Integrity: ue.EIA()})
+	}
+
 	arriving := ueConn.ArrivingFrom5GS
 	if arriving == nil {
 		return false

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -108,6 +108,21 @@ func unprotectedBody(pdu []byte) ([]byte, bool) {
 	}
 }
 
+func adoptIdlePDNsFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn) {
+	arriving := ueConn.ArrivingFrom5GS
+	if arriving == nil {
+		return
+	}
+
+	m.CommitUEIdentity(ctx, ue, mme.MintAuthProofForInterworking())
+
+	adopted := m.AdoptIdlePDNs(ctx, ue, arriving.PDN)
+
+	logger.From(ctx, logger.MmeLog).Info("adopted the PDU sessions of a UE arriving from 5GS in idle mode",
+		zap.String("imsi", ue.IMSI()), zap.Int("adopted", len(adopted)),
+		zap.Int("offered", len(arriving.PDN)))
+}
+
 func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 	plain []byte,
 ) (answered bool) {
@@ -125,9 +140,7 @@ func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeCont
 
 	ueConn.ArrivingFrom5GS = nil
 
-	m.CommitUEIdentity(ctx, ue, mme.MintAuthProofForInterworking())
-
-	transferred := m.AdoptIdlePDNs(ctx, ue, arriving.PDN)
+	transferred := heldPDUSessions(m, ue)
 
 	if len(transferred) == 0 {
 		logger.From(ctx, logger.MmeLog).Info("no PDU session of a UE arriving from 5GS could become a PDN connection; rejecting the update",
@@ -143,12 +156,19 @@ func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeCont
 			zap.Error(err), zap.String("imsi", ue.IMSI()))
 	}
 
-	logger.From(ctx, logger.MmeLog).Info("adopted the PDU sessions of a UE arriving from 5GS in idle mode",
-		zap.String("imsi", ue.IMSI()), zap.Int("adopted", len(transferred)),
-		zap.Int("offered", len(arriving.PDN)))
-
 	return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, plain,
 		interworking.EPSNASAlgorithms{Ciphering: ue.EEA(), Integrity: ue.EIA()})
+}
+
+func heldPDUSessions(m *mme.MME, ue *mme.UeContext) []uint8 {
+	pdns := m.SnapshotPDNs(ue)
+
+	out := make([]uint8, 0, len(pdns))
+	for _, p := range pdns {
+		out = append(out, p.PDUSessionID)
+	}
+
+	return out
 }
 
 func changeNASAlgorithmsForMappedContext(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
@@ -169,9 +189,16 @@ func changeNASAlgorithmsForMappedContext(ctx context.Context, m *mme.MME, ue *mm
 	logger.From(ctx, logger.MmeLog).Info("the mapped EPS context uses algorithms this MME does not select; re-keying before the update",
 		zap.String("imsi", ue.IMSI()))
 
-	ueConn.DeferredTAUPlain = plain
+	switch startSecurityMode(ctx, m, ue, ueConn, rekeyedKeys) {
+	case securityModeCommandSent:
+		ueConn.DeferredTAUPlain = plain
 
-	startSecurityMode(ctx, m, ue, ueConn, rekeyedKeys)
+		return true
+	case securityModeNoCommonAlgorithm:
+		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseUESecurityCapabilitiesMismatch)
 
-	return true
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -68,10 +68,6 @@ func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pd
 	return ue, plain
 }
 
-// remapHeldContext resumes an inter-system update the UE repeated before it completed:
-// the AMF re-ran the integrity check and derived the mapped context from the new uplink
-// NAS COUNT (TS 33.501 §8.6.1), and the PDN connections of the first pass already moved,
-// so only the security context is taken over (TS 24.301 §5.5.3.2.7 d).
 func remapHeldContext(ctx context.Context, m *mme.MME, held *mme.UeContext, conn *mme.UeConn,
 	resp interworking.EPSContextResponse, plain []byte,
 ) (*mme.UeContext, []byte) {

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -83,9 +83,11 @@ func unprotectedBody(pdu []byte) ([]byte, bool) {
 	}
 }
 
+// answered reports that the update was replied to here, either by the reject an
+// empty transfer draws or by the security mode command a re-key defers it behind.
 func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 	req *eps.TrackingAreaUpdateRequest, plain []byte,
-) (deferred bool) {
+) (answered bool) {
 	arriving := ueConn.ArrivingFrom5GS
 	if arriving == nil {
 		return false
@@ -93,7 +95,27 @@ func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeCont
 
 	ueConn.ArrivingFrom5GS = nil
 
+	// Before the sessions move, so a prior context for the same subscriber gives up
+	// its M-TMSI and EPS bearers first and the transfer cannot be undone by
+	// superseding it afterwards. The 5GS peer verified the update, which is what
+	// entitles this context to the subscriber's identity (TS 24.301 §4.4.4.3).
+	m.CommitUEIdentity(ctx, ue, mme.MintAuthProofForInterworking())
+
 	transferred := m.AdoptIdlePDNs(ctx, ue, arriving.PDNConnections)
+
+	// TS 23.401 §5.3.3.1 step 8, which TS 23.502 §4.11.1.3.2 step 7-14 performs:
+	// with no bearer context at all the update is rejected. Cause #10 sends the UE
+	// to EMM-DEREGISTERED.NORMAL-SERVICE to attach afresh (TS 24.301 §5.5.3.2.5,
+	// §5.5.3.3.5). The 5GS peer is left unacknowledged so it keeps the sessions
+	// this MME could not take (TS 23.401 §5.3.3.1 step 7).
+	if len(transferred) == 0 {
+		logger.From(ctx, logger.MmeLog).Info("no PDU session of a UE arriving from 5GS could become a PDN connection; rejecting the update",
+			zap.String("imsi", ue.IMSI()), zap.Int("offered", len(arriving.PDNConnections)))
+
+		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseImplicitlyDetached)
+
+		return true
+	}
 
 	if err := m.AckEPSContext(ctx, ue.Supi(), transferred); err != nil {
 		logger.From(ctx, logger.MmeLog).Warn("the 5GS peer refused the context acknowledgement for an idle-mode change",
@@ -104,13 +126,13 @@ func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeCont
 		zap.String("imsi", ue.IMSI()), zap.Int("adopted", len(transferred)),
 		zap.Int("offered", len(arriving.PDNConnections)))
 
-	return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, req, plain, arriving.Security)
+	return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, req, plain, arriving.Security.Algorithms)
 }
 
 func changeNASAlgorithmsForMappedContext(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
-	req *eps.TrackingAreaUpdateRequest, plain []byte, security interworking.EPSSecurityContext,
+	req *eps.TrackingAreaUpdateRequest, plain []byte, current interworking.EPSNASAlgorithms,
 ) bool {
-	_, changed, err := m.NASAlgorithmsForMappedContext(ctx, security)
+	_, changed, err := m.NASAlgorithmsForMappedContext(ctx, ue.UeNetCap(), current)
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Warn("could not compare the mapped context's NAS algorithms with the operator policy",
 			zap.Error(err), zap.String("imsi", ue.IMSI()))
@@ -128,7 +150,7 @@ func changeNASAlgorithmsForMappedContext(ctx context.Context, m *mme.MME, ue *mm
 	ueConn.DeferredTAU = req
 	ueConn.DeferredTAUPlain = plain
 
-	startSecurityMode(ctx, m, ue, ueConn)
+	startSecurityMode(ctx, m, ue, ueConn, rekeyedKeys)
 
 	return true
 }

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -453,3 +453,77 @@ func TestInterSystemTAURekeyReplaysTheCapabilitiesTheUEJustSent(t *testing.T) {
 			smc.ReplayedUESecurityCapability, want)
 	}
 }
+
+// TS 23.401 §5.3.3.1 step 8
+func TestAnArrivalWithNoSessionsIsStillAnArrival(t *testing.T) {
+	resp := arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})
+	resp.PDNConnections = nil
+
+	peer := &fakeFiveGSPeer{Response: resp}
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	if conn.ArrivingFrom5GS != nil {
+		t.Error("the arriving context outlived the update")
+	}
+
+	if peer.Acked {
+		t.Error("the 5GS peer was acknowledged for a transfer that moved nothing")
+	}
+}
+
+// TS 24.301 §5.4.3.4, TS 33.501 §8.5.2 steps 7-11
+func TestDeferredInterSystemTAUResumesAfterTheRekey(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tail []byte
+	}{
+		{name: "a well-formed update"},
+		{name: "an update with a truncated optional IE", tail: []byte{0x50, 0x08, 0x01}},
+	} {
+		t.Run(tc.name, func(t *testing.T) { deferredTAUResumes(t, tc.tail) })
+	}
+}
+
+func deferredTAUResumes(t *testing.T, tail []byte) {
+	t.Helper()
+
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,
+	})}
+
+	m, conn, cc := idleArrivalMME(t, peer)
+
+	dispositionForNAS(context.Background(), m, conn, append(interSystemTAU(t, nil), tail...))
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	if len(conn.DeferredTAUPlain) == 0 {
+		t.Fatal("the update was not deferred behind the security mode command")
+	}
+
+	sent := cc.count()
+
+	if got := handleSecurityModeComplete(context.Background(), m, ue, conn, &eps.SecurityModeComplete{}); got.Reason != 0 {
+		t.Fatalf("disposition = %+v, want the update handled", got)
+	}
+
+	if conn.DeferredTAUPlain != nil {
+		t.Error("the deferred update outlived its resume, so a later security mode complete would replay it")
+	}
+
+	if cc.count() <= sent {
+		t.Fatal("nothing was sent after the security mode completed, so the deferred update was dropped")
+	}
+
+	plain := decodeProtectedDownlink(t, ue, cc.sent[cc.count()-1])
+	if _, err := eps.ParseTrackingAreaUpdateAccept(plain); err != nil {
+		t.Fatalf("the resumed update was not answered with a TRACKING AREA UPDATE ACCEPT: %v", err)
+	}
+}

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -91,7 +91,7 @@ func interSystemTAU(t *testing.T, mutate func(*eps.TrackingAreaUpdateRequest)) [
 	req := &eps.TrackingAreaUpdateRequest{
 		EPSUpdateType: 0,
 		OldGUTI: eps.GUTIIdentity(eps.GUTI{
-			PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x0100, MMECode: 0x40,
+			PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x8100, MMECode: 0x40,
 			TMSI: [4]byte{0x00, 0x00, 0xde, 0xad},
 		}),
 		OldGUTIType: &native,
@@ -203,6 +203,95 @@ func TestInterSystemTAURecoversTheContextFromTheAMF(t *testing.T) {
 
 	if p := m.LookupPDN(ue, 6); p == nil {
 		t.Error("the arriving PDU session was not published as a PDN connection on EBI 6")
+	}
+}
+
+// TS 24.301 §5.5.3.2.7 d)
+func TestRepeatedInterSystemTAUReKeysTheHeldContext(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})}
+
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	first := conn.UeContext()
+	if first == nil {
+		t.Fatal("no context was bound by the first update")
+	}
+
+	peer.Acked, peer.Transferred = false, nil
+
+	var remapped [32]byte
+	for i := range remapped {
+		remapped[i] = byte(0xa0 + i)
+	}
+
+	peer.Response.Security.KASME = remapped
+
+	repeat := m.NewUeConn(&captureConn{}, 9)
+	repeat.ServingTAI = servedAttachTAI
+
+	dispositionForNAS(context.Background(), m, repeat, interSystemTAU(t, nil))
+
+	resumed := repeat.UeContext()
+	if resumed != first {
+		t.Fatal("the repeated update built a second context, so committing it releases the sessions the first pass moved")
+	}
+
+	if len(peer.Requests) != 2 {
+		t.Fatalf("context requests = %d, want the repeated update forwarded to the AMF as well", len(peer.Requests))
+	}
+
+	held, err := resumed.EPSSecurityContextForRelocation()
+	if err != nil {
+		t.Fatalf("EPSSecurityContextForRelocation: %v", err)
+	}
+
+	if held.KASME != remapped {
+		t.Errorf("K'ASME = %x, want the one the AMF derived from the repeated TAU's count %x", held.KASME, remapped)
+	}
+
+	if p := m.LookupPDN(resumed, 6); p == nil {
+		t.Error("the PDN connection of the first pass is gone, so the UE keeps no bearer through the retransmission")
+	}
+
+	if peer.Acked {
+		t.Error("the AMF was acknowledged a second time for sessions that moved once")
+	}
+}
+
+// TS 24.301 §5.5.3.2.7 d)
+func TestInterSystemTAUAfterTheProcedureCompletedStartsAfresh(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})}
+
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	first := conn.UeContext()
+	if first == nil {
+		t.Fatal("no context was bound by the first update")
+	}
+
+	handleTrackingAreaUpdateComplete(context.Background(), m, first, conn)
+
+	peer.Acked, peer.Transferred = false, nil
+
+	later := m.NewUeConn(&captureConn{}, 9)
+	later.ServingTAI = servedAttachTAI
+
+	dispositionForNAS(context.Background(), m, later, interSystemTAU(t, nil))
+
+	if later.UeContext() == first {
+		t.Error("a later inter-system change resumed a context whose procedure had completed, so its PDU sessions never moved")
+	}
+
+	if !peer.Acked {
+		t.Error("the AMF was not acknowledged, so it keeps serving a UE that has left again")
 	}
 }
 

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// fakeFiveGSPeer stands in for the AMF an inter-system change recovers from.
 type fakeFiveGSPeer struct {
 	Requests    []interworking.EPSContextRequest
 	Response    interworking.EPSContextResponse
@@ -53,8 +52,6 @@ func (p *fakeFiveGSPeer) EPSContextAck(_ context.Context, _ etsi.SUPI, transferr
 	return nil
 }
 
-// arrivingEPSContext is the context an AMF returns for a UE changing system in
-// idle mode: an EPS context mapped from the 5G one, and one PDU session.
 func arrivingEPSContext(t *testing.T, algorithms interworking.EPSNASAlgorithms) interworking.EPSContextResponse {
 	t.Helper()
 
@@ -86,10 +83,6 @@ func arrivingEPSContext(t *testing.T, algorithms interworking.EPSNASAlgorithms) 
 	}
 }
 
-// interSystemTAU is the TRACKING AREA UPDATE REQUEST of TS 24.301 §5.5.3.2.2
-// case z: a mapped Old GUTI typed native, the UE status reporting
-// 5GMM-REGISTERED, and an integrity-protected frame the MME cannot verify —
-// its MAC is computed over the 5G security context.
 func interSystemTAU(t *testing.T, mutate func(*eps.TrackingAreaUpdateRequest)) []byte {
 	t.Helper()
 
@@ -114,8 +107,6 @@ func interSystemTAU(t *testing.T, mutate func(*eps.TrackingAreaUpdateRequest)) [
 		t.Fatalf("encode TAU: %v", err)
 	}
 
-	// The MAC is the UE's, computed with keys no node in EPS holds; the MME reads
-	// the message without checking it and asks the AMF instead.
 	return append([]byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x00}, plain...)
 }
 
@@ -157,8 +148,6 @@ func TestMovingFrom5GSInIdleModeNeedsTheMappedIdentity(t *testing.T) {
 	}
 }
 
-// idleArrivalMME is an MME with a bare S1 connection: a UE arriving from 5GS is
-// one this node has never seen.
 func idleArrivalMME(t *testing.T, peer *fakeFiveGSPeer) (*mme.MME, *mme.UeConn, *captureConn) {
 	t.Helper()
 
@@ -173,8 +162,7 @@ func idleArrivalMME(t *testing.T, peer *fakeFiveGSPeer) (*mme.MME, *mme.UeConn, 
 	return m, conn, cc
 }
 
-// TS 33.501 §8.5.2 steps 3-6: the MME cannot verify this message, so it asks the
-// AMF, and serves the update on the context that comes back.
+// TS 33.501 §8.5.2 steps 3-6
 func TestInterSystemTAURecoversTheContextFromTheAMF(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
 		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
@@ -192,8 +180,6 @@ func TestInterSystemTAURecoversTheContextFromTheAMF(t *testing.T) {
 		t.Fatalf("context requests = %d, want 1", len(peer.Requests))
 	}
 
-	// TS 23.003 §2.10.2.2.3: the MME reverse-maps the presented identity and the
-	// AMF compares it against its stored values.
 	if got := peer.Requests[0].Mapped5GGUTI.TMSI; got != [4]byte{0x00, 0x00, 0xde, 0xad} {
 		t.Errorf("the AMF was asked about 5G-TMSI %x, want the one the Old GUTI maps back to", got)
 	}
@@ -220,8 +206,7 @@ func TestInterSystemTAURecoversTheContextFromTheAMF(t *testing.T) {
 	}
 }
 
-// TS 24.301 §5.5.3.2.5: with no context to recover, the update resolves nothing
-// and the S1AP layer answers EMM cause #9, which sends the UE to re-attach.
+// TS 24.301 §5.5.3.2.5
 func TestInterSystemTAUWithoutARecoverableContext(t *testing.T) {
 	peer := &fakeFiveGSPeer{Err: interworking.ErrUnknownUEContext}
 	m, conn, _ := idleArrivalMME(t, peer)
@@ -249,8 +234,6 @@ func TestInterSystemTAUWithAFailedIntegrityCheck(t *testing.T) {
 	}
 }
 
-// An ordinary TAU on a bare connection still resolves nothing: only the
-// inter-system form recovers a context from the peer.
 func TestOrdinaryTAUOnABareConnectionMintsNothing(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
 		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
@@ -271,8 +254,7 @@ func TestOrdinaryTAUOnABareConnectionMintsNothing(t *testing.T) {
 	}
 }
 
-// TS 33.501 §8.5.2 steps 7-10: when the MME's policy names other algorithms than
-// the mapped context carries, it re-keys before answering the update.
+// TS 33.501 §8.5.2 steps 7-10
 func TestInterSystemTAURekeysOnAnAlgorithmChange(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
 		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/nasreply"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// fakeFiveGSPeer stands in for the AMF an inter-system change recovers from.
+type fakeFiveGSPeer struct {
+	Requests    []interworking.EPSContextRequest
+	Response    interworking.EPSContextResponse
+	Err         error
+	Acked       bool
+	Transferred []uint8
+}
+
+func (*fakeFiveGSPeer) ForwardRelocation(context.Context, interworking.FiveGSRelocationRequest) (interworking.FiveGSRelocationResponse, error) {
+	return interworking.FiveGSRelocationResponse{}, nil
+}
+
+func (*fakeFiveGSPeer) RelocationCancel(context.Context, etsi.SUPI, interworking.RelocationID) error {
+	return nil
+}
+
+func (*fakeFiveGSPeer) RelocationComplete(context.Context, etsi.SUPI, interworking.RelocationID) error {
+	return nil
+}
+
+func (p *fakeFiveGSPeer) EPSContext(_ context.Context, req interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
+	p.Requests = append(p.Requests, req)
+
+	if p.Err != nil {
+		return interworking.EPSContextResponse{}, p.Err
+	}
+
+	return p.Response, nil
+}
+
+func (p *fakeFiveGSPeer) EPSContextAck(_ context.Context, _ etsi.SUPI, transferred []uint8) error {
+	p.Acked, p.Transferred = true, transferred
+
+	return nil
+}
+
+// arrivingEPSContext is the context an AMF returns for a UE changing system in
+// idle mode: an EPS context mapped from the 5G one, and one PDU session.
+func arrivingEPSContext(t *testing.T, algorithms interworking.EPSNASAlgorithms) interworking.EPSContextResponse {
+	t.Helper()
+
+	supi, err := etsi.NewSUPIFromIMSI(testSubscriber.IMSI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var kasme [32]byte
+	for i := range kasme {
+		kasme[i] = byte(i + 1)
+	}
+
+	return interworking.EPSContextResponse{
+		SUPI: supi,
+		Security: interworking.EPSSecurityContext{
+			KASME:                kasme,
+			EKSI:                 nas.KeySetIdentifier{Value: 4, Mapped: true},
+			ULNASCount:           nas.MakeCount(0, 7),
+			DLNASCount:           nas.MakeCount(0, 2),
+			Algorithms:           algorithms,
+			UESecurityCapability: eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70},
+		},
+		PDNConnections: []interworking.PDNConnection{
+			{PDUSessionID: 3, EPSBearerIdentity: 6, APN: "internet", Snssai: models.Snssai{Sst: 1, Sd: "010203"}},
+		},
+		AMBRUplink:   models.MustParseBitRate("50 Mbps"),
+		AMBRDownlink: models.MustParseBitRate("100 Mbps"),
+	}
+}
+
+// interSystemTAU is the TRACKING AREA UPDATE REQUEST of TS 24.301 §5.5.3.2.2
+// case z: a mapped Old GUTI typed native, the UE status reporting
+// 5GMM-REGISTERED, and an integrity-protected frame the MME cannot verify —
+// its MAC is computed over the 5G security context.
+func interSystemTAU(t *testing.T, mutate func(*eps.TrackingAreaUpdateRequest)) []byte {
+	t.Helper()
+
+	native := eps.GUTITypeNative
+
+	req := &eps.TrackingAreaUpdateRequest{
+		EPSUpdateType: 0,
+		OldGUTI: eps.GUTIIdentity(eps.GUTI{
+			PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x0100, MMECode: 0x40,
+			TMSI: [4]byte{0x00, 0x00, 0xde, 0xad},
+		}),
+		OldGUTIType: &native,
+		UEStatus:    &eps.UEStatus{N1ModeReg: true},
+	}
+
+	if mutate != nil {
+		mutate(req)
+	}
+
+	plain, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode TAU: %v", err)
+	}
+
+	// The MAC is the UE's, computed with keys no node in EPS holds; the MME reads
+	// the message without checking it and asks the AMF instead.
+	return append([]byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x00}, plain...)
+}
+
+func TestMovingFrom5GSInIdleModeNeedsTheMappedIdentity(t *testing.T) {
+	native := eps.GUTITypeNative
+	mapped := eps.GUTIType(1)
+
+	base := func() *eps.TrackingAreaUpdateRequest {
+		return &eps.TrackingAreaUpdateRequest{
+			OldGUTI:     eps.GUTIIdentity(eps.GUTI{PLMN: nas.PLMN{MCC: "001", MNC: "01"}}),
+			OldGUTIType: &native,
+			UEStatus:    &eps.UEStatus{N1ModeReg: true},
+		}
+	}
+
+	if !movingFrom5GSInIdleMode(base()) {
+		t.Error("a TAU with a native-typed GUTI and 5GMM-REGISTERED is not taken as an inter-system change")
+	}
+
+	noStatus := base()
+	noStatus.UEStatus = nil
+
+	if movingFrom5GSInIdleMode(noStatus) {
+		t.Error("a TAU with no UE status is taken as an inter-system change")
+	}
+
+	notRegistered := base()
+	notRegistered.UEStatus = &eps.UEStatus{S1ModeReg: true}
+
+	if movingFrom5GSInIdleMode(notRegistered) {
+		t.Error("a TAU reporting no 5GMM registration is taken as an inter-system change")
+	}
+
+	mappedType := base()
+	mappedType.OldGUTIType = &mapped
+
+	if movingFrom5GSInIdleMode(mappedType) {
+		t.Error("a TAU whose Old GUTI is typed mapped is taken as an inter-system change from 5GS")
+	}
+}
+
+// idleArrivalMME is an MME with a bare S1 connection: a UE arriving from 5GS is
+// one this node has never seen.
+func idleArrivalMME(t *testing.T, peer *fakeFiveGSPeer) (*mme.MME, *mme.UeConn, *captureConn) {
+	t.Helper()
+
+	m := newTestMME(t)
+	m.FiveGS = peer
+
+	cc := &captureConn{}
+
+	conn := m.NewUeConn(cc, 7)
+	conn.ServingTAI = servedAttachTAI
+
+	return m, conn, cc
+}
+
+// TS 33.501 §8.5.2 steps 3-6: the MME cannot verify this message, so it asks the
+// AMF, and serves the update on the context that comes back.
+func TestInterSystemTAURecoversTheContextFromTheAMF(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})}
+
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	pdu := interSystemTAU(t, nil)
+
+	if got := dispositionForNAS(context.Background(), m, conn, pdu); got.Reason == nasreply.ReasonNoContext {
+		t.Fatalf("the update was dropped: %+v", got)
+	}
+
+	if len(peer.Requests) != 1 {
+		t.Fatalf("context requests = %d, want 1", len(peer.Requests))
+	}
+
+	// TS 23.003 §2.10.2.2.3: the MME reverse-maps the presented identity and the
+	// AMF compares it against its stored values.
+	if got := peer.Requests[0].Mapped5GGUTI.TMSI; got != [4]byte{0x00, 0x00, 0xde, 0xad} {
+		t.Errorf("the AMF was asked about 5G-TMSI %x, want the one the Old GUTI maps back to", got)
+	}
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound, so the UE would be told to re-attach")
+	}
+
+	if !ue.Secured() {
+		t.Error("the mapped EPS security context was not installed")
+	}
+
+	if !peer.Acked {
+		t.Fatal("the AMF was never acknowledged, so it keeps serving a UE that has left")
+	}
+
+	if len(peer.Transferred) != 1 || peer.Transferred[0] != 3 {
+		t.Errorf("acknowledged sessions = %v, want the adopted PDU session 3", peer.Transferred)
+	}
+
+	if p := m.LookupPDN(ue, 6); p == nil {
+		t.Error("the arriving PDU session was not published as a PDN connection on EBI 6")
+	}
+}
+
+// TS 24.301 §5.5.3.2.5: with no context to recover, the update resolves nothing
+// and the S1AP layer answers EMM cause #9, which sends the UE to re-attach.
+func TestInterSystemTAUWithoutARecoverableContext(t *testing.T) {
+	peer := &fakeFiveGSPeer{Err: interworking.ErrUnknownUEContext}
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	got := dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+	if got.Reason != nasreply.ReasonNoContext {
+		t.Fatalf("disposition = %+v, want the connection left bare", got)
+	}
+
+	if conn.UeContext() != nil {
+		t.Error("a context was minted for an update no peer vouched for")
+	}
+}
+
+func TestInterSystemTAUWithAFailedIntegrityCheck(t *testing.T) {
+	peer := &fakeFiveGSPeer{Err: interworking.ErrIntegrityCheckFailed}
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	if got := dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil)); got.Reason != nasreply.ReasonNoContext {
+		t.Fatalf("disposition = %+v, want the connection left bare", got)
+	}
+
+	if conn.UeContext() != nil {
+		t.Error("a context was minted for an update the AMF could not verify")
+	}
+}
+
+// An ordinary TAU on a bare connection still resolves nothing: only the
+// inter-system form recovers a context from the peer.
+func TestOrdinaryTAUOnABareConnectionMintsNothing(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})}
+
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	pdu := interSystemTAU(t, func(req *eps.TrackingAreaUpdateRequest) {
+		req.UEStatus = nil
+	})
+
+	if got := dispositionForNAS(context.Background(), m, conn, pdu); got.Reason != nasreply.ReasonNoContext {
+		t.Fatalf("disposition = %+v, want the connection left bare", got)
+	}
+
+	if len(peer.Requests) != 0 {
+		t.Error("the AMF was asked about an update that is not an inter-system change")
+	}
+}
+
+// TS 33.501 §8.5.2 steps 7-10: when the MME's policy names other algorithms than
+// the mapped context carries, it re-keys before answering the update.
+func TestInterSystemTAURekeysOnAnAlgorithmChange(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,
+	})}
+
+	m, conn, cc := idleArrivalMME(t, peer)
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	if len(cc.sent) == 0 {
+		t.Fatal("the MME sent nothing, want a SECURITY MODE COMMAND before the update is answered")
+	}
+
+	if ue.RegStep() != mme.RegStepSecurityMode {
+		t.Errorf("registration step = %v, want the security mode sub-phase", ue.RegStep())
+	}
+}

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -254,6 +254,106 @@ func TestOrdinaryTAUOnABareConnectionMintsNothing(t *testing.T) {
 	}
 }
 
+// TS 24.301 §4.4.4.3: a subscriber maps to exactly one context. Without the
+// commit the arriving context is never indexed by SUPI, so the 5GS peer's later
+// context acknowledgement finds nothing and this MME keeps PDN connections for a
+// UE that has left (TS 23.502 §4.11.1.3.3 step 14).
+func TestInterSystemTAUIndexesTheArrivingContextBySubscriber(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})}
+
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	supi, err := etsi.NewSUPIFromIMSI(testSubscriber.IMSI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := mme.NewUeContext()
+	stale.SetSupi(supi)
+	m.CommitUEIdentity(context.Background(), stale, mme.MintAuthProofForInterworking())
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	held, ok := m.LookupUeBySupi(supi)
+	if !ok {
+		t.Fatal("the subscriber resolves to no context, so the 5GS peer cannot acknowledge a later move back")
+	}
+
+	if held == stale {
+		t.Error("the subscriber still resolves to the context it held before the move")
+	}
+
+	if held != ue {
+		t.Errorf("the subscriber resolves to a context other than the one serving the update")
+	}
+
+	if err := m.MMContextAck(context.Background(), supi, nil); err != nil {
+		t.Errorf("MMContextAck: %v: a move back to 5GS would leave this MME serving PDN connections the UE has left", err)
+	}
+}
+
+// TS 23.401 §5.3.3.1 step 8, performed by TS 23.502 §4.11.1.3.2 steps 7-14:
+// with no bearer context at all the MME rejects the update rather than telling
+// the UE its connectivity survived. The 5GS peer keeps what it still holds
+// (TS 23.401 §5.3.3.1 step 7).
+func TestInterSystemTAUWithNothingToAdoptIsRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		conns []interworking.PDNConnection
+	}{
+		{
+			name: "the offered session has no subscription on this MME",
+			conns: []interworking.PDNConnection{
+				{PDUSessionID: 3, EPSBearerIdentity: 6, APN: "unsubscribed", Snssai: models.Snssai{Sst: 1, Sd: "010203"}},
+			},
+		},
+		{name: "the 5GS peer offered no session at all"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+				Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+			})
+			resp.PDNConnections = tc.conns
+
+			peer := &fakeFiveGSPeer{Response: resp}
+			m, conn, cc := idleArrivalMME(t, peer)
+
+			dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+			ue := conn.UeContext()
+			if ue == nil {
+				t.Fatal("no context was bound")
+			}
+
+			if cc.count() == 0 {
+				t.Fatal("the MME sent nothing, want a TRACKING AREA UPDATE REJECT")
+			}
+
+			plain := decodeProtectedDownlink(t, ue, cc.sent[0])
+
+			rej, err := eps.ParseTrackingAreaUpdateReject(plain)
+			if err != nil {
+				t.Fatalf("the MME answered something other than a reject, so the UE believes its bearers survived: %v", err)
+			}
+
+			if rej.Cause != eps.EMMCauseImplicitlyDetached {
+				t.Errorf("reject cause = %d, want #%d so the UE attaches afresh", rej.Cause, eps.EMMCauseImplicitlyDetached)
+			}
+
+			if peer.Acked {
+				t.Error("the 5GS peer was acknowledged for a transfer that moved nothing, so it released sessions the UE still needs")
+			}
+		})
+	}
+}
+
 // TS 33.501 §8.5.2 steps 7-10
 func TestInterSystemTAURekeysOnAnAlgorithmChange(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
@@ -275,5 +375,93 @@ func TestInterSystemTAURekeysOnAnAlgorithmChange(t *testing.T) {
 
 	if ue.RegStep() != mme.RegStepSecurityMode {
 		t.Errorf("registration step = %v, want the security mode sub-phase", ue.RegStep())
+	}
+}
+
+// TS 24.301 §4.4.3.1, §5.4.3.2; TS 33.401 §6.5. A context mapped from 5GS
+// inherits the 5G NAS COUNTs; changing its algorithms re-keys it under the same
+// K'ASME, which is not a new context, so neither side restarts the counters. The
+// UE keeps its uplink NAS COUNT because the eKSI matches its current mapped
+// context (TS 24.301 §5.4.3.3).
+func TestInterSystemTAURekeyKeepsTheMappedNASCounts(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,
+	})}
+
+	m, conn, cc := idleArrivalMME(t, peer)
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	if cc.count() == 0 {
+		t.Fatal("the MME sent nothing, want a SECURITY MODE COMMAND")
+	}
+
+	if got := ue.ULCount(); got != 8 {
+		t.Errorf("next expected uplink NAS COUNT = %d, want 8 after the inherited 7: the MME would reject the Security Mode Complete the UE sends", got)
+	}
+
+	wire := decodeDownlinkNAS(t, cc.sent[0])
+	if len(wire) < 6 {
+		t.Fatalf("downlink NAS message is %d octets, too short to be security protected", len(wire))
+	}
+
+	if wire[5] != 2 {
+		t.Errorf("Security Mode Command rides NAS sequence number %d, want the inherited downlink COUNT 2", wire[5])
+	}
+
+	plain := decodeProtectedDownlink(t, ue, cc.sent[0])
+	if _, err := eps.ParseSecurityModeCommand(plain); err != nil {
+		t.Fatalf("the re-keyed Security Mode Command does not verify under the new algorithms: %v", err)
+	}
+}
+
+// TS 33.401 §7.2.4.4, TS 24.301 §5.4.3.3. The UE checks the replay against what
+// it sent, and §8.2.29.7 makes the UE network capability IE mandatory in every
+// non-periodic TRACKING AREA UPDATE REQUEST, so the peer's relayed copy is never
+// the one to replay.
+func TestInterSystemTAURekeyReplaysTheCapabilitiesTheUEJustSent(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,
+	})}
+
+	m, conn, cc := idleArrivalMME(t, peer)
+
+	sent := eps.UENetworkCapability{EEA: 0x20, EIA: 0x20, HasUMTS: true, UEA: 0x40, UIA: 0x40}
+
+	ms, err := eps.ParseMSNetworkCapability([]byte{0x80, 0x00})
+	if err != nil {
+		t.Fatalf("ParseMSNetworkCapability: %v", err)
+	}
+
+	pdu := interSystemTAU(t, func(req *eps.TrackingAreaUpdateRequest) {
+		req.UENetworkCapability = &sent
+		req.MSNetworkCapability = &ms
+	})
+
+	dispositionForNAS(context.Background(), m, conn, pdu)
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	if cc.count() == 0 {
+		t.Fatal("the MME sent nothing, want a SECURITY MODE COMMAND")
+	}
+
+	smc, err := eps.ParseSecurityModeCommand(decodeProtectedDownlink(t, ue, cc.sent[0]))
+	if err != nil {
+		t.Fatalf("parse Security Mode Command: %v", err)
+	}
+
+	want := eps.ReplayedUESecurityCapability(sent, &ms)
+	if smc.ReplayedUESecurityCapability != want {
+		t.Errorf("replayed UE security capability = %+v, want the %+v derived from the update's own IEs: the UE answers Security Mode Reject on a mismatch",
+			smc.ReplayedUESecurityCapability, want)
 	}
 }

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -206,6 +206,41 @@ func TestInterSystemTAURecoversTheContextFromTheAMF(t *testing.T) {
 	}
 }
 
+// TS 24.301 §5.1.3.4.3, §5.5.3.2.4
+func TestInterSystemTAULeavesTheUERegistered(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})}
+
+	m, conn, _ := idleArrivalMME(t, peer)
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	if got := ue.EMMState(); got != mme.EMMRegistered {
+		t.Fatalf("EMM state after the accepted update = %v, want %v", got, mme.EMMRegistered)
+	}
+
+	m.ReleaseUEContextLocally(ue, "test")
+
+	if p := m.LookupPDN(ue, 6); p == nil {
+		t.Error("the S1 release destroyed the PDN connection the inter-system change moved")
+	}
+
+	supi, err := etsi.NewSUPIFromIMSI(testSubscriber.IMSI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := m.LookupUeBySupi(supi); !ok {
+		t.Error("the S1 release removed the context, so the UE cannot be paged and cannot move back to 5GS")
+	}
+}
+
 // TS 24.301 §5.5.3.2.7 d)
 func TestRepeatedInterSystemTAUReKeysTheHeldContext(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
@@ -292,6 +327,91 @@ func TestInterSystemTAUAfterTheProcedureCompletedStartsAfresh(t *testing.T) {
 
 	if !peer.Acked {
 		t.Error("the AMF was not acknowledged, so it keeps serving a UE that has left again")
+	}
+}
+
+type crossAccessSessionManager struct {
+	fakeSessionManager
+	onEPS     map[string]bool
+	destroyed map[string]bool
+}
+
+func newCrossAccessSessionManager() *crossAccessSessionManager {
+	return &crossAccessSessionManager{onEPS: map[string]bool{}, destroyed: map[string]bool{}}
+}
+
+func (f *crossAccessSessionManager) ReleaseEPSSession(_ context.Context, ref string) error {
+	if f.onEPS[ref] {
+		f.destroyed[ref] = true
+		delete(f.onEPS, ref)
+	}
+
+	return nil
+}
+
+func (f *crossAccessSessionManager) TransferIdleToEPS(ctx context.Context, supi etsi.SUPI, pduSessionID, epsBearerIdentity uint8, dnn string, snssai *models.Snssai) (models.EPSBearer, error) {
+	bearer, err := f.fakeSessionManager.TransferIdleToEPS(ctx, supi, pduSessionID, epsBearerIdentity, dnn, snssai)
+	if err != nil {
+		return models.EPSBearer{}, err
+	}
+
+	if f.destroyed[bearer.Ref] {
+		return models.EPSBearer{}, interworking.ErrUnknownUEContext
+	}
+
+	f.onEPS[bearer.Ref] = true
+
+	return bearer, nil
+}
+
+// TS 24.301 §4.4.4.3, §5.5.1.2.7 f)
+func TestInterSystemTAUKeepsTheArrivingSessionAStaleContextStillNames(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
+	})}
+
+	sessions := newCrossAccessSessionManager()
+
+	m, conn, _ := idleArrivalMME(t, peer)
+	m.Session = sessions
+
+	supi, err := etsi.NewSUPIFromIMSI(testSubscriber.IMSI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := mme.NewUeContext()
+	stale.SetSupi(supi)
+
+	if got := m.AdoptIdlePDNs(context.Background(), stale, peer.Response.PDNConnections); len(got) != 1 {
+		t.Fatalf("the stale context adopted %d sessions, want the 1 it later names", len(got))
+	}
+
+	sessions.onEPS = map[string]bool{}
+
+	m.CommitUEIdentity(context.Background(), stale, mme.MintAuthProofForInterworking())
+
+	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	if ue == stale {
+		t.Fatal("the update resumed the stale context")
+	}
+
+	for ref := range sessions.destroyed {
+		t.Errorf("superseding the stale context destroyed session %q, the one the update is moving onto EPS", ref)
+	}
+
+	if p := m.LookupPDN(ue, 6); p == nil {
+		t.Error("the arriving PDU session was not published as a PDN connection on EBI 6")
+	}
+
+	if len(peer.Transferred) != 1 || peer.Transferred[0] != 3 {
+		t.Errorf("acknowledged sessions = %v, want the adopted PDU session 3", peer.Transferred)
 	}
 }
 
@@ -614,5 +734,44 @@ func deferredTAUResumes(t *testing.T, tail []byte) {
 	plain := decodeProtectedDownlink(t, ue, cc.sent[cc.count()-1])
 	if _, err := eps.ParseTrackingAreaUpdateAccept(plain); err != nil {
 		t.Fatalf("the resumed update was not answered with a TRACKING AREA UPDATE ACCEPT: %v", err)
+	}
+
+	if got := ue.EMMState(); got != mme.EMMRegistered {
+		t.Errorf("EMM state after the resumed update = %v, want %v", got, mme.EMMRegistered)
+	}
+}
+
+// TS 24.301 §4.4.2.3, §5.4.3.7 a); TS 33.501 §8.5.2 step 7
+func TestInterSystemTAUIsAnsweredWhenTheRekeyCannotStart(t *testing.T) {
+	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
+		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,
+	})}
+
+	m, conn, cc := idleArrivalMME(t, peer)
+
+	plain := interSystemTAU(t, nil)
+
+	dispositionForNAS(context.Background(), m, conn, plain)
+
+	ue := conn.UeContext()
+	if ue == nil {
+		t.Fatal("no context was bound")
+	}
+
+	if cc.count() == 0 {
+		t.Fatal("the update sent nothing, want a SECURITY MODE COMMAND holding the key chain")
+	}
+
+	conn.DeferredTAUPlain = nil
+
+	answered := changeNASAlgorithmsForMappedContext(context.Background(), m, ue, conn, plain,
+		interworking.EPSNASAlgorithms{Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G})
+
+	if answered {
+		t.Error("the update is reported as answered though no Security Mode Command was sent, so the UE waits out T3430")
+	}
+
+	if conn.DeferredTAUPlain != nil {
+		t.Error("the update was buffered behind a command that never left, so nothing will replay it")
 	}
 }

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -254,10 +254,7 @@ func TestOrdinaryTAUOnABareConnectionMintsNothing(t *testing.T) {
 	}
 }
 
-// TS 24.301 §4.4.4.3: a subscriber maps to exactly one context. Without the
-// commit the arriving context is never indexed by SUPI, so the 5GS peer's later
-// context acknowledgement finds nothing and this MME keeps PDN connections for a
-// UE that has left (TS 23.502 §4.11.1.3.3 step 14).
+// TS 24.301 §4.4.4.3
 func TestInterSystemTAUIndexesTheArrivingContextBySubscriber(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
 		Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES,
@@ -299,10 +296,7 @@ func TestInterSystemTAUIndexesTheArrivingContextBySubscriber(t *testing.T) {
 	}
 }
 
-// TS 23.401 §5.3.3.1 step 8, performed by TS 23.502 §4.11.1.3.2 steps 7-14:
-// with no bearer context at all the MME rejects the update rather than telling
-// the UE its connectivity survived. The 5GS peer keeps what it still holds
-// (TS 23.401 §5.3.3.1 step 7).
+// TS 23.401 §5.3.3.1 step 8, TS 24.301 annex A.2 cause #40
 func TestInterSystemTAUWithNothingToAdoptIsRejected(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -343,8 +337,9 @@ func TestInterSystemTAUWithNothingToAdoptIsRejected(t *testing.T) {
 				t.Fatalf("the MME answered something other than a reject, so the UE believes its bearers survived: %v", err)
 			}
 
-			if rej.Cause != eps.EMMCauseImplicitlyDetached {
-				t.Errorf("reject cause = %d, want #%d so the UE attaches afresh", rej.Cause, eps.EMMCauseImplicitlyDetached)
+			if rej.Cause != eps.EMMCauseNoEPSBearerContextActivated {
+				t.Errorf("reject cause = %d, want #%d so the UE drops its mapped bearers and attaches afresh",
+					rej.Cause, eps.EMMCauseNoEPSBearerContextActivated)
 			}
 
 			if peer.Acked {
@@ -378,11 +373,7 @@ func TestInterSystemTAURekeysOnAnAlgorithmChange(t *testing.T) {
 	}
 }
 
-// TS 24.301 §4.4.3.1, §5.4.3.2; TS 33.401 §6.5. A context mapped from 5GS
-// inherits the 5G NAS COUNTs; changing its algorithms re-keys it under the same
-// K'ASME, which is not a new context, so neither side restarts the counters. The
-// UE keeps its uplink NAS COUNT because the eKSI matches its current mapped
-// context (TS 24.301 §5.4.3.3).
+// TS 24.301 §4.4.3.1, §5.4.3.2; TS 33.401 §6.5.
 func TestInterSystemTAURekeyKeepsTheMappedNASCounts(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
 		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,
@@ -420,10 +411,7 @@ func TestInterSystemTAURekeyKeepsTheMappedNASCounts(t *testing.T) {
 	}
 }
 
-// TS 33.401 §7.2.4.4, TS 24.301 §5.4.3.3. The UE checks the replay against what
-// it sent, and §8.2.29.7 makes the UE network capability IE mandatory in every
-// non-periodic TRACKING AREA UPDATE REQUEST, so the peer's relayed copy is never
-// the one to replay.
+// TS 33.401 §7.2.4.4, TS 24.301 §5.4.3.3.
 func TestInterSystemTAURekeyReplaysTheCapabilitiesTheUEJustSent(t *testing.T) {
 	peer := &fakeFiveGSPeer{Response: arrivingEPSContext(t, interworking.EPSNASAlgorithms{
 		Ciphering: nas.CipheringNull, Integrity: nas.IntegritySNOW3G,

--- a/internal/mme/nas/nas_gate_test.go
+++ b/internal/mme/nas/nas_gate_test.go
@@ -29,8 +29,8 @@ func TestIsAttachRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isAttachRequest(tt.nas); got != tt.want {
-				t.Fatalf("isAttachRequest = %v, want %v", got, tt.want)
+			if got := peekEMMMessageType(tt.nas) == eps.MsgAttachRequest; got != tt.want {
+				t.Fatalf("peekEMMMessageType names an ATTACH REQUEST = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/mme/nas/nas_security_nas_test.go
+++ b/internal/mme/nas/nas_security_nas_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas/eps"
 )
 
+// TS 24.301 §5.4.3.5
 func TestStartSecurityModeRejectsNoCommonIntegrity(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
@@ -19,10 +21,40 @@ func TestStartSecurityModeRejectsNoCommonIntegrity(t *testing.T) {
 	ue.SetKASMEForTest(make([]byte, 32))
 	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xff, EIA: 0x00}, nil, mme.MintAuthProofForAttachRequest())
 
-	startSecurityMode(context.Background(), m, ue, ue.Conn(), freshKeys)
+	if got := startSecurityMode(context.Background(), m, ue, ue.Conn(), freshKeys); got != securityModeNoCommonAlgorithm {
+		t.Fatalf("outcome = %d, want the no-common-algorithm report", got)
+	}
 
 	if ue.SecuredForTest() {
 		t.Fatal("UE secured despite no common integrity algorithm")
+	}
+
+	if cc.count() != 0 {
+		t.Fatalf("the security mode procedure sent %d messages, want the triggering procedure to answer", cc.count())
+	}
+}
+
+// TS 24.301 §5.5.1.2.5
+func TestAttachWithNoCommonIntegrityIsRejected(t *testing.T) {
+	m := newTestMME(t)
+	cc := &captureConn{}
+	ue := newAttachUe(m, cc, 7)
+	ue.SetIMSIForTest(testSubscriber.IMSI)
+	ue.ForceRegStepForTest(mme.RegStepAuthenticating)
+	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xff, EIA: 0x00}, nil, mme.MintAuthProofForAttachRequest())
+
+	xres := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	ue.Conn().AuthVector = &udm.EPSAV{XRES: xres, KASME: make([]byte, 32)}
+
+	resp, err := (&eps.AuthenticationResponse{RES: xres}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	HandleNAS(context.Background(), m, ue.Conn(), resp)
+
+	if cc.count() == 0 {
+		t.Fatal("the MME answered nothing, so the UE waits out T3410 before re-attaching")
 	}
 
 	reject, err := eps.ParseAttachReject(decodeDownlinkNAS(t, cc.sent[0]))
@@ -35,10 +67,7 @@ func TestStartSecurityModeRejectsNoCommonIntegrity(t *testing.T) {
 	}
 }
 
-// TestStartSecurityModeClaimsKeyChain asserts the security mode procedure claims
-// the {NH,NCC} key chain while the SECURITY MODE COMMAND is in flight, so a
-// concurrent S1 handover / Path Switch is refused (TS 33.501 §6.9.5.1, TS 33.401
-// §7.2.8).
+// TS 33.501 §6.9.5.1, TS 33.401 §7.2.8
 func TestStartSecurityModeClaimsKeyChain(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}

--- a/internal/mme/nas/nas_security_nas_test.go
+++ b/internal/mme/nas/nas_security_nas_test.go
@@ -19,7 +19,7 @@ func TestStartSecurityModeRejectsNoCommonIntegrity(t *testing.T) {
 	ue.SetKASMEForTest(make([]byte, 32))
 	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xff, EIA: 0x00}, nil, mme.MintAuthProofForAttachRequest())
 
-	startSecurityMode(context.Background(), m, ue, ue.Conn())
+	startSecurityMode(context.Background(), m, ue, ue.Conn(), freshKeys)
 
 	if ue.SecuredForTest() {
 		t.Fatal("UE secured despite no common integrity algorithm")
@@ -47,7 +47,7 @@ func TestStartSecurityModeClaimsKeyChain(t *testing.T) {
 	ue.SetKASMEForTest(make([]byte, 32))
 	ue.SetUESecurityCapability(eps.UENetworkCapability{EEA: 0xff, EIA: 0xff}, nil, mme.MintAuthProofForAttachRequest())
 
-	startSecurityMode(context.Background(), m, ue, ue.Conn())
+	startSecurityMode(context.Background(), m, ue, ue.Conn(), freshKeys)
 
 	if len(cc.sent) == 0 {
 		t.Fatal("expected a Security Mode Command to be sent")

--- a/internal/mme/nas/network_name_test.go
+++ b/internal/mme/nas/network_name_test.go
@@ -22,6 +22,7 @@ func (spnBearerStore) GetOperator(_ context.Context) (*db.Operator, error) {
 		Mcc: "001", Mnc: "01", SupportedTACs: `["1"]`,
 		Ciphering: `["AES"]`, Integrity: `["AES"]`,
 		SpnFullName: "Ella", SpnShortName: "Ella",
+		AmfRegionID: 1, AmfSetID: 1,
 	}, nil
 }
 

--- a/internal/mme/nas/security_mode.go
+++ b/internal/mme/nas/security_mode.go
@@ -19,7 +19,15 @@ const (
 	rekeyedKeys
 )
 
-func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, install keyInstall) {
+type securityModeOutcome uint8
+
+const (
+	securityModeCommandSent securityModeOutcome = iota
+	securityModeNoCommonAlgorithm
+	securityModeNotSent
+)
+
+func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, install keyInstall) securityModeOutcome {
 	// TS 33.501 §6.9.5.1 / TS 33.401 §7.2.8: the security mode procedure re-keys the
 	// AS context, so it must not run concurrently with an S1 handover or Path Switch
 	// advancing the {NH, NCC} chain. Claim the chain; if a handover holds it, defer.
@@ -27,7 +35,7 @@ func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 		logger.From(ctx, logger.MmeLog).Warn("not starting Security Mode Command: a key-changing procedure is in progress (TS 33.401 §7.2.8)",
 			zap.String("imsi", ue.IMSI()))
 
-		return
+		return securityModeNotSent
 	}
 
 	// Release the claim if the SECURITY MODE COMMAND is not sent, so a failure before
@@ -45,16 +53,15 @@ func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 	intOrder, encOrder, err := m.SecurityAlgorithms(ctx)
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to resolve operator security policy", zap.Error(err))
-		return
+		return securityModeNotSent
 	}
 
 	eea, eia, ok := eps.SelectNASAlgorithms(ue.UeNetCap(), intOrder, encOrder)
 	if !ok {
 		logger.From(ctx, logger.MmeLog).Warn("no NAS security algorithm common to UE and operator policy",
 			zap.Stringer("ue-network-capability", ue.UeNetCap()))
-		rejectAttach(ctx, m, ue, ueConn, eps.EMMCauseUESecurityCapabilitiesMismatch)
 
-		return
+		return securityModeNoCommonAlgorithm
 	}
 
 	installKeys := ue.InstallNASSecurityContext
@@ -64,7 +71,7 @@ func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 
 	if err := installKeys(eea, eia, mme.MintAuthProofForSecurityMode()); err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to install NAS security context", zap.Error(err))
-		return
+		return securityModeNotSent
 	}
 
 	imeisvRequested := eps.IMEISVRequested
@@ -81,7 +88,7 @@ func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 	plain, err := smc.MarshalBinary()
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build Security Mode Command", zap.Error(err))
-		return
+		return securityModeNotSent
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Security Mode Command",
@@ -91,10 +98,12 @@ func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 		zap.Stringer("replayed-ue-security-capability", smc.ReplayedUESecurityCapability))
 
 	if err := ueConn.SendGuardedProtected(ctx, "Security Mode Command", plain, eps.SHTIntegrityProtectedNewContext); err != nil {
-		return
+		return securityModeNotSent
 	}
 
 	ue.AdvanceRegStep(mme.RegStepSecurityMode)
 
 	committed = true
+
+	return securityModeCommandSent
 }

--- a/internal/mme/nas/security_mode.go
+++ b/internal/mme/nas/security_mode.go
@@ -12,7 +12,14 @@ import (
 	"go.uber.org/zap"
 )
 
-func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn) {
+type keyInstall uint8
+
+const (
+	freshKeys keyInstall = iota
+	rekeyedKeys
+)
+
+func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, install keyInstall) {
 	// TS 33.501 §6.9.5.1 / TS 33.401 §7.2.8: the security mode procedure re-keys the
 	// AS context, so it must not run concurrently with an S1 handover or Path Switch
 	// advancing the {NH, NCC} chain. Claim the chain; if a handover holds it, defer.
@@ -50,7 +57,12 @@ func startSecurityMode(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 		return
 	}
 
-	if err := ue.InstallNASSecurityContext(eea, eia, mme.MintAuthProofForSecurityMode()); err != nil {
+	installKeys := ue.InstallNASSecurityContext
+	if install == rekeyedKeys {
+		installKeys = ue.RekeyNASSecurityContext
+	}
+
+	if err := installKeys(eea, eia, mme.MintAuthProofForSecurityMode()); err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to install NAS security context", zap.Error(err))
 		return
 	}

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -16,10 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// handleTrackingAreaUpdate handles a verified TRACKING AREA UPDATE REQUEST
-// (TS 24.301). A UE already ECM-CONNECTED keeps its bearers; a UE returning from
-// ECM-IDLE re-establishes them when it sets the active flag, else is released back
-// to ECM-IDLE after acknowledging the accept.
 func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, req *eps.TrackingAreaUpdateRequest, plain []byte) nasreply.Disposition {
 	logger.From(ctx, logger.MmeLog).Info("Tracking Area Update Request",
 		zap.String("imsi", ue.IMSI()),
@@ -58,17 +54,20 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		ue.SetUESecurityCapability(ueNetCap, msNetCap, mme.MintAuthProofForTrackingAreaUpdate())
 	}
 
-	if completeIdleMobilityFrom5GS(ctx, m, ue, ueConn, plain) {
-		return nasreply.Handled()
-	}
+	adoptIdlePDNsFrom5GS(ctx, m, ue, ueConn)
 
 	if req.EPSBearerContextStatus != nil {
 		reconcileBearerContextStatus(ctx, m, ue, *req.EPSBearerContextStatus)
 	}
 
+	if completeIdleMobilityFrom5GS(ctx, m, ue, ueConn, plain) {
+		return nasreply.Handled()
+	}
+
 	accept, err := trackingAreaUpdateAccept(ctx, m, ue, tauAcceptOptions{
-		combined:     isCombinedUpdate(uint8(req.EPSUpdateType)),
-		bearerStatus: req.EPSBearerContextStatus != nil && len(m.SnapshotPDNs(ue)) > 0,
+		combined: isCombinedUpdate(uint8(req.EPSUpdateType)),
+		bearerStatus: (req.EPSBearerContextStatus != nil || ue.LocalBearerDeactivationPending()) &&
+			len(m.SnapshotPDNs(ue)) > 0,
 	})
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build Tracking Area Update Accept", zap.String("imsi", ue.IMSI()), zap.Error(err))
@@ -131,6 +130,10 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 
 	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultAccept)
 
+	if ue.IdleMobilityFrom5GSPending() {
+		ue.TransitionTo(mme.EMMRegistered)
+	}
+
 	ueConn.TauRequestPlain = plain
 	ueConn.TauAcceptPlain = acceptPlain
 
@@ -165,6 +168,7 @@ func handleTrackingAreaUpdateComplete(ctx context.Context, m *mme.MME, ue *mme.U
 	ueConn.StopNASGuard()
 	m.CommitGUTIRealloc(ue)
 	ue.EndIdleMobilityFrom5GS()
+	ue.ClearLocalBearerDeactivation()
 
 	ueConn.TauRequestPlain = nil
 	ueConn.TauAcceptPlain = nil

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -62,7 +62,7 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		ue.SetUESecurityCapability(ueNetCap, msNetCap, mme.MintAuthProofForTrackingAreaUpdate())
 	}
 
-	if completeIdleMobilityFrom5GS(ctx, m, ue, ueConn, req, plain) {
+	if completeIdleMobilityFrom5GS(ctx, m, ue, ueConn, plain) {
 		return nasreply.Handled()
 	}
 

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -67,7 +67,8 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	}
 
 	accept, err := trackingAreaUpdateAccept(ctx, m, ue, tauAcceptOptions{
-		combined: isCombinedUpdate(uint8(req.EPSUpdateType)),
+		combined:     isCombinedUpdate(uint8(req.EPSUpdateType)),
+		bearerStatus: req.EPSBearerContextStatus != nil && len(m.SnapshotPDNs(ue)) > 0,
 	})
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build Tracking Area Update Accept", zap.String("imsi", ue.IMSI()), zap.Error(err))
@@ -203,6 +204,10 @@ func isCombinedUpdate(updateType uint8) bool {
 
 type tauAcceptOptions struct {
 	combined bool
+	// bearerStatus reports the active EPS bearer contexts, which the accept
+	// carries when the request asked for them and the MME holds at least one
+	// (TS 24.301 §5.5.3.2.4).
+	bearerStatus bool
 }
 
 // trackingAreaUpdateAccept builds a TRACKING AREA UPDATE ACCEPT with the operator's
@@ -248,8 +253,10 @@ func trackingAreaUpdateAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		accept.Cause = &cause
 	}
 
-	status := bearerContextStatus(m, ue)
-	accept.EPSBearerContextStatus = &status
+	if opts.bearerStatus {
+		status := bearerContextStatus(m, ue)
+		accept.EPSBearerContextStatus = &status
+	}
 
 	return accept, nil
 }

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -26,7 +26,6 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		zap.String("update-type", epsUpdateTypeName(uint8(req.EPSUpdateType))),
 		zap.Bool("active-flag", req.ActiveFlag))
 
-	// TS 24.301 §5.5.3.2.7 case d: an identical retransmission gets the stored accept.
 	if len(ueConn.TauAcceptPlain) > 0 && bytes.Equal(plain, ueConn.TauRequestPlain) {
 		logger.From(ctx, logger.MmeLog).Info("duplicate Tracking Area Update Request with identical IEs; resending Tracking Area Update Accept",
 			zap.String("imsi", ue.IMSI()))
@@ -35,8 +34,6 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	// The UE's serving cell must be in this MME's served area, as at attach, or TAU
-	// REJECT #12 (TS 24.301 §5.5.3.2.5).
 	if served, err := m.ServesTAI(ctx, ueConn.ServingTAI); err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to evaluate serving TAI for Tracking Area Update", zap.Error(err))
 		return nasreply.Handled()
@@ -47,9 +44,10 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	// When the UE reports its EPS bearer context status, the MME deactivates the
-	// bearers it holds but the UE considers inactive, then reflects the resulting
-	// active set in the accept (TS 24.301 §5.5.3.2.4).
+	if completeIdleMobilityFrom5GS(ctx, m, ue, ueConn, req, plain) {
+		return nasreply.Handled()
+	}
+
 	if req.EPSBearerContextStatus != nil {
 		reconcileBearerContextStatus(ctx, m, ue, *req.EPSBearerContextStatus)
 	}
@@ -104,8 +102,6 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 
 	var releaseOnComplete bool
 
-	// A fully connected UE (bearers up) keeps its connection; a UE resuming for this
-	// TAU needs re-establishment or a deferred release.
 	switch {
 	case ueConn.ICS == mme.ICSCompleted:
 		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update accepted", zap.String("imsi", ue.IMSI()))
@@ -152,8 +148,6 @@ func rejectTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
 	ueConn.StopNASGuard()
 
-	// A secured UE discards an unprotected downlink (TS 24.301 §4.4.4.2); the
-	// plain form is for the rejects preceding security activation.
 	reject := &eps.TrackingAreaUpdateReject{Cause: cause}
 	if ue.Secured() {
 		ueConn.SendDownlinkProtected(ctx, reject)

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -44,14 +44,10 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	if completeIdleMobilityFrom5GS(ctx, m, ue, ueConn, req, plain) {
-		return nasreply.Handled()
-	}
-
-	if req.EPSBearerContextStatus != nil {
-		reconcileBearerContextStatus(ctx, m, ue, *req.EPSBearerContextStatus)
-	}
-
+	// Ahead of any security mode command this update may start, so the command
+	// replays the capabilities of this TRACKING AREA UPDATE REQUEST rather than
+	// an earlier copy the UE cannot match (TS 33.401 §7.2.4.4,
+	// TS 24.301 §5.4.3.3, §8.2.29.7).
 	if req.UENetworkCapability != nil || req.MSNetworkCapability != nil {
 		ueNetCap := ue.UeNetCap()
 		if req.UENetworkCapability != nil {
@@ -64,6 +60,14 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		}
 
 		ue.SetUESecurityCapability(ueNetCap, msNetCap, mme.MintAuthProofForTrackingAreaUpdate())
+	}
+
+	if completeIdleMobilityFrom5GS(ctx, m, ue, ueConn, req, plain) {
+		return nasreply.Handled()
+	}
+
+	if req.EPSBearerContextStatus != nil {
+		reconcileBearerContextStatus(ctx, m, ue, *req.EPSBearerContextStatus)
 	}
 
 	accept, err := trackingAreaUpdateAccept(ctx, m, ue, tauAcceptOptions{

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -44,10 +44,6 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	// Ahead of any security mode command this update may start, so the command
-	// replays the capabilities of this TRACKING AREA UPDATE REQUEST rather than
-	// an earlier copy the UE cannot match (TS 33.401 §7.2.4.4,
-	// TS 24.301 §5.4.3.3, §8.2.29.7).
 	if req.UENetworkCapability != nil || req.MSNetworkCapability != nil {
 		ueNetCap := ue.UeNetCap()
 		if req.UENetworkCapability != nil {
@@ -168,6 +164,7 @@ func rejectTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 func handleTrackingAreaUpdateComplete(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn) nasreply.Disposition {
 	ueConn.StopNASGuard()
 	m.CommitGUTIRealloc(ue)
+	ue.EndIdleMobilityFrom5GS()
 
 	ueConn.TauRequestPlain = nil
 	ueConn.TauAcceptPlain = nil

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -235,7 +235,7 @@ func trackingAreaUpdateAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nil, err
 	}
 
-	mmeGroupID, mmeCode := m.MmeIdentity()
+	mmeGroupID, mmeCode := operator.GUMMEI()
 
 	guti, err := m.ReallocateGUTI(ctx, ue, plmn, mmeGroupID, mmeCode)
 	if err != nil {

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -203,10 +203,7 @@ func isCombinedUpdate(updateType uint8) bool {
 }
 
 type tauAcceptOptions struct {
-	combined bool
-	// bearerStatus reports the active EPS bearer contexts, which the accept
-	// carries when the request asked for them and the MME holds at least one
-	// (TS 24.301 §5.5.3.2.4).
+	combined     bool
 	bearerStatus bool
 }
 

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -222,6 +222,62 @@ func TestTrackingAreaUpdateReconcilesBearerContextStatus(t *testing.T) {
 	}
 }
 
+// TS 24.301 §5.5.3.2.4: the accept reports the active bearers when the request
+// asked for them, "except for the case no EPS bearer context exists on the
+// network side".
+func TestTrackingAreaUpdateOmitsTheBearerStatusWithNoBearer(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	status := uint16(1 << 5)
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, &status))
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected one downlink (TAU Accept), got %d", len(cc.sent))
+	}
+
+	if parsed := parseTAUAccept(t, ue, cc.sent[0]); parsed.EPSBearerContextStatus != nil {
+		t.Fatalf("TAU Accept bearer status = %v, want the IE omitted for a UE with no bearer", parsed.EPSBearerContextStatus)
+	}
+}
+
+func TestTrackingAreaUpdateOmitsTheBearerStatusWhenNoneWasAsked(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	m.AddDefaultPDN(ue)
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected one downlink (TAU Accept), got %d", len(cc.sent))
+	}
+
+	if parsed := parseTAUAccept(t, ue, cc.sent[0]); parsed.EPSBearerContextStatus != nil {
+		t.Fatalf("TAU Accept bearer status = %v, want the IE omitted: the request carried none and nothing was deactivated",
+			parsed.EPSBearerContextStatus)
+	}
+}
+
+func parseTAUAccept(t *testing.T, ue *mme.UeContext, sent []byte) *eps.TrackingAreaUpdateAccept {
+	t.Helper()
+
+	dl := decodeDownlinkNAS(t, sent)
+
+	accept, err := unprotected(eps.Unprotect(dl, nas.MakeCount(0, dl[5]), nas.DirectionDownlink,
+		mustSecurityContext(t, ue.EIA(), ue.EEA(), ue.KnasIntForTest(), ue.KnasEncForTest())))
+	if err != nil {
+		t.Fatalf("unprotect TAU Accept: %v", err)
+	}
+
+	parsed, err := eps.ParseTrackingAreaUpdateAccept(accept)
+	if err != nil {
+		t.Fatalf("parse TAU Accept: %v", err)
+	}
+
+	return parsed
+}
+
 // TestTrackingAreaUpdateCombinedSignalsCSDomainUnavailable checks that a
 // combined TAU (the UE also requesting CS-domain registration) is accepted for
 // EPS services only with EMM cause #18, so the UE stops attempting CS

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -267,7 +267,11 @@ func TestTrackingAreaUpdateReallocatesGUTI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	group, code := m.MmeIdentity()
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := m.ReallocateGUTI(t.Context(), ue, plmn, group, code); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -440,8 +440,8 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 
 	mmes1ap.HandleInitialUEMessage(m, context.Background(), mme.NewRadioForTest(cc), initiatingValue(t, initialUEMessagePDU(t, 7, pdu)))
 
-	if len(cc.sent) != 1 {
-		t.Fatalf("expected one downlink (TAU Reject), got %d", len(cc.sent))
+	if len(cc.sent) != 2 {
+		t.Fatalf("expected a TAU Reject and a UE Context Release Command, got %d messages", len(cc.sent))
 	}
 
 	rej, err := eps.ParseTrackingAreaUpdateReject(decodeDownlinkNAS(t, cc.sent[0]))
@@ -453,9 +453,58 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 		t.Fatalf("TAU Reject cause = %d, want %d", rej.Cause, eps.EMMCauseUEIdentityCannotBeDerived)
 	}
 
-	if m.ConnCountForTest() != 0 {
-		t.Fatalf("bare connection not released after the TAU Reject: %d remain", m.ConnCountForTest())
+	// TS 24.301 §5.3.1.2.1 d), TS 36.413 §8.3.1
+	cmd := parseUEContextReleaseCommandPDU(t, cc.sent[1])
+	if cmd.UES1APIDs.ENBUES1APID != 7 {
+		t.Fatalf("release command names eNB-UE-S1AP-ID %d, want the rejected connection's 7", cmd.UES1APIDs.ENBUES1APID)
 	}
+
+	// TS 36.413 §8.3.3.1: the eNB can name the connection until it answers.
+	if m.ConnCountForTest() != 1 {
+		t.Fatalf("the MME-UE-S1AP-ID was freed before the Release Complete: %d connections remain", m.ConnCountForTest())
+	}
+
+	complete := &s1ap.UEContextReleaseComplete{
+		MMEUES1APID: s1ap.Ptr(cmd.UES1APIDs.MMEUES1APID),
+		ENBUES1APID: s1ap.Ptr(cmd.UES1APIDs.ENBUES1APID),
+	}
+
+	b, err := complete.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cpdu, err := s1ap.Unmarshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mmes1ap.HandleUEContextReleaseComplete(m, context.Background(), mme.NewRadioForTest(cc), cpdu.(*s1ap.SuccessfulOutcome).Value)
+
+	if m.ConnCountForTest() != 0 {
+		t.Fatalf("bare connection not released after the Release Complete: %d remain", m.ConnCountForTest())
+	}
+}
+
+func parseUEContextReleaseCommandPDU(t *testing.T, pdu []byte) *s1ap.UEContextReleaseCommand {
+	t.Helper()
+
+	msg, err := s1ap.Unmarshal(pdu)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	im, ok := msg.(*s1ap.InitiatingMessage)
+	if !ok || im.ProcedureCode != s1ap.ProcUEContextRelease {
+		t.Fatalf("expected a UE Context Release Command, got %T", msg)
+	}
+
+	cmd, err := s1ap.ParseUEContextReleaseCommand(im.Value)
+	if err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+
+	return cmd
 }
 
 func TestTrackingAreaUpdateStoresReplayedCapabilities(t *testing.T) {

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -287,7 +287,6 @@ func TestTrackingAreaUpdateReportsALocalDeactivation(t *testing.T) {
 	}
 }
 
-// The obligation is discharged once the UE acknowledges the accept that carried it.
 func TestTrackingAreaUpdateReportsALocalDeactivationOnce(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
@@ -511,13 +510,11 @@ func TestTrackingAreaUpdateRecovery(t *testing.T) {
 		t.Fatalf("TAU Reject cause = %d, want %d", rej.Cause, eps.EMMCauseUEIdentityCannotBeDerived)
 	}
 
-	// TS 24.301 §5.3.1.2.1 d), TS 36.413 §8.3.1
 	cmd := parseUEContextReleaseCommandPDU(t, cc.sent[1])
 	if cmd.UES1APIDs.ENBUES1APID != 7 {
 		t.Fatalf("release command names eNB-UE-S1AP-ID %d, want the rejected connection's 7", cmd.UES1APIDs.ENBUES1APID)
 	}
 
-	// TS 36.413 §8.3.3.1: the eNB can name the connection until it answers.
 	if m.ConnCountForTest() != 1 {
 		t.Fatalf("the MME-UE-S1AP-ID was freed before the Release Complete: %d connections remain", m.ConnCountForTest())
 	}

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -257,6 +257,64 @@ func TestTrackingAreaUpdateOmitsTheBearerStatusWhenNoneWasAsked(t *testing.T) {
 	}
 }
 
+// TS 24.301 §5.5.3.2.4
+func TestTrackingAreaUpdateReportsALocalDeactivation(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	m.AddDefaultPDN(ue)
+
+	dropped := ue.EnsurePDN(6)
+	m.ReleasePDN(context.Background(), ue, dropped)
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected one downlink (TAU Accept), got %d", len(cc.sent))
+	}
+
+	var want nas.EPSBearerContextStatus
+
+	want.Active[5] = true
+
+	parsed := parseTAUAccept(t, ue, cc.sent[0])
+	if parsed.EPSBearerContextStatus == nil {
+		t.Fatal("TAU Accept carries no bearer status, so the UE keeps sending on a bearer the MME dropped")
+	}
+
+	if *parsed.EPSBearerContextStatus != want {
+		t.Fatalf("TAU Accept bearer status = %v, want only EBI 5", parsed.EPSBearerContextStatus)
+	}
+}
+
+// The obligation is discharged once the UE acknowledges the accept that carried it.
+func TestTrackingAreaUpdateReportsALocalDeactivationOnce(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	ue.Conn().ICS = mme.ICSCompleted // stay connected across both updates
+
+	m.AddDefaultPDN(ue)
+
+	dropped := ue.EnsurePDN(6)
+	m.ReleasePDN(context.Background(), ue, dropped)
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+
+	handleTrackingAreaUpdateComplete(context.Background(), m, ue, ue.Conn())
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+
+	if len(cc.sent) != 2 {
+		t.Fatalf("expected a second TAU Accept, got %d downlinks", len(cc.sent))
+	}
+
+	if parsed := parseTAUAccept(t, ue, cc.sent[1]); parsed.EPSBearerContextStatus != nil {
+		t.Fatalf("TAU Accept bearer status = %v, want the IE omitted once the deactivation was reported",
+			parsed.EPSBearerContextStatus)
+	}
+}
+
 func parseTAUAccept(t *testing.T, ue *mme.UeContext, sent []byte) *eps.TrackingAreaUpdateAccept {
 	t.Helper()
 

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -222,9 +222,7 @@ func TestTrackingAreaUpdateReconcilesBearerContextStatus(t *testing.T) {
 	}
 }
 
-// TS 24.301 §5.5.3.2.4: the accept reports the active bearers when the request
-// asked for them, "except for the case no EPS bearer context exists on the
-// network side".
+// TS 24.301 §5.5.3.2.4
 func TestTrackingAreaUpdateOmitsTheBearerStatusWithNoBearer(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
@@ -278,15 +276,11 @@ func parseTAUAccept(t *testing.T, ue *mme.UeContext, sent []byte) *eps.TrackingA
 	return parsed
 }
 
-// TestTrackingAreaUpdateCombinedSignalsCSDomainUnavailable checks that a
-// combined TAU (the UE also requesting CS-domain registration) is accepted for
-// EPS services only with EMM cause #18, so the UE stops attempting CS
-// registration (TS 24.301 §8.2.26.8, §5.5.3.3.4.3).
+// TS 24.301 §8.2.26.8, §5.5.3.3.4.3
 func TestTrackingAreaUpdateCombinedSignalsCSDomainUnavailable(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m) // ECM-CONNECTED, secured, EMM-REGISTERED
 
-	// EPS update type 2 = combined TA/LA updating with IMSI attach.
 	handleTAU(t, m, ue, tauRequest(2))
 
 	if len(cc.sent) != 1 {
@@ -310,10 +304,7 @@ func TestTrackingAreaUpdateCombinedSignalsCSDomainUnavailable(t *testing.T) {
 	}
 }
 
-// TestTrackingAreaUpdateReallocatesGUTI checks that a TAU reallocates the GUTI:
-// the accept carries a new GUTI, both old and new M-TMSIs resolve during the
-// window, and TAU Complete commits the new one and frees the old (TS 24.301
-// §5.5.3.2.4).
+// TS 24.301 §5.5.3.2.4
 func TestTrackingAreaUpdateReallocatesGUTI(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
@@ -383,10 +374,7 @@ func TestTrackingAreaUpdateReallocatesGUTI(t *testing.T) {
 	}
 }
 
-// TestTrackingAreaUpdateIdleNoActiveFlagReleases checks that a TAU from an idle
-// UE without the active flag is accepted (reallocating the GUTI), and that the
-// S1 release back to ECM-IDLE is deferred until the UE acknowledges the new GUTI
-// with TAU Complete (TS 24.301 §5.5.3.2.4).
+// TS 24.301 §5.5.3.2.4
 func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
@@ -394,14 +382,10 @@ func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 
 	handleTAU(t, m, ue, tauRequest(0))
 
-	// Only the TAU Accept goes out; the release waits for TAU Complete.
 	if len(cc.sent) != 1 {
 		t.Fatalf("expected only a TAU Accept before TAU Complete, got %d", len(cc.sent))
 	}
 
-	// The UE is ECM-CONNECTED for the exchange so its TAU Complete resolves on the
-	// re-established connection (would be dropped as "no active connection"
-	// otherwise, TS 36.413 §10.6).
 	if !ue.Connected() {
 		t.Fatal("UE not ECM-CONNECTED for the TAU exchange; TAU Complete would be rejected")
 	}
@@ -427,9 +411,7 @@ func TestTrackingAreaUpdateIdleNoActiveFlagReleases(t *testing.T) {
 	}
 }
 
-// TestTrackingAreaUpdateIdleActiveFlagReestablishes checks that a TAU from an
-// idle UE with the active flag re-establishes the radio bearer via the Initial
-// Context Setup and moves the UE to ECM-CONNECTED (TS 24.301 §5.5.3.2.4).
+// TS 24.301 §5.5.3.2.4
 func TestTrackingAreaUpdateIdleActiveFlagReestablishes(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := idleRegisteredUE(t, m)
@@ -449,17 +431,11 @@ func TestTrackingAreaUpdateIdleActiveFlagReestablishes(t *testing.T) {
 	parseInitialContextSetup(t, cc.sent[0])
 }
 
-// TestTrackingAreaUpdateRecovery checks that an integrity-protected TRACKING AREA
-// UPDATE REQUEST arriving as an Initial UE Message that the MME cannot resolve (no
-// security context, e.g. after an MME restart, TS 24.301 §5.5.3.2.5) is answered
-// with TAU REJECT #9 over the bare connection rather than dropped, and that no UE
-// context or connection is left behind, so the UE re-attaches at once.
+// TTS 24.301 §5.5.3.2.5
 func TestTrackingAreaUpdateRecovery(t *testing.T) {
 	m := newTestMME(t)
 	cc := &captureConn{}
 
-	// Security-protected NAS: SHT=integrity-protected | PD=EMM, a MAC the MME
-	// cannot reproduce (no context), sequence 1, and an inner plain TAU REQUEST.
 	pdu := []byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x07, byte(eps.MsgTrackingAreaUpdateRequest)}
 
 	mmes1ap.HandleInitialUEMessage(m, context.Background(), mme.NewRadioForTest(cc), initiatingValue(t, initialUEMessagePDU(t, 7, pdu)))

--- a/internal/mme/nas_security_context_test.go
+++ b/internal/mme/nas_security_context_test.go
@@ -3,7 +3,11 @@
 
 package mme
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+)
 
 // TestNextEksi verifies the eKSI cycles to a distinct value and skips 7 ("no key
 // available"), so a new authentication never reuses the stored eKSI (TS 24.301
@@ -41,5 +45,46 @@ func TestInstallNASSecurityContext_ResetsNASCounts(t *testing.T) {
 
 	if got := ue.DLCountForTest(); got != 0 {
 		t.Errorf("downlink NAS COUNT = %d, want 0 after installing a new security context", got)
+	}
+}
+
+// TestRekeyNASSecurityContextKeepsNASCounts verifies that changing the NAS
+// algorithms of the EPS security context already in use re-derives the keys from
+// the same K_ASME without restarting its NAS COUNTs (TS 24.301 §5.4.3.2,
+// TS 33.401 §6.5, §7.2.8.1.2). A context mapped from 5GS inherits the 5G NAS
+// COUNTs, which the UE keeps (TS 24.301 §4.4.3.1, §5.4.3.3).
+func TestRekeyNASSecurityContextKeepsNASCounts(t *testing.T) {
+	m := newTestMME(t)
+	ue := m.NewUe(&captureConn{}, 7)
+
+	ue.SetKASMEForTest(make([]byte, 32))
+
+	if err := ue.InstallNASSecurityContext(nas.CipheringAES, nas.IntegritySNOW3G, MintAuthProofForSecurityMode()); err != nil {
+		t.Fatalf("InstallNASSecurityContext: %v", err)
+	}
+
+	ue.SetULCountForTest(5)
+	ue.SetDLCountForTest(9)
+
+	before := ue.KnasIntForTest()
+
+	if err := ue.RekeyNASSecurityContext(nas.CipheringAES, nas.IntegrityAES, MintAuthProofForSecurityMode()); err != nil {
+		t.Fatalf("RekeyNASSecurityContext: %v", err)
+	}
+
+	if got := ue.ULCount(); got != 5 {
+		t.Errorf("uplink NAS COUNT = %d, want the inherited 5: the UE does not reset it when the eKSI matches its current mapped context", got)
+	}
+
+	if got := ue.DLCountForTest(); got != 9 {
+		t.Errorf("downlink NAS COUNT = %d, want the inherited 9: the Security Mode Command must not reuse a COUNT under the same K_ASME", got)
+	}
+
+	if ue.KnasIntForTest() == before {
+		t.Error("K_NASint is unchanged, so the new integrity algorithm was never taken into use")
+	}
+
+	if ue.EIA() != nas.IntegrityAES {
+		t.Errorf("integrity algorithm = %v, want the re-selected %v", ue.EIA(), nas.IntegrityAES)
 	}
 }

--- a/internal/mme/nas_security_context_test.go
+++ b/internal/mme/nas_security_context_test.go
@@ -48,11 +48,7 @@ func TestInstallNASSecurityContext_ResetsNASCounts(t *testing.T) {
 	}
 }
 
-// TestRekeyNASSecurityContextKeepsNASCounts verifies that changing the NAS
-// algorithms of the EPS security context already in use re-derives the keys from
-// the same K_ASME without restarting its NAS COUNTs (TS 24.301 §5.4.3.2,
-// TS 33.401 §6.5, §7.2.8.1.2). A context mapped from 5GS inherits the 5G NAS
-// COUNTs, which the UE keeps (TS 24.301 §4.4.3.1, §5.4.3.3).
+// TS 24.301 §5.4.3.2, TS 33.401 §6.5, §7.2.8.1.2)
 func TestRekeyNASSecurityContextKeepsNASCounts(t *testing.T) {
 	m := newTestMME(t)
 	ue := m.NewUe(&captureConn{}, 7)

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -37,7 +37,7 @@ func (m *MME) Page(ctx context.Context, imsi string) error {
 		return nil
 	}
 
-	paging, err := m.buildPaging(ue)
+	paging, err := m.buildPaging(ctx, ue)
 	if err != nil {
 		return err
 	}
@@ -124,8 +124,11 @@ func (m *MME) abandonPaging(ue *UeContext) {
 
 // buildPaging assembles the Paging message for a UE (TS 36.413). The TAI list is the
 // UE's registration area.
-func (m *MME) buildPaging(ue *UeContext) (*s1ap.Paging, error) {
-	_, mmeCode := m.MmeIdentity()
+func (m *MME) buildPaging(ctx context.Context, ue *UeContext) (*s1ap.Paging, error) {
+	_, mmeCode, err := m.MmeIdentity(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("paging: %w", err)
+	}
 
 	taiList, err := areaToS1APTAIs(ue.RegistrationArea())
 	if err != nil {

--- a/internal/mme/paging_test.go
+++ b/internal/mme/paging_test.go
@@ -36,7 +36,7 @@ func TestBuildPaging(t *testing.T) {
 	ue := idleRegisteredUE(t, m)
 	ue.RadioCapabilityForPaging = []byte{0xaa, 0xbb, 0xcc}
 
-	paging, err := m.buildPaging(ue)
+	paging, err := m.buildPaging(t.Context(), ue)
 	if err != nil {
 		t.Fatalf("buildPaging: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestBuildPagingOldMTMSISentinel(t *testing.T) {
 	ue.SetTmsiForTest(0x1234)
 	ue.SetOldTmsiForTest(0)
 
-	paging, err := m.buildPaging(ue)
+	paging, err := m.buildPaging(t.Context(), ue)
 	if err != nil {
 		t.Fatalf("buildPaging: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestBuildPagingOldMTMSISentinel(t *testing.T) {
 	// paging uses the current M-TMSI.
 	ue.SetOldTmsiForTest(0xFFFFFFFF)
 
-	paging, err = m.buildPaging(ue)
+	paging, err = m.buildPaging(t.Context(), ue)
 	if err != nil {
 		t.Fatalf("buildPaging: %v", err)
 	}

--- a/internal/mme/relocation_test.go
+++ b/internal/mme/relocation_test.go
@@ -469,6 +469,12 @@ func (f *fakeFiveGSPeer) RelocationComplete(_ context.Context, supi etsi.SUPI, i
 	return f.err
 }
 
+func (f *fakeFiveGSPeer) EPSContext(context.Context, interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
+	return interworking.EPSContextResponse{}, interworking.ErrUnknownUEContext
+}
+
+func (f *fakeFiveGSPeer) EPSContextAck(context.Context, etsi.SUPI, []uint8) error { return nil }
+
 func (f *fakeFiveGSPeer) ForwardRelocation(_ context.Context, _ interworking.FiveGSRelocationRequest) (interworking.FiveGSRelocationResponse, error) {
 	return interworking.FiveGSRelocationResponse{}, errors.New("the 5GS peer was asked to admit a handover")
 }

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -51,6 +51,7 @@ type UeConn struct {
 	TauAcceptPlain            []byte
 	TauReleaseOnComplete      bool
 	ArrivingFrom5GS           *interworking.ArrivingSessions
+	RemappedFrom5GS           bool
 	DeferredTAUPlain          []byte
 	nasGuard                  guard.Guard
 	nasGuardName              string

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/udm"
-	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
 )
@@ -51,8 +50,7 @@ type UeConn struct {
 	TauRequestPlain           []byte
 	TauAcceptPlain            []byte
 	TauReleaseOnComplete      bool
-	ArrivingFrom5GS           *interworking.EPSContextResponse
-	DeferredTAU               *eps.TrackingAreaUpdateRequest
+	ArrivingFrom5GS           *interworking.ArrivingSessions
 	DeferredTAUPlain          []byte
 	nasGuard                  guard.Guard
 	nasGuardName              string

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -7,8 +7,10 @@ import (
 	"sync/atomic"
 
 	"github.com/ellanetworks/core/internal/guard"
+	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/udm"
+	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
 )
@@ -32,92 +34,30 @@ const (
 // on each idle→active transition; the persistent UeContext it belongs to survives
 // across them. Fields are guarded by MME.mu unless noted.
 type UeConn struct {
-	ENBUES1APID s1ap.ENBUES1APID
-	MMEUES1APID s1ap.MMEUES1APID
-
-	// Atomic rather than a plain interface: CommitPathSwitch re-points a live
-	// connection under MME.mu while SendS1AP reads it on the eNB dispatch
-	// goroutine without it, and an interface value is two words — a torn read
-	// calls through a method table that does not belong to the value.
-	conn atomic.Pointer[S1APWriter]
-
-	// Log carries the connection's MME-UE-S1AP-ID (the temporary identity, TS
-	// 33.401 §7.1) so handlers correlate by it. Per-connection with an immutable id.
-	Log *zap.Logger
-
-	// ue is the persistent UE context bound to this connection, nil until a UE
-	// is identified (a bare connection carries an Initial UE Message not yet
-	// attached to a context). Guarded by MME.mu.
-	ue *UeContext
-
-	// ServingTAI is the UE's current serving-cell TAI, from the User Location of its
-	// INITIAL UE MESSAGE and refreshed on each UPLINK NAS TRANSPORT (TS 36.413). It
-	// gates attach/TAU against the operator's served area (EMM cause #12).
-	// Dispatch-confined.
-	ServingTAI s1ap.TAI
-
-	// Location is the UE's serving-cell User Location (E-UTRAN CGI + TAI) from the
-	// same messages as ServingTAI, mirrored to the persistent UeContext when one is
-	// bound (TS 36.413). Dispatch-confined.
-	Location models.UserLocation
-
-	m *MME
-
-	// ICS is the S1AP Initial Context Setup progress: it distinguishes a
-	// fully-established connection (ICSCompleted) from one a UE is still resuming on
-	// (e.g. a TAU resume that has not re-established bearers). Dispatch-confined
-	// (mutated only on the eNB's S1AP goroutine), so a plain field suffices.
-	ICS ICSState
-
-	// secureExchangeEstablished records that secure NAS exchange is established on
-	// this connection (a message integrity-checked, or a verified resume). Once
-	// set, TS 24.301 §4.4.4.3 requires discarding any further message that is not
-	// integrity protected or fails the check. Per-connection, as the spec scopes
-	// it to the NAS signalling connection.
+	ENBUES1APID               s1ap.ENBUES1APID
+	MMEUES1APID               s1ap.MMEUES1APID
+	conn                      atomic.Pointer[S1APWriter]
+	Log                       *zap.Logger
+	ue                        *UeContext
+	ServingTAI                s1ap.TAI
+	Location                  models.UserLocation
+	m                         *MME
+	ICS                       ICSState
 	secureExchangeEstablished bool
-
-	// In-flight authentication working-state, scoped to this connection's attach: a
-	// dropped connection re-authenticates from scratch, so it lives on the connection,
-	// not the persistent context. AuthVector is the EPS challenge vector, resyncTried
-	// whether SQN re-synchronisation has been attempted this exchange
-	// (TS 24.301 §5.4.2.7). Dispatch-confined.
-	AuthVector  *udm.EPSAV
-	resyncTried bool
-
-	// In-flight attach working-state (TS 24.301 §5.5.1.2.7 case d): AttachRequestPlain
-	// is the plaintext ATTACH REQUEST that started the attach, AttachAcceptPlain the
-	// plaintext ATTACH ACCEPT last sent — kept to resend the ACCEPT on a duplicate
-	// ATTACH REQUEST with identical IEs while awaiting ATTACH COMPLETE. The resend is
-	// protected afresh, under the next downlink NAS COUNT (TS 24.301 §4.4.3.1).
-	// Connection-scoped like the auth state above. Dispatch-confined.
-	AttachRequestPlain []byte
-	AttachAcceptPlain  []byte
-
-	// In-flight TAU working-state (TS 24.301 §5.5.3.2.7 case d), like the attach
-	// state above; cleared when TAU COMPLETE commits the reallocated GUTI.
-	TauRequestPlain []byte
-	TauAcceptPlain  []byte
-
-	// TauReleaseOnComplete defers the S1 release of a no-active TAU until the
-	// GUTI reallocation it carried is acknowledged.
-	TauReleaseOnComplete bool
-
-	// EMM common-procedure guard (TS 24.301: T3450/T3460/T3470). EMM common and
-	// specific procedures are mutually exclusive, so a single guard suffices; it
-	// invalidates a callback whose firing races a release or re-arm. ESM bearer
-	// procedures are guarded per-bearer on PdnConnection, running on the
-	// independent ESM sublayer concurrently with each other and EMM.
-	nasGuard guard.Guard
-	// nasGuardName is the EMM procedure the guard currently supervises, for the status
-	// export. Set at arm and cleared at stop under m.mu, so a plain string suffices.
-	nasGuardName string
-	// T3489. Separate from nasGuard because it runs inside the attach, whose own
-	// guard is already armed.
-	esmInfoGuard guard.Guard
-	// releaseGuard supervises a sent UE Context Release Command: armed when the command
-	// is sent, stopped on the Release Complete; a lost Complete fires it once and runs
-	// the EMMState-keyed local cleanup so the UeConn + M-TMSI cannot leak.
-	releaseGuard guard.Guard
+	AuthVector                *udm.EPSAV
+	resyncTried               bool
+	AttachRequestPlain        []byte
+	AttachAcceptPlain         []byte
+	TauRequestPlain           []byte
+	TauAcceptPlain            []byte
+	TauReleaseOnComplete      bool
+	ArrivingFrom5GS           *interworking.EPSContextResponse
+	DeferredTAU               *eps.TrackingAreaUpdateRequest
+	DeferredTAUPlain          []byte
+	nasGuard                  guard.Guard
+	nasGuardName              string
+	esmInfoGuard              guard.Guard
+	releaseGuard              guard.Guard
 }
 
 // StopReleaseGuard cancels the Release-Complete supervision timer. Nil-safe.

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -217,7 +217,7 @@ func (fakeBearerStore) GetNetworkSliceByID(_ context.Context, id string) (*db.Ne
 }
 
 func (fakeBearerStore) GetOperator(_ context.Context) (*db.Operator, error) {
-	return &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: `["1"]`, Ciphering: `["AES"]`, Integrity: `["AES"]`}, nil
+	return &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: `["1"]`, Ciphering: `["AES"]`, Integrity: `["AES"]`, AmfRegionID: 1, AmfSetID: 1}, nil
 }
 
 func (fakeBearerStore) NodeID() int { return 1 }

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/mme/nas"
@@ -119,6 +120,17 @@ func (f *fakeSessionManager) failModify(ebi uint8, err error) {
 	}
 
 	f.modifyErr[ebi] = err
+}
+
+func (f *fakeSessionManager) TransferIdleToEPS(_ context.Context, _ etsi.SUPI, pduSessionID, _ uint8, _ string, snssai *models.Snssai) (models.EPSBearer, error) {
+	return models.EPSBearer{
+		Ref:          fmt.Sprintf("idle-ref-%d", pduSessionID),
+		PDNType:      eps.PDNTypeIPv4,
+		IPv4:         testUEIP,
+		SGW:          testSGWFTEID,
+		PDUSessionID: pduSessionID,
+		Snssai:       snssai,
+	}, nil
 }
 
 func (f *fakeSessionManager) CreateEPSSession(_ context.Context, req models.EPSBearerRequest) (models.EPSBearer, error) {

--- a/internal/mme/s1ap/handle_initial_ue_message.go
+++ b/internal/mme/s1ap/handle_initial_ue_message.go
@@ -87,10 +87,19 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update rejected; UE will re-attach",
 			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
 		c.SendDownlinkMessage(ctx, &eps.TrackingAreaUpdateReject{Cause: eps.EMMCauseUEIdentityCannotBeDerived})
-	} else {
-		logger.From(ctx, logger.MmeLog).Debug("dropping non-Attach Initial UE Message",
-			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+
+		// T3440 is the UE's grace period for the network to release the NAS signalling
+		// connection it was answered on (TS 24.301 §5.3.1.2.1 d).
+		m.ReleaseAnsweredBareConn(ctx, c, mme.CauseNASUnspecified)
+
+		return
 	}
+
+	// Nothing was answered on the connection, so the eNB's own supervision reclaims its
+	// context; holding the MME-UE-S1AP-ID for the release guard instead would let a peer
+	// exhaust them with unrecognised Initial UE Messages.
+	logger.From(ctx, logger.MmeLog).Debug("dropping non-Attach Initial UE Message",
+		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
 
 	m.ReleaseBareConn(c)
 }

--- a/internal/mme/s1ap/handle_initial_ue_message.go
+++ b/internal/mme/s1ap/handle_initial_ue_message.go
@@ -88,16 +88,11 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
 		c.SendDownlinkMessage(ctx, &eps.TrackingAreaUpdateReject{Cause: eps.EMMCauseUEIdentityCannotBeDerived})
 
-		// T3440 is the UE's grace period for the network to release the NAS signalling
-		// connection it was answered on (TS 24.301 §5.3.1.2.1 d).
 		m.ReleaseAnsweredBareConn(ctx, c, mme.CauseNASUnspecified)
 
 		return
 	}
 
-	// Nothing was answered on the connection, so the eNB's own supervision reclaims its
-	// context; holding the MME-UE-S1AP-ID for the release guard instead would let a peer
-	// exhaust them with unrecognised Initial UE Messages.
 	logger.From(ctx, logger.MmeLog).Debug("dropping non-Attach Initial UE Message",
 		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
 

--- a/internal/mme/s1ap/handle_s1_setup.go
+++ b/internal/mme/s1ap/handle_s1_setup.go
@@ -56,7 +56,7 @@ func handleS1Setup(m *mme.MME, ctx context.Context, conn *sctp.SCTPConn, value [
 		return
 	}
 
-	mmeGroupID, mmeCode := m.MmeIdentity()
+	mmeGroupID, mmeCode := operator.GUMMEI()
 
 	req, outBytes, accepted, reason, err := s1SetupOutcomeFor(value, plmn, tacs, mmeGroupID, mmeCode, m.Name, m.RelativeCapacity)
 	if err != nil {

--- a/internal/mme/s1ap/handover_to_5gs_test.go
+++ b/internal/mme/s1ap/handover_to_5gs_test.go
@@ -36,6 +36,12 @@ type fiveGSPeerStub struct {
 	gate      chan struct{}
 }
 
+func (p *fiveGSPeerStub) EPSContext(context.Context, interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
+	return interworking.EPSContextResponse{}, interworking.ErrUnknownUEContext
+}
+
+func (p *fiveGSPeerStub) EPSContextAck(context.Context, etsi.SUPI, []uint8) error { return nil }
+
 func (p *fiveGSPeerStub) ForwardRelocation(_ context.Context, req interworking.FiveGSRelocationRequest) (interworking.FiveGSRelocationResponse, error) {
 	p.mu.Lock()
 	p.request = &req

--- a/internal/mme/s1ap/idle_mobility_from_5gs_test.go
+++ b/internal/mme/s1ap/idle_mobility_from_5gs_test.go
@@ -37,9 +37,7 @@ func (p *refusingFiveGSPeer) EPSContext(context.Context, interworking.EPSContext
 
 func (*refusingFiveGSPeer) EPSContextAck(context.Context, etsi.SUPI, []uint8) error { return nil }
 
-// TS 24.301 §5.5.3.2.5: an inter-system change whose context no peer can return
-// resolves nothing, and the UE is told to re-attach with EMM cause #9 rather
-// than left waiting out T3430.
+// TS 24.301 §5.5.3.2.5
 func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/internal/mme/s1ap/idle_mobility_from_5gs_test.go
+++ b/internal/mme/s1ap/idle_mobility_from_5gs_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/s1ap"
+)
+
+type refusingFiveGSPeer struct {
+	err error
+}
+
+func (*refusingFiveGSPeer) ForwardRelocation(context.Context, interworking.FiveGSRelocationRequest) (interworking.FiveGSRelocationResponse, error) {
+	return interworking.FiveGSRelocationResponse{}, nil
+}
+
+func (*refusingFiveGSPeer) RelocationCancel(context.Context, etsi.SUPI, interworking.RelocationID) error {
+	return nil
+}
+
+func (*refusingFiveGSPeer) RelocationComplete(context.Context, etsi.SUPI, interworking.RelocationID) error {
+	return nil
+}
+
+func (p *refusingFiveGSPeer) EPSContext(context.Context, interworking.EPSContextRequest) (interworking.EPSContextResponse, error) {
+	return interworking.EPSContextResponse{}, p.err
+}
+
+func (*refusingFiveGSPeer) EPSContextAck(context.Context, etsi.SUPI, []uint8) error { return nil }
+
+// TS 24.301 §5.5.3.2.5: an inter-system change whose context no peer can return
+// resolves nothing, and the UE is told to re-attach with EMM cause #9 rather
+// than left waiting out T3430.
+func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"the 5GS peer holds no context", interworking.ErrUnknownUEContext},
+		{"the 5GS peer could not verify the update", interworking.ErrIntegrityCheckFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMME(t)
+			m.FiveGS = &refusingFiveGSPeer{err: tc.err}
+
+			native := eps.GUTITypeNative
+
+			tau, err := (&eps.TrackingAreaUpdateRequest{
+				OldGUTI: eps.GUTIIdentity(eps.GUTI{
+					PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x0100, MMECode: 0x40,
+					TMSI: [4]byte{0x00, 0x00, 0xde, 0xad},
+				}),
+				OldGUTIType: &native,
+				UEStatus:    &eps.UEStatus{N1ModeReg: true},
+			}).MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wire := append([]byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x00}, tau...)
+
+			plmnID := s1ap.PLMNIdentity{0x00, 0xf1, 0x10}
+
+			initialUE := &s1ap.InitialUEMessage{
+				ENBUES1APID:           1001,
+				NASPDU:                s1ap.NASPDU(wire),
+				TAI:                   s1ap.TAI{PLMNIdentity: plmnID, TAC: 1},
+				EUTRANCGI:             s1ap.Ptr(s1ap.EUTRANCGI{PLMNIdentity: plmnID, CellID: 1}),
+				RRCEstablishmentCause: s1ap.Ptr(s1ap.RRCCauseMOSignalling),
+			}
+
+			im, err := initialUE.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			conn := &captureConn{}
+			HandleInitialUEMessage(m, context.Background(), mme.NewRadioForTest(conn), initiatingValue(t, im))
+
+			if conn.count() != 1 {
+				t.Fatalf("expected one downlink (TAU Reject), got %d", conn.count())
+			}
+
+			rej, err := eps.ParseTrackingAreaUpdateReject(decodeDownlinkNAS(t, conn.sent[0]))
+			if err != nil {
+				t.Fatalf("parse TAU Reject: %v", err)
+			}
+
+			if rej.Cause != eps.EMMCauseUEIdentityCannotBeDerived {
+				t.Fatalf("TAU Reject cause = %d, want #%d", rej.Cause, eps.EMMCauseUEIdentityCannotBeDerived)
+			}
+		})
+	}
+}

--- a/internal/mme/s1ap/idle_mobility_from_5gs_test.go
+++ b/internal/mme/s1ap/idle_mobility_from_5gs_test.go
@@ -40,15 +40,24 @@ func (*refusingFiveGSPeer) EPSContextAck(context.Context, etsi.SUPI, []uint8) er
 // TS 24.301 §5.5.3.2.5
 func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		err  error
+		name        string
+		err         error
+		noPeer      bool
+		unprotected bool
 	}{
-		{"the 5GS peer holds no context", interworking.ErrUnknownUEContext},
-		{"the 5GS peer could not verify the update", interworking.ErrIntegrityCheckFailed},
+		{name: "the 5GS peer holds no context", err: interworking.ErrUnknownUEContext},
+		{name: "the 5GS peer could not verify the update", err: interworking.ErrIntegrityCheckFailed},
+		// TS 24.301 §5.5.3.2.2 case z: a UE holding no valid 5G NAS security
+		// context sends the update without integrity protection.
+		{name: "the update carries no integrity protection", err: interworking.ErrIntegrityCheckFailed, unprotected: true},
+		{name: "the operator configured no 5GS peer", noPeer: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newTestMME(t)
-			m.FiveGS = &refusingFiveGSPeer{err: tc.err}
+
+			if !tc.noPeer {
+				m.FiveGS = &refusingFiveGSPeer{err: tc.err}
+			}
 
 			native := eps.GUTITypeNative
 
@@ -65,6 +74,9 @@ func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 			}
 
 			wire := append([]byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x00}, tau...)
+			if tc.unprotected {
+				wire = tau
+			}
 
 			plmnID := s1ap.PLMNIdentity{0x00, 0xf1, 0x10}
 

--- a/internal/mme/s1ap/idle_mobility_from_5gs_test.go
+++ b/internal/mme/s1ap/idle_mobility_from_5gs_test.go
@@ -61,7 +61,7 @@ func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 
 			tau, err := (&eps.TrackingAreaUpdateRequest{
 				OldGUTI: eps.GUTIIdentity(eps.GUTI{
-					PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x0100, MMECode: 0x40,
+					PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x8100, MMECode: 0x40,
 					TMSI: [4]byte{0x00, 0x00, 0xde, 0xad},
 				}),
 				OldGUTIType: &native,
@@ -94,8 +94,8 @@ func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 			conn := &captureConn{}
 			HandleInitialUEMessage(m, context.Background(), mme.NewRadioForTest(conn), initiatingValue(t, im))
 
-			if conn.count() != 1 {
-				t.Fatalf("expected one downlink (TAU Reject), got %d", conn.count())
+			if conn.count() != 2 {
+				t.Fatalf("expected a TAU Reject and a UE Context Release Command, got %d messages", conn.count())
 			}
 
 			rej, err := eps.ParseTrackingAreaUpdateReject(decodeDownlinkNAS(t, conn.sent[0]))
@@ -105,6 +105,11 @@ func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 
 			if rej.Cause != eps.EMMCauseUEIdentityCannotBeDerived {
 				t.Fatalf("TAU Reject cause = %d, want #%d", rej.Cause, eps.EMMCauseUEIdentityCannotBeDerived)
+			}
+
+			// TS 24.301 §5.3.1.2.1 d)
+			if cmd := parseUEContextReleaseCommand(t, lastSent(t, conn)); cmd.UES1APIDs.ENBUES1APID != 1001 {
+				t.Errorf("release command names eNB-UE-S1AP-ID %d, want the rejected connection's 1001", cmd.UES1APIDs.ENBUES1APID)
 			}
 		})
 	}

--- a/internal/mme/s1ap/idle_mobility_from_5gs_test.go
+++ b/internal/mme/s1ap/idle_mobility_from_5gs_test.go
@@ -47,8 +47,6 @@ func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 	}{
 		{name: "the 5GS peer holds no context", err: interworking.ErrUnknownUEContext},
 		{name: "the 5GS peer could not verify the update", err: interworking.ErrIntegrityCheckFailed},
-		// TS 24.301 §5.5.3.2.2 case z: a UE holding no valid 5G NAS security
-		// context sends the update without integrity protection.
 		{name: "the update carries no integrity protection", err: interworking.ErrIntegrityCheckFailed, unprotected: true},
 		{name: "the operator configured no 5GS peer", noPeer: true},
 	} {

--- a/internal/mme/s1ap/resume_test.go
+++ b/internal/mme/s1ap/resume_test.go
@@ -25,7 +25,11 @@ func TestInitialUEMessageResumeMacFailedTAURejects(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	group, code := m.MmeIdentity()
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := m.ReallocateGUTI(t.Context(), ue, plmn, group, code); err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +95,11 @@ func TestInitialUEMessageResumeVerifiedBindsAndDispatches(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	group, code := m.MmeIdentity()
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := m.ReallocateGUTI(t.Context(), ue, plmn, group, code); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mme/s1ap/resume_test.go
+++ b/internal/mme/s1ap/resume_test.go
@@ -67,8 +67,8 @@ func TestInitialUEMessageResumeMacFailedTAURejects(t *testing.T) {
 	conn := &captureConn{}
 	HandleInitialUEMessage(m, context.Background(), mme.NewRadioForTest(conn), initiatingValue(t, im))
 
-	if conn.count() != 1 {
-		t.Fatalf("expected one downlink (TAU Reject), got %d", conn.count())
+	if conn.count() != 2 {
+		t.Fatalf("expected a TAU Reject and a UE Context Release Command, got %d messages", conn.count())
 	}
 
 	rej, err := eps.ParseTrackingAreaUpdateReject(decodeDownlinkNAS(t, conn.sent[0]))
@@ -79,6 +79,9 @@ func TestInitialUEMessageResumeMacFailedTAURejects(t *testing.T) {
 	if rej.Cause != eps.EMMCauseUEIdentityCannotBeDerived {
 		t.Fatalf("TAU Reject cause = %d, want #%d", rej.Cause, eps.EMMCauseUEIdentityCannotBeDerived)
 	}
+
+	// TS 24.301 §5.3.1.2.1 d)
+	parseUEContextReleaseCommand(t, lastSent(t, conn))
 }
 
 // TestInitialUEMessageResumeVerifiedBindsAndDispatches verifies the folded resume

--- a/internal/mme/s1ap/superseded_release_test.go
+++ b/internal/mme/s1ap/superseded_release_test.go
@@ -27,7 +27,11 @@ func resumeOntoNewConnection(t *testing.T, m *mme.MME, ue *mme.UeContext) (oldMM
 		t.Fatal(err)
 	}
 
-	group, code := m.MmeIdentity()
+	group, code, err := m.MmeIdentity(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := m.ReallocateGUTI(t.Context(), ue, plmn, group, code); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mme/session.go
+++ b/internal/mme/session.go
@@ -40,12 +40,27 @@ func (m *MME) SnapshotPDNs(ue *UeContext) []*PdnConnection {
 	return out
 }
 
+func (ue *UeContext) ClearLocalBearerDeactivation() {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.localBearerDeactivation = false
+}
+
+func (ue *UeContext) LocalBearerDeactivationPending() bool {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return ue.localBearerDeactivation
+}
+
 func (m *MME) ReleasePDN(ctx context.Context, ue *UeContext, p *PdnConnection) {
 	m.releaseAnchorSession(ctx, ue, p)
 
 	ue.mu.Lock()
 	if held, ok := ue.Pdns[p.Ebi]; ok && held == p {
 		delete(ue.Pdns, p.Ebi)
+		ue.localBearerDeactivation = true
 	}
 
 	last := len(ue.Pdns) == 0
@@ -146,6 +161,7 @@ func takePDNByRef(ue *UeContext, ebi uint8, ref string) (p *PdnConnection, last 
 	}
 
 	delete(ue.Pdns, ebi)
+	ue.localBearerDeactivation = true
 
 	return p, len(ue.Pdns) == 0
 }

--- a/internal/mme/states.go
+++ b/internal/mme/states.go
@@ -98,9 +98,6 @@ func (ue *UeContext) transitionEMMLocked(target EMMState) {
 	ue.setEMMStateLocked(EMMDeregistered)
 }
 
-// setEMMStateLocked sets the EMM state and resets the coupled registration sub-phase:
-// entering EMM-REGISTERED-INITIATED starts at the authentication exchange; any other
-// state carries no sub-phase (TS 24.301 §5.4). The caller holds ue.mu.
 func (ue *UeContext) setEMMStateLocked(target EMMState) {
 	ue.emmState = target
 
@@ -108,6 +105,11 @@ func (ue *UeContext) setEMMStateLocked(target EMMState) {
 		ue.regStep = RegStepAuthenticating
 	} else {
 		ue.regStep = RegStepNone
+	}
+
+	if target == EMMDeregistered {
+		ue.idleMobilityFrom5GS = false
+		ue.localBearerDeactivation = false
 	}
 }
 

--- a/internal/mme/ue_accessors.go
+++ b/internal/mme/ue_accessors.go
@@ -211,10 +211,6 @@ func (ue *UeContext) InstallNASSecurityContext(eea nas.CipheringAlgorithm, eia n
 	return nil
 }
 
-// RekeyNASSecurityContext re-derives the NAS keys of the EPS security context
-// already in use, from the same K_ASME with new algorithm identities as the only
-// changed input (TS 33.401 §7.2.8.1.2). The context is not a new one, so its NAS
-// COUNTs carry on (TS 24.301 §5.4.3.2, TS 33.401 §6.5).
 func (ue *UeContext) RekeyNASSecurityContext(eea nas.CipheringAlgorithm, eia nas.IntegrityAlgorithm, _ AuthProof) error {
 	sc, err := ue.deriveNASKeys(eea, eia, keepNASCounts)
 	if err != nil {

--- a/internal/mme/ue_accessors.go
+++ b/internal/mme/ue_accessors.go
@@ -199,7 +199,7 @@ func protectEPSDownlink(plain []byte, sht uint8, count nas.Count, sc *nas.Securi
 // algorithms and installs the EPS NAS security context (TS 33.401). The
 // AuthProof witnesses that EPS-AKA authentication has succeeded.
 func (ue *UeContext) InstallNASSecurityContext(eea nas.CipheringAlgorithm, eia nas.IntegrityAlgorithm, _ AuthProof) error {
-	sc, err := ue.deriveNASKeys(eea, eia)
+	sc, err := ue.deriveNASKeys(eea, eia, resetNASCounts)
 	if err != nil {
 		ue.downlink().Clear()
 
@@ -211,7 +211,31 @@ func (ue *UeContext) InstallNASSecurityContext(eea nas.CipheringAlgorithm, eia n
 	return nil
 }
 
-func (ue *UeContext) deriveNASKeys(eea nas.CipheringAlgorithm, eia nas.IntegrityAlgorithm) (*nas.SecurityContext, error) {
+// RekeyNASSecurityContext re-derives the NAS keys of the EPS security context
+// already in use, from the same K_ASME with new algorithm identities as the only
+// changed input (TS 33.401 §7.2.8.1.2). The context is not a new one, so its NAS
+// COUNTs carry on (TS 24.301 §5.4.3.2, TS 33.401 §6.5).
+func (ue *UeContext) RekeyNASSecurityContext(eea nas.CipheringAlgorithm, eia nas.IntegrityAlgorithm, _ AuthProof) error {
+	sc, err := ue.deriveNASKeys(eea, eia, keepNASCounts)
+	if err != nil {
+		ue.downlink().Clear()
+
+		return err
+	}
+
+	ue.downlink().Rekey(sc)
+
+	return nil
+}
+
+type nasCountHandling uint8
+
+const (
+	resetNASCounts nasCountHandling = iota
+	keepNASCounts
+)
+
+func (ue *UeContext) deriveNASKeys(eea nas.CipheringAlgorithm, eia nas.IntegrityAlgorithm, counts nasCountHandling) (*nas.SecurityContext, error) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
@@ -233,8 +257,10 @@ func (ue *UeContext) deriveNASKeys(eea nas.CipheringAlgorithm, eia nas.Integrity
 		return nil, err
 	}
 
-	ue.ulCount.Reset()
-	ue.kenbCount = 0
+	if counts == resetNASCounts {
+		ue.ulCount.Reset()
+		ue.kenbCount = 0
+	}
 
 	return sc, nil
 }

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -64,11 +64,6 @@ func (m *MME) AnswerDetachedRelease(ctx context.Context, conn S1APWriter, mmeUEI
 	return true
 }
 
-// ReleaseAnsweredBareConn orders the eNB to release the UE-associated logical
-// S1-connection of a bare connection the MME answered a NAS message on, and guards the
-// Complete (TS 36.413 §8.3.1). The MME-UE-S1AP-ID stays reserved until the Complete
-// arrives or the guard reaps it, so the eNB can still name the connection. A connection
-// that has since bound a UE context is left to its own release.
 func (m *MME) ReleaseAnsweredBareConn(ctx context.Context, c *UeConn, cause s1ap.Cause) {
 	if c == nil {
 		return

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -64,6 +64,30 @@ func (m *MME) AnswerDetachedRelease(ctx context.Context, conn S1APWriter, mmeUEI
 	return true
 }
 
+// ReleaseAnsweredBareConn orders the eNB to release the UE-associated logical
+// S1-connection of a bare connection the MME answered a NAS message on, and guards the
+// Complete (TS 36.413 §8.3.1). The MME-UE-S1AP-ID stays reserved until the Complete
+// arrives or the guard reaps it, so the eNB can still name the connection. A connection
+// that has since bound a UE context is left to its own release.
+func (m *MME) ReleaseAnsweredBareConn(ctx context.Context, c *UeConn, cause s1ap.Cause) {
+	if c == nil {
+		return
+	}
+
+	m.mu.RLock()
+	held, ok := m.conns[uint32(c.MMEUES1APID)]
+	bare := ok && held == c && c.ue == nil
+
+	m.mu.RUnlock()
+
+	if !bare {
+		return
+	}
+
+	c.SendUEContextReleaseCommand(ctx, cause)
+	m.guardDetachedRelease(c)
+}
+
 // SendUEContextReleaseCommand builds a UE Context Release Command for this
 // connection's S1AP identities and sends it to the eNB (TS 36.413 §8.3.1).
 func (c *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause s1ap.Cause) {

--- a/internal/smf/access_binding.go
+++ b/internal/smf/access_binding.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+type bindingRules struct {
+	policyID string
+	pdrs     []*PDR
+	fars     []*FAR
+	qers     []*QER
+}
+
+type accessBinding struct {
+	access         AccessType
+	keepOnRollback bool
+	build          func(commit *transferCommit) (bindingRules, error)
+	onBound        func()
+}
+
+func (s *SMF) commitAccessBinding(ctx context.Context, sc *SMContext, b accessBinding) (*droppedSource, error) {
+	span := trace.SpanFromContext(ctx)
+
+	commit, err := s.beginTransferCommit(ctx, sc, b.access)
+	if err != nil {
+		return nil, failBinding(span, "failed to move the session", fmt.Errorf("failed to move session %q to %s: %w", sc.Ref, b.access, err))
+	}
+
+	restoreBinding := sc.stageAccessBinding()
+
+	rollback := func(err error) error {
+		restoreBinding()
+
+		if commit == nil {
+			return failBinding(span, "failed to bind the downlink", err)
+		}
+
+		commit.restore()
+
+		if b.keepOnRollback {
+			return failBinding(span, "failed to bind the downlink", err)
+		}
+
+		sc.releasing = true
+
+		return failBinding(span, "failed to bind the downlink", fmt.Errorf("%w: %v", errTransferRolledBack, err))
+	}
+
+	rules, err := b.build(commit)
+	if err != nil {
+		return nil, rollback(err)
+	}
+
+	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
+		sc.PFCPContext.SEID,
+		rules.policyID,
+		rules.pdrs,
+		rules.fars,
+		rules.qers,
+	)); err != nil {
+		return nil, rollback(fmt.Errorf("failed to send PFCP session modification request: %w", err))
+	}
+
+	var dropped *droppedSource
+	if commit != nil {
+		dropped = sc.finishTransferCommit(commit)
+	}
+
+	if b.onBound != nil {
+		b.onBound()
+	}
+
+	return dropped, nil
+}
+
+func failBinding(span trace.Span, status string, err error) error {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, status)
+
+	return err
+}
+
+func (sc *SMContext) pendingTransferTo(access AccessType) bool {
+	return sc.pending != nil && sc.pending.to == access
+}
+
+// finishAccessBinding applies the outcome of a downlink re-binding: one that unwound a
+// transfer leaves the session with nowhere to be, so it is released and the peer that
+// asked for the move is told it did not happen; a successful one drops the routing of
+// the access the session left.
+func (s *SMF) finishAccessBinding(ctx context.Context, sc *SMContext, dropped *droppedSource, err error) error {
+	if err != nil {
+		if errors.Is(err, errTransferRolledBack) {
+			s.reportSessionNotMovedTo5GS(ctx, sc)
+
+			if releaseErr := s.releaseSession(ctx, sc.Ref); releaseErr != nil {
+				logger.WithTrace(ctx, logger.SmfLog).Warn("failed to release a session whose move was rolled back",
+					zap.Error(releaseErr), zap.String("ref", sc.Ref))
+			}
+		}
+
+		return err
+	}
+
+	s.dropSourceRouting(ctx, sc.Ref, dropped)
+
+	return nil
+}

--- a/internal/smf/access_binding.go
+++ b/internal/smf/access_binding.go
@@ -94,10 +94,6 @@ func (sc *SMContext) pendingTransferTo(access AccessType) bool {
 	return sc.pending != nil && sc.pending.to == access
 }
 
-// finishAccessBinding applies the outcome of a downlink re-binding: one that unwound a
-// transfer leaves the session with nowhere to be, so it is released and the peer that
-// asked for the move is told it did not happen; a successful one drops the routing of
-// the access the session left.
 func (s *SMF) finishAccessBinding(ctx context.Context, sc *SMContext, dropped *droppedSource, err error) error {
 	if err != nil {
 		if errors.Is(err, errTransferRolledBack) {

--- a/internal/smf/access_binding_test.go
+++ b/internal/smf/access_binding_test.go
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/smf"
+)
+
+func modifySummary(req *models.ModifyRequest) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "policy=%q", req.PolicyID)
+
+	pdrs := make([]string, 0, len(req.UpdatePDRs))
+	for _, p := range req.UpdatePDRs {
+		ohr := "none"
+		if p.OuterHeaderRemoval != nil {
+			ohr = fmt.Sprintf("%d", *p.OuterHeaderRemoval)
+		}
+
+		pdrs = append(pdrs, fmt.Sprintf("id=%d far=%d qer=%d ohr=%s", p.PDRID, p.FARID, p.QERID, ohr))
+	}
+
+	sort.Strings(pdrs)
+	fmt.Fprintf(&b, " pdrs=[%s]", strings.Join(pdrs, "; "))
+
+	fars := make([]string, 0, len(req.UpdateFARs))
+
+	for _, f := range req.UpdateFARs {
+		action := "drop"
+
+		switch {
+		case f.ApplyAction.Forw:
+			action = "forw"
+		case f.ApplyAction.Buff && f.ApplyAction.Nocp:
+			action = "buff+nocp"
+		case f.ApplyAction.Buff:
+			action = "buff"
+		}
+
+		ohc := "none"
+
+		if f.ForwardingParameters != nil && f.ForwardingParameters.OuterHeaderCreation != nil {
+			o := f.ForwardingParameters.OuterHeaderCreation
+			ohc = fmt.Sprintf("teid=%#x desc=%d s1u=%t", o.TEID, o.Description, o.S1U)
+		}
+
+		fars = append(fars, fmt.Sprintf("id=%d %s ohc=%s", f.FARID, action, ohc))
+	}
+
+	sort.Strings(fars)
+	fmt.Fprintf(&b, " fars=[%s]", strings.Join(fars, "; "))
+
+	qers := make([]string, 0, len(req.UpdateQERs))
+	for _, q := range req.UpdateQERs {
+		qers = append(qers, fmt.Sprintf("id=%d qfi=%d", q.QERID, q.QFI))
+	}
+
+	sort.Strings(qers)
+	fmt.Fprintf(&b, " qers=[%s]", strings.Join(qers, "; "))
+
+	return b.String()
+}
+
+func lastModify(t *testing.T, upf *fakeUPF) *models.ModifyRequest {
+	t.Helper()
+
+	upf.mu.Lock()
+	defer upf.mu.Unlock()
+
+	if len(upf.modifyCalls) == 0 {
+		t.Fatal("the UPF was sent no session modification")
+	}
+
+	return upf.modifyCalls[len(upf.modifyCalls)-1]
+}
+
+func assertSEID(t *testing.T, sc *smf.SMContext, req *models.ModifyRequest) {
+	t.Helper()
+
+	sc.Mutex.Lock()
+	seid := sc.PFCPContext.SEID
+	sc.Mutex.Unlock()
+
+	if req.SEID != seid {
+		t.Errorf("modification SEID = %d, want the session's %d", req.SEID, seid)
+	}
+}
+
+// TS 23.502 §4.11.1.3.3 step 8
+func TestIdleTransferModificationRebindsTheDownlinkAlone(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	pcf.policy.PolicyID = "policy-1"
+
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	sc := establishEPSOnENB(t, s)
+
+	if _, err := s.TransferIdle(context.Background(), testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai, smf.Access5G); err != nil {
+		t.Fatalf("TransferIdle: %v", err)
+	}
+
+	req := lastModify(t, upf)
+	assertSEID(t, sc, req)
+
+	const want = `policy="policy-1" pdrs=[] fars=[id=2 buff+nocp ohc=none] qers=[id=1 qfi=1]`
+	if got := modifySummary(req); got != want {
+		t.Errorf("idle transfer modification:\n got %s\nwant %s", got, want)
+	}
+}
+
+// TS 23.401 §5.3.3.1
+func TestEPSBindModificationCarriesBothPDRs(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	pcf.policy.PolicyID = "policy-1"
+
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	create := epsRequest(3)
+	create.APN = testDNN
+	create.PDUSessionID = movedPDUSessionID
+	create.Snssai = testSnssai
+	create.PolicyID = "eps-policy"
+
+	bearer, err := s.CreateEPSSession(ctx, create)
+	if err != nil {
+		t.Fatalf("CreateEPSSession: %v", err)
+	}
+
+	enb := models.FTEID{TEID: 0x6001, Addr: netip.MustParseAddr("192.168.40.10")}
+	if err := s.ModifyEPSSession(ctx, bearer.Ref, epsTestEBI, enb); err != nil {
+		t.Fatalf("ModifyEPSSession: %v", err)
+	}
+
+	sc := s.GetSession(bearer.Ref)
+	if sc == nil {
+		t.Fatal("EPS session is not in the pool")
+	}
+
+	req := lastModify(t, upf)
+	assertSEID(t, sc, req)
+
+	const want = `policy="eps-policy" pdrs=[id=1 far=1 qer=1 ohr=0; id=2 far=2 qer=1 ohr=none] fars=[id=2 forw ohc=teid=0x6001 desc=256 s1u=true] qers=[]`
+	if got := modifySummary(req); got != want {
+		t.Errorf("EPS downlink bind modification:\n got %s\nwant %s", got, want)
+	}
+}
+
+// TS 23.502 §4.3.2.2.1: the gNB's setup response rebinds the downlink and carries the
+// PDRs the N2 transfer resolved.
+func TestNGRANBindModificationCarriesTheN2Rules(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	pcf.policy.PolicyID = "policy-1"
+
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	sc := establish5GS(t, s)
+
+	n2, err := buildPDUSessionResourceSetupResponseTransfer(0x7001, net.ParseIP("10.3.0.9"))
+	if err != nil {
+		t.Fatalf("build N2 setup response: %v", err)
+	}
+
+	if err := s.UpdateSmContextN2InfoPduResSetupRsp(ctx, sc.Ref, n2); err != nil {
+		t.Fatalf("UpdateSmContextN2InfoPduResSetupRsp: %v", err)
+	}
+
+	req := lastModify(t, upf)
+	assertSEID(t, sc, req)
+
+	const want = `policy="" pdrs=[id=1 far=1 qer=1 ohr=0; id=2 far=2 qer=1 ohr=none] fars=[id=2 forw ohc=teid=0x7001 desc=256 s1u=false] qers=[]`
+	if got := modifySummary(req); got != want {
+		t.Errorf("NG-RAN downlink bind modification:\n got %s\nwant %s", got, want)
+	}
+}
+
+// TS 23.502 §4.11.1.2.1
+func TestHandoverFromEPSModificationSwitchesTheDownlink(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	pcf.policy.PolicyID = "policy-1"
+
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	sc := establishEPSOnENB(t, s)
+
+	ref, _, err := s.PrepareSmContextFromEPS(ctx, testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai)
+	if err != nil {
+		t.Fatalf("PrepareSmContextFromEPS: %v", err)
+	}
+
+	ack, err := buildHandoverRequestAcknowledgeTransfer(0x8001, net.ParseIP("10.3.0.11"))
+	if err != nil {
+		t.Fatalf("build handover ack transfer: %v", err)
+	}
+
+	if _, err := s.UpdateSmContextN2HandoverPrepared(ctx, ref, ack); err != nil {
+		t.Fatalf("UpdateSmContextN2HandoverPrepared: %v", err)
+	}
+
+	if err := s.UpdateSmContextN2HandoverComplete(ctx, ref); err != nil {
+		t.Fatalf("UpdateSmContextN2HandoverComplete: %v", err)
+	}
+
+	req := lastModify(t, upf)
+	assertSEID(t, sc, req)
+
+	const want = `policy="policy-1" pdrs=[id=1 far=1 qer=1 ohr=0] fars=[id=2 forw ohc=teid=0x8001 desc=256 s1u=false] qers=[id=1 qfi=1]`
+	if got := modifySummary(req); got != want {
+		t.Errorf("handover-from-EPS modification:\n got %s\nwant %s", got, want)
+	}
+}

--- a/internal/smf/access_binding_test.go
+++ b/internal/smf/access_binding_test.go
@@ -160,8 +160,7 @@ func TestEPSBindModificationCarriesBothPDRs(t *testing.T) {
 	}
 }
 
-// TS 23.502 §4.3.2.2.1: the gNB's setup response rebinds the downlink and carries the
-// PDRs the N2 transfer resolved.
+// TS 23.502 §4.3.2.2.1
 func TestNGRANBindModificationCarriesTheN2Rules(t *testing.T) {
 	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
 	pcf.policy.PolicyID = "policy-1"

--- a/internal/smf/eps.go
+++ b/internal/smf/eps.go
@@ -11,13 +11,11 @@ import (
 	"net/netip"
 
 	"github.com/ellanetworks/core/etsi"
-	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/metrics"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/eps"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 )
 
 func validateEPSBearerRequest(req models.EPSBearerRequest) (models.Ambr, error) {
@@ -156,22 +154,8 @@ func (s *SMF) ModifyEPSSession(ctx context.Context, ref string, ebi uint8, enb m
 	}
 
 	dropped, err := s.bindEPSDownlink(ctx, smContext, enb)
-	if err != nil {
-		if errors.Is(err, errTransferRolledBack) {
-			s.reportSessionNotMovedTo5GS(ctx, smContext)
 
-			if releaseErr := s.releaseSession(ctx, ref); releaseErr != nil {
-				logger.WithTrace(ctx, logger.SmfLog).Warn("failed to release a session whose move was rolled back",
-					zap.Error(releaseErr), zap.String("ref", ref))
-			}
-		}
-
-		return err
-	}
-
-	s.dropSourceRouting(ctx, smContext.Ref, dropped)
-
-	return nil
+	return s.finishAccessBinding(ctx, smContext, dropped, err)
 }
 
 func (s *SMF) bindEPSDownlink(ctx context.Context, smContext *SMContext, enb models.FTEID) (*droppedSource, error) {
@@ -182,86 +166,47 @@ func (s *SMF) bindEPSDownlink(ctx context.Context, smContext *SMContext, enb mod
 		return nil, fmt.Errorf("EPS session %q is not activated", smContext.Ref)
 	}
 
-	commit, err := s.beginTransferCommit(ctx, smContext, Access4G)
-	if err != nil {
-		return nil, fmt.Errorf("failed to move the session to EPS: %w", err)
-	}
-
-	if smContext.Access != Access4G {
-		return nil, fmt.Errorf("session %q is on %s, not EPS", smContext.Ref, smContext.Access)
-	}
-
-	restoreBinding := smContext.stageAccessBinding()
-
-	dl := smContext.Tunnel.DownlinkPDR
-	ul := smContext.Tunnel.UplinkPDR
-	dl.FAR.ApplyAction = models.ApplyAction{Forw: true}
-
-	// bindAccessTunnel aligns the uplink OuterHeaderRemoval, which defaults to IPv4
-	// at session creation, to the eNB's address family.
-	enbIP := net.IP(enb.Addr.AsSlice())
-
-	an := AnchorBinding{TEID: enb.TEID}
-	if enbIP.To4() == nil {
-		an.IPv6 = enbIP
-	} else {
-		an.IPv4 = enbIP
-	}
-
-	smContext.bindAccessTunnel(an, Access4G)
-
-	var (
-		policyID string
-		qers     []*QER
-	)
-
-	if smContext.PolicyData != nil {
-		policyID = smContext.PolicyData.PolicyID
-	}
-
-	if commit != nil {
-		policyID = commit.policy.PolicyID
-		qers = commit.qers
-	}
-
 	if smContext.PFCPContext == nil {
-		restoreBinding()
-
-		if commit != nil {
-			commit.restore()
-		}
-
 		return nil, fmt.Errorf("pfcp session context not found for %q", smContext.Ref)
 	}
 
-	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
-		smContext.PFCPContext.SEID,
-		policyID,
-		[]*PDR{dl, ul},
-		[]*FAR{dl.FAR},
-		qers,
-	)); err != nil {
-		restoreBinding()
+	return s.commitAccessBinding(ctx, smContext, accessBinding{
+		access: Access4G,
+		build: func(commit *transferCommit) (bindingRules, error) {
+			if commit == nil && smContext.Access != Access4G {
+				return bindingRules{}, fmt.Errorf("session %q is on %s, not EPS", smContext.Ref, smContext.Access)
+			}
 
-		if commit != nil {
-			commit.restore()
+			dl := smContext.Tunnel.DownlinkPDR
+			ul := smContext.Tunnel.UplinkPDR
+			dl.FAR.ApplyAction = models.ApplyAction{Forw: true}
 
-			smContext.releasing = true
+			enbIP := net.IP(enb.Addr.AsSlice())
 
-			return nil, fmt.Errorf("%w: %v", errTransferRolledBack, err)
-		}
+			an := AnchorBinding{TEID: enb.TEID}
+			if enbIP.To4() == nil {
+				an.IPv6 = enbIP
+			} else {
+				an.IPv4 = enbIP
+			}
 
-		return nil, err
-	}
+			smContext.bindAccessTunnel(an, Access4G)
 
-	var dropped *droppedSource
-	if commit != nil {
-		dropped = smContext.finishTransferCommit(commit)
-	}
+			rules := bindingRules{pdrs: []*PDR{dl, ul}, fars: []*FAR{dl.FAR}}
 
-	s.registerIPv6SessionIfNeeded(ctx, smContext, Access4G)
+			if smContext.PolicyData != nil {
+				rules.policyID = smContext.PolicyData.PolicyID
+			}
 
-	return dropped, nil
+			if commit != nil {
+				rules.policyID = commit.policy.PolicyID
+				rules.qers = commit.qers
+			}
+
+			return rules, nil
+		},
+		onBound: func() { s.registerIPv6SessionIfNeeded(ctx, smContext, Access4G) },
+	})
 }
 
 func (s *SMF) UpdateEPSSessionAMBR(ctx context.Context, ref string, ambrUplink, ambrDownlink models.BitRate) error {

--- a/internal/smf/handover.go
+++ b/internal/smf/handover.go
@@ -5,7 +5,6 @@ package smf
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/ellanetworks/core/internal/logger"
@@ -149,22 +148,8 @@ func (s *SMF) UpdateSmContextN2HandoverComplete(ctx context.Context, smContextRe
 	}
 
 	dropped, err := s.switchDownlinkToTargetNGRAN(ctx, smContext, span)
-	if err != nil {
-		if errors.Is(err, errTransferRolledBack) {
-			s.reportSessionNotMovedTo5GS(ctx, smContext)
 
-			if releaseErr := s.releaseSession(ctx, smContextRef); releaseErr != nil {
-				logger.WithTrace(ctx, logger.SmfLog).Warn("failed to release a session whose move onto 5GS was rolled back",
-					zap.Error(releaseErr), zap.String("ref", smContextRef))
-			}
-		}
-
-		return err
-	}
-
-	s.dropSourceRouting(ctx, smContext.Ref, dropped)
-
-	return nil
+	return s.finishAccessBinding(ctx, smContext, dropped, err)
 }
 
 func (s *SMF) switchDownlinkToTargetNGRAN(ctx context.Context, smContext *SMContext, span trace.Span) (*droppedSource, error) {
@@ -175,95 +160,52 @@ func (s *SMF) switchDownlinkToTargetNGRAN(ctx context.Context, smContext *SMCont
 		return nil, fmt.Errorf("sm context has no user-plane tunnel: %s", smContext.Ref)
 	}
 
-	commit, err := s.beginTransferCommit(ctx, smContext, Access5G)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to move a PDN connection onto 5GS")
+	// A session whose user plane is already down and that no transfer is waiting on has
+	// nothing to switch; the source binding is simply forgotten.
+	if !smContext.Tunnel.Activated && !smContext.pendingTransferTo(Access5G) {
+		smContext.handoverSourceAN = nil
 
-		return nil, fmt.Errorf("failed to move a PDN connection onto 5GS: %w", err)
-	}
-
-	if commit == nil && smContext.Access != Access5G {
-		err := fmt.Errorf("session %q is on %s, not 5GS", smContext.Ref, smContext.Access)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "session is not on 5GS")
-
-		return nil, err
-	}
-
-	if !smContext.Tunnel.Activated {
-		if commit == nil {
-			smContext.handoverSourceAN = nil
-
-			return nil, nil
-		}
-
-		commit.restore()
-
-		return nil, fmt.Errorf("session %q has no activated user plane to switch onto 5GS", smContext.Ref)
+		return nil, nil
 	}
 
 	if smContext.PFCPContext == nil {
-		if commit != nil {
-			commit.restore()
-		}
-
-		span.RecordError(fmt.Errorf("pfcp session context not found"))
-		span.SetStatus(codes.Error, "pfcp session context not found")
-
-		return nil, fmt.Errorf("pfcp session context not found")
+		return nil, failBinding(span, "pfcp session context not found", fmt.Errorf("pfcp session context not found"))
 	}
 
-	var (
-		policyID string
-		qers     []*QER
-	)
+	return s.commitAccessBinding(ctx, smContext, accessBinding{
+		access: Access5G,
+		build: func(commit *transferCommit) (bindingRules, error) {
+			if commit == nil && smContext.Access != Access5G {
+				return bindingRules{}, fmt.Errorf("session %q is on %s, not 5GS", smContext.Ref, smContext.Access)
+			}
 
-	restoreBinding := func() {}
+			if !smContext.Tunnel.Activated {
+				return bindingRules{}, fmt.Errorf("session %q has no activated user plane to switch onto 5GS", smContext.Ref)
+			}
 
-	if commit != nil {
-		policyID = commit.policy.PolicyID
-		qers = commit.qers
-		restoreBinding = smContext.stageAccessBinding()
-		smContext.Tunnel.DownlinkPDR.FAR.ApplyAction = models.ApplyAction{Forw: true}
-	}
+			rules := bindingRules{
+				pdrs: []*PDR{smContext.Tunnel.UplinkPDR},
+				fars: []*FAR{smContext.Tunnel.DownlinkPDR.FAR},
+			}
 
-	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
-		smContext.PFCPContext.SEID,
-		policyID,
-		[]*PDR{smContext.Tunnel.UplinkPDR},
-		[]*FAR{smContext.Tunnel.DownlinkPDR.FAR},
-		qers,
-	)); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to modify PFCP session")
+			if commit != nil {
+				rules.policyID = commit.policy.PolicyID
+				rules.qers = commit.qers
+				smContext.Tunnel.DownlinkPDR.FAR.ApplyAction = models.ApplyAction{Forw: true}
+			}
 
-		if commit != nil {
-			restoreBinding()
-			commit.restore()
+			return rules, nil
+		},
+		onBound: func() {
+			smContext.handoverSourceAN = nil
 
-			smContext.releasing = true
+			s.registerIPv6SessionIfNeeded(ctx, smContext, Access5G)
 
-			return nil, fmt.Errorf("%w: %v", errTransferRolledBack, err)
-		}
-
-		return nil, fmt.Errorf("failed to send PFCP session modification request: %v", err)
-	}
-
-	smContext.handoverSourceAN = nil
-
-	var dropped *droppedSource
-	if commit != nil {
-		dropped = smContext.finishTransferCommit(commit)
-	}
-
-	s.registerIPv6SessionIfNeeded(ctx, smContext, Access5G)
-
-	logger.SmfLog.Info("Sent PFCP session modification for N2 handover completion",
-		logger.SUPI(smContext.Supi.String()),
-		logger.PDUSessionID(smContext.PDUSessionID))
-
-	return dropped, nil
+			logger.SmfLog.Info("Sent PFCP session modification for N2 handover completion",
+				logger.SUPI(smContext.Supi.String()),
+				logger.PDUSessionID(smContext.PDUSessionID))
+		},
+	})
 }
 
 func handleHandoverRequestAcknowledgeTransfer(b []byte, smContext *SMContext) error {

--- a/internal/smf/handover.go
+++ b/internal/smf/handover.go
@@ -160,8 +160,6 @@ func (s *SMF) switchDownlinkToTargetNGRAN(ctx context.Context, smContext *SMCont
 		return nil, fmt.Errorf("sm context has no user-plane tunnel: %s", smContext.Ref)
 	}
 
-	// A session whose user plane is already down and that no transfer is waiting on has
-	// nothing to switch; the source binding is simply forgotten.
 	if !smContext.Tunnel.Activated && !smContext.pendingTransferTo(Access5G) {
 		smContext.handoverSourceAN = nil
 

--- a/internal/smf/transfer_eps.go
+++ b/internal/smf/transfer_eps.go
@@ -39,7 +39,7 @@ func (s *SMF) transferToEPS(ctx context.Context, supi etsi.SUPI, req models.EPSB
 		return models.EPSBearer{}, err
 	}
 
-	bearer, err := epsBearerForSession(sc, req)
+	bearer, err := epsBearerForSession(sc, req.DNS)
 	if err != nil {
 		sc.abandonTransferTo(Access4G)
 
@@ -53,12 +53,23 @@ func (s *SMF) transferToEPS(ctx context.Context, supi etsi.SUPI, req models.EPSB
 	return bearer, nil
 }
 
-func epsBearerForSession(sc *SMContext, req models.EPSBearerRequest) (models.EPSBearer, error) {
+func sessionDNS(sc *SMContext) string {
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+
+	if sc.PolicyData == nil || sc.PolicyData.DNS == nil {
+		return ""
+	}
+
+	return sc.PolicyData.DNS.String()
+}
+
+func epsBearerForSession(sc *SMContext, dns string) (models.EPSBearer, error) {
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
 	if sc.Tunnel == nil {
-		return models.EPSBearer{}, fmt.Errorf("%w: PDU session %d has no tunnel to report", ErrSessionNotMovable, req.PDUSessionID)
+		return models.EPSBearer{}, fmt.Errorf("%w: PDU session %d has no tunnel to report", ErrSessionNotMovable, sc.PDUSessionID)
 	}
 
 	pdnType, err := pdnTypeFor(sc.PDUSessionType)
@@ -88,7 +99,7 @@ func epsBearerForSession(sc *SMContext, req models.EPSBearerRequest) (models.EPS
 		}
 	}
 
-	if dns := net.ParseIP(req.DNS); dns != nil {
+	if dns := net.ParseIP(dns); dns != nil {
 		if addr, ok := netip.AddrFromSlice(dns); ok {
 			bearer.DNS = addr.Unmap()
 		}

--- a/internal/smf/transfer_idle.go
+++ b/internal/smf/transfer_idle.go
@@ -15,6 +15,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// TransferIdleTo5GS is TransferIdle onto 5GS, for the AMF's idle-mode adoption.
+func (s *SMF) TransferIdleTo5GS(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai) (string, error) {
+	return s.TransferIdle(ctx, supi, pduSessionID, ebi, dnn, snssai, Access5G)
+}
+
+// TransferIdleToEPS is TransferIdle onto EPS, for the MME's idle-mode adoption.
+func (s *SMF) TransferIdleToEPS(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai) (string, error) {
+	return s.TransferIdle(ctx, supi, pduSessionID, ebi, dnn, snssai, Access4G)
+}
+
 func (s *SMF) TransferIdle(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai, access AccessType) (string, error) {
 	ctx, span := tracer.Start(ctx, "smf/transfer_idle",
 		trace.WithAttributes(

--- a/internal/smf/transfer_idle.go
+++ b/internal/smf/transfer_idle.go
@@ -15,14 +15,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// TransferIdle moves a session to access and leaves it there with the user plane
-// down: the downlink FAR buffers and notifies, so data arriving for the moved
-// session pages the UE. An idle-mode inter-system change binds no AN tunnel
-// unless the UE asks for one — the active flag of a TRACKING AREA UPDATE
-// REQUEST (TS 23.401 §5.3.3.1) or the Uplink data status IE of a mobility
-// registration update (TS 24.501 §5.5.1.3.2) — so the move commits here rather
-// than at a bind that may never come, and the target's activation path brings
-// the user plane up when it does.
 func (s *SMF) TransferIdle(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai, access AccessType) (string, error) {
 	ctx, span := tracer.Start(ctx, "smf/transfer_idle",
 		trace.WithAttributes(

--- a/internal/smf/transfer_idle.go
+++ b/internal/smf/transfer_idle.go
@@ -15,14 +15,22 @@ import (
 	"go.uber.org/zap"
 )
 
-// TransferIdleTo5GS is TransferIdle onto 5GS, for the AMF's idle-mode adoption.
 func (s *SMF) TransferIdleTo5GS(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai) (string, error) {
 	return s.TransferIdle(ctx, supi, pduSessionID, ebi, dnn, snssai, Access5G)
 }
 
-// TransferIdleToEPS is TransferIdle onto EPS, for the MME's idle-mode adoption.
-func (s *SMF) TransferIdleToEPS(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai) (string, error) {
-	return s.TransferIdle(ctx, supi, pduSessionID, ebi, dnn, snssai, Access4G)
+func (s *SMF) TransferIdleToEPS(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai) (models.EPSBearer, error) {
+	ref, err := s.TransferIdle(ctx, supi, pduSessionID, ebi, dnn, snssai, Access4G)
+	if err != nil {
+		return models.EPSBearer{}, err
+	}
+
+	sc := s.GetSession(ref)
+	if sc == nil {
+		return models.EPSBearer{}, fmt.Errorf("%w: session %q left the pool as it moved", ErrSessionNotMovable, ref)
+	}
+
+	return epsBearerForSession(sc, sessionDNS(sc))
 }
 
 func (s *SMF) TransferIdle(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai, access AccessType) (string, error) {

--- a/internal/smf/transfer_idle.go
+++ b/internal/smf/transfer_idle.go
@@ -86,9 +86,7 @@ func (s *SMF) commitIdleTransfer(ctx context.Context, sc *SMContext, access Acce
 	}
 
 	return s.commitAccessBinding(ctx, sc, accessBinding{
-		access: access,
-		// TS 23.502 §4.11.1.3.3: a move that does not commit leaves the UE served on
-		// the access it has not left.
+		access:         access,
 		keepOnRollback: true,
 		build: func(commit *transferCommit) (bindingRules, error) {
 			if commit == nil {

--- a/internal/smf/transfer_idle.go
+++ b/internal/smf/transfer_idle.go
@@ -81,37 +81,26 @@ func (s *SMF) commitIdleTransfer(ctx context.Context, sc *SMContext, access Acce
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
-	commit, err := s.beginTransferCommit(ctx, sc, access)
-	if err != nil {
-		return nil, fmt.Errorf("failed to move the session to %s: %w", access, err)
+	if sc.PFCPContext == nil {
+		return nil, fmt.Errorf("pfcp session context not found for %q", sc.Ref)
 	}
 
-	if commit == nil {
-		return nil, fmt.Errorf("%w: the move of session %q to %s was abandoned before it committed", ErrSessionNotMovable, sc.Ref, access)
-	}
+	return s.commitAccessBinding(ctx, sc, accessBinding{
+		access: access,
+		// TS 23.502 §4.11.1.3.3: a move that does not commit leaves the UE served on
+		// the access it has not left.
+		keepOnRollback: true,
+		build: func(commit *transferCommit) (bindingRules, error) {
+			if commit == nil {
+				return bindingRules{}, fmt.Errorf("%w: the move of session %q to %s was abandoned before it committed", ErrSessionNotMovable, sc.Ref, access)
+			}
 
-	restoreBinding := sc.stageAccessBinding()
+			farList, err := handleUpCnxStateDeactivate(sc)
+			if err != nil {
+				return bindingRules{}, fmt.Errorf("failed to stage the downlink of a session moved in idle mode: %w", err)
+			}
 
-	farList, err := handleUpCnxStateDeactivate(sc)
-	if err != nil {
-		restoreBinding()
-		commit.restore()
-
-		return nil, fmt.Errorf("failed to stage the downlink of a session moved in idle mode: %w", err)
-	}
-
-	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
-		sc.PFCPContext.SEID,
-		commit.policy.PolicyID,
-		nil,
-		farList,
-		commit.qers,
-	)); err != nil {
-		restoreBinding()
-		commit.restore()
-
-		return nil, fmt.Errorf("failed to send PFCP session modification request: %w", err)
-	}
-
-	return sc.finishTransferCommit(commit), nil
+			return bindingRules{policyID: commit.policy.PolicyID, fars: farList, qers: commit.qers}, nil
+		},
+	})
 }

--- a/internal/smf/transfer_idle.go
+++ b/internal/smf/transfer_idle.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+// TransferIdle moves a session to access and leaves it there with the user plane
+// down: the downlink FAR buffers and notifies, so data arriving for the moved
+// session pages the UE. An idle-mode inter-system change binds no AN tunnel
+// unless the UE asks for one — the active flag of a TRACKING AREA UPDATE
+// REQUEST (TS 23.401 §5.3.3.1) or the Uplink data status IE of a mobility
+// registration update (TS 24.501 §5.5.1.3.2) — so the move commits here rather
+// than at a bind that may never come, and the target's activation path brings
+// the user plane up when it does.
+func (s *SMF) TransferIdle(ctx context.Context, supi etsi.SUPI, pduSessionID, ebi uint8, dnn string, snssai *models.Snssai, access AccessType) (string, error) {
+	ctx, span := tracer.Start(ctx, "smf/transfer_idle",
+		trace.WithAttributes(
+			attribute.String("ue.supi", supi.String()),
+			attribute.Int("smf.pdu_session_id", int(pduSessionID)),
+			attribute.Int("eps.bearer_id", int(ebi)),
+			attribute.String("smf.dnn", dnn),
+			attribute.String("smf.access", access.String()),
+		),
+	)
+	defer span.End()
+
+	policy, err := s.GetSessionPolicy(ctx, supi, snssai, dnn)
+	if err != nil {
+		return "", fmt.Errorf("no policy for a session moving to %s in idle mode: %w", access, err)
+	}
+
+	move := transferRequest{Access: access, EBI: ebi, Dnn: dnn, Snssai: snssai, Policy: policy}
+
+	sc, err := s.findTransferable(supi, pduSessionID, move)
+	if err != nil {
+		return "", fmt.Errorf("no session to move to %s in idle mode: %w", access, err)
+	}
+
+	if err := s.prepareTransfer(sc, move); err != nil {
+		return "", fmt.Errorf("failed to prepare a session move to %s in idle mode: %w", access, err)
+	}
+
+	dropped, err := s.commitIdleTransfer(ctx, sc, access)
+	if err != nil {
+		sc.abandonTransferTo(access)
+
+		return "", err
+	}
+
+	logger.WithTrace(ctx, logger.SmfLog).Info("moved a session between systems in idle mode",
+		logger.SUPI(supi.String()), logger.PDUSessionID(pduSessionID),
+		zap.Uint8("ebi", ebi), zap.String("dnn", dnn), zap.Stringer("to", access))
+
+	s.dropSourceRouting(ctx, sc.Ref, dropped)
+
+	return sc.Ref, nil
+}
+
+func (s *SMF) commitIdleTransfer(ctx context.Context, sc *SMContext, access AccessType) (*droppedSource, error) {
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+
+	commit, err := s.beginTransferCommit(ctx, sc, access)
+	if err != nil {
+		return nil, fmt.Errorf("failed to move the session to %s: %w", access, err)
+	}
+
+	if commit == nil {
+		return nil, fmt.Errorf("%w: the move of session %q to %s was abandoned before it committed", ErrSessionNotMovable, sc.Ref, access)
+	}
+
+	restoreBinding := sc.stageAccessBinding()
+
+	farList, err := handleUpCnxStateDeactivate(sc)
+	if err != nil {
+		restoreBinding()
+		commit.restore()
+
+		return nil, fmt.Errorf("failed to stage the downlink of a session moved in idle mode: %w", err)
+	}
+
+	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
+		sc.PFCPContext.SEID,
+		commit.policy.PolicyID,
+		nil,
+		farList,
+		commit.qers,
+	)); err != nil {
+		restoreBinding()
+		commit.restore()
+
+		return nil, fmt.Errorf("failed to send PFCP session modification request: %w", err)
+	}
+
+	return sc.finishTransferCommit(commit), nil
+}

--- a/internal/smf/transfer_idle_test.go
+++ b/internal/smf/transfer_idle_test.go
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/smf"
+)
+
+// establishEPSOnENB brings up a PDN connection on the DNN and slice the 5GS
+// tests use, with its downlink bound to an eNB, so it can move onto 5GS.
+func establishEPSOnENB(t *testing.T, s *smf.SMF) *smf.SMContext {
+	t.Helper()
+
+	ctx := context.Background()
+
+	req := epsRequest(3)
+	req.APN = testDNN
+	req.PDUSessionID = movedPDUSessionID
+	req.Snssai = testSnssai
+
+	bearer, err := s.CreateEPSSession(ctx, req)
+	if err != nil {
+		t.Fatalf("CreateEPSSession: %v", err)
+	}
+
+	enb := models.FTEID{TEID: 0x6001, Addr: netip.MustParseAddr("192.168.40.10")}
+	if err := s.ModifyEPSSession(ctx, bearer.Ref, epsTestEBI, enb); err != nil {
+		t.Fatalf("ModifyEPSSession: %v", err)
+	}
+
+	sc := s.GetSession(bearer.Ref)
+	if sc == nil {
+		t.Fatal("EPS session is not in the pool")
+	}
+
+	return sc
+}
+
+// assertDownlinkBuffers reports whether the session's downlink is in the state a
+// UE in idle mode is served from: buffered, notifying the control plane, and
+// aimed at no access-network endpoint (TS 29.244 §8.2.26).
+func assertDownlinkBuffers(t *testing.T, sc *smf.SMContext) {
+	t.Helper()
+
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+
+	far := sc.Tunnel.DownlinkPDR.FAR
+
+	if want := (models.ApplyAction{Buff: true, Nocp: true}); far.ApplyAction != want {
+		t.Errorf("downlink apply action = %+v, want %+v", far.ApplyAction, want)
+	}
+
+	if far.ForwardingParameters != nil && far.ForwardingParameters.OuterHeaderCreation != nil {
+		t.Errorf("downlink still aims at %s, want no outer header: the UE left that access",
+			ohcSummary(far.ForwardingParameters.OuterHeaderCreation))
+	}
+}
+
+func accessAndEBI(t *testing.T, sc *smf.SMContext) (smf.AccessType, uint8) {
+	t.Helper()
+
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+
+	return sc.Access, sc.EBI
+}
+
+// TS 23.401 §5.3.3.1: a TAU with the active flag clear sets up no S1-U, so the
+// PDN connection is adopted with its user plane down.
+func TestTransferIdle5GSToEPSKeepsTheSessionWithTheUserPlaneDown(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	sc := establish5GS(t, s)
+	before := invariantsOf(t, sc)
+	establishes := len(store.ops())
+
+	ref, err := s.TransferIdle(ctx, testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai, smf.Access4G)
+	if err != nil {
+		t.Fatalf("TransferIdle: %v", err)
+	}
+
+	if ref != sc.Ref {
+		t.Errorf("move returned ref %q, want the session's own %q", ref, sc.Ref)
+	}
+
+	access, ebi := accessAndEBI(t, sc)
+	if access != smf.Access4G {
+		t.Errorf("session on %s after the move, want EPS", access)
+	}
+
+	if ebi != epsTestEBI {
+		t.Errorf("session EBI = %d, want the %d the MME allocated", ebi, epsTestEBI)
+	}
+
+	if after := invariantsOf(t, sc); after != before {
+		t.Errorf("session invariants changed across the move: %+v, want %+v", after, before)
+	}
+
+	if got := len(store.ops()); got != establishes {
+		t.Errorf("IP pool operations = %d, want %d: the move must not touch the lease", got, establishes)
+	}
+
+	assertDownlinkBuffers(t, sc)
+	assertMovable(t, sc)
+
+	calls := amfCb.dropped()
+	if len(calls) != 1 {
+		t.Fatalf("AMF SessionDropped calls = %d, want 1", len(calls))
+	}
+
+	if calls[0].ref != sc.Ref || calls[0].pduSessionID != movedPDUSessionID {
+		t.Errorf("AMF told about ref %q pdu session %d, want %q / %d",
+			calls[0].ref, calls[0].pduSessionID, sc.Ref, movedPDUSessionID)
+	}
+}
+
+// TS 24.501 §5.5.1.3.2: a mobility registration update activates only the PDU
+// sessions the Uplink data status IE names, so an arriving session with none
+// pending is adopted with its user plane down.
+func TestTransferIdleEPSTo5GSKeepsTheSessionWithTheUserPlaneDown(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	sc := establishEPSOnENB(t, s)
+	before := invariantsOf(t, sc)
+	establishes := len(store.ops())
+
+	ref, err := s.TransferIdle(ctx, testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai, smf.Access5G)
+	if err != nil {
+		t.Fatalf("TransferIdle: %v", err)
+	}
+
+	if ref != sc.Ref {
+		t.Errorf("move returned ref %q, want the session's own %q", ref, sc.Ref)
+	}
+
+	access, ebi := accessAndEBI(t, sc)
+	if access != smf.Access5G {
+		t.Errorf("session on %s after the move, want 5GS", access)
+	}
+
+	// TS 23.502 §4.11.1.4.1: the session keeps the mapped EPS bearer identity on
+	// 5GS, so it can move back without a new one.
+	if ebi != epsTestEBI {
+		t.Errorf("session EBI = %d, want the mapped %d it keeps on 5GS", ebi, epsTestEBI)
+	}
+
+	if after := invariantsOf(t, sc); after != before {
+		t.Errorf("session invariants changed across the move: %+v, want %+v", after, before)
+	}
+
+	if got := len(store.ops()); got != establishes {
+		t.Errorf("IP pool operations = %d, want %d: the move must not touch the lease", got, establishes)
+	}
+
+	assertDownlinkBuffers(t, sc)
+	assertMovable(t, sc)
+
+	calls := mmeCb.dropped()
+	if len(calls) != 1 {
+		t.Fatalf("MME SessionDropped calls = %d, want 1", len(calls))
+	}
+
+	if calls[0].ref != sc.Ref || calls[0].ebi != epsTestEBI {
+		t.Errorf("MME told about ref %q ebi %d, want %q / %d", calls[0].ref, calls[0].ebi, sc.Ref, epsTestEBI)
+	}
+}
+
+// The commit lands in TransferIdle itself, so the supervision guard that returns
+// an unbound move to its source access has nothing left to fire on.
+func TestTransferIdleLeavesNoMoveForTheGuardToAbandon(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	defer smf.SetTransferSupervisionForTest(20 * time.Millisecond)()
+
+	ctx := context.Background()
+	sc := establish5GS(t, s)
+
+	if _, err := s.TransferIdle(ctx, testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai, smf.Access4G); err != nil {
+		t.Fatalf("TransferIdle: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	access, _ := accessAndEBI(t, sc)
+	if access != smf.Access4G {
+		t.Errorf("session on %s once the supervision window passed, want EPS: the move was committed, not staged", access)
+	}
+
+	assertMovable(t, sc)
+
+	if s.GetSession(sc.Ref) == nil {
+		t.Error("the session was released after the move committed")
+	}
+}
+
+func TestTransferIdleRestoresTheSourceWhenTheModifyFails(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	sc := establishEPSOnENB(t, s)
+
+	sc.Mutex.Lock()
+	before := ohcSummary(sc.Tunnel.DownlinkPDR.FAR.ForwardingParameters.OuterHeaderCreation)
+	beforeAction := sc.Tunnel.DownlinkPDR.FAR.ApplyAction
+	sc.Mutex.Unlock()
+
+	upf.err = errors.New("PFCP modify refused")
+
+	if _, err := s.TransferIdle(ctx, testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai, smf.Access5G); err == nil {
+		t.Fatal("the move succeeded though the UPF refused the modify")
+	}
+
+	upf.err = nil
+
+	access, ebi := accessAndEBI(t, sc)
+	if access != smf.Access4G {
+		t.Errorf("session on %s after a refused move, want EPS", access)
+	}
+
+	if ebi != epsTestEBI {
+		t.Errorf("session EBI = %d after a refused move, want %d", ebi, epsTestEBI)
+	}
+
+	sc.Mutex.Lock()
+	after := ohcSummary(sc.Tunnel.DownlinkPDR.FAR.ForwardingParameters.OuterHeaderCreation)
+	afterAction := sc.Tunnel.DownlinkPDR.FAR.ApplyAction
+	sc.Mutex.Unlock()
+
+	if after != before {
+		t.Errorf("downlink outer header = %s, want the eNB's %s: the data plane still holds it", after, before)
+	}
+
+	if afterAction != beforeAction {
+		t.Errorf("downlink apply action = %+v, want %+v", afterAction, beforeAction)
+	}
+
+	assertMovable(t, sc)
+
+	if len(mmeCb.dropped()) != 0 {
+		t.Error("the MME was told to drop a session that never left EPS")
+	}
+}
+
+// TS 23.401 §5.3.3.1: the user plane comes up on the target when the UE asks for
+// it, through the access's ordinary activation path.
+func TestTransferIdleTo4GLetsTheENBBindTheDownlink(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	sc := establish5GS(t, s)
+
+	ref, err := s.TransferIdle(ctx, testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai, smf.Access4G)
+	if err != nil {
+		t.Fatalf("TransferIdle: %v", err)
+	}
+
+	enb := models.FTEID{TEID: 0x6001, Addr: netip.MustParseAddr("192.168.40.10")}
+	if err := s.ModifyEPSSession(ctx, ref, epsTestEBI, enb); err != nil {
+		t.Fatalf("ModifyEPSSession: %v", err)
+	}
+
+	sc.Mutex.Lock()
+	far := sc.Tunnel.DownlinkPDR.FAR
+	forwarding := far.ApplyAction.Forw
+	ohc := far.ForwardingParameters.OuterHeaderCreation
+	sc.Mutex.Unlock()
+
+	if !forwarding {
+		t.Error("the downlink still buffers after the eNB bound it")
+	}
+
+	if ohc == nil || ohc.TEID != enb.TEID {
+		t.Errorf("downlink outer header = %s, want the eNB's TEID %#x", ohcSummary(ohc), enb.TEID)
+	}
+}
+
+func TestTransferIdleTo5GSLetsTheGNBBindTheDownlink(t *testing.T) {
+	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+	s.SetMME(mmeCb)
+
+	ctx := context.Background()
+
+	sc := establishEPSOnENB(t, s)
+
+	ref, err := s.TransferIdle(ctx, testSUPI(), movedPDUSessionID, epsTestEBI, testDNN, testSnssai, smf.Access5G)
+	if err != nil {
+		t.Fatalf("TransferIdle: %v", err)
+	}
+
+	if _, err := s.ActivateSmContext(ctx, ref); err != nil {
+		t.Fatalf("ActivateSmContext: %v", err)
+	}
+
+	n2, err := buildPDUSessionResourceSetupResponseTransfer(0x7001, net.ParseIP("10.3.0.9"))
+	if err != nil {
+		t.Fatalf("build N2 setup response: %v", err)
+	}
+
+	if err := s.UpdateSmContextN2InfoPduResSetupRsp(ctx, ref, n2); err != nil {
+		t.Fatalf("UpdateSmContextN2InfoPduResSetupRsp: %v", err)
+	}
+
+	sc.Mutex.Lock()
+	far := sc.Tunnel.DownlinkPDR.FAR
+	forwarding := far.ApplyAction.Forw
+	ohc := far.ForwardingParameters.OuterHeaderCreation
+	sc.Mutex.Unlock()
+
+	if !forwarding {
+		t.Error("the downlink still buffers after the gNB bound it")
+	}
+
+	if ohc == nil || ohc.TEID != 0x7001 {
+		t.Errorf("downlink outer header = %s, want the gNB's TEID 0x7001", ohcSummary(ohc))
+	}
+}

--- a/internal/smf/transfer_idle_test.go
+++ b/internal/smf/transfer_idle_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/ellanetworks/core/internal/smf"
 )
 
-// establishEPSOnENB brings up a PDN connection on the DNN and slice the 5GS
-// tests use, with its downlink bound to an eNB, so it can move onto 5GS.
 func establishEPSOnENB(t *testing.T, s *smf.SMF) *smf.SMContext {
 	t.Helper()
 
@@ -45,9 +43,7 @@ func establishEPSOnENB(t *testing.T, s *smf.SMF) *smf.SMContext {
 	return sc
 }
 
-// assertDownlinkBuffers reports whether the session's downlink is in the state a
-// UE in idle mode is served from: buffered, notifying the control plane, and
-// aimed at no access-network endpoint (TS 29.244 §8.2.26).
+// TS 29.244 §8.2.26
 func assertDownlinkBuffers(t *testing.T, sc *smf.SMContext) {
 	t.Helper()
 
@@ -75,8 +71,7 @@ func accessAndEBI(t *testing.T, sc *smf.SMContext) (smf.AccessType, uint8) {
 	return sc.Access, sc.EBI
 }
 
-// TS 23.401 §5.3.3.1: a TAU with the active flag clear sets up no S1-U, so the
-// PDN connection is adopted with its user plane down.
+// TS 23.401 §5.3.3.1
 func TestTransferIdle5GSToEPSKeepsTheSessionWithTheUserPlaneDown(t *testing.T) {
 	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
@@ -128,9 +123,7 @@ func TestTransferIdle5GSToEPSKeepsTheSessionWithTheUserPlaneDown(t *testing.T) {
 	}
 }
 
-// TS 24.501 §5.5.1.3.2: a mobility registration update activates only the PDU
-// sessions the Uplink data status IE names, so an arriving session with none
-// pending is adopted with its user plane down.
+// TS 24.501 §5.5.1.3.2
 func TestTransferIdleEPSTo5GSKeepsTheSessionWithTheUserPlaneDown(t *testing.T) {
 	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
@@ -156,8 +149,6 @@ func TestTransferIdleEPSTo5GSKeepsTheSessionWithTheUserPlaneDown(t *testing.T) {
 		t.Errorf("session on %s after the move, want 5GS", access)
 	}
 
-	// TS 23.502 §4.11.1.4.1: the session keeps the mapped EPS bearer identity on
-	// 5GS, so it can move back without a new one.
 	if ebi != epsTestEBI {
 		t.Errorf("session EBI = %d, want the mapped %d it keeps on 5GS", ebi, epsTestEBI)
 	}
@@ -183,8 +174,6 @@ func TestTransferIdleEPSTo5GSKeepsTheSessionWithTheUserPlaneDown(t *testing.T) {
 	}
 }
 
-// The commit lands in TransferIdle itself, so the supervision guard that returns
-// an unbound move to its source access has nothing left to fire on.
 func TestTransferIdleLeavesNoMoveForTheGuardToAbandon(t *testing.T) {
 	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
@@ -264,8 +253,7 @@ func TestTransferIdleRestoresTheSourceWhenTheModifyFails(t *testing.T) {
 	}
 }
 
-// TS 23.401 §5.3.3.1: the user plane comes up on the target when the UE asks for
-// it, through the access's ordinary activation path.
+// TS 23.401 §5.3.3.1
 func TestTransferIdleTo4GLetsTheENBBindTheDownlink(t *testing.T) {
 	pcf, store, upf, amfCb, mmeCb := interworkingFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -211,23 +211,11 @@ func (s *SMF) UpdateSmContextN2InfoPduResSetupRsp(ctx context.Context, smContext
 	}
 
 	dropped, err := s.bindNGRANDownlink(ctx, smContext, n2Data, span)
-	if err != nil {
-		if errors.Is(err, errTransferRolledBack) {
-			s.rejectUnforwardedEstablishment(ctx, smContext)
-			s.reportSessionNotMovedTo5GS(ctx, smContext)
-
-			if releaseErr := s.releaseSession(ctx, smContextRef); releaseErr != nil {
-				logger.WithTrace(ctx, logger.SmfLog).Warn("failed to release a session whose move was rolled back",
-					zap.Error(releaseErr), zap.String("ref", smContextRef))
-			}
-		}
-
-		return err
+	if errors.Is(err, errTransferRolledBack) {
+		s.rejectUnforwardedEstablishment(ctx, smContext)
 	}
 
-	s.dropSourceRouting(ctx, smContext.Ref, dropped)
-
-	return nil
+	return s.finishAccessBinding(ctx, smContext, dropped, err)
 }
 
 func (s *SMF) bindNGRANDownlink(ctx context.Context, smContext *SMContext, n2Data []byte, span trace.Span) (*droppedSource, error) {
@@ -235,97 +223,41 @@ func (s *SMF) bindNGRANDownlink(ctx context.Context, smContext *SMContext, n2Dat
 	defer smContext.Mutex.Unlock()
 
 	if smContext.Tunnel == nil || !smContext.Tunnel.Activated {
-		span.RecordError(fmt.Errorf("session already released"))
-		span.SetStatus(codes.Error, "session already released")
-
-		return nil, fmt.Errorf("session already released")
+		return nil, failBinding(span, "session already released", fmt.Errorf("session already released"))
 	}
 
 	if smContext.PFCPContext == nil {
-		span.RecordError(fmt.Errorf("pfcp session context not found"))
-		span.SetStatus(codes.Error, "pfcp session context not found")
-
-		return nil, fmt.Errorf("pfcp session context not found")
+		return nil, failBinding(span, "pfcp session context not found", fmt.Errorf("pfcp session context not found"))
 	}
 
-	commit, err := s.beginTransferCommit(ctx, smContext, Access5G)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to move the session to 5GS")
+	return s.commitAccessBinding(ctx, smContext, accessBinding{
+		access: Access5G,
+		build: func(commit *transferCommit) (bindingRules, error) {
+			if commit == nil && smContext.Access != Access5G {
+				return bindingRules{}, fmt.Errorf("session %q is on %s, not 5GS", smContext.Ref, smContext.Access)
+			}
 
-		return nil, fmt.Errorf("failed to move the session to 5GS: %w", err)
-	}
+			pdrList, farList, err := handleUpdateN2MsgPDUResourceSetupResp(n2Data, smContext)
+			if err != nil {
+				return bindingRules{}, fmt.Errorf("error handling N2 message: %v", err)
+			}
 
-	if commit == nil && smContext.Access != Access5G {
-		err := fmt.Errorf("session %q is on %s, not 5GS", smContext.Ref, smContext.Access)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "session is not on 5GS")
+			rules := bindingRules{pdrs: pdrList, fars: farList}
+			if commit != nil {
+				rules.policyID = commit.policy.PolicyID
+				rules.qers = commit.qers
+			}
 
-		return nil, err
-	}
+			return rules, nil
+		},
+		onBound: func() {
+			smContext.establishmentOutstanding = false
 
-	restoreBinding := smContext.stageAccessBinding()
+			s.registerIPv6SessionIfNeeded(ctx, smContext, Access5G)
 
-	pdrList, farList, err := handleUpdateN2MsgPDUResourceSetupResp(n2Data, smContext)
-	if err != nil {
-		restoreBinding()
-
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to handle N2 message")
-
-		if commit != nil {
-			commit.restore()
-
-			smContext.releasing = true
-
-			return nil, fmt.Errorf("%w: %v", errTransferRolledBack, err)
-		}
-
-		return nil, fmt.Errorf("error handling N2 message: %v", err)
-	}
-
-	var qers []*QER
-
-	policyID := ""
-
-	if commit != nil {
-		qers = commit.qers
-		policyID = commit.policy.PolicyID
-	}
-
-	if err := s.upf.ModifySession(ctx, BuildModifyRequest(
-		smContext.PFCPContext.SEID,
-		policyID,
-		pdrList, farList, qers,
-	)); err != nil {
-		restoreBinding()
-
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to modify PFCP session")
-
-		if commit != nil {
-			commit.restore()
-
-			smContext.releasing = true
-
-			return nil, fmt.Errorf("%w: %v", errTransferRolledBack, err)
-		}
-
-		return nil, fmt.Errorf("failed to send PFCP session modification request: %v", err)
-	}
-
-	smContext.establishmentOutstanding = false
-
-	var dropped *droppedSource
-	if commit != nil {
-		dropped = smContext.finishTransferCommit(commit)
-	}
-
-	s.registerIPv6SessionIfNeeded(ctx, smContext, Access5G)
-
-	logger.SmfLog.Info("Sent PFCP session modification request", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
-
-	return dropped, nil
+			logger.SmfLog.Info("Sent PFCP session modification request", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+		},
+	})
 }
 
 func handleUpdateN2MsgPDUResourceSetupResp(binaryDataN2SmInformation []byte, smContext *SMContext) ([]*PDR, []*FAR, error) {

--- a/internal/tester/s1enb/attach.go
+++ b/internal/tester/s1enb/attach.go
@@ -17,55 +17,25 @@ import (
 
 // AttachResult reports the identifiers and GUTI established by a completed attach.
 type AttachResult struct {
-	MMEUES1APID int64
-	ENBUES1APID int64
-	ERABID      s1ap.ERABID
-	GUTI        *eps.EPSMobileIdentity
-
-	// IdentityRequested is set when the MME answered the Attach Request with an
-	// Identity Request (an unresolvable GUTI, TS 24.301 §5.4.4).
-	IdentityRequested bool
-
-	// PDNType is the PDN type negotiated for the default bearer in the Attach
-	// Accept (eps.PDNTypeIPv4 / IPv6 / IPv4v6).
-	PDNType eps.PDNType
-
-	// QCI is the default bearer's QoS Class Identifier from the Activate Default
-	// EPS Bearer Context Request (TS 24.301 §9.9.4.3, octet 1 of the EPS QoS IE).
-	// Ella Core aligns it with the policy's 5QI for the standardized values.
-	QCI byte
-
-	// ARP is the default bearer's Allocation and Retention Priority level (1-15)
-	// from the S1AP E-RAB Level QoS Parameters in the Initial Context Setup
-	// Request (TS 36.413 §9.2.1.60).
-	ARP byte
-
-	// UEAmbrDownlinkBps / UEAmbrUplinkBps are the UE Aggregate Maximum Bit Rate
-	// (bits/s) from the Initial Context Setup Request (TS 36.413 §9.2.1.20), the
-	// per-UE aggregate across all non-GBR bearers.
-	UEAmbrDownlinkBps uint64
-	UEAmbrUplinkBps   uint64
-
-	// APN is the Access Point Name carried in the Activate Default EPS Bearer
-	// Context Request — the EPS analogue of the 5G DNN.
-	APN string
-
-	// SessAmbrDownlinkBps / SessAmbrUplinkBps are the per-APN Session-AMBR (bits
-	// per second) decoded from the APN-AMBR IE (TS 24.301 §9.9.4.2), the EPS
-	// analogue of the 5G Session-AMBR. Zero when the network omits the IE.
+	MMEUES1APID         int64
+	ENBUES1APID         int64
+	ERABID              s1ap.ERABID
+	GUTI                *eps.EPSMobileIdentity
+	IdentityRequested   bool
+	PDNType             eps.PDNType
+	QCI                 byte
+	ARP                 byte
+	UEAmbrDownlinkBps   uint64
+	UEAmbrUplinkBps     uint64
+	APN                 string
 	SessAmbrDownlinkBps uint64
 	SessAmbrUplinkBps   uint64
-
-	// User-plane endpoints for a GTP-U tunnel.
-	UEIPv4     string // UE IPv4 assigned in the Attach Accept
-	UEIPv6     string // UE IPv6 link-local derived from the Attach Accept PDN IID
-	UpfAddress string // S-GW/UPF S1-U address (uplink target)
-
-	// BearerStatus is the EPS bearer context status of a Tracking Area Update
-	// Accept, naming the bearers active in the MME (TS 24.301 §5.5.3.2.4).
-	BearerStatus *nas.EPSBearerContextStatus
-	ULTEID       uint32 // S-GW/UPF uplink TEID
-	DLTEID       uint32 // eNB downlink TEID reported to the MME
+	UEIPv4              string // UE IPv4 assigned in the Attach Accept
+	UEIPv6              string // UE IPv6 link-local derived from the Attach Accept PDN IID
+	UpfAddress          string // S-GW/UPF S1-U address (uplink target)
+	BearerStatus        *nas.EPSBearerContextStatus
+	ULTEID              uint32 // S-GW/UPF uplink TEID
+	DLTEID              uint32 // eNB downlink TEID reported to the MME
 }
 
 // Attach drives a full EPS attach for ue (TS 24.301 §5.5.1.2), returning once

--- a/internal/tester/s1enb/attach.go
+++ b/internal/tester/s1enb/attach.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
@@ -59,8 +60,12 @@ type AttachResult struct {
 	UEIPv4     string // UE IPv4 assigned in the Attach Accept
 	UEIPv6     string // UE IPv6 link-local derived from the Attach Accept PDN IID
 	UpfAddress string // S-GW/UPF S1-U address (uplink target)
-	ULTEID     uint32 // S-GW/UPF uplink TEID
-	DLTEID     uint32 // eNB downlink TEID reported to the MME
+
+	// BearerStatus is the EPS bearer context status of a Tracking Area Update
+	// Accept, naming the bearers active in the MME (TS 24.301 §5.5.3.2.4).
+	BearerStatus *nas.EPSBearerContextStatus
+	ULTEID       uint32 // S-GW/UPF uplink TEID
+	DLTEID       uint32 // eNB downlink TEID reported to the MME
 }
 
 // Attach drives a full EPS attach for ue (TS 24.301 §5.5.1.2), returning once

--- a/internal/tester/s1enb/idle_mobility.go
+++ b/internal/tester/s1enb/idle_mobility.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1enb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/internal/util/ueauth"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/s1ap"
+	"go.uber.org/zap"
+)
+
+const fcKASMEPrimeIdle = "73"
+
+type IdleMobilityFrom5GS struct {
+	KAMF             []byte
+	KNASInt          [16]byte
+	NIA              uint8
+	UplinkNASCount   nas.Count
+	DownlinkNASCount nas.Count
+	EPSCiphering     uint8
+	EPSIntegrity     uint8
+	EKSI             uint8
+}
+
+func (ue *UE) InstallMappedSecurityContextForIdleMobility(in IdleMobilityFrom5GS) error {
+	if len(in.KAMF) != 32 {
+		return fmt.Errorf("s1enb: K_AMF is %d octets, want 32", len(in.KAMF))
+	}
+
+	p0 := make([]byte, 4)
+	binary.BigEndian.PutUint32(p0, in.UplinkNASCount.Value())
+
+	kasme, err := ueauth.GetKDFValue(in.KAMF, fcKASMEPrimeIdle, p0, ueauth.KDFLen(p0))
+	if err != nil {
+		return fmt.Errorf("s1enb: derive K'ASME: %w", err)
+	}
+
+	ue.kasme = kasme
+	ue.eea, ue.eia = in.EPSCiphering, in.EPSIntegrity
+
+	if err := ue.deriveNASKeys(); err != nil {
+		return err
+	}
+
+	ue.ulCount = in.UplinkNASCount.Next().SQN()
+	ue.dlCount.seed(in.DownlinkNASCount)
+
+	return nil
+}
+
+type IdleTrackingAreaUpdateOpts struct {
+	GUTI         eps.GUTI
+	ActiveFlag   bool
+	BearerStatus *nas.EPSBearerContextStatus
+	Security     IdleMobilityFrom5GS
+}
+
+func (ue *UE) BuildIdleTrackingAreaUpdate(opts IdleTrackingAreaUpdateOpts) ([]byte, error) {
+	gutiType := eps.GUTITypeNative
+
+	plain, err := (&eps.TrackingAreaUpdateRequest{
+		EPSUpdateType:          eps.EPSUpdateTypeTA,
+		ActiveFlag:             opts.ActiveFlag,
+		NASKeySetIdentifier:    nas.KeySetIdentifier{Value: opts.Security.EKSI, Mapped: true},
+		OldGUTI:                eps.GUTIIdentity(opts.GUTI),
+		OldGUTIType:            &gutiType,
+		UEStatus:               &eps.UEStatus{N1ModeReg: true},
+		EPSBearerContextStatus: opts.BearerStatus,
+		UENetworkCapability:    &eps.UENetworkCapability{EEA: ue.netCapEEA, EIA: ue.netCapEIA},
+	}).MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: build Tracking Area Update Request: %w", err)
+	}
+
+	sc, err := nas.NewSecurityContext(nas.SecurityContextOptions{
+		Integrity:          nas.IntegrityAlgorithm(opts.Security.NIA),
+		IntegrityKey:       opts.Security.KNASInt,
+		Ciphering:          nas.CipheringNull,
+		AllowNullIntegrity: nas.IntegrityAlgorithm(opts.Security.NIA) == nas.IntegrityNull,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: build the 5G NAS security context: %w", err)
+	}
+
+	count := opts.Security.UplinkNASCount
+
+	mac, err := sc.MAC(append([]byte{count.SQN()}, plain...), count, nas.Bearer3GPP, nas.DirectionUplink)
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: MAC the Tracking Area Update Request: %w", err)
+	}
+
+	wire, err := (&eps.SecurityProtectedMessage{
+		SecurityHeaderType: eps.SHTIntegrityProtected,
+		MAC:                mac,
+		SequenceNumber:     count.SQN(),
+		UnverifiedPayload:  plain,
+	}).MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: frame the Tracking Area Update Request: %w", err)
+	}
+
+	if err := ue.InstallMappedSecurityContextForIdleMobility(opts.Security); err != nil {
+		return nil, err
+	}
+
+	return wire, nil
+}
+
+func (e *ENB) TrackingAreaUpdateFrom5GS(ue *UE, opts IdleTrackingAreaUpdateOpts, timeout time.Duration) (*AttachResult, error) {
+	enbUEID := e.AllocateENBUEID()
+
+	wire, err := ue.BuildIdleTrackingAreaUpdate(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := e.SendInitialUEMessage(enbUEID, wire); err != nil {
+		return nil, fmt.Errorf("s1enb: send the Tracking Area Update Request: %w", err)
+	}
+
+	if !opts.ActiveFlag {
+		return nil, fmt.Errorf("s1enb: an idle-mode update without the active flag establishes no bearer to report")
+	}
+
+	icsFrame, err := e.WaitForMessage(enbUEID, Initiating, s1ap.ProcInitialContextSetup, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: await Initial Context Setup Request: %w", err)
+	}
+
+	ics, err := s1ap.ParseInitialContextSetupRequest(icsFrame.Value)
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: parse Initial Context Setup Request: %w", err)
+	}
+
+	if len(ics.ERABToBeSetup) == 0 {
+		return nil, fmt.Errorf("s1enb: initial context setup request without an E-RAB")
+	}
+
+	erab := ics.ERABToBeSetup[0]
+
+	upf, err := e.selectUpfAddr(erab.TransportLayerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	dlTEID := e.allocTEID()
+
+	if err := e.sendInitialContextSetupResponse(ics, enbUEID, dlTEID); err != nil {
+		return nil, err
+	}
+
+	acceptPlain, err := ue.unprotectDownlink([]byte(erab.NASPDU))
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: unprotect Tracking Area Update Accept: %w", err)
+	}
+
+	accept, err := expectDownlink[*eps.TrackingAreaUpdateAccept](acceptPlain)
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: await Tracking Area Update Accept: %w", err)
+	}
+
+	mmeUEID := int64(ics.MMEUES1APID)
+
+	complete, err := ue.buildTrackingAreaUpdateComplete()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := e.SendUplinkNASTransport(mmeUEID, enbUEID, complete); err != nil {
+		return nil, fmt.Errorf("s1enb: send Tracking Area Update Complete: %w", err)
+	}
+
+	logger.GnbLogger.Debug("Tracking area update from 5GS complete",
+		zap.String("imsi", ue.IMSI), zap.Int64("mme-ue-id", mmeUEID), zap.Int64("enb-ue-id", enbUEID))
+
+	return &AttachResult{
+		MMEUES1APID:  mmeUEID,
+		ENBUES1APID:  enbUEID,
+		ERABID:       erab.ERABID,
+		GUTI:         accept.GUTI,
+		UpfAddress:   upf.Unmap().String(),
+		ULTEID:       uint32(erab.GTPTEID),
+		DLTEID:       dlTEID,
+		BearerStatus: accept.EPSBearerContextStatus,
+	}, nil
+}

--- a/internal/tester/s1enb/idle_mobility.go
+++ b/internal/tester/s1enb/idle_mobility.go
@@ -126,7 +126,7 @@ func (e *ENB) TrackingAreaUpdateFrom5GS(ue *UE, opts IdleTrackingAreaUpdateOpts,
 	}
 
 	if !opts.ActiveFlag {
-		return nil, fmt.Errorf("s1enb: an idle-mode update without the active flag establishes no bearer to report")
+		return e.idleTrackingAreaUpdateReturningToIdle(ue, enbUEID, timeout)
 	}
 
 	icsFrame, err := e.WaitForMessage(enbUEID, Initiating, s1ap.ProcInitialContextSetup, timeout)
@@ -188,6 +188,41 @@ func (e *ENB) TrackingAreaUpdateFrom5GS(ue *UE, opts IdleTrackingAreaUpdateOpts,
 		UpfAddress:   upf.Unmap().String(),
 		ULTEID:       uint32(erab.GTPTEID),
 		DLTEID:       dlTEID,
+		BearerStatus: accept.EPSBearerContextStatus,
+	}, nil
+}
+
+func (e *ENB) idleTrackingAreaUpdateReturningToIdle(ue *UE, enbUEID int64, timeout time.Duration) (*AttachResult, error) {
+	mmeUEID, acceptPlain, err := e.awaitDownlinkNAS(ue, enbUEID, eps.MsgTrackingAreaUpdateAccept, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: await Tracking Area Update Accept: %w", err)
+	}
+
+	accept, err := expectDownlink[*eps.TrackingAreaUpdateAccept](acceptPlain)
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: parse Tracking Area Update Accept: %w", err)
+	}
+
+	complete, err := ue.buildTrackingAreaUpdateComplete()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := e.SendUplinkNASTransport(mmeUEID, enbUEID, complete); err != nil {
+		return nil, fmt.Errorf("s1enb: send Tracking Area Update Complete: %w", err)
+	}
+
+	if err := e.completeContextRelease(enbUEID, timeout); err != nil {
+		return nil, fmt.Errorf("s1enb: release the UE back to ECM-IDLE: %w", err)
+	}
+
+	logger.GnbLogger.Debug("Tracking area update from 5GS complete, UE returned to idle",
+		zap.String("imsi", ue.IMSI), zap.Int64("mme-ue-id", mmeUEID), zap.Int64("enb-ue-id", enbUEID))
+
+	return &AttachResult{
+		MMEUES1APID:  mmeUEID,
+		ENBUES1APID:  enbUEID,
+		GUTI:         accept.GUTI,
 		BearerStatus: accept.EPSBearerContextStatus,
 	}, nil
 }

--- a/internal/tester/s1enb/idle_mobility.go
+++ b/internal/tester/s1enb/idle_mobility.go
@@ -191,3 +191,48 @@ func (e *ENB) TrackingAreaUpdateFrom5GS(ue *UE, opts IdleTrackingAreaUpdateOpts,
 		BearerStatus: accept.EPSBearerContextStatus,
 	}, nil
 }
+
+func (ue *UE) BuildTrackingAreaUpdateForContainer(guti eps.GUTI, status *nas.EPSBearerContextStatus) ([]byte, error) {
+	gutiType := eps.GUTITypeNative
+
+	plain, err := (&eps.TrackingAreaUpdateRequest{
+		EPSUpdateType:          eps.EPSUpdateTypeTA,
+		NASKeySetIdentifier:    nas.KeySetIdentifier{Value: ue.eksi},
+		OldGUTI:                eps.GUTIIdentity(guti),
+		OldGUTIType:            &gutiType,
+		UEStatus:               &eps.UEStatus{S1ModeReg: true},
+		EPSBearerContextStatus: status,
+		UENetworkCapability:    &eps.UENetworkCapability{EEA: ue.netCapEEA, EIA: ue.netCapEIA},
+	}).MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: build the enclosed Tracking Area Update Request: %w", err)
+	}
+
+	wire, err := eps.Protect(plain, eps.SHTIntegrityProtected,
+		nas.MakeCount(0, ue.ulCount), nas.DirectionUplink, ue.sc)
+	if err != nil {
+		return nil, fmt.Errorf("s1enb: protect the enclosed Tracking Area Update Request: %w", err)
+	}
+
+	ue.ulCount++
+
+	return wire, nil
+}
+
+func (ue *UE) MappedContextForIdleMobility() MappedFromEPSIdle {
+	var kasme [32]byte
+
+	copy(kasme[:], ue.kasme)
+
+	return MappedFromEPSIdle{
+		KASME:          kasme,
+		UplinkNASCount: nas.MakeCount(0, ue.ulCount-1),
+		EKSI:           ue.eksi,
+	}
+}
+
+type MappedFromEPSIdle struct {
+	KASME          [32]byte
+	UplinkNASCount nas.Count
+	EKSI           uint8
+}

--- a/internal/tester/s1enb/idle_mobility_test.go
+++ b/internal/tester/s1enb/idle_mobility_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1enb_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/tester/s1enb"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// TS 33.501 §8.6.1, Annex A.14.1: the UE and the AMF derive the same mapped EPS
+// context from K_AMF and the uplink 5G NAS COUNT of the TRACKING AREA UPDATE
+// REQUEST — not the downlink one the handover variant uses.
+func TestIdleMappedSecurityContextAgreesWithTheCore(t *testing.T) {
+	const (
+		ulCount = 7
+		dlCount = 11
+	)
+
+	mapped, err := interworking.MapToEPSOnIdleMobility(interworking.FiveGToEPSInput{
+		KAMF:       testKAMF(),
+		NgKSI:      nas.KeySetIdentifier{Value: 4},
+		ULNASCount: ulCount,
+		DLNASCount: dlCount,
+		Algorithms: interworking.EPSNASAlgorithms{
+			Ciphering: nas.CipheringAES,
+			Integrity: nas.IntegrityAES,
+		},
+		UESecurityCapability: eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70},
+	})
+	if err != nil {
+		t.Fatalf("MapToEPSOnIdleMobility: %v", err)
+	}
+
+	e := s1enb.NewUnboundUE()
+
+	if err := e.InstallMappedSecurityContextForIdleMobility(s1enb.IdleMobilityFrom5GS{
+		KAMF:             testKAMF(),
+		UplinkNASCount:   ulCount,
+		DownlinkNASCount: dlCount,
+		EPSCiphering:     uint8(nas.CipheringAES),
+		EPSIntegrity:     uint8(nas.IntegrityAES),
+		EKSI:             4,
+	}); err != nil {
+		t.Fatalf("InstallMappedSecurityContextForIdleMobility: %v", err)
+	}
+
+	if !bytes.Equal(e.MappedKASME(), mapped.KASME[:]) {
+		t.Fatalf("K'ASME = %x, want the core's %x", e.MappedKASME(), mapped.KASME)
+	}
+
+	handover, err := interworking.MapToEPSOnHandover(interworking.FiveGToEPSInput{
+		KAMF:       testKAMF(),
+		ULNASCount: ulCount,
+		DLNASCount: dlCount,
+	})
+	if err != nil {
+		t.Fatalf("MapToEPSOnHandover: %v", err)
+	}
+
+	if bytes.Equal(e.MappedKASME(), handover.Context.KASME[:]) {
+		t.Fatal("the idle-mode derivation produced the handover key, so a real UE would not follow")
+	}
+}
+
+// TS 33.501 §8.5.2 step 4: the AMF verifies the TAU as a 5G NAS message over
+// 3GPP access, so the tester has to MAC it that way for the core to accept it.
+func TestIdleTrackingAreaUpdateIsMACdWithThe5GContext(t *testing.T) {
+	security := s1enb.IdleMobilityFrom5GS{
+		KAMF:             testKAMF(),
+		KNASInt:          [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		NIA:              uint8(nas.IntegrityAES),
+		UplinkNASCount:   nas.MakeCount(0, 3),
+		DownlinkNASCount: nas.MakeCount(0, 1),
+		EPSCiphering:     uint8(nas.CipheringAES),
+		EPSIntegrity:     uint8(nas.IntegrityAES),
+		EKSI:             4,
+	}
+
+	e := s1enb.NewUnboundUE()
+
+	wire, err := e.BuildIdleTrackingAreaUpdate(s1enb.IdleTrackingAreaUpdateOpts{
+		GUTI: eps.GUTI{
+			PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x0100, MMECode: 0x40,
+			TMSI: [4]byte{0x00, 0x00, 0xde, 0xad},
+		},
+		ActiveFlag: true,
+		Security:   security,
+	})
+	if err != nil {
+		t.Fatalf("BuildIdleTrackingAreaUpdate: %v", err)
+	}
+
+	sc, err := nas.NewSecurityContext(nas.SecurityContextOptions{
+		Integrity:    nas.IntegrityAES,
+		IntegrityKey: security.KNASInt,
+		Ciphering:    nas.CipheringNull,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plain, err := eps.VerifyWith5GContext(wire, security.UplinkNASCount, nas.DirectionUplink, sc)
+	if err != nil {
+		t.Fatalf("the core could not verify the update against the 5G context: %v", err)
+	}
+
+	req, err := eps.ParseTrackingAreaUpdateRequest(plain)
+	if err != nil {
+		t.Fatalf("parse TAU: %v", err)
+	}
+
+	if req.OldGUTIType == nil || *req.OldGUTIType != eps.GUTITypeNative {
+		t.Errorf("Old GUTI type = %v, want native (TS 24.301 §5.5.3.2.2 case z)", req.OldGUTIType)
+	}
+
+	if req.UEStatus == nil || !req.UEStatus.N1ModeReg {
+		t.Errorf("UE status = %v, want 5GMM-REGISTERED", req.UEStatus)
+	}
+
+	if !req.ActiveFlag {
+		t.Error("the active flag was not set, so no S1-U would be established")
+	}
+
+	if _, _, err := eps.Unprotect(wire, security.UplinkNASCount, nas.DirectionUplink, sc); err == nil {
+		t.Error("the update also verifies as an ordinary EPS message, so the bearer is not the 3GPP access one")
+	}
+}

--- a/internal/tester/s1enb/idle_mobility_test.go
+++ b/internal/tester/s1enb/idle_mobility_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// TS 33.501 §8.6.1, Annex A.14.1: the UE and the AMF derive the same mapped EPS
-// context from K_AMF and the uplink 5G NAS COUNT of the TRACKING AREA UPDATE
-// REQUEST — not the downlink one the handover variant uses.
+// TS 33.501 §8.6.1, Annex A.14.1
 func TestIdleMappedSecurityContextAgreesWithTheCore(t *testing.T) {
 	const (
 		ulCount = 7
@@ -68,8 +66,7 @@ func TestIdleMappedSecurityContextAgreesWithTheCore(t *testing.T) {
 	}
 }
 
-// TS 33.501 §8.5.2 step 4: the AMF verifies the TAU as a 5G NAS message over
-// 3GPP access, so the tester has to MAC it that way for the core to accept it.
+// TS 33.501 §8.5.2 step 4
 func TestIdleTrackingAreaUpdateIsMACdWithThe5GContext(t *testing.T) {
 	security := s1enb.IdleMobilityFrom5GS{
 		KAMF:             testKAMF(),

--- a/internal/tester/s1enb/idle_mobility_test.go
+++ b/internal/tester/s1enb/idle_mobility_test.go
@@ -83,7 +83,7 @@ func TestIdleTrackingAreaUpdateIsMACdWithThe5GContext(t *testing.T) {
 
 	wire, err := e.BuildIdleTrackingAreaUpdate(s1enb.IdleTrackingAreaUpdateOpts{
 		GUTI: eps.GUTI{
-			PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x0100, MMECode: 0x40,
+			PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 0x8100, MMECode: 0x40,
 			TMSI: [4]byte{0x00, 0x00, 0xde, 0xad},
 		},
 		ActiveFlag: true,

--- a/internal/tester/s1enb/lifecycle.go
+++ b/internal/tester/s1enb/lifecycle.go
@@ -152,7 +152,7 @@ func (e *ENB) PeriodicTrackingAreaUpdate(ue *UE, guti *eps.EPSMobileIdentity, ti
 
 	// mmeUEID is taken from the Accept so the Complete is delivered on the
 	// connection the MME re-keyed for this update.
-	mmeUEID, err := e.awaitDownlinkNAS(ue, enbUEID, eps.MsgTrackingAreaUpdateAccept, timeout)
+	mmeUEID, _, err := e.awaitDownlinkNAS(ue, enbUEID, eps.MsgTrackingAreaUpdateAccept, timeout)
 	if err != nil {
 		return fmt.Errorf("await Tracking Area Update Accept: %w", err)
 	}
@@ -171,36 +171,32 @@ func (e *ENB) PeriodicTrackingAreaUpdate(ue *UE, guti *eps.EPSMobileIdentity, ti
 	return e.completeContextRelease(enbUEID, timeout)
 }
 
-// awaitDownlinkNAS waits for a protected downlink NAS message of the wanted EMM
-// message type, skipping any proactive messages the MME interleaves (e.g. EMM
-// INFORMATION 0x61), which a real UE ignores. It returns the MME-UE-S1AP-ID the
-// matching message arrived on.
-func (e *ENB) awaitDownlinkNAS(ue *UE, enbUEID int64, want eps.MessageType, timeout time.Duration) (int64, error) {
+func (e *ENB) awaitDownlinkNAS(ue *UE, enbUEID int64, want eps.MessageType, timeout time.Duration) (int64, []byte, error) {
 	deadline := time.Now().Add(timeout)
 
 	for {
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
-			return 0, fmt.Errorf("timed out awaiting message type %#x", want)
+			return 0, nil, fmt.Errorf("timed out awaiting message type %#x", want)
 		}
 
 		wire, mmeUEID, err := e.WaitForDownlinkNAS(enbUEID, remaining)
 		if err != nil {
-			return 0, err
+			return 0, nil, err
 		}
 
 		plain, err := ue.unprotectDownlink(wire)
 		if err != nil {
-			return 0, fmt.Errorf("unprotect downlink NAS: %w", err)
+			return 0, nil, fmt.Errorf("unprotect downlink NAS: %w", err)
 		}
 
 		mt, err := eps.PeekMessageType(plain)
 		if err != nil {
-			return 0, fmt.Errorf("peek downlink NAS: %w", err)
+			return 0, nil, fmt.Errorf("peek downlink NAS: %w", err)
 		}
 
 		if mt == want {
-			return mmeUEID, nil
+			return mmeUEID, plain, nil
 		}
 	}
 }

--- a/internal/tester/s1enb/mapped_context.go
+++ b/internal/tester/s1enb/mapped_context.go
@@ -106,7 +106,7 @@ func (e *ENB) TrackingAreaUpdateAfterHandover(ue *UE, mmeUEID, enbUEID int64, gu
 		return fmt.Errorf("s1enb: send Tracking Area Update Request: %w", err)
 	}
 
-	if _, err := e.awaitDownlinkNAS(ue, enbUEID, eps.MsgTrackingAreaUpdateAccept, timeout); err != nil {
+	if _, _, err := e.awaitDownlinkNAS(ue, enbUEID, eps.MsgTrackingAreaUpdateAccept, timeout); err != nil {
 		return fmt.Errorf("s1enb: await Tracking Area Update Accept: %w", err)
 	}
 

--- a/internal/tester/s1enb/ue.go
+++ b/internal/tester/s1enb/ue.go
@@ -48,6 +48,7 @@ type UE struct {
 	sc                        *nas.SecurityContext
 	eea                       uint8
 	eia                       uint8
+	eksi                      uint8
 	ulCount                   uint8           // uplink NAS COUNT for protected uplink messages
 	dlCount                   downlinkCounter // largest downlink NAS COUNT accepted
 	kenbCount                 uint32
@@ -225,6 +226,7 @@ func (ue *UE) handleSecurityModeCommand(wire []byte) ([]byte, error) {
 
 	ue.eea = uint8(smc.CipheringAlgorithm)
 	ue.eia = uint8(smc.IntegrityAlgorithm)
+	ue.eksi = smc.NASKeySetIdentifier.Value
 
 	if ue.contextFromAuthentication {
 		ue.ulCount = 0

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/ellanetworks/core/client"
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/s1enb"
@@ -16,10 +18,18 @@ import (
 	"github.com/ellanetworks/core/internal/tester/ue"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/nas/fgs"
 	"github.com/spf13/pflag"
 )
 
 func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "interworking/idle_eps_to_5gs",
+		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
+		Run:       runIdleEPSTo5GS,
+		Fixture:   fixture,
+	})
+
 	scenarios.Register(scenarios.Scenario{
 		Name:      "interworking/idle_5gs_to_eps",
 		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
@@ -172,4 +182,161 @@ func assertAdoptedBearer(res *s1enb.AttachResult) error {
 	}
 
 	return nil
+}
+
+const (
+	sessionSettle = 10 * time.Second
+	idleCiphering = uint8(nas.CipheringAES)
+	idleIntegrity = uint8(nas.IntegrityAES)
+)
+
+func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
+	e, err := startENB(env)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = e.Close() }()
+
+	k, opc, err := defaultKeyAndOPc()
+	if err != nil {
+		return err
+	}
+
+	epsUE := e.NewUE(interworkingIMSI, k, opc)
+	epsUE.RequestPDNType(uint8(eps.PDNTypeIPv4v6))
+	epsUE.AnnounceN1Mode(movedPDUSessionID)
+
+	res, err := e.Attach(epsUE, attachTimeout)
+	if err != nil {
+		return fmt.Errorf("attach over E-UTRAN: %w", err)
+	}
+
+	before, err := probeOverEPS(ctx, env, e, res, "before the idle move to 5GS")
+	if err != nil {
+		return err
+	}
+
+	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
+		return err
+	}
+
+	if res.GUTI == nil || res.GUTI.GUTI == nil {
+		return errors.New("the attach accept assigned no GUTI to map into a registration")
+	}
+
+	var bearerStatus nas.EPSBearerContextStatus
+
+	bearerStatus.Active[movedEPSBearerIdentity] = true
+
+	container, err := epsUE.BuildTrackingAreaUpdateForContainer(*res.GUTI.GUTI, &bearerStatus)
+	if err != nil {
+		return err
+	}
+
+	mapped := epsUE.MappedContextForIdleMobility()
+
+	gNodeB, err := startGNB(env)
+	if err != nil {
+		return err
+	}
+
+	defer gNodeB.Close()
+
+	u, err := newInterworkingUE(gNodeB, false)
+	if err != nil {
+		return err
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+	gNodeB.AddUE(ranUENGAPID, u)
+
+	var sessions [16]bool
+
+	sessions[movedPDUSessionID] = true
+
+	if err := u.SendIdleMobilityRegistration(ue.IdleRegistrationOpts{
+		RANUENGAPID:            ranUENGAPID,
+		MappedGUTI:             fgs.GUTIIdentity(etsi.MapGUTIEPSTo5G(*res.GUTI.GUTI)),
+		EPSNASMessageContainer: container,
+		PDUSessionStatus:       &sessions,
+		Mapped: ue.MappedFromEPSIdle{
+			KASME:          mapped.KASME,
+			UplinkNASCount: mapped.UplinkNASCount,
+			EKSI:           mapped.EKSI,
+			Ciphering:      idleCiphering,
+			Integrity:      idleIntegrity,
+		},
+	}); err != nil {
+		return fmt.Errorf("mobility registration update over NR: %w", err)
+	}
+
+	accept, err := u.WaitForNASGMMMessage(uint8(fgs.MsgRegistrationAccept), attachTimeout)
+	if err != nil {
+		return fmt.Errorf("registration accept for the inter-system change: %w", err)
+	}
+
+	if err := assertAdoptedSession(accept); err != nil {
+		return err
+	}
+
+	return assertSessionOn(ctx, env, "5G", before.addrs)
+}
+
+func assertAdoptedSession(plain []byte) error {
+	accept, err := fgs.ParseRegistrationAccept(plain)
+	if err != nil {
+		return fmt.Errorf("parse the registration accept: %w", err)
+	}
+
+	if accept.PDUSessionStatus == nil || !accept.PDUSessionStatus.PSI[movedPDUSessionID] {
+		return fmt.Errorf("PDU session status = %+v, want PDU session %d active: the PDN connection did not become one",
+			accept.PDUSessionStatus, movedPDUSessionID)
+	}
+
+	if accept.EPSBearerContextStatus == nil || !accept.EPSBearerContextStatus.Active[movedEPSBearerIdentity] {
+		return fmt.Errorf("EPS bearer context status = %+v, want EBI %d active",
+			accept.EPSBearerContextStatus, movedEPSBearerIdentity)
+	}
+
+	return nil
+}
+
+func assertSessionOn(ctx context.Context, env scenarios.Env, want string, addrs ueAddresses) error {
+	cl, err := client.New(&client.Config{BaseURL: env.APIAddress})
+	if err != nil {
+		return fmt.Errorf("create core client: %w", err)
+	}
+
+	cl.SetToken(env.APIToken)
+
+	deadline := time.Now().Add(sessionSettle)
+
+	var last string
+
+	for {
+		sub, err := cl.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: interworkingIMSI})
+		if err == nil {
+			for _, s := range sub.Sessions {
+				last = s.RadioAccessType
+
+				if s.RadioAccessType != want {
+					continue
+				}
+
+				if addrs.v4 != "" && s.IPv4Address != addrs.v4 {
+					return fmt.Errorf("session on %s holds address %s, want the %s it had before the move",
+						want, s.IPv4Address, addrs.v4)
+				}
+
+				return nil
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("no session on %s after the move (last seen on %q)", want, last)
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
 }

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -62,12 +62,12 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 		return fmt.Errorf("initial registration over NR: %w", err)
 	}
 
-	before, err := probeOver5GS(ctx, env, gNodeB, u, ranUENGAPID, "over N3 before the idle move")
-	if err != nil {
+	if err := provisionEPSNASAlgorithms(gNodeB, u, ranUENGAPID); err != nil {
 		return err
 	}
 
-	if err := provisionEPSNASAlgorithms(gNodeB, u, ranUENGAPID); err != nil {
+	before, err := probeOver5GS(ctx, env, gNodeB, u, mobilityRANUENGAPID, "over N3 before the idle move")
+	if err != nil {
 		return err
 	}
 

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -80,7 +80,7 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	e, err := startENB(env)
+	e, err := startENBOnSecondaryN3(env)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ const (
 )
 
 func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
-	e, err := startENB(env)
+	e, err := startENBOnSecondaryN3(env)
 	if err != nil {
 		return err
 	}

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -33,12 +33,23 @@ func init() {
 	scenarios.Register(scenarios.Scenario{
 		Name:      "interworking/idle_5gs_to_eps",
 		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
-		Run:       runIdle5GSToEPS,
-		Fixture:   fixture,
+		Run: func(ctx context.Context, env scenarios.Env, _ any) error {
+			return runIdle5GSToEPS(ctx, env, true)
+		},
+		Fixture: fixture,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name:      "interworking/idle_5gs_to_eps_returning_to_idle",
+		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
+		Run: func(ctx context.Context, env scenarios.Env, _ any) error {
+			return runIdle5GSToEPS(ctx, env, false)
+		},
+		Fixture: fixture,
 	})
 }
 
-func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
+func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, activeFlag bool) error {
 	gNodeB, err := startGNB(env)
 	if err != nil {
 		return err
@@ -100,7 +111,7 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 
 	res, err := e.TrackingAreaUpdateFrom5GS(epsUE, s1enb.IdleTrackingAreaUpdateOpts{
 		GUTI:         guti,
-		ActiveFlag:   true,
+		ActiveFlag:   activeFlag,
 		BearerStatus: &bearerStatus,
 		Security:     security,
 	}, attachTimeout)
@@ -110,6 +121,10 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 
 	if err := assertAdoptedBearer(res); err != nil {
 		return err
+	}
+
+	if !activeFlag {
+		return assertSessionOn(ctx, env, "4G", before.addrs)
 	}
 
 	after, err := probeAfterHandover(ctx, env, e, handoverBearer{

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package interworking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/tester/gnb"
+	"github.com/ellanetworks/core/internal/tester/s1enb"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/internal/tester/testutil/procedure"
+	"github.com/ellanetworks/core/internal/tester/ue"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/spf13/pflag"
+)
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "interworking/idle_5gs_to_eps",
+		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
+		Run:       runIdle5GSToEPS,
+		Fixture:   fixture,
+	})
+}
+
+func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
+	gNodeB, err := startGNB(env)
+	if err != nil {
+		return err
+	}
+
+	defer gNodeB.Close()
+
+	u, err := newInterworkingUE(gNodeB, true)
+	if err != nil {
+		return err
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+	gNodeB.AddUE(ranUENGAPID, u)
+
+	if _, err := procedure.InitialRegistration(&procedure.InitialRegistrationOpts{
+		RANUENGAPID:  ranUENGAPID,
+		PDUSessionID: movedPDUSessionID,
+		UE:           u,
+	}); err != nil {
+		return fmt.Errorf("initial registration over NR: %w", err)
+	}
+
+	before, err := probeOver5GS(ctx, env, gNodeB, u, ranUENGAPID, "over N3 before the idle move")
+	if err != nil {
+		return err
+	}
+
+	if err := provisionEPSNASAlgorithms(gNodeB, u, ranUENGAPID); err != nil {
+		return err
+	}
+
+	if err := goIdleOnNR(gNodeB, u); err != nil {
+		return err
+	}
+
+	security, guti, err := idleMobilityMaterial(u)
+	if err != nil {
+		return err
+	}
+
+	e, err := startENB(env)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = e.Close() }()
+
+	k, opc, err := defaultKeyAndOPc()
+	if err != nil {
+		return err
+	}
+
+	epsUE := e.NewUE(interworkingIMSI, k, opc)
+
+	var bearerStatus nas.EPSBearerContextStatus
+
+	bearerStatus.Active[movedEPSBearerIdentity] = true
+
+	res, err := e.TrackingAreaUpdateFrom5GS(epsUE, s1enb.IdleTrackingAreaUpdateOpts{
+		GUTI:         guti,
+		ActiveFlag:   true,
+		BearerStatus: &bearerStatus,
+		Security:     security,
+	}, attachTimeout)
+	if err != nil {
+		return fmt.Errorf("tracking area update after the idle move to EPS: %w", err)
+	}
+
+	if err := assertAdoptedBearer(res); err != nil {
+		return err
+	}
+
+	after, err := probeAfterHandover(ctx, env, e, handoverBearer{
+		upfAddress: res.UpfAddress,
+		ulTEID:     res.ULTEID,
+		dlTEID:     res.DLTEID,
+		mmeUEID:    res.MMEUES1APID,
+		epsUE:      epsUE,
+	}, before.addrs)
+	if err != nil {
+		return err
+	}
+
+	return assertContinuity(before, after)
+}
+
+func goIdleOnNR(gNodeB *gnb.GnodeB, u *ue.UE) error {
+	var sessions [16]bool
+
+	sessions[movedPDUSessionID] = true
+
+	if err := procedure.UEContextRelease(&procedure.UEContextReleaseOpts{
+		AMFUENGAPID:   gNodeB.GetAMFUENGAPID(mobilityRANUENGAPID),
+		RANUENGAPID:   mobilityRANUENGAPID,
+		GnodeB:        gNodeB,
+		UE:            u,
+		PDUSessionIDs: sessions,
+	}); err != nil {
+		return fmt.Errorf("release the NR connection before the inter-system change: %w", err)
+	}
+
+	return nil
+}
+
+func idleMobilityMaterial(u *ue.UE) (s1enb.IdleMobilityFrom5GS, eps.GUTI, error) {
+	var none s1enb.IdleMobilityFrom5GS
+
+	if u.UeSecurity.Guti == nil || u.UeSecurity.Guti.GUTI == nil {
+		return none, eps.GUTI{}, errors.New("the UE holds no 5G-GUTI to map into a tracking area update")
+	}
+
+	if u.UeSecurity.EPSNASAlgorithms == nil {
+		return none, eps.GUTI{}, errors.New("the AMF signalled no EPS NAS algorithms, so no mapped context can be derived")
+	}
+
+	return s1enb.IdleMobilityFrom5GS{
+		KAMF:             u.UeSecurity.Kamf,
+		KNASInt:          u.UeSecurity.KnasInt,
+		NIA:              u.UeSecurity.IntegrityAlg,
+		UplinkNASCount:   u.UeSecurity.ULCount,
+		DownlinkNASCount: u.UeSecurity.DLCount,
+		EPSCiphering:     uint8(u.UeSecurity.EPSNASAlgorithms.Ciphering),
+		EPSIntegrity:     uint8(u.UeSecurity.EPSNASAlgorithms.Integrity),
+		EKSI:             uint8(u.UeSecurity.NgKsi.Ksi),
+	}, etsi.MapGUTI5GToEPS(*u.UeSecurity.Guti.GUTI), nil
+}
+
+func assertAdoptedBearer(res *s1enb.AttachResult) error {
+	if res.BearerStatus == nil {
+		return errors.New("the tracking area update accept carried no EPS bearer context status, so the UE cannot tell which session survived")
+	}
+
+	if !res.BearerStatus.Active[movedEPSBearerIdentity] {
+		return fmt.Errorf("EPS bearer context status = %v, want EBI %d active: the PDU session did not become a PDN connection",
+			res.BearerStatus.Active, movedEPSBearerIdentity)
+	}
+
+	if res.GUTI == nil {
+		return errors.New("the tracking area update accept reallocated no GUTI")
+	}
+
+	return nil
+}

--- a/internal/tester/ue/build_registration_request.go
+++ b/internal/tester/ue/build_registration_request.go
@@ -21,7 +21,9 @@ type RegistrationRequestOpts struct {
 	PDUSessionStatus      *[16]bool
 	S1UENetworkCapability []byte
 
-	UEStatus *fgs.UEStatus
+	UEStatus               *fgs.UEStatus
+	EPSNASMessageContainer []byte
+	AdditionalGUTI         *fgs.MobileIdentity
 }
 
 func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
@@ -41,8 +43,10 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 			Value:  uint8(opts.UESecurity.NgKsi.Ksi),
 			Mapped: opts.UESecurity.NgKsi.Tsc == models.ScTypeMapped,
 		},
-		MobileIdentity: mobileIdentity,
-		UEStatus:       opts.UEStatus,
+		MobileIdentity:         mobileIdentity,
+		UEStatus:               opts.UEStatus,
+		EPSNASMessageContainer: opts.EPSNASMessageContainer,
+		AdditionalGUTI:         opts.AdditionalGUTI,
 	}
 
 	if opts.IncludeCapability {

--- a/internal/tester/ue/build_security_mode_complete.go
+++ b/internal/tester/ue/build_security_mode_complete.go
@@ -13,6 +13,7 @@ type SecurityModeCompleteOpts struct {
 	UESecurity       *UESecurity
 	IMEISV           string
 	PDUSessionStatus *[16]bool
+	Replay           []byte
 }
 
 func BuildSecurityModeComplete(opts *SecurityModeCompleteOpts) ([]byte, error) {
@@ -34,9 +35,15 @@ func BuildSecurityModeComplete(opts *SecurityModeCompleteOpts) ([]byte, error) {
 		regReqOpts.S1UENetworkCapability = s1
 	}
 
-	registrationRequest, err := BuildRegistrationRequest(regReqOpts)
-	if err != nil {
-		return nil, fmt.Errorf("error encoding %s IMSI UE  NAS Registration Request message: %v", opts.UESecurity.Supi, err)
+	registrationRequest := opts.Replay
+
+	if registrationRequest == nil {
+		built, err := BuildRegistrationRequest(regReqOpts)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding %s IMSI UE  NAS Registration Request message: %v", opts.UESecurity.Supi, err)
+		}
+
+		registrationRequest = built
 	}
 
 	imeisv := fgs.PEIIdentity(fgs.PEI{Type: fgs.IdentityIMEISV, Digits: opts.IMEISV})

--- a/internal/tester/ue/handle_security_mode_command.go
+++ b/internal/tester/ue/handle_security_mode_command.go
@@ -45,6 +45,7 @@ func handleSecurityModeCommand(ue *UE, plain []byte, amfUENGAPID int64, ranUENGA
 	securityModeComplete, err := BuildSecurityModeComplete(&SecurityModeCompleteOpts{
 		UESecurity: ue.UeSecurity,
 		IMEISV:     ue.IMEISV,
+		Replay:     ue.replayRegistration,
 	})
 	if err != nil {
 		return fmt.Errorf("error sending Security Mode Complete: %w", err)

--- a/internal/tester/ue/handle_security_mode_command.go
+++ b/internal/tester/ue/handle_security_mode_command.go
@@ -24,6 +24,11 @@ func handleSecurityModeCommand(ue *UE, plain []byte, amfUENGAPID int64, ranUENGA
 		return fmt.Errorf("could not parse Security Mode Command: %v", err)
 	}
 
+	if !smc.ReplayedUESecurityCapability.Equal(ue.UeSecurity.UeSecurityCapability) {
+		return fmt.Errorf("replayed UE security capability is %s, want the %s the UE sent: a real UE answers Security Mode Reject (TS 33.501 §6.7.2)",
+			smc.ReplayedUESecurityCapability, ue.UeSecurity.UeSecurityCapability)
+	}
+
 	ksi := int32(smc.NgKSI.Value)
 
 	tsc := models.ScTypeNative

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -73,17 +73,43 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	ue.UeSecurity.Guti = &opts.MappedGUTI
 	ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(opts.Mapped.EKSI), Tsc: models.ScTypeMapped}
 
-	plain, err := BuildRegistrationRequest(&RegistrationRequestOpts{
+	cleartext := &RegistrationRequestOpts{
 		RegistrationType:       uint8(fgs.RegistrationTypeMobilityUpdating),
 		IncludeCapability:      true,
 		UESecurity:             ue.UeSecurity,
 		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
 		EPSNASMessageContainer: opts.EPSNASMessageContainer,
-		PDUSessionStatus:       opts.PDUSessionStatus,
-	})
+	}
+
+	plain, err := BuildRegistrationRequest(cleartext)
 	if err != nil {
 		return fmt.Errorf("could not build the Registration Request of an inter-system change: %w", err)
 	}
+
+	replayMsg := &fgs.RegistrationRequest{
+		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,
+		FOR:                    true,
+		NgKSI:                  nas.KeySetIdentifier{Value: opts.Mapped.EKSI, Mapped: true},
+		MobileIdentity:         opts.MappedGUTI,
+		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
+		EPSNASMessageContainer: opts.EPSNASMessageContainer,
+		GMMCapability:          &fgs.GMMCapability{RestrictEC: true, LPP: true, HOAttach: true, S1Mode: true},
+		UESecurityCapability:   &ue.UeSecurity.UeSecurityCapability,
+	}
+
+	if opts.PDUSessionStatus != nil {
+		var bitmap fgs.PSIBitmap
+
+		bitmap.PSI = *opts.PDUSessionStatus
+		replayMsg.PDUSessionStatus = &bitmap
+	}
+
+	replayBytes, err := replayMsg.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("could not build the replayed Registration Request: %w", err)
+	}
+
+	ue.replayRegistration = replayBytes
 
 	gutiIE, err := opts.MappedGUTI.MarshalBinary()
 	if err != nil {

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ue
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/util/ueauth"
+	"github.com/ellanetworks/core/nas"
+)
+
+const fcKAMFPrimeIdle = "75"
+
+type MappedFromEPSIdle struct {
+	KASME          [32]byte
+	UplinkNASCount nas.Count
+	EKSI           uint8
+	Ciphering      uint8
+	Integrity      uint8
+}
+
+func (ue *UE) InstallMappedSecurityContextForIdleMobility(in MappedFromEPSIdle) error {
+	p0 := make([]byte, 4)
+	binary.BigEndian.PutUint32(p0, in.UplinkNASCount.Value())
+
+	kamf, err := ueauth.GetKDFValue(in.KASME[:], fcKAMFPrimeIdle, p0, ueauth.KDFLen(p0))
+	if err != nil {
+		return fmt.Errorf("derive K'AMF: %w", err)
+	}
+
+	if len(kamf) != len(in.KASME) {
+		return fmt.Errorf("K'AMF is %d octets, want %d", len(kamf), len(in.KASME))
+	}
+
+	var (
+		knasEnc [16]uint8
+		knasInt [16]uint8
+	)
+
+	if err := AlgorithmKeyDerivation(in.Ciphering, kamf, &knasEnc, in.Integrity, &knasInt); err != nil {
+		return fmt.Errorf("derive the mapped 5G NAS keys: %w", err)
+	}
+
+	ue.UeSecurity.Kamf = kamf
+	ue.UeSecurity.CipheringAlg, ue.UeSecurity.IntegrityAlg = in.Ciphering, in.Integrity
+	ue.UeSecurity.KnasEnc, ue.UeSecurity.KnasInt = knasEnc, knasInt
+	ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(in.EKSI), Tsc: models.ScTypeMapped}
+	ue.UeSecurity.ULCount = 0
+	ue.UeSecurity.DLCount = 0
+	ue.UeSecurity.contextFromAuthentication = false
+
+	return nil
+}

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/util/ueauth"
 	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+	"github.com/ellanetworks/core/ngap"
 )
 
 const fcKAMFPrimeIdle = "75"
@@ -53,4 +55,44 @@ func (ue *UE) InstallMappedSecurityContextForIdleMobility(in MappedFromEPSIdle) 
 	ue.UeSecurity.contextFromAuthentication = false
 
 	return nil
+}
+
+type IdleRegistrationOpts struct {
+	RANUENGAPID            int64
+	MappedGUTI             fgs.MobileIdentity
+	EPSNASMessageContainer []byte
+	PDUSessionStatus       *[16]bool
+	Mapped                 MappedFromEPSIdle
+}
+
+func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
+	if ue.Gnb == nil {
+		return fmt.Errorf("GNB is not set for UE")
+	}
+
+	ue.UeSecurity.Guti = &opts.MappedGUTI
+	ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(opts.Mapped.EKSI), Tsc: models.ScTypeMapped}
+
+	plain, err := BuildRegistrationRequest(&RegistrationRequestOpts{
+		RegistrationType:       uint8(fgs.RegistrationTypeMobilityUpdating),
+		IncludeCapability:      true,
+		UESecurity:             ue.UeSecurity,
+		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
+		EPSNASMessageContainer: opts.EPSNASMessageContainer,
+		PDUSessionStatus:       opts.PDUSessionStatus,
+	})
+	if err != nil {
+		return fmt.Errorf("could not build the Registration Request of an inter-system change: %w", err)
+	}
+
+	gutiIE, err := opts.MappedGUTI.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("could not encode the mapped 5G-GUTI: %w", err)
+	}
+
+	if err := ue.Gnb.SendInitialUEMessage(plain, opts.RANUENGAPID, gutiIE, ngap.RRCCauseMOSignalling); err != nil {
+		return fmt.Errorf("could not send the Initial UE Message: %w", err)
+	}
+
+	return ue.InstallMappedSecurityContextForIdleMobility(opts.Mapped)
 }

--- a/internal/tester/ue/idle_mobility_test.go
+++ b/internal/tester/ue/idle_mobility_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ue
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/nas/fgs"
+	"go.uber.org/zap/zapcore"
+)
+
+// TS 33.501 §8.6.2, Annex A.15.1: the UE and the AMF derive the same mapped 5G
+// context from K_ASME and the uplink EPS NAS COUNT of the enclosed TRACKING AREA
+// UPDATE REQUEST — not the NH the handover variant uses.
+func TestIdleMappedSecurityContextFromEPSAgreesWithTheCore(t *testing.T) {
+	logger.Init(zapcore.ErrorLevel)
+
+	var in interworking.EPSSecurityContext
+
+	for i := range in.KASME {
+		in.KASME[i] = byte(i * 3)
+		in.NH[i] = byte(i*5 + 1)
+	}
+
+	in.EKSI = nas.KeySetIdentifier{Value: 3}
+	in.ULNASCount = nas.MakeCount(0, 9)
+	in.Algorithms = interworking.EPSNASAlgorithms{Ciphering: nas.CipheringAES, Integrity: nas.IntegrityAES}
+	in.UESecurityCapability = eps.UESecurityCapability{EEA: 0xf0, EIA: 0x70}
+	in.UE5GSecurityCapability = &fgs.UESecurityCapability{EA: 0xe0, IA: 0xe0}
+
+	mapped, err := interworking.MapTo5GSOnIdleMobility(in,
+		[]nas.IntegrityAlgorithm{nas.IntegrityAES}, []nas.CipheringAlgorithm{nas.CipheringAES})
+	if err != nil {
+		t.Fatalf("MapTo5GSOnIdleMobility: %v", err)
+	}
+
+	u := &UE{UeSecurity: &UESecurity{}}
+
+	if err := u.InstallMappedSecurityContextForIdleMobility(MappedFromEPSIdle{
+		KASME:          in.KASME,
+		UplinkNASCount: in.ULNASCount,
+		EKSI:           in.EKSI.Value,
+		Ciphering:      uint8(mapped.Ciphering),
+		Integrity:      uint8(mapped.Integrity),
+	}); err != nil {
+		t.Fatalf("InstallMappedSecurityContextForIdleMobility: %v", err)
+	}
+
+	if !bytes.Equal(u.UeSecurity.Kamf, mapped.KAMF[:]) {
+		t.Fatalf("K'AMF = %x, want the core's %x", u.UeSecurity.Kamf, mapped.KAMF)
+	}
+
+	if u.UeSecurity.KnasInt != mapped.KNASInt || u.UeSecurity.KnasEnc != mapped.KNASEnc {
+		t.Fatal("the mapped NAS keys differ from the core's, so the security mode command would not verify")
+	}
+
+	if u.UeSecurity.NgKsi.Tsc != models.ScTypeMapped || u.UeSecurity.NgKsi.Ksi != int32(in.EKSI.Value) {
+		t.Fatalf("ngKSI = %+v, want the eKSI %d of a mapped context", u.UeSecurity.NgKsi, in.EKSI.Value)
+	}
+
+	if u.UeSecurity.ULCount != 0 || u.UeSecurity.DLCount != 0 {
+		t.Fatalf("NAS COUNTs = %d/%d, want both 0 (TS 33.501 §8.6.2)", u.UeSecurity.ULCount, u.UeSecurity.DLCount)
+	}
+
+	handover, err := interworking.MapTo5GSOnHandover(in,
+		[]nas.IntegrityAlgorithm{nas.IntegrityAES}, []nas.CipheringAlgorithm{nas.CipheringAES})
+	if err != nil {
+		t.Fatalf("MapTo5GSOnHandover: %v", err)
+	}
+
+	if bytes.Equal(u.UeSecurity.Kamf, handover.Context.KAMF[:]) {
+		t.Fatal("the idle-mode derivation produced the handover key, so a real UE would not follow")
+	}
+}
+
+// TS 24.501 §5.5.1.3.2 c: the registration of an inter-system change in idle
+// mode carries the TAU REQUEST the UE would have sent in S1 mode, plus the
+// native 5G-GUTI it still holds (§8.2.6.12 a).
+func TestRegistrationRequestCarriesTheEPSNASContainerAndAdditionalGUTI(t *testing.T) {
+	logger.Init(zapcore.ErrorLevel)
+
+	tau := []byte{0x17, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x07, 0x48}
+
+	native := fgs.GUTIIdentity(fgs.GUTI{
+		PLMN: nas.PLMN{MCC: "001", MNC: "01"}, AMFRegionID: 1, AMFSetID: 1, AMFPointer: 0,
+		TMSI: [4]byte{1, 2, 3, 4},
+	})
+
+	mapped := fgs.GUTIIdentity(fgs.GUTI{
+		PLMN: nas.PLMN{MCC: "001", MNC: "01"}, AMFRegionID: 1, AMFSetID: 1, AMFPointer: 0,
+		TMSI: [4]byte{9, 9, 9, 9},
+	})
+
+	raw, err := BuildRegistrationRequest(&RegistrationRequestOpts{
+		RegistrationType:       uint8(fgs.RegistrationTypeMobilityUpdating),
+		IncludeCapability:      true,
+		UESecurity:             &UESecurity{Guti: &mapped, NgKsi: models.NgKsi{Ksi: 4, Tsc: models.ScTypeMapped}},
+		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
+		EPSNASMessageContainer: tau,
+		AdditionalGUTI:         &native,
+	})
+	if err != nil {
+		t.Fatalf("BuildRegistrationRequest: %v", err)
+	}
+
+	req, err := fgs.ParseRegistrationRequest(raw)
+	if err != nil {
+		t.Fatalf("ParseRegistrationRequest: %v", err)
+	}
+
+	if !bytes.Equal(req.EPSNASMessageContainer, tau) {
+		t.Errorf("EPS NAS message container = %x, want %x", req.EPSNASMessageContainer, tau)
+	}
+
+	if req.AdditionalGUTI == nil || req.AdditionalGUTI.GUTI == nil ||
+		req.AdditionalGUTI.GUTI.TMSI != [4]byte{1, 2, 3, 4} {
+		t.Errorf("Additional GUTI = %+v, want the native 5G-GUTI", req.AdditionalGUTI)
+	}
+
+	if req.UEStatus == nil || !req.UEStatus.S1ModeReg {
+		t.Errorf("UE status = %v, want EMM-REGISTERED", req.UEStatus)
+	}
+}

--- a/internal/tester/ue/idle_mobility_test.go
+++ b/internal/tester/ue/idle_mobility_test.go
@@ -16,9 +16,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// TS 33.501 §8.6.2, Annex A.15.1: the UE and the AMF derive the same mapped 5G
-// context from K_ASME and the uplink EPS NAS COUNT of the enclosed TRACKING AREA
-// UPDATE REQUEST — not the NH the handover variant uses.
+// TS 33.501 §8.6.2, Annex A.15.1
 func TestIdleMappedSecurityContextFromEPSAgreesWithTheCore(t *testing.T) {
 	logger.Init(zapcore.ErrorLevel)
 
@@ -80,9 +78,7 @@ func TestIdleMappedSecurityContextFromEPSAgreesWithTheCore(t *testing.T) {
 	}
 }
 
-// TS 24.501 §5.5.1.3.2 c: the registration of an inter-system change in idle
-// mode carries the TAU REQUEST the UE would have sent in S1 mode, plus the
-// native 5G-GUTI it still holds (§8.2.6.12 a).
+// TS 24.501 §5.5.1.3.2 c
 func TestRegistrationRequestCarriesTheEPSNASContainerAndAdditionalGUTI(t *testing.T) {
 	logger.Init(zapcore.ErrorLevel)
 

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -92,6 +92,7 @@ type UE struct {
 	Snssai                 models.Snssai
 	amfInfo                Amf
 	IMEISV                 string
+	replayRegistration     []byte
 	Gnb                    air.UplinkSender
 	mu                     sync.Mutex
 	cond                   *sync.Cond

--- a/nas/downlink_sender.go
+++ b/nas/downlink_sender.go
@@ -48,6 +48,18 @@ func (s *DownlinkSender) Install(sc *SecurityContext, count DownlinkCounter) {
 	s.count = count
 }
 
+// Rekey makes sc the security context protecting downlink messages, leaving the
+// downlink NAS COUNT as it is. It takes into use keys re-derived from the same
+// root key with new algorithm identities, which is not a new security context
+// and so does not restart its COUNTs (TS 24.301 §5.4.3.2, TS 33.401 §6.5,
+// TS 24.501 §5.4.2.1, TS 33.501 §6.4.5).
+func (s *DownlinkSender) Rekey(sc *SecurityContext) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.sc = sc
+}
+
 // Clear drops the security context, leaving the counter as it is.
 // [DownlinkSender.Send] reports [ErrNoSecurityContext] until another context is
 // installed.

--- a/nas/eps/emm_tau.go
+++ b/nas/eps/emm_tau.go
@@ -83,11 +83,10 @@ var tauRequestOptionalIEs = []nas.OptionalIE{
 	{IEI: ieiRequestedWUSAssistance, Format: nas.IETLV, Name: "Requested WUS assistance"},
 }
 
-// AppendBinary encodes the plain TRACKING AREA UPDATE REQUEST. Only the mandatory EPS
-// update type octet (NAS key set identifier | active flag | update type) is
-// written; the UE is resolved from the S-TMSI in the S1AP Initial UE Message, so
-// the old GUTI is omitted (the receiver here ignores it, TS 24.301).
-// The encoding is appended to b.
+// AppendBinary encodes the plain TRACKING AREA UPDATE REQUEST: the mandatory EPS
+// update type octet (NAS key set identifier | active flag | update type), the
+// mandatory Old GUTI, and the optional IEs this message models
+// (TS 24.301 table 8.2.29.1). The encoding is appended to b.
 func (m *TrackingAreaUpdateRequest) AppendBinary(b []byte) ([]byte, error) {
 	w := nas.NewWriter(b)
 
@@ -163,9 +162,11 @@ func (m *TrackingAreaUpdateRequest) AppendBinary(b []byte) ([]byte, error) {
 // MarshalBinary encodes the message.
 func (m *TrackingAreaUpdateRequest) MarshalBinary() ([]byte, error) { return marshalMessage(m) }
 
-// ParseTrackingAreaUpdateRequest decodes a plain TRACKING AREA UPDATE REQUEST.
-// The old GUTI and optional IEs are not decoded; the UE is resolved from the
-// S-TMSI carried in the S1AP Initial UE Message.
+// ParseTrackingAreaUpdateRequest decodes a plain TRACKING AREA UPDATE REQUEST,
+// including the mandatory Old GUTI and the optional IEs of
+// TS 24.301 table 8.2.29.1. An inter-system change from N1 mode is recognised
+// from those elements alone, before any security context exists for the UE
+// (§5.5.3.2.2 case z).
 func ParseTrackingAreaUpdateRequest(b []byte) (*TrackingAreaUpdateRequest, error) {
 	r := nas.NewReader(b)
 

--- a/nas/eps/emm_tau_test.go
+++ b/nas/eps/emm_tau_test.go
@@ -299,3 +299,47 @@ func TestTrackingAreaUpdateRequestRejectsMalformedCapabilities(t *testing.T) {
 		})
 	}
 }
+
+// TS 24.301 §8.2.29.1: the NAS key set identifier shares octet 3 with the EPS
+// update type, so a reader that wants only the identifier must take the high
+// half. TS 33.501 §8.5.2 step 4 has the AMF name a security context with it
+// before it holds one to decode the rest of the message with.
+func TestPeekKeySetIdentifierReadsTheHalfOctet(t *testing.T) {
+	for _, ksi := range []nas.KeySetIdentifier{
+		{Value: 0},
+		{Value: 5},
+		{Value: 3, Mapped: true},
+		{Value: 7},
+	} {
+		b, err := (&TrackingAreaUpdateRequest{
+			EPSUpdateType:       EPSUpdateTypeCombinedTALA,
+			NASKeySetIdentifier: ksi,
+			OldGUTI: GUTIIdentity(GUTI{
+				PLMN: nas.PLMN{MCC: "001", MNC: "01"}, MMEGroupID: 1, MMECode: 1, TMSI: [4]byte{1, 2, 3, 4},
+			}),
+		}).MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := PeekKeySetIdentifier(b)
+		if err != nil {
+			t.Fatalf("PeekKeySetIdentifier: %v", err)
+		}
+
+		if got != ksi {
+			t.Errorf("key set identifier = %+v, want %+v", got, ksi)
+		}
+	}
+}
+
+func TestPeekKeySetIdentifierRefusals(t *testing.T) {
+	if _, err := PeekKeySetIdentifier([]byte{uint8(PDEMM), uint8(MsgTrackingAreaUpdateRequest)}); err == nil {
+		t.Error("a message with no octet 3 yielded a key set identifier")
+	}
+
+	protected := []byte{uint8(SHTIntegrityProtected)<<4 | uint8(PDEMM), 0xde, 0xad, 0xbe, 0xef, 0x00}
+	if _, err := PeekKeySetIdentifier(protected); err == nil {
+		t.Error("a security protected message yielded a key set identifier, but its octet 3 is a MAC byte")
+	}
+}

--- a/nas/eps/emm_tau_test.go
+++ b/nas/eps/emm_tau_test.go
@@ -300,10 +300,7 @@ func TestTrackingAreaUpdateRequestRejectsMalformedCapabilities(t *testing.T) {
 	}
 }
 
-// TS 24.301 §8.2.29.1: the NAS key set identifier shares octet 3 with the EPS
-// update type, so a reader that wants only the identifier must take the high
-// half. TS 33.501 §8.5.2 step 4 has the AMF name a security context with it
-// before it holds one to decode the rest of the message with.
+// TS 24.301 §8.2.29.1
 func TestPeekKeySetIdentifierReadsTheHalfOctet(t *testing.T) {
 	for _, ksi := range []nas.KeySetIdentifier{
 		{Value: 0},

--- a/nas/eps/ie_interworking.go
+++ b/nas/eps/ie_interworking.go
@@ -11,10 +11,6 @@ import "fmt"
 // move rather than a fresh arrival — TS 24.301 §5.5.3.2.2 case zd has a UE
 // handed over from 5GS report "UE is in 5GMM-REGISTERED state" in the TAU that
 // follows.
-//
-// It is the EPS counterpart of fgs.UEStatus, and the two are the same element:
-// TS 24.301 defines it by reference. They stay separate types because neither
-// generation's codec reaches across the boundary.
 type UEStatus struct {
 	// S1ModeReg reports the UE is in EMM-REGISTERED state (octet 3, bit 1).
 	S1ModeReg bool

--- a/nas/eps/message.go
+++ b/nas/eps/message.go
@@ -82,6 +82,24 @@ func PeekMessageType(b []byte) (MessageType, error) {
 	return MessageType(mt), nil
 }
 
+// PeekKeySetIdentifier returns the NAS key set identifier of a plain EMM message
+// that carries it in the high half of octet 3, which the ATTACH REQUEST, the
+// TRACKING AREA UPDATE REQUEST and the DETACH REQUEST all do (TS 24.301
+// §8.2.4, §8.2.29, §8.2.11). It reads the identifier alone, so a receiver can
+// name the security context a message cites before it has a context to decode
+// the rest with.
+func PeekKeySetIdentifier(b []byte) (nas.KeySetIdentifier, error) {
+	if _, err := PeekMessageType(b); err != nil {
+		return nas.KeySetIdentifier{}, err
+	}
+
+	if len(b) < 3 {
+		return nas.KeySetIdentifier{}, fmt.Errorf("nas/eps: message is %d octets, too short for its NAS key set identifier", len(b))
+	}
+
+	return nas.ParseKeySetIdentifier(b[2] >> 4), nil
+}
+
 // PeekProtocolDiscriminator returns the protocol discriminator of a NAS message
 // (PDEMM or PDESM), so the receiver can route between the EMM and ESM handlers
 // before calling the matching Peek/Parse function.

--- a/nas/eps/security_5gs.go
+++ b/nas/eps/security_5gs.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package eps
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/ellanetworks/core/nas"
+)
+
+// VerifyWith5GContext verifies an EPS-framed, integrity-protected NAS message
+// against a 5G NAS security context.
+//
+// A UE changing system from 5GS to EPS in idle mode protects its TRACKING AREA
+// UPDATE REQUEST with the 5G context named by the mapped EPS GUTI, computing the
+// NAS-MAC "as it is done for a 5G NAS message over a 3GPP access" over a message
+// framed by TS 24.301 §9.1 (TS 33.501 §8.5.2 steps 1 and 4). The frame is
+// therefore this package's, while BEARER is the 3GPP access connection
+// identifier of the 5G system rather than the EPS constant [Unprotect] uses, and
+// the count is the 5G uplink NAS COUNT.
+//
+// The caller owns the count: estimate it from the message's sequence number and
+// commit it only once this returns without error, or the same message verifies
+// again (TS 33.501 §8.5.2 step 1 increments the UE's stored count).
+//
+// The message arrives unciphered — the MME reads its Old GUTI and UE status to
+// find the AMF (TS 24.301 §4.4.2.3) — so no ciphered security header type is
+// admitted and the payload is returned as it was framed.
+func VerifyWith5GContext(b []byte, count nas.Count, dir nas.Direction, sc *nas.SecurityContext) ([]byte, error) {
+	if sc == nil {
+		return nil, nas.ErrNoSecurityContext
+	}
+
+	m, err := ParseSecurityProtectedMessage(b)
+	if err != nil {
+		return nil, err
+	}
+
+	permitted := []SecurityHeaderType{SHTIntegrityProtected, SHTIntegrityProtectedNewContext}
+	if !slices.Contains(permitted, m.SecurityHeaderType) {
+		return nil, fmt.Errorf("%w: %s", ErrSecurityHeaderTypeNotPermitted, m.SecurityHeaderType)
+	}
+
+	if m.SequenceNumber != count.SQN() {
+		return nil, fmt.Errorf("%w: message carries %#02x, NAS COUNT carries %#02x",
+			ErrSequenceNumberMismatch, m.SequenceNumber, count.SQN())
+	}
+
+	if err := sc.VerifyMAC(macInput(m.SequenceNumber, m.UnverifiedPayload), m.MAC, count, nas.Bearer3GPP, dir); err != nil {
+		if errors.Is(err, nas.ErrMACMismatch) {
+			return nil, ErrMACMismatch
+		}
+
+		return nil, err
+	}
+
+	return m.UnverifiedPayload, nil
+}

--- a/nas/eps/security_5gs.go
+++ b/nas/eps/security_5gs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ellanetworks/core/nas"
 )
 
+// VerifyWith5GContext checks that the given NAS message is a valid 5G NAS message with the given security context, and returns the inner plain payload if so.
 func VerifyWith5GContext(b []byte, count nas.Count, dir nas.Direction, sc *nas.SecurityContext) ([]byte, error) {
 	if sc == nil {
 		return nil, nas.ErrNoSecurityContext

--- a/nas/eps/security_5gs.go
+++ b/nas/eps/security_5gs.go
@@ -11,24 +11,6 @@ import (
 	"github.com/ellanetworks/core/nas"
 )
 
-// VerifyWith5GContext verifies an EPS-framed, integrity-protected NAS message
-// against a 5G NAS security context.
-//
-// A UE changing system from 5GS to EPS in idle mode protects its TRACKING AREA
-// UPDATE REQUEST with the 5G context named by the mapped EPS GUTI, computing the
-// NAS-MAC "as it is done for a 5G NAS message over a 3GPP access" over a message
-// framed by TS 24.301 §9.1 (TS 33.501 §8.5.2 steps 1 and 4). The frame is
-// therefore this package's, while BEARER is the 3GPP access connection
-// identifier of the 5G system rather than the EPS constant [Unprotect] uses, and
-// the count is the 5G uplink NAS COUNT.
-//
-// The caller owns the count: estimate it from the message's sequence number and
-// commit it only once this returns without error, or the same message verifies
-// again (TS 33.501 §8.5.2 step 1 increments the UE's stored count).
-//
-// The message arrives unciphered — the MME reads its Old GUTI and UE status to
-// find the AMF (TS 24.301 §4.4.2.3) — so no ciphered security header type is
-// admitted and the payload is returned as it was framed.
 func VerifyWith5GContext(b []byte, count nas.Count, dir nas.Direction, sc *nas.SecurityContext) ([]byte, error) {
 	if sc == nil {
 		return nil, nas.ErrNoSecurityContext

--- a/nas/eps/security_5gs_test.go
+++ b/nas/eps/security_5gs_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/ellanetworks/core/nas"
 )
 
-// protectWithBearer frames plain as an EPS security-protected message whose
-// NAS-MAC is computed over the named bearer, standing in for a UE that MACs its
-// TAU REQUEST as a 5G NAS message (bearer 3GPP) or as an EPS one (bearer EPS).
 func protectWithBearer(t *testing.T, sc *nas.SecurityContext, plain []byte, count nas.Count, bearer nas.Bearer) []byte {
 	t.Helper()
 
@@ -37,9 +34,7 @@ func protectWithBearer(t *testing.T, sc *nas.SecurityContext, plain []byte, coun
 	return raw
 }
 
-// TS 33.501 §8.5.2: the UE computes the NAS-MAC for the TAU REQUEST as it is
-// done for a 5G NAS message over a 3GPP access, so the bearer is the 3GPP access
-// connection identifier and not the EPS constant Unprotect uses.
+// TS 33.501 §8.5.2
 func TestVerifyWith5GContextTakesTheThreeGPPBearer(t *testing.T) {
 	sc := testContext(t, "aes")
 	count := nas.Count(7)
@@ -61,8 +56,6 @@ func TestVerifyWith5GContextTakesTheThreeGPPBearer(t *testing.T) {
 	}
 }
 
-// The count is the caller's replay gate, so a message whose sequence number does
-// not belong to it is refused before the MAC is even checked.
 func TestVerifyWith5GContextChecksTheSequenceNumber(t *testing.T) {
 	sc := testContext(t, "aes")
 
@@ -73,8 +66,7 @@ func TestVerifyWith5GContextChecksTheSequenceNumber(t *testing.T) {
 	}
 }
 
-// TS 24.301 §4.4.2.3: the message arrives unciphered so the MME can read its Old
-// GUTI and UE status. A ciphered header type would hide them.
+// TS 24.301 §4.4.2.3
 func TestVerifyWith5GContextRefusesCipheredAndPlainHeaders(t *testing.T) {
 	sc := testContext(t, "aes")
 	count := nas.Count(7)
@@ -108,8 +100,7 @@ func TestVerifyWith5GContextRefusesCipheredAndPlainHeaders(t *testing.T) {
 	}
 }
 
-// TS 24.301 §4.4.2.3 case 1 has the MME run a NAS SMC when it changes algorithm,
-// so the UE's next message carries the new-context header type.
+// TS 24.301 §4.4.2.3 case 1
 func TestVerifyWith5GContextAdmitsTheNewContextHeaderType(t *testing.T) {
 	sc := testContext(t, "aes")
 	count := nas.Count(3)

--- a/nas/eps/security_5gs_test.go
+++ b/nas/eps/security_5gs_test.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package eps
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+)
+
+// protectWithBearer frames plain as an EPS security-protected message whose
+// NAS-MAC is computed over the named bearer, standing in for a UE that MACs its
+// TAU REQUEST as a 5G NAS message (bearer 3GPP) or as an EPS one (bearer EPS).
+func protectWithBearer(t *testing.T, sc *nas.SecurityContext, plain []byte, count nas.Count, bearer nas.Bearer) []byte {
+	t.Helper()
+
+	seq := count.SQN()
+
+	mac, err := sc.MAC(macInput(seq, plain), count, bearer, nas.DirectionUplink)
+	if err != nil {
+		t.Fatalf("MAC: %v", err)
+	}
+
+	raw, err := (&SecurityProtectedMessage{
+		SecurityHeaderType: SHTIntegrityProtected,
+		MAC:                mac,
+		SequenceNumber:     seq,
+		UnverifiedPayload:  plain,
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+
+	return raw
+}
+
+// TS 33.501 §8.5.2: the UE computes the NAS-MAC for the TAU REQUEST as it is
+// done for a 5G NAS message over a 3GPP access, so the bearer is the 3GPP access
+// connection identifier and not the EPS constant Unprotect uses.
+func TestVerifyWith5GContextTakesTheThreeGPPBearer(t *testing.T) {
+	sc := testContext(t, "aes")
+	count := nas.Count(7)
+
+	raw := protectWithBearer(t, sc, testPlain, count, nas.Bearer3GPP)
+
+	plain, err := VerifyWith5GContext(raw, count, nas.DirectionUplink, sc)
+	if err != nil {
+		t.Fatalf("VerifyWith5GContext: %v", err)
+	}
+
+	if !bytes.Equal(plain, testPlain) {
+		t.Errorf("plain = %x, want %x", plain, testPlain)
+	}
+
+	epsFramed := protectWithBearer(t, sc, testPlain, count, nas.BearerEPS)
+	if _, err := VerifyWith5GContext(epsFramed, count, nas.DirectionUplink, sc); !errors.Is(err, nas.ErrMACMismatch) {
+		t.Errorf("a message MAC'd over the EPS bearer verified with error %v, want a MAC mismatch", err)
+	}
+}
+
+// The count is the caller's replay gate, so a message whose sequence number does
+// not belong to it is refused before the MAC is even checked.
+func TestVerifyWith5GContextChecksTheSequenceNumber(t *testing.T) {
+	sc := testContext(t, "aes")
+
+	raw := protectWithBearer(t, sc, testPlain, nas.Count(7), nas.Bearer3GPP)
+
+	if _, err := VerifyWith5GContext(raw, nas.Count(8), nas.DirectionUplink, sc); !errors.Is(err, ErrSequenceNumberMismatch) {
+		t.Errorf("error = %v, want a sequence number mismatch", err)
+	}
+}
+
+// TS 24.301 §4.4.2.3: the message arrives unciphered so the MME can read its Old
+// GUTI and UE status. A ciphered header type would hide them.
+func TestVerifyWith5GContextRefusesCipheredAndPlainHeaders(t *testing.T) {
+	sc := testContext(t, "aes")
+	count := nas.Count(7)
+
+	for _, sht := range []SecurityHeaderType{
+		SHTIntegrityProtectedCiphered,
+		SHTIntegrityProtectedCipheredNewContext,
+	} {
+		mac, err := sc.MAC(macInput(count.SQN(), testPlain), count, nas.Bearer3GPP, nas.DirectionUplink)
+		if err != nil {
+			t.Fatalf("MAC: %v", err)
+		}
+
+		raw, err := (&SecurityProtectedMessage{
+			SecurityHeaderType: sht,
+			MAC:                mac,
+			SequenceNumber:     count.SQN(),
+			UnverifiedPayload:  testPlain,
+		}).MarshalBinary()
+		if err != nil {
+			t.Fatalf("MarshalBinary: %v", err)
+		}
+
+		if _, err := VerifyWith5GContext(raw, count, nas.DirectionUplink, sc); !errors.Is(err, ErrSecurityHeaderTypeNotPermitted) {
+			t.Errorf("%s: error = %v, want the header type refused", sht, err)
+		}
+	}
+
+	if _, err := VerifyWith5GContext(testPlain, count, nas.DirectionUplink, sc); err == nil {
+		t.Error("a plain message verified, want a refusal")
+	}
+}
+
+// TS 24.301 §4.4.2.3 case 1 has the MME run a NAS SMC when it changes algorithm,
+// so the UE's next message carries the new-context header type.
+func TestVerifyWith5GContextAdmitsTheNewContextHeaderType(t *testing.T) {
+	sc := testContext(t, "aes")
+	count := nas.Count(3)
+
+	mac, err := sc.MAC(macInput(count.SQN(), testPlain), count, nas.Bearer3GPP, nas.DirectionUplink)
+	if err != nil {
+		t.Fatalf("MAC: %v", err)
+	}
+
+	raw, err := (&SecurityProtectedMessage{
+		SecurityHeaderType: SHTIntegrityProtectedNewContext,
+		MAC:                mac,
+		SequenceNumber:     count.SQN(),
+		UnverifiedPayload:  testPlain,
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+
+	if _, err := VerifyWith5GContext(raw, count, nas.DirectionUplink, sc); err != nil {
+		t.Errorf("VerifyWith5GContext: %v", err)
+	}
+}
+
+func TestVerifyWith5GContextWithoutAContext(t *testing.T) {
+	if _, err := VerifyWith5GContext(testPlain, 0, nas.DirectionUplink, nil); !errors.Is(err, nas.ErrNoSecurityContext) {
+		t.Errorf("error = %v, want no security context", err)
+	}
+}

--- a/nas/fgs/gmm_eps_nas_container_test.go
+++ b/nas/fgs/gmm_eps_nas_container_test.go
@@ -11,10 +11,7 @@ import (
 	"github.com/ellanetworks/core/nas"
 )
 
-// TS 24.501 §8.2.6.16: a single-registration UE moving from S1 mode in
-// 5GMM-IDLE mode carries its complete TRACKING AREA UPDATE REQUEST here,
-// protected with the EPS security context. Only the MME can verify it, so the
-// bytes have to survive the AMF's decode unaltered.
+// TS 24.501 §8.2.6.16
 func TestRegistrationRequestCarriesTheEPSNASMessageContainer(t *testing.T) {
 	// Opaque to this codec (§7.5.2), so the content only has to be recognisable.
 	tau := []byte{0x07, 0x48, 0x0b, 0xf6, 0x00, 0xf1, 0x10, 0x00, 0x01, 0x01, 0x02, 0x03, 0x04}
@@ -46,8 +43,6 @@ func TestRegistrationRequestCarriesTheEPSNASMessageContainer(t *testing.T) {
 	}
 }
 
-// A container long enough to need a two-octet length is the ordinary case: a TAU
-// REQUEST carrying its own optional IEs exceeds 255 octets.
 func TestEPSNASMessageContainerSurvivesALongTAU(t *testing.T) {
 	tau := make([]byte, 300)
 	for i := range tau {
@@ -75,10 +70,7 @@ func TestEPSNASMessageContainerSurvivesALongTAU(t *testing.T) {
 	}
 }
 
-// TS 24.501 table 8.2.6.1.1 orders the optional IEs, and a UE is entitled to
-// stop at the first IEI it does not expect. The encoder emits them in that
-// order; this pins the three the inter-system change adds against the order the
-// table lists them in (§8.2.6.15, §8.2.6.16, §8.2.6.20, §8.2.6.21, §8.2.6.23).
+// TS 24.501 table 8.2.6.1.1
 func TestRegistrationRequestEmitsOptionalIEsInTableOrder(t *testing.T) {
 	m := &RegistrationRequest{
 		RegistrationType:       RegistrationTypeMobilityUpdating,

--- a/nas/fgs/gmm_eps_nas_container_test.go
+++ b/nas/fgs/gmm_eps_nas_container_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fgs
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+)
+
+// TS 24.501 §8.2.6.16: a single-registration UE moving from S1 mode in
+// 5GMM-IDLE mode carries its complete TRACKING AREA UPDATE REQUEST here,
+// protected with the EPS security context. Only the MME can verify it, so the
+// bytes have to survive the AMF's decode unaltered.
+func TestRegistrationRequestCarriesTheEPSNASMessageContainer(t *testing.T) {
+	// Opaque to this codec (§7.5.2), so the content only has to be recognisable.
+	tau := []byte{0x07, 0x48, 0x0b, 0xf6, 0x00, 0xf1, 0x10, 0x00, 0x01, 0x01, 0x02, 0x03, 0x04}
+
+	m := &RegistrationRequest{
+		RegistrationType:       RegistrationTypeMobilityUpdating,
+		NgKSI:                  nas.KeySetIdentifier{Value: 1, Mapped: true},
+		MobileIdentity:         epsContainerTestGUTI(),
+		UEStatus:               &UEStatus{S1ModeReg: true},
+		EPSNASMessageContainer: tau,
+	}
+
+	raw, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	back, err := ParseRegistrationRequest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(back.EPSNASMessageContainer, tau) {
+		t.Errorf("EPS NAS message container = %x, want %x", back.EPSNASMessageContainer, tau)
+	}
+
+	if len(back.Unrecognized) != 0 {
+		t.Errorf("unrecognized = %+v, want none: the container has a parse case", back.Unrecognized)
+	}
+}
+
+// A container long enough to need a two-octet length is the ordinary case: a TAU
+// REQUEST carrying its own optional IEs exceeds 255 octets.
+func TestEPSNASMessageContainerSurvivesALongTAU(t *testing.T) {
+	tau := make([]byte, 300)
+	for i := range tau {
+		tau[i] = uint8(i)
+	}
+
+	m := &RegistrationRequest{
+		RegistrationType:       RegistrationTypeMobilityUpdating,
+		MobileIdentity:         epsContainerTestGUTI(),
+		EPSNASMessageContainer: tau,
+	}
+
+	raw, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	back, err := ParseRegistrationRequest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(back.EPSNASMessageContainer, tau) {
+		t.Errorf("EPS NAS message container is %d octets, want the %d sent", len(back.EPSNASMessageContainer), len(tau))
+	}
+}
+
+// TS 24.501 table 8.2.6.1.1 orders the optional IEs, and a UE is entitled to
+// stop at the first IEI it does not expect. The encoder emits them in that
+// order; this pins the three the inter-system change adds against the order the
+// table lists them in (§8.2.6.15, §8.2.6.16, §8.2.6.20, §8.2.6.21, §8.2.6.23).
+func TestRegistrationRequestEmitsOptionalIEsInTableOrder(t *testing.T) {
+	m := &RegistrationRequest{
+		RegistrationType:       RegistrationTypeMobilityUpdating,
+		MobileIdentity:         epsContainerTestGUTI(),
+		RequestedDRXParameters: &DRXParameter{Value: DRXCycleParameterT32},
+		EPSNASMessageContainer: []byte{0x07, 0x48},
+		UpdateType5GS:          &UpdateType5GS{},
+		NASMessageContainer:    []byte{0x7e, 0x00},
+		EPSBearerContextStatus: &nas.EPSBearerContextStatus{},
+	}
+
+	raw, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []uint8{
+		ieiRequestedDRXParameters, // 8.2.6.15
+		ieiEPSNASMessageContainer, // 8.2.6.16
+		ieiUpdateType5GS,          // 8.2.6.20
+		ieiNASMessageContainer,    // 8.2.6.21
+		ieiEPSBearerContextStatus, // 8.2.6.23
+	}
+
+	got := make([]uint8, 0, len(want))
+
+	for _, iei := range want {
+		if at := bytes.IndexByte(raw, iei); at >= 0 {
+			got = append(got, iei)
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("encoded IEIs %#x, want all of %#x", got, want)
+	}
+
+	positions := make([]int, len(want))
+	for i, iei := range want {
+		positions[i] = bytes.IndexByte(raw, iei)
+	}
+
+	if !slices.IsSorted(positions) {
+		t.Errorf("optional IE positions %v for IEIs %#x are out of table order", positions, want)
+	}
+}
+
+func epsContainerTestGUTI() MobileIdentity {
+	return GUTIIdentity(GUTI{
+		PLMN: nas.PLMN{MCC: "001", MNC: "01"}, AMFRegionID: 0x01, AMFSetID: 0x002, AMFPointer: 0x03,
+		TMSI: [4]byte{1, 2, 3, 4},
+	})
+}

--- a/nas/fgs/gmm_registration.go
+++ b/nas/fgs/gmm_registration.go
@@ -34,56 +34,26 @@ const (
 // reads the fields below; the many other optional IEs are still walked (so a later
 // IE Ella reads is reached) but their values are discarded.
 type RegistrationRequest struct {
-	RegistrationType RegistrationType     // bits 1-3 of the ngKSI/registration-type octet
-	FOR              bool                 // follow-on request pending, bit 4
-	NgKSI            nas.KeySetIdentifier // bits 5-8
-	MobileIdentity   MobileIdentity       // mandatory 5GS mobile identity (type 6, LVE)
-
-	GMMCapability        *GMMCapability        // IEI 0x10
-	UESecurityCapability *UESecurityCapability // IEI 0x2E
-
-	// Opaque for the same reason SECURITY MODE COMMAND's replayed copy is: the UE
-	// compares the replay byte-for-byte (TS 33.501 §6.7.2), so decoding and
-	// re-encoding could only lose that. Modelled rather than left to Unrecognized
-	// because Critical is only consulted when the parse callback rejects a value,
-	// so an element with no case there can never fire it.
-	S1UENetworkCapability []byte // IEI 0x17
-
-	RequestedNSSAI          NSSAI         // IEI 0x2F
-	UplinkDataStatus        *PSIBitmap    // IEI 0x40
-	PDUSessionStatus        *PSIBitmap    // IEI 0x50
-	AllowedPDUSessionStatus *PSIBitmap    // IEI 0x25
-	UEStatus                *UEStatus     // IEI 0x2B
-	RequestedDRXParameters  *DRXParameter // IEI 0x51
-
-	// AdditionalGUTI is the UE's native 5G-GUTI (IEI 0x77), which it includes
-	// when registering after an inter-system change from S1 mode in
-	// single-registration mode (TS 24.501 §8.2.6.12 a). The 5GS mobile identity
-	// IE of the message itself then carries the 5G-GUTI mapped from the 4G-GUTI,
-	// so this is what names the context the AMF can still recover
-	// (§5.5.1.3.2 case e).
-	AdditionalGUTI      *MobileIdentity
-	NASMessageContainer []byte          // IEI 0x71
-	MICOIndication      *MICOIndication // IEI 0xB0 (type 1)
-	UpdateType5GS       *UpdateType5GS  // IEI 0x53
-
-	// EPSNASMessageContainer (IEI 0x70) carries the complete integrity-protected
-	// TRACKING AREA UPDATE REQUEST the UE would have sent in S1 mode, protected
-	// with its EPS security context, on an inter-system change performed in
-	// 5GMM-IDLE mode (TS 24.501 §8.2.6.16, §5.5.1.3.2 c). It is opaque here:
-	// §7.5.2 admits no diagnosis of its content beyond presence and length, and
-	// only the MME holds the context that verifies it.
-	EPSNASMessageContainer []byte
-
-	// EPSBearerContextStatus (IEI 0x60) reports which EPS bearer contexts are
-	// active in the UE. A UE that locally deactivated one in S1 mode without
-	// telling the network shall include it on the inter-system change
-	// (TS 24.501 §5.5.1.3.2 d, §8.2.6.23).
-	EPSBearerContextStatus *nas.EPSBearerContextStatus
-
-	// Unrecognized carries the optional information elements this message does
-	// not model, so they survive decoding and re-encode unchanged.
-	Unrecognized []nas.RawIE
+	RegistrationType        RegistrationType      // bits 1-3 of the ngKSI/registration-type octet
+	FOR                     bool                  // follow-on request pending, bit 4
+	NgKSI                   nas.KeySetIdentifier  // bits 5-8
+	MobileIdentity          MobileIdentity        // mandatory 5GS mobile identity (type 6, LVE)
+	GMMCapability           *GMMCapability        // IEI 0x10
+	UESecurityCapability    *UESecurityCapability // IEI 0x2E
+	S1UENetworkCapability   []byte                // IEI 0x17
+	RequestedNSSAI          NSSAI                 // IEI 0x2F
+	UplinkDataStatus        *PSIBitmap            // IEI 0x40
+	PDUSessionStatus        *PSIBitmap            // IEI 0x50
+	AllowedPDUSessionStatus *PSIBitmap            // IEI 0x25
+	UEStatus                *UEStatus             // IEI 0x2B
+	RequestedDRXParameters  *DRXParameter         // IEI 0x51
+	AdditionalGUTI          *MobileIdentity
+	NASMessageContainer     []byte          // IEI 0x71
+	MICOIndication          *MICOIndication // IEI 0xB0 (type 1)
+	UpdateType5GS           *UpdateType5GS  // IEI 0x53
+	EPSNASMessageContainer  []byte
+	EPSBearerContextStatus  *nas.EPSBearerContextStatus
+	Unrecognized            []nas.RawIE
 }
 
 // registrationRequestIEs is the full-octet optional-IE table of the REGISTRATION

--- a/nas/fgs/gmm_registration.go
+++ b/nas/fgs/gmm_registration.go
@@ -67,6 +67,14 @@ type RegistrationRequest struct {
 	MICOIndication      *MICOIndication // IEI 0xB0 (type 1)
 	UpdateType5GS       *UpdateType5GS  // IEI 0x53
 
+	// EPSNASMessageContainer (IEI 0x70) carries the complete integrity-protected
+	// TRACKING AREA UPDATE REQUEST the UE would have sent in S1 mode, protected
+	// with its EPS security context, on an inter-system change performed in
+	// 5GMM-IDLE mode (TS 24.501 §8.2.6.16, §5.5.1.3.2 c). It is opaque here:
+	// §7.5.2 admits no diagnosis of its content beyond presence and length, and
+	// only the MME holds the context that verifies it.
+	EPSNASMessageContainer []byte
+
 	// EPSBearerContextStatus (IEI 0x60) reports which EPS bearer contexts are
 	// active in the UE. A UE that locally deactivated one in S1 mode without
 	// telling the network shall include it on the inter-system change
@@ -208,6 +216,10 @@ func (m *RegistrationRequest) AppendBinary(b []byte) ([]byte, error) {
 		o.TLV(ieiRequestedDRXParameters, raw)
 	}
 
+	if m.EPSNASMessageContainer != nil {
+		o.TLVE(ieiEPSNASMessageContainer, m.EPSNASMessageContainer)
+	}
+
 	if m.UpdateType5GS != nil {
 		raw, err := m.UpdateType5GS.MarshalBinary()
 		if err != nil {
@@ -217,6 +229,10 @@ func (m *RegistrationRequest) AppendBinary(b []byte) ([]byte, error) {
 		o.TLV(ieiUpdateType5GS, raw)
 	}
 
+	if m.NASMessageContainer != nil {
+		o.TLVE(ieiNASMessageContainer, m.NASMessageContainer)
+	}
+
 	if m.EPSBearerContextStatus != nil {
 		raw, err := m.EPSBearerContextStatus.MarshalBinary()
 		if err != nil {
@@ -224,10 +240,6 @@ func (m *RegistrationRequest) AppendBinary(b []byte) ([]byte, error) {
 		}
 
 		o.TLV(ieiEPSBearerContextStatus, raw)
-	}
-
-	if m.NASMessageContainer != nil {
-		o.TLVE(ieiNASMessageContainer, m.NASMessageContainer)
 	}
 
 	o.Raw(m.Unrecognized...)
@@ -379,6 +391,8 @@ func ParseRegistrationRequest(b []byte) (*RegistrationRequest, error) {
 			out.RequestedDRXParameters = &drx
 		case ieiNASMessageContainer:
 			out.NASMessageContainer = value
+		case ieiEPSNASMessageContainer:
+			out.EPSNASMessageContainer = value
 		case ieiUpdateType5GS:
 			ut, err := ParseUpdateType5GS(value)
 			if err != nil {


### PR DESCRIPTION
# Description

Add idle-mode inter-system change in both directions (4g->5g and 5g->4g) over N26. A UE moving between two radios will keep its IP address, even if it is in idle mode.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
