### PR TITLE
fix: normalise IPv4-mapped prefixes in kernel route reconciliation

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -458,6 +458,13 @@ func ReconcileKernelRouting(ctx context.Context, dbInstance *db.Database, kernel
 			return fmt.Errorf("invalid gateway: %v", route.Gateway)
 		}
 
+		// Both sides of the diff below must agree on how an IPv4 address is
+		// spelled. The kernel listing is normalised to true IPv4; a stored
+		// destination is whatever the operator typed, and "::ffff:0.0.0.0/0"
+		// parses just as happily as "0.0.0.0/0".
+		destPrefix = kernel.UnmapPrefix(destPrefix)
+		gwAddr = gwAddr.Unmap()
+
 		kernelNetworkInterface, ok := interfaceDBKernelMap[route.Interface]
 		if !ok {
 			return fmt.Errorf("invalid interface: %v", route.Interface)
@@ -495,9 +502,12 @@ func ReconcileKernelRouting(ctx context.Context, dbInstance *db.Database, kernel
 				continue
 			}
 
+			dest := kernel.UnmapPrefix(r.Destination)
+			gw := r.Gateway.Unmap()
+
 			key := routeKey{
-				destination: r.Destination.String(),
-				gateway:     r.Gateway.String(),
+				destination: dest.String(),
+				gateway:     gw.String(),
 				priority:    r.Priority,
 				ifKey:       netIf,
 			}
@@ -506,10 +516,10 @@ func ReconcileKernelRouting(ctx context.Context, dbInstance *db.Database, kernel
 				continue
 			}
 
-			if err := kernelInt.DeleteRoute(r.Destination, r.Gateway, r.Priority, netIf); err != nil {
+			if err := kernelInt.DeleteRoute(dest, gw, r.Priority, netIf); err != nil {
 				logger.APILog.Warn("couldn't delete stale route",
-					zap.String("destination", r.Destination.String()),
-					zap.String("gateway", r.Gateway.String()),
+					zap.String("destination", dest.String()),
+					zap.String("gateway", gw.String()),
 					zap.Int("priority", r.Priority),
 					zap.Error(err))
 			}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -458,10 +458,6 @@ func ReconcileKernelRouting(ctx context.Context, dbInstance *db.Database, kernel
 			return fmt.Errorf("invalid gateway: %v", route.Gateway)
 		}
 
-		// Both sides of the diff below must agree on how an IPv4 address is
-		// spelled. The kernel listing is normalised to true IPv4; a stored
-		// destination is whatever the operator typed, and "::ffff:0.0.0.0/0"
-		// parses just as happily as "0.0.0.0/0".
 		destPrefix = kernel.UnmapPrefix(destPrefix)
 		gwAddr = gwAddr.Unmap()
 

--- a/internal/api/route_reconciler_test.go
+++ b/internal/api/route_reconciler_test.go
@@ -14,11 +14,6 @@ import (
 	"github.com/ellanetworks/core/internal/kernel"
 )
 
-// sameRoute reports whether two route identities refer to the same kernel
-// route. Matching is family-normalised because that is what the kernel does:
-// RealKernel narrows an IPv4-mapped prefix to true IPv4 before handing it to
-// netlink, so "::ffff:0.0.0.0/0" and "0.0.0.0/0" address one and the same
-// route.
 func sameRoute(a kernel.ManagedRoute, dest netip.Prefix, gw netip.Addr, prio int) bool {
 	return kernel.UnmapPrefix(a.Destination) == kernel.UnmapPrefix(dest) &&
 		a.Gateway.Unmap() == gw.Unmap() &&
@@ -52,11 +47,14 @@ func newRecordingKernel() *recordingKernel {
 	}
 }
 
-func (k *recordingKernel) seedManaged(ifKey kernel.NetworkInterface, routes ...kernel.ManagedRoute) {
+// seedManaged adds routes to the N6 view. The set stays keyed by interface
+// because the reconciler sweeps every entry in interfaceDBKernelMap, and N3
+// having no managed routes is part of what these tests exercise.
+func (k *recordingKernel) seedManaged(routes ...kernel.ManagedRoute) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
-	k.managed[ifKey] = append(k.managed[ifKey], routes...)
+	k.managed[kernel.N6] = append(k.managed[kernel.N6], routes...)
 }
 
 func (k *recordingKernel) EnableIPForwarding() error {
@@ -196,7 +194,7 @@ func TestReconcileKernelRouting_RemovesStaleRoute(t *testing.T) {
 		Gateway:     netip.MustParseAddr("192.168.1.1"),
 		Priority:    100,
 	}
-	k.seedManaged(kernel.N6, stale)
+	k.seedManaged(stale)
 
 	if err := ReconcileKernelRouting(context.Background(), dbInstance, k); err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -220,7 +218,7 @@ func TestReconcileKernelRouting_PreservesBGPMetricRoutes(t *testing.T) {
 		Gateway:     netip.MustParseAddr("10.0.0.1"),
 		Priority:    bgpRouteMetric,
 	}
-	k.seedManaged(kernel.N6, bgpLearned)
+	k.seedManaged(bgpLearned)
 
 	if err := ReconcileKernelRouting(context.Background(), dbInstance, k); err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -244,7 +242,7 @@ func TestReconcileKernelRouting_KeepsExistingRouteUntouched(t *testing.T) {
 		t.Fatalf("seed route: %v", err)
 	}
 
-	k.seedManaged(kernel.N6, kernel.ManagedRoute{
+	k.seedManaged(kernel.ManagedRoute{
 		Destination: netip.MustParsePrefix("10.0.0.0/24"),
 		Gateway:     netip.MustParseAddr("192.168.1.1"),
 		Priority:    100,
@@ -277,11 +275,6 @@ func TestReconcileKernelRouting_EnablesIPForwardingWhenOff(t *testing.T) {
 	}
 }
 
-// TestReconcileKernelRouting_V4DefaultNotStale covers the IPv4 default route.
-// netlink synthesises its Dst from the 16-byte IPv4-mapped net.IPv4zero, so an
-// unnormalised listing reports "::ffff:0.0.0.0/0", which never matches the
-// "0.0.0.0/0" parsed from the database. The live N6 route was then classified
-// stale on every cycle and a delete attempted against it.
 func TestReconcileKernelRouting_V4DefaultNotStale(t *testing.T) {
 	v4MappedDefault := netip.PrefixFrom(netip.MustParseAddr("::ffff:0.0.0.0"), 0)
 
@@ -302,7 +295,7 @@ func TestReconcileKernelRouting_V4DefaultNotStale(t *testing.T) {
 				t.Fatalf("seed route: %v", err)
 			}
 
-			k.seedManaged(kernel.N6, kernel.ManagedRoute{
+			k.seedManaged(kernel.ManagedRoute{
 				Destination: listed,
 				Gateway:     netip.MustParseAddr("10.0.20.129"),
 				Priority:    100,
@@ -323,9 +316,6 @@ func TestReconcileKernelRouting_V4DefaultNotStale(t *testing.T) {
 	}
 }
 
-// TestReconcileKernelRouting_V4MappedDBDestination is the same mismatch from
-// the other side: netip.ParsePrefix accepts "::ffff:0.0.0.0/0", so an operator
-// can store a destination that no kernel listing will ever equal.
 func TestReconcileKernelRouting_V4MappedDBDestination(t *testing.T) {
 	dbInstance := newReconcileTestDB(t)
 	k := newRecordingKernel()
@@ -339,7 +329,7 @@ func TestReconcileKernelRouting_V4MappedDBDestination(t *testing.T) {
 		t.Fatalf("seed route: %v", err)
 	}
 
-	k.seedManaged(kernel.N6, kernel.ManagedRoute{
+	k.seedManaged(kernel.ManagedRoute{
 		Destination: netip.MustParsePrefix("0.0.0.0/0"),
 		Gateway:     netip.MustParseAddr("10.0.20.129"),
 		Priority:    100,

--- a/internal/api/route_reconciler_test.go
+++ b/internal/api/route_reconciler_test.go
@@ -14,6 +14,17 @@ import (
 	"github.com/ellanetworks/core/internal/kernel"
 )
 
+// sameRoute reports whether two route identities refer to the same kernel
+// route. Matching is family-normalised because that is what the kernel does:
+// RealKernel narrows an IPv4-mapped prefix to true IPv4 before handing it to
+// netlink, so "::ffff:0.0.0.0/0" and "0.0.0.0/0" address one and the same
+// route.
+func sameRoute(a kernel.ManagedRoute, dest netip.Prefix, gw netip.Addr, prio int) bool {
+	return kernel.UnmapPrefix(a.Destination) == kernel.UnmapPrefix(dest) &&
+		a.Gateway.Unmap() == gw.Unmap() &&
+		a.Priority == prio
+}
+
 // recordingKernel captures route operations and exposes a configurable
 // "managed routes" view so the reconciler's deletion pass can be
 // exercised without netlink.
@@ -84,7 +95,7 @@ func (k *recordingKernel) DeleteRoute(dest netip.Prefix, gw netip.Addr, prio int
 	filtered := k.managed[ifKey][:0]
 
 	for _, r := range k.managed[ifKey] {
-		if r.Destination == dest && r.Gateway == gw && r.Priority == prio {
+		if sameRoute(r, dest, gw, prio) {
 			continue
 		}
 
@@ -98,21 +109,6 @@ func (k *recordingKernel) DeleteRoute(dest netip.Prefix, gw netip.Addr, prio int
 
 func (k *recordingKernel) ReplaceRoute(_ netip.Prefix, _ netip.Addr, _ int, _ kernel.NetworkInterface) error {
 	return nil
-}
-
-func (k *recordingKernel) ListRoutesByPriority(prio int, ifKey kernel.NetworkInterface) ([]netip.Prefix, error) {
-	k.mu.Lock()
-	defer k.mu.Unlock()
-
-	var out []netip.Prefix
-
-	for _, r := range k.managed[ifKey] {
-		if r.Priority == prio {
-			out = append(out, r.Destination)
-		}
-	}
-
-	return out, nil
 }
 
 func (k *recordingKernel) ListManagedRoutes(ifKey kernel.NetworkInterface) ([]kernel.ManagedRoute, error) {
@@ -136,7 +132,7 @@ func (k *recordingKernel) RouteExists(dest netip.Prefix, gw netip.Addr, prio int
 	defer k.mu.Unlock()
 
 	for _, r := range k.managed[ifKey] {
-		if r.Destination == dest && r.Gateway == gw && r.Priority == prio {
+		if sameRoute(r, dest, gw, prio) {
 			return true, nil
 		}
 	}
@@ -278,5 +274,86 @@ func TestReconcileKernelRouting_EnablesIPForwardingWhenOff(t *testing.T) {
 
 	if !k.enableCalled {
 		t.Fatal("expected EnableIPForwarding to be called when forwarding was off")
+	}
+}
+
+// TestReconcileKernelRouting_V4DefaultNotStale covers the IPv4 default route.
+// netlink synthesises its Dst from the 16-byte IPv4-mapped net.IPv4zero, so an
+// unnormalised listing reports "::ffff:0.0.0.0/0", which never matches the
+// "0.0.0.0/0" parsed from the database. The live N6 route was then classified
+// stale on every cycle and a delete attempted against it.
+func TestReconcileKernelRouting_V4DefaultNotStale(t *testing.T) {
+	v4MappedDefault := netip.PrefixFrom(netip.MustParseAddr("::ffff:0.0.0.0"), 0)
+
+	for _, listed := range []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/0"), // normalised, as RealKernel now returns
+		v4MappedDefault,                    // raw netlink spelling, belt and braces
+	} {
+		t.Run(listed.String(), func(t *testing.T) {
+			dbInstance := newReconcileTestDB(t)
+			k := newRecordingKernel()
+
+			if _, err := dbInstance.CreateRoute(context.Background(), &db.Route{
+				Destination: "0.0.0.0/0",
+				Gateway:     "10.0.20.129",
+				Interface:   db.N6,
+				Metric:      100,
+			}); err != nil {
+				t.Fatalf("seed route: %v", err)
+			}
+
+			k.seedManaged(kernel.N6, kernel.ManagedRoute{
+				Destination: listed,
+				Gateway:     netip.MustParseAddr("10.0.20.129"),
+				Priority:    100,
+			})
+
+			if err := ReconcileKernelRouting(context.Background(), dbInstance, k); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+
+			if got := len(k.deleted); got != 0 {
+				t.Errorf("live default route must not be deleted, but DeleteRoute called %d times: %v", got, k.deleted)
+			}
+
+			if got := len(k.created); got != 0 {
+				t.Errorf("live default route must not be re-created, but CreateRoute called %d times: %v", got, k.created)
+			}
+		})
+	}
+}
+
+// TestReconcileKernelRouting_V4MappedDBDestination is the same mismatch from
+// the other side: netip.ParsePrefix accepts "::ffff:0.0.0.0/0", so an operator
+// can store a destination that no kernel listing will ever equal.
+func TestReconcileKernelRouting_V4MappedDBDestination(t *testing.T) {
+	dbInstance := newReconcileTestDB(t)
+	k := newRecordingKernel()
+
+	if _, err := dbInstance.CreateRoute(context.Background(), &db.Route{
+		Destination: "::ffff:0.0.0.0/0",
+		Gateway:     "::ffff:10.0.20.129",
+		Interface:   db.N6,
+		Metric:      100,
+	}); err != nil {
+		t.Fatalf("seed route: %v", err)
+	}
+
+	k.seedManaged(kernel.N6, kernel.ManagedRoute{
+		Destination: netip.MustParsePrefix("0.0.0.0/0"),
+		Gateway:     netip.MustParseAddr("10.0.20.129"),
+		Priority:    100,
+	})
+
+	if err := ReconcileKernelRouting(context.Background(), dbInstance, k); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if got := len(k.deleted); got != 0 {
+		t.Errorf("expected no DeleteRoute, got %d (%v)", got, k.deleted)
+	}
+
+	if got := len(k.created); got != 0 {
+		t.Errorf("expected no CreateRoute, got %d (%v)", got, k.created)
 	}
 }

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -64,10 +64,6 @@ func (fk FakeKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr, 
 	return nil
 }
 
-func (fk FakeKernel) ListRoutesByPriority(priority int, networkInterface kernel.NetworkInterface) ([]netip.Prefix, error) {
-	return nil, nil
-}
-
 func (fk FakeKernel) ListManagedRoutes(networkInterface kernel.NetworkInterface) ([]kernel.ManagedRoute, error) {
 	return nil, nil
 }

--- a/internal/bgp/watcher.go
+++ b/internal/bgp/watcher.go
@@ -294,9 +294,6 @@ func (b *BGPService) cleanStaleRoutes() {
 			continue
 		}
 
-		// Delete with the route's own gateway. A wildcard gateway omits
-		// RTA_GATEWAY, which for IPv6 sets fc_delete_all_nh and removes
-		// every ECMP nexthop of the matched prefix rather than this one.
 		err := b.kernel.DeleteRoute(r.Destination, r.Gateway, r.Priority, kernel.N6)
 		if err != nil {
 			b.logger.Warn("failed to remove stale BGP route",

--- a/internal/bgp/watcher.go
+++ b/internal/bgp/watcher.go
@@ -280,28 +280,38 @@ func (b *BGPService) syncRoutes(ctx context.Context) {
 // cleanStaleRoutes removes leftover metric-200 routes from a prior crash.
 // Called before the BGP speaker starts so we begin with a clean slate.
 func (b *BGPService) cleanStaleRoutes() {
-	stale, err := b.kernel.ListRoutesByPriority(bgpRouteMetric, kernel.N6)
+	managed, err := b.kernel.ListManagedRoutes(kernel.N6)
 	if err != nil {
 		b.logger.Warn("failed to list stale BGP routes", zap.Error(err))
 
 		return
 	}
 
-	for i := range stale {
-		dst := stale[i]
+	var count int
 
-		// We don't know the original gateway, but DeleteRoute with an invalid
-		// gateway will match on destination + priority + interface.
-		err := b.kernel.DeleteRoute(dst, netip.Addr{}, bgpRouteMetric, kernel.N6)
+	for _, r := range managed {
+		if r.Priority != bgpRouteMetric {
+			continue
+		}
+
+		// Delete with the route's own gateway. A wildcard gateway omits
+		// RTA_GATEWAY, which for IPv6 sets fc_delete_all_nh and removes
+		// every ECMP nexthop of the matched prefix rather than this one.
+		err := b.kernel.DeleteRoute(r.Destination, r.Gateway, r.Priority, kernel.N6)
 		if err != nil {
 			b.logger.Warn("failed to remove stale BGP route",
-				zap.String("prefix", dst.String()), zap.Error(err))
+				zap.String("prefix", r.Destination.String()),
+				zap.String("gateway", r.Gateway.String()), zap.Error(err))
+
+			continue
 		}
+
+		count++
 	}
 
-	if len(stale) > 0 {
+	if count > 0 {
 		b.logger.Info("cleaned stale BGP routes from prior run",
-			zap.Int("count", len(stale)))
+			zap.Int("count", count))
 	}
 }
 

--- a/internal/bgp/watcher_test.go
+++ b/internal/bgp/watcher_test.go
@@ -137,8 +137,6 @@ func TestCleanStaleRoutes(t *testing.T) {
 
 	defer func() { _ = svc.Stop() }()
 
-	// cleanStaleRoutes should have been called during Start, deleting the
-	// metric-200 routes with their own gateways and leaving the rest alone.
 	fk.mu.Lock()
 	deleted := append([]fakeRoute(nil), fk.deleted...)
 	fk.mu.Unlock()

--- a/internal/bgp/watcher_test.go
+++ b/internal/bgp/watcher_test.go
@@ -20,7 +20,7 @@ type fakeKernel struct {
 	mu       sync.Mutex
 	replaced []fakeRoute
 	deleted  []fakeRoute
-	listed   []netip.Prefix // routes returned by ListRoutesByPriority
+	managed  []kernel.ManagedRoute // routes returned by ListManagedRoutes
 }
 
 type fakeRoute struct {
@@ -64,15 +64,11 @@ func (fk *fakeKernel) ReplaceRoute(dst netip.Prefix, gw netip.Addr, priority int
 	return nil
 }
 
-func (fk *fakeKernel) ListRoutesByPriority(priority int, _ kernel.NetworkInterface) ([]netip.Prefix, error) {
+func (fk *fakeKernel) ListManagedRoutes(_ kernel.NetworkInterface) ([]kernel.ManagedRoute, error) {
 	fk.mu.Lock()
 	defer fk.mu.Unlock()
 
-	return fk.listed, nil
-}
-
-func (fk *fakeKernel) ListManagedRoutes(_ kernel.NetworkInterface) ([]kernel.ManagedRoute, error) {
-	return nil, nil
+	return fk.managed, nil
 }
 
 func (fk *fakeKernel) InterfaceExists(_ kernel.NetworkInterface) (bool, error) { return true, nil }
@@ -105,11 +101,25 @@ func TestGetLearnedRoutes_EmptyByDefault(t *testing.T) {
 }
 
 func TestCleanStaleRoutes(t *testing.T) {
-	n1 := netip.MustParsePrefix("0.0.0.0/0")
-	n2 := netip.MustParsePrefix("10.100.0.0/16")
-
 	fk := &fakeKernel{
-		listed: []netip.Prefix{n1, n2},
+		managed: []kernel.ManagedRoute{
+			{
+				Destination: netip.MustParsePrefix("0.0.0.0/0"),
+				Gateway:     netip.MustParseAddr("10.0.20.129"),
+				Priority:    200,
+			},
+			{
+				Destination: netip.MustParsePrefix("10.100.0.0/16"),
+				Gateway:     netip.MustParseAddr("10.0.20.130"),
+				Priority:    200,
+			},
+			// A route at the reconciler's metric, not BGP's. Must survive.
+			{
+				Destination: netip.MustParsePrefix("::/0"),
+				Gateway:     netip.MustParseAddr("2001:db8::2"),
+				Priority:    100,
+			},
+		},
 	}
 
 	svc := newTestServiceWithLearning(t, fk, &fakeImportStore{})
@@ -127,13 +137,25 @@ func TestCleanStaleRoutes(t *testing.T) {
 
 	defer func() { _ = svc.Stop() }()
 
-	// cleanStaleRoutes should have been called during Start, deleting the stale routes
+	// cleanStaleRoutes should have been called during Start, deleting the
+	// metric-200 routes with their own gateways and leaving the rest alone.
 	fk.mu.Lock()
-	deletedCount := len(fk.deleted)
+	deleted := append([]fakeRoute(nil), fk.deleted...)
 	fk.mu.Unlock()
 
-	if deletedCount < 2 {
-		t.Fatalf("expected at least 2 stale routes deleted, got %d", deletedCount)
+	want := []fakeRoute{
+		{destination: "0.0.0.0/0", gateway: "10.0.20.129", priority: 200},
+		{destination: "10.100.0.0/16", gateway: "10.0.20.130", priority: 200},
+	}
+
+	if len(deleted) != len(want) {
+		t.Fatalf("expected %d stale routes deleted, got %d: %+v", len(want), len(deleted), deleted)
+	}
+
+	for i, w := range want {
+		if deleted[i] != w {
+			t.Errorf("delete %d: got %+v, want %+v", i, deleted[i], w)
+		}
 	}
 }
 

--- a/internal/kernel/routes.go
+++ b/internal/kernel/routes.go
@@ -46,7 +46,6 @@ type Kernel interface {
 	CreateRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error
 	DeleteRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error
 	ReplaceRoute(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) error
-	ListRoutesByPriority(priority int, ifKey NetworkInterface) ([]netip.Prefix, error)
 	ListManagedRoutes(ifKey NetworkInterface) ([]ManagedRoute, error)
 	InterfaceExists(ifKey NetworkInterface) (bool, error)
 	RouteExists(destination netip.Prefix, gateway netip.Addr, priority int, ifKey NetworkInterface) (bool, error)
@@ -69,8 +68,73 @@ func NewRealKernel(n3Interface, n6Interface string) *RealKernel {
 	}
 }
 
+// UnmapPrefix rewrites an IPv4-mapped IPv6 prefix (::ffff:a.b.c.d/n) as the
+// equivalent true IPv4 prefix, and leaves anything else alone.
+//
+// Prefix lengths on such a prefix can be expressed against either width: a
+// length of 96 or more is relative to the 128-bit address and is rebased,
+// while a shorter one is already relative to the 32-bit address and is kept.
+// netlink produces the latter — a 16-byte net.IPv4zero paired with a 4-byte
+// CIDRMask(0, 32) — so an IPv4 default route arrives as ::ffff:0.0.0.0/0.
+func UnmapPrefix(p netip.Prefix) netip.Prefix {
+	if !p.Addr().Is4In6() {
+		return p
+	}
+
+	bits := p.Bits()
+	if bits >= 96 {
+		bits -= 96
+	}
+
+	if bits < 0 || bits > 32 {
+		return p
+	}
+
+	return netip.PrefixFrom(p.Addr().Unmap(), bits)
+}
+
+// prefixFromIPNet converts a netlink-supplied *net.IPNet to a netip.Prefix,
+// normalising IPv4-mapped IPv6 destinations to true IPv4 so the result
+// compares equal to the prefixes the rest of the system parses from config.
+func prefixFromIPNet(n *net.IPNet) (netip.Prefix, bool) {
+	addr, ok := netip.AddrFromSlice(n.IP)
+	if !ok {
+		return netip.Prefix{}, false
+	}
+
+	ones, bits := n.Mask.Size()
+	if bits == 0 {
+		// Absent or non-canonical mask. netlink never produces one, but
+		// treating it as zero ones would invent a default route.
+		return netip.Prefix{}, false
+	}
+
+	p := UnmapPrefix(netip.PrefixFrom(addr, ones))
+	if !p.IsValid() {
+		return netip.Prefix{}, false
+	}
+
+	return p, true
+}
+
+// addrFromNetIP converts a netlink-supplied net.IP to a netip.Addr,
+// normalising IPv4-mapped IPv6 addresses to true IPv4.
+func addrFromNetIP(ip net.IP) (netip.Addr, bool) {
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return netip.Addr{}, false
+	}
+
+	return addr.Unmap(), true
+}
+
 // prefixToIPNet converts a netip.Prefix to a *net.IPNet for netlink.
 func prefixToIPNet(p netip.Prefix) *net.IPNet {
+	// Unmap before masking: masking an IPv4-mapped prefix at /0 zeroes the
+	// ::ffff: marker along with the host bits, leaving netlink to infer
+	// AF_INET6 for what is really an IPv4 route.
+	p = UnmapPrefix(p)
+
 	addr := p.Masked().Addr()
 
 	var maskBits int
@@ -92,7 +156,7 @@ func addrToNetIP(a netip.Addr) net.IP {
 		return nil
 	}
 
-	return a.AsSlice()
+	return a.Unmap().AsSlice()
 }
 
 // gwOrVia builds the gateway/via fields for a route.
@@ -104,21 +168,24 @@ func gwOrVia(destination netip.Prefix, gateway netip.Addr) (net.IP, *netlink.Via
 		return nil, nil
 	}
 
-	dstIs4 := destination.Addr().Is4()
-	gwIs4 := gateway.Is4()
+	// Compare the true families: an IPv4-mapped address is IPv4 as far as
+	// the kernel is concerned, and treating it as IPv6 here would emit an
+	// RTA_VIA that the destination's own family rejects.
+	dst := destination.Addr().Unmap()
+	gw := gateway.Unmap()
 
-	if dstIs4 == gwIs4 {
-		return addrToNetIP(gateway), nil
+	if dst.Is4() == gw.Is4() {
+		return addrToNetIP(gw), nil
 	}
 
 	family := netlink.FAMILY_V4
-	if gateway.Is6() {
+	if gw.Is6() {
 		family = netlink.FAMILY_V6
 	}
 
 	return nil, &netlink.Via{
 		AddrFamily: family,
-		Addr:       net.IP(gateway.AsSlice()),
+		Addr:       net.IP(gw.AsSlice()),
 	}
 }
 
@@ -247,54 +314,6 @@ func (rk *RealKernel) ReplaceRoute(destination netip.Prefix, gateway netip.Addr,
 	return nil
 }
 
-// ListRoutesByPriority returns Ella-owned route destinations with the given
-// priority (metric) on the interface defined by ifKey. Only routes carrying
-// Ella's protocol marker are returned; operator-installed routes are skipped.
-func (rk *RealKernel) ListRoutesByPriority(priority int, ifKey NetworkInterface) ([]netip.Prefix, error) {
-	interfaceName, ok := rk.ifMapping[ifKey]
-	if !ok {
-		return nil, fmt.Errorf("invalid interface key: %v", ifKey)
-	}
-
-	link, err := netlink.LinkByName(interfaceName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find network interface %q: %v", interfaceName, err)
-	}
-
-	nlRoute := netlink.Route{
-		LinkIndex: link.Attrs().Index,
-		Table:     unix.RT_TABLE_MAIN,
-		Protocol:  rtProtoElla,
-	}
-
-	var allRoutes []netlink.Route
-
-	for _, af := range []int{unix.AF_INET, unix.AF_INET6} {
-		routes, err := netlink.RouteListFiltered(af, &nlRoute, netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PROTOCOL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list routes: %v", err)
-		}
-
-		allRoutes = append(allRoutes, routes...)
-	}
-
-	var result []netip.Prefix
-
-	for _, r := range allRoutes {
-		if r.Priority == priority && r.Dst != nil {
-			addr, ok := netip.AddrFromSlice(r.Dst.IP)
-			if !ok {
-				continue
-			}
-
-			ones, _ := r.Dst.Mask.Size()
-			result = append(result, netip.PrefixFrom(addr, ones))
-		}
-	}
-
-	return result, nil
-}
-
 // ListManagedRoutes returns every Ella-owned route on the interface
 // identified by ifKey, with full destination/gateway/priority info so the
 // caller can diff against a desired set and call DeleteRoute for stale
@@ -334,26 +353,24 @@ func (rk *RealKernel) ListManagedRoutes(ifKey NetworkInterface) ([]ManagedRoute,
 			continue
 		}
 
-		dstAddr, ok := netip.AddrFromSlice(r.Dst.IP)
+		dst, ok := prefixFromIPNet(r.Dst)
 		if !ok {
 			continue
 		}
 
-		ones, _ := r.Dst.Mask.Size()
-
 		var gw netip.Addr
 		if r.Gw != nil {
-			gw, _ = netip.AddrFromSlice(r.Gw)
+			gw, _ = addrFromNetIP(r.Gw)
 		} else if r.Via != nil {
 			if via, ok := r.Via.(*netlink.Via); ok {
-				if viaAddr, ok := netip.AddrFromSlice(via.Addr); ok {
+				if viaAddr, ok := addrFromNetIP(via.Addr); ok {
 					gw = viaAddr
 				}
 			}
 		}
 
 		result = append(result, ManagedRoute{
-			Destination: netip.PrefixFrom(dstAddr, ones),
+			Destination: dst,
 			Gateway:     gw,
 			Priority:    r.Priority,
 		})
@@ -404,7 +421,7 @@ func (rk *RealKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, 
 	}
 
 	af := unix.AF_INET
-	if !destination.Addr().Is4() {
+	if !destination.Addr().Unmap().Is4() {
 		af = unix.AF_INET6
 	}
 
@@ -417,7 +434,7 @@ func (rk *RealKernel) RouteExists(destination netip.Prefix, gateway netip.Addr, 
 
 	for _, r := range routes {
 		if r.Gw != nil {
-			if gw, ok := netip.AddrFromSlice(r.Gw); ok && gw == gateway {
+			if gw, ok := addrFromNetIP(r.Gw); ok && gw == gateway.Unmap() {
 				return true, nil
 			}
 		}

--- a/internal/kernel/routes.go
+++ b/internal/kernel/routes.go
@@ -68,14 +68,6 @@ func NewRealKernel(n3Interface, n6Interface string) *RealKernel {
 	}
 }
 
-// UnmapPrefix rewrites an IPv4-mapped IPv6 prefix (::ffff:a.b.c.d/n) as the
-// equivalent true IPv4 prefix, and leaves anything else alone.
-//
-// Prefix lengths on such a prefix can be expressed against either width: a
-// length of 96 or more is relative to the 128-bit address and is rebased,
-// while a shorter one is already relative to the 32-bit address and is kept.
-// netlink produces the latter — a 16-byte net.IPv4zero paired with a 4-byte
-// CIDRMask(0, 32) — so an IPv4 default route arrives as ::ffff:0.0.0.0/0.
 func UnmapPrefix(p netip.Prefix) netip.Prefix {
 	if !p.Addr().Is4In6() {
 		return p
@@ -93,9 +85,6 @@ func UnmapPrefix(p netip.Prefix) netip.Prefix {
 	return netip.PrefixFrom(p.Addr().Unmap(), bits)
 }
 
-// prefixFromIPNet converts a netlink-supplied *net.IPNet to a netip.Prefix,
-// normalising IPv4-mapped IPv6 destinations to true IPv4 so the result
-// compares equal to the prefixes the rest of the system parses from config.
 func prefixFromIPNet(n *net.IPNet) (netip.Prefix, bool) {
 	addr, ok := netip.AddrFromSlice(n.IP)
 	if !ok {
@@ -104,8 +93,6 @@ func prefixFromIPNet(n *net.IPNet) (netip.Prefix, bool) {
 
 	ones, bits := n.Mask.Size()
 	if bits == 0 {
-		// Absent or non-canonical mask. netlink never produces one, but
-		// treating it as zero ones would invent a default route.
 		return netip.Prefix{}, false
 	}
 
@@ -117,8 +104,6 @@ func prefixFromIPNet(n *net.IPNet) (netip.Prefix, bool) {
 	return p, true
 }
 
-// addrFromNetIP converts a netlink-supplied net.IP to a netip.Addr,
-// normalising IPv4-mapped IPv6 addresses to true IPv4.
 func addrFromNetIP(ip net.IP) (netip.Addr, bool) {
 	addr, ok := netip.AddrFromSlice(ip)
 	if !ok {
@@ -130,9 +115,6 @@ func addrFromNetIP(ip net.IP) (netip.Addr, bool) {
 
 // prefixToIPNet converts a netip.Prefix to a *net.IPNet for netlink.
 func prefixToIPNet(p netip.Prefix) *net.IPNet {
-	// Unmap before masking: masking an IPv4-mapped prefix at /0 zeroes the
-	// ::ffff: marker along with the host bits, leaving netlink to infer
-	// AF_INET6 for what is really an IPv4 route.
 	p = UnmapPrefix(p)
 
 	addr := p.Masked().Addr()
@@ -168,9 +150,6 @@ func gwOrVia(destination netip.Prefix, gateway netip.Addr) (net.IP, *netlink.Via
 		return nil, nil
 	}
 
-	// Compare the true families: an IPv4-mapped address is IPv4 as far as
-	// the kernel is concerned, and treating it as IPv6 here would emit an
-	// RTA_VIA that the destination's own family rejects.
 	dst := destination.Addr().Unmap()
 	gw := gateway.Unmap()
 

--- a/internal/kernel/routes_test.go
+++ b/internal/kernel/routes_test.go
@@ -167,8 +167,6 @@ func TestPrefixFromIPNet_V4Default(t *testing.T) {
 }
 
 func TestPrefixFromIPNet_RejectsAbsentMask(t *testing.T) {
-	// A missing mask must not be read as zero ones, which would invent a
-	// default route out of a host route.
 	if p, ok := prefixFromIPNet(&net.IPNet{IP: net.IP{10, 0, 0, 1}}); ok {
 		t.Errorf("expected !ok for absent mask, got %q", p.String())
 	}

--- a/internal/kernel/routes_test.go
+++ b/internal/kernel/routes_test.go
@@ -120,10 +120,6 @@ func TestPrefixToIPNet(t *testing.T) {
 	}
 }
 
-// TestPrefixFromIPNet_V4Default pins the conversion of the Dst that netlink
-// synthesises for an IPv4 default route. It pairs the 16-byte IPv4-mapped
-// net.IPv4zero with a 4-byte CIDRMask(0, 32), so a naive AddrFromSlice yields
-// "::ffff:0.0.0.0/0" — which matches no true-IPv4 prefix and cannot be deleted.
 func TestPrefixFromIPNet_V4Default(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -189,9 +185,6 @@ func TestAddrFromNetIP_Unmaps(t *testing.T) {
 	}
 }
 
-// TestPrefixToIPNet_V4Mapped covers the send side: masking an IPv4-mapped
-// prefix at /0 zeroes the ::ffff: marker, so without an unmap netlink infers
-// AF_INET6 for what is really an IPv4 route.
 func TestPrefixToIPNet_V4Mapped(t *testing.T) {
 	p := netip.PrefixFrom(netip.MustParseAddr("::ffff:0.0.0.0"), 0)
 
@@ -209,9 +202,6 @@ func TestPrefixToIPNet_V4Mapped(t *testing.T) {
 	}
 }
 
-// TestGwOrVia_V4MappedDestination guards the third independent family
-// decision: an IPv4-mapped destination with an IPv4 gateway is same-family,
-// so it must use RTA_GATEWAY rather than an RTA_VIA the kernel rejects.
 func TestGwOrVia_V4MappedDestination(t *testing.T) {
 	p := netip.PrefixFrom(netip.MustParseAddr("::ffff:0.0.0.0"), 0)
 

--- a/internal/kernel/routes_test.go
+++ b/internal/kernel/routes_test.go
@@ -4,6 +4,7 @@
 package kernel
 
 import (
+	"net"
 	"net/netip"
 	"testing"
 
@@ -116,5 +117,114 @@ func TestPrefixToIPNet(t *testing.T) {
 	ipNet = prefixToIPNet(zero)
 	if ipNet.String() != "0.0.0.0/0" {
 		t.Errorf("got %q, want %q", ipNet.String(), "0.0.0.0/0")
+	}
+}
+
+// TestPrefixFromIPNet_V4Default pins the conversion of the Dst that netlink
+// synthesises for an IPv4 default route. It pairs the 16-byte IPv4-mapped
+// net.IPv4zero with a 4-byte CIDRMask(0, 32), so a naive AddrFromSlice yields
+// "::ffff:0.0.0.0/0" — which matches no true-IPv4 prefix and cannot be deleted.
+func TestPrefixFromIPNet_V4Default(t *testing.T) {
+	tests := []struct {
+		name  string
+		ipNet *net.IPNet
+		want  string
+	}{
+		{
+			name:  "v4 default as netlink synthesises it",
+			ipNet: &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+			want:  "0.0.0.0/0",
+		},
+		{
+			name:  "v6 default",
+			ipNet: &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+			want:  "::/0",
+		},
+		{
+			name:  "non-default v4 via RTA_DST, 4-byte",
+			ipNet: &net.IPNet{IP: net.IP{10, 0, 0, 0}, Mask: net.CIDRMask(8, 32)},
+			want:  "10.0.0.0/8",
+		},
+		{
+			name:  "v4-mapped with a v6-relative prefix length",
+			ipNet: &net.IPNet{IP: net.IPv4(10, 0, 0, 0), Mask: net.CIDRMask(104, 128)},
+			want:  "10.0.0.0/8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := prefixFromIPNet(tt.ipNet)
+			if !ok {
+				t.Fatalf("prefixFromIPNet(%v) returned !ok", tt.ipNet)
+			}
+
+			if got.String() != tt.want {
+				t.Errorf("got %q, want %q", got.String(), tt.want)
+			}
+
+			if got.Addr().Is4In6() {
+				t.Errorf("got an IPv4-mapped address: %q", got.String())
+			}
+		})
+	}
+}
+
+func TestPrefixFromIPNet_RejectsAbsentMask(t *testing.T) {
+	// A missing mask must not be read as zero ones, which would invent a
+	// default route out of a host route.
+	if p, ok := prefixFromIPNet(&net.IPNet{IP: net.IP{10, 0, 0, 1}}); ok {
+		t.Errorf("expected !ok for absent mask, got %q", p.String())
+	}
+}
+
+func TestAddrFromNetIP_Unmaps(t *testing.T) {
+	got, ok := addrFromNetIP(net.IPv4(10, 0, 20, 129))
+	if !ok {
+		t.Fatal("addrFromNetIP returned !ok")
+	}
+
+	if !got.Is4() || got.String() != "10.0.20.129" {
+		t.Errorf("got %q (Is4=%v), want 10.0.20.129 (Is4=true)", got.String(), got.Is4())
+	}
+}
+
+// TestPrefixToIPNet_V4Mapped covers the send side: masking an IPv4-mapped
+// prefix at /0 zeroes the ::ffff: marker, so without an unmap netlink infers
+// AF_INET6 for what is really an IPv4 route.
+func TestPrefixToIPNet_V4Mapped(t *testing.T) {
+	p := netip.PrefixFrom(netip.MustParseAddr("::ffff:0.0.0.0"), 0)
+
+	ipNet := prefixToIPNet(p)
+	if len(ipNet.IP) != net.IPv4len {
+		t.Errorf("got a %d-byte IP, want %d", len(ipNet.IP), net.IPv4len)
+	}
+
+	if len(ipNet.Mask) != net.IPv4len {
+		t.Errorf("got a %d-byte mask, want %d", len(ipNet.Mask), net.IPv4len)
+	}
+
+	if ipNet.String() != "0.0.0.0/0" {
+		t.Errorf("got %q, want %q", ipNet.String(), "0.0.0.0/0")
+	}
+}
+
+// TestGwOrVia_V4MappedDestination guards the third independent family
+// decision: an IPv4-mapped destination with an IPv4 gateway is same-family,
+// so it must use RTA_GATEWAY rather than an RTA_VIA the kernel rejects.
+func TestGwOrVia_V4MappedDestination(t *testing.T) {
+	p := netip.PrefixFrom(netip.MustParseAddr("::ffff:0.0.0.0"), 0)
+
+	gw, via := gwOrVia(p, netip.MustParseAddr("10.0.20.129"))
+	if via != nil {
+		t.Errorf("expected nil Via for an IPv4-mapped dst with an IPv4 gw, got %+v", via)
+	}
+
+	if gw == nil {
+		t.Fatal("expected non-nil Gw")
+	}
+
+	if len(gw) != net.IPv4len {
+		t.Errorf("got a %d-byte Gw, want %d", len(gw), net.IPv4len)
 	}
 }


### PR DESCRIPTION
# Description

The router periodically compares the routes it should have against the routes actually installed, and a quirk in how Linux reports IPv4 default routes made it misread its own live default route as an orphan — spamming errors as it repeatedly failed to remove it, leaving genuinely obsolete default routes stuck in place permanently, and, on BGP startup, deleting the wrong route entirely (an active IPv6 default instead of the stale IPv4 one).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
