### PR TITLE
fix: preserve the data session across 4G/5G idle-mode transitions

### DIFF
--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -72,9 +72,7 @@ type UeContext struct {
 
 	gmmCapability         *fgs.GMMCapability
 	s1UENetworkCapability []byte
-	// s1ModeAttested records S1 mode support demonstrated by an arrival from EPS,
-	// for the window before the UE sends a 5GMM capability of its own (AttestS1Mode).
-	s1ModeAttested bool
+	s1ModeAttested        bool
 
 	epsNASAlgorithmsOffered *interworking.EPSNASAlgorithms
 	epsNASAlgorithms        *interworking.EPSNASAlgorithms

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -72,6 +72,9 @@ type UeContext struct {
 
 	gmmCapability         *fgs.GMMCapability
 	s1UENetworkCapability []byte
+	// s1ModeAttested records S1 mode support demonstrated by an arrival from EPS,
+	// for the window before the UE sends a 5GMM capability of its own (AttestS1Mode).
+	s1ModeAttested bool
 
 	epsNASAlgorithmsOffered *interworking.EPSNASAlgorithms
 	epsNASAlgorithms        *interworking.EPSNASAlgorithms

--- a/internal/amf/eps_bearer_identity.go
+++ b/internal/amf/eps_bearer_identity.go
@@ -19,11 +19,6 @@ func (ue *UeContext) SetAllow4G(v bool) {
 	ue.allow4G = v
 }
 
-// EPSInterworkingAllowed reports whether a PDU session established now may be
-// given a mapped EPS bearer context. TS 23.502 §4.11.5.3 step 3: the AMF decides
-// EPS interworking support for a PDU session from the 5GMM capability, the
-// subscription and network configuration — once, when the session is created.
-// It is not re-asked at inter-system mobility; see transferableEPSSessions.
 func (ue *UeContext) EPSInterworkingAllowed() bool {
 	if !ue.SupportsS1Mode() {
 		return false

--- a/internal/amf/eps_bearer_identity.go
+++ b/internal/amf/eps_bearer_identity.go
@@ -19,11 +19,20 @@ func (ue *UeContext) SetAllow4G(v bool) {
 	ue.allow4G = v
 }
 
-func (ue *UeContext) TransfersToEPS() bool {
+// EPSInterworkingAllowed reports whether a PDU session established now may be
+// given a mapped EPS bearer context. TS 23.502 §4.11.5.3 step 3: the AMF decides
+// EPS interworking support for a PDU session from the 5GMM capability, the
+// subscription and network configuration — once, when the session is created.
+// It is not re-asked at inter-system mobility; see transferableEPSSessions.
+func (ue *UeContext) EPSInterworkingAllowed() bool {
+	if !ue.SupportsS1Mode() {
+		return false
+	}
+
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	return ue.allow4G && ue.gmmCapability != nil && ue.gmmCapability.S1Mode
+	return ue.allow4G
 }
 
 func (ue *UeContext) NextEPSBearerIdentity(pduSessionID uint8) (uint8, error) {

--- a/internal/amf/eps_idle_mobility.go
+++ b/internal/amf/eps_idle_mobility.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
-	"github.com/ellanetworks/core/nas/fgs"
 )
 
 func (a *AMF) FetchMMContext(ctx context.Context, presented etsi.GUTI5G, epsNAS []byte) (interworking.MMContextResponse, error) {
@@ -47,8 +46,6 @@ func (a *AMF) AdoptMMContext(ctx context.Context, ue *UeContext, resp interworki
 
 	ue.SetSupi(resp.SUPI)
 	ue.SetAmbr(&models.Ambr{Uplink: resp.AMBRUplink, Downlink: resp.AMBRDownlink})
-
-	ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: true}, nil)
 
 	if _, ok := ue.EPSNetworkCapability(); !ok {
 		if raw, err := resp.UENetworkCapability.MarshalBinary(); err == nil {

--- a/internal/amf/eps_relocation.go
+++ b/internal/amf/eps_relocation.go
@@ -29,22 +29,6 @@ func (ue *UeContext) AllTransferableEPSSessions() []interworking.PDNConnection {
 	return ue.transferableEPSSessions(func(uint8) bool { return true })
 }
 
-// transferableEPSSessions returns the sessions that carry a mapped EPS bearer
-// context, which is what makes a PDU session movable to EPS.
-//
-// The EPS bearer identity is the interworking state: TS 23.501 §5.17.2.1 and
-// TS 23.502 §4.11.1.4.1 make EBI allocation the procedure by which a PDU session
-// becomes one that supports EPS interworking with N26, and TS 23.502 §4.11.5.3
-// step 3 places the decision — 5GMM capability, subscription, configuration — at
-// the moment the EBI is assigned (see assignEPSBearerIdentity). Re-deriving it
-// here would ask the same question against state that can legitimately be absent:
-// the 5GMM capability is a non-cleartext IE (TS 24.501 §4.4.6), so a UE arriving
-// from EPS on a resumed native security context reaches the AMF before it has
-// re-sent one. Sessions adopted from EPS carry the EBI the MME assigned, and are
-// interworking sessions by construction.
-//
-// Admission remains with the receiving system: the MME re-checks the subscriber's
-// 4G entitlement per arriving session (AdoptIdlePDNs), as the AMF does for 5G.
 func (ue *UeContext) transferableEPSSessions(include func(pduSessionID uint8) bool) []interworking.PDNConnection {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/amf/eps_relocation.go
+++ b/internal/amf/eps_relocation.go
@@ -29,11 +29,23 @@ func (ue *UeContext) AllTransferableEPSSessions() []interworking.PDNConnection {
 	return ue.transferableEPSSessions(func(uint8) bool { return true })
 }
 
+// transferableEPSSessions returns the sessions that carry a mapped EPS bearer
+// context, which is what makes a PDU session movable to EPS.
+//
+// The EPS bearer identity is the interworking state: TS 23.501 §5.17.2.1 and
+// TS 23.502 §4.11.1.4.1 make EBI allocation the procedure by which a PDU session
+// becomes one that supports EPS interworking with N26, and TS 23.502 §4.11.5.3
+// step 3 places the decision — 5GMM capability, subscription, configuration — at
+// the moment the EBI is assigned (see assignEPSBearerIdentity). Re-deriving it
+// here would ask the same question against state that can legitimately be absent:
+// the 5GMM capability is a non-cleartext IE (TS 24.501 §4.4.6), so a UE arriving
+// from EPS on a resumed native security context reaches the AMF before it has
+// re-sent one. Sessions adopted from EPS carry the EBI the MME assigned, and are
+// interworking sessions by construction.
+//
+// Admission remains with the receiving system: the MME re-checks the subscriber's
+// 4G entitlement per arriving session (AdoptIdlePDNs), as the AMF does for 5G.
 func (ue *UeContext) transferableEPSSessions(include func(pduSessionID uint8) bool) []interworking.PDNConnection {
-	if !ue.TransfersToEPS() {
-		return nil
-	}
-
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 

--- a/internal/amf/eps_relocation_test.go
+++ b/internal/amf/eps_relocation_test.go
@@ -60,12 +60,7 @@ func TestTransferableEPSSessions(t *testing.T) {
 	}
 }
 
-// TS 23.502 §4.11.1.4.1: the EPS bearer identity is what makes a PDU session an
-// EPS interworking session, so a session that holds one stays transferable. The
-// AMF must not re-derive interworking support at mobility time from state that
-// can legitimately be absent — a UE arriving from EPS on a resumed native security
-// context has sent no 5GMM capability (TS 24.501 §4.4.6) — or it hands EPS zero
-// sessions and strands the very PDN connection it just adopted.
+// TS 23.502 §4.11.1.4.1
 func TestTransferableEPSSessionsKeepsASessionThatHoldsABearerIdentity(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -93,7 +88,7 @@ func TestTransferableEPSSessionsKeepsASessionThatHoldsABearerIdentity(t *testing
 	}
 }
 
-// TS 23.502 §4.11.5.3 step 3: the decision belongs at EBI assignment instead.
+// TS 23.502 §4.11.5.3
 func TestEPSInterworkingAllowedGatesBearerIdentityAssignment(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -121,9 +116,7 @@ func TestEPSInterworkingAllowedGatesBearerIdentityAssignment(t *testing.T) {
 	}
 }
 
-// TS 24.501 §4.4.6, TS 23.502 §4.11.5.3: an arrival from EPS is evidence of S1
-// mode support in its own right, for the window before the UE re-sends the
-// non-cleartext 5GMM capability that carries the bit.
+// TS 24.501 §4.4.6
 func TestArrivalFromEPSAttestsS1Mode(t *testing.T) {
 	ue := relocatableUE(t)
 	ue.ForgetGMMCapabilityForTest()
@@ -138,7 +131,6 @@ func TestArrivalFromEPSAttestsS1Mode(t *testing.T) {
 		t.Fatal("a UE whose EPS context the MME just handed over does not support S1 mode")
 	}
 
-	// The UE's own word still wins where it has given one.
 	ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: false}, nil)
 
 	if ue.SupportsS1Mode() {

--- a/internal/amf/eps_relocation_test.go
+++ b/internal/amf/eps_relocation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/fgs"
 	"github.com/ellanetworks/core/ngap"
 )
 
@@ -59,13 +60,89 @@ func TestTransferableEPSSessions(t *testing.T) {
 	}
 }
 
-// TS 24.501 §6.1.4.1
-func TestTransferableEPSSessionsSkipsAUEThatCannotMoveToEPS(t *testing.T) {
-	ue := relocatableUE(t)
-	ue.SetAllow4G(false)
+// TS 23.502 §4.11.1.4.1: the EPS bearer identity is what makes a PDU session an
+// EPS interworking session, so a session that holds one stays transferable. The
+// AMF must not re-derive interworking support at mobility time from state that
+// can legitimately be absent — a UE arriving from EPS on a resumed native security
+// context has sent no 5GMM capability (TS 24.501 §4.4.6) — or it hands EPS zero
+// sessions and strands the very PDN connection it just adopted.
+func TestTransferableEPSSessionsKeepsASessionThatHoldsABearerIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		blur func(ue *amf.UeContext)
+	}{
+		{"the AMF holds no 5GMM capability", func(ue *amf.UeContext) { ue.ForgetGMMCapabilityForTest() }},
+		{"the UE reports no S1 mode support", func(ue *amf.UeContext) {
+			ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: false}, nil)
+		}},
+		{"the subscriber is barred from 4G", func(ue *amf.UeContext) { ue.SetAllow4G(false) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ue := relocatableUE(t)
+			tc.blur(ue)
 
-	if got := ue.TransferableEPSSessions([]uint8{1}); len(got) != 0 {
-		t.Fatalf("got %d transferable sessions for a UE barred from 4G, want none", len(got))
+			got := ue.TransferableEPSSessions([]uint8{1})
+			if len(got) != 1 || got[0].EPSBearerIdentity != 5 {
+				t.Fatalf("transferable sessions = %+v, want the session holding EBI 5", got)
+			}
+
+			if all := ue.AllTransferableEPSSessions(); len(all) != 1 {
+				t.Fatalf("got %d transferable sessions, want the same one", len(all))
+			}
+		})
+	}
+}
+
+// TS 23.502 §4.11.5.3 step 3: the decision belongs at EBI assignment instead.
+func TestEPSInterworkingAllowedGatesBearerIdentityAssignment(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		blur func(ue *amf.UeContext)
+	}{
+		{"the AMF holds no 5GMM capability", func(ue *amf.UeContext) { ue.ForgetGMMCapabilityForTest() }},
+		{"the UE reports no S1 mode support", func(ue *amf.UeContext) {
+			ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: false}, nil)
+		}},
+		{"the subscriber is barred from 4G", func(ue *amf.UeContext) { ue.SetAllow4G(false) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ue := relocatableUE(t)
+
+			if !ue.EPSInterworkingAllowed() {
+				t.Fatal("a UE that reports S1 mode and is allowed 4G may not open an interworking session")
+			}
+
+			tc.blur(ue)
+
+			if ue.EPSInterworkingAllowed() {
+				t.Fatal("a new PDU session would be given a mapped EPS bearer context anyway")
+			}
+		})
+	}
+}
+
+// TS 24.501 §4.4.6, TS 23.502 §4.11.5.3: an arrival from EPS is evidence of S1
+// mode support in its own right, for the window before the UE re-sends the
+// non-cleartext 5GMM capability that carries the bit.
+func TestArrivalFromEPSAttestsS1Mode(t *testing.T) {
+	ue := relocatableUE(t)
+	ue.ForgetGMMCapabilityForTest()
+
+	if ue.SupportsS1Mode() {
+		t.Fatal("S1 mode support is claimed with nothing to claim it from")
+	}
+
+	ue.AttestS1Mode()
+
+	if !ue.SupportsS1Mode() {
+		t.Fatal("a UE whose EPS context the MME just handed over does not support S1 mode")
+	}
+
+	// The UE's own word still wins where it has given one.
+	ue.SetUECapabilities(&fgs.GMMCapability{S1Mode: false}, nil)
+
+	if ue.SupportsS1Mode() {
+		t.Fatal("the attestation outranks the 5GMM capability the UE actually sent")
 	}
 }
 
@@ -113,12 +190,6 @@ func TestAllTransferableEPSSessionsAppliesTheSameFilters(t *testing.T) {
 
 	if got := ue.AllTransferableEPSSessions(); len(got) != 1 || got[0].PDUSessionID != 1 {
 		t.Fatalf("transferable sessions = %+v, want PDU session 1 alone", got)
-	}
-
-	ue.SetAllow4G(false)
-
-	if got := ue.AllTransferableEPSSessions(); len(got) != 0 {
-		t.Fatalf("got %d transferable sessions for a UE barred from 4G, want none", len(got))
 	}
 }
 

--- a/internal/amf/eps_security.go
+++ b/internal/amf/eps_security.go
@@ -18,6 +18,7 @@ var (
 	ErrNoEPSSecurityCapability = errors.New("amf: UE has no EPS security capability")
 	ErrNo5GSecurityContext     = errors.New("amf: UE has no current 5G NAS security context")
 	ErrNoTransferableSessions  = errors.New("amf: UE has no PDU session that can transfer to EPS")
+	ErrEPSMobilityBarred       = errors.New("amf: the subscriber may not be moved to EPS")
 )
 
 func (ue *UeContext) EPSNetworkCapability() (eps.UENetworkCapability, bool) {

--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -42,6 +42,11 @@ func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest
 			interworking.ErrUnknownUEContext, presented.String())
 	}
 
+	if !ue.EPSInterworkingAllowed() {
+		return none, fmt.Errorf("%w: EPC is restricted for the subscriber of 5G-GUTI %s",
+			interworking.ErrUnknownUEContext, presented.String())
+	}
+
 	ambrUplink, ambrDownlink, ok := ue.AmbrRates()
 	if !ok {
 		return none, fmt.Errorf("amf: UE has no AMBR")

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -178,6 +178,28 @@ func TestEPSContextReturnsTheMappedContext(t *testing.T) {
 	}
 }
 
+// TS 23.501 §5.17.2
+func TestEPSContextRefusesASubscriberBarredFromEPS(t *testing.T) {
+	a := idleMobilityAMF()
+	guti := idleMobilityGUTI(t)
+	ue := leavingUE(t, a, guti)
+	ue.SetAllow4G(false)
+
+	count, err := ue.ulCount.Estimate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count))
+	if !errors.Is(err, interworking.ErrUnknownUEContext) {
+		t.Fatalf("error = %v, want the AMF to hand out no context for a subscriber restricted from EPC", err)
+	}
+
+	if ue.State() != Registered {
+		t.Error("the refusal disturbed the UE's 5GS registration")
+	}
+}
+
 // TS 33.501 §8.5.2 step 1
 func TestEPSContextCommitsTheCountItVerifiedAt(t *testing.T) {
 	a := idleMobilityAMF()

--- a/internal/amf/fivegs_relocation.go
+++ b/internal/amf/fivegs_relocation.go
@@ -129,6 +129,7 @@ func (a *AMF) ForwardRelocation(ctx context.Context, req interworking.FiveGSRelo
 	ue.SetAmbr(&models.Ambr{Uplink: req.UEAMBRUplink, Downlink: req.UEAMBRDownlink})
 	ue.AllowedNssai = snssaiList
 	ue.SetAllow4G(subscriberProfile.Allow4G)
+	ue.AttestS1Mode()
 	ue.smf = a.Session
 
 	if err := ue.InstallMappedSecurityContextFromEPS(mapped.Context, MintAuthProofForInterworking()); err != nil {

--- a/internal/amf/nas/handle_ul_nas_transport.go
+++ b/internal/amf/nas/handle_ul_nas_transport.go
@@ -320,7 +320,7 @@ func establishPDUSession(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeCo
 }
 
 func assignEPSBearerIdentity(ctx context.Context, ue *amf.UeContext, pduSessionID uint8) uint8 {
-	if !ue.TransfersToEPS() {
+	if !ue.EPSInterworkingAllowed() {
 		return 0
 	}
 

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -41,6 +41,11 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
+	// The MME held a registered, secured context for this UE and verified the
+	// enclosed TAU: whichever security context the arrival then resumes, the UE
+	// has demonstrated S1 mode support.
+	ue.AttestS1Mode()
+
 	if integrityVerified && ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI {
 		err := ue.CitesCurrentNgKSI(req.NgKSI)
 		if err == nil {

--- a/internal/amf/nas/idle_mobility_from_eps.go
+++ b/internal/amf/nas/idle_mobility_from_eps.go
@@ -41,9 +41,6 @@ func recoverContextFromEPS(ctx context.Context, amfInstance *amf.AMF, ue *amf.Ue
 		return
 	}
 
-	// The MME held a registered, secured context for this UE and verified the
-	// enclosed TAU: whichever security context the arrival then resumes, the UE
-	// has demonstrated S1 mode support.
 	ue.AttestS1Mode()
 
 	if integrityVerified && ue.SecurityContextIsValid() && ue.Supi() == resp.SUPI {

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -728,9 +728,6 @@ func TestBothArrivalPathsAttestS1Mode(t *testing.T) {
 				t.Error("a UE whose EPS context the MME just handed over is not credited with S1 mode support")
 			}
 
-			// Mapping the EPS context installs the algorithms it was built from;
-			// resuming a native one leaves the AMF to offer them, which it only
-			// does for a UE it believes supports S1 mode.
 			if got := ue.NeedsEPSNASAlgorithms(); got != tc.resumeNative {
 				t.Errorf("NeedsEPSNASAlgorithms = %v, want %v: the UE cannot derive a mapped EPS security context to return on",
 					got, tc.resumeNative)

--- a/internal/amf/nas/idle_mobility_from_eps_test.go
+++ b/internal/amf/nas/idle_mobility_from_eps_test.go
@@ -654,3 +654,87 @@ func TestASecondRegistrationDoesNotInheritTheMappedArrival(t *testing.T) {
 		t.Errorf("downlink NAS COUNT went from %d back to %d: the second registration restarted a context the UE is still counting on", before, got)
 	}
 }
+
+func TestSessionAdoptedFromEPSTransfersBack(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		capability *fgs.GMMCapability
+	}{
+		{"the UE has sent no 5GMM capability", nil},
+		{"the UE reports S1 mode support", &fgs.GMMCapability{S1Mode: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ue, amfInstance, _, _ := idleArrivalUE(t)
+
+			ue.ForgetGMMCapabilityForTest()
+
+			if tc.capability != nil {
+				ue.SetUECapabilities(tc.capability, nil)
+			}
+
+			ue.SetAllow4G(true)
+			ue.SetSecuredForTest(true)
+
+			recoverContextFromEPS(context.Background(), amfInstance, ue, nativeIdleArrivalRequest(), true)
+
+			if !ue.Conn().ArrivedFromEPS() {
+				t.Fatal("the arrival recovered no EPS context")
+			}
+
+			if !adoptArrivingSessions(context.Background(), amfInstance, ue, ue.Conn()) {
+				t.Fatal("the arriving PDN connections were not adopted")
+			}
+
+			sessions := ue.AllTransferableEPSSessions()
+			if len(sessions) != 1 {
+				t.Fatalf("transferable sessions = %d, want the 1 just adopted: the AMF strands the session it took from the MME", len(sessions))
+			}
+
+			if sessions[0].PDUSessionID != 3 || sessions[0].EPSBearerIdentity != 6 {
+				t.Errorf("transferable session = %+v, want PDU session 3 as the EBI 6 the MME assigned", sessions[0])
+			}
+		})
+	}
+}
+
+// TS 24.501 §4.4.6
+func TestBothArrivalPathsAttestS1Mode(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		resumeNative      bool
+		integrityVerified bool
+	}{
+		{"resumed native security context", true, true},
+		{"mapped EPS security context", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ue, amfInstance, _, _ := idleArrivalUE(t)
+
+			ue.ForgetGMMCapabilityForTest()
+			ue.SetSecuredForTest(true)
+
+			req := nativeIdleArrivalRequest()
+			if !tc.resumeNative {
+				req = idleArrivalRequest()
+			}
+
+			recoverContextFromEPS(context.Background(), amfInstance, ue, req, tc.integrityVerified)
+
+			if ue.Conn().ArrivalNeedsSecurityModeControl() == tc.resumeNative {
+				t.Fatalf("the arrival did not take the %s path", tc.name)
+			}
+
+			if !ue.SupportsS1Mode() {
+				t.Error("a UE whose EPS context the MME just handed over is not credited with S1 mode support")
+			}
+
+			// Mapping the EPS context installs the algorithms it was built from;
+			// resuming a native one leaves the AMF to offer them, which it only
+			// does for a UE it believes supports S1 mode.
+			if got := ue.NeedsEPSNASAlgorithms(); got != tc.resumeNative {
+				t.Errorf("NeedsEPSNASAlgorithms = %v, want %v: the UE cannot derive a mapped EPS security context to return on",
+					got, tc.resumeNative)
+			}
+		})
+	}
+}

--- a/internal/amf/ngap/handover_to_eps.go
+++ b/internal/amf/ngap/handover_to_eps.go
@@ -54,7 +54,7 @@ func handoverRequiredToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 	prep, err := amfInstance.PrepareHandoverToEPS(amfUe, sourceUe, target, msg.SourceToTargetTransparentContainer, requested, msg.Cause)
 	if err != nil {
 		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [handover to EPS could not be prepared]", zap.Error(err))
-		sourceUe.SendHandoverPreparationFailure(ctx, causeHOFailureInTarget, nil, nil)
+		sourceUe.SendHandoverPreparationFailure(ctx, preparationFailureCause(err), nil, nil)
 
 		return
 	}
@@ -112,6 +112,17 @@ func completeHandoverToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 	)
 
 	amfInstance.SuperviseHandoverToEPS(amfUe, prep.Request.ID)
+}
+
+func preparationFailureCause(err error) ngap.Cause {
+	switch {
+	case errors.Is(err, amf.ErrEPSMobilityBarred), errors.Is(err, amf.ErrNoTransferableSessions):
+		return causeHOTargetNotAllowed
+	case errors.Is(err, amf.ErrRelocationRefused):
+		return causeHandoverPrepUnspecific
+	default:
+		return causeHOFailureInTarget
+	}
 }
 
 func handoverToEPSFailureCause(err error) ngap.Cause {

--- a/internal/amf/relocation.go
+++ b/internal/amf/relocation.go
@@ -44,6 +44,10 @@ func (a *AMF) PrepareHandoverToEPS(ue *UeContext, sourceUe *UeConn, target inter
 		return nil, ErrNoUEIdentity
 	}
 
+	if !ue.EPSInterworkingAllowed() {
+		return nil, ErrEPSMobilityBarred
+	}
+
 	candidates := make([]HandoverCandidate, 0, len(requested))
 	for _, pduSessionID := range requested {
 		candidates = append(candidates, HandoverCandidate{PDUSessionID: ngap.PDUSessionID(pduSessionID)})

--- a/internal/amf/relocation_test.go
+++ b/internal/amf/relocation_test.go
@@ -132,6 +132,22 @@ func TestPrepareHandoverToEPS(t *testing.T) {
 	}
 }
 
+// TS 23.501 §5.17.2
+func TestPrepareHandoverToEPSRefusesASubscriberBarredFromEPS(t *testing.T) {
+	peer := &fakeEPSPeer{}
+	a, ue, source := newRelocatingAMF(t, peer)
+	ue.SetAllow4G(false)
+
+	_, err := a.PrepareHandoverToEPS(ue, source, testTarget, nil, []uint8{1}, nil)
+	if !errors.Is(err, amf.ErrEPSMobilityBarred) {
+		t.Fatalf("error = %v, want the handover to EPS to be refused before it is prepared", err)
+	}
+
+	if a.HandoverToEPSInProgress(ue) {
+		t.Error("the refused handover was staged anyway")
+	}
+}
+
 func TestPrepareHandoverToEPSOffersOnlyTheRequestedSessions(t *testing.T) {
 	peer := &fakeEPSPeer{}
 	a, ue, source := newRelocatingAMF(t, peer)

--- a/internal/amf/security_state.go
+++ b/internal/amf/security_state.go
@@ -169,13 +169,6 @@ func NextNgKsi(current int32) int32 {
 	return 0
 }
 
-// AttestS1Mode records that the UE demonstrated S1 mode support by arriving from
-// EPS: this core fetched an EPS context for it from the MME, which verified the
-// enclosed TRACKING AREA UPDATE REQUEST first. The 5GMM capability carrying the
-// S1 mode bit is a non-cleartext IE (TS 24.501 §4.4.6), so an inter-system change
-// can reach the AMF before the UE has (re-)sent it — on a resumed native security
-// context the UE need not send one at all. The UE's own word still wins where it
-// has given one; this only fills the gap where it has not.
 func (ue *UeContext) AttestS1Mode() {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/amf/security_state.go
+++ b/internal/amf/security_state.go
@@ -169,9 +169,27 @@ func NextNgKsi(current int32) int32 {
 	return 0
 }
 
+// AttestS1Mode records that the UE demonstrated S1 mode support by arriving from
+// EPS: this core fetched an EPS context for it from the MME, which verified the
+// enclosed TRACKING AREA UPDATE REQUEST first. The 5GMM capability carrying the
+// S1 mode bit is a non-cleartext IE (TS 24.501 §4.4.6), so an inter-system change
+// can reach the AMF before the UE has (re-)sent it — on a resumed native security
+// context the UE need not send one at all. The UE's own word still wins where it
+// has given one; this only fills the gap where it has not.
+func (ue *UeContext) AttestS1Mode() {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.s1ModeAttested = true
+}
+
 func (ue *UeContext) SupportsS1Mode() bool {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	return ue.gmmCapability != nil && ue.gmmCapability.S1Mode
+	if ue.gmmCapability != nil {
+		return ue.gmmCapability.S1Mode
+	}
+
+	return ue.s1ModeAttested
 }

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -28,10 +28,6 @@ func (amf *AMF) AddUeContextToPoolForTest(ue *UeContext) error {
 	return nil
 }
 
-// ForgetGMMCapabilityForTest drops the stored 5GMM capability, reproducing the UE
-// context of an inter-system change that reached the AMF before the UE re-sent the
-// non-cleartext IE that carries it. SetUECapabilities cannot express this: an
-// omitted element does not withdraw a stored one (TS 24.501 §5.5.1.2.4).
 func (ue *UeContext) ForgetGMMCapabilityForTest() {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -28,6 +28,18 @@ func (amf *AMF) AddUeContextToPoolForTest(ue *UeContext) error {
 	return nil
 }
 
+// ForgetGMMCapabilityForTest drops the stored 5GMM capability, reproducing the UE
+// context of an inter-system change that reached the AMF before the UE re-sent the
+// non-cleartext IE that carries it. SetUECapabilities cannot express this: an
+// omitted element does not withdraw a stored one (TS 24.501 §5.5.1.2.4).
+func (ue *UeContext) ForgetGMMCapabilityForTest() {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.gmmCapability = nil
+	ue.s1ModeAttested = false
+}
+
 // ForceStateForTest sets the UE state unconditionally, bypassing transition
 // validation, for test precondition setup. Production code must use TransitionTo.
 func (ue *UeContext) ForceStateForTest(s StateType) {

--- a/internal/mme/access.go
+++ b/internal/mme/access.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"fmt"
+)
+
+type Access struct {
+	Allow4G bool
+	Allow5G bool
+}
+
+func ResolveAccess(ctx context.Context, m *MME, imsi string) (Access, error) {
+	sub, err := m.Bearer.GetSubscriber(ctx, imsi)
+	if err != nil {
+		return Access{}, fmt.Errorf("get subscriber: %w", err)
+	}
+
+	profile, err := m.Bearer.GetProfileByID(ctx, sub.ProfileID)
+	if err != nil {
+		return Access{}, fmt.Errorf("get profile: %w", err)
+	}
+
+	return Access{Allow4G: profile.Allow4G, Allow5G: profile.Allow5G}, nil
+}
+
+func (ue *UeContext) SetAccess(a Access) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.allow5G = a.Allow5G
+}
+
+func (ue *UeContext) FiveGSInterworkingAllowed() bool {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return ue.allow5G
+}

--- a/internal/mme/detach_test.go
+++ b/internal/mme/detach_test.go
@@ -78,6 +78,7 @@ func securedUE(t *testing.T, m *MME) (*UeContext, *captureConn) {
 	ue.secured = true
 	ue.Conn().secureExchangeEstablished = true
 	ue.ForceStateForTest(EMMRegistered)
+	ue.SetAccess(Access{Allow4G: true, Allow5G: true})
 	registerTestUE(m, ue, testSubscriber.IMSI)
 
 	return ue, cc

--- a/internal/mme/eps_security.go
+++ b/internal/mme/eps_security.go
@@ -94,6 +94,35 @@ func (ue *UeContext) IdleMobilityFrom5GSPending() bool {
 	return ue.idleMobilityFrom5GS
 }
 
+func (ue *UeContext) BeginIdleMobilityTo5GS() {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.idleMobilityTo5GS = true
+}
+
+func (ue *UeContext) EndIdleMobilityTo5GS() {
+	if ue == nil {
+		return
+	}
+
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.idleMobilityTo5GS = false
+}
+
+func (ue *UeContext) IdleMobilityTo5GSPending() bool {
+	if ue == nil {
+		return false
+	}
+
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	return ue.idleMobilityTo5GS
+}
+
 var ErrNoEPSSecurityContext = errors.New("mme: UE has no current EPS NAS security context")
 
 func (ue *UeContext) EPSSecurityContextForRelocation() (interworking.EPSSecurityContext, error) {

--- a/internal/mme/fivegs_idle_mobility.go
+++ b/internal/mme/fivegs_idle_mobility.go
@@ -49,13 +49,6 @@ func (m *MME) AdoptIdlePDNs(ctx context.Context, ue *UeContext, conns []interwor
 			continue
 		}
 
-		if !qos.Allow4G {
-			logger.From(ctx, logger.MmeLog).Warn("arriving PDU session is not allowed on 4G; leaving it behind",
-				zap.String("imsi", ue.IMSI()), zap.String("apn", c.APN))
-
-			continue
-		}
-
 		snssai := c.Snssai
 
 		bearer, err := m.Session.TransferIdleToEPS(ctx, ue.Supi(), c.PDUSessionID, c.EPSBearerIdentity, c.APN, &snssai)

--- a/internal/mme/idle_mobility_to_5gs.go
+++ b/internal/mme/idle_mobility_to_5gs.go
@@ -46,6 +46,11 @@ func (m *MME) MMContext(ctx context.Context, req interworking.MMContextRequest) 
 			interworking.ErrUnknownUEContext, req.MappedEPSGUTI.TMSI)
 	}
 
+	if !ue.FiveGSInterworkingAllowed() {
+		return none, fmt.Errorf("%w: 5GC is restricted for the subscriber of M-TMSI %x",
+			interworking.ErrUnknownUEContext, req.MappedEPSGUTI.TMSI)
+	}
+
 	plain, count, err := ue.TryUnprotectUplink(req.EPSNAS)
 	if err != nil {
 		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
@@ -66,6 +71,8 @@ func (m *MME) MMContext(ctx context.Context, req interworking.MMContextRequest) 
 
 	ambrUL, ambrDL := ue.AmbrRates()
 
+	ue.BeginIdleMobilityTo5GS()
+
 	logger.From(ctx, logger.MmeLog).Info("handing the UE's EPS context to 5GS for an idle-mode change",
 		zap.String("imsi", ue.IMSI()), zap.Int("pdn-connections", len(connections)))
 
@@ -84,6 +91,8 @@ func (m *MME) MMContextAck(ctx context.Context, supi etsi.SUPI, transferred []ui
 	if !ok {
 		return fmt.Errorf("%w: %s", interworking.ErrUnknownUEContext, supi)
 	}
+
+	ue.EndIdleMobilityTo5GS()
 
 	for _, p := range m.SnapshotPDNs(ue) {
 		if slices.Contains(transferred, p.PDUSessionID) {

--- a/internal/mme/idle_mobility_to_5gs_test.go
+++ b/internal/mme/idle_mobility_to_5gs_test.go
@@ -248,3 +248,36 @@ func TestMMContextAckKeepsNothingForAnUnknownSubscriber(t *testing.T) {
 		t.Fatalf("error = %v, want an unknown context", err)
 	}
 }
+
+// TS 23.501 §5.17.2
+func TestMMContextRefusesASubscriberBarredFrom5G(t *testing.T) {
+	m := newTestMME(t)
+	ue, guti := idleMobilityUE(t, m)
+	ue.SetAccess(Access{Allow4G: true, Allow5G: false})
+
+	_, err := m.MMContext(t.Context(), interworking.MMContextRequest{
+		MappedEPSGUTI: guti,
+		EPSNAS:        enclosedTAU(t, ue, nas.MakeCount(0, 0)),
+	})
+	if !errors.Is(err, interworking.ErrUnknownUEContext) {
+		t.Fatalf("error = %v, want the MME to hand out no context for a subscriber restricted from 5GC", err)
+	}
+
+	if ue.PDNCount() != 1 || ue.EMMState() != EMMRegistered {
+		t.Error("the refusal disturbed the UE's EPS context")
+	}
+}
+
+// TS 23.501 §5.17.2
+func TestHandoverToFiveGSRefusesASubscriberBarredFrom5G(t *testing.T) {
+	m := newTestMME(t)
+	m.FiveGS = &fakeFiveGSPeer{}
+
+	ue, _ := idleMobilityUE(t, m)
+	ue.SetAccess(Access{Allow4G: true, Allow5G: false})
+
+	_, err := m.PrepareHandoverToFiveGS(ue, ue.Conn(), interworking.NGRANIdentity{}, nil, nil)
+	if !errors.Is(err, ErrFiveGSMobilityBarred) {
+		t.Fatalf("error = %v, want the handover to 5GS to be refused before it is prepared", err)
+	}
+}

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -178,6 +178,9 @@ type UeContext struct {
 	emmState EMMState
 
 	idleMobilityFrom5GS bool
+	idleMobilityTo5GS   bool
+
+	allow5G bool
 
 	localBearerDeactivation bool
 

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -49,17 +49,22 @@ func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext, u
 		return
 	}
 
-	if allowed, err := mme.AllowedOn4G(ctx, m, ue.IMSI()); err != nil {
-		logger.From(ctx, logger.MmeLog).Error("failed to resolve the subscriber profile", zap.String("imsi", ue.IMSI()), zap.Error(err))
+	access, err := mme.ResolveAccess(ctx, m, ue.IMSI())
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to resolve the subscriber's access", zap.String("imsi", ue.IMSI()), zap.Error(err))
 
 		return
-	} else if !allowed {
+	}
+
+	if !access.Allow4G {
 		logger.From(ctx, logger.MmeLog).Info("attach rejected: 4G not allowed for subscriber",
 			zap.String("imsi", ue.IMSI()))
 		rejectAttach(ctx, m, ue, ueConn, eps.EMMCauseEPSServicesNotAllowed)
 
 		return
 	}
+
+	ue.SetAccess(access)
 
 	qos, err := mme.ResolveAttachQoS(ctx, m, ue)
 	if errors.Is(err, mme.ErrUnknownAPN) {

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -49,6 +49,18 @@ func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext, u
 		return
 	}
 
+	if allowed, err := mme.AllowedOn4G(ctx, m, ue.IMSI()); err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to resolve the subscriber profile", zap.String("imsi", ue.IMSI()), zap.Error(err))
+
+		return
+	} else if !allowed {
+		logger.From(ctx, logger.MmeLog).Info("attach rejected: 4G not allowed for subscriber",
+			zap.String("imsi", ue.IMSI()))
+		rejectAttach(ctx, m, ue, ueConn, eps.EMMCauseEPSServicesNotAllowed)
+
+		return
+	}
+
 	qos, err := mme.ResolveAttachQoS(ctx, m, ue)
 	if errors.Is(err, mme.ErrUnknownAPN) {
 		// The requested APN is not bound to any policy in the subscriber's profile
@@ -62,16 +74,6 @@ func activateDefaultBearer(ctx context.Context, m *mme.MME, ue *mme.UeContext, u
 
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to resolve subscriber QoS", zap.String("imsi", ue.IMSI()), zap.Error(err))
-		return
-	}
-
-	// A profile that does not permit 4G (Core Network type restriction, TS 23.501)
-	// is rejected with EMM cause #7 "EPS services not allowed" (TS 24.301).
-	if !qos.Allow4G {
-		logger.From(ctx, logger.MmeLog).Info("attach rejected: 4G not allowed for subscriber",
-			zap.String("imsi", ue.IMSI()))
-		rejectAttach(ctx, m, ue, ueConn, eps.EMMCauseEPSServicesNotAllowed)
-
 		return
 	}
 

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -41,6 +41,19 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
+	if allowed, err := mme.AllowedOn4G(ctx, m, ue.IMSI()); err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to resolve the subscriber profile for Tracking Area Update",
+			zap.String("imsi", ue.IMSI()), zap.Error(err))
+
+		return nasreply.Handled()
+	} else if !allowed {
+		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update rejected: 4G not allowed for subscriber",
+			zap.String("imsi", ue.IMSI()))
+		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseEPSServicesNotAllowed)
+
+		return nasreply.Handled()
+	}
+
 	if req.UENetworkCapability != nil || req.MSNetworkCapability != nil {
 		ueNetCap := ue.UeNetCap()
 		if req.UENetworkCapability != nil {

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -41,18 +41,23 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	if allowed, err := mme.AllowedOn4G(ctx, m, ue.IMSI()); err != nil {
-		logger.From(ctx, logger.MmeLog).Error("failed to resolve the subscriber profile for Tracking Area Update",
+	access, err := mme.ResolveAccess(ctx, m, ue.IMSI())
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to resolve the subscriber's access for Tracking Area Update",
 			zap.String("imsi", ue.IMSI()), zap.Error(err))
 
 		return nasreply.Handled()
-	} else if !allowed {
+	}
+
+	if !access.Allow4G {
 		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update rejected: 4G not allowed for subscriber",
 			zap.String("imsi", ue.IMSI()))
 		rejectTrackingAreaUpdate(ctx, m, ue, ueConn, eps.EMMCauseEPSServicesNotAllowed)
 
 		return nasreply.Handled()
 	}
+
+	ue.SetAccess(access)
 
 	if req.UENetworkCapability != nil || req.MSNetworkCapability != nil {
 		ueNetCap := ue.UeNetCap()

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/mme"
 	mmes1ap "github.com/ellanetworks/core/internal/mme/s1ap"
+	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
@@ -679,4 +680,27 @@ func TestTrackingAreaUpdateKeepsTheLastPDNReportedInactive(t *testing.T) {
 	}
 
 	decodeDownlinkNAS(t, cc.sent[0])
+}
+
+// TS 23.501 §5.3.4.1.1
+func TestTrackingAreaUpdateRejectedWhen4GNotAllowed(t *testing.T) {
+	m := mme.New(udm.New(newFakeCredStore(), noopKeyResolver), barredBearerStore{}, &fakeSessionManager{})
+	m.NAS = &nasHandler{m: m}
+
+	ue, cc := securedUE(t, m)
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+
+	if len(cc.sent) == 0 {
+		t.Fatal("expected a TAU Reject, got no downlink")
+	}
+
+	rej, err := eps.ParseTrackingAreaUpdateReject(decodeProtectedDownlink(t, ue, cc.sent[0]))
+	if err != nil {
+		t.Fatalf("not a TAU Reject: %v", err)
+	}
+
+	if rej.Cause != eps.EMMCauseEPSServicesNotAllowed {
+		t.Fatalf("TAU Reject cause = %d, want %d (EPS services not allowed)", rej.Cause, eps.EMMCauseEPSServicesNotAllowed)
+	}
 }

--- a/internal/mme/qos.go
+++ b/internal/mme/qos.go
@@ -31,8 +31,21 @@ type EpsQoS struct {
 	IPv6Pool   string
 	DNS        string // data-network DNS server, advertised to the UE via PCO
 	MTU        uint16
-	Allow4G    bool
 	Snssai     *models.Snssai
+}
+
+func AllowedOn4G(ctx context.Context, m *MME, imsi string) (bool, error) {
+	sub, err := m.Bearer.GetSubscriber(ctx, imsi)
+	if err != nil {
+		return false, fmt.Errorf("get subscriber: %w", err)
+	}
+
+	profile, err := m.Bearer.GetProfileByID(ctx, sub.ProfileID)
+	if err != nil {
+		return false, fmt.Errorf("get profile: %w", err)
+	}
+
+	return profile.Allow4G, nil
 }
 
 // ResolveQoS maps the subscriber's profile → policy → data network to the EPS
@@ -166,7 +179,6 @@ func qosForPolicyDN(profile *db.Profile, pol *db.Policy, dn *db.DataNetwork, sns
 		IPv6Pool:   dn.IPv6Pool,
 		DNS:        dn.DNS,
 		MTU:        uint16(dn.MTU),
-		Allow4G:    profile.Allow4G,
 		Snssai:     snssai,
 	}, nil
 }

--- a/internal/mme/qos.go
+++ b/internal/mme/qos.go
@@ -34,20 +34,6 @@ type EpsQoS struct {
 	Snssai     *models.Snssai
 }
 
-func AllowedOn4G(ctx context.Context, m *MME, imsi string) (bool, error) {
-	sub, err := m.Bearer.GetSubscriber(ctx, imsi)
-	if err != nil {
-		return false, fmt.Errorf("get subscriber: %w", err)
-	}
-
-	profile, err := m.Bearer.GetProfileByID(ctx, sub.ProfileID)
-	if err != nil {
-		return false, fmt.Errorf("get profile: %w", err)
-	}
-
-	return profile.Allow4G, nil
-}
-
 // ResolveQoS maps the subscriber's profile → policy → data network to the EPS
 // default-bearer QoS. With no S-NSSAI in 4G, the profile's first policy is the
 // default bearer.

--- a/internal/mme/relocation.go
+++ b/internal/mme/relocation.go
@@ -58,12 +58,12 @@ func (m *MME) ForwardRelocation(ctx context.Context, req interworking.ForwardRel
 			req.Target.SelectedEPSTAI.PlmnID, req.Target.SelectedEPSTAI.TAC)
 	}
 
-	allowed, err := AllowedOn4G(ctx, m, req.SUPI.IMSI())
+	access, err := ResolveAccess(ctx, m, req.SUPI.IMSI())
 	if err != nil {
-		return none, fmt.Errorf("mme: resolve the subscriber profile: %w", err)
+		return none, fmt.Errorf("mme: resolve the subscriber's access: %w", err)
 	}
 
-	if !allowed {
+	if !access.Allow4G {
 		return none, interworking.TargetRefusal{Cause: s1ap.Cause{
 			Group: s1ap.CauseGroupRadioNetwork,
 			Value: s1ap.CauseRadioNetworkHOTargetNotAllowed,
@@ -72,6 +72,7 @@ func (m *MME) ForwardRelocation(ctx context.Context, req interworking.ForwardRel
 
 	ue := NewUeContext()
 	ue.SetSupi(req.SUPI)
+	ue.SetAccess(access)
 
 	if err := ue.InstallRelocatedSecurityContext(req.SecurityContext, MintAuthProofForInterworking()); err != nil {
 		return none, err

--- a/internal/mme/relocation.go
+++ b/internal/mme/relocation.go
@@ -58,6 +58,18 @@ func (m *MME) ForwardRelocation(ctx context.Context, req interworking.ForwardRel
 			req.Target.SelectedEPSTAI.PlmnID, req.Target.SelectedEPSTAI.TAC)
 	}
 
+	allowed, err := AllowedOn4G(ctx, m, req.SUPI.IMSI())
+	if err != nil {
+		return none, fmt.Errorf("mme: resolve the subscriber profile: %w", err)
+	}
+
+	if !allowed {
+		return none, interworking.TargetRefusal{Cause: s1ap.Cause{
+			Group: s1ap.CauseGroupRadioNetwork,
+			Value: s1ap.CauseRadioNetworkHOTargetNotAllowed,
+		}}
+	}
+
 	ue := NewUeContext()
 	ue.SetSupi(req.SUPI)
 
@@ -176,13 +188,6 @@ func (m *MME) openRelocatedPDNs(ctx context.Context, ue *UeContext, conns []inte
 		if err != nil {
 			logger.From(ctx, logger.MmeLog).Warn("relocated PDN connection has no QoS in the subscriber profile; leaving it behind",
 				zap.String("imsi", ue.IMSI()), zap.String("apn", c.APN), zap.Error(err))
-
-			continue
-		}
-
-		if !qos.Allow4G {
-			logger.From(ctx, logger.MmeLog).Warn("relocated PDN connection is not allowed on 4G; leaving it behind",
-				zap.String("imsi", ue.IMSI()), zap.String("apn", c.APN))
 
 			continue
 		}

--- a/internal/mme/relocation_test.go
+++ b/internal/mme/relocation_test.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
@@ -917,5 +919,28 @@ func TestForwardRelocationTakesTheSliceFromTheSource(t *testing.T) {
 	got := sessions.lastRequest.Snssai
 	if got == nil || *got != onAnotherSlice {
 		t.Fatalf("session created on slice %+v, want the %+v the source named", got, onAnotherSlice)
+	}
+}
+
+type barredBearerStore struct{ fakeBearerStore }
+
+func (barredBearerStore) GetProfileByID(_ context.Context, id string) (*db.Profile, error) {
+	return &db.Profile{ID: id, UeAmbrDownlink: "1 Gbps", UeAmbrUplink: "1 Gbps", Allow4G: false, Allow5G: true}, nil
+}
+
+// TS 23.501 §5.3.4.1.1
+func TestForwardRelocationRefusesASubscriberBarredFrom4G(t *testing.T) {
+	m := New(udm.New(newFakeCredStore(), noopKeyResolver), barredBearerStore{}, &fakeSessionManager{})
+	newRelocationTarget(t, m)
+
+	_, err := m.ForwardRelocation(context.Background(), relocationRequest())
+
+	var refusal interworking.TargetRefusal
+	if !errors.As(err, &refusal) {
+		t.Fatalf("error = %v, want a TargetRefusal", err)
+	}
+
+	if refusal.Cause.Value != s1ap.CauseRadioNetworkHOTargetNotAllowed {
+		t.Fatalf("refusal cause = %+v, want handover target not allowed", refusal.Cause)
 	}
 }

--- a/internal/mme/relocation_to_5gs.go
+++ b/internal/mme/relocation_to_5gs.go
@@ -22,6 +22,7 @@ var (
 	ErrRelocationToFiveGSBusy  = errors.New("mme: another procedure holds the UE's key chain")
 	ErrNoTransferablePDNs      = errors.New("mme: UE has no PDN connection that can transfer to 5GS")
 	ErrNoUEIdentityForRelocate = errors.New("mme: the UE has no IMSI to hand over under")
+	ErrFiveGSMobilityBarred    = errors.New("mme: the subscriber may not be moved to 5GS")
 )
 
 func (m *MME) PrepareHandoverToFiveGS(ue *UeContext, source *UeConn, target interworking.NGRANIdentity, sourceToTarget []byte, cause *s1ap.Cause) (*interworking.FiveGSRelocationRequest, error) {
@@ -36,6 +37,10 @@ func (m *MME) PrepareHandoverToFiveGS(ue *UeContext, source *UeConn, target inte
 	supi := ue.Supi()
 	if supi.IMSI() == "" {
 		return nil, ErrNoUEIdentityForRelocate
+	}
+
+	if !ue.FiveGSInterworkingAllowed() {
+		return nil, ErrFiveGSMobilityBarred
 	}
 
 	connections, candidates := TransferablePDNConnections(ue)

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -331,6 +331,7 @@ func securedUE(t *testing.T, m *mme.MME) (*mme.UeContext, *captureConn) {
 
 	ue.Conn().MarkSecureExchangeEstablished()
 	ue.ForceStateForTest(mme.EMMRegistered)
+	ue.SetAccess(mme.Access{Allow4G: true, Allow5G: true})
 	m.RegisterUEForTest(ue, testSubscriber.IMSI)
 
 	return ue, cc

--- a/internal/mme/s1ap/handover_to_5gs.go
+++ b/internal/mme/s1ap/handover_to_5gs.go
@@ -119,7 +119,7 @@ func preparationFailureCause(err error) s1ap.Cause {
 		return causeN26NotAvailable
 	case errors.Is(err, mme.ErrRelocationToFiveGSBusy):
 		return causeProcedureConflict
-	case errors.Is(err, mme.ErrNoTransferablePDNs):
+	case errors.Is(err, mme.ErrNoTransferablePDNs), errors.Is(err, mme.ErrFiveGSMobilityBarred):
 		return causeHOTargetNotAllowed
 	default:
 		return causeHandoverPrepUnspecific

--- a/internal/mme/session.go
+++ b/internal/mme/session.go
@@ -121,17 +121,6 @@ func (m *MME) DeactivateAllSessions(ctx context.Context, ue *UeContext) {
 	}
 }
 
-// SessionDropped reports that a PDN connection's anchor session has moved to 5GS.
-// It drops the EPS routing context and nothing else: the UE context belongs to the
-// inter-system change procedure that moved the session, and is torn down when that
-// procedure completes — MMContextAck for an idle-mode change (TS 23.502
-// §4.11.1.3.3 step 8), RelocationComplete for a handover.
-//
-// Releasing it here instead would destroy the context before the acknowledgement
-// could reach it, so the MME could neither release PDN connections 5GS declined to
-// adopt nor "continue as if the Context Request was never received" on a failed
-// relocation (TS 23.401 §5.3.3.1). The AMF's mirror of this — AMF.SessionDropped —
-// is likewise routing-only, with EPSContextAck owning the teardown.
 func (m *MME) SessionDropped(ctx context.Context, imsi string, ebi uint8, ref string) {
 	ue, ok := m.LookupUeByIMSI(imsi)
 	if !ok {
@@ -152,11 +141,6 @@ func (m *MME) SessionDropped(ctx context.Context, imsi string, ebi uint8, ref st
 		zap.String("imsi", imsi), zap.Uint8("ebi", ebi), zap.Bool("last-pdn", last))
 }
 
-// takePDNByRef detaches the PDN connection ebi names, but only while it still
-// holds the session ref the report is about, so a stale report cannot detach a
-// connection re-established since. A connection that moved to the other system was
-// not deactivated locally, so it does not raise localBearerDeactivation: nothing
-// has to be reported to the UE in a bearer context status (TS 24.301 §9.9.2.1).
 func takePDNByRef(ue *UeContext, ebi uint8, ref string) (p *PdnConnection, last bool) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()

--- a/internal/mme/session.go
+++ b/internal/mme/session.go
@@ -121,6 +121,17 @@ func (m *MME) DeactivateAllSessions(ctx context.Context, ue *UeContext) {
 	}
 }
 
+// SessionDropped reports that a PDN connection's anchor session has moved to 5GS.
+// It drops the EPS routing context and nothing else: the UE context belongs to the
+// inter-system change procedure that moved the session, and is torn down when that
+// procedure completes — MMContextAck for an idle-mode change (TS 23.502
+// §4.11.1.3.3 step 8), RelocationComplete for a handover.
+//
+// Releasing it here instead would destroy the context before the acknowledgement
+// could reach it, so the MME could neither release PDN connections 5GS declined to
+// adopt nor "continue as if the Context Request was never received" on a failed
+// relocation (TS 23.401 §5.3.3.1). The AMF's mirror of this — AMF.SessionDropped —
+// is likewise routing-only, with EPSContextAck owning the teardown.
 func (m *MME) SessionDropped(ctx context.Context, imsi string, ebi uint8, ref string) {
 	ue, ok := m.LookupUeByIMSI(imsi)
 	if !ok {
@@ -139,18 +150,13 @@ func (m *MME) SessionDropped(ctx context.Context, imsi string, ebi uint8, ref st
 
 	logger.From(ctx, logger.MmeLog).Info("PDN connection moved to 5GS; dropping the EPS routing context",
 		zap.String("imsi", imsi), zap.Uint8("ebi", ebi), zap.Bool("last-pdn", last))
-
-	// TS 23.502 §4.11.2.3
-	if last {
-		if _, relocating := m.RelocationToFiveGS(ue); relocating {
-			return
-		}
-
-		ue.TransitionTo(EMMDeregistered)
-		m.ReleaseUEContext(ctx, ue, CauseNASNormalRelease)
-	}
 }
 
+// takePDNByRef detaches the PDN connection ebi names, but only while it still
+// holds the session ref the report is about, so a stale report cannot detach a
+// connection re-established since. A connection that moved to the other system was
+// not deactivated locally, so it does not raise localBearerDeactivation: nothing
+// has to be reported to the UE in a bearer context status (TS 24.301 §9.9.2.1).
 func takePDNByRef(ue *UeContext, ebi uint8, ref string) (p *PdnConnection, last bool) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
@@ -161,7 +167,6 @@ func takePDNByRef(ue *UeContext, ebi uint8, ref string) (p *PdnConnection, last 
 	}
 
 	delete(ue.Pdns, ebi)
-	ue.localBearerDeactivation = true
 
 	return p, len(ue.Pdns) == 0
 }

--- a/internal/mme/session.go
+++ b/internal/mme/session.go
@@ -139,6 +139,20 @@ func (m *MME) SessionDropped(ctx context.Context, imsi string, ebi uint8, ref st
 
 	logger.From(ctx, logger.MmeLog).Info("PDN connection moved to 5GS; dropping the EPS routing context",
 		zap.String("imsi", imsi), zap.Uint8("ebi", ebi), zap.Bool("last-pdn", last))
+
+	if !last {
+		return
+	}
+
+	if _, relocating := m.RelocationToFiveGS(ue); relocating {
+		return
+	}
+
+	if ue.IdleMobilityTo5GSPending() {
+		return
+	}
+
+	m.DeregisterEmptyUE(ctx, ue)
 }
 
 func takePDNByRef(ue *UeContext, ebi uint8, ref string) (p *PdnConnection, last bool) {
@@ -151,6 +165,8 @@ func takePDNByRef(ue *UeContext, ebi uint8, ref string) (p *PdnConnection, last 
 	}
 
 	delete(ue.Pdns, ebi)
+
+	ue.localBearerDeactivation = true
 
 	return p, len(ue.Pdns) == 0
 }

--- a/internal/mme/session_dropped_test.go
+++ b/internal/mme/session_dropped_test.go
@@ -40,11 +40,6 @@ func TestSessionDropped(t *testing.T) {
 		}
 	})
 
-	// TS 23.502 §4.11.1.3.3 step 8, TS 23.401 §5.3.3.1: the context belongs to the
-	// inter-system change until it is acknowledged. Releasing it when the last PDN
-	// connection moves would destroy it before the Context Acknowledge could reach
-	// it, so the MME could neither release what 5GS declined to adopt nor continue
-	// as if the Context Request had never been received.
 	t.Run("the last PDN: the context waits for the acknowledgement", func(t *testing.T) {
 		m := newTestMME(t)
 		ue, _ := securedUE(t, m)
@@ -121,9 +116,7 @@ func TestReleasePDNKeepsAUEWithAnotherConnection(t *testing.T) {
 	}
 }
 
-// TS 23.502 §4.11.1.3.3 step 8: the Context Acknowledge completes the idle-mode
-// change and owns the teardown, so the context of a UE that has left E-UTRAN is
-// released — and its M-TMSI freed — when the acknowledgement arrives, not before.
+// TS 23.502 §4.11.1.3.3
 func TestMMContextAckReleasesTheContextOfAUEThatLeftEUTRAN(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
@@ -151,9 +144,7 @@ func TestMMContextAckReleasesTheContextOfAUEThatLeftEUTRAN(t *testing.T) {
 	}
 }
 
-// The acknowledgement releases what 5GS did not adopt (TS 23.502 §4.11.1.3.3
-// step 8). Before the context lifetime moved here, a single-PDN change tore the
-// context down as the session moved, so this arm of the procedure was unreachable.
+// TS 23.502 §4.11.1.3.3
 func TestMMContextAckReleasesPDNsFiveGSDidNotAdopt(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)

--- a/internal/mme/session_dropped_test.go
+++ b/internal/mme/session_dropped_test.go
@@ -40,10 +40,11 @@ func TestSessionDropped(t *testing.T) {
 		}
 	})
 
-	t.Run("the last PDN: the context waits for the acknowledgement", func(t *testing.T) {
+	t.Run("the last PDN of an idle-mode move: the context waits for the acknowledgement", func(t *testing.T) {
 		m := newTestMME(t)
 		ue, _ := securedUE(t, m)
 		ue.TransitionTo(EMMRegistered)
+		ue.BeginIdleMobilityTo5GS()
 
 		p := testPDN(ue)
 		p.SessionRef = "imsi-001010000000001-3#1"
@@ -60,6 +61,21 @@ func TestSessionDropped(t *testing.T) {
 
 		if _, ok := m.LookupUeBySupi(ue.Supi()); !ok {
 			t.Fatal("the context is unreachable by SUPI, so MMContextAck cannot find it")
+		}
+	})
+
+	t.Run("the last PDN outside an inter-system move: the context goes with it", func(t *testing.T) {
+		m := newTestMME(t)
+		ue, _ := securedUE(t, m)
+		ue.TransitionTo(EMMRegistered)
+
+		p := testPDN(ue)
+		p.SessionRef = "imsi-001010000000001-3#1"
+
+		m.SessionDropped(context.Background(), ue.IMSI(), DefaultERABID, p.SessionRef)
+
+		if ue.EMMState() != EMMDeregistered {
+			t.Error("an attached UE was left with no PDN connection, which it cannot be served in, and no acknowledgement is coming")
 		}
 	})
 
@@ -121,6 +137,7 @@ func TestMMContextAckReleasesTheContextOfAUEThatLeftEUTRAN(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
 	ue.TransitionTo(EMMRegistered)
+	ue.BeginIdleMobilityTo5GS()
 
 	p := testPDN(ue)
 	p.SessionRef = "imsi-001010000000001-3#1"

--- a/internal/mme/session_dropped_test.go
+++ b/internal/mme/session_dropped_test.go
@@ -40,17 +40,31 @@ func TestSessionDropped(t *testing.T) {
 		}
 	})
 
-	t.Run("the last PDN: the context goes with it", func(t *testing.T) {
+	// TS 23.502 §4.11.1.3.3 step 8, TS 23.401 §5.3.3.1: the context belongs to the
+	// inter-system change until it is acknowledged. Releasing it when the last PDN
+	// connection moves would destroy it before the Context Acknowledge could reach
+	// it, so the MME could neither release what 5GS declined to adopt nor continue
+	// as if the Context Request had never been received.
+	t.Run("the last PDN: the context waits for the acknowledgement", func(t *testing.T) {
 		m := newTestMME(t)
 		ue, _ := securedUE(t, m)
+		ue.TransitionTo(EMMRegistered)
 
 		p := testPDN(ue)
 		p.SessionRef = "imsi-001010000000001-3#1"
 
 		m.SessionDropped(context.Background(), ue.IMSI(), DefaultERABID, p.SessionRef)
 
-		if ue.EMMState() != EMMDeregistered {
-			t.Error("an attached UE was left with no PDN connection, which it cannot be served in")
+		if m.LookupPDN(ue, DefaultERABID) != nil {
+			t.Error("the moved PDN connection was not dropped")
+		}
+
+		if ue.EMMState() == EMMDeregistered {
+			t.Fatal("the context was released before the acknowledgement, which now has nothing to acknowledge")
+		}
+
+		if _, ok := m.LookupUeBySupi(ue.Supi()); !ok {
+			t.Fatal("the context is unreachable by SUPI, so MMContextAck cannot find it")
 		}
 	})
 
@@ -107,8 +121,10 @@ func TestReleasePDNKeepsAUEWithAnotherConnection(t *testing.T) {
 	}
 }
 
-// TS 23.401 §5.4.4.1
-func TestSessionDroppedReleasesTheContextOfAUEThatLeftEUTRAN(t *testing.T) {
+// TS 23.502 §4.11.1.3.3 step 8: the Context Acknowledge completes the idle-mode
+// change and owns the teardown, so the context of a UE that has left E-UTRAN is
+// released — and its M-TMSI freed — when the acknowledgement arrives, not before.
+func TestMMContextAckReleasesTheContextOfAUEThatLeftEUTRAN(t *testing.T) {
 	m := newTestMME(t)
 	ue, _ := securedUE(t, m)
 	ue.TransitionTo(EMMRegistered)
@@ -122,8 +138,45 @@ func TestSessionDroppedReleasesTheContextOfAUEThatLeftEUTRAN(t *testing.T) {
 
 	m.SessionDropped(context.Background(), ue.IMSI(), DefaultERABID, p.SessionRef)
 
+	if _, ok := m.LookupUeByIMSI(ue.IMSI()); !ok {
+		t.Fatal("the context was released before the acknowledgement could reach it")
+	}
+
+	if err := m.MMContextAck(context.Background(), ue.Supi(), []uint8{p.PDUSessionID}); err != nil {
+		t.Fatalf("MMContextAck: %v", err)
+	}
+
 	if _, ok := m.LookupUeByIMSI(ue.IMSI()); ok {
 		t.Error("the UE context outlived its last PDN connection: it has left E-UTRAN, so nothing else will ever release it and its M-TMSI stays allocated")
+	}
+}
+
+// The acknowledgement releases what 5GS did not adopt (TS 23.502 §4.11.1.3.3
+// step 8). Before the context lifetime moved here, a single-PDN change tore the
+// context down as the session moved, so this arm of the procedure was unreachable.
+func TestMMContextAckReleasesPDNsFiveGSDidNotAdopt(t *testing.T) {
+	m := newTestMME(t)
+	ue, _ := securedUE(t, m)
+	ue.TransitionTo(EMMRegistered)
+
+	moved := testPDN(ue)
+	moved.SessionRef = "imsi-001010000000001-3#1"
+
+	left := ue.EnsurePDN(6)
+	left.PDUSessionID = 2
+
+	m.SessionDropped(context.Background(), ue.IMSI(), DefaultERABID, moved.SessionRef)
+
+	if err := m.MMContextAck(context.Background(), ue.Supi(), []uint8{moved.PDUSessionID}); err != nil {
+		t.Fatalf("MMContextAck: %v", err)
+	}
+
+	if ue.PDNCount() != 0 {
+		t.Errorf("PDN connections = %d, want 0: the connection 5GS left behind is still anchored in EPS", ue.PDNCount())
+	}
+
+	if ue.EMMState() != EMMDeregistered {
+		t.Error("the UE stayed attached to a system it has no PDN connection in")
 	}
 }
 

--- a/internal/tester/gnb/lifecycle.go
+++ b/internal/tester/gnb/lifecycle.go
@@ -145,7 +145,7 @@ func (g *GnodeB) MobilityRegistrationUpdate(u *ue.UE, ranUENGAPID int64, pduSess
 
 	g.AddUE(ranUENGAPID, u)
 
-	if err := u.SendRegistrationRequest(ranUENGAPID, uint8(fgs.RegistrationTypeMobilityUpdating)); err != nil {
+	if err := u.SendMobilityRegistrationRequest(ranUENGAPID, []uint8{pduSessionID}); err != nil {
 		return nil, fmt.Errorf("send Registration Request (mobility updating): %w", err)
 	}
 

--- a/internal/tester/ue/build_registration_request.go
+++ b/internal/tester/ue/build_registration_request.go
@@ -24,6 +24,14 @@ type RegistrationRequestOpts struct {
 	EPSNASMessageContainer []byte
 	AdditionalGUTI         *fgs.MobileIdentity
 	MobileIdentity         *fgs.MobileIdentity
+
+	// ProtectAsInitialNASMessage sends the message the way a UE with a valid 5G
+	// NAS security context sends an initial NAS message: cleartext IEs on the
+	// wire, everything else in a ciphered NAS message container (TS 24.501
+	// §4.4.6 b). Leave it clear to build the complete message, which is what
+	// goes in the container of SECURITY MODE COMPLETE, and what a UE with no
+	// security context to protect with sends as-is.
+	ProtectAsInitialNASMessage bool
 }
 
 func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
@@ -31,6 +39,21 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 		return nil, fmt.Errorf("RegistrationRequestOpts is nil")
 	}
 
+	m, err := registrationRequestMessage(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if !opts.ProtectAsInitialNASMessage {
+		return m.MarshalBinary()
+	}
+
+	return protectInitialRegistrationRequest(m, opts.UESecurity)
+}
+
+// registrationRequestMessage builds the complete REGISTRATION REQUEST: every IE
+// the options ask for, cleartext and non-cleartext alike.
+func registrationRequestMessage(opts *RegistrationRequestOpts) (*fgs.RegistrationRequest, error) {
 	mobileIdentity := opts.UESecurity.Suci
 	if opts.UESecurity.Guti != nil {
 		mobileIdentity = *opts.UESecurity.Guti
@@ -70,44 +93,67 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 		return nil, fmt.Errorf("encode PDU session status: %w", err)
 	}
 
+	if haveStatus {
+		m.PDUSessionStatus = &status
+	}
+
 	uplink, haveUplink, err := psiBitmap(opts.UplinkDataStatus)
 	if err != nil {
 		return nil, fmt.Errorf("encode uplink data status: %w", err)
 	}
 
-	if !haveStatus && !haveUplink {
-		return m.MarshalBinary()
-	}
-
-	inner := *m
-
-	if haveStatus {
-		inner.PDUSessionStatus = &status
-	}
-
 	if haveUplink {
-		inner.UplinkDataStatus = &uplink
+		m.UplinkDataStatus = &uplink
 	}
 
-	innerBytes, err := inner.MarshalBinary()
+	return m, nil
+}
+
+// protectInitialRegistrationRequest splits the complete message the way TS 24.501
+// §4.4.6 b)1) requires of a UE that holds a valid 5G NAS security context: the
+// cleartext IEs travel in the clear, and the entire message travels beside them in
+// a NAS message container whose value part is ciphered.
+//
+// A real UE sends no non-cleartext IE outside the container, so neither does this
+// one. Leaving a copy in the clear would let the AMF read the 5GMM capability, the
+// PDU session status and the rest without ever decrypting the container, and a core
+// that only ever worked because of that would fail against real handsets.
+func protectInitialRegistrationRequest(complete *fgs.RegistrationRequest, sec *UESecurity) ([]byte, error) {
+	inner, err := complete.MarshalBinary()
 	if err != nil {
-		return nil, fmt.Errorf("encode inner REGISTRATION REQUEST: %w", err)
+		return nil, fmt.Errorf("encode the complete REGISTRATION REQUEST: %w", err)
 	}
 
-	sc, err := securityContext(opts.UESecurity.IntegrityAlg, opts.UESecurity.CipheringAlg,
-		opts.UESecurity.KnasInt, opts.UESecurity.KnasEnc)
+	sc, err := securityContext(sec.IntegrityAlg, sec.CipheringAlg, sec.KnasInt, sec.KnasEnc)
 	if err != nil {
 		return nil, err
 	}
 
-	container, err := sc.Cipher(innerBytes, opts.UESecurity.ULCount, nas.Bearer3GPP, nas.DirectionUplink)
+	container, err := sc.Cipher(inner, sec.ULCount, nas.Bearer3GPP, nas.DirectionUplink)
 	if err != nil {
 		return nil, fmt.Errorf("error encrypting NAS message: %w", err)
 	}
 
-	m.NASMessageContainer = container
+	outer := cleartextRegistrationIEs(complete)
+	outer.NASMessageContainer = container
 
-	return m.MarshalBinary()
+	return outer.MarshalBinary()
+}
+
+// cleartextRegistrationIEs returns the IEs TS 24.501 §4.4.6 lists as the cleartext
+// IEs of a REGISTRATION REQUEST. The registration type, ngKSI and mobile identity
+// are part of the message rather than optional IEs, so they are always carried.
+func cleartextRegistrationIEs(m *fgs.RegistrationRequest) *fgs.RegistrationRequest {
+	return &fgs.RegistrationRequest{
+		RegistrationType:       m.RegistrationType,
+		FOR:                    m.FOR,
+		NgKSI:                  m.NgKSI,
+		MobileIdentity:         m.MobileIdentity,
+		UESecurityCapability:   m.UESecurityCapability,
+		AdditionalGUTI:         m.AdditionalGUTI,
+		UEStatus:               m.UEStatus,
+		EPSNASMessageContainer: m.EPSNASMessageContainer,
+	}
 }
 
 func psiBitmap(sessions *[16]bool) (fgs.PSIBitmap, bool, error) {

--- a/internal/tester/ue/build_registration_request.go
+++ b/internal/tester/ue/build_registration_request.go
@@ -33,9 +33,6 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 	return wire, err
 }
 
-// buildRegistrationRequest returns the octets to put on the wire and the
-// complete message they were built from, which is what the UE replays in the NAS
-// message container of SECURITY MODE COMPLETE (TS 24.501 §4.4.6 a).
 func buildRegistrationRequest(opts *RegistrationRequestOpts) (wire, complete []byte, err error) {
 	if opts == nil {
 		return nil, nil, fmt.Errorf("RegistrationRequestOpts is nil")

--- a/internal/tester/ue/build_registration_request.go
+++ b/internal/tester/ue/build_registration_request.go
@@ -13,35 +13,65 @@ import (
 )
 
 type RegistrationRequestOpts struct {
-	RegistrationType           uint8
-	RequestedNSSAI             fgs.NSSAI
-	IncludeCapability          bool
-	UESecurity                 *UESecurity
-	PDUSessionStatus           *[16]bool
-	UplinkDataStatus           *[16]bool
-	S1UENetworkCapability      []byte
-	UEStatus                   *fgs.UEStatus
-	EPSNASMessageContainer     []byte
-	AdditionalGUTI             *fgs.MobileIdentity
-	MobileIdentity             *fgs.MobileIdentity
-	ProtectAsInitialNASMessage bool
+	RegistrationType       uint8
+	RequestedNSSAI         fgs.NSSAI
+	IncludeCapability      bool
+	UESecurity             *UESecurity
+	PDUSessionStatus       *[16]bool
+	UplinkDataStatus       *[16]bool
+	S1UENetworkCapability  []byte
+	UEStatus               *fgs.UEStatus
+	EPSNASMessageContainer []byte
+	AdditionalGUTI         *fgs.MobileIdentity
+	MobileIdentity         *fgs.MobileIdentity
+	InitialNASMessage      bool
 }
 
 func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
+	wire, _, err := buildRegistrationRequest(opts)
+
+	return wire, err
+}
+
+// buildRegistrationRequest returns the octets to put on the wire and the
+// complete message they were built from, which is what the UE replays in the NAS
+// message container of SECURITY MODE COMPLETE (TS 24.501 §4.4.6 a).
+func buildRegistrationRequest(opts *RegistrationRequestOpts) (wire, complete []byte, err error) {
 	if opts == nil {
-		return nil, fmt.Errorf("RegistrationRequestOpts is nil")
+		return nil, nil, fmt.Errorf("RegistrationRequestOpts is nil")
 	}
 
 	m, err := registrationRequestMessage(opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	if !opts.ProtectAsInitialNASMessage {
-		return m.MarshalBinary()
+	complete, err = m.MarshalBinary()
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return protectInitialRegistrationRequest(m, opts.UESecurity)
+	if !opts.InitialNASMessage || !hasNonCleartextIEs(m) {
+		return complete, complete, nil
+	}
+
+	if opts.UESecurity.NgKsi.Ksi == ngKSINoKey {
+		wire, err = cleartextRegistrationIEs(m).MarshalBinary()
+
+		return wire, complete, err
+	}
+
+	wire, err = protectInitialRegistrationRequest(m, opts.UESecurity)
+
+	return wire, complete, err
+}
+
+func hasNonCleartextIEs(m *fgs.RegistrationRequest) bool {
+	return m.GMMCapability != nil ||
+		m.S1UENetworkCapability != nil ||
+		m.RequestedNSSAI != nil ||
+		m.PDUSessionStatus != nil ||
+		m.UplinkDataStatus != nil
 }
 
 func registrationRequestMessage(opts *RegistrationRequestOpts) (*fgs.RegistrationRequest, error) {

--- a/internal/tester/ue/build_registration_request.go
+++ b/internal/tester/ue/build_registration_request.go
@@ -13,24 +13,17 @@ import (
 )
 
 type RegistrationRequestOpts struct {
-	RegistrationType       uint8
-	RequestedNSSAI         fgs.NSSAI
-	IncludeCapability      bool
-	UESecurity             *UESecurity
-	PDUSessionStatus       *[16]bool
-	UplinkDataStatus       *[16]bool
-	S1UENetworkCapability  []byte
-	UEStatus               *fgs.UEStatus
-	EPSNASMessageContainer []byte
-	AdditionalGUTI         *fgs.MobileIdentity
-	MobileIdentity         *fgs.MobileIdentity
-
-	// ProtectAsInitialNASMessage sends the message the way a UE with a valid 5G
-	// NAS security context sends an initial NAS message: cleartext IEs on the
-	// wire, everything else in a ciphered NAS message container (TS 24.501
-	// §4.4.6 b). Leave it clear to build the complete message, which is what
-	// goes in the container of SECURITY MODE COMPLETE, and what a UE with no
-	// security context to protect with sends as-is.
+	RegistrationType           uint8
+	RequestedNSSAI             fgs.NSSAI
+	IncludeCapability          bool
+	UESecurity                 *UESecurity
+	PDUSessionStatus           *[16]bool
+	UplinkDataStatus           *[16]bool
+	S1UENetworkCapability      []byte
+	UEStatus                   *fgs.UEStatus
+	EPSNASMessageContainer     []byte
+	AdditionalGUTI             *fgs.MobileIdentity
+	MobileIdentity             *fgs.MobileIdentity
 	ProtectAsInitialNASMessage bool
 }
 
@@ -51,8 +44,6 @@ func BuildRegistrationRequest(opts *RegistrationRequestOpts) ([]byte, error) {
 	return protectInitialRegistrationRequest(m, opts.UESecurity)
 }
 
-// registrationRequestMessage builds the complete REGISTRATION REQUEST: every IE
-// the options ask for, cleartext and non-cleartext alike.
 func registrationRequestMessage(opts *RegistrationRequestOpts) (*fgs.RegistrationRequest, error) {
 	mobileIdentity := opts.UESecurity.Suci
 	if opts.UESecurity.Guti != nil {
@@ -109,15 +100,6 @@ func registrationRequestMessage(opts *RegistrationRequestOpts) (*fgs.Registratio
 	return m, nil
 }
 
-// protectInitialRegistrationRequest splits the complete message the way TS 24.501
-// §4.4.6 b)1) requires of a UE that holds a valid 5G NAS security context: the
-// cleartext IEs travel in the clear, and the entire message travels beside them in
-// a NAS message container whose value part is ciphered.
-//
-// A real UE sends no non-cleartext IE outside the container, so neither does this
-// one. Leaving a copy in the clear would let the AMF read the 5GMM capability, the
-// PDU session status and the rest without ever decrypting the container, and a core
-// that only ever worked because of that would fail against real handsets.
 func protectInitialRegistrationRequest(complete *fgs.RegistrationRequest, sec *UESecurity) ([]byte, error) {
 	inner, err := complete.MarshalBinary()
 	if err != nil {
@@ -140,9 +122,6 @@ func protectInitialRegistrationRequest(complete *fgs.RegistrationRequest, sec *U
 	return outer.MarshalBinary()
 }
 
-// cleartextRegistrationIEs returns the IEs TS 24.501 §4.4.6 lists as the cleartext
-// IEs of a REGISTRATION REQUEST. The registration type, ngKSI and mobile identity
-// are part of the message rather than optional IEs, so they are always carried.
 func cleartextRegistrationIEs(m *fgs.RegistrationRequest) *fgs.RegistrationRequest {
 	return &fgs.RegistrationRequest{
 		RegistrationType:       m.RegistrationType,

--- a/internal/tester/ue/builders_golden_test.go
+++ b/internal/tester/ue/builders_golden_test.go
@@ -70,21 +70,23 @@ func goldenBuilders(t *testing.T) map[string][]byte {
 	}
 
 	regContainer, err := BuildRegistrationRequest(&RegistrationRequestOpts{
-		RegistrationType:  uint8(fgs.RegistrationTypeInitial),
-		IncludeCapability: true,
-		UESecurity:        sec,
-		PDUSessionStatus:  pduStatus,
-		UplinkDataStatus:  pduStatus,
+		RegistrationType:           uint8(fgs.RegistrationTypeInitial),
+		IncludeCapability:          true,
+		UESecurity:                 sec,
+		PDUSessionStatus:           pduStatus,
+		UplinkDataStatus:           pduStatus,
+		ProtectAsInitialNASMessage: true,
 	})
 	if err != nil {
 		t.Fatalf("BuildRegistrationRequest (container): %v", err)
 	}
 
 	regContainerStatusOnly, err := BuildRegistrationRequest(&RegistrationRequestOpts{
-		RegistrationType:  uint8(fgs.RegistrationTypeInitial),
-		IncludeCapability: true,
-		UESecurity:        sec,
-		PDUSessionStatus:  pduStatus,
+		RegistrationType:           uint8(fgs.RegistrationTypeInitial),
+		IncludeCapability:          true,
+		UESecurity:                 sec,
+		PDUSessionStatus:           pduStatus,
+		ProtectAsInitialNASMessage: true,
 	})
 	if err != nil {
 		t.Fatalf("BuildRegistrationRequest (container, status only): %v", err)
@@ -151,8 +153,11 @@ var builderGolden = map[string]string{
 	"identity_response":                  "7e005c000d0100f110000000000000000010",
 	"deregistration_request":             "7e004519000bf200f11001020304050607",
 	"registration_request":               "7e004119000bf200f1100102030405060710012f2e02e0e0",
-	"registration_container":             "7e004119000bf200f1100102030405060710012f2e02e0e07100207e004119000bf200f1100102030405060710012f2e02e0e04002050050020500",
-	"registration_container_status_only": "7e004119000bf200f1100102030405060710012f2e02e0e071001c7e004119000bf200f1100102030405060710012f2e02e0e050020500",
+	// The outer message carries only cleartext IEs (TS 24.501 §4.4.6): the UE
+	// security capability 2e02e0e0 stays, the 5GMM capability 10012f moves into
+	// the container 7100.. with the rest of the complete message.
+	"registration_container":             "7e004119000bf200f110010203040506072e02e0e07100207e004119000bf200f1100102030405060710012f2e02e0e04002050050020500",
+	"registration_container_status_only": "7e004119000bf200f110010203040506072e02e0e071001c7e004119000bf200f1100102030405060710012f2e02e0e050020500",
 	"service_request":                    "7e004c110007f440830a0b0c0d40020500500205007100157e004c110007f440830a0b0c0d4002050050020500",
 	"security_mode_complete":             "7e005e7700091532547698103254f67100187e004119000bf200f1100102030405060710012f2e02e0e0",
 	"ul_nas_transport":                   "7e00670100062e0101c1ffff120181220401010203250908696e7465726e6574",

--- a/internal/tester/ue/builders_golden_test.go
+++ b/internal/tester/ue/builders_golden_test.go
@@ -153,9 +153,6 @@ var builderGolden = map[string]string{
 	"identity_response":                  "7e005c000d0100f110000000000000000010",
 	"deregistration_request":             "7e004519000bf200f11001020304050607",
 	"registration_request":               "7e004119000bf200f1100102030405060710012f2e02e0e0",
-	// The outer message carries only cleartext IEs (TS 24.501 §4.4.6): the UE
-	// security capability 2e02e0e0 stays, the 5GMM capability 10012f moves into
-	// the container 7100.. with the rest of the complete message.
 	"registration_container":             "7e004119000bf200f110010203040506072e02e0e07100207e004119000bf200f1100102030405060710012f2e02e0e04002050050020500",
 	"registration_container_status_only": "7e004119000bf200f110010203040506072e02e0e071001c7e004119000bf200f1100102030405060710012f2e02e0e050020500",
 	"service_request":                    "7e004c110007f440830a0b0c0d40020500500205007100157e004c110007f440830a0b0c0d4002050050020500",

--- a/internal/tester/ue/builders_golden_test.go
+++ b/internal/tester/ue/builders_golden_test.go
@@ -70,23 +70,23 @@ func goldenBuilders(t *testing.T) map[string][]byte {
 	}
 
 	regContainer, err := BuildRegistrationRequest(&RegistrationRequestOpts{
-		RegistrationType:           uint8(fgs.RegistrationTypeInitial),
-		IncludeCapability:          true,
-		UESecurity:                 sec,
-		PDUSessionStatus:           pduStatus,
-		UplinkDataStatus:           pduStatus,
-		ProtectAsInitialNASMessage: true,
+		RegistrationType:  uint8(fgs.RegistrationTypeInitial),
+		IncludeCapability: true,
+		UESecurity:        sec,
+		PDUSessionStatus:  pduStatus,
+		UplinkDataStatus:  pduStatus,
+		InitialNASMessage: true,
 	})
 	if err != nil {
 		t.Fatalf("BuildRegistrationRequest (container): %v", err)
 	}
 
 	regContainerStatusOnly, err := BuildRegistrationRequest(&RegistrationRequestOpts{
-		RegistrationType:           uint8(fgs.RegistrationTypeInitial),
-		IncludeCapability:          true,
-		UESecurity:                 sec,
-		PDUSessionStatus:           pduStatus,
-		ProtectAsInitialNASMessage: true,
+		RegistrationType:  uint8(fgs.RegistrationTypeInitial),
+		IncludeCapability: true,
+		UESecurity:        sec,
+		PDUSessionStatus:  pduStatus,
+		InitialNASMessage: true,
 	})
 	if err != nil {
 		t.Fatalf("BuildRegistrationRequest (container, status only): %v", err)

--- a/internal/tester/ue/handle_registration_accept.go
+++ b/internal/tester/ue/handle_registration_accept.go
@@ -50,7 +50,7 @@ func handleRegistrationAccept(ue *UE, plain []byte, amfUENGAPID int64, ranUENGAP
 		zap.String("IMSI", ue.UeSecurity.Supi),
 	)
 
-	if ue.NoAutoPDUSession {
+	if ue.skipAutoPDUSession() {
 		return nil
 	}
 

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -90,9 +90,13 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	}
 
 	if native != nil {
+		// TS 24.501 §5.5.1.3.2: the UE holds a valid native 5G NAS security
+		// context, so it protects the arrival with it and puts the non-cleartext
+		// IEs — 5GMM capability among them — in the ciphered container.
 		cleartext.PDUSessionStatus = opts.PDUSessionStatus
 		cleartext.UplinkDataStatus = opts.UplinkDataStatus
 		cleartext.IncludeCapability = true
+		cleartext.ProtectAsInitialNASMessage = true
 	} else {
 		ue.UeSecurity.Guti = &opts.MappedGUTI
 		ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(opts.Mapped.EKSI), Tsc: models.ScTypeMapped}

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -93,7 +93,7 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 		cleartext.PDUSessionStatus = opts.PDUSessionStatus
 		cleartext.UplinkDataStatus = opts.UplinkDataStatus
 		cleartext.IncludeCapability = true
-		cleartext.ProtectAsInitialNASMessage = true
+		cleartext.InitialNASMessage = true
 	} else {
 		ue.UeSecurity.Guti = &opts.MappedGUTI
 		ue.UeSecurity.NgKsi = models.NgKsi{Ksi: int32(opts.Mapped.EKSI), Tsc: models.ScTypeMapped}

--- a/internal/tester/ue/idle_mobility.go
+++ b/internal/tester/ue/idle_mobility.go
@@ -90,9 +90,6 @@ func (ue *UE) SendIdleMobilityRegistration(opts IdleRegistrationOpts) error {
 	}
 
 	if native != nil {
-		// TS 24.501 §5.5.1.3.2: the UE holds a valid native 5G NAS security
-		// context, so it protects the arrival with it and puts the non-cleartext
-		// IEs — 5GMM capability among them — in the ciphered container.
 		cleartext.PDUSessionStatus = opts.PDUSessionStatus
 		cleartext.UplinkDataStatus = opts.UplinkDataStatus
 		cleartext.IncludeCapability = true

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -741,13 +741,24 @@ func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDa
 		return fmt.Errorf("GNB is not set for UE")
 	}
 
+	var err error
+
+	var s1Capability []byte
+
+	if ue.UeSecurity.S1UENetworkCapability != nil {
+		if s1Capability, err = ue.UeSecurity.S1UENetworkCapability.MarshalBinary(); err != nil {
+			return fmt.Errorf("could not encode the S1 UE network capability: %w", err)
+		}
+	}
+
 	nasPDU, complete, err := buildRegistrationRequest(&RegistrationRequestOpts{
-		RegistrationType:  regType,
-		RequestedNSSAI:    nil,
-		UplinkDataStatus:  uplinkDataStatus,
-		IncludeCapability: true,
-		UESecurity:        ue.UeSecurity,
-		InitialNASMessage: true,
+		RegistrationType:      regType,
+		RequestedNSSAI:        nil,
+		UplinkDataStatus:      uplinkDataStatus,
+		IncludeCapability:     true,
+		S1UENetworkCapability: s1Capability,
+		UESecurity:            ue.UeSecurity,
+		InitialNASMessage:     true,
 	})
 	if err != nil {
 		return fmt.Errorf("could not build Registration Request NAS PDU: %v", err)

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -102,6 +102,7 @@ type UE struct {
 	receivedRRCRelease     bool
 	lppRequests            []*LPPRequest // queue of received LPP requests
 	lppCapsSent            bool          // true after first ProvideLocationCapabilities
+	skipNextAutoPDUSession bool
 }
 
 func (ue *UE) SetPDUSession(pduSession PDUSessionInfo) {
@@ -704,6 +705,52 @@ func (ue *UE) WaitForRRCRelease(timeout time.Duration) error {
 }
 
 func (ue *UE) SendRegistrationRequest(ranUENGAPID int64, regType uint8) error {
+	return ue.sendRegistrationRequest(ranUENGAPID, regType, nil)
+}
+
+func (ue *UE) SendMobilityRegistrationRequest(ranUENGAPID int64, reactivate []uint8) error {
+	var uplinkDataStatus [16]bool
+
+	for _, pduSessionID := range reactivate {
+		if int(pduSessionID) >= len(uplinkDataStatus) {
+			return fmt.Errorf("PDU session ID %d is out of range", pduSessionID)
+		}
+
+		uplinkDataStatus[pduSessionID] = true
+	}
+
+	ue.setSkipNextAutoPDUSession(true)
+
+	if err := ue.sendRegistrationRequest(ranUENGAPID, uint8(fgs.RegistrationTypeMobilityUpdating), &uplinkDataStatus); err != nil {
+		ue.setSkipNextAutoPDUSession(false)
+
+		return err
+	}
+
+	return nil
+}
+
+func (ue *UE) setSkipNextAutoPDUSession(skip bool) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	ue.skipNextAutoPDUSession = skip
+}
+
+func (ue *UE) skipAutoPDUSession() bool {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if ue.skipNextAutoPDUSession {
+		ue.skipNextAutoPDUSession = false
+
+		return true
+	}
+
+	return ue.NoAutoPDUSession
+}
+
+func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDataStatus *[16]bool) error {
 	if ue.Gnb == nil {
 		return fmt.Errorf("GNB is not set for UE")
 	}
@@ -711,7 +758,7 @@ func (ue *UE) SendRegistrationRequest(ranUENGAPID int64, regType uint8) error {
 	nasPDU, err := BuildRegistrationRequest(&RegistrationRequestOpts{
 		RegistrationType:  regType,
 		RequestedNSSAI:    nil,
-		UplinkDataStatus:  nil,
+		UplinkDataStatus:  uplinkDataStatus,
 		IncludeCapability: false,
 		UESecurity:        ue.UeSecurity,
 	})

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -102,7 +102,7 @@ type UE struct {
 	receivedRRCRelease     bool
 	lppRequests            []*LPPRequest // queue of received LPP requests
 	lppCapsSent            bool          // true after first ProvideLocationCapabilities
-	skipNextAutoPDUSession bool
+	lastRegistrationType   uint8
 }
 
 func (ue *UE) SetPDUSession(pduSession PDUSessionInfo) {
@@ -719,35 +719,21 @@ func (ue *UE) SendMobilityRegistrationRequest(ranUENGAPID int64, reactivate []ui
 		uplinkDataStatus[pduSessionID] = true
 	}
 
-	ue.setSkipNextAutoPDUSession(true)
-
-	if err := ue.sendRegistrationRequest(ranUENGAPID, uint8(fgs.RegistrationTypeMobilityUpdating), &uplinkDataStatus); err != nil {
-		ue.setSkipNextAutoPDUSession(false)
-
-		return err
-	}
-
-	return nil
+	return ue.sendRegistrationRequest(ranUENGAPID, uint8(fgs.RegistrationTypeMobilityUpdating), &uplinkDataStatus)
 }
 
-func (ue *UE) setSkipNextAutoPDUSession(skip bool) {
+func (ue *UE) setLastRegistrationType(regType uint8) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	ue.skipNextAutoPDUSession = skip
+	ue.lastRegistrationType = regType
 }
 
 func (ue *UE) skipAutoPDUSession() bool {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	if ue.skipNextAutoPDUSession {
-		ue.skipNextAutoPDUSession = false
-
-		return true
-	}
-
-	return ue.NoAutoPDUSession
+	return ue.NoAutoPDUSession || ue.lastRegistrationType != uint8(fgs.RegistrationTypeInitial)
 }
 
 func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDataStatus *[16]bool) error {
@@ -755,16 +741,21 @@ func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDa
 		return fmt.Errorf("GNB is not set for UE")
 	}
 
-	nasPDU, err := BuildRegistrationRequest(&RegistrationRequestOpts{
+	nasPDU, complete, err := buildRegistrationRequest(&RegistrationRequestOpts{
 		RegistrationType:  regType,
 		RequestedNSSAI:    nil,
 		UplinkDataStatus:  uplinkDataStatus,
 		IncludeCapability: false,
 		UESecurity:        ue.UeSecurity,
+		InitialNASMessage: true,
 	})
 	if err != nil {
 		return fmt.Errorf("could not build Registration Request NAS PDU: %v", err)
 	}
+
+	// TS 24.501 §4.4.6 a: a security mode control procedure the AMF starts on this
+	// registration is answered with the entire message, not a fresh one.
+	ue.replayRegistration = complete
 
 	// TS 24.501 §4.4.6: a UE with a current 5G NAS security context integrity
 	// protects the initial NAS message of a new connection, so the AMF can
@@ -787,6 +778,8 @@ func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDa
 	if err != nil {
 		return fmt.Errorf("could not send UplinkNASTransport: %v", err)
 	}
+
+	ue.setLastRegistrationType(regType)
 
 	logger.UeLogger.Debug(
 		"Sent Registration Request NAS message",

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -745,7 +745,7 @@ func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDa
 		RegistrationType:  regType,
 		RequestedNSSAI:    nil,
 		UplinkDataStatus:  uplinkDataStatus,
-		IncludeCapability: false,
+		IncludeCapability: true,
 		UESecurity:        ue.UeSecurity,
 		InitialNASMessage: true,
 	})

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -102,7 +102,7 @@ type UE struct {
 	receivedRRCRelease     bool
 	lppRequests            []*LPPRequest // queue of received LPP requests
 	lppCapsSent            bool          // true after first ProvideLocationCapabilities
-	lastRegistrationType   uint8
+	requestedReactivation  bool
 }
 
 func (ue *UE) SetPDUSession(pduSession PDUSessionInfo) {
@@ -722,18 +722,18 @@ func (ue *UE) SendMobilityRegistrationRequest(ranUENGAPID int64, reactivate []ui
 	return ue.sendRegistrationRequest(ranUENGAPID, uint8(fgs.RegistrationTypeMobilityUpdating), &uplinkDataStatus)
 }
 
-func (ue *UE) setLastRegistrationType(regType uint8) {
+func (ue *UE) setRequestedReactivation(requested bool) {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	ue.lastRegistrationType = regType
+	ue.requestedReactivation = requested
 }
 
 func (ue *UE) skipAutoPDUSession() bool {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	return ue.NoAutoPDUSession || ue.lastRegistrationType != uint8(fgs.RegistrationTypeInitial)
+	return ue.NoAutoPDUSession || ue.requestedReactivation
 }
 
 func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDataStatus *[16]bool) error {
@@ -755,7 +755,7 @@ func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDa
 		RegistrationType:      regType,
 		RequestedNSSAI:        nil,
 		UplinkDataStatus:      uplinkDataStatus,
-		IncludeCapability:     true,
+		IncludeCapability:     regType != uint8(fgs.RegistrationTypePeriodicUpdating),
 		S1UENetworkCapability: s1Capability,
 		UESecurity:            ue.UeSecurity,
 		InitialNASMessage:     true,
@@ -790,7 +790,7 @@ func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDa
 		return fmt.Errorf("could not send UplinkNASTransport: %v", err)
 	}
 
-	ue.setLastRegistrationType(regType)
+	ue.setRequestedReactivation(uplinkDataStatus != nil)
 
 	logger.UeLogger.Debug(
 		"Sent Registration Request NAS message",

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -764,8 +764,6 @@ func (ue *UE) sendRegistrationRequest(ranUENGAPID int64, regType uint8, uplinkDa
 		return fmt.Errorf("could not build Registration Request NAS PDU: %v", err)
 	}
 
-	// TS 24.501 §4.4.6 a: a security mode control procedure the AMF starts on this
-	// registration is answered with the entire message, not a fresh one.
 	ue.replayRegistration = complete
 
 	// TS 24.501 §4.4.6: a UE with a current 5G NAS security context integrity


### PR DESCRIPTION
# Description

A device moving between 4G and 5G while idle could come up attached with its IP address but no working data path, and then lose the session entirely on the way back — it now keeps a usable session across repeated transitions in both directions.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
