### PR TITLE
fix(ui): use import.meta.dirname instead of __dirname in vite configs

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "src"),
+      "@": path.resolve(import.meta.dirname, "src"),
     },
   },
   server: {

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 
 export default defineConfig({
   resolve: {
-    alias: { "@": path.resolve(__dirname, "./src") },
+    alias: { "@": path.resolve(import.meta.dirname, "./src") },
   },
   test: {
     environment: "node",


### PR DESCRIPTION
# Description

Silence Vite's `configLoader: 'native'` deprecation warning.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
