### PR TITLE
fix: don't request acknowledgement on NITZ-only Configuration Update Command

### DIFF
--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -335,14 +335,18 @@ func BuildRegistrationAccept(
 // TS 24.501 Generic UE configuration update procedure.
 // includeGUTI controls whether a new 5G-GUTI is included (e.g. during service request GUTI re-allocation).
 func BuildConfigurationUpdateCommand(guti etsi.GUTI5G, spnFullName, spnShortName string, includeGUTI bool) ([]byte, error) {
-	ack := fgs.ConfigurationUpdateIndication{ACK: true}
-
-	m := &fgs.ConfigurationUpdateCommand{ConfigurationUpdateIndication: &ack}
+	m := &fgs.ConfigurationUpdateCommand{}
 
 	if includeGUTI {
 		if guti == etsi.InvalidGUTI5G {
 			return nil, fmt.Errorf("5G-GUTI is required")
 		}
+
+		// TS 24.501 §5.4.4.2: acknowledgement is requested for all parameters
+		// except when only NITZ information is included. The 5G-GUTI is the only
+		// non-NITZ parameter this message carries, so it alone warrants the ACK.
+		ack := fgs.ConfigurationUpdateIndication{ACK: true}
+		m.ConfigurationUpdateIndication = &ack
 
 		gutiNas, err := guti.MobileIdentity()
 		if err != nil {

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -342,9 +342,6 @@ func BuildConfigurationUpdateCommand(guti etsi.GUTI5G, spnFullName, spnShortName
 			return nil, fmt.Errorf("5G-GUTI is required")
 		}
 
-		// TS 24.501 §5.4.4.2: acknowledgement is requested for all parameters
-		// except when only NITZ information is included. The 5G-GUTI is the only
-		// non-NITZ parameter this message carries, so it alone warrants the ACK.
 		ack := fgs.ConfigurationUpdateIndication{ACK: true}
 		m.ConfigurationUpdateIndication = &ack
 

--- a/internal/amf/build_test.go
+++ b/internal/amf/build_test.go
@@ -51,6 +51,11 @@ func TestBuildConfigurationUpdateCommand_WithoutGUTI(t *testing.T) {
 	if cuc.ShortNameForNetwork == nil {
 		t.Fatal("expected ShortNameForNetwork to be present")
 	}
+
+	// TS 24.501 §5.4.4.2: no acknowledgement when only NITZ information is included.
+	if cuc.ConfigurationUpdateIndication != nil {
+		t.Fatalf("expected no ConfigurationUpdateIndication for a NITZ-only command, got %s", cuc.ConfigurationUpdateIndication)
+	}
 }
 
 func TestBuildConfigurationUpdateCommand_WithGUTI(t *testing.T) {
@@ -88,6 +93,15 @@ func TestBuildConfigurationUpdateCommand_WithGUTI(t *testing.T) {
 
 	if cuc.ShortNameForNetwork == nil {
 		t.Fatal("expected ShortNameForNetwork to be present")
+	}
+
+	// TS 24.501 §5.4.4.2: the 5G-GUTI is a non-NITZ parameter, so it is acknowledged.
+	if cuc.ConfigurationUpdateIndication == nil {
+		t.Fatal("expected ConfigurationUpdateIndication when a 5G-GUTI is included")
+	}
+
+	if !cuc.ConfigurationUpdateIndication.ACK {
+		t.Error("expected acknowledgement requested when a 5G-GUTI is included")
 	}
 }
 

--- a/internal/amf/build_test.go
+++ b/internal/amf/build_test.go
@@ -52,7 +52,6 @@ func TestBuildConfigurationUpdateCommand_WithoutGUTI(t *testing.T) {
 		t.Fatal("expected ShortNameForNetwork to be present")
 	}
 
-	// TS 24.501 §5.4.4.2: no acknowledgement when only NITZ information is included.
 	if cuc.ConfigurationUpdateIndication != nil {
 		t.Fatalf("expected no ConfigurationUpdateIndication for a NITZ-only command, got %s", cuc.ConfigurationUpdateIndication)
 	}
@@ -95,7 +94,6 @@ func TestBuildConfigurationUpdateCommand_WithGUTI(t *testing.T) {
 		t.Fatal("expected ShortNameForNetwork to be present")
 	}
 
-	// TS 24.501 §5.4.4.2: the 5G-GUTI is a non-NITZ parameter, so it is acknowledged.
 	if cuc.ConfigurationUpdateIndication == nil {
 		t.Fatal("expected ConfigurationUpdateIndication when a 5G-GUTI is included")
 	}

--- a/internal/amf/nas/handle_registration_complete_test.go
+++ b/internal/amf/nas/handle_registration_complete_test.go
@@ -137,6 +137,17 @@ func TestHandleRegistrationComplete_SendsConfigurationUpdateCommand(t *testing.T
 	if cuc.ShortNameForNetwork == nil {
 		t.Fatal("expected ShortNameForNetwork in ConfigurationUpdateCommand")
 	}
+
+	// TS 24.501 §5.4.4.2: acknowledgement is requested for all parameters except
+	// when only NITZ information is included, so this NITZ-only command asks for
+	// none — and with nothing to acknowledge, T3555 must not be armed.
+	if cuc.ConfigurationUpdateIndication != nil {
+		t.Errorf("expected no ConfigurationUpdateIndication on the NITZ-only path, got %s", cuc.ConfigurationUpdateIndication)
+	}
+
+	if ue.Conn().NASGuardForTest().Active() {
+		t.Error("expected T3555 not to be armed for a NITZ-only ConfigurationUpdateCommand")
+	}
 }
 
 func TestHandleRegistrationComplete_ReleasedWhenNoFORPending_NoUDSPending_and_NoActiveSessions(t *testing.T) {

--- a/internal/amf/nas/handle_registration_complete_test.go
+++ b/internal/amf/nas/handle_registration_complete_test.go
@@ -138,9 +138,6 @@ func TestHandleRegistrationComplete_SendsConfigurationUpdateCommand(t *testing.T
 		t.Fatal("expected ShortNameForNetwork in ConfigurationUpdateCommand")
 	}
 
-	// TS 24.501 §5.4.4.2: acknowledgement is requested for all parameters except
-	// when only NITZ information is included, so this NITZ-only command asks for
-	// none — and with nothing to acknowledge, T3555 must not be armed.
 	if cuc.ConfigurationUpdateIndication != nil {
 		t.Errorf("expected no ConfigurationUpdateIndication on the NITZ-only path, got %s", cuc.ConfigurationUpdateIndication)
 	}

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -516,9 +516,6 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 		return
 	}
 
-	// T3555 guards only a command that requested an acknowledgement (TS 24.501
-	// clause 10 timer table); a NITZ-only command asks for none, so there is
-	// nothing to wait for and retransmitting it is pure signalling noise.
 	if includeGUTI && amfInstance.NASGuardCfg.Enable {
 		cfg := amfInstance.NASGuardCfg
 

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -516,7 +516,10 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 		return
 	}
 
-	if amfInstance.NASGuardCfg.Enable {
+	// T3555 guards only a command that requested an acknowledgement (TS 24.501
+	// clause 10 timer table); a NITZ-only command asks for none, so there is
+	// nothing to wait for and retransmitting it is pure signalling noise.
+	if includeGUTI && amfInstance.NASGuardCfg.Enable {
 		cfg := amfInstance.NASGuardCfg
 
 		logger.From(ctx, logger.AmfLog).Info("start T3555 timer")

--- a/internal/tester/ue/handle_configuration_update_command.go
+++ b/internal/tester/ue/handle_configuration_update_command.go
@@ -21,6 +21,17 @@ func handleConfigurationUpdateCommand(ue *UE, plain []byte, amfUENGAPID int64, r
 		ue.Set5gGuti(cmd.GUTI)
 	}
 
+	// TS 24.501 §5.4.4.3: the UE answers only when "acknowledgement requested" is
+	// indicated in the Configuration update indication IE.
+	if cmd.ConfigurationUpdateIndication == nil || !cmd.ConfigurationUpdateIndication.ACK {
+		logger.UeLogger.Debug(
+			"Configuration Update Command without acknowledgement requested, not replying",
+			zap.String("IMSI", ue.UeSecurity.Supi),
+		)
+
+		return nil
+	}
+
 	commandComplete, err := BuildConfigurationUpdateComplete()
 	if err != nil {
 		return fmt.Errorf("could not build Configuration Update Complete NAS PDU: %v", err)

--- a/internal/tester/ue/handle_configuration_update_command.go
+++ b/internal/tester/ue/handle_configuration_update_command.go
@@ -21,8 +21,6 @@ func handleConfigurationUpdateCommand(ue *UE, plain []byte, amfUENGAPID int64, r
 		ue.Set5gGuti(cmd.GUTI)
 	}
 
-	// TS 24.501 §5.4.4.3: the UE answers only when "acknowledgement requested" is
-	// indicated in the Configuration update indication IE.
 	if cmd.ConfigurationUpdateIndication == nil || !cmd.ConfigurationUpdateIndication.ACK {
 		logger.UeLogger.Debug(
 			"Configuration Update Command without acknowledgement requested, not replying",


### PR DESCRIPTION
# Description

After every 5G registration the core asked handsets to confirm receipt of a message that carries nothing but the operator's network name so phones that follow the spec stayed silent and the core needlessly resent the message four times over ~24 seconds per attach; it now asks for confirmation only when the message carries something that genuinely needs one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
