### PR TITLE
chore(ui): enforce accessibility rules in lint

### DIFF
--- a/ui/.oxlintrc.json
+++ b/ui/.oxlintrc.json
@@ -1,13 +1,19 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "ignorePatterns": ["dist/**", "node_modules/**"],
-  "plugins": ["react", "typescript"],
+  "plugins": ["react", "typescript", "jsx-a11y"],
   "categories": {
     "correctness": "error",
     "suspicious": "warn"
   },
   "rules": {
     "typescript/no-explicit-any": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "jsx-a11y/no-autofocus": [
+      "error",
+      {
+        "ignoreNonDOM": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
# Description

Enable oxlint's 35 `jsx-a11y` rules. The codebase already passed those.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
