### PR TITLE
fix: don't restart NAS COUNT when idle inter-system change resumes

### DIFF
--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -76,6 +76,9 @@ var scenarioFollowsDeploymentIPFamily = map[string]bool{
 	"interworking/idle_5gs_to_eps":                    true,
 	"interworking/idle_5gs_to_eps_returning_to_idle":  true,
 	"interworking/idle_eps_to_5gs":                    true,
+	"interworking/idle_eps_to_5gs_returning_to_idle":  true,
+	"interworking/idle_round_trip_through_eps":        true,
+	"interworking/idle_round_trip_through_5gs":        true,
 }
 
 // scenarioIPFamilyExclusions returns a map of scenario name → set of IP

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -591,11 +591,6 @@ func (ue *UeContext) SendDownlinkNAS(plain []byte, sht uint8, write nas.WriteFun
 		return err
 	}
 
-	// TS 24.501 §4.4.2.5: replying to the UE ciphered is what re-establishes the
-	// secure exchange on this connection, and §4.4.5 starts the AMF's ciphering
-	// and deciphering from that point. A SECURITY MODE COMMAND does not count —
-	// it goes out unciphered, and the procedure it opens establishes the exchange
-	// only once it completes.
 	if fgs.SecurityHeaderType(sht).Ciphered() {
 		ue.Conn().MarkCipheringStarted()
 	}

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -464,7 +464,7 @@ func (ue *UeContext) ClearRegistrationRequestData() {
 	conn.resyncTried = false
 	conn.RetransmissionOfInitialNASMsg = false
 	conn.RegistrationAcceptPlain = nil
-	conn.ArrivedFromEPS = false
+	conn.EPSArrival = nil
 
 	if r := ue.active.Load(); r != nil {
 		r.UeContextRequest = false
@@ -587,7 +587,20 @@ func (ue *UeContext) SendDownlinkNAS(plain []byte, sht uint8, write nas.WriteFun
 		return write(plain)
 	}
 
-	return ue.dl.Send(plain, sht, write)
+	if err := ue.dl.Send(plain, sht, write); err != nil {
+		return err
+	}
+
+	// TS 24.501 §4.4.2.5: replying to the UE ciphered is what re-establishes the
+	// secure exchange on this connection, and §4.4.5 starts the AMF's ciphering
+	// and deciphering from that point. A SECURITY MODE COMMAND does not count —
+	// it goes out unciphered, and the procedure it opens establishes the exchange
+	// only once it completes.
+	if fgs.SecurityHeaderType(sht).Ciphered() {
+		ue.Conn().MarkCipheringStarted()
+	}
+
+	return nil
 }
 
 func (ue *UeContext) StopProcedureTimers() {

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -450,12 +450,15 @@ func (ue *UeContext) deriveNextNHLocked() ([32]uint8, uint8, error) {
 
 func (ue *UeContext) ClearRegistrationRequestData() {
 	conn := ue.Conn()
-	if conn == nil {
-		return
-	}
 
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
+
+	ue.arrivedFromEPSHandover = false
+
+	if conn == nil {
+		return
+	}
 
 	conn.RegistrationRequest = nil
 	conn.RegistrationRequestPlain = nil

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -321,7 +321,7 @@ func BuildRegistrationAccept(
 		m.NegotiatedDRX = &fgs.DRXParameter{Value: ue.DRXParameter}
 	}
 
-	if conn := ue.Conn(); conn != nil && conn.ArrivedFromEPS && amfInstance.EPS != nil {
+	if conn := ue.Conn(); conn.ArrivedFromEPS() && amfInstance.EPS != nil {
 		var status nas.EPSBearerContextStatus
 
 		for _, ebi := range ue.EPSBearerIdentities() {

--- a/internal/amf/build_test.go
+++ b/internal/amf/build_test.go
@@ -218,7 +218,7 @@ func TestRegistrationAcceptDropsTheEPSBearerStatusOnceTheRegistrationIsDone(t *t
 		t.Fatal("no NAS connection")
 	}
 
-	conn.ArrivedFromEPS = true
+	conn.EPSArrival = &amf.EPSArrival{}
 
 	if status := epsBearerStatusOf(t, amfInstance, ue); status == nil || !status.Active[6] {
 		t.Fatalf("EPS bearer context status = %+v, want EBI 6 active while the arrival is being registered", status)

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -376,9 +376,6 @@ func decodeProtectedNAS(ue *UeContext, headerType fgs.SecurityHeaderType, payloa
 
 		conn.MarkSecureExchangeEstablished()
 
-		// A message that arrived ciphered proves the secure exchange is already
-		// established on this connection, however that happened, so the UE is
-		// ciphering and everything further from it must be (TS 24.501 §4.4.5).
 		if headerType.Ciphered() {
 			conn.MarkCipheringStarted()
 		}

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -358,11 +358,14 @@ func decodeProtectedNAS(ue *UeContext, headerType fgs.SecurityHeaderType, payloa
 	plain, _, uerr := fgs.Unprotect(payload, cnt, nas.DirectionUplink, ue.sc,
 		fgs.SHTIntegrityProtected, fgs.SHTIntegrityProtectedCiphered, fgs.SHTIntegrityProtectedCipheredNewContext)
 	if uerr == nil {
-		// Before the commit so a discarded message does not advance the count, and
-		// before MarkSecureExchangeEstablished so the initial NAS message of a new
-		// connection stays outside the guard (TS 24.501 §4.4.5).
-		if conn.SecureExchangeEstablished() && headerType == fgs.SHTIntegrityProtected && cipheringRequiredFor(plain) &&
-			(conn.CipheringStarted() || !admissibleBeforeCipheringFor(plain)) {
+		if requiresNewContextSecurityHeader(plain) && headerType != fgs.SHTIntegrityProtectedCipheredNewContext {
+			logger.AmfLog.Warn("discarding SECURITY MODE COMPLETE sent without the new-context security header type")
+
+			return nil, silentDecode(nasreply.ReasonIntegrityFail,
+				"NAS discarded: SECURITY MODE COMPLETE without the new-context security header type (TS 24.501 §5.4.2.3)")
+		}
+
+		if conn.CipheringStarted() && headerType == fgs.SHTIntegrityProtected && cipheringRequiredFor(plain) {
 			logger.AmfLog.Warn("discarding unciphered NAS message received after ciphering started")
 
 			return nil, silentDecode(nasreply.ReasonIntegrityFail, "NAS discarded: unciphered after ciphering started (TS 24.501 §4.4.5)")

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -361,7 +361,8 @@ func decodeProtectedNAS(ue *UeContext, headerType fgs.SecurityHeaderType, payloa
 		// Before the commit so a discarded message does not advance the count, and
 		// before MarkSecureExchangeEstablished so the initial NAS message of a new
 		// connection stays outside the guard (TS 24.501 §4.4.5).
-		if conn.SecureExchangeEstablished() && headerType == fgs.SHTIntegrityProtected && cipheringRequiredFor(plain) {
+		if conn.SecureExchangeEstablished() && headerType == fgs.SHTIntegrityProtected && cipheringRequiredFor(plain) &&
+			(conn.CipheringStarted() || !admissibleBeforeCipheringFor(plain)) {
 			logger.AmfLog.Warn("discarding unciphered NAS message received after ciphering started")
 
 			return nil, silentDecode(nasreply.ReasonIntegrityFail, "NAS discarded: unciphered after ciphering started (TS 24.501 §4.4.5)")
@@ -374,6 +375,13 @@ func decodeProtectedNAS(ue *UeContext, headerType fgs.SecurityHeaderType, payloa
 		ue.ulCount = counter
 
 		conn.MarkSecureExchangeEstablished()
+
+		// A message that arrived ciphered proves the secure exchange is already
+		// established on this connection, however that happened, so the UE is
+		// ciphering and everything further from it must be (TS 24.501 §4.4.5).
+		if headerType.Ciphered() {
+			conn.MarkCipheringStarted()
+		}
 
 		msgType, isGMM, derr := DecodePlainGmm(plain)
 		if derr != nil {

--- a/internal/amf/decode_nas_message.go
+++ b/internal/amf/decode_nas_message.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
@@ -153,6 +154,30 @@ func (ue *UeContext) CitesCurrentSecurityContext(plain []byte) error {
 	}
 
 	return nil
+}
+
+func (ue *UeContext) CitesCurrentNgKSI(cited nas.KeySetIdentifier) error {
+	held := ue.NgKsi()
+
+	if cited.Mapped != (held.Tsc == models.ScTypeMapped) {
+		return fmt.Errorf("amf: the message cites a %s ngKSI, the UE's current 5G NAS security context is %s",
+			securityContextTypeName(cited.Mapped), held.Tsc)
+	}
+
+	if uint8(held.Ksi) != cited.Value {
+		return fmt.Errorf("amf: the message cites ngKSI %d, the UE's current 5G NAS security context is ngKSI %d",
+			cited.Value, held.Ksi)
+	}
+
+	return nil
+}
+
+func securityContextTypeName(mapped bool) models.ScType {
+	if mapped {
+		return models.ScTypeMapped
+	}
+
+	return models.ScTypeNative
 }
 
 func (ue *UeContext) VerifyEnclosedEPSNAS(payload []byte) (nas.Count, error) {

--- a/internal/amf/eps_idle_mobility.go
+++ b/internal/amf/eps_idle_mobility.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/fgs"
 )
 
 func (a *AMF) FetchMMContext(ctx context.Context, presented etsi.GUTI5G, epsNAS []byte) (interworking.MMContextResponse, error) {
@@ -46,6 +47,15 @@ func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworki
 
 	ue.SetSupi(resp.SUPI)
 	ue.SetAmbr(&models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink})
+
+	// A UE that has just been served by an MME supports S1 mode, whatever it did
+	// or did not manage to say about itself: TS 24.501 §4.4.6 keeps the 5GMM
+	// capability IE out of an initial NAS message a UE with no security context
+	// can send, so the AMF would otherwise not know until the SECURITY MODE
+	// COMPLETE replays it — after the command that has to carry the selected EPS
+	// NAS algorithms was already built (§5.4.2.2), leaving the UE unable to
+	// derive the same mapped context on its way back.
+	ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: true}, nil)
 
 	if _, ok := ue.EPSNetworkCapability(); !ok {
 		if raw, err := resp.UENetworkCapability.MarshalBinary(); err == nil {

--- a/internal/amf/eps_idle_mobility.go
+++ b/internal/amf/eps_idle_mobility.go
@@ -48,13 +48,6 @@ func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworki
 	ue.SetSupi(resp.SUPI)
 	ue.SetAmbr(&models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink})
 
-	// A UE that has just been served by an MME supports S1 mode, whatever it did
-	// or did not manage to say about itself: TS 24.501 §4.4.6 keeps the 5GMM
-	// capability IE out of an initial NAS message a UE with no security context
-	// can send, so the AMF would otherwise not know until the SECURITY MODE
-	// COMPLETE replays it — after the command that has to carry the selected EPS
-	// NAS algorithms was already built (§5.4.2.2), leaving the UE unable to
-	// derive the same mapped context on its way back.
 	ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: true}, nil)
 
 	if _, ok := ue.EPSNetworkCapability(); !ok {

--- a/internal/amf/fivegs_relocation.go
+++ b/internal/amf/fivegs_relocation.go
@@ -426,14 +426,11 @@ func (ue *UeContext) MarkArrivedFromEPSHandover() {
 	ue.arrivedFromEPSHandover = true
 }
 
-func (ue *UeContext) TakeArrivedFromEPSHandover() bool {
+func (ue *UeContext) ArrivedFromEPSHandover() bool {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	arrived := ue.arrivedFromEPSHandover
-	ue.arrivedFromEPSHandover = false
-
-	return arrived
+	return ue.arrivedFromEPSHandover
 }
 
 type fromEPSRelocation struct {

--- a/internal/amf/nas/authentication.go
+++ b/internal/amf/nas/authentication.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
@@ -28,6 +30,14 @@ func sendUEAuthenticationAuthenticateRequest(ctx context.Context, amfInstance *a
 
 func identityVerification(ue *amf.UeContext) bool {
 	return ue.Supi().IsValid() || len(ue.Suci) != 0
+}
+
+func citedNgKsi(conn *amf.UeConn) int32 {
+	if conn == nil || conn.RegistrationRequest == nil {
+		return int32(nas.NoKeyAvailable)
+	}
+
+	return int32(conn.RegistrationRequest.NgKSI.Value)
 }
 
 func authenticationProcedure(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) (bool, error) {
@@ -57,6 +67,8 @@ func authenticationProcedure(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 	}
 
 	logger.From(ctx, logger.AmfLog).Debug("UE has no valid security context - continue with the authentication procedure")
+
+	ue.SetNgKsi(models.NgKsi{Tsc: models.ScTypeNative, Ksi: amf.NextNgKsi(citedNgKsi(ue.Conn()))})
 
 	response, err := sendUEAuthenticationAuthenticateRequest(ctx, amfInstance, ue, nil)
 	if err != nil {

--- a/internal/amf/nas/context_setup.go
+++ b/internal/amf/nas/context_setup.go
@@ -44,12 +44,14 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, 
 		arrivedByHandover := ue.TakeArrivedFromEPSHandover()
 
 		if movingFromEPC(msg) {
-			if conn.ArrivingFromEPS == nil && !arrivedByHandover {
+			if arrivedByHandover && conn.EPSArrival == nil {
+				conn.EPSArrival = &amf.EPSArrival{}
+			}
+
+			if conn.EPSArrival == nil {
 				HandleInitialRegistration(ctx, amfInstance, ue)
 				return
 			}
-
-			conn.ArrivedFromEPS = true
 		}
 
 		HandleMobilityAndPeriodicRegistrationUpdating(ctx, amfInstance, ue)

--- a/internal/amf/nas/context_setup.go
+++ b/internal/amf/nas/context_setup.go
@@ -41,17 +41,9 @@ func contextSetup(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, 
 	case fgs.RegistrationTypeInitial:
 		HandleInitialRegistration(ctx, amfInstance, ue)
 	case fgs.RegistrationTypeMobilityUpdating:
-		arrivedByHandover := ue.TakeArrivedFromEPSHandover()
-
-		if movingFromEPC(msg) {
-			if arrivedByHandover && conn.EPSArrival == nil {
-				conn.EPSArrival = &amf.EPSArrival{}
-			}
-
-			if conn.EPSArrival == nil {
-				HandleInitialRegistration(ctx, amfInstance, ue)
-				return
-			}
+		if movingFromEPC(msg) && conn.EPSArrival == nil {
+			HandleInitialRegistration(ctx, amfInstance, ue)
+			return
 		}
 
 		HandleMobilityAndPeriodicRegistrationUpdating(ctx, amfInstance, ue)

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -107,7 +107,11 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	conn.RegistrationRequestPlain = slices.Clone(plain)
 	conn.RegistrationRequestReplayRequired = arrivedPlain
 	conn.SetRegistrationType5GS(uint8(req.RegistrationType))
+
 	conn.EPSArrival = nil
+	if conn.RegistrationType5GS == fgs.RegistrationTypeMobilityUpdating && movingFromEPC(req) && ue.ArrivedFromEPSHandover() {
+		conn.EPSArrival = &amf.EPSArrival{}
+	}
 
 	regName := registrationTypeName(conn.RegistrationType5GS)
 

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ellanetworks/core/internal/amf/procedure"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/metrics"
-	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/ellanetworks/core/nas/fgs"
 	"go.uber.org/zap"
@@ -108,6 +107,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	conn.RegistrationRequestPlain = slices.Clone(plain)
 	conn.RegistrationRequestReplayRequired = arrivedPlain
 	conn.SetRegistrationType5GS(uint8(req.RegistrationType))
+	conn.EPSArrival = nil
 
 	regName := registrationTypeName(conn.RegistrationType5GS)
 
@@ -150,24 +150,6 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 	operatorInfo, err := amfInstance.OperatorInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting operator info: %v", err)
-	}
-
-	if !req.NgKSI.Mapped || !integrityVerified {
-		ngKsi := models.NgKsi{}
-
-		if req.NgKSI.Mapped {
-			ngKsi.Tsc = models.ScTypeMapped
-		} else {
-			ngKsi.Tsc = models.ScTypeNative
-		}
-
-		ngKsi.Ksi = amf.NextNgKsi(int32(req.NgKSI.Value))
-		if ngKsi.Tsc != models.ScTypeNative || ngKsi.Ksi == 7 {
-			ngKsi.Tsc = models.ScTypeNative
-			ngKsi.Ksi = 0
-		}
-
-		ue.SetNgKsi(ngKsi)
 	}
 
 	ue.Location = ueConn.Location

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -275,7 +275,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 		ue.TransitionTo(amf.RegistrationInitiated)
 
 		if movingFromEPCInIdleMode(ue.Conn(), req) {
-			recoverContextFromEPS(ctx, amfInstance, ue, req)
+			recoverContextFromEPS(ctx, amfInstance, ue, req, integrityVerified)
 		}
 
 		pass, err := authenticationProcedure(ctx, amfInstance, ue)

--- a/internal/amf/nas/handle_security_mode_complete.go
+++ b/internal/amf/nas/handle_security_mode_complete.go
@@ -33,6 +33,8 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 
 	conn.StopNASGuard()
 
+	conn.MarkCipheringStarted()
+
 	ue.EndKeyChainProc(procedure.SecurityMode)
 
 	if ue.SecurityContextIsValid() && integrityVerified {

--- a/internal/amf/nas/handle_security_mode_complete.go
+++ b/internal/amf/nas/handle_security_mode_complete.go
@@ -33,8 +33,6 @@ func handleSecurityModeComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 
 	conn.StopNASGuard()
 
-	conn.MarkCipheringStarted()
-
 	ue.EndKeyChainProc(procedure.SecurityMode)
 
 	if ue.SecurityContextIsValid() && integrityVerified {

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/logger"
-	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/fgs"
 	"go.uber.org/zap"
 )
@@ -20,16 +19,6 @@ func movingFromEPCInIdleMode(conn *amf.UeConn, req *fgs.RegistrationRequest) boo
 		conn.RegistrationType5GS == fgs.RegistrationTypeMobilityUpdating &&
 		movingFromEPC(req) &&
 		len(req.EPSNASMessageContainer) > 0
-}
-
-func citedNgKsiIdentifiesCurrentContext(ue *amf.UeContext, req *fgs.RegistrationRequest) bool {
-	held := ue.NgKsi()
-
-	if req.NgKSI.Mapped != (held.Tsc == models.ScTypeMapped) {
-		return false
-	}
-
-	return int32(req.NgKSI.Value) == held.Ksi
 }
 
 func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, integrityVerified bool) {
@@ -52,13 +41,19 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
-	if integrityVerified && ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI && citedNgKsiIdentifiesCurrentContext(ue, req) {
-		logger.From(ctx, logger.AmfLog).Info("inter-system change resumed on the UE's native 5G security context",
-			logger.SUPI(resp.SUPI.String()))
+	if integrityVerified && ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI {
+		err := ue.CitesCurrentNgKSI(req.NgKSI)
+		if err == nil {
+			logger.From(ctx, logger.AmfLog).Info("inter-system change resumed on the UE's native 5G security context",
+				logger.SUPI(resp.SUPI.String()))
 
-		conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
+			conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 
-		return
+			return
+		}
+
+		logger.From(ctx, logger.AmfLog).Info("the inter-system change cites a 5G security context the AMF does not hold; mapping the EPS context instead",
+			zap.Error(err))
 	}
 
 	if err := amfInstance.AdoptMMContext(ctx, ue, resp); err != nil {

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -58,6 +58,8 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 
 	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
 
+	conn.MappedContextFromEPS = true
+
 	logger.From(ctx, logger.AmfLog).Info("mapped the UE's EPS security context onto 5GS for an idle-mode change",
 		logger.SUPI(resp.SUPI.String()), zap.Int("pdn-connections", len(resp.PDNConnections)))
 }

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/fgs"
 	"go.uber.org/zap"
 )
@@ -21,7 +22,17 @@ func movingFromEPCInIdleMode(conn *amf.UeConn, req *fgs.RegistrationRequest) boo
 		len(req.EPSNASMessageContainer) > 0
 }
 
-func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest) {
+func citedNgKsiIdentifiesCurrentContext(ue *amf.UeContext, req *fgs.RegistrationRequest) bool {
+	held := ue.NgKsi()
+
+	if req.NgKSI.Mapped != (held.Tsc == models.ScTypeMapped) {
+		return false
+	}
+
+	return int32(req.NgKSI.Value) == held.Ksi
+}
+
+func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest, integrityVerified bool) {
 	conn := ue.Conn()
 	if conn == nil {
 		return
@@ -41,7 +52,7 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
-	if ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI {
+	if integrityVerified && ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI && citedNgKsiIdentifiesCurrentContext(ue, req) {
 		logger.From(ctx, logger.AmfLog).Info("inter-system change resumed on the UE's native 5G security context",
 			logger.SUPI(resp.SUPI.String()))
 
@@ -57,8 +68,8 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 	}
 
 	conn.EPSArrival = &amf.EPSArrival{
-		Sessions:              &interworking.ArrivingSessions{PDN: resp.PDNConnections},
-		MappedSecurityContext: true,
+		Sessions:                 &interworking.ArrivingSessions{PDN: resp.PDNConnections},
+		NeedsSecurityModeControl: true,
 	}
 
 	logger.From(ctx, logger.AmfLog).Info("mapped the UE's EPS security context onto 5GS for an idle-mode change",

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -45,7 +45,7 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		logger.From(ctx, logger.AmfLog).Info("inter-system change resumed on the UE's native 5G security context",
 			logger.SUPI(resp.SUPI.String()))
 
-		conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+		conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 
 		return
 	}
@@ -56,21 +56,22 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
-	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
-
-	conn.MappedContextFromEPS = true
+	conn.EPSArrival = &amf.EPSArrival{
+		Sessions:              &interworking.ArrivingSessions{PDN: resp.PDNConnections},
+		MappedSecurityContext: true,
+	}
 
 	logger.From(ctx, logger.AmfLog).Info("mapped the UE's EPS security context onto 5GS for an idle-mode change",
 		logger.SUPI(resp.SUPI.String()), zap.Int("pdn-connections", len(resp.PDNConnections)))
 }
 
 func adoptArrivingSessions(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, conn *amf.UeConn) bool {
-	arriving := conn.ArrivingFromEPS
+	arriving := conn.EPSArrival.ArrivingSessions()
 	if arriving == nil {
 		return true
 	}
 
-	conn.ArrivingFromEPS = nil
+	conn.EPSArrival.Sessions = nil
 
 	supi := ue.Supi()
 

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -110,7 +110,7 @@ func TestMovingFromEPCInIdleModeNeedsTheContainer(t *testing.T) {
 func TestRecoverContextFromEPSInstallsTheMappedContext(t *testing.T) {
 	ue, amfInstance, peer, _ := idleArrivalUE(t)
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest(), false)
 
 	if len(peer.MMContextRequests) != 1 {
 		t.Fatalf("MME context requests = %d, want 1", len(peer.MMContextRequests))
@@ -171,7 +171,7 @@ func TestIdleArrivalReplaysTheUEsOwn5GSecurityCapability(t *testing.T) {
 
 	ue.SetUESecurityCapabilityForTest(req.UESecurityCapability)
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, req)
+	recoverContextFromEPS(context.Background(), amfInstance, ue, req, false)
 
 	raw, err := amf.BuildSecurityModeCommand(ue)
 	if err != nil {
@@ -198,7 +198,7 @@ func TestRecoverContextFromEPSFallsBackWhenTheMMEHasNoContext(t *testing.T) {
 	ue, amfInstance, peer, _ := idleArrivalUE(t)
 	peer.MMContextErr = interworking.ErrUnknownUEContext
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest(), false)
 
 	if ue.SecurityContextIsValid() {
 		t.Error("a security context was installed though the MME returned none")
@@ -213,7 +213,7 @@ func TestRecoverContextFromEPSFallsBackOnAFailedIntegrityCheck(t *testing.T) {
 	ue, amfInstance, peer, _ := idleArrivalUE(t)
 	peer.MMContextErr = interworking.ErrIntegrityCheckFailed
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest(), false)
 
 	if ue.SecurityContextIsValid() {
 		t.Error("a security context was installed though the MME could not verify the TAU")
@@ -228,7 +228,7 @@ func TestRecoverContextFromEPSKeepsANativeContext(t *testing.T) {
 
 	native := ue.NgKsi()
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+	recoverContextFromEPS(context.Background(), amfInstance, ue, nativeIdleArrivalRequest(), true)
 
 	if got := ue.NgKsi(); got != native {
 		t.Errorf("ngKSI = %+v, want the native %+v: the UE holds no mapped context to answer under", got, native)
@@ -240,6 +240,36 @@ func TestRecoverContextFromEPSKeepsANativeContext(t *testing.T) {
 
 	if len(peer.MMContextRequests) != 1 {
 		t.Error("the MME was not asked for the UE's PDN connections")
+	}
+}
+
+// TS 33.501 §8.2, TS 24.501 §4.4.2.5
+func TestRecoverContextFromEPSDoesNotResumeOnAnUnverifiedRegistrationRequest(t *testing.T) {
+	ue, amfInstance, _, _ := idleArrivalUE(t)
+
+	ue.SetSecuredForTest(true)
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, nativeIdleArrivalRequest(), false)
+
+	if !ue.Conn().ArrivalNeedsSecurityModeControl() {
+		t.Fatal("the AMF resumed on a native context without verifying the registration request that claimed it")
+	}
+
+	if got := ue.NgKsi(); got.Tsc != models.ScTypeMapped {
+		t.Errorf("ngKSI = %+v, want a mapped context derived from the EPS one", got)
+	}
+}
+
+// TS 24.501 §4.4.2.5
+func TestRecoverContextFromEPSDoesNotResumeOnAnNgKSIItDoesNotHold(t *testing.T) {
+	ue, amfInstance, _, _ := idleArrivalUE(t)
+
+	ue.SetSecuredForTest(true)
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest(), true)
+
+	if !ue.Conn().ArrivalNeedsSecurityModeControl() {
+		t.Fatal("the AMF resumed on a context the ngKSI in the registration request does not identify")
 	}
 }
 
@@ -428,7 +458,7 @@ func TestIdleArrivalFromEPSAlwaysRunsTheSecurityModeProcedure(t *testing.T) {
 	ue.SetSecuredForTest(false)
 	ue.ForceStateForTest(amf.RegistrationInitiated)
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest(), false)
 
 	if !ue.SecurityContextIsValid() {
 		t.Fatal("no mapped context was installed")
@@ -490,9 +520,9 @@ func TestIdleArrivalOnANativeContextRunsNoSecurityModeProcedure(t *testing.T) {
 		t.Fatalf("handleRegistrationRequestMessage: %v", err)
 	}
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, req)
+	recoverContextFromEPS(context.Background(), amfInstance, ue, req, true)
 
-	if conn.MappedContextFromEPS() {
+	if conn.ArrivalNeedsSecurityModeControl() {
 		t.Fatal("the AMF mapped the EPS context over a native one it could verify and resume on")
 	}
 
@@ -585,9 +615,9 @@ func TestASecondRegistrationDoesNotInheritTheMappedArrival(t *testing.T) {
 	conn := ue.Conn()
 	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest(), false)
 
-	if !conn.MappedContextFromEPS() {
+	if !conn.ArrivalNeedsSecurityModeControl() {
 		t.Fatal("the arrival did not map the EPS context, so this test proves nothing")
 	}
 

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -456,6 +456,64 @@ func TestIdleArrivalFromEPSAlwaysRunsTheSecurityModeProcedure(t *testing.T) {
 	}
 }
 
+// TS 24.501 §4.4.2.5 case a), §5.4.2.2
+func TestIdleArrivalOnANativeContextRunsNoSecurityModeProcedure(t *testing.T) {
+	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	amfInstance.EPS = &fakeEPSPeer{MMContextResponse: arrivingMMContext(ue.Supi())}
+
+	ue.SetSecuredForTest(true)
+	ue.SetDLCountForTest(7)
+	ue.ForceStateForTest(amf.RegistrationInitiated)
+
+	native := ue.NgKsi()
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+
+	conn := ue.Conn()
+	if conn.MappedContextFromEPS {
+		t.Fatal("the AMF mapped the EPS context over a native one it could verify and resume on")
+	}
+
+	if conn.ArrivingFromEPS == nil {
+		t.Fatal("the PDN connections were discarded with the EPS security parameters")
+	}
+
+	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
+	conn.RegistrationRequest = idleArrivalRequest()
+
+	securityMode(context.Background(), amfInstance, ue)
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlink NAS messages = %d, want the registration accept alone", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	wire := ngapSender.SentDownlinkNASTransport[0].NASPDU
+	if len(wire) < 7 {
+		t.Fatalf("downlink NAS PDU is %d octets, too short to be security protected", len(wire))
+	}
+
+	if sht := fgs.SecurityHeaderType(wire[1]); sht == fgs.SHTIntegrityProtectedNewContext {
+		t.Error("the AMF sent a SECURITY MODE COMMAND to take into use a context the UE was already using")
+	}
+
+	if wire[6] != 7 {
+		t.Errorf("the reply carries NAS sequence number %d, want the 7 the context was already at", wire[6])
+	}
+
+	if got := ue.DLCountForTest(); got != 8 {
+		t.Errorf("downlink NAS COUNT = %d, want 8: the count carries on across the inter-system change", got)
+	}
+
+	if got := ue.NgKsi(); got != native {
+		t.Errorf("ngKSI = %+v, want the native %+v it arrived on", got, native)
+	}
+
+	if ue.RegStep() != amf.RegStepContextSetup {
+		t.Errorf("registration step = %v, want the context setup sub-phase: the registration should carry straight on", ue.RegStep())
+	}
+}
+
 // TS 24.501 §5.5.1.3.4, TS 23.502 §4.11.1.3.3 step 14
 func TestAnArrivalThatMovesNothingIsStillAccepted(t *testing.T) {
 	ue, amfInstance, peer, smf := idleArrivalUE(t)

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -17,7 +17,11 @@ import (
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
-const idleEKSI uint8 = 4
+const (
+	idleEKSI uint8 = 4
+	// nativeKSI is the ngKSI buildMobilityRegUeAndAMF gives its UE.
+	nativeKSI uint8 = 1
+)
 
 func arrivingMMContext(supi etsi.SUPI) interworking.MMContextResponse {
 	var kasme [32]byte
@@ -53,6 +57,15 @@ func idleArrivalRequest() *fgs.RegistrationRequest {
 		EPSNASMessageContainer: []byte{uint8(eps.PDEMM), 0x01, 0xde, 0xad, 0xbe, 0xef, 0x00},
 		UESecurityCapability:   &fgs.UESecurityCapability{EA: 0xe0, IA: 0xe0},
 	}
+}
+
+// nativeIdleArrivalRequest is the arrival of TS 24.501 §4.4.2.5 case a): the UE
+// cites the ngKSI of the native 5G context it kept, rather than a mapped one.
+func nativeIdleArrivalRequest() *fgs.RegistrationRequest {
+	req := idleArrivalRequest()
+	req.NgKSI = nas.KeySetIdentifier{Value: nativeKSI}
+
+	return req
 }
 
 func idleArrivalUE(t *testing.T) (*amf.UeContext, *amf.AMF, *fakeEPSPeer, *fakeSmf) {
@@ -194,7 +207,7 @@ func TestRecoverContextFromEPSFallsBackWhenTheMMEHasNoContext(t *testing.T) {
 		t.Error("a security context was installed though the MME returned none")
 	}
 
-	if ue.Conn().ArrivingFromEPS != nil {
+	if ue.Conn().EPSArrival.ArrivingSessions() != nil {
 		t.Error("the connection holds an arriving context the MME never returned")
 	}
 }
@@ -224,7 +237,7 @@ func TestRecoverContextFromEPSKeepsANativeContext(t *testing.T) {
 		t.Errorf("ngKSI = %+v, want the native %+v: the UE holds no mapped context to answer under", got, native)
 	}
 
-	if ue.Conn().ArrivingFromEPS == nil {
+	if ue.Conn().EPSArrival.ArrivingSessions() == nil {
 		t.Fatal("the PDN connections were discarded with the EPS security parameters")
 	}
 
@@ -238,7 +251,7 @@ func TestAdoptArrivingSessionsMovesThemAndAcksTheMME(t *testing.T) {
 	ue, amfInstance, peer, smf := idleArrivalUE(t)
 
 	resp := arrivingMMContext(ue.Supi())
-	ue.Conn().ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+	ue.Conn().EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 
 	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
 
@@ -271,7 +284,7 @@ func TestAdoptArrivingSessionsMovesThemAndAcksTheMME(t *testing.T) {
 		t.Errorf("acknowledged sessions = %v, want the adopted PDU session 3", peer.Transferred)
 	}
 
-	if ue.Conn().ArrivingFromEPS != nil {
+	if ue.Conn().EPSArrival.ArrivingSessions() != nil {
 		t.Error("the arriving context outlived the adoption, so a later registration would move it again")
 	}
 }
@@ -282,7 +295,7 @@ func TestAdoptArrivingSessionsLeavesBehindWhatCannotMove(t *testing.T) {
 	smf.IdleTransferErr = context.DeadlineExceeded
 
 	resp := arrivingMMContext(ue.Supi())
-	ue.Conn().ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+	ue.Conn().EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 
 	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
 
@@ -305,7 +318,7 @@ func TestAdoptArrivingSessionsReleasesASessionItCannotAddress(t *testing.T) {
 
 	resp := arrivingMMContext(ue.Supi())
 	resp.PDNConnections[0].PDUSessionID = 16
-	ue.Conn().ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+	ue.Conn().EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 
 	adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn())
 
@@ -336,8 +349,7 @@ func TestIdleArrivalIsAbortedWhenTheIdentityCannotBeCommitted(t *testing.T) {
 
 	resp := arrivingMMContext(ue.Supi())
 	conn := ue.Conn()
-	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
-	conn.ArrivedFromEPS = true
+	conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 	conn.RegistrationRequest = &fgs.RegistrationRequest{
 		RegistrationType: fgs.RegistrationTypeMobilityUpdating,
 		UEStatus:         &fgs.UEStatus{S1ModeReg: true},
@@ -376,8 +388,7 @@ func TestIdleArrivalAcceptReportsTheAdoptedSessions(t *testing.T) {
 
 	resp := arrivingMMContext(ue.Supi())
 	conn := ue.Conn()
-	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
-	conn.ArrivedFromEPS = true
+	conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 	conn.RegistrationRequest = &fgs.RegistrationRequest{
 		RegistrationType: fgs.RegistrationTypeMobilityUpdating,
 		UEStatus:         &fgs.UEStatus{S1ModeReg: true},
@@ -468,19 +479,28 @@ func TestIdleArrivalOnANativeContextRunsNoSecurityModeProcedure(t *testing.T) {
 
 	native := ue.NgKsi()
 
-	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
-
 	conn := ue.Conn()
-	if conn.MappedContextFromEPS {
+	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
+	req := nativeIdleArrivalRequest()
+
+	wire, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode the arrival request: %v", err)
+	}
+
+	if err := handleRegistrationRequestMessage(context.Background(), amfInstance, ue, req, wire, true, false); err != nil {
+		t.Fatalf("handleRegistrationRequestMessage: %v", err)
+	}
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, req)
+
+	if conn.MappedContextFromEPS() {
 		t.Fatal("the AMF mapped the EPS context over a native one it could verify and resume on")
 	}
 
-	if conn.ArrivingFromEPS == nil {
+	if conn.EPSArrival.ArrivingSessions() == nil {
 		t.Fatal("the PDN connections were discarded with the EPS security parameters")
 	}
-
-	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
-	conn.RegistrationRequest = idleArrivalRequest()
 
 	securityMode(context.Background(), amfInstance, ue)
 
@@ -488,17 +508,17 @@ func TestIdleArrivalOnANativeContextRunsNoSecurityModeProcedure(t *testing.T) {
 		t.Fatalf("downlink NAS messages = %d, want the registration accept alone", len(ngapSender.SentDownlinkNASTransport))
 	}
 
-	wire := ngapSender.SentDownlinkNASTransport[0].NASPDU
-	if len(wire) < 7 {
-		t.Fatalf("downlink NAS PDU is %d octets, too short to be security protected", len(wire))
+	sent := ngapSender.SentDownlinkNASTransport[0].NASPDU
+	if len(sent) < 7 {
+		t.Fatalf("downlink NAS PDU is %d octets, too short to be security protected", len(sent))
 	}
 
-	if sht := fgs.SecurityHeaderType(wire[1]); sht == fgs.SHTIntegrityProtectedNewContext {
+	if sht := fgs.SecurityHeaderType(sent[1]); sht == fgs.SHTIntegrityProtectedNewContext {
 		t.Error("the AMF sent a SECURITY MODE COMMAND to take into use a context the UE was already using")
 	}
 
-	if wire[6] != 7 {
-		t.Errorf("the reply carries NAS sequence number %d, want the 7 the context was already at", wire[6])
+	if sent[6] != 7 {
+		t.Errorf("the reply carries NAS sequence number %d, want the 7 the context was already at", sent[6])
 	}
 
 	if got := ue.DLCountForTest(); got != 8 {
@@ -520,10 +540,10 @@ func TestAnArrivalThatMovesNothingIsStillAccepted(t *testing.T) {
 	smf.IdleTransferErr = context.DeadlineExceeded
 
 	conn := ue.Conn()
-	conn.ArrivedFromEPS = true
+	conn.EPSArrival = &amf.EPSArrival{}
 
 	resp := arrivingMMContext(ue.Supi())
-	conn.ArrivingFromEPS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+	conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 
 	if !adoptArrivingSessions(context.Background(), amfInstance, ue, conn) {
 		t.Fatal("the registration was abandoned, so the UE gets no 5GS service until it retries")
@@ -552,5 +572,58 @@ func TestAnArrivalThatMovesNothingIsStillAccepted(t *testing.T) {
 		if active {
 			t.Errorf("EPS bearer %d reported active though no PDN connection moved onto 5GS", ebi)
 		}
+	}
+}
+
+// TS 24.501 §5.4.2.2.
+func TestASecondRegistrationDoesNotInheritTheMappedArrival(t *testing.T) {
+	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	amfInstance.EPS = &fakeEPSPeer{MMContextResponse: arrivingMMContext(ue.Supi())}
+
+	ue.SetSecuredForTest(false)
+	ue.ForceStateForTest(amf.RegistrationInitiated)
+
+	conn := ue.Conn()
+	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
+
+	recoverContextFromEPS(context.Background(), amfInstance, ue, idleArrivalRequest())
+
+	if !conn.MappedContextFromEPS() {
+		t.Fatal("the arrival did not map the EPS context, so this test proves nothing")
+	}
+
+	// The UE stays connected and registers again on the same connection.
+	plain := idleArrivalRequest()
+	plain.UEStatus = nil
+	plain.EPSNASMessageContainer = nil
+
+	wire, err := plain.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode the second registration: %v", err)
+	}
+
+	before := ue.DLCountForTest()
+
+	if err := handleRegistrationRequestMessage(context.Background(), amfInstance, ue, plain, wire, true, false); err != nil {
+		t.Fatalf("handleRegistrationRequestMessage: %v", err)
+	}
+
+	if conn.ArrivedFromEPS() {
+		t.Fatal("the second registration inherited the first one's arrival from EPS")
+	}
+
+	sentBefore := len(ngapSender.SentDownlinkNASTransport)
+
+	securityMode(context.Background(), amfInstance, ue)
+
+	for _, sent := range ngapSender.SentDownlinkNASTransport[sentBefore:] {
+		if len(sent.NASPDU) > 1 && fgs.SecurityHeaderType(sent.NASPDU[1]) == fgs.SHTIntegrityProtectedNewContext {
+			t.Error("the second registration ran a security mode procedure on a context that was already current")
+		}
+	}
+
+	if got := ue.DLCountForTest(); got < before {
+		t.Errorf("downlink NAS COUNT went from %d back to %d: the second registration restarted a context the UE is still counting on", before, got)
 	}
 }

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	idleEKSI uint8 = 4
-	// nativeKSI is the ngKSI buildMobilityRegUeAndAMF gives its UE.
+	idleEKSI  uint8 = 4
 	nativeKSI uint8 = 1
 )
 
@@ -59,8 +58,6 @@ func idleArrivalRequest() *fgs.RegistrationRequest {
 	}
 }
 
-// nativeIdleArrivalRequest is the arrival of TS 24.501 §4.4.2.5 case a): the UE
-// cites the ngKSI of the native 5G context it kept, rather than a mapped one.
 func nativeIdleArrivalRequest() *fgs.RegistrationRequest {
 	req := idleArrivalRequest()
 	req.NgKSI = nas.KeySetIdentifier{Value: nativeKSI}
@@ -467,7 +464,7 @@ func TestIdleArrivalFromEPSAlwaysRunsTheSecurityModeProcedure(t *testing.T) {
 	}
 }
 
-// TS 24.501 §4.4.2.5 case a), §5.4.2.2
+// TS 24.501 §4.4.2.5, §5.4.2.2
 func TestIdleArrivalOnANativeContextRunsNoSecurityModeProcedure(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
@@ -481,6 +478,7 @@ func TestIdleArrivalOnANativeContextRunsNoSecurityModeProcedure(t *testing.T) {
 
 	conn := ue.Conn()
 	conn.SetRegistrationType5GS(uint8(fgs.RegistrationTypeMobilityUpdating))
+
 	req := nativeIdleArrivalRequest()
 
 	wire, err := req.MarshalBinary()
@@ -575,7 +573,7 @@ func TestAnArrivalThatMovesNothingIsStillAccepted(t *testing.T) {
 	}
 }
 
-// TS 24.501 §5.4.2.2.
+// TS 24.501 §5.4.2.2
 func TestASecondRegistrationDoesNotInheritTheMappedArrival(t *testing.T) {
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
@@ -593,7 +591,6 @@ func TestASecondRegistrationDoesNotInheritTheMappedArrival(t *testing.T) {
 		t.Fatal("the arrival did not map the EPS context, so this test proves nothing")
 	}
 
-	// The UE stays connected and registers again on the same connection.
 	plain := idleArrivalRequest()
 	plain.UEStatus = nil
 	plain.EPSNASMessageContainer = nil

--- a/internal/amf/nas/interworking_conformance_test.go
+++ b/internal/amf/nas/interworking_conformance_test.go
@@ -220,11 +220,11 @@ func TestIdleArrivalSupersedesALeftoverHandoverMark(t *testing.T) {
 
 	req := idleArrivalRequest()
 	openRegistration(t, amfInstance, ue, req)
-	recoverContextFromEPS(context.TODO(), amfInstance, ue, req)
+	recoverContextFromEPS(context.TODO(), amfInstance, ue, req, false)
 
 	conn := ue.Conn()
 
-	if !conn.MappedContextFromEPS() {
+	if !conn.ArrivalNeedsSecurityModeControl() {
 		t.Error("the idle arrival did not map the EPS context: the leftover mark stood in for a context the MME had to supply")
 	}
 

--- a/internal/amf/nas/interworking_conformance_test.go
+++ b/internal/amf/nas/interworking_conformance_test.go
@@ -170,16 +170,17 @@ func TestIdleArrivalSpendsALeftoverHandoverMark(t *testing.T) {
 
 	conn := ue.Conn()
 	conn.RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
-	conn.ArrivingFromEPS = &interworking.ArrivingSessions{}
+	conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{}}
 
 	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)
 
-	conn.ArrivingFromEPS = nil
-	conn.ArrivedFromEPS = false
+	// The next registration on this connection starts from a clean arrival, as
+	// handleRegistrationRequestMessage would leave it.
+	conn.EPSArrival = nil
 
 	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)
 
-	if conn.ArrivedFromEPS {
+	if conn.ArrivedFromEPS() {
 		t.Error("an update the AMF holds no EPS arrival for was taken as one: the handover mark outlived the idle arrival that short-circuited it")
 	}
 }

--- a/internal/amf/nas/interworking_conformance_test.go
+++ b/internal/amf/nas/interworking_conformance_test.go
@@ -174,8 +174,6 @@ func TestIdleArrivalSpendsALeftoverHandoverMark(t *testing.T) {
 
 	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)
 
-	// The next registration on this connection starts from a clean arrival, as
-	// handleRegistrationRequestMessage would leave it.
 	conn.EPSArrival = nil
 
 	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)

--- a/internal/amf/nas/interworking_conformance_test.go
+++ b/internal/amf/nas/interworking_conformance_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
-	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/fgs"
 )
@@ -19,6 +18,18 @@ func movingFromEPCRequest() *fgs.RegistrationRequest {
 		GMMCapability: &fgs.GMMCapability{},
 		UEStatus:      &fgs.UEStatus{S1ModeReg: true},
 	}
+}
+
+func handoverFollowUpRequest() *fgs.RegistrationRequest {
+	req := nativeIdleArrivalRequest()
+	req.EPSNASMessageContainer = nil
+
+	return req
+}
+
+func arrivedByHandover(ue *amf.UeContext) {
+	ue.MarkArrivedFromEPSHandover()
+	ue.Conn().EPSArrival = &amf.EPSArrival{}
 }
 
 // TS 24.501 §5.5.1.3.4
@@ -100,7 +111,7 @@ func TestInterworkingRegistrationAcceptReportsSessionsThatSurvivedTheHandover(t 
 	ue, ngapSender, smfStub, amfInstance := buildMobilityRegUeAndAMF(t)
 
 	ue.SmContextList[1] = &amf.SmContext{Ref: "ref-1"}
-	ue.MarkArrivedFromEPSHandover()
+	arrivedByHandover(ue)
 
 	req := movingFromEPCRequest()
 	req.PDUSessionStatus = &fgs.PSIBitmap{PSI: [16]bool{1: true}}
@@ -146,7 +157,7 @@ func TestRegistrationAfterAnEPSHandoverKeepsTheMovedSessions(t *testing.T) {
 		t.Fatalf("CreateSmContext: %v", err)
 	}
 
-	ue.MarkArrivedFromEPSHandover()
+	arrivedByHandover(ue)
 
 	req := movingFromEPCRequest()
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
@@ -162,24 +173,76 @@ func TestRegistrationAfterAnEPSHandoverKeepsTheMovedSessions(t *testing.T) {
 	}
 }
 
-// TS 23.502 §4.11.2.3
-func TestIdleArrivalSpendsALeftoverHandoverMark(t *testing.T) {
+func openRegistration(t *testing.T, amfInstance *amf.AMF, ue *amf.UeContext, req *fgs.RegistrationRequest) {
+	t.Helper()
+
+	wire, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode the registration request: %v", err)
+	}
+
+	if err := handleRegistrationRequestMessage(context.TODO(), amfInstance, ue, req, wire, true, false); err != nil {
+		t.Fatalf("handleRegistrationRequestMessage: %v", err)
+	}
+}
+
+func TestHandoverMarkOpensTheRegistrationThatFollowsIt(t *testing.T) {
 	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
 	ue.MarkArrivedFromEPSHandover()
 
+	openRegistration(t, amfInstance, ue, handoverFollowUpRequest())
+
+	if !ue.Conn().ArrivedFromEPS() {
+		t.Error("the registration that follows a completed relocation was not taken as an arrival from EPS, so the UE's moved sessions are torn down")
+	}
+}
+
+func TestHandoverMarkEndsWithTheRegistrationItServed(t *testing.T) {
+	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	ue.MarkArrivedFromEPSHandover()
+
+	openRegistration(t, amfInstance, ue, handoverFollowUpRequest())
+	ue.ClearRegistrationRequestData()
+
+	openRegistration(t, amfInstance, ue, handoverFollowUpRequest())
+
+	if ue.Conn().ArrivedFromEPS() {
+		t.Error("a later registration on the same connection inherited the handover mark of one that had already completed")
+	}
+}
+
+func TestIdleArrivalSupersedesALeftoverHandoverMark(t *testing.T) {
+	ue, amfInstance, _, _ := idleArrivalUE(t)
+
+	ue.MarkArrivedFromEPSHandover()
+
+	req := idleArrivalRequest()
+	openRegistration(t, amfInstance, ue, req)
+	recoverContextFromEPS(context.TODO(), amfInstance, ue, req)
+
 	conn := ue.Conn()
-	conn.RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
-	conn.EPSArrival = &amf.EPSArrival{Sessions: &interworking.ArrivingSessions{}}
 
-	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)
+	if !conn.MappedContextFromEPS() {
+		t.Error("the idle arrival did not map the EPS context: the leftover mark stood in for a context the MME had to supply")
+	}
 
-	conn.EPSArrival = nil
+	if conn.EPSArrival.ArrivingSessions() == nil {
+		t.Error("the arrival carries no PDN connections, so the UE's sessions are left behind in EPS")
+	}
+}
 
-	contextSetup(context.TODO(), amfInstance, ue, movingFromEPCRequest(), nil)
+func TestHandoverMarkOutlivesARegistrationThatDidNotComplete(t *testing.T) {
+	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	if conn.ArrivedFromEPS() {
-		t.Error("an update the AMF holds no EPS arrival for was taken as one: the handover mark outlived the idle arrival that short-circuited it")
+	ue.MarkArrivedFromEPSHandover()
+
+	openRegistration(t, amfInstance, ue, handoverFollowUpRequest())
+	openRegistration(t, amfInstance, ue, handoverFollowUpRequest())
+
+	if !ue.Conn().ArrivedFromEPS() {
+		t.Error("the retry of a registration that did not complete lost the arrival, so the UE is put through an initial registration instead")
 	}
 }
 

--- a/internal/amf/nas/interworking_registration_test.go
+++ b/internal/amf/nas/interworking_registration_test.go
@@ -101,7 +101,13 @@ func TestMobilityRegistrationAfterAnArrivalFromEPSKeepsTheMappedContext(t *testi
 	}
 }
 
-func TestMobilityRegistrationTakesAFreshNgKSIWithoutAMappedContext(t *testing.T) {
+// TS 24.501 §5.4.2.2, TS 33.501 §6.7.2: an ngKSI names a security context, so
+// taking in a REGISTRATION REQUEST must not move it. Whether this registration
+// creates a context is not known yet, and if it turns out to reuse the one the
+// UE cited, a value moved here would leave the two ends naming different
+// contexts with nothing to reconcile them — TS 33.501 §8.6.1 derives the eKSI of
+// a later move to EPS from it, so the AMF would refuse its own UE.
+func TestRegistrationRequestLeavesTheNgKSIAlone(t *testing.T) {
 	amfInstance := arrivedRegistrationAMF()
 
 	ue, _, err := buildUeAndRadio()
@@ -110,6 +116,8 @@ func TestMobilityRegistrationTakesAFreshNgKSIWithoutAMappedContext(t *testing.T)
 	}
 
 	setTestUESecurityCapability(ue)
+
+	before := ue.NgKsi()
 
 	wire, err := buildRegReqBytes(uint8(fgs.RegistrationTypeMobilityUpdating), testMobileIdentity(),
 		&fgs.UESecurityCapability{EA: 0xe0, IA: 0xe0}, 0, nil, 0, 2)
@@ -121,7 +129,46 @@ func TestMobilityRegistrationTakesAFreshNgKSIWithoutAMappedContext(t *testing.T)
 		t.Fatalf("handleRegistrationRequestMessage: %v", err)
 	}
 
+	if got := ue.NgKsi(); got != before {
+		t.Errorf("ngKSI = %+v, want the %+v held before the request was taken in", got, before)
+	}
+}
+
+// The allocation belongs where the AMF decides to create a fresh native
+// context, because the AUTHENTICATION REQUEST is what names it to the UE
+// (TS 24.501 §5.4.1.3.2). authenticationProcedure assigns it before it builds
+// that request, so stopping the procedure at its first guard still shows the
+// value the request would have carried.
+func TestAuthenticationTakesAFreshNgKSIAfterTheOneTheUECited(t *testing.T) {
+	amfInstance := arrivedRegistrationAMF()
+
+	ue, _, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	setTestUESecurityCapability(ue)
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+
+	wire, err := buildRegReqBytes(uint8(fgs.RegistrationTypeMobilityUpdating), testMobileIdentity(),
+		&fgs.UESecurityCapability{EA: 0xe0, IA: 0xe0}, 0, nil, 0, 2)
+	if err != nil {
+		t.Fatalf("build the registration request: %v", err)
+	}
+
+	if err := handleRegistrationRequestMessage(context.Background(), amfInstance, ue, mustParseRegistrationRequest(t, wire), wire, true, false); err != nil {
+		t.Fatalf("handleRegistrationRequestMessage: %v", err)
+	}
+
+	// Stop the procedure at the first guard inside the request build, which sits
+	// after the allocation.
+	ue.Tai.PlmnID = nil
+
+	if _, err := authenticationProcedure(context.Background(), amfInstance, ue); err == nil {
+		t.Fatal("authentication built a request for a UE with no serving PLMN")
+	}
+
 	if got := ue.NgKsi(); got.Tsc != models.ScTypeNative || got.Ksi != 3 {
-		t.Errorf("ngKSI = %+v, want the native identifier after the received 2", got)
+		t.Errorf("ngKSI = %+v, want the native identifier after the 2 the UE cited", got)
 	}
 }

--- a/internal/amf/nas/interworking_registration_test.go
+++ b/internal/amf/nas/interworking_registration_test.go
@@ -101,12 +101,7 @@ func TestMobilityRegistrationAfterAnArrivalFromEPSKeepsTheMappedContext(t *testi
 	}
 }
 
-// TS 24.501 §5.4.2.2, TS 33.501 §6.7.2: an ngKSI names a security context, so
-// taking in a REGISTRATION REQUEST must not move it. Whether this registration
-// creates a context is not known yet, and if it turns out to reuse the one the
-// UE cited, a value moved here would leave the two ends naming different
-// contexts with nothing to reconcile them — TS 33.501 §8.6.1 derives the eKSI of
-// a later move to EPS from it, so the AMF would refuse its own UE.
+// TS 24.501 §5.4.2.2, TS 33.501 §6.7.2
 func TestRegistrationRequestLeavesTheNgKSIAlone(t *testing.T) {
 	amfInstance := arrivedRegistrationAMF()
 
@@ -134,11 +129,7 @@ func TestRegistrationRequestLeavesTheNgKSIAlone(t *testing.T) {
 	}
 }
 
-// The allocation belongs where the AMF decides to create a fresh native
-// context, because the AUTHENTICATION REQUEST is what names it to the UE
-// (TS 24.501 §5.4.1.3.2). authenticationProcedure assigns it before it builds
-// that request, so stopping the procedure at its first guard still shows the
-// value the request would have carried.
+// TS 24.501 §5.4.1.3.2
 func TestAuthenticationTakesAFreshNgKSIAfterTheOneTheUECited(t *testing.T) {
 	amfInstance := arrivedRegistrationAMF()
 
@@ -160,8 +151,6 @@ func TestAuthenticationTakesAFreshNgKSIAfterTheOneTheUECited(t *testing.T) {
 		t.Fatalf("handleRegistrationRequestMessage: %v", err)
 	}
 
-	// Stop the procedure at the first guard inside the request build, which sits
-	// after the allocation.
 	ue.Tai.PlmnID = nil
 
 	if _, err := authenticationProcedure(context.Background(), amfInstance, ue); err == nil {

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -309,7 +309,7 @@ func movingFromEPC(req *fgs.RegistrationRequest) bool {
 
 func releaseLocallyDeactivatedEPSBearers(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, conn *amf.UeConn) {
 	status := conn.RegistrationRequest.EPSBearerContextStatus
-	if status == nil || !conn.ArrivedFromEPS || amfInstance.EPS == nil {
+	if status == nil || !conn.ArrivedFromEPS() || amfInstance.EPS == nil {
 		return
 	}
 

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -935,7 +935,7 @@ func TestMobilityReg_ReportsTheEPSBearerContextStatusAfterAnArrivalFromEPS(t *te
 	}
 
 	ue.SetEPSBearerIdentity(5, 6)
-	ue.Conn().ArrivedFromEPS = true
+	ue.Conn().EPSArrival = &amf.EPSArrival{}
 	ue.Conn().MarkICSCompleted()
 
 	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
@@ -1047,7 +1047,7 @@ func TestMobilityReg_ReleasesPDUSessionsTheUEDeactivatedInEPS(t *testing.T) {
 	status := new(nas.EPSBearerContextStatus)
 	status.Active[5] = true
 
-	ue.Conn().ArrivedFromEPS = true
+	ue.Conn().EPSArrival = &amf.EPSArrival{}
 	ue.Conn().RegistrationRequest.EPSBearerContextStatus = status
 	ue.Conn().MarkICSCompleted()
 

--- a/internal/amf/nas/security_mode.go
+++ b/internal/amf/nas/security_mode.go
@@ -41,7 +41,7 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) 
 		return
 	}
 
-	if ue.SecurityContextIsValid() && conn.ArrivingFromEPS == nil {
+	if ue.SecurityContextIsValid() && !conn.MappedContextFromEPS {
 		if ue.NeedsEPSNASAlgorithms() && provideEPSNASAlgorithms(ctx, amfInstance, ue, conn) {
 			return
 		}

--- a/internal/amf/nas/security_mode.go
+++ b/internal/amf/nas/security_mode.go
@@ -41,7 +41,7 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) 
 		return
 	}
 
-	if ue.SecurityContextIsValid() && !conn.MappedContextFromEPS() {
+	if ue.SecurityContextIsValid() && !conn.ArrivalNeedsSecurityModeControl() {
 		if ue.NeedsEPSNASAlgorithms() && provideEPSNASAlgorithms(ctx, amfInstance, ue, conn) {
 			return
 		}

--- a/internal/amf/nas/security_mode.go
+++ b/internal/amf/nas/security_mode.go
@@ -41,7 +41,7 @@ func securityMode(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) 
 		return
 	}
 
-	if ue.SecurityContextIsValid() && !conn.MappedContextFromEPS {
+	if ue.SecurityContextIsValid() && !conn.MappedContextFromEPS() {
 		if ue.NeedsEPSNASAlgorithms() && provideEPSNASAlgorithms(ctx, amfInstance, ue, conn) {
 			return
 		}

--- a/internal/amf/nas_ciphering_window_test.go
+++ b/internal/amf/nas_ciphering_window_test.go
@@ -22,17 +22,11 @@ func encodePlainSecurityModeReject(t *testing.T) []byte {
 	return payload
 }
 
-// TS 24.501 §4.4.5 starts the AMF's ciphering as described in §4.4.2.5, which
-// re-establishes the secure exchange on the AMF's ciphered reply — not on its
-// receipt of the UE's initial NAS message. Until then the UE has not started
-// ciphering either, so its answer to a security mode command it could not
-// accept arrives unciphered and the AMF has to act on it (§5.4.2.5), not
-// silently drop it and leave the UE to time out.
+// TS 24.501 §4.4.5, §4.4.2.5, §5.4.2.5
 func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringStarts(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
 
-	// The initial NAS message of the connection: integrity protected, unciphered.
 	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
 		t.Fatalf("initial NAS message not accepted: %v", err)
 	}
@@ -46,8 +40,7 @@ func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringSta
 	}
 }
 
-// The window admits the common-procedure answers and nothing else: ordinary
-// signalling that should have been ciphered is still discarded.
+// TS 24.501 §4.4.5
 func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
@@ -62,8 +55,7 @@ func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingBeforeCipheringStar
 	}
 }
 
-// Once the AMF has replied ciphered the window shuts, and even a SECURITY MODE
-// REJECT has to arrive ciphered (§5.4.2.5 protects it under the rules of §4.4.5).
+// TS 24.501 §4.4.5, §5.4.2.5
 func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringStarts(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)

--- a/internal/amf/nas_ciphering_window_test.go
+++ b/internal/amf/nas_ciphering_window_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func encodePlainSecurityModeReject(t *testing.T) []byte {
+	t.Helper()
+
+	m := &fgs.SecurityModeReject{Cause: fgs.GMMCauseSecurityModeRejectedUnspecified}
+
+	payload, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode plain SecurityModeReject: %v", err)
+	}
+
+	return payload
+}
+
+// TS 24.501 §4.4.5 starts the AMF's ciphering as described in §4.4.2.5, which
+// re-establishes the secure exchange on the AMF's ciphered reply — not on its
+// receipt of the UE's initial NAS message. Until then the UE has not started
+// ciphering either, so its answer to a security mode command it could not
+// accept arrives unciphered and the AMF has to act on it (§5.4.2.5), not
+// silently drop it and leave the UE to time out.
+func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringStarts(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	// The initial NAS message of the connection: integrity protected, unciphered.
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
+		t.Fatalf("initial NAS message not accepted: %v", err)
+	}
+
+	if ue.Conn().CipheringStarted() {
+		t.Fatal("the AMF counts itself as ciphering before it has replied to the UE")
+	}
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeReject(t), 1)); err != nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %v, want it accepted so the AMF can abort the procedure", err)
+	}
+}
+
+// The window admits the common-procedure answers and nothing else: ordinary
+// signalling that should have been ciphered is still discarded.
+func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
+		t.Fatalf("initial NAS message not accepted: %v", err)
+	}
+
+	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 1))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered UL NAS TRANSPORT) = %+v, nil, want it discarded", res)
+	}
+}
+
+// Once the AMF has replied ciphered the window shuts, and even a SECURITY MODE
+// REJECT has to arrive ciphered (§5.4.2.5 protects it under the rules of §4.4.5).
+func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringStarts(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
+		t.Fatalf("initial NAS message not accepted: %v", err)
+	}
+
+	ue.Conn().MarkCipheringStarted()
+
+	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeReject(t), 1))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %+v, nil, want it discarded once ciphering started", res)
+	}
+}

--- a/internal/amf/nas_ciphering_window_test.go
+++ b/internal/amf/nas_ciphering_window_test.go
@@ -34,8 +34,8 @@ func encodePlainSecurityModeComplete(t *testing.T) []byte {
 	return payload
 }
 
-// TS 24.501 §4.4.5, §4.4.2.5, §5.4.2.5
-func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringStarts(t *testing.T) {
+// TS 24.501 §4.4.2.5, §4.4.5
+func TestDecodeNASMessageAcceptsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
 
@@ -45,20 +45,6 @@ func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringSta
 
 	if ue.Conn().CipheringStarted() {
 		t.Fatal("the AMF counts itself as ciphering before it has replied to the UE")
-	}
-
-	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeReject(t), 1)); err != nil {
-		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %v, want it accepted so the AMF can abort the procedure", err)
-	}
-}
-
-// TS 24.501 §4.4.2.5, §4.4.5
-func TestDecodeNASMessageAcceptsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
-	ue := newSecuredUE(t)
-	ue.SetULCountForTest(0)
-
-	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
-		t.Fatalf("initial NAS message not accepted: %v", err)
 	}
 
 	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 1)); err != nil {
@@ -83,7 +69,42 @@ func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingAfterCipheringStart
 	}
 }
 
-// TS 24.501 §5.4.2.3, §4.4.6, table 9.3.1
+// TS 24.501 §4.4.2.5, §4.4.5, §5.4.2.5
+func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringStarts(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
+		t.Fatalf("initial NAS message not accepted: %v", err)
+	}
+
+	if ue.Conn().CipheringStarted() {
+		t.Fatal("the AMF counts itself as ciphering before it has replied to the UE")
+	}
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeReject(t), 1)); err != nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %v, want it accepted so the AMF can abort the procedure", err)
+	}
+}
+
+// TS 24.501 §4.4.5, §5.4.2.5
+func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringStarts(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
+		t.Fatalf("initial NAS message not accepted: %v", err)
+	}
+
+	ue.Conn().MarkCipheringStarted()
+
+	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeReject(t), 1))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %+v, nil, want it discarded once ciphering started", res)
+	}
+}
+
+// TS 24.501 §5.4.2.3, table 9.3.1
 func TestDecodeNASMessageAcceptsASecurityModeCompleteWithTheNewContextHeaderType(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
@@ -124,22 +145,5 @@ func TestDecodeNASMessageDiscardsASecurityModeCompleteWithoutTheNewContextHeader
 	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeComplete(t), 1))
 	if err == nil {
 		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE COMPLETE) = %+v, nil, want it discarded: it would carry the replayed initial NAS message in the clear", res)
-	}
-}
-
-// TS 24.501 §4.4.5, §5.4.2.5
-func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringStarts(t *testing.T) {
-	ue := newSecuredUE(t)
-	ue.SetULCountForTest(0)
-
-	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
-		t.Fatalf("initial NAS message not accepted: %v", err)
-	}
-
-	ue.Conn().MarkCipheringStarted()
-
-	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeReject(t), 1))
-	if err == nil {
-		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %+v, nil, want it discarded once ciphering started", res)
 	}
 }

--- a/internal/amf/nas_ciphering_window_test.go
+++ b/internal/amf/nas_ciphering_window_test.go
@@ -6,6 +6,7 @@ package amf
 import (
 	"testing"
 
+	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
@@ -17,6 +18,17 @@ func encodePlainSecurityModeReject(t *testing.T) []byte {
 	payload, err := m.MarshalBinary()
 	if err != nil {
 		t.Fatalf("encode plain SecurityModeReject: %v", err)
+	}
+
+	return payload
+}
+
+func encodePlainSecurityModeComplete(t *testing.T) []byte {
+	t.Helper()
+
+	payload, err := (&fgs.SecurityModeComplete{}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode plain SecurityModeComplete: %v", err)
 	}
 
 	return payload
@@ -40,8 +52,8 @@ func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringSta
 	}
 }
 
-// TS 24.501 §4.4.5
-func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
+// TS 24.501 §4.4.2.5, §4.4.5
+func TestDecodeNASMessageAcceptsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
 	ue := newSecuredUE(t)
 	ue.SetULCountForTest(0)
 
@@ -49,9 +61,69 @@ func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingBeforeCipheringStar
 		t.Fatalf("initial NAS message not accepted: %v", err)
 	}
 
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 1)); err != nil {
+		t.Fatalf("DecodeNASMessage(unciphered UL NAS TRANSPORT) = %v, want it accepted before the AMF has replied ciphered", err)
+	}
+}
+
+// TS 24.501 §4.4.5
+func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingAfterCipheringStarts(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
+		t.Fatalf("initial NAS message not accepted: %v", err)
+	}
+
+	ue.Conn().MarkCipheringStarted()
+
 	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainULNasTransport(t), 1))
 	if err == nil {
-		t.Fatalf("DecodeNASMessage(unciphered UL NAS TRANSPORT) = %+v, nil, want it discarded", res)
+		t.Fatalf("DecodeNASMessage(unciphered UL NAS TRANSPORT) = %+v, nil, want it discarded once ciphering started", res)
+	}
+}
+
+// TS 24.501 §5.4.2.3, §4.4.6, table 9.3.1
+func TestDecodeNASMessageAcceptsASecurityModeCompleteWithTheNewContextHeaderType(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+	ue.ForceRegStepForTest(RegStepSecurityMode)
+
+	cnt, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wire, err := fgs.Protect(encodePlainSecurityModeComplete(t), fgs.SHTIntegrityProtectedCipheredNewContext, cnt, nas.DirectionUplink, ue.sc)
+	if err != nil {
+		t.Fatalf("protect SECURITY MODE COMPLETE: %v", err)
+	}
+
+	if _, err := DecodeNASMessage(ue, wire); err != nil {
+		t.Fatalf("DecodeNASMessage(SECURITY MODE COMPLETE, new-context header type) = %v, want it accepted", err)
+	}
+
+	if !ue.Conn().CipheringStarted() {
+		t.Error("a ciphered SECURITY MODE COMPLETE did not start ciphering on the connection")
+	}
+}
+
+// TS 24.501 §5.4.2.3, §4.4.6, table 9.3.1
+func TestDecodeNASMessageDiscardsASecurityModeCompleteWithoutTheNewContextHeaderType(t *testing.T) {
+	ue := newSecuredUE(t)
+	ue.SetULCountForTest(0)
+
+	if _, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainRegistrationRequest(t), 0)); err != nil {
+		t.Fatalf("initial NAS message not accepted: %v", err)
+	}
+
+	if ue.Conn().CipheringStarted() {
+		t.Fatal("the AMF counts itself as ciphering before it has replied to the UE")
+	}
+
+	res, err := DecodeNASMessage(ue, wrapIntegrityProtected(t, ue, encodePlainSecurityModeComplete(t), 1))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE COMPLETE) = %+v, nil, want it discarded: it would carry the replayed initial NAS message in the clear", res)
 	}
 }
 

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -47,6 +47,40 @@ func cipheringRequired(mt fgs.MessageType) bool {
 	return true
 }
 
+// admissibleBeforeCipheringFor reports whether plain is a message the UE may
+// still send unciphered while the AMF has not yet started ciphering on this
+// connection.
+//
+// The window exists because TS 24.501 §4.4.5 starts the AMF's ciphering "as
+// described in subclause 4.4.2.5", and §4.4.2.5 has the AMF re-establish the
+// secure exchange by replying ciphered or by completing a security mode control
+// procedure — so between a verified initial NAS message and that reply, neither
+// end is ciphering yet. What the UE legitimately sends in that window is the
+// answers to the common procedures the AMF runs there, SECURITY MODE REJECT
+// among them (§5.4.2.5, which the AMF must act on by stopping T3560 and
+// aborting the triggering procedure). Anything else that should have been
+// ciphered is still discarded, so the window admits no ordinary signalling.
+func admissibleBeforeCipheringFor(plain []byte) bool {
+	mt, err := fgs.PeekMessageType(plain)
+	if err != nil {
+		return false
+	}
+
+	switch mt {
+	case fgs.MsgSecurityModeReject,
+		fgs.MsgSecurityModeComplete,
+		fgs.MsgAuthenticationResponse,
+		fgs.MsgAuthenticationFailure,
+		fgs.MsgIdentityResponse,
+		fgs.MsgGMMStatus,
+		fgs.MsgDeregistrationRequestUEOrig,
+		fgs.MsgDeregistrationAcceptUETerm:
+		return true
+	}
+
+	return false
+}
+
 // plainNasAllowed reports whether a NAS message type may be processed without a verified
 // MAC before secure exchange (TS 24.501 §4.4.4.3, TS 33.501) — either sent as plain NAS,
 // or received integrity-protected with a failed MAC. SERVICE REQUEST is on the spec's

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -47,25 +47,13 @@ func cipheringRequired(mt fgs.MessageType) bool {
 	return true
 }
 
-func admissibleBeforeCipheringFor(plain []byte) bool {
+func requiresNewContextSecurityHeader(plain []byte) bool {
 	mt, err := fgs.PeekMessageType(plain)
 	if err != nil {
 		return false
 	}
 
-	switch mt {
-	case fgs.MsgSecurityModeReject,
-		fgs.MsgSecurityModeComplete,
-		fgs.MsgAuthenticationResponse,
-		fgs.MsgAuthenticationFailure,
-		fgs.MsgIdentityResponse,
-		fgs.MsgGMMStatus,
-		fgs.MsgDeregistrationRequestUEOrig,
-		fgs.MsgDeregistrationAcceptUETerm:
-		return true
-	}
-
-	return false
+	return mt == fgs.MsgSecurityModeComplete
 }
 
 // plainNasAllowed reports whether a NAS message type may be processed without a verified

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -47,19 +47,6 @@ func cipheringRequired(mt fgs.MessageType) bool {
 	return true
 }
 
-// admissibleBeforeCipheringFor reports whether plain is a message the UE may
-// still send unciphered while the AMF has not yet started ciphering on this
-// connection.
-//
-// The window exists because TS 24.501 §4.4.5 starts the AMF's ciphering "as
-// described in subclause 4.4.2.5", and §4.4.2.5 has the AMF re-establish the
-// secure exchange by replying ciphered or by completing a security mode control
-// procedure — so between a verified initial NAS message and that reply, neither
-// end is ciphering yet. What the UE legitimately sends in that window is the
-// answers to the common procedures the AMF runs there, SECURITY MODE REJECT
-// among them (§5.4.2.5, which the AMF must act on by stopping T3560 and
-// aborting the triggering procedure). Anything else that should have been
-// ciphered is still discarded, so the window admits no ordinary signalling.
 func admissibleBeforeCipheringFor(plain []byte) bool {
 	mt, err := fgs.PeekMessageType(plain)
 	if err != nil {

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -57,7 +57,13 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 					smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 					if !ok {
-						logger.WithTrace(ctx, ueConn.Log).Debug("no SM context for a PDU session the NG-RAN node reported; it is already released",
+						// Routine when the session has already gone — moved to EPS in an
+						// inter-system change, or released while this request was in
+						// flight — and a genuine divergence when the NG-RAN node is
+						// holding a session the AMF never did. The AMF cannot tell the
+						// two apart here, so it says only what it knows and leaves the
+						// signal visible.
+						logger.WithTrace(ctx, ueConn.Log).Warn("no SM context for a PDU session the NG-RAN node reported as established",
 							zap.Uint8("PduSessionID", pduSessionID))
 
 						continue

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -57,12 +57,6 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 					smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 					if !ok {
-						// Routine when the session has already gone — moved to EPS in an
-						// inter-system change, or released while this request was in
-						// flight — and a genuine divergence when the NG-RAN node is
-						// holding a session the AMF never did. The AMF cannot tell the
-						// two apart here, so it says only what it knows and leaves the
-						// signal visible.
 						logger.WithTrace(ctx, ueConn.Log).Warn("no SM context for a PDU session the NG-RAN node reported as established",
 							zap.Uint8("PduSessionID", pduSessionID))
 

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -57,7 +57,9 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 					smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 					if !ok {
-						logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+						logger.WithTrace(ctx, ueConn.Log).Debug("no SM context for a PDU session the NG-RAN node reported; it is already released",
+							zap.Uint8("PduSessionID", pduSessionID))
+
 						continue
 					}
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -94,17 +94,6 @@ type UeConn struct {
 	// integrity protected or fails the check.
 	secureExchangeEstablished bool
 
-	// cipheringStarted records that the AMF has started ciphering and deciphering
-	// on this connection, which TS 24.501 §4.4.5 defers to §4.4.2.5: the AMF
-	// re-establishes the secure exchange by replying to the initial NAS message
-	// ciphered, or by completing a security mode control procedure — not by
-	// receiving that initial message. Until then the UE has not started ciphering
-	// either (its initial NAS message is integrity protected only, §4.4.6), so a
-	// message that arrives unciphered before this is set is not the "unciphered
-	// message which shall have been ciphered" §4.4.5 has the receiver discard.
-	//
-	// Written from the downlink send path and read from NAS decode, which are not
-	// the same goroutine, so it is atomic.
 	cipheringStarted atomic.Bool
 
 	AuthenticationCtx *ausf.AuthResult
@@ -124,51 +113,25 @@ type UeConn struct {
 	IdentityTypeUsedForRegistration   uint8
 	RetransmissionOfInitialNASMsg     bool
 
-	// EPSArrival is non-nil when the registration in progress is an inter-system
-	// change from EPS. Like the fields above it is registration-scoped: reset
-	// when a REGISTRATION REQUEST is taken in, so nothing it records can outlive
-	// the procedure that established it and be read by the next one.
 	EPSArrival *EPSArrival
 
 	RegistrationAcceptPlain []byte
 }
 
-// EPSArrival is what the AMF learns about an inter-system change from EPS while
-// the registration that carries it is running (TS 24.501 §4.4.2.5, §5.5.1.3).
-// Its presence is the fact "this registration is an arrival from EPS"; the
-// fields are the two things that differ between arrivals.
 type EPSArrival struct {
-	// Sessions are the PDN connections the MME handed over for the AMF to adopt.
-	// Nil for a handover arrival, whose sessions come across in the relocation
-	// instead, and nilled once adopted. It stays a pointer so an idle arrival
-	// that moves no session is still distinguishable from a handover: it owes
-	// the MME an identity commit and a context acknowledgement either way.
 	Sessions *interworking.ArrivingSessions
 
-	// MappedSecurityContext records that the AMF mapped the EPS security context
-	// onto 5GS for this arrival (§4.4.2.5 case b), so the security mode control
-	// procedure still has to take it into use. It is false when the AMF resumed
-	// on the UE's own native context (case a), which is current at both ends
-	// already — commanding that one into use again would restart NAS COUNTs
-	// §5.4.2.2 does not allow to be restarted.
 	MappedSecurityContext bool
 }
 
-// ArrivedFromEPS reports whether the registration in progress is an
-// inter-system change from EPS.
 func (ueConn *UeConn) ArrivedFromEPS() bool {
 	return ueConn != nil && ueConn.EPSArrival != nil
 }
 
-// MappedContextFromEPS reports whether this registration mapped the EPS
-// security context onto 5GS, which the security mode control procedure has to
-// take into use (TS 24.501 §4.4.2.5 case b).
 func (ueConn *UeConn) MappedContextFromEPS() bool {
 	return ueConn.ArrivedFromEPS() && ueConn.EPSArrival.MappedSecurityContext
 }
 
-// ArrivingSessions returns the PDN connections still waiting to be adopted, or
-// nil when there are none or this is not an arrival from EPS.
 func (a *EPSArrival) ArrivingSessions() *interworking.ArrivingSessions {
 	if a == nil {
 		return nil
@@ -404,8 +367,6 @@ func (ueConn *UeConn) MarkSecureExchangeEstablished() {
 	}
 }
 
-// CipheringStarted reports whether the AMF has started ciphering and deciphering
-// on this connection (TS 24.501 §4.4.5, §4.4.2.5).
 func (ueConn *UeConn) CipheringStarted() bool {
 	if ueConn == nil {
 		return false
@@ -414,9 +375,6 @@ func (ueConn *UeConn) CipheringStarted() bool {
 	return ueConn.cipheringStarted.Load()
 }
 
-// MarkCipheringStarted records that the AMF has re-established the secure
-// exchange of NAS messages on this connection, so from now on a message that
-// should have been ciphered and was not is discarded (TS 24.501 §4.4.5).
 func (ueConn *UeConn) MarkCipheringStarted() {
 	if ueConn != nil {
 		ueConn.cipheringStarted.Store(true)

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -94,6 +94,19 @@ type UeConn struct {
 	// integrity protected or fails the check.
 	secureExchangeEstablished bool
 
+	// cipheringStarted records that the AMF has started ciphering and deciphering
+	// on this connection, which TS 24.501 §4.4.5 defers to §4.4.2.5: the AMF
+	// re-establishes the secure exchange by replying to the initial NAS message
+	// ciphered, or by completing a security mode control procedure — not by
+	// receiving that initial message. Until then the UE has not started ciphering
+	// either (its initial NAS message is integrity protected only, §4.4.6), so a
+	// message that arrives unciphered before this is set is not the "unciphered
+	// message which shall have been ciphered" §4.4.5 has the receiver discard.
+	//
+	// Written from the downlink send path and read from NAS decode, which are not
+	// the same goroutine, so it is atomic.
+	cipheringStarted atomic.Bool
+
 	AuthenticationCtx *ausf.AuthResult
 	// resyncTried records whether an SQN re-synchronisation (AUTS) has been attempted
 	// this authentication exchange: the first synch failure resyncs, a second rejects
@@ -111,12 +124,57 @@ type UeConn struct {
 	IdentityTypeUsedForRegistration   uint8
 	RetransmissionOfInitialNASMsg     bool
 
-	ArrivedFromEPS  bool
-	ArrivingFromEPS *interworking.ArrivingSessions
-
-	MappedContextFromEPS bool
+	// EPSArrival is non-nil when the registration in progress is an inter-system
+	// change from EPS. Like the fields above it is registration-scoped: reset
+	// when a REGISTRATION REQUEST is taken in, so nothing it records can outlive
+	// the procedure that established it and be read by the next one.
+	EPSArrival *EPSArrival
 
 	RegistrationAcceptPlain []byte
+}
+
+// EPSArrival is what the AMF learns about an inter-system change from EPS while
+// the registration that carries it is running (TS 24.501 §4.4.2.5, §5.5.1.3).
+// Its presence is the fact "this registration is an arrival from EPS"; the
+// fields are the two things that differ between arrivals.
+type EPSArrival struct {
+	// Sessions are the PDN connections the MME handed over for the AMF to adopt.
+	// Nil for a handover arrival, whose sessions come across in the relocation
+	// instead, and nilled once adopted. It stays a pointer so an idle arrival
+	// that moves no session is still distinguishable from a handover: it owes
+	// the MME an identity commit and a context acknowledgement either way.
+	Sessions *interworking.ArrivingSessions
+
+	// MappedSecurityContext records that the AMF mapped the EPS security context
+	// onto 5GS for this arrival (§4.4.2.5 case b), so the security mode control
+	// procedure still has to take it into use. It is false when the AMF resumed
+	// on the UE's own native context (case a), which is current at both ends
+	// already — commanding that one into use again would restart NAS COUNTs
+	// §5.4.2.2 does not allow to be restarted.
+	MappedSecurityContext bool
+}
+
+// ArrivedFromEPS reports whether the registration in progress is an
+// inter-system change from EPS.
+func (ueConn *UeConn) ArrivedFromEPS() bool {
+	return ueConn != nil && ueConn.EPSArrival != nil
+}
+
+// MappedContextFromEPS reports whether this registration mapped the EPS
+// security context onto 5GS, which the security mode control procedure has to
+// take into use (TS 24.501 §4.4.2.5 case b).
+func (ueConn *UeConn) MappedContextFromEPS() bool {
+	return ueConn.ArrivedFromEPS() && ueConn.EPSArrival.MappedSecurityContext
+}
+
+// ArrivingSessions returns the PDN connections still waiting to be adopted, or
+// nil when there are none or this is not an arrival from EPS.
+func (a *EPSArrival) ArrivingSessions() *interworking.ArrivingSessions {
+	if a == nil {
+		return nil
+	}
+
+	return a.Sessions
 }
 
 // Parent returns the UeContext this connection is bound to, or nil when bare.
@@ -343,6 +401,25 @@ func (ueConn *UeConn) SecureExchangeEstablished() bool {
 func (ueConn *UeConn) MarkSecureExchangeEstablished() {
 	if ueConn != nil {
 		ueConn.secureExchangeEstablished = true
+	}
+}
+
+// CipheringStarted reports whether the AMF has started ciphering and deciphering
+// on this connection (TS 24.501 §4.4.5, §4.4.2.5).
+func (ueConn *UeConn) CipheringStarted() bool {
+	if ueConn == nil {
+		return false
+	}
+
+	return ueConn.cipheringStarted.Load()
+}
+
+// MarkCipheringStarted records that the AMF has re-established the secure
+// exchange of NAS messages on this connection, so from now on a message that
+// should have been ciphered and was not is discarded (TS 24.501 §4.4.5).
+func (ueConn *UeConn) MarkCipheringStarted() {
+	if ueConn != nil {
+		ueConn.cipheringStarted.Store(true)
 	}
 }
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -114,6 +114,8 @@ type UeConn struct {
 	ArrivedFromEPS  bool
 	ArrivingFromEPS *interworking.ArrivingSessions
 
+	MappedContextFromEPS bool
+
 	RegistrationAcceptPlain []byte
 }
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -121,15 +121,15 @@ type UeConn struct {
 type EPSArrival struct {
 	Sessions *interworking.ArrivingSessions
 
-	MappedSecurityContext bool
+	NeedsSecurityModeControl bool
 }
 
 func (ueConn *UeConn) ArrivedFromEPS() bool {
 	return ueConn != nil && ueConn.EPSArrival != nil
 }
 
-func (ueConn *UeConn) MappedContextFromEPS() bool {
-	return ueConn.ArrivedFromEPS() && ueConn.EPSArrival.MappedSecurityContext
+func (ueConn *UeConn) ArrivalNeedsSecurityModeControl() bool {
+	return ueConn.ArrivedFromEPS() && ueConn.EPSArrival.NeedsSecurityModeControl
 }
 
 func (a *EPSArrival) ArrivingSessions() *interworking.ArrivingSessions {

--- a/internal/mme/decode_nas_message.go
+++ b/internal/mme/decode_nas_message.go
@@ -108,10 +108,15 @@ func DecodeNASMessage(ue *UeContext, nas []byte) (*DecodeResult, error) {
 	// is dropped (TS 24.301).
 	p, count, err := ue.TryUnprotectUplink(nas)
 	if err == nil {
-		// connSecured is per connection, leaving the initial NAS message of a new
-		// one outside this guard.
-		if connSecured && spm.SecurityHeaderType == eps.SHTIntegrityProtected && cipheringRequiredFor(p) &&
-			(conn.CipheringStarted() || !admissibleBeforeCipheringFor(p)) {
+		if requiresNewContextSecurityHeader(p) && spm.SecurityHeaderType != eps.SHTIntegrityProtectedCipheredNewContext {
+			logger.MmeLog.Warn("discarding SECURITY MODE COMPLETE sent without the new-context security header type",
+				zap.String("imsi", ue.IMSI()))
+
+			return nil, silentDecode(nasreply.ReasonIntegrityFail,
+				"NAS discarded: SECURITY MODE COMPLETE without the new-context security header type (TS 24.301 §5.4.3.3)")
+		}
+
+		if conn.CipheringStarted() && spm.SecurityHeaderType == eps.SHTIntegrityProtected && cipheringRequiredFor(p) {
 			logger.MmeLog.Warn("discarding unciphered NAS message received after ciphering started",
 				zap.String("imsi", ue.IMSI()))
 

--- a/internal/mme/decode_nas_message.go
+++ b/internal/mme/decode_nas_message.go
@@ -110,7 +110,8 @@ func DecodeNASMessage(ue *UeContext, nas []byte) (*DecodeResult, error) {
 	if err == nil {
 		// connSecured is per connection, leaving the initial NAS message of a new
 		// one outside this guard.
-		if connSecured && spm.SecurityHeaderType == eps.SHTIntegrityProtected && cipheringRequiredFor(p) {
+		if connSecured && spm.SecurityHeaderType == eps.SHTIntegrityProtected && cipheringRequiredFor(p) &&
+			(conn.CipheringStarted() || !admissibleBeforeCipheringFor(p)) {
 			logger.MmeLog.Warn("discarding unciphered NAS message received after ciphering started",
 				zap.String("imsi", ue.IMSI()))
 
@@ -122,6 +123,10 @@ func DecodeNASMessage(ue *UeContext, nas []byte) (*DecodeResult, error) {
 		// First verified message establishes secure exchange on the connection (TS 24.301 §4.4.4.3).
 		if conn != nil {
 			conn.MarkSecureExchangeEstablished()
+
+			if spm.SecurityHeaderType.Ciphered() {
+				conn.MarkCipheringStarted()
+			}
 		}
 
 		return &DecodeResult{Plain: p, IntegrityVerified: true}, nil

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -505,7 +505,7 @@ func TestAttachAuthenticationAndSecurityMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	smCompleteWire, err := eps.Protect(smCompletePlain, eps.SHTIntegrityProtectedCiphered, nas.MakeCount(0, 0), nas.DirectionUplink, mustSecurityContext(t, nas.IntegrityAES, nas.CipheringAES, knasInt, knasEnc))
+	smCompleteWire, err := eps.Protect(smCompletePlain, eps.SHTIntegrityProtectedCipheredNewContext, nas.MakeCount(0, 0), nas.DirectionUplink, mustSecurityContext(t, nas.IntegrityAES, nas.CipheringAES, knasInt, knasEnc))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mme/nas/handle_security_mode_complete.go
+++ b/internal/mme/nas/handle_security_mode_complete.go
@@ -24,6 +24,8 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 
 	ueConn.StopNASGuard()
 
+	ueConn.MarkCipheringStarted()
+
 	m.ClearKeyChainBusy(ue)
 
 	var pei etsi.IMEI

--- a/internal/mme/nas/handle_security_mode_complete.go
+++ b/internal/mme/nas/handle_security_mode_complete.go
@@ -24,8 +24,6 @@ func handleSecurityModeComplete(ctx context.Context, m *mme.MME, ue *mme.UeConte
 
 	ueConn.StopNASGuard()
 
-	ueConn.MarkCipheringStarted()
-
 	m.ClearKeyChainBusy(ue)
 
 	var pei etsi.IMEI

--- a/internal/mme/nas/handle_service_request.go
+++ b/internal/mme/nas/handle_service_request.go
@@ -69,6 +69,7 @@ func HandleServiceRequest(ctx context.Context, m *mme.MME, conn mme.S1APWriter, 
 	// outset.
 	m.AttachUeConn(ue, c)
 	c.MarkSecureExchangeEstablished()
+	c.MarkCipheringStarted()
 
 	c.ServingTAI = msg.TAI
 

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -60,7 +60,7 @@ func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pd
 
 	m.AttachUeConn(ue, conn)
 
-	conn.ArrivingFrom5GS = &interworking.ArrivingSessions{PDN: resp.PDNConnections}
+	conn.FiveGSArrival = &mme.FiveGSArrival{Sessions: &interworking.ArrivingSessions{PDN: resp.PDNConnections}}
 
 	logger.From(ctx, logger.MmeLog).Info("recovered the UE's context from 5GS for an idle-mode change",
 		zap.String("imsi", ue.IMSI()), zap.Int("pdu-sessions", len(resp.PDNConnections)))
@@ -80,7 +80,7 @@ func remapHeldContext(ctx context.Context, m *mme.MME, held *mme.UeContext, conn
 
 	m.AttachUeConn(held, conn)
 
-	conn.RemappedFrom5GS = true
+	conn.FiveGSArrival = &mme.FiveGSArrival{RemappedHeldContext: true}
 
 	logger.From(ctx, logger.MmeLog).Info("re-keyed a held context for an inter-system change the UE repeated",
 		zap.String("imsi", held.IMSI()))
@@ -109,7 +109,7 @@ func unprotectedBody(pdu []byte) ([]byte, bool) {
 }
 
 func adoptIdlePDNsFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn) {
-	arriving := ueConn.ArrivingFrom5GS
+	arriving := ueConn.FiveGSArrival.ArrivingSessions()
 	if arriving == nil {
 		return
 	}
@@ -130,25 +130,28 @@ func adoptIdlePDNsFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ue
 func completeIdleMobilityFrom5GS(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 	plain []byte,
 ) (answered bool) {
-	if ueConn.RemappedFrom5GS {
-		ueConn.RemappedFrom5GS = false
+	arrival := ueConn.FiveGSArrival
+	if arrival == nil {
+		return false
+	}
 
+	ueConn.FiveGSArrival = nil
+
+	if arrival.RemappedHeldContext {
 		return changeNASAlgorithmsForMappedContext(ctx, m, ue, ueConn, plain,
 			interworking.EPSNASAlgorithms{Ciphering: ue.EEA(), Integrity: ue.EIA()})
 	}
 
-	arriving := ueConn.ArrivingFrom5GS
-	if arriving == nil {
-		return false
+	var offered int
+	if arrival.Sessions != nil {
+		offered = len(arrival.Sessions.PDN)
 	}
-
-	ueConn.ArrivingFrom5GS = nil
 
 	transferred := heldPDUSessions(m, ue)
 
 	if len(transferred) == 0 {
 		logger.From(ctx, logger.MmeLog).Info("no PDU session of a UE arriving from 5GS could become a PDN connection; rejecting the update",
-			zap.String("imsi", ue.IMSI()), zap.Int("offered", len(arriving.PDN)))
+			zap.String("imsi", ue.IMSI()), zap.Int("offered", offered))
 
 		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseNoEPSBearerContextActivated)
 

--- a/internal/mme/nas/idle_mobility_from_5gs_test.go
+++ b/internal/mme/nas/idle_mobility_from_5gs_test.go
@@ -680,7 +680,7 @@ func TestAnArrivalWithNoSessionsIsStillAnArrival(t *testing.T) {
 
 	dispositionForNAS(context.Background(), m, conn, interSystemTAU(t, nil))
 
-	if conn.ArrivingFrom5GS != nil {
+	if conn.ArrivedFrom5GS() {
 		t.Error("the arriving context outlived the update")
 	}
 

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -173,6 +173,7 @@ func handleTrackingAreaUpdateComplete(ctx context.Context, m *mme.MME, ue *mme.U
 
 	ueConn.TauRequestPlain = nil
 	ueConn.TauAcceptPlain = nil
+	ueConn.FiveGSArrival = nil
 
 	logger.From(ctx, logger.MmeLog).Info("Tracking Area Update Complete", zap.String("imsi", ue.IMSI()))
 

--- a/internal/mme/nas_ciphering_window_test.go
+++ b/internal/mme/nas_ciphering_window_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-func uplinkOn(t *testing.T, ue *UeContext, plain []byte, sht eps.SecurityHeaderType, sqn uint8) []byte {
+func uplinkOn(t *testing.T, ue *UeContext, plain []byte, sht eps.SecurityHeaderType) []byte {
 	t.Helper()
 
 	sc := mustSecurityContext(t, ue.EIA(), ue.EEA(), ue.KnasIntForTest(), ue.KnasEncForTest())
 
-	wire, err := eps.Protect(plain, sht, nas.MakeCount(0, sqn), nas.DirectionUplink, sc)
+	wire, err := eps.Protect(plain, sht, nas.MakeCount(0, 0), nas.DirectionUplink, sc)
 	if err != nil {
 		t.Fatalf("protect uplink message: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringSta
 		t.Fatal("the MME counts itself as ciphering before it has replied to the UE")
 	}
 
-	if _, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeReject(t), eps.SHTIntegrityProtected, 0)); err != nil {
+	if _, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeReject(t), eps.SHTIntegrityProtected)); err != nil {
 		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %v, want it accepted so the MME can abort the procedure", err)
 	}
 }
@@ -57,8 +57,89 @@ func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringSta
 	ue.Conn().SetSecureExchangeEstablishedForTest(true)
 	ue.Conn().MarkCipheringStarted()
 
-	res, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeReject(t), eps.SHTIntegrityProtected, 0))
+	res, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeReject(t), eps.SHTIntegrityProtected))
 	if err == nil {
 		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %+v, nil, want it discarded once ciphering started", res)
 	}
+}
+
+func encodePlainEPSSecurityModeComplete(t *testing.T) []byte {
+	t.Helper()
+
+	payload, err := (&eps.SecurityModeComplete{}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode plain SecurityModeComplete: %v", err)
+	}
+
+	return payload
+}
+
+// TS 24.301 §5.4.3.3, table 9.3.1
+func TestDecodeNASMessageAcceptsASecurityModeCompleteWithTheNewContextHeaderType(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+
+	if _, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeComplete(t), eps.SHTIntegrityProtectedCipheredNewContext)); err != nil {
+		t.Fatalf("DecodeNASMessage(SECURITY MODE COMPLETE, new-context header type) = %v, want it accepted", err)
+	}
+
+	if !ue.Conn().CipheringStarted() {
+		t.Error("a ciphered SECURITY MODE COMPLETE did not start ciphering on the connection")
+	}
+}
+
+// TS 24.301 §5.4.3.3, table 9.3.1
+func TestDecodeNASMessageDiscardsASecurityModeCompleteWithoutTheNewContextHeaderType(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+
+	if ue.Conn().CipheringStarted() {
+		t.Fatal("the MME counts itself as ciphering before it has replied to the UE")
+	}
+
+	res, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeComplete(t), eps.SHTIntegrityProtected))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE COMPLETE) = %+v, nil, want it discarded (TS 24.301 §5.4.3.3)", res)
+	}
+}
+
+// TS 24.301 §4.4.2.3, §4.4.5
+func TestDecodeNASMessageAcceptsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+
+	if _, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSEMMStatus(t), eps.SHTIntegrityProtected)); err != nil {
+		t.Fatalf("DecodeNASMessage(unciphered EMM STATUS) = %v, want it accepted before the MME has replied ciphered", err)
+	}
+}
+
+// TS 24.301 §4.4.5
+func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingAfterCipheringStarts(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+	ue.Conn().MarkCipheringStarted()
+
+	res, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSEMMStatus(t), eps.SHTIntegrityProtected))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered EMM STATUS) = %+v, nil, want it discarded once ciphering started", res)
+	}
+}
+
+func encodePlainEPSEMMStatus(t *testing.T) []byte {
+	t.Helper()
+
+	payload, err := (&eps.EMMStatus{Cause: eps.EMMCauseMessageNotCompatible}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode plain EMMStatus: %v", err)
+	}
+
+	return payload
 }

--- a/internal/mme/nas_ciphering_window_test.go
+++ b/internal/mme/nas_ciphering_window_test.go
@@ -34,7 +34,59 @@ func encodePlainEPSSecurityModeReject(t *testing.T) []byte {
 	return payload
 }
 
+func encodePlainEPSSecurityModeComplete(t *testing.T) []byte {
+	t.Helper()
+
+	payload, err := (&eps.SecurityModeComplete{}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode plain SecurityModeComplete: %v", err)
+	}
+
+	return payload
+}
+
+func encodePlainEPSEMMStatus(t *testing.T) []byte {
+	t.Helper()
+
+	payload, err := (&eps.EMMStatus{Cause: eps.EMMCauseMessageNotCompatible}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode plain EMMStatus: %v", err)
+	}
+
+	return payload
+}
+
+// TS 24.301 §4.4.2.3, §4.4.5
+func TestDecodeNASMessageAcceptsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+
+	if ue.Conn().CipheringStarted() {
+		t.Fatal("the MME counts itself as ciphering before it has replied to the UE")
+	}
+
+	if _, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSEMMStatus(t), eps.SHTIntegrityProtected)); err != nil {
+		t.Fatalf("DecodeNASMessage(unciphered EMM STATUS) = %v, want it accepted before the MME has replied ciphered", err)
+	}
+}
+
 // TS 24.301 §4.4.5
+func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingAfterCipheringStarts(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+	ue.Conn().MarkCipheringStarted()
+
+	res, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSEMMStatus(t), eps.SHTIntegrityProtected))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered EMM STATUS) = %+v, nil, want it discarded once ciphering started", res)
+	}
+}
+
+// TS 24.301 §4.4.2.3, §4.4.5, §5.4.3.5
 func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringStarts(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -50,6 +102,7 @@ func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringSta
 	}
 }
 
+// TS 24.301 §4.4.5, §5.4.3.5
 func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringStarts(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -61,17 +114,6 @@ func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringSta
 	if err == nil {
 		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %+v, nil, want it discarded once ciphering started", res)
 	}
-}
-
-func encodePlainEPSSecurityModeComplete(t *testing.T) []byte {
-	t.Helper()
-
-	payload, err := (&eps.SecurityModeComplete{}).MarshalBinary()
-	if err != nil {
-		t.Fatalf("encode plain SecurityModeComplete: %v", err)
-	}
-
-	return payload
 }
 
 // TS 24.301 §5.4.3.3, table 9.3.1
@@ -105,41 +147,4 @@ func TestDecodeNASMessageDiscardsASecurityModeCompleteWithoutTheNewContextHeader
 	if err == nil {
 		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE COMPLETE) = %+v, nil, want it discarded (TS 24.301 §5.4.3.3)", res)
 	}
-}
-
-// TS 24.301 §4.4.2.3, §4.4.5
-func TestDecodeNASMessageAcceptsUncipheredOrdinarySignallingBeforeCipheringStarts(t *testing.T) {
-	m := newTestMME(t)
-	ue, _ := securedUE(t, m)
-
-	ue.Conn().SetSecureExchangeEstablishedForTest(true)
-
-	if _, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSEMMStatus(t), eps.SHTIntegrityProtected)); err != nil {
-		t.Fatalf("DecodeNASMessage(unciphered EMM STATUS) = %v, want it accepted before the MME has replied ciphered", err)
-	}
-}
-
-// TS 24.301 §4.4.5
-func TestDecodeNASMessageDiscardsUncipheredOrdinarySignallingAfterCipheringStarts(t *testing.T) {
-	m := newTestMME(t)
-	ue, _ := securedUE(t, m)
-
-	ue.Conn().SetSecureExchangeEstablishedForTest(true)
-	ue.Conn().MarkCipheringStarted()
-
-	res, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSEMMStatus(t), eps.SHTIntegrityProtected))
-	if err == nil {
-		t.Fatalf("DecodeNASMessage(unciphered EMM STATUS) = %+v, nil, want it discarded once ciphering started", res)
-	}
-}
-
-func encodePlainEPSEMMStatus(t *testing.T) []byte {
-	t.Helper()
-
-	payload, err := (&eps.EMMStatus{Cause: eps.EMMCauseMessageNotCompatible}).MarshalBinary()
-	if err != nil {
-		t.Fatalf("encode plain EMMStatus: %v", err)
-	}
-
-	return payload
 }

--- a/internal/mme/nas_ciphering_window_test.go
+++ b/internal/mme/nas_ciphering_window_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+func uplinkOn(t *testing.T, ue *UeContext, plain []byte, sht eps.SecurityHeaderType, sqn uint8) []byte {
+	t.Helper()
+
+	sc := mustSecurityContext(t, ue.EIA(), ue.EEA(), ue.KnasIntForTest(), ue.KnasEncForTest())
+
+	wire, err := eps.Protect(plain, sht, nas.MakeCount(0, sqn), nas.DirectionUplink, sc)
+	if err != nil {
+		t.Fatalf("protect uplink message: %v", err)
+	}
+
+	return wire
+}
+
+func encodePlainEPSSecurityModeReject(t *testing.T) []byte {
+	t.Helper()
+
+	payload, err := (&eps.SecurityModeReject{Cause: eps.EMMCauseSecurityModeRejectedUnspecified}).MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode plain SecurityModeReject: %v", err)
+	}
+
+	return payload
+}
+
+// TS 24.301 §4.4.5
+func TestDecodeNASMessageAcceptsAnUncipheredSecurityModeRejectBeforeCipheringStarts(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+
+	if ue.Conn().CipheringStarted() {
+		t.Fatal("the MME counts itself as ciphering before it has replied to the UE")
+	}
+
+	if _, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeReject(t), eps.SHTIntegrityProtected, 0)); err != nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %v, want it accepted so the MME can abort the procedure", err)
+	}
+}
+
+func TestDecodeNASMessageDiscardsAnUncipheredSecurityModeRejectAfterCipheringStarts(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+
+	ue.Conn().SetSecureExchangeEstablishedForTest(true)
+	ue.Conn().MarkCipheringStarted()
+
+	res, err := DecodeNASMessage(ue, uplinkOn(t, ue, encodePlainEPSSecurityModeReject(t), eps.SHTIntegrityProtected, 0))
+	if err == nil {
+		t.Fatalf("DecodeNASMessage(unciphered SECURITY MODE REJECT) = %+v, nil, want it discarded once ciphering started", res)
+	}
+}

--- a/internal/mme/nas_classify.go
+++ b/internal/mme/nas_classify.go
@@ -29,25 +29,13 @@ func cipheringRequired(mt eps.MessageType) bool {
 	return true
 }
 
-func admissibleBeforeCipheringFor(plain []byte) bool {
+func requiresNewContextSecurityHeader(plain []byte) bool {
 	mt, err := eps.PeekMessageType(plain)
 	if err != nil {
 		return false
 	}
 
-	switch mt {
-	case eps.MsgSecurityModeReject,
-		eps.MsgSecurityModeComplete,
-		eps.MsgAuthenticationResponse,
-		eps.MsgAuthenticationFailure,
-		eps.MsgIdentityResponse,
-		eps.MsgEMMStatus,
-		eps.MsgDetachRequest,
-		eps.MsgDetachAccept:
-		return true
-	}
-
-	return false
+	return mt == eps.MsgSecurityModeComplete
 }
 
 // plainNasAllowed reports whether an EMM message may be processed without a verified

--- a/internal/mme/nas_classify.go
+++ b/internal/mme/nas_classify.go
@@ -29,6 +29,27 @@ func cipheringRequired(mt eps.MessageType) bool {
 	return true
 }
 
+func admissibleBeforeCipheringFor(plain []byte) bool {
+	mt, err := eps.PeekMessageType(plain)
+	if err != nil {
+		return false
+	}
+
+	switch mt {
+	case eps.MsgSecurityModeReject,
+		eps.MsgSecurityModeComplete,
+		eps.MsgAuthenticationResponse,
+		eps.MsgAuthenticationFailure,
+		eps.MsgIdentityResponse,
+		eps.MsgEMMStatus,
+		eps.MsgDetachRequest,
+		eps.MsgDetachAccept:
+		return true
+	}
+
+	return false
+}
+
 // plainNasAllowed reports whether an EMM message may be processed without a verified
 // MAC before secure exchange is established (TS 24.301 §4.4.4.3) — either sent as plain
 // NAS, or received integrity-protected with a failed MAC. The spec's plain and

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -51,13 +51,30 @@ type UeConn struct {
 	TauRequestPlain           []byte
 	TauAcceptPlain            []byte
 	TauReleaseOnComplete      bool
-	ArrivingFrom5GS           *interworking.ArrivingSessions
-	RemappedFrom5GS           bool
-	DeferredTAUPlain          []byte
-	nasGuard                  guard.Guard
-	nasGuardName              string
-	esmInfoGuard              guard.Guard
-	releaseGuard              guard.Guard
+	FiveGSArrival    *FiveGSArrival
+	DeferredTAUPlain []byte
+	nasGuard         guard.Guard
+	nasGuardName     string
+	esmInfoGuard     guard.Guard
+	releaseGuard     guard.Guard
+}
+
+type FiveGSArrival struct {
+	Sessions *interworking.ArrivingSessions
+
+	RemappedHeldContext bool
+}
+
+func (c *UeConn) ArrivedFrom5GS() bool {
+	return c != nil && c.FiveGSArrival != nil
+}
+
+func (a *FiveGSArrival) ArrivingSessions() *interworking.ArrivingSessions {
+	if a == nil {
+		return nil
+	}
+
+	return a.Sessions
 }
 
 // StopReleaseGuard cancels the Release-Complete supervision timer. Nil-safe.

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -43,6 +43,7 @@ type UeConn struct {
 	m                         *MME
 	ICS                       ICSState
 	secureExchangeEstablished bool
+	cipheringStarted          atomic.Bool
 	AuthVector                *udm.EPSAV
 	resyncTried               bool
 	AttachRequestPlain        []byte
@@ -105,5 +106,19 @@ func (c *UeConn) SecureExchangeEstablished() bool {
 func (c *UeConn) MarkSecureExchangeEstablished() {
 	if c != nil {
 		c.secureExchangeEstablished = true
+	}
+}
+
+func (c *UeConn) CipheringStarted() bool {
+	if c == nil {
+		return false
+	}
+
+	return c.cipheringStarted.Load()
+}
+
+func (c *UeConn) MarkCipheringStarted() {
+	if c != nil {
+		c.cipheringStarted.Store(true)
 	}
 }

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -51,12 +51,12 @@ type UeConn struct {
 	TauRequestPlain           []byte
 	TauAcceptPlain            []byte
 	TauReleaseOnComplete      bool
-	FiveGSArrival    *FiveGSArrival
-	DeferredTAUPlain []byte
-	nasGuard         guard.Guard
-	nasGuardName     string
-	esmInfoGuard     guard.Guard
-	releaseGuard     guard.Guard
+	FiveGSArrival             *FiveGSArrival
+	DeferredTAUPlain          []byte
+	nasGuard                  guard.Guard
+	nasGuardName              string
+	esmInfoGuard              guard.Guard
+	releaseGuard              guard.Guard
 }
 
 type FiveGSArrival struct {

--- a/internal/mme/send.go
+++ b/internal/mme/send.go
@@ -29,7 +29,15 @@ func (c *UeConn) SendProtected(plain []byte, sht eps.SecurityHeaderType, write n
 		return nil
 	}
 
-	return c.ue.downlink().Send(plain, uint8(sht), write)
+	if err := c.ue.downlink().Send(plain, uint8(sht), write); err != nil {
+		return err
+	}
+
+	if sht.Ciphered() {
+		c.MarkCipheringStarted()
+	}
+
+	return nil
 }
 
 // SendProtectedNASTransport protects plain and sends it in a Downlink NAS

--- a/internal/mme/unciphered_esm_test.go
+++ b/internal/mme/unciphered_esm_test.go
@@ -14,6 +14,8 @@ func TestDecodeNASMessageDiscardsAnUncipheredESMMessage(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
 
+	ue.Conn().MarkCipheringStarted()
+
 	esm, err := (&eps.PDNConnectivityRequest{PTI: 1, RequestType: 1, PDNType: 1}).MarshalBinary()
 	if err != nil {
 		t.Fatalf("marshal PDN CONNECTIVITY REQUEST: %v", err)

--- a/internal/tester/s1enb/idle_mobility.go
+++ b/internal/tester/s1enb/idle_mobility.go
@@ -44,6 +44,7 @@ func (ue *UE) InstallMappedSecurityContextForIdleMobility(in IdleMobilityFrom5GS
 
 	ue.kasme = kasme
 	ue.eea, ue.eia = in.EPSCiphering, in.EPSIntegrity
+	ue.eksi = in.EKSI
 
 	if err := ue.deriveNASKeys(); err != nil {
 		return err

--- a/internal/tester/s1enb/ue.go
+++ b/internal/tester/s1enb/ue.go
@@ -245,7 +245,7 @@ func (ue *UE) handleSecurityModeCommand(wire []byte) ([]byte, error) {
 		return nil, fmt.Errorf("build Security Mode Complete: %w", err)
 	}
 
-	out, err := eps.Protect(complete, eps.SHTIntegrityProtectedCiphered,
+	out, err := eps.Protect(complete, eps.SHTIntegrityProtectedCipheredNewContext,
 		nas.MakeCount(0, ue.ulCount), nas.DirectionUplink, ue.sc)
 	if err != nil {
 		return nil, fmt.Errorf("protect Security Mode Complete: %w", err)

--- a/internal/tester/scenarios/interworking/handover.go
+++ b/internal/tester/scenarios/interworking/handover.go
@@ -256,12 +256,10 @@ func probeAfterHandover(ctx context.Context, env scenarios.Env, e *s1enb.ENB, be
 	return sessionFactsFor(ctx, env, addrs, enbTunIface, bearer.upfAddress, bearer.ulTEID, "S1-U after the handover")
 }
 
-// provisionEPSNASAlgorithms drops the UE's first NR connection and comes back
-// with a mobility registration update, which is what makes the AMF hand the UE
-// its EPS NAS algorithms. It returns the session as re-established under
-// mobilityRANUENGAPID, which is the one the datapath now runs on; every caller
-// registers on scenarios.DefaultRANUENGAPID first, so the pair of connections
-// is fixed here rather than passed in.
+// provisionEPSNASAlgorithms drops the NR connection and comes back with a
+// mobility registration update, which is what makes the AMF hand the UE its EPS
+// NAS algorithms. It returns the session as re-established under
+// mobilityRANUENGAPID, which is the one the datapath now runs on.
 func provisionEPSNASAlgorithms(gNodeB *gnb.GnodeB, u *ue.UE) (gnb.PDUSessionResult, error) {
 	sessions := []uint8{movedPDUSessionID}
 

--- a/internal/tester/scenarios/interworking/handover.go
+++ b/internal/tester/scenarios/interworking/handover.go
@@ -67,7 +67,7 @@ func runHandover5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 		return fmt.Errorf("initial registration over NR: %w", err)
 	}
 
-	moved, err := provisionEPSNASAlgorithms(gNodeB, newUE, ranUENGAPID)
+	moved, err := provisionEPSNASAlgorithms(gNodeB, newUE)
 	if err != nil {
 		return err
 	}
@@ -256,14 +256,16 @@ func probeAfterHandover(ctx context.Context, env scenarios.Env, e *s1enb.ENB, be
 	return sessionFactsFor(ctx, env, addrs, enbTunIface, bearer.upfAddress, bearer.ulTEID, "S1-U after the handover")
 }
 
-// provisionEPSNASAlgorithms drops the NR connection and comes back with a
-// mobility registration update, which is what makes the AMF hand the UE its EPS
-// NAS algorithms. It returns the session as re-established under
-// mobilityRANUENGAPID, which is the one the datapath now runs on.
-func provisionEPSNASAlgorithms(gNodeB *gnb.GnodeB, u *ue.UE, ranUENGAPID int64) (gnb.PDUSessionResult, error) {
+// provisionEPSNASAlgorithms drops the UE's first NR connection and comes back
+// with a mobility registration update, which is what makes the AMF hand the UE
+// its EPS NAS algorithms. It returns the session as re-established under
+// mobilityRANUENGAPID, which is the one the datapath now runs on; every caller
+// registers on scenarios.DefaultRANUENGAPID first, so the pair of connections
+// is fixed here rather than passed in.
+func provisionEPSNASAlgorithms(gNodeB *gnb.GnodeB, u *ue.UE) (gnb.PDUSessionResult, error) {
 	sessions := []uint8{movedPDUSessionID}
 
-	if err := gNodeB.ReleaseContext(u, ranUENGAPID, sessions, releaseTimeout); err != nil {
+	if err := gNodeB.ReleaseContext(u, int64(scenarios.DefaultRANUENGAPID), sessions, releaseTimeout); err != nil {
 		return gnb.PDUSessionResult{}, fmt.Errorf("release the connection before the mobility registration update: %w", err)
 	}
 
@@ -316,7 +318,7 @@ func runHandover5GSToEPSTargetRefuses(ctx context.Context, env scenarios.Env, _ 
 		return fmt.Errorf("initial registration over NR: %w", err)
 	}
 
-	moved, err := provisionEPSNASAlgorithms(gNodeB, newUE, ranUENGAPID)
+	moved, err := provisionEPSNASAlgorithms(gNodeB, newUE)
 	if err != nil {
 		return err
 	}

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -393,32 +393,34 @@ func runIdleRoundTripThroughEPS(ctx context.Context, env scenarios.Env, _ any) e
 		return err
 	}
 
-	epsUE, tau, err := roundTripOutboundLeg(ctx, env, gNodeB, u, before)
+	e, epsUE, tau, err := roundTripOutboundLeg(ctx, env, gNodeB, u, before)
 	if err != nil {
 		return err
 	}
 
-	return roundTripReturnLeg(ctx, env, gNodeB, u, epsUE, tau, before)
+	defer func() { _ = e.Close() }()
+
+	return roundTripReturnLeg(ctx, env, e, gNodeB, u, epsUE, tau, before)
 }
 
-func roundTripOutboundLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.GnodeB, u *ue.UE, before sessionFacts) (*s1enb.UE, *s1enb.AttachResult, error) {
+func roundTripOutboundLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.GnodeB, u *ue.UE, before sessionFacts) (*s1enb.ENB, *s1enb.UE, *s1enb.AttachResult, error) {
 	if err := goIdleOnNR(gNodeB, u); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	security, guti, err := idleMobilityMaterial(u)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	e, err := startENBOnSecondaryN3(env)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	k, opc, err := defaultKeyAndOPc()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	epsUE := e.NewUE(interworkingIMSI, k, opc)
@@ -434,21 +436,23 @@ func roundTripOutboundLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.Gn
 		Security:     security,
 	}, attachTimeout)
 	if err != nil {
-		return nil, nil, fmt.Errorf("tracking area update after the idle move to EPS: %w", err)
+		return nil, nil, nil, fmt.Errorf("tracking area update after the idle move to EPS: %w", err)
 	}
 
 	if err := assertAdoptedBearer(tau); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return epsUE, tau, nil
+	return e, epsUE, tau, nil
 }
 
-func roundTripReturnLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.GnodeB, u *ue.UE, epsUE *s1enb.UE, tau *s1enb.AttachResult, before sessionFacts) error {
+func roundTripReturnLeg(ctx context.Context, env scenarios.Env, e *s1enb.ENB, gNodeB *gnb.GnodeB,
+	u *ue.UE, epsUE *s1enb.UE, tau *s1enb.AttachResult, before sessionFacts,
+) error {
 	if tau.GUTI == nil || tau.GUTI.GUTI == nil {
 		return errors.New("the tracking area update accept assigned no GUTI to enclose in the return to 5GS")
 	}
@@ -470,7 +474,7 @@ func roundTripReturnLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.Gnod
 
 	authenticated := u.ReceivedNASGMMCount(uint8(fgs.MsgAuthenticationRequest))
 
-	if err := u.SendNativeIdleMobilityRegistration(ue.NativeIdleRegistrationOpts{
+	if err := u.SendIdleMobilityRegistration(ue.IdleRegistrationOpts{
 		RANUENGAPID:            returnRANUENGAPID,
 		MappedGUTI:             fgs.GUTIIdentity(etsi.MapGUTIEPSTo5G(*tau.GUTI.GUTI)),
 		EPSNASMessageContainer: container,
@@ -498,7 +502,52 @@ func roundTripReturnLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.Gnod
 			"the UE arrived on a native 5G NAS security context the AMF still holds", got)
 	}
 
-	return assertSessionOn(ctx, env, "5G", before.addrs)
+	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
+		return err
+	}
+
+	return roundTripLeaveAgain(ctx, env, e, gNodeB, u, epsUE, before)
+}
+
+// roundTripLeaveAgain sends the UE back to EPS once more.
+//
+// The hop matters out of proportion to its length: it is the first thing that
+// reads the security context the resumed arrival left behind. The AMF derives
+// the eKSI of the enclosed TRACKING AREA UPDATE REQUEST from its stored ngKSI
+// (TS 33.501 §8.6.1) and refuses the move when it does not match the one the UE
+// cites, so a registration that moved the ngKSI without telling the UE strands
+// it here rather than on the hop that moved it.
+func roundTripLeaveAgain(ctx context.Context, env scenarios.Env, e *s1enb.ENB, gNodeB *gnb.GnodeB,
+	u *ue.UE, epsUE *s1enb.UE, before sessionFacts,
+) error {
+	if err := goIdleOnNRConnection(gNodeB, u, returnRANUENGAPID); err != nil {
+		return err
+	}
+
+	security, guti, err := idleMobilityMaterial(u)
+	if err != nil {
+		return err
+	}
+
+	var bearerStatus nas.EPSBearerContextStatus
+
+	bearerStatus.Active[movedEPSBearerIdentity] = true
+
+	tau, err := e.TrackingAreaUpdateFrom5GS(epsUE, s1enb.IdleTrackingAreaUpdateOpts{
+		GUTI:         guti,
+		ActiveFlag:   false,
+		BearerStatus: &bearerStatus,
+		Security:     security,
+	}, attachTimeout)
+	if err != nil {
+		return fmt.Errorf("tracking area update leaving 5GS again after the resumed arrival: %w", err)
+	}
+
+	if err := assertAdoptedBearer(tau); err != nil {
+		return err
+	}
+
+	return assertSessionOn(ctx, env, "4G", before.addrs)
 }
 
 func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) error {

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -25,8 +25,19 @@ func init() {
 	scenarios.Register(scenarios.Scenario{
 		Name:      "interworking/idle_eps_to_5gs",
 		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
-		Run:       runIdleEPSTo5GS,
-		Fixture:   fixture,
+		Run: func(ctx context.Context, env scenarios.Env, _ any) error {
+			return runIdleEPSTo5GS(ctx, env, arriveAndResumeUserPlane)
+		},
+		Fixture: fixture,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name:      "interworking/idle_eps_to_5gs_returning_to_idle",
+		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
+		Run: func(ctx context.Context, env scenarios.Env, _ any) error {
+			return runIdleEPSTo5GS(ctx, env, arriveAndStayIdle)
+		},
+		Fixture: fixture,
 	})
 
 	scenarios.Register(scenarios.Scenario{
@@ -45,6 +56,20 @@ func init() {
 			return runIdle5GSToEPS(ctx, env, false)
 		},
 		Fixture: fixture,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name:      "interworking/idle_round_trip_through_eps",
+		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
+		Run:       runIdleRoundTripThroughEPS,
+		Fixture:   fixture,
+	})
+
+	scenarios.Register(scenarios.Scenario{
+		Name:      "interworking/idle_round_trip_through_5gs",
+		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
+		Run:       runIdleRoundTripThrough5GS,
+		Fixture:   fixture,
 	})
 }
 
@@ -139,9 +164,13 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, activeFlag bool) er
 }
 
 func goIdleOnNR(gNodeB *gnb.GnodeB, u *ue.UE) error {
+	return goIdleOnNRConnection(gNodeB, u, mobilityRANUENGAPID)
+}
+
+func goIdleOnNRConnection(gNodeB *gnb.GnodeB, u *ue.UE, ranUENGAPID int64) error {
 	sessions := []uint8{movedPDUSessionID}
 
-	if err := gNodeB.ReleaseContext(u, mobilityRANUENGAPID, sessions, releaseTimeout); err != nil {
+	if err := gNodeB.ReleaseContext(u, ranUENGAPID, sessions, releaseTimeout); err != nil {
 		return fmt.Errorf("release the NR connection before the inter-system change: %w", err)
 	}
 
@@ -163,7 +192,7 @@ func idleMobilityMaterial(u *ue.UE) (s1enb.IdleMobilityFrom5GS, eps.GUTI, error)
 		KAMF:             u.UeSecurity.Kamf,
 		KNASInt:          u.UeSecurity.KnasInt,
 		NIA:              u.UeSecurity.IntegrityAlg,
-		UplinkNASCount:   u.UeSecurity.ULCount,
+		UplinkNASCount:   u.TakeUplinkNASCountForInterSystemChange(),
 		DownlinkNASCount: u.UeSecurity.DLCount,
 		EPSCiphering:     uint8(u.UeSecurity.EPSNASAlgorithms.Ciphering),
 		EPSIntegrity:     uint8(u.UeSecurity.EPSNASAlgorithms.Integrity),
@@ -194,7 +223,7 @@ const (
 	idleIntegrity = uint8(nas.IntegrityAES)
 )
 
-func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
+func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, resume resumeUserPlane) error {
 	e, err := startENBOnSecondaryN3(env)
 	if err != nil {
 		return err
@@ -229,17 +258,6 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 		return errors.New("the attach accept assigned no GUTI to map into a registration")
 	}
 
-	var bearerStatus nas.EPSBearerContextStatus
-
-	bearerStatus.Active[movedEPSBearerIdentity] = true
-
-	container, err := epsUE.BuildTrackingAreaUpdateForContainer(*res.GUTI.GUTI, &bearerStatus)
-	if err != nil {
-		return err
-	}
-
-	mapped := epsUE.MappedContextForIdleMobility()
-
 	gNodeB, err := startGNB(env)
 	if err != nil {
 		return err
@@ -252,7 +270,32 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+	if err := arriveOn5GSFromEPS(gNodeB, epsUE, u, *res.GUTI.GUTI, int64(scenarios.DefaultRANUENGAPID), resume); err != nil {
+		return err
+	}
+
+	return assertSessionOn(ctx, env, "5G", before.addrs)
+}
+
+type resumeUserPlane bool
+
+const (
+	arriveAndResumeUserPlane resumeUserPlane = true
+	arriveAndStayIdle        resumeUserPlane = false
+)
+
+func arriveOn5GSFromEPS(gNodeB *gnb.GnodeB, epsUE *s1enb.UE, u *ue.UE, epsGUTI eps.GUTI, ranUENGAPID int64, resume resumeUserPlane) error {
+	var bearerStatus nas.EPSBearerContextStatus
+
+	bearerStatus.Active[movedEPSBearerIdentity] = true
+
+	container, err := epsUE.BuildTrackingAreaUpdateForContainer(epsGUTI, &bearerStatus)
+	if err != nil {
+		return err
+	}
+
+	mapped := epsUE.MappedContextForIdleMobility()
+
 	gNodeB.AddUE(ranUENGAPID, u)
 
 	var sessions [16]bool
@@ -261,9 +304,10 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 
 	if err := u.SendIdleMobilityRegistration(ue.IdleRegistrationOpts{
 		RANUENGAPID:            ranUENGAPID,
-		MappedGUTI:             fgs.GUTIIdentity(etsi.MapGUTIEPSTo5G(*res.GUTI.GUTI)),
+		MappedGUTI:             fgs.GUTIIdentity(etsi.MapGUTIEPSTo5G(epsGUTI)),
 		EPSNASMessageContainer: container,
 		PDUSessionStatus:       &sessions,
+		UplinkDataStatus:       uplinkDataStatusFor(resume, sessions),
 		Mapped: ue.MappedFromEPSIdle{
 			KASME:          mapped.KASME,
 			UplinkNASCount: mapped.UplinkNASCount,
@@ -284,7 +328,270 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
+	return assertReactivation(accept, resume)
+}
+
+func assertReactivation(plain []byte, resume resumeUserPlane) error {
+	accept, err := fgs.ParseRegistrationAccept(plain)
+	if err != nil {
+		return fmt.Errorf("parse the registration accept: %w", err)
+	}
+
+	switch {
+	case bool(resume) && accept.PDUSessionReactivationResult == nil:
+		return errors.New("the registration accept reports no PDU session reactivation result, " +
+			"so the AMF did not act on the uplink data status the UE arrived with")
+	case !bool(resume) && accept.PDUSessionReactivationResult != nil:
+		return fmt.Errorf("the registration accept reports the reactivation result %+v though the UE asked for no user plane, "+
+			"so the AMF re-established one the UE is not ready to use", accept.PDUSessionReactivationResult)
+	}
+
+	return nil
+}
+
+func uplinkDataStatusFor(resume resumeUserPlane, sessions [16]bool) *[16]bool {
+	if !resume {
+		return nil
+	}
+
+	return &sessions
+}
+
+const returnRANUENGAPID = int64(scenarios.DefaultRANUENGAPID + 2)
+
+func runIdleRoundTripThroughEPS(ctx context.Context, env scenarios.Env, _ any) error {
+	gNodeB, err := startGNB(env)
+	if err != nil {
+		return err
+	}
+
+	defer gNodeB.Close()
+
+	u, err := newInterworkingUE(gNodeB, true)
+	if err != nil {
+		return err
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+	gNodeB.AddUE(ranUENGAPID, u)
+
+	if _, err := gNodeB.Register(u, ranUENGAPID, movedPDUSessionID, registrationTimeout); err != nil {
+		return fmt.Errorf("initial registration over NR: %w", err)
+	}
+
+	moved, err := provisionEPSNASAlgorithms(gNodeB, u, ranUENGAPID)
+	if err != nil {
+		return err
+	}
+
+	before, err := probeOver5GS(ctx, env, gNodeB, moved, "over N3 before the round trip")
+	if err != nil {
+		return err
+	}
+
+	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
+		return err
+	}
+
+	epsUE, tau, err := roundTripOutboundLeg(ctx, env, gNodeB, u, before)
+	if err != nil {
+		return err
+	}
+
+	return roundTripReturnLeg(ctx, env, gNodeB, u, epsUE, tau, before)
+}
+
+func roundTripOutboundLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.GnodeB, u *ue.UE, before sessionFacts) (*s1enb.UE, *s1enb.AttachResult, error) {
+	if err := goIdleOnNR(gNodeB, u); err != nil {
+		return nil, nil, err
+	}
+
+	security, guti, err := idleMobilityMaterial(u)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	e, err := startENBOnSecondaryN3(env)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k, opc, err := defaultKeyAndOPc()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	epsUE := e.NewUE(interworkingIMSI, k, opc)
+
+	var bearerStatus nas.EPSBearerContextStatus
+
+	bearerStatus.Active[movedEPSBearerIdentity] = true
+
+	tau, err := e.TrackingAreaUpdateFrom5GS(epsUE, s1enb.IdleTrackingAreaUpdateOpts{
+		GUTI:         guti,
+		ActiveFlag:   false,
+		BearerStatus: &bearerStatus,
+		Security:     security,
+	}, attachTimeout)
+	if err != nil {
+		return nil, nil, fmt.Errorf("tracking area update after the idle move to EPS: %w", err)
+	}
+
+	if err := assertAdoptedBearer(tau); err != nil {
+		return nil, nil, err
+	}
+
+	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
+		return nil, nil, err
+	}
+
+	return epsUE, tau, nil
+}
+
+func roundTripReturnLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.GnodeB, u *ue.UE, epsUE *s1enb.UE, tau *s1enb.AttachResult, before sessionFacts) error {
+	if tau.GUTI == nil || tau.GUTI.GUTI == nil {
+		return errors.New("the tracking area update accept assigned no GUTI to enclose in the return to 5GS")
+	}
+
+	var bearerStatus nas.EPSBearerContextStatus
+
+	bearerStatus.Active[movedEPSBearerIdentity] = true
+
+	container, err := epsUE.BuildTrackingAreaUpdateForContainer(*tau.GUTI.GUTI, &bearerStatus)
+	if err != nil {
+		return err
+	}
+
+	var sessions [16]bool
+
+	sessions[movedPDUSessionID] = true
+
+	gNodeB.AddUE(returnRANUENGAPID, u)
+
+	authenticated := u.ReceivedNASGMMCount(uint8(fgs.MsgAuthenticationRequest))
+
+	if err := u.SendNativeIdleMobilityRegistration(ue.NativeIdleRegistrationOpts{
+		RANUENGAPID:            returnRANUENGAPID,
+		MappedGUTI:             fgs.GUTIIdentity(etsi.MapGUTIEPSTo5G(*tau.GUTI.GUTI)),
+		EPSNASMessageContainer: container,
+		PDUSessionStatus:       &sessions,
+		UplinkDataStatus:       &sessions,
+	}); err != nil {
+		return fmt.Errorf("mobility registration update back over NR: %w", err)
+	}
+
+	accept, err := u.WaitForNASGMMMessage(uint8(fgs.MsgRegistrationAccept), attachTimeout)
+	if err != nil {
+		return fmt.Errorf("registration accept for the return to 5GS on the UE's native security context: %w", err)
+	}
+
+	if err := assertAdoptedSession(accept); err != nil {
+		return err
+	}
+
+	if err := assertReactivation(accept, arriveAndResumeUserPlane); err != nil {
+		return err
+	}
+
+	if got := u.ReceivedNASGMMCount(uint8(fgs.MsgAuthenticationRequest)) - authenticated; got != 0 {
+		return fmt.Errorf("the AMF ran %d authentication request(s) on the return to 5GS, want none: "+
+			"the UE arrived on a native 5G NAS security context the AMF still holds", got)
+	}
+
 	return assertSessionOn(ctx, env, "5G", before.addrs)
+}
+
+func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) error {
+	e, err := startENBOnSecondaryN3(env)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = e.Close() }()
+
+	k, opc, err := defaultKeyAndOPc()
+	if err != nil {
+		return err
+	}
+
+	epsUE := e.NewUE(interworkingIMSI, k, opc)
+	epsUE.RequestPDNType(uint8(eps.PDNTypeIPv4v6))
+	epsUE.AnnounceN1Mode(movedPDUSessionID)
+
+	res, err := e.Attach(epsUE, attachTimeout)
+	if err != nil {
+		return fmt.Errorf("attach over E-UTRAN: %w", err)
+	}
+
+	before, err := probeOverEPS(ctx, env, e, res, "over S1-U before the round trip")
+	if err != nil {
+		return err
+	}
+
+	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
+		return err
+	}
+
+	if res.GUTI == nil || res.GUTI.GUTI == nil {
+		return errors.New("the attach accept assigned no GUTI to map into a registration")
+	}
+
+	gNodeB, err := startGNB(env)
+	if err != nil {
+		return err
+	}
+
+	defer gNodeB.Close()
+
+	u, err := newInterworkingUE(gNodeB, false)
+	if err != nil {
+		return err
+	}
+
+	ranUENGAPID := int64(scenarios.DefaultRANUENGAPID)
+
+	if err := arriveOn5GSFromEPS(gNodeB, epsUE, u, *res.GUTI.GUTI, ranUENGAPID, arriveAndResumeUserPlane); err != nil {
+		return err
+	}
+
+	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
+		return err
+	}
+
+	return roundTripReturnToEPS(ctx, env, e, gNodeB, u, epsUE, ranUENGAPID, before)
+}
+
+func roundTripReturnToEPS(ctx context.Context, env scenarios.Env, e *s1enb.ENB, gNodeB *gnb.GnodeB,
+	u *ue.UE, epsUE *s1enb.UE, ranUENGAPID int64, before sessionFacts,
+) error {
+	if err := goIdleOnNRConnection(gNodeB, u, ranUENGAPID); err != nil {
+		return err
+	}
+
+	security, guti, err := idleMobilityMaterial(u)
+	if err != nil {
+		return err
+	}
+
+	var bearerStatus nas.EPSBearerContextStatus
+
+	bearerStatus.Active[movedEPSBearerIdentity] = true
+
+	tau, err := e.TrackingAreaUpdateFrom5GS(epsUE, s1enb.IdleTrackingAreaUpdateOpts{
+		GUTI:         guti,
+		ActiveFlag:   false,
+		BearerStatus: &bearerStatus,
+		Security:     security,
+	}, attachTimeout)
+	if err != nil {
+		return fmt.Errorf("tracking area update on the return to EPS: %w", err)
+	}
+
+	if err := assertAdoptedBearer(tau); err != nil {
+		return err
+	}
+
+	return assertSessionOn(ctx, env, "4G", before.addrs)
 }
 
 func assertAdoptedSession(plain []byte) error {

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -94,7 +94,7 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, activeFlag bool) er
 		return fmt.Errorf("initial registration over NR: %w", err)
 	}
 
-	moved, err := provisionEPSNASAlgorithms(gNodeB, u, ranUENGAPID)
+	moved, err := provisionEPSNASAlgorithms(gNodeB, u)
 	if err != nil {
 		return err
 	}
@@ -379,7 +379,7 @@ func runIdleRoundTripThroughEPS(ctx context.Context, env scenarios.Env, _ any) e
 		return fmt.Errorf("initial registration over NR: %w", err)
 	}
 
-	moved, err := provisionEPSNASAlgorithms(gNodeB, u, ranUENGAPID)
+	moved, err := provisionEPSNASAlgorithms(gNodeB, u)
 	if err != nil {
 		return err
 	}

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -509,14 +509,6 @@ func roundTripReturnLeg(ctx context.Context, env scenarios.Env, e *s1enb.ENB, gN
 	return roundTripLeaveAgain(ctx, env, e, gNodeB, u, epsUE, before)
 }
 
-// roundTripLeaveAgain sends the UE back to EPS once more.
-//
-// The hop matters out of proportion to its length: it is the first thing that
-// reads the security context the resumed arrival left behind. The AMF derives
-// the eKSI of the enclosed TRACKING AREA UPDATE REQUEST from its stored ngKSI
-// (TS 33.501 §8.6.1) and refuses the move when it does not match the one the UE
-// cites, so a registration that moved the ngKSI without telling the UE strands
-// it here rather than on the hop that moved it.
 func roundTripLeaveAgain(ctx context.Context, env scenarios.Env, e *s1enb.ENB, gNodeB *gnb.GnodeB,
 	u *ue.UE, epsUE *s1enb.UE, before sessionFacts,
 ) error {

--- a/internal/tester/ue/build_registration_request.go
+++ b/internal/tester/ue/build_registration_request.go
@@ -64,6 +64,7 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 		m.RequestedNSSAI = opts.RequestedNSSAI
 	}
 
+	// TS 24.501 §5.5.1.2.2
 	status, haveStatus, err := psiBitmap(opts.PDUSessionStatus)
 	if err != nil {
 		return nil, fmt.Errorf("encode PDU session status: %w", err)

--- a/internal/tester/ue/build_registration_request.go
+++ b/internal/tester/ue/build_registration_request.go
@@ -13,17 +13,17 @@ import (
 )
 
 type RegistrationRequestOpts struct {
-	RegistrationType      uint8
-	RequestedNSSAI        fgs.NSSAI
-	UplinkDataStatus      []byte
-	IncludeCapability     bool
-	UESecurity            *UESecurity
-	PDUSessionStatus      *[16]bool
-	S1UENetworkCapability []byte
-
+	RegistrationType       uint8
+	RequestedNSSAI         fgs.NSSAI
+	IncludeCapability      bool
+	UESecurity             *UESecurity
+	PDUSessionStatus       *[16]bool
+	UplinkDataStatus       *[16]bool
+	S1UENetworkCapability  []byte
 	UEStatus               *fgs.UEStatus
 	EPSNASMessageContainer []byte
 	AdditionalGUTI         *fgs.MobileIdentity
+	MobileIdentity         *fgs.MobileIdentity
 }
 
 func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
@@ -34,6 +34,10 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 	mobileIdentity := opts.UESecurity.Suci
 	if opts.UESecurity.Guti != nil {
 		mobileIdentity = *opts.UESecurity.Guti
+	}
+
+	if opts.MobileIdentity != nil {
+		mobileIdentity = *opts.MobileIdentity
 	}
 
 	m := &fgs.RegistrationRequest{
@@ -60,30 +64,29 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 		m.RequestedNSSAI = opts.RequestedNSSAI
 	}
 
-	pduFlag := uint16(0)
-
-	if opts.PDUSessionStatus != nil {
-		for i, pduSession := range opts.PDUSessionStatus {
-			pduFlag += boolToUint16(pduSession) << i
-		}
-	}
-
-	if pduFlag == 0 {
-		return m.MarshalBinary()
-	}
-
-	// TS 24.501 §5.5.1.2.2
-	statusBuf := make([]byte, 2)
-	binary.LittleEndian.PutUint16(statusBuf, pduFlag)
-
-	status, err := fgs.ParsePSIBitmap(statusBuf)
+	status, haveStatus, err := psiBitmap(opts.PDUSessionStatus)
 	if err != nil {
 		return nil, fmt.Errorf("encode PDU session status: %w", err)
 	}
 
+	uplink, haveUplink, err := psiBitmap(opts.UplinkDataStatus)
+	if err != nil {
+		return nil, fmt.Errorf("encode uplink data status: %w", err)
+	}
+
+	if !haveStatus && !haveUplink {
+		return m.MarshalBinary()
+	}
+
 	inner := *m
-	inner.UplinkDataStatus = &status
-	inner.PDUSessionStatus = &status
+
+	if haveStatus {
+		inner.PDUSessionStatus = &status
+	}
+
+	if haveUplink {
+		inner.UplinkDataStatus = &uplink
+	}
 
 	innerBytes, err := inner.MarshalBinary()
 	if err != nil {
@@ -104,6 +107,34 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 	m.NASMessageContainer = container
 
 	return m.MarshalBinary()
+}
+
+func psiBitmap(sessions *[16]bool) (fgs.PSIBitmap, bool, error) {
+	var none fgs.PSIBitmap
+
+	if sessions == nil {
+		return none, false, nil
+	}
+
+	flag := uint16(0)
+
+	for i, set := range sessions {
+		flag += boolToUint16(set) << i
+	}
+
+	if flag == 0 {
+		return none, false, nil
+	}
+
+	buf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf, flag)
+
+	bitmap, err := fgs.ParsePSIBitmap(buf)
+	if err != nil {
+		return none, false, err
+	}
+
+	return bitmap, true, nil
 }
 
 func boolToUint16(b bool) uint16 {

--- a/internal/tester/ue/builders_golden_test.go
+++ b/internal/tester/ue/builders_golden_test.go
@@ -74,9 +74,20 @@ func goldenBuilders(t *testing.T) map[string][]byte {
 		IncludeCapability: true,
 		UESecurity:        sec,
 		PDUSessionStatus:  pduStatus,
+		UplinkDataStatus:  pduStatus,
 	})
 	if err != nil {
 		t.Fatalf("BuildRegistrationRequest (container): %v", err)
+	}
+
+	regContainerStatusOnly, err := BuildRegistrationRequest(&RegistrationRequestOpts{
+		RegistrationType:  uint8(fgs.RegistrationTypeInitial),
+		IncludeCapability: true,
+		UESecurity:        sec,
+		PDUSessionStatus:  pduStatus,
+	})
+	if err != nil {
+		t.Fatalf("BuildRegistrationRequest (container, status only): %v", err)
 	}
 
 	svc, err := BuildServiceRequest(&ServiceRequestOpts{
@@ -123,28 +134,30 @@ func goldenBuilders(t *testing.T) map[string][]byte {
 	}
 
 	return map[string][]byte{
-		"identity_response":       idResp,
-		"deregistration_request":  dereg,
-		"registration_request":    regNoContainer,
-		"registration_container":  regContainer,
-		"service_request":         svc,
-		"security_mode_complete":  smc,
-		"ul_nas_transport":        ulnas,
-		"ul_nas_transport_lpp":    ulnasLPP,
-		"pdu_session_est_request": pduEst,
+		"identity_response":                  idResp,
+		"deregistration_request":             dereg,
+		"registration_request":               regNoContainer,
+		"registration_container":             regContainer,
+		"registration_container_status_only": regContainerStatusOnly,
+		"service_request":                    svc,
+		"security_mode_complete":             smc,
+		"ul_nas_transport":                   ulnas,
+		"ul_nas_transport_lpp":               ulnasLPP,
+		"pdu_session_est_request":            pduEst,
 	}
 }
 
 var builderGolden = map[string]string{
-	"identity_response":       "7e005c000d0100f110000000000000000010",
-	"deregistration_request":  "7e004519000bf200f11001020304050607",
-	"registration_request":    "7e004119000bf200f1100102030405060710012f2e02e0e0",
-	"registration_container":  "7e004119000bf200f1100102030405060710012f2e02e0e07100207e004119000bf200f1100102030405060710012f2e02e0e04002050050020500",
-	"service_request":         "7e004c110007f440830a0b0c0d40020500500205007100157e004c110007f440830a0b0c0d4002050050020500",
-	"security_mode_complete":  "7e005e7700091532547698103254f67100187e004119000bf200f1100102030405060710012f2e02e0e0",
-	"ul_nas_transport":        "7e00670100062e0101c1ffff120181220401010203250908696e7465726e6574",
-	"ul_nas_transport_lpp":    "7e0067030003010203",
-	"pdu_session_est_request": "2e0101c1ffff917b000a80000a00000d00000300",
+	"identity_response":                  "7e005c000d0100f110000000000000000010",
+	"deregistration_request":             "7e004519000bf200f11001020304050607",
+	"registration_request":               "7e004119000bf200f1100102030405060710012f2e02e0e0",
+	"registration_container":             "7e004119000bf200f1100102030405060710012f2e02e0e07100207e004119000bf200f1100102030405060710012f2e02e0e04002050050020500",
+	"registration_container_status_only": "7e004119000bf200f1100102030405060710012f2e02e0e071001c7e004119000bf200f1100102030405060710012f2e02e0e050020500",
+	"service_request":                    "7e004c110007f440830a0b0c0d40020500500205007100157e004c110007f440830a0b0c0d4002050050020500",
+	"security_mode_complete":             "7e005e7700091532547698103254f67100187e004119000bf200f1100102030405060710012f2e02e0e0",
+	"ul_nas_transport":                   "7e00670100062e0101c1ffff120181220401010203250908696e7465726e6574",
+	"ul_nas_transport_lpp":               "7e0067030003010203",
+	"pdu_session_est_request":            "2e0101c1ffff917b000a80000a00000d00000300",
 }
 
 func TestBuildersGolden(t *testing.T) {

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -64,37 +64,15 @@ func (ue *UE) TakeUplinkNASCountForInterSystemChange() nas.Count {
 	return spent
 }
 
-// IdleRegistrationOpts drives an inter-system change from S1 mode to N1 mode in
-// 5GMM-IDLE mode (TS 24.501 §4.4.2.5).
-//
-// Which of the spec's two cases it performs follows from the UE's own state, as
-// it does for a real UE: one holding a valid native 5G NAS security context
-// resumes on it (case a), one holding none arrives on the context the AMF maps
-// from EPS (case b). Both present the 5G-GUTI mapped from the 4G-GUTI as their
-// mobile identity, which is what lets the AMF claim the UE's PDN connections
-// from the MME. Case a additionally carries the native 5G-GUTI in the Additional
-// GUTI IE, cites the native ngKSI, integrity protects the request with that
-// context, and continues its NAS COUNTs rather than restarting them
-// (§5.5.1.3.2 case a).
 type IdleRegistrationOpts struct {
-	RANUENGAPID int64
-	// MappedGUTI is the 5G-GUTI mapped from the 4G-GUTI the MME assigned.
+	RANUENGAPID            int64
 	MappedGUTI             fgs.MobileIdentity
 	EPSNASMessageContainer []byte
-	// PDUSessionStatus names the PDU sessions the UE does not hold inactive.
-	PDUSessionStatus *[16]bool
-	// UplinkDataStatus asks the AMF to re-establish the user plane of the named
-	// sessions as part of the arrival (TS 24.501 §9.11.3.57). Nil arrives without
-	// one, leaving the UE in CM-IDLE with its sessions preserved — the 5GS
-	// counterpart of a TRACKING AREA UPDATE REQUEST with the active flag clear.
-	UplinkDataStatus *[16]bool
-	// Mapped is the EPS security context to map onto 5GS, used only when the UE
-	// holds no native 5G context of its own to resume on.
-	Mapped MappedFromEPSIdle
+	PDUSessionStatus       *[16]bool
+	UplinkDataStatus       *[16]bool
+	Mapped                 MappedFromEPSIdle
 }
 
-// SendIdleMobilityRegistration sends the REGISTRATION REQUEST of an
-// inter-system change from S1 mode in 5GMM-IDLE mode.
 func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	if ue.Gnb == nil {
 		return fmt.Errorf("GNB is not set for UE")
@@ -112,16 +90,10 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	}
 
 	if native != nil {
-		// TS 24.501 §4.4.6 case b): the non-cleartext IEs travel in the ciphered
-		// NAS message container of the request itself, the 5GMM capability among
-		// them — §4.4.6 lists the cleartext IEs exhaustively and it is not one.
 		cleartext.PDUSessionStatus = opts.PDUSessionStatus
 		cleartext.UplinkDataStatus = opts.UplinkDataStatus
 		cleartext.IncludeCapability = true
 	} else {
-		// §4.4.6 case a): with no context to cipher a container with, the request
-		// carries the cleartext IEs alone and the AMF asks for the rest in the
-		// SECURITY MODE COMPLETE.
 		ue.UeSecurity.Guti = &opts.MappedGUTI
 		ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(opts.Mapped.EKSI), Tsc: models.ScTypeMapped}
 	}
@@ -134,8 +106,6 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	wire := plain
 
 	if native != nil {
-		// §4.4.2.5 case a): integrity protected on the native context, with the
-		// uplink NAS COUNT carrying on from where NR left it.
 		if wire, err = ue.EncodeNasPduWithSecurity(plain, uint8(fgs.SHTIntegrityProtected)); err != nil {
 			return fmt.Errorf("could not integrity-protect the Registration Request of an inter-system change: %w", err)
 		}
@@ -143,8 +113,6 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 		return err
 	}
 
-	// The RAN-level identity follows the 5GS mobile identity IE: the UE arrives
-	// on a radio that knows it by the mapped 5G-S-TMSI.
 	gutiIE, err := opts.MappedGUTI.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("could not encode the mapped 5G-GUTI: %w", err)
@@ -161,8 +129,6 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	return ue.InstallMappedSecurityContextForIdleMobility(opts.Mapped)
 }
 
-// nativeContextForIdleArrival returns the UE's own 5G-GUTI when it holds a
-// native 5G NAS security context to resume on, and nil when it does not.
 func (ue *UE) nativeContextForIdleArrival() *fgs.MobileIdentity {
 	if ue.UeSecurity.NgKsi.Ksi == ngKSINoKey || ue.UeSecurity.NgKsi.Tsc != models.ScTypeNative {
 		return nil
@@ -177,11 +143,6 @@ func (ue *UE) nativeContextForIdleArrival() *fgs.MobileIdentity {
 	return &guti
 }
 
-// armReplay stores the complete REGISTRATION REQUEST for the AMF to ask back in
-// the SECURITY MODE COMPLETE (TS 24.501 §4.4.6 case a). Only the arrival that
-// runs a security mode procedure needs it: a UE resuming on its native context
-// expects no such command, so arming it there would let the UE answer one it
-// never planned for and hide the defect from the scenario.
 func (ue *UE) armReplay(opts IdleRegistrationOpts) error {
 	replay := &fgs.RegistrationRequest{
 		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -64,37 +64,66 @@ func (ue *UE) TakeUplinkNASCountForInterSystemChange() nas.Count {
 	return spent
 }
 
+// IdleRegistrationOpts drives an inter-system change from S1 mode to N1 mode in
+// 5GMM-IDLE mode (TS 24.501 §4.4.2.5).
+//
+// Which of the spec's two cases it performs follows from the UE's own state, as
+// it does for a real UE: one holding a valid native 5G NAS security context
+// resumes on it (case a), one holding none arrives on the context the AMF maps
+// from EPS (case b). Both present the 5G-GUTI mapped from the 4G-GUTI as their
+// mobile identity, which is what lets the AMF claim the UE's PDN connections
+// from the MME. Case a additionally carries the native 5G-GUTI in the Additional
+// GUTI IE, cites the native ngKSI, integrity protects the request with that
+// context, and continues its NAS COUNTs rather than restarting them
+// (§5.5.1.3.2 case a).
 type IdleRegistrationOpts struct {
-	RANUENGAPID            int64
+	RANUENGAPID int64
+	// MappedGUTI is the 5G-GUTI mapped from the 4G-GUTI the MME assigned.
 	MappedGUTI             fgs.MobileIdentity
 	EPSNASMessageContainer []byte
-	PDUSessionStatus       *[16]bool
-	UplinkDataStatus       *[16]bool
-	Mapped                 MappedFromEPSIdle
+	// PDUSessionStatus names the PDU sessions the UE does not hold inactive.
+	PDUSessionStatus *[16]bool
+	// UplinkDataStatus asks the AMF to re-establish the user plane of the named
+	// sessions as part of the arrival (TS 24.501 §9.11.3.57). Nil arrives without
+	// one, leaving the UE in CM-IDLE with its sessions preserved — the 5GS
+	// counterpart of a TRACKING AREA UPDATE REQUEST with the active flag clear.
+	UplinkDataStatus *[16]bool
+	// Mapped is the EPS security context to map onto 5GS, used only when the UE
+	// holds no native 5G context of its own to resume on.
+	Mapped MappedFromEPSIdle
 }
 
-type NativeIdleRegistrationOpts struct {
-	RANUENGAPID            int64
-	MappedGUTI             fgs.MobileIdentity
-	EPSNASMessageContainer []byte
-	PDUSessionStatus       *[16]bool
-	UplinkDataStatus       *[16]bool
-}
-
+// SendIdleMobilityRegistration sends the REGISTRATION REQUEST of an
+// inter-system change from S1 mode in 5GMM-IDLE mode.
 func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	if ue.Gnb == nil {
 		return fmt.Errorf("GNB is not set for UE")
 	}
 
-	ue.UeSecurity.Guti = &opts.MappedGUTI
-	ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(opts.Mapped.EKSI), Tsc: models.ScTypeMapped}
+	native := ue.nativeContextForIdleArrival()
 
 	cleartext := &RegistrationRequestOpts{
 		RegistrationType:       uint8(fgs.RegistrationTypeMobilityUpdating),
-		IncludeCapability:      true,
 		UESecurity:             ue.UeSecurity,
 		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
 		EPSNASMessageContainer: opts.EPSNASMessageContainer,
+		MobileIdentity:         &opts.MappedGUTI,
+		AdditionalGUTI:         native,
+	}
+
+	if native != nil {
+		// TS 24.501 §4.4.6 case b): the non-cleartext IEs travel in the ciphered
+		// NAS message container of the request itself, the 5GMM capability among
+		// them — §4.4.6 lists the cleartext IEs exhaustively and it is not one.
+		cleartext.PDUSessionStatus = opts.PDUSessionStatus
+		cleartext.UplinkDataStatus = opts.UplinkDataStatus
+		cleartext.IncludeCapability = true
+	} else {
+		// §4.4.6 case a): with no context to cipher a container with, the request
+		// carries the cleartext IEs alone and the AMF asks for the rest in the
+		// SECURITY MODE COMPLETE.
+		ue.UeSecurity.Guti = &opts.MappedGUTI
+		ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(opts.Mapped.EKSI), Tsc: models.ScTypeMapped}
 	}
 
 	plain, err := BuildRegistrationRequest(cleartext)
@@ -102,7 +131,59 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 		return fmt.Errorf("could not build the Registration Request of an inter-system change: %w", err)
 	}
 
-	replayMsg := &fgs.RegistrationRequest{
+	wire := plain
+
+	if native != nil {
+		// §4.4.2.5 case a): integrity protected on the native context, with the
+		// uplink NAS COUNT carrying on from where NR left it.
+		if wire, err = ue.EncodeNasPduWithSecurity(plain, uint8(fgs.SHTIntegrityProtected)); err != nil {
+			return fmt.Errorf("could not integrity-protect the Registration Request of an inter-system change: %w", err)
+		}
+	} else if err := ue.armReplay(opts); err != nil {
+		return err
+	}
+
+	// The RAN-level identity follows the 5GS mobile identity IE: the UE arrives
+	// on a radio that knows it by the mapped 5G-S-TMSI.
+	gutiIE, err := opts.MappedGUTI.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("could not encode the mapped 5G-GUTI: %w", err)
+	}
+
+	if err := ue.Gnb.SendInitialUEMessage(wire, opts.RANUENGAPID, gutiIE, ngap.RRCCauseMOSignalling); err != nil {
+		return fmt.Errorf("could not send the Initial UE Message: %w", err)
+	}
+
+	if native != nil {
+		return nil
+	}
+
+	return ue.InstallMappedSecurityContextForIdleMobility(opts.Mapped)
+}
+
+// nativeContextForIdleArrival returns the UE's own 5G-GUTI when it holds a
+// native 5G NAS security context to resume on, and nil when it does not.
+func (ue *UE) nativeContextForIdleArrival() *fgs.MobileIdentity {
+	if ue.UeSecurity.NgKsi.Ksi == ngKSINoKey || ue.UeSecurity.NgKsi.Tsc != models.ScTypeNative {
+		return nil
+	}
+
+	if ue.UeSecurity.Guti == nil || ue.UeSecurity.Guti.GUTI == nil {
+		return nil
+	}
+
+	guti := *ue.UeSecurity.Guti
+
+	return &guti
+}
+
+// armReplay stores the complete REGISTRATION REQUEST for the AMF to ask back in
+// the SECURITY MODE COMPLETE (TS 24.501 §4.4.6 case a). Only the arrival that
+// runs a security mode procedure needs it: a UE resuming on its native context
+// expects no such command, so arming it there would let the UE answer one it
+// never planned for and hide the defect from the scenario.
+func (ue *UE) armReplay(opts IdleRegistrationOpts) error {
+	replay := &fgs.RegistrationRequest{
 		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,
 		FOR:                    true,
 		NgKSI:                  nas.KeySetIdentifier{Value: opts.Mapped.EKSI, Mapped: true},
@@ -117,113 +198,22 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 		var bitmap fgs.PSIBitmap
 
 		bitmap.PSI = *opts.PDUSessionStatus
-		replayMsg.PDUSessionStatus = &bitmap
+		replay.PDUSessionStatus = &bitmap
 	}
 
 	if opts.UplinkDataStatus != nil {
 		var bitmap fgs.PSIBitmap
 
 		bitmap.PSI = *opts.UplinkDataStatus
-		replayMsg.UplinkDataStatus = &bitmap
+		replay.UplinkDataStatus = &bitmap
 	}
 
-	replayBytes, err := replayMsg.MarshalBinary()
+	replayBytes, err := replay.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("could not build the replayed Registration Request: %w", err)
 	}
 
 	ue.replayRegistration = replayBytes
-
-	gutiIE, err := opts.MappedGUTI.MarshalBinary()
-	if err != nil {
-		return fmt.Errorf("could not encode the mapped 5G-GUTI: %w", err)
-	}
-
-	if err := ue.Gnb.SendInitialUEMessage(plain, opts.RANUENGAPID, gutiIE, ngap.RRCCauseMOSignalling); err != nil {
-		return fmt.Errorf("could not send the Initial UE Message: %w", err)
-	}
-
-	return ue.InstallMappedSecurityContextForIdleMobility(opts.Mapped)
-}
-
-func (ue *UE) SendNativeIdleMobilityRegistration(opts NativeIdleRegistrationOpts) error {
-	if ue.Gnb == nil {
-		return fmt.Errorf("GNB is not set for UE")
-	}
-
-	if ue.UeSecurity.Guti == nil || ue.UeSecurity.Guti.GUTI == nil {
-		return fmt.Errorf("the UE holds no native 5G-GUTI to arrive from EPS with")
-	}
-
-	if ue.UeSecurity.NgKsi.Ksi == ngKSINoKey {
-		return fmt.Errorf("the UE holds no native 5G NAS security context to arrive from EPS on")
-	}
-
-	native := *ue.UeSecurity.Guti
-
-	cleartext := &RegistrationRequestOpts{
-		RegistrationType:       uint8(fgs.RegistrationTypeMobilityUpdating),
-		IncludeCapability:      true,
-		UESecurity:             ue.UeSecurity,
-		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
-		EPSNASMessageContainer: opts.EPSNASMessageContainer,
-		PDUSessionStatus:       opts.PDUSessionStatus,
-		UplinkDataStatus:       opts.UplinkDataStatus,
-		MobileIdentity:         &opts.MappedGUTI,
-		AdditionalGUTI:         &native,
-	}
-
-	plain, err := BuildRegistrationRequest(cleartext)
-	if err != nil {
-		return fmt.Errorf("could not build the Registration Request of an inter-system change: %w", err)
-	}
-
-	replayMsg := &fgs.RegistrationRequest{
-		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,
-		FOR:                    true,
-		NgKSI:                  nas.KeySetIdentifier{Value: uint8(ue.UeSecurity.NgKsi.Ksi)},
-		MobileIdentity:         opts.MappedGUTI,
-		AdditionalGUTI:         &native,
-		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
-		EPSNASMessageContainer: opts.EPSNASMessageContainer,
-		GMMCapability:          &fgs.GMMCapability{RestrictEC: true, LPP: true, HOAttach: true, S1Mode: true},
-		UESecurityCapability:   &ue.UeSecurity.UeSecurityCapability,
-	}
-
-	if opts.PDUSessionStatus != nil {
-		var bitmap fgs.PSIBitmap
-
-		bitmap.PSI = *opts.PDUSessionStatus
-		replayMsg.PDUSessionStatus = &bitmap
-	}
-
-	if opts.UplinkDataStatus != nil {
-		var bitmap fgs.PSIBitmap
-
-		bitmap.PSI = *opts.UplinkDataStatus
-		replayMsg.UplinkDataStatus = &bitmap
-	}
-
-	replayBytes, err := replayMsg.MarshalBinary()
-	if err != nil {
-		return fmt.Errorf("could not build the replayed Registration Request: %w", err)
-	}
-
-	ue.replayRegistration = replayBytes
-
-	wire, err := ue.EncodeNasPduWithSecurity(plain, uint8(fgs.SHTIntegrityProtected))
-	if err != nil {
-		return fmt.Errorf("could not integrity-protect the Registration Request of an inter-system change: %w", err)
-	}
-
-	gutiIE, err := opts.MappedGUTI.MarshalBinary()
-	if err != nil {
-		return fmt.Errorf("could not encode the mapped 5G-GUTI: %w", err)
-	}
-
-	if err := ue.Gnb.SendInitialUEMessage(wire, opts.RANUENGAPID, gutiIE, ngap.RRCCauseMOSignalling); err != nil {
-		return fmt.Errorf("could not send the Initial UE Message: %w", err)
-	}
 
 	return nil
 }

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -57,12 +57,28 @@ func (ue *UE) InstallMappedSecurityContextForIdleMobility(in MappedFromEPSIdle) 
 	return nil
 }
 
+func (ue *UE) TakeUplinkNASCountForInterSystemChange() nas.Count {
+	spent := ue.UeSecurity.ULCount
+	ue.UeSecurity.ULCount = spent.Next()
+
+	return spent
+}
+
 type IdleRegistrationOpts struct {
 	RANUENGAPID            int64
 	MappedGUTI             fgs.MobileIdentity
 	EPSNASMessageContainer []byte
 	PDUSessionStatus       *[16]bool
+	UplinkDataStatus       *[16]bool
 	Mapped                 MappedFromEPSIdle
+}
+
+type NativeIdleRegistrationOpts struct {
+	RANUENGAPID            int64
+	MappedGUTI             fgs.MobileIdentity
+	EPSNASMessageContainer []byte
+	PDUSessionStatus       *[16]bool
+	UplinkDataStatus       *[16]bool
 }
 
 func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
@@ -104,6 +120,13 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 		replayMsg.PDUSessionStatus = &bitmap
 	}
 
+	if opts.UplinkDataStatus != nil {
+		var bitmap fgs.PSIBitmap
+
+		bitmap.PSI = *opts.UplinkDataStatus
+		replayMsg.UplinkDataStatus = &bitmap
+	}
+
 	replayBytes, err := replayMsg.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("could not build the replayed Registration Request: %w", err)
@@ -121,4 +144,86 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	}
 
 	return ue.InstallMappedSecurityContextForIdleMobility(opts.Mapped)
+}
+
+func (ue *UE) SendNativeIdleMobilityRegistration(opts NativeIdleRegistrationOpts) error {
+	if ue.Gnb == nil {
+		return fmt.Errorf("GNB is not set for UE")
+	}
+
+	if ue.UeSecurity.Guti == nil || ue.UeSecurity.Guti.GUTI == nil {
+		return fmt.Errorf("the UE holds no native 5G-GUTI to arrive from EPS with")
+	}
+
+	if ue.UeSecurity.NgKsi.Ksi == ngKSINoKey {
+		return fmt.Errorf("the UE holds no native 5G NAS security context to arrive from EPS on")
+	}
+
+	native := *ue.UeSecurity.Guti
+
+	cleartext := &RegistrationRequestOpts{
+		RegistrationType:       uint8(fgs.RegistrationTypeMobilityUpdating),
+		IncludeCapability:      true,
+		UESecurity:             ue.UeSecurity,
+		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
+		EPSNASMessageContainer: opts.EPSNASMessageContainer,
+		PDUSessionStatus:       opts.PDUSessionStatus,
+		UplinkDataStatus:       opts.UplinkDataStatus,
+		MobileIdentity:         &opts.MappedGUTI,
+		AdditionalGUTI:         &native,
+	}
+
+	plain, err := BuildRegistrationRequest(cleartext)
+	if err != nil {
+		return fmt.Errorf("could not build the Registration Request of an inter-system change: %w", err)
+	}
+
+	replayMsg := &fgs.RegistrationRequest{
+		RegistrationType:       fgs.RegistrationTypeMobilityUpdating,
+		FOR:                    true,
+		NgKSI:                  nas.KeySetIdentifier{Value: uint8(ue.UeSecurity.NgKsi.Ksi)},
+		MobileIdentity:         opts.MappedGUTI,
+		AdditionalGUTI:         &native,
+		UEStatus:               &fgs.UEStatus{S1ModeReg: true},
+		EPSNASMessageContainer: opts.EPSNASMessageContainer,
+		GMMCapability:          &fgs.GMMCapability{RestrictEC: true, LPP: true, HOAttach: true, S1Mode: true},
+		UESecurityCapability:   &ue.UeSecurity.UeSecurityCapability,
+	}
+
+	if opts.PDUSessionStatus != nil {
+		var bitmap fgs.PSIBitmap
+
+		bitmap.PSI = *opts.PDUSessionStatus
+		replayMsg.PDUSessionStatus = &bitmap
+	}
+
+	if opts.UplinkDataStatus != nil {
+		var bitmap fgs.PSIBitmap
+
+		bitmap.PSI = *opts.UplinkDataStatus
+		replayMsg.UplinkDataStatus = &bitmap
+	}
+
+	replayBytes, err := replayMsg.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("could not build the replayed Registration Request: %w", err)
+	}
+
+	ue.replayRegistration = replayBytes
+
+	wire, err := ue.EncodeNasPduWithSecurity(plain, uint8(fgs.SHTIntegrityProtected))
+	if err != nil {
+		return fmt.Errorf("could not integrity-protect the Registration Request of an inter-system change: %w", err)
+	}
+
+	gutiIE, err := opts.MappedGUTI.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("could not encode the mapped 5G-GUTI: %w", err)
+	}
+
+	if err := ue.Gnb.SendInitialUEMessage(wire, opts.RANUENGAPID, gutiIE, ngap.RRCCauseMOSignalling); err != nil {
+		return fmt.Errorf("could not send the Initial UE Message: %w", err)
+	}
+
+	return nil
 }

--- a/internal/tester/ue/nas_decode.go
+++ b/internal/tester/ue/nas_decode.go
@@ -63,6 +63,10 @@ func (ue *UE) DecodeNAS(message []byte) ([]byte, error) {
 	return plain, nil
 }
 
+// decodeNewSecurityContext handles a SECURITY MODE COMMAND carried with a new 5G
+// NAS security context (TS 24.501 §4.4.4.3): the message is integrity-protected
+// but not ciphered, so its plaintext names the selected algorithms; the UE derives
+// the new NAS keys from them and verifies the NAS-MAC with the new context.
 func (ue *UE) decodeNewSecurityContext(spm *fgs.SecurityProtectedMessage, held nas.Count) ([]byte, error) {
 	plain := spm.UnverifiedPayload
 

--- a/internal/tester/ue/nas_decode.go
+++ b/internal/tester/ue/nas_decode.go
@@ -36,6 +36,8 @@ func (ue *UE) DecodeNAS(message []byte) ([]byte, error) {
 		return nil, fmt.Errorf("decode NAS error: %v", err)
 	}
 
+	held := ue.UeSecurity.DLCount
+
 	// Estimate the downlink NAS COUNT from the received sequence number, carrying
 	// into the overflow counter on wrap-around (TS 24.501 §4.4.3.1).
 	if ue.UeSecurity.DLCount.SQN() > spm.SequenceNumber {
@@ -45,7 +47,7 @@ func (ue *UE) DecodeNAS(message []byte) ([]byte, error) {
 	}
 
 	if sht == fgs.SHTIntegrityProtectedNewContext {
-		return ue.decodeNewSecurityContext(spm)
+		return ue.decodeNewSecurityContext(spm, held)
 	}
 
 	sc, err := ue.securityContext()
@@ -61,11 +63,7 @@ func (ue *UE) DecodeNAS(message []byte) ([]byte, error) {
 	return plain, nil
 }
 
-// decodeNewSecurityContext handles a SECURITY MODE COMMAND carried with a new 5G
-// NAS security context (TS 24.501 §4.4.4.3): the message is integrity-protected
-// but not ciphered, so its plaintext names the selected algorithms; the UE derives
-// the new NAS keys from them and verifies the NAS-MAC with the new context.
-func (ue *UE) decodeNewSecurityContext(spm *fgs.SecurityProtectedMessage) ([]byte, error) {
+func (ue *UE) decodeNewSecurityContext(spm *fgs.SecurityProtectedMessage, held nas.Count) ([]byte, error) {
 	plain := spm.UnverifiedPayload
 
 	msg, err := fgs.ParseMessage(plain)
@@ -77,6 +75,8 @@ func (ue *UE) decodeNewSecurityContext(spm *fgs.SecurityProtectedMessage) ([]byt
 	if !ok {
 		return nil, fmt.Errorf("received %T with security header \"Integrity protected with new 5G NAS security context\", which is reserved for a SECURITY MODE COMMAND", msg)
 	}
+
+	entitled := ue.UeSecurity.contextFromAuthentication || smc.NgKSI.Mapped
 
 	if ue.UeSecurity.contextFromAuthentication {
 		ue.UeSecurity.DLCount = 0
@@ -98,10 +98,31 @@ func (ue *UE) decodeNewSecurityContext(spm *fgs.SecurityProtectedMessage) ([]byt
 
 	if err := sc.VerifyMAC(macInput(spm.SequenceNumber, spm.UnverifiedPayload), spm.MAC,
 		ue.UeSecurity.DLCount, nas.Bearer3GPP, nas.DirectionDownlink); err != nil {
+		if reset := rolledBackDownlinkCount(smc, held, spm.SequenceNumber, entitled); reset != "" {
+			return nil, fmt.Errorf("%s: %w", reset, err)
+		}
+
 		return nil, fmt.Errorf("MAC verification failed: %w", err)
 	}
 
 	return plain, nil
+}
+
+func rolledBackDownlinkCount(smc *fgs.SecurityModeCommand, held nas.Count, received uint8, entitled bool) string {
+	if entitled || held.SQN() <= received {
+		return ""
+	}
+
+	kind := "native"
+	if smc.NgKSI.Mapped {
+		kind = "mapped"
+	}
+
+	return fmt.Sprintf("SECURITY MODE COMMAND restarted the downlink NAS COUNT at %d on the %s 5G NAS security context "+
+		"ngKSI %d the UE already holds at COUNT %d, without taking a mapped context into use or following a primary "+
+		"authentication; TS 24.501 §5.4.2.2 does not allow that reset and §5.4.2.3 does not let the UE follow it, so the "+
+		"integrity check cannot pass and a real UE answers SECURITY MODE REJECT",
+		received, kind, smc.NgKSI.Value, held.Value())
 }
 
 // securityContext builds the NAS security context from the UE's current

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -607,6 +607,13 @@ func updateReceivedGSMMessages(ue *UE, plain []byte) {
 	ue.cond.Broadcast()
 }
 
+func (ue *UE) ReceivedNASGMMCount(msgType uint8) int {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return len(ue.receivedNASGMMMessages[msgType])
+}
+
 func (ue *UE) WaitForNASGMMMessage(msgType uint8, timeout time.Duration) ([]byte, error) {
 	deadline := time.Now().Add(timeout)
 

--- a/nas/eps/header.go
+++ b/nas/eps/header.go
@@ -61,9 +61,6 @@ const (
 	SHTServiceRequest SecurityHeaderType = 12
 )
 
-// Ciphered reports whether this header type marks a message whose body is
-// ciphered. Receiving or sending one means the secure exchange of NAS messages
-// is established on the connection (TS 24.301 §4.4.2.3, §4.4.5).
 func (s SecurityHeaderType) Ciphered() bool {
 	return s == SHTIntegrityProtectedCiphered || s == SHTIntegrityProtectedCipheredNewContext
 }

--- a/nas/eps/header.go
+++ b/nas/eps/header.go
@@ -61,7 +61,10 @@ const (
 	SHTServiceRequest SecurityHeaderType = 12
 )
 
-func (s SecurityHeaderType) ciphered() bool {
+// Ciphered reports whether this header type marks a message whose body is
+// ciphered. Receiving or sending one means the secure exchange of NAS messages
+// is established on the connection (TS 24.301 §4.4.2.3, §4.4.5).
+func (s SecurityHeaderType) Ciphered() bool {
 	return s == SHTIntegrityProtectedCiphered || s == SHTIntegrityProtectedCipheredNewContext
 }
 

--- a/nas/eps/header.go
+++ b/nas/eps/header.go
@@ -61,6 +61,7 @@ const (
 	SHTServiceRequest SecurityHeaderType = 12
 )
 
+// Ciphered reports whether this header type marks a ciphered message (TS 24.301 §4.4.5).
 func (s SecurityHeaderType) Ciphered() bool {
 	return s == SHTIntegrityProtectedCiphered || s == SHTIntegrityProtectedCipheredNewContext
 }

--- a/nas/eps/security.go
+++ b/nas/eps/security.go
@@ -67,7 +67,7 @@ func Protect(
 
 	payload := plain
 
-	if sht.ciphered() {
+	if sht.Ciphered() {
 		c, err := sc.Cipher(plain, count, nasBearer, dir)
 		if err != nil {
 			return nil, err
@@ -142,7 +142,7 @@ func Unprotect(
 		return nil, m.SecurityHeaderType, err
 	}
 
-	if !m.SecurityHeaderType.ciphered() {
+	if !m.SecurityHeaderType.Ciphered() {
 		return m.UnverifiedPayload, m.SecurityHeaderType, nil
 	}
 

--- a/nas/fgs/header.go
+++ b/nas/fgs/header.go
@@ -53,6 +53,7 @@ const (
 	SHTIntegrityProtectedCipheredNewContext SecurityHeaderType = 4 // SECURITY MODE COMPLETE only
 )
 
+// Ciphered reports whether this header type marks a ciphered message (TS 24.501 §4.4.5).
 func (s SecurityHeaderType) Ciphered() bool {
 	return s == SHTIntegrityProtectedCiphered || s == SHTIntegrityProtectedCipheredNewContext
 }

--- a/nas/fgs/header.go
+++ b/nas/fgs/header.go
@@ -53,9 +53,6 @@ const (
 	SHTIntegrityProtectedCipheredNewContext SecurityHeaderType = 4 // SECURITY MODE COMPLETE only
 )
 
-// Ciphered reports whether this header type marks a message whose body is
-// ciphered. Receiving or sending one means the secure exchange of NAS messages
-// is established on the connection (TS 24.501 §4.4.2.5, §4.4.5).
 func (s SecurityHeaderType) Ciphered() bool {
 	return s == SHTIntegrityProtectedCiphered || s == SHTIntegrityProtectedCipheredNewContext
 }

--- a/nas/fgs/header.go
+++ b/nas/fgs/header.go
@@ -53,7 +53,10 @@ const (
 	SHTIntegrityProtectedCipheredNewContext SecurityHeaderType = 4 // SECURITY MODE COMPLETE only
 )
 
-func (s SecurityHeaderType) ciphered() bool {
+// Ciphered reports whether this header type marks a message whose body is
+// ciphered. Receiving or sending one means the secure exchange of NAS messages
+// is established on the connection (TS 24.501 §4.4.2.5, §4.4.5).
+func (s SecurityHeaderType) Ciphered() bool {
 	return s == SHTIntegrityProtectedCiphered || s == SHTIntegrityProtectedCipheredNewContext
 }
 

--- a/nas/fgs/security.go
+++ b/nas/fgs/security.go
@@ -60,7 +60,7 @@ func Protect(
 
 	payload := plain
 
-	if sht.ciphered() {
+	if sht.Ciphered() {
 		c, err := sc.Cipher(plain, count, nasBearer, dir)
 		if err != nil {
 			return nil, err
@@ -135,7 +135,7 @@ func Unprotect(
 		return nil, m.SecurityHeaderType, err
 	}
 
-	if !m.SecurityHeaderType.ciphered() {
+	if !m.SecurityHeaderType.Ciphered() {
 		return m.UnverifiedPayload, m.SecurityHeaderType, nil
 	}
 


### PR DESCRIPTION
# Description

Phones moving from 4G back to 5G re-authenticated instead of ~1 second, because the network needlessly restarted a security handshake it should have skipped.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
