### PR TITLE
fix: halt on unapplicable raft log entries

### DIFF
--- a/internal/api/server/cluster_http_forward.go
+++ b/internal/api/server/cluster_http_forward.go
@@ -106,9 +106,9 @@ func mapApplyErrorToHTTP(ctx context.Context, w http.ResponseWriter, err error) 
 		writeProposeForwardError(ctx, w, http.StatusMisdirectedRequest,
 			"not leader; nothing was applied, retry", err)
 
-	case errors.Is(err, hraft.ErrLeadershipLost):
+	case errors.Is(err, db.ErrOutcomeUnknown), errors.Is(err, hraft.ErrLeadershipLost):
 		writeProposeForwardCodedError(ctx, w, http.StatusConflict,
-			"leadership lost after propose; outcome unknown, do not retry",
+			"propose may have committed; outcome unknown, do not retry",
 			ellaraft.ForwardCodeOutcomeUnknown, err)
 
 	case errors.Is(err, db.ErrProposeTimeout),

--- a/internal/api/server/cluster_http_forward.go
+++ b/internal/api/server/cluster_http_forward.go
@@ -102,9 +102,14 @@ func mapApplyErrorToHTTP(ctx context.Context, w http.ResponseWriter, err error) 
 		writeProposeForwardError(ctx, w, http.StatusBadRequest,
 			"unknown operation", err)
 
-	case errors.Is(err, hraft.ErrNotLeader), errors.Is(err, hraft.ErrLeadershipLost):
+	case errors.Is(err, hraft.ErrNotLeader):
 		writeProposeForwardError(ctx, w, http.StatusMisdirectedRequest,
-			"leadership changed during apply; retry", err)
+			"not leader; nothing was applied, retry", err)
+
+	case errors.Is(err, hraft.ErrLeadershipLost):
+		writeProposeForwardCodedError(ctx, w, http.StatusConflict,
+			"leadership lost after propose; outcome unknown, do not retry",
+			ellaraft.ForwardCodeOutcomeUnknown, err)
 
 	case errors.Is(err, db.ErrProposeTimeout),
 		errors.Is(err, hraft.ErrEnqueueTimeout),
@@ -119,6 +124,10 @@ func mapApplyErrorToHTTP(ctx context.Context, w http.ResponseWriter, err error) 
 }
 
 func writeProposeForwardError(ctx context.Context, w http.ResponseWriter, status int, message string, cause error) {
+	writeProposeForwardCodedError(ctx, w, status, message, "", cause)
+}
+
+func writeProposeForwardCodedError(ctx context.Context, w http.ResponseWriter, status int, message string, code string, cause error) {
 	if cause != nil {
 		logger.APILog.Warn("cluster propose forward error",
 			zap.Int("status", status),
@@ -126,7 +135,7 @@ func writeProposeForwardError(ctx context.Context, w http.ResponseWriter, status
 			zap.Error(cause))
 	}
 
-	body := ellaraft.ProposeForwardErrorBody{Message: message}
+	body := ellaraft.ProposeForwardErrorBody{Message: message, Code: code}
 	if cause != nil {
 		body.Message = message + ": " + cause.Error()
 	}

--- a/internal/api/server/cluster_http_forward_test.go
+++ b/internal/api/server/cluster_http_forward_test.go
@@ -207,7 +207,7 @@ func TestMapApplyErrorToHTTP(t *testing.T) {
 	}{
 		{"unknown operation", db.ErrUnknownOperation, http.StatusBadRequest},
 		{"not leader", hraft.ErrNotLeader, http.StatusMisdirectedRequest},
-		{"leadership lost", hraft.ErrLeadershipLost, http.StatusMisdirectedRequest},
+		{"leadership lost", hraft.ErrLeadershipLost, http.StatusConflict},
 		{"enqueue timeout", hraft.ErrEnqueueTimeout, http.StatusServiceUnavailable},
 		{"raft shutdown", hraft.ErrRaftShutdown, http.StatusServiceUnavailable},
 		{"propose timeout", fmt.Errorf("%w: barrier", db.ErrProposeTimeout), http.StatusServiceUnavailable},
@@ -222,5 +222,35 @@ func TestMapApplyErrorToHTTP(t *testing.T) {
 				t.Fatalf("status for %v: want %d, got %d", tc.err, tc.want, w.Code)
 			}
 		})
+	}
+}
+
+func TestMapApplyErrorToHTTP_LeadershipLostCarriesOutcomeUnknownCode(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	mapApplyErrorToHTTP(context.Background(), w, hraft.ErrLeadershipLost)
+
+	var body ellaraft.ProposeForwardErrorBody
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+
+	if body.Code != ellaraft.ForwardCodeOutcomeUnknown {
+		t.Fatalf("want code %q, got %q", ellaraft.ForwardCodeOutcomeUnknown, body.Code)
+	}
+}
+
+func TestMapApplyErrorToHTTP_NotLeaderHasNoCode(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	mapApplyErrorToHTTP(context.Background(), w, hraft.ErrNotLeader)
+
+	var body ellaraft.ProposeForwardErrorBody
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+
+	if body.Code != "" {
+		t.Fatalf("not-leader must stay retryable with no code, got %q", body.Code)
 	}
 }

--- a/internal/api/server/response.go
+++ b/internal/api/server/response.go
@@ -64,6 +64,11 @@ func writeError(ctx context.Context, w http.ResponseWriter, status int, message 
 		message = "raft commit timeout"
 	}
 
+	if errors.Is(err, db.ErrOutcomeUnknown) {
+		status = http.StatusInternalServerError
+		message = "write outcome unknown; verify state before retrying"
+	}
+
 	if errors.Is(err, db.ErrMigrationPending) {
 		status = http.StatusServiceUnavailable
 		message = "cluster is upgrading; feature unavailable until schema migration completes"

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -257,7 +257,7 @@ type (
 // the caller should retry or surface a 503.
 func isTransientRaftErr(err error) bool {
 	return errors.Is(err, hraft.ErrEnqueueTimeout) ||
-		errors.Is(err, hraft.ErrLeadershipLost) ||
+		errors.Is(err, hraft.ErrNotLeader) ||
 		errors.Is(err, hraft.ErrLeadershipTransferInProgress) ||
 		errors.Is(err, hraft.ErrRaftShutdown)
 }

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -6,6 +6,7 @@ package db
 import (
 	"errors"
 
+	ellaraft "github.com/ellanetworks/core/internal/raft"
 	"github.com/mattn/go-sqlite3"
 )
 
@@ -23,6 +24,10 @@ var (
 	// (queue full, leader lost mid-commit, or Raft shutting down). Callers
 	// should treat it as a transient 503 condition.
 	ErrProposeTimeout = errors.New("raft commit timeout")
+
+	// ErrOutcomeUnknown reports a write that may or may not have been
+	// applied. Callers must verify state rather than retry.
+	ErrOutcomeUnknown = ellaraft.ErrOutcomeUnknown
 	// ErrMigrationPending is returned when a handler depends on a schema
 	// version the cluster has not yet rolled forward to. Surfaces as 503
 	// with Retry-After so clients back off until the slowest voter

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -20,9 +20,9 @@ var (
 	ErrDNNNotInSlice     = errors.New("data network not found in slice")
 	ErrRestoreInProgress = errors.New("a restore is already in progress")
 	ErrInvalidBackupFile = errors.New("uploaded file is not a valid SQLite database")
-	// ErrProposeTimeout is returned when a Raft proposal cannot be committed
-	// (queue full, leader lost mid-commit, or Raft shutting down). Callers
-	// should treat it as a transient 503 condition.
+	// ErrProposeTimeout is returned when a Raft proposal was rejected before
+	// dispatch (queue full, not leader, or Raft shutting down). Nothing was
+	// applied, so callers may retry; the API maps it to 503.
 	ErrProposeTimeout = errors.New("raft commit timeout")
 
 	// ErrOutcomeUnknown reports a write that may or may not have been

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -21,8 +21,10 @@ var (
 	ErrRestoreInProgress = errors.New("a restore is already in progress")
 	ErrInvalidBackupFile = errors.New("uploaded file is not a valid SQLite database")
 	// ErrProposeTimeout is returned when a Raft proposal was rejected before
-	// dispatch (queue full, not leader, or Raft shutting down). Nothing was
-	// applied, so callers may retry; the API maps it to 503.
+	// dispatch (queue full, leadership transfer in progress) or a write
+	// barrier did not complete. No user entry was appended, so callers may
+	// retry; the API maps it to 503. Failures that may have committed are
+	// ErrOutcomeUnknown instead.
 	ErrProposeTimeout = errors.New("raft commit timeout")
 
 	// ErrOutcomeUnknown reports a write that may or may not have been

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -11,39 +11,18 @@ import (
 )
 
 var (
-	ErrAlreadyExists       = errors.New("already exists")
-	ErrNotFound            = errors.New("not found")
-	ErrDataNetworkNotFound = errors.New("data network not found")
-	ErrNoMatchingPolicy    = errors.New("no matching policy for slice and DNN")
-	// ErrDNNNotInSlice is returned by GetSessionPolicy when a policy matches the
-	// requested slice but none serves the requested DNN.
-	ErrDNNNotInSlice     = errors.New("data network not found in slice")
-	ErrRestoreInProgress = errors.New("a restore is already in progress")
-	ErrInvalidBackupFile = errors.New("uploaded file is not a valid SQLite database")
-	// ErrProposeTimeout is returned when a Raft proposal was rejected before
-	// dispatch (queue full, leadership transfer in progress) or a write
-	// barrier did not complete. No user entry was appended, so callers may
-	// retry; the API maps it to 503. Failures that may have committed are
-	// ErrOutcomeUnknown instead.
-	ErrProposeTimeout = errors.New("raft commit timeout")
-
-	// ErrOutcomeUnknown reports a write that may or may not have been
-	// applied. Callers must verify state rather than retry.
-	ErrOutcomeUnknown = ellaraft.ErrOutcomeUnknown
-	// ErrMigrationPending is returned when a handler depends on a schema
-	// version the cluster has not yet rolled forward to. Surfaces as 503
-	// with Retry-After so clients back off until the slowest voter
-	// catches up and the leader proposes the migration.
-	ErrMigrationPending = errors.New("schema migration pending")
-	// ErrJoinTokenAlreadyConsumed is returned by ConsumeJoinToken when the
-	// conditional UPDATE affected zero rows — either the id is unknown or
-	// the token has already been consumed by a prior (racing) caller.
+	ErrAlreadyExists            = errors.New("already exists")
+	ErrNotFound                 = errors.New("not found")
+	ErrDataNetworkNotFound      = errors.New("data network not found")
+	ErrNoMatchingPolicy         = errors.New("no matching policy for slice and DNN")
+	ErrDNNNotInSlice            = errors.New("data network not found in slice")
+	ErrRestoreInProgress        = errors.New("a restore is already in progress")
+	ErrInvalidBackupFile        = errors.New("uploaded file is not a valid SQLite database")
+	ErrProposeTimeout           = errors.New("raft commit timeout")
+	ErrOutcomeUnknown           = ellaraft.ErrOutcomeUnknown
+	ErrMigrationPending         = errors.New("schema migration pending")
 	ErrJoinTokenAlreadyConsumed = errors.New("join token already consumed")
-	// ErrUnknownOperation is returned by ApplyForwardedOperation when the
-	// operation name is not in the registered dispatch table. The HTTP
-	// handler maps it to 400 so a buggy follower surfaces as a client
-	// error rather than fail-stopping the leader.
-	ErrUnknownOperation = errors.New("unknown forwarded operation")
+	ErrUnknownOperation         = errors.New("unknown forwarded operation")
 )
 
 func isUniqueNameError(err error) bool {

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -342,8 +342,8 @@ func (op intentOp[R]) Invoke(db *Database, payload any) (R, error) {
 			return narrowResult[R](op.name, result.Value)
 		}
 
-		if classified := classifyProposeErr(applyErr); !errors.Is(classified, hraft.ErrNotLeader) {
-			return zero, classified
+		if !errors.Is(applyErr, hraft.ErrNotLeader) {
+			return zero, applyErr
 		}
 		// Lost leadership mid-apply — fall through to forward path.
 	}
@@ -365,7 +365,9 @@ func (db *Database) leaderProposeIntent(data []byte) (*ellaraft.ProposeResult, e
 	db.proposeMu.Lock()
 	defer db.proposeMu.Unlock()
 
-	return db.raftManager.ApplyBytes(data, db.proposeTimeout)
+	result, err := db.raftManager.ApplyBytes(data, db.proposeTimeout)
+
+	return result, classifyProposeErr(err)
 }
 
 // classifyBarrierErr maps a write-barrier failure. The barrier runs before
@@ -384,14 +386,16 @@ func classifyBarrierErr(err error) error {
 	}
 }
 
-// classifyProposeErr maps an error from a raft Apply that has already been
-// dispatched. Only ErrLeadershipLost is outcome-unknown; ErrNotLeader is
-// rejected before dispatch and stays retryable so callers can forward.
+// classifyProposeErr maps an error from a raft Apply. ErrLeadershipLost and
+// ErrRaftShutdown are outcome-unknown: raft raises both after commit as well
+// as before dispatch (api.go:847, raft.go:1300-1306) and the future cannot
+// tell the two apart. ErrNotLeader is rejected before dispatch and stays
+// retryable so callers can forward.
 func classifyProposeErr(err error) error {
 	switch {
 	case err == nil:
 		return nil
-	case errors.Is(err, hraft.ErrLeadershipLost):
+	case errors.Is(err, hraft.ErrLeadershipLost), errors.Is(err, hraft.ErrRaftShutdown):
 		return fmt.Errorf("%w: %v", ErrOutcomeUnknown, err)
 	case errors.Is(err, hraft.ErrNotLeader):
 		return err
@@ -546,7 +550,7 @@ func (db *Database) applyForwardedChangesetOp(opName string, h changesetOpHandle
 
 	res, err := db.raftManager.ApplyBytes(data, db.proposeTimeout)
 	if err != nil {
-		return nil, err
+		return nil, classifyProposeErr(err)
 	}
 
 	return &ellaraft.ProposeResult{Index: res.Index, Value: applyResult}, nil

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -282,13 +282,13 @@ func (op *ChangesetOp[P, R]) Invoke(db *Database, payload *P) (R, error) {
 			return narrowResult[R](op.name, result)
 		}
 
-		if !errors.Is(err, hraft.ErrNotLeader) && !errors.Is(err, hraft.ErrLeadershipLost) {
+		if !errors.Is(err, hraft.ErrNotLeader) {
 			return zero, err
 		}
 
-		// Leadership lost between IsLeader() and Propose(); fall through
-		// to the forward path. The payload is still valid; the leader
-		// we forward to will capture against its own state.
+		// Not leader, so nothing was proposed; fall through to the
+		// forward path. The payload is still valid; the leader we
+		// forward to will capture against its own state.
 	}
 
 	return op.invokeFollower(db, payload)
@@ -342,16 +342,8 @@ func (op intentOp[R]) Invoke(db *Database, payload any) (R, error) {
 			return narrowResult[R](op.name, result.Value)
 		}
 
-		if errors.Is(applyErr, hraft.ErrLeadershipLost) {
-			return zero, fmt.Errorf("%w: %v", ErrOutcomeUnknown, applyErr)
-		}
-
-		if !errors.Is(applyErr, hraft.ErrNotLeader) {
-			if isTransientRaftErr(applyErr) {
-				return zero, fmt.Errorf("%w: %v", ErrProposeTimeout, applyErr)
-			}
-
-			return zero, applyErr
+		if classified := classifyProposeErr(applyErr); !errors.Is(classified, hraft.ErrNotLeader) {
+			return zero, classified
 		}
 		// Lost leadership mid-apply — fall through to forward path.
 	}
@@ -376,18 +368,42 @@ func (db *Database) leaderProposeIntent(data []byte) (*ellaraft.ProposeResult, e
 	return db.raftManager.ApplyBytes(data, db.proposeTimeout)
 }
 
-func (db *Database) writeBarrier() error {
-	err := db.raftManager.WriteBarrier(db.proposeTimeout)
+// classifyBarrierErr maps a write-barrier failure. The barrier runs before
+// capture, so no user log entry exists yet: a leadership change here is
+// always "nothing was proposed", never an unknown outcome.
+func classifyBarrierErr(err error) error {
 	switch {
 	case err == nil:
 		return nil
 	case errors.Is(err, hraft.ErrNotLeader), errors.Is(err, hraft.ErrLeadershipLost):
-		return err
+		return fmt.Errorf("%w: write barrier: %v", hraft.ErrNotLeader, err)
 	case errors.Is(err, ellaraft.ErrBarrierTimeout), isTransientRaftErr(err):
 		return fmt.Errorf("%w: %v", ErrProposeTimeout, err)
 	default:
 		return err
 	}
+}
+
+// classifyProposeErr maps an error from a raft Apply that has already been
+// dispatched. Only ErrLeadershipLost is outcome-unknown; ErrNotLeader is
+// rejected before dispatch and stays retryable so callers can forward.
+func classifyProposeErr(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, hraft.ErrLeadershipLost):
+		return fmt.Errorf("%w: %v", ErrOutcomeUnknown, err)
+	case errors.Is(err, hraft.ErrNotLeader):
+		return err
+	case isTransientRaftErr(err):
+		return fmt.Errorf("%w: %v", ErrProposeTimeout, err)
+	default:
+		return err
+	}
+}
+
+func (db *Database) writeBarrier() error {
+	return classifyBarrierErr(db.raftManager.WriteBarrier(db.proposeTimeout))
 }
 
 // leaderCaptureAndPropose runs the capture→propose cycle on the leader.
@@ -433,15 +449,7 @@ func (db *Database) leaderCaptureAndPropose(operation string, minSchema int, app
 
 	index, err := db.raftManager.ApplyBytes(data, db.proposeTimeout)
 	if err != nil {
-		if errors.Is(err, hraft.ErrLeadershipLost) {
-			return nil, fmt.Errorf("%w: %v", ErrOutcomeUnknown, err)
-		}
-
-		if isTransientRaftErr(err) {
-			return nil, fmt.Errorf("%w: %v", ErrProposeTimeout, err)
-		}
-
-		return nil, err
+		return nil, classifyProposeErr(err)
 	}
 
 	logger.DBLog.Debug("proposed changeset",

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -285,10 +285,6 @@ func (op *ChangesetOp[P, R]) Invoke(db *Database, payload *P) (R, error) {
 		if !errors.Is(err, hraft.ErrNotLeader) {
 			return zero, err
 		}
-
-		// Not leader, so nothing was proposed; fall through to the
-		// forward path. The payload is still valid; the leader we
-		// forward to will capture against its own state.
 	}
 
 	return op.invokeFollower(db, payload)
@@ -370,9 +366,6 @@ func (db *Database) leaderProposeIntent(data []byte) (*ellaraft.ProposeResult, e
 	return result, classifyProposeErr(err)
 }
 
-// classifyBarrierErr maps a write-barrier failure. The barrier runs before
-// capture, so no user log entry exists yet: a leadership change here is
-// always "nothing was proposed", never an unknown outcome.
 func classifyBarrierErr(err error) error {
 	switch {
 	case err == nil:
@@ -386,11 +379,6 @@ func classifyBarrierErr(err error) error {
 	}
 }
 
-// classifyProposeErr maps an error from a raft Apply. ErrLeadershipLost and
-// ErrRaftShutdown are outcome-unknown: raft raises both after commit as well
-// as before dispatch (api.go:847, raft.go:1300-1306) and the future cannot
-// tell the two apart. ErrNotLeader is rejected before dispatch and stays
-// retryable so callers can forward.
 func classifyProposeErr(err error) error {
 	switch {
 	case err == nil:

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -342,7 +342,11 @@ func (op intentOp[R]) Invoke(db *Database, payload any) (R, error) {
 			return narrowResult[R](op.name, result.Value)
 		}
 
-		if !errors.Is(applyErr, hraft.ErrNotLeader) && !errors.Is(applyErr, hraft.ErrLeadershipLost) {
+		if errors.Is(applyErr, hraft.ErrLeadershipLost) {
+			return zero, fmt.Errorf("%w: %v", ErrOutcomeUnknown, applyErr)
+		}
+
+		if !errors.Is(applyErr, hraft.ErrNotLeader) {
 			if isTransientRaftErr(applyErr) {
 				return zero, fmt.Errorf("%w: %v", ErrProposeTimeout, applyErr)
 			}
@@ -429,6 +433,10 @@ func (db *Database) leaderCaptureAndPropose(operation string, minSchema int, app
 
 	index, err := db.raftManager.ApplyBytes(data, db.proposeTimeout)
 	if err != nil {
+		if errors.Is(err, hraft.ErrLeadershipLost) {
+			return nil, fmt.Errorf("%w: %v", ErrOutcomeUnknown, err)
+		}
+
 		if isTransientRaftErr(err) {
 			return nil, fmt.Errorf("%w: %v", ErrProposeTimeout, err)
 		}
@@ -458,6 +466,10 @@ func (db *Database) forwardOperation(opName string, payload json.RawMessage) (*e
 
 	result, err := db.raftManager.ForwardOperation(ctx, opName, payload, db.proposeTimeout)
 	if err != nil {
+		if errors.Is(err, ErrOutcomeUnknown) {
+			return nil, err
+		}
+
 		if isTransientRaftErr(err) {
 			return nil, fmt.Errorf("%w: %v", ErrProposeTimeout, err)
 		}

--- a/internal/db/propose_classify_test.go
+++ b/internal/db/propose_classify_test.go
@@ -57,9 +57,29 @@ func TestClassifyProposeErr_LeadershipLostIsOutcomeUnknown(t *testing.T) {
 	}
 }
 
-func TestClassifyProposeErr_ShutdownStaysTransient(t *testing.T) {
+// raft raises ErrRaftShutdown both at enqueue and from processLogs after
+// commit, so a propose that returns it may have been applied.
+func TestClassifyProposeErr_ShutdownIsOutcomeUnknown(t *testing.T) {
 	got := classifyProposeErr(hraft.ErrRaftShutdown)
+
+	if !errors.Is(got, ErrOutcomeUnknown) {
+		t.Fatalf("want ErrOutcomeUnknown, got %v", got)
+	}
+
+	if errors.Is(got, ErrProposeTimeout) {
+		t.Fatal("shutdown must not be advertised as retryable")
+	}
+}
+
+// The barrier carries no user payload, so a shutdown there applied nothing.
+func TestClassifyBarrierErr_ShutdownStaysRetryable(t *testing.T) {
+	got := classifyBarrierErr(hraft.ErrRaftShutdown)
+
 	if !errors.Is(got, ErrProposeTimeout) {
 		t.Fatalf("want ErrProposeTimeout, got %v", got)
+	}
+
+	if errors.Is(got, ErrOutcomeUnknown) {
+		t.Fatal("barrier shutdown applied nothing and must stay retryable")
 	}
 }

--- a/internal/db/propose_classify_test.go
+++ b/internal/db/propose_classify_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package db
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	ellaraft "github.com/ellanetworks/core/internal/raft"
+	hraft "github.com/hashicorp/raft"
+)
+
+func TestClassifyBarrierErr_LeadershipLossIsNotOutcomeUnknown(t *testing.T) {
+	for _, cause := range []error{hraft.ErrLeadershipLost, hraft.ErrNotLeader} {
+		got := classifyBarrierErr(cause)
+
+		if errors.Is(got, ErrOutcomeUnknown) {
+			t.Fatalf("barrier runs before capture; %v must not be outcome-unknown, got %v", cause, got)
+		}
+
+		if !errors.Is(got, hraft.ErrNotLeader) {
+			t.Fatalf("want ErrNotLeader so the forwarder retries, got %v", got)
+		}
+	}
+}
+
+func TestClassifyBarrierErr_TimeoutStaysRetryable(t *testing.T) {
+	got := classifyBarrierErr(fmt.Errorf("wrapped: %w", ellaraft.ErrBarrierTimeout))
+	if !errors.Is(got, ErrProposeTimeout) {
+		t.Fatalf("want ErrProposeTimeout, got %v", got)
+	}
+}
+
+func TestClassifyProposeErr_NotLeaderStaysForwardable(t *testing.T) {
+	got := classifyProposeErr(hraft.ErrNotLeader)
+
+	if !errors.Is(got, hraft.ErrNotLeader) {
+		t.Fatalf("ErrNotLeader must survive classification so Invoke can forward, got %v", got)
+	}
+
+	if errors.Is(got, ErrProposeTimeout) {
+		t.Fatal("ErrNotLeader must not be laundered into ErrProposeTimeout")
+	}
+}
+
+func TestClassifyProposeErr_LeadershipLostIsOutcomeUnknown(t *testing.T) {
+	got := classifyProposeErr(hraft.ErrLeadershipLost)
+
+	if !errors.Is(got, ErrOutcomeUnknown) {
+		t.Fatalf("want ErrOutcomeUnknown, got %v", got)
+	}
+
+	if errors.Is(got, hraft.ErrNotLeader) {
+		t.Fatal("an ambiguous outcome must not be forwardable")
+	}
+}
+
+func TestClassifyProposeErr_ShutdownStaysTransient(t *testing.T) {
+	got := classifyProposeErr(hraft.ErrRaftShutdown)
+	if !errors.Is(got, ErrProposeTimeout) {
+		t.Fatalf("want ErrProposeTimeout, got %v", got)
+	}
+}

--- a/internal/db/propose_classify_test.go
+++ b/internal/db/propose_classify_test.go
@@ -57,8 +57,6 @@ func TestClassifyProposeErr_LeadershipLostIsOutcomeUnknown(t *testing.T) {
 	}
 }
 
-// raft raises ErrRaftShutdown both at enqueue and from processLogs after
-// commit, so a propose that returns it may have been applied.
 func TestClassifyProposeErr_ShutdownIsOutcomeUnknown(t *testing.T) {
 	got := classifyProposeErr(hraft.ErrRaftShutdown)
 
@@ -71,7 +69,6 @@ func TestClassifyProposeErr_ShutdownIsOutcomeUnknown(t *testing.T) {
 	}
 }
 
-// The barrier carries no user payload, so a shutdown there applied nothing.
 func TestClassifyBarrierErr_ShutdownStaysRetryable(t *testing.T) {
 	got := classifyBarrierErr(hraft.ErrRaftShutdown)
 

--- a/internal/mme/nas/authentication.go
+++ b/internal/mme/nas/authentication.go
@@ -36,7 +36,9 @@ func startAuthentication(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 }
 
 func authRejectCause(err error) eps.EMMCause {
-	if errors.Is(err, db.ErrProposeTimeout) || errors.Is(err, db.ErrMigrationPending) {
+	if errors.Is(err, db.ErrProposeTimeout) ||
+		errors.Is(err, db.ErrOutcomeUnknown) ||
+		errors.Is(err, db.ErrMigrationPending) {
 		return eps.EMMCauseNetworkFailure
 	}
 

--- a/internal/raft/forward.go
+++ b/internal/raft/forward.go
@@ -101,7 +101,17 @@ type ProposeForwardResponse struct {
 // ProposeForwardErrorBody is the JSON envelope for non-2xx responses.
 type ProposeForwardErrorBody struct {
 	Message string `json:"error"`
+	Code    string `json:"code,omitempty"`
 }
+
+// ForwardCodeOutcomeUnknown marks a forwarded write whose log entry may
+// have committed before the leader lost leadership. Callers must not
+// retry it blindly; no idempotency key exists to make that safe.
+const ForwardCodeOutcomeUnknown = "outcome_unknown"
+
+// ErrOutcomeUnknown reports that a forwarded write may or may not have
+// been applied. It is deliberately not part of the retryable set.
+var ErrOutcomeUnknown = errors.New("forwarded write outcome unknown")
 
 type forwardAttemptFn func(ctx context.Context) (*ProposeResult, int, error)
 
@@ -133,7 +143,7 @@ func (m *Manager) ForwardOperation(ctx context.Context, opName string, payload j
 func (m *Manager) runForwardRetryLoop(ctx context.Context, timeout time.Duration, attempt forwardAttemptFn) (*ProposeResult, error) {
 	deadline := time.Now().Add(timeout)
 
-	lastErr := hraft.ErrLeadershipLost
+	lastErr := hraft.ErrNotLeader
 
 	for range maxForwardAttempts {
 		if err := ctx.Err(); err != nil {
@@ -157,12 +167,15 @@ func (m *Manager) runForwardRetryLoop(ctx context.Context, timeout time.Duration
 		}
 
 		switch status {
+		case http.StatusConflict:
+			return nil, err
+
 		case http.StatusMisdirectedRequest:
-			lastErr = hraft.ErrLeadershipLost
+			lastErr = hraft.ErrNotLeader
 			continue
 
 		case http.StatusServiceUnavailable:
-			lastErr = hraft.ErrLeadershipLost
+			lastErr = hraft.ErrNotLeader
 
 			if err := waitOrDone(ctx, noLeaderBackoff); err != nil {
 				return nil, err
@@ -253,7 +266,15 @@ func (m *Manager) doForwardRequest(ctx context.Context, leaderAddr string, leade
 func decodeForwardError(body []byte, status int) error {
 	var env ProposeForwardErrorBody
 	if err := json.Unmarshal(body, &env); err == nil && env.Message != "" {
+		if env.Code == ForwardCodeOutcomeUnknown {
+			return fmt.Errorf("%w: %s", ErrOutcomeUnknown, env.Message)
+		}
+
 		return errors.New(env.Message)
+	}
+
+	if status == http.StatusConflict {
+		return ErrOutcomeUnknown
 	}
 
 	return fmt.Errorf("leader returned status %d", status)

--- a/internal/raft/forward.go
+++ b/internal/raft/forward.go
@@ -104,13 +104,8 @@ type ProposeForwardErrorBody struct {
 	Code    string `json:"code,omitempty"`
 }
 
-// ForwardCodeOutcomeUnknown marks a forwarded write whose log entry may
-// have committed before the leader lost leadership. Callers must not
-// retry it blindly; no idempotency key exists to make that safe.
 const ForwardCodeOutcomeUnknown = "outcome_unknown"
 
-// ErrOutcomeUnknown reports that a forwarded write may or may not have
-// been applied. It is deliberately not part of the retryable set.
 var ErrOutcomeUnknown = errors.New("forwarded write outcome unknown")
 
 type forwardAttemptFn func(ctx context.Context) (*ProposeResult, int, error)

--- a/internal/raft/forward_test.go
+++ b/internal/raft/forward_test.go
@@ -210,8 +210,10 @@ func TestRunForwardRetryLoop_MaxAttemptsExhausted(t *testing.T) {
 		t.Fatal("expected error after exhausting retries")
 	}
 
-	// Every retried status means nothing was applied, so the exhausted
-	// loop must surface a retryable sentinel, not an ambiguous one.
+	// A 421 is raft rejecting before dispatch, so nothing was applied and
+	// the exhausted loop must surface a retryable sentinel. Note 503 is
+	// weaker: hashicorp/raft also raises ErrRaftShutdown from processLogs
+	// after commit (raft.go:1300-1306), which this loop still retries.
 	if !errors.Is(err, hraft.ErrNotLeader) {
 		t.Fatalf("want ErrNotLeader, got %v", err)
 	}

--- a/internal/raft/forward_test.go
+++ b/internal/raft/forward_test.go
@@ -210,10 +210,9 @@ func TestRunForwardRetryLoop_MaxAttemptsExhausted(t *testing.T) {
 		t.Fatal("expected error after exhausting retries")
 	}
 
-	// A 421 is raft rejecting before dispatch, so nothing was applied and
-	// the exhausted loop must surface a retryable sentinel. Note 503 is
-	// weaker: hashicorp/raft also raises ErrRaftShutdown from processLogs
-	// after commit (raft.go:1300-1306), which this loop still retries.
+	// Both retried statuses mean nothing was applied: 421 is raft rejecting
+	// before dispatch, and the leader now classifies any propose that may
+	// have committed as outcome-unknown (409) rather than 503.
 	if !errors.Is(err, hraft.ErrNotLeader) {
 		t.Fatalf("want ErrNotLeader, got %v", err)
 	}

--- a/internal/raft/forward_test.go
+++ b/internal/raft/forward_test.go
@@ -210,9 +210,6 @@ func TestRunForwardRetryLoop_MaxAttemptsExhausted(t *testing.T) {
 		t.Fatal("expected error after exhausting retries")
 	}
 
-	// Both retried statuses mean nothing was applied: 421 is raft rejecting
-	// before dispatch, and the leader now classifies any propose that may
-	// have committed as outcome-unknown (409) rather than 503.
 	if !errors.Is(err, hraft.ErrNotLeader) {
 		t.Fatalf("want ErrNotLeader, got %v", err)
 	}

--- a/internal/raft/forward_test.go
+++ b/internal/raft/forward_test.go
@@ -5,7 +5,9 @@ package raft
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -208,11 +210,14 @@ func TestRunForwardRetryLoop_MaxAttemptsExhausted(t *testing.T) {
 		t.Fatal("expected error after exhausting retries")
 	}
 
-	// Must surface ErrLeadershipLost so db.isTransientRaftErr classifies
-	// the failure as transient — the NF caller then gets ErrProposeTimeout
-	// and HTTP callers get 503.
-	if !errors.Is(err, hraft.ErrLeadershipLost) {
-		t.Fatalf("want ErrLeadershipLost, got %v", err)
+	// Every retried status means nothing was applied, so the exhausted
+	// loop must surface a retryable sentinel, not an ambiguous one.
+	if !errors.Is(err, hraft.ErrNotLeader) {
+		t.Fatalf("want ErrNotLeader, got %v", err)
+	}
+
+	if errors.Is(err, ErrOutcomeUnknown) {
+		t.Fatal("exhausted retries must not report an unknown outcome")
 	}
 
 	if got := s.calls.Load(); got != int32(maxForwardAttempts) {
@@ -323,4 +328,49 @@ func contains(s, substr string) bool {
 	}
 
 	return false
+}
+
+func TestRunForwardRetryLoop_OutcomeUnknownIsTerminal(t *testing.T) {
+	m := newRetryLoopTestManager(t)
+
+	s := &scriptedAttempter{
+		responses: []attemptResponse{
+			{status: http.StatusConflict, err: fmt.Errorf("%w: leadership lost after propose", ErrOutcomeUnknown)},
+			{status: http.StatusOK, result: &ProposeResult{Index: 9}},
+		},
+	}
+
+	_, err := m.runForwardRetryLoop(context.Background(), time.Second, s.fn())
+	if !errors.Is(err, ErrOutcomeUnknown) {
+		t.Fatalf("want ErrOutcomeUnknown, got %v", err)
+	}
+
+	if got := s.calls.Load(); got != 1 {
+		t.Fatalf("an ambiguous outcome must not be retried; got %d attempts", got)
+	}
+}
+
+func TestDecodeForwardError_OutcomeUnknownCode(t *testing.T) {
+	body, err := json.Marshal(ProposeForwardErrorBody{
+		Message: "leadership lost after propose",
+		Code:    ForwardCodeOutcomeUnknown,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if got := decodeForwardError(body, http.StatusConflict); !errors.Is(got, ErrOutcomeUnknown) {
+		t.Fatalf("want ErrOutcomeUnknown, got %v", got)
+	}
+}
+
+func TestDecodeForwardError_NoCodeStaysPlain(t *testing.T) {
+	body, err := json.Marshal(ProposeForwardErrorBody{Message: "not leader; nothing was applied, retry"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if got := decodeForwardError(body, http.StatusMisdirectedRequest); errors.Is(got, ErrOutcomeUnknown) {
+		t.Fatalf("retryable error must not decode as outcome-unknown: %v", got)
+	}
 }

--- a/internal/raft/fsm.go
+++ b/internal/raft/fsm.go
@@ -100,78 +100,15 @@ func (f *FSM) AppliedIndex() uint64 {
 }
 
 // Apply implements raft.FSM. It is called by the Raft library on every node
-// (leader and followers) for each committed log entry.
+// (leader and followers) for each committed log entry. Raft selects
+// ApplyBatch over Apply for a BatchingFSM, so this path runs only for
+// RecoverCluster replay; it delegates so both share one implementation.
 func (f *FSM) Apply(l *raft.Log) interface{} {
 	if l.Type != raft.LogCommand {
 		return nil
 	}
 
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-
-	// Skip already-applied entries. After a crash without a recent
-	// snapshot, hashicorp/raft replays committed entries from index 0.
-	// Changesets are not idempotent, so re-applying them would hit the
-	// conflict callback and crash-loop. The durable lastApplied value
-	// (fsm_state table) lets us skip entries that were already applied
-	// before the crash.
-	lastApplied, err := f.readLastApplied()
-	if err != nil {
-		logger.RaftLog.Error("FSM: failed to read lastApplied",
-			zap.Uint64("index", l.Index),
-			zap.Error(err))
-
-		return fmt.Errorf("read lastApplied: %w", err)
-	}
-
-	if l.Index <= lastApplied {
-		f.appliedIndex.Store(l.Index)
-		return nil
-	}
-
-	cmd, err := UnmarshalCommand(l.Data)
-	if err != nil {
-		logger.RaftLog.Error("FSM: failed to unmarshal command",
-			zap.Uint64("index", l.Index),
-			zap.Error(err))
-
-		return fmt.Errorf("unmarshal command: %w", err)
-	}
-
-	ctx := context.Background()
-
-	result, err := f.applier.ApplyCommand(ctx, cmd, l.Index)
-	if cmd.Type == CmdChangeset {
-		ObserveChangesetBytes(len(cmd.Payload))
-	}
-
-	if err != nil {
-		logger.RaftLog.Error("FSM: command failed — halting node",
-			zap.Uint64("index", l.Index),
-			zap.String("command", cmd.Label()),
-			zap.Error(err))
-
-		// A committed log entry that fails to apply means this node has
-		// diverged from the cluster. Continuing would silently desync
-		// state. The SAVEPOINT inside sqlite3changeset_apply guarantees
-		// the DB is clean (fully applied or fully rolled back), so the
-		// safest response is to stop the node. Recovery: restart and
-		// replay from the latest snapshot, or rejoin the cluster.
-		panic(fmt.Sprintf("FSM.Apply: fatal apply error at index %d (cmd=%s): %v", l.Index, cmd.Label(), err))
-	}
-
-	// Persist the applied index so crash-recovery replay can skip it.
-	if err := f.writeLastApplied(l.Index); err != nil {
-		logger.RaftLog.Error("FSM: failed to persist lastApplied — halting node",
-			zap.Uint64("index", l.Index),
-			zap.Error(err))
-
-		panic(fmt.Sprintf("FSM.Apply: failed to write lastApplied at index %d: %v", l.Index, err))
-	}
-
-	f.appliedIndex.Store(l.Index)
-
-	return result
+	return f.ApplyBatch([]*raft.Log{l})[0]
 }
 
 // ApplyBatch implements raft.BatchingFSM. The Raft library calls this instead
@@ -184,15 +121,10 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 
 	lastApplied, err := f.readLastApplied()
 	if err != nil {
-		logger.RaftLog.Error("FSM: failed to read lastApplied in batch",
+		logger.RaftLog.Error("FSM: failed to read lastApplied in batch — halting node",
 			zap.Error(err))
 
-		ret := make([]interface{}, len(logs))
-		for i := range ret {
-			ret[i] = fmt.Errorf("read lastApplied: %w", err)
-		}
-
-		return ret
+		panic(fmt.Sprintf("FSM.ApplyBatch: failed to read lastApplied: %v", err))
 	}
 
 	results := make([]interface{}, len(logs))
@@ -214,13 +146,11 @@ func (f *FSM) ApplyBatch(logs []*raft.Log) []interface{} {
 
 		cmd, err := UnmarshalCommand(l.Data)
 		if err != nil {
-			logger.RaftLog.Error("FSM: failed to unmarshal command in batch",
+			logger.RaftLog.Error("FSM: failed to unmarshal command in batch — halting node",
 				zap.Uint64("index", l.Index),
 				zap.Error(err))
 
-			results[i] = fmt.Errorf("unmarshal command: %w", err)
-
-			continue
+			panic(fmt.Sprintf("FSM.ApplyBatch: failed to unmarshal command at index %d: %v", l.Index, err))
 		}
 
 		result, applyErr := f.applier.ApplyCommand(ctx, cmd, l.Index)

--- a/internal/raft/fsm.go
+++ b/internal/raft/fsm.go
@@ -99,10 +99,6 @@ func (f *FSM) AppliedIndex() uint64 {
 	return f.appliedIndex.Load()
 }
 
-// Apply implements raft.FSM. It is called by the Raft library on every node
-// (leader and followers) for each committed log entry. Raft selects
-// ApplyBatch over Apply for a BatchingFSM, so this path runs only for
-// RecoverCluster replay; it delegates so both share one implementation.
 func (f *FSM) Apply(l *raft.Log) interface{} {
 	if l.Type != raft.LogCommand {
 		return nil

--- a/internal/raft/fsm_test.go
+++ b/internal/raft/fsm_test.go
@@ -163,31 +163,33 @@ func TestFSM_Apply_AdvancesAppliedIndex(t *testing.T) {
 	}
 }
 
-// TestFSM_Apply_BadPayload returns an error and leaves appliedIndex unchanged.
-func TestFSM_Apply_BadPayload(t *testing.T) {
+func TestFSM_Apply_PanicsOnBadPayload(t *testing.T) {
 	a := newTestApplier(t)
 	fsm := NewFSM(a, t.TempDir())
 
-	// One-byte payload is shorter than the 2-byte header.
-	resp := fsm.Apply(&hraft.Log{Index: 3, Data: []byte{0x01}})
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on undecodable payload, but Apply returned normally")
+		}
 
-	err, ok := resp.(error)
-	if !ok {
-		t.Fatalf("expected error response, got %T: %v", resp, resp)
-	}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
 
-	if err == nil {
-		t.Fatal("expected non-nil error")
-	}
+		if !strings.Contains(msg, "unmarshal") {
+			t.Fatalf("panic message should mention unmarshal, got: %s", msg)
+		}
 
-	if got := fsm.AppliedIndex(); got != 0 {
-		t.Fatalf("applied index must not advance on unmarshal failure, got %d", got)
-	}
+		if len(a.seen()) != 0 {
+			t.Fatalf("no command should have been applied, got %d", len(a.seen()))
+		}
+	}()
+
+	fsm.Apply(&hraft.Log{Index: 3, Data: []byte{0x01}})
 }
 
-// TestFSM_Apply_PanicsOnApplierError verifies that an applier error causes
-// the FSM to panic (fail-stop) rather than silently continuing with a
-// diverged state.
 func TestFSM_Apply_PanicsOnApplierError(t *testing.T) {
 	a := newTestApplier(t)
 	a.applyErr = errors.New("boom")
@@ -611,10 +613,7 @@ func TestFSM_ApplyBatch_AllSkipped(t *testing.T) {
 	}
 }
 
-// TestFSM_ApplyBatch_BadPayloadMidBatch verifies that an unmarshal error for
-// one entry in a batch returns an error for that slot but does not panic and
-// does not prevent subsequent entries from being applied.
-func TestFSM_ApplyBatch_BadPayloadMidBatch(t *testing.T) {
+func TestFSM_ApplyBatch_PanicsOnBadPayloadMidBatch(t *testing.T) {
 	a := newTestApplier(t)
 	fsm := NewFSM(a, t.TempDir())
 
@@ -630,44 +629,31 @@ func TestFSM_ApplyBatch_BadPayloadMidBatch(t *testing.T) {
 
 	logs := []*hraft.Log{
 		{Index: 1, Data: goodData},
-		{Index: 2, Data: []byte{0xFF}}, // too short to unmarshal
+		{Index: 2, Data: []byte{0xFF}},
 		{Index: 3, Data: goodData},
 	}
 
-	results := fsm.ApplyBatch(logs)
-	if len(results) != 3 {
-		t.Fatalf("expected 3 results, got %d", len(results))
-	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on undecodable payload, but ApplyBatch returned normally")
+		}
 
-	if results[0] != nil {
-		t.Fatalf("result[0]: expected nil, got %v", results[0])
-	}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
 
-	if results[1] == nil {
-		t.Fatal("result[1]: expected error for bad payload, got nil")
-	}
+		if !strings.Contains(msg, "unmarshal") {
+			t.Fatalf("panic message should mention unmarshal, got: %s", msg)
+		}
 
-	errMsg, ok := results[1].(error)
-	if !ok {
-		t.Fatalf("result[1]: expected error type, got %T", results[1])
-	}
+		if got := len(a.seen()); got != 1 {
+			t.Fatalf("only the entry before the bad payload should have applied, got %d", got)
+		}
+	}()
 
-	if !strings.Contains(errMsg.Error(), "unmarshal") {
-		t.Fatalf("result[1] error should mention unmarshal, got: %v", errMsg)
-	}
-
-	if results[2] != nil {
-		t.Fatalf("result[2]: expected nil, got %v", results[2])
-	}
-
-	// Entries 1 and 3 applied; entry 2 skipped due to bad payload.
-	if got := len(a.seen()); got != 2 {
-		t.Fatalf("expected 2 commands applied, got %d", got)
-	}
-
-	if got := fsm.AppliedIndex(); got != 3 {
-		t.Fatalf("applied index: want 3, got %d", got)
-	}
+	fsm.ApplyBatch(logs)
 }
 
 // TestFSM_ApplyBatch_SingleEntry verifies that a batch with a single element
@@ -867,4 +853,91 @@ func (byteReadCloser) Close() error { return nil }
 
 func newReadCloser(b []byte) byteReadCloser {
 	return byteReadCloser{Reader: bytes.NewReader(b)}
+}
+
+func TestFSM_Apply_PanicsOnReadLastAppliedError(t *testing.T) {
+	a := newTestApplier(t)
+	fsm := NewFSM(a, t.TempDir())
+
+	cmd, err := NewCommand(CmdChangeset, map[string]string{"v": "x"})
+	if err != nil {
+		t.Fatalf("new command: %v", err)
+	}
+
+	data, err := cmd.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if err := a.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on readLastApplied error, but Apply returned normally")
+		}
+
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
+
+		if !strings.Contains(msg, "failed to read lastApplied") {
+			t.Fatalf("panic message should name the read failure, got: %s", msg)
+		}
+
+		if len(a.seen()) != 0 {
+			t.Fatalf("no command should have been applied, got %d", len(a.seen()))
+		}
+	}()
+
+	fsm.Apply(&hraft.Log{Index: 5, Data: data})
+}
+
+func TestFSM_ApplyBatch_PanicsOnReadLastAppliedError(t *testing.T) {
+	a := newTestApplier(t)
+	fsm := NewFSM(a, t.TempDir())
+
+	cmd, err := NewCommand(CmdChangeset, map[string]string{"v": "y"})
+	if err != nil {
+		t.Fatalf("new command: %v", err)
+	}
+
+	data, err := cmd.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	logs := []*hraft.Log{
+		{Index: 1, Data: data},
+		{Index: 2, Data: data},
+	}
+
+	if err := a.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on readLastApplied error, but ApplyBatch returned normally")
+		}
+
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
+
+		if !strings.Contains(msg, "failed to read lastApplied") {
+			t.Fatalf("panic message should name the read failure, got: %s", msg)
+		}
+
+		if len(a.seen()) != 0 {
+			t.Fatalf("no command should have been applied, got %d", len(a.seen()))
+		}
+	}()
+
+	fsm.ApplyBatch(logs)
 }

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -568,7 +568,7 @@ func (m *Manager) WriteBarrier(timeout time.Duration) error {
 		return raft.ErrNotLeader
 	}
 
-	att := m.barrierFor(term, timeout)
+	att := m.barrierFor(term)
 
 	select {
 	case <-att.done:
@@ -580,7 +580,7 @@ func (m *Manager) WriteBarrier(timeout time.Duration) error {
 
 // barrierFor shares one in-flight barrier per term: a caller that gives up
 // leaves it running, so repeated timeouts still cost the log a single entry.
-func (m *Manager) barrierFor(term uint64, timeout time.Duration) *barrierAttempt {
+func (m *Manager) barrierFor(term uint64) *barrierAttempt {
 	m.barrierMu.Lock()
 	defer m.barrierMu.Unlock()
 
@@ -592,7 +592,7 @@ func (m *Manager) barrierFor(term uint64, timeout time.Duration) *barrierAttempt
 	m.barrier = att
 
 	go func() {
-		att.err = m.raft.Barrier(timeout).Error()
+		att.err = m.raft.Barrier(0).Error()
 
 		if att.err == nil {
 			m.barrieredTerm.Store(term)

--- a/internal/raft/write_barrier_test.go
+++ b/internal/raft/write_barrier_test.go
@@ -87,6 +87,40 @@ func awaitLeader(t *testing.T, tc *TestCluster, survivors []int, appliers []*slo
 	}
 }
 
+func awaitStableLastIndex(t *testing.T, m *Manager) uint64 {
+	t.Helper()
+
+	const (
+		tick        = 10 * time.Millisecond
+		stableTicks = 50
+	)
+
+	deadline := time.After(15 * time.Second)
+	last := m.raft.LastIndex()
+	stable := 0
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("last index never settled (still %d)", last)
+		case <-time.After(tick):
+		}
+
+		cur := m.raft.LastIndex()
+		if cur != last {
+			last = cur
+			stable = 0
+
+			continue
+		}
+
+		stable++
+		if stable == stableTicks {
+			return last
+		}
+	}
+}
+
 func TestWriteBarrier_WaitsForPriorTermEntries(t *testing.T) {
 	const proposals = 30
 
@@ -153,7 +187,7 @@ func TestWriteBarrier_TimesOutOnBacklog(t *testing.T) {
 		t.Fatalf("write barrier against a backlog: want ErrBarrierTimeout, got %v", err)
 	}
 
-	beforeRetries := newLeader.raft.LastIndex()
+	beforeRetries := awaitStableLastIndex(t, newLeader)
 
 	for range 5 {
 		if err := newLeader.WriteBarrier(10 * time.Millisecond); !errors.Is(err, ErrBarrierTimeout) {
@@ -161,7 +195,7 @@ func TestWriteBarrier_TimesOutOnBacklog(t *testing.T) {
 		}
 	}
 
-	if got := newLeader.raft.LastIndex(); got != beforeRetries {
+	if got := awaitStableLastIndex(t, newLeader); got != beforeRetries {
 		t.Fatalf("last index after 5 timed-out retries: want %d (one barrier in flight), got %d", beforeRetries, got)
 	}
 

--- a/internal/tester/scenarios/ha/failover_connectivity_5g.go
+++ b/internal/tester/scenarios/ha/failover_connectivity_5g.go
@@ -132,12 +132,6 @@ func runFailoverConnectivity(ctx context.Context, env scenarios.Env) error {
 		return fmt.Errorf("phase2: wait for NG Setup Response on new peer: %w", err)
 	}
 
-	// Registration bumps the subscriber's sequenceNumber, a Raft-replicated
-	// write. Killing the leader starts a heartbeat-timeout → election cycle
-	// of a few seconds, during which forwarded writes find no leader and
-	// NAS sends Registration Reject. Each retry is a fresh registration,
-	// not a replay of a possibly-committed write. Retry with backoff until
-	// the new leader settles.
 	const (
 		phase2Deadline = 30 * time.Second
 		phase2Backoff  = 2 * time.Second

--- a/internal/tester/scenarios/ha/failover_connectivity_5g.go
+++ b/internal/tester/scenarios/ha/failover_connectivity_5g.go
@@ -134,9 +134,10 @@ func runFailoverConnectivity(ctx context.Context, env scenarios.Env) error {
 
 	// Registration bumps the subscriber's sequenceNumber, a Raft-replicated
 	// write. Killing the leader starts a heartbeat-timeout → election cycle
-	// of a few seconds, during which forwarded writes return
-	// ErrLeadershipLost and NAS sends Registration Reject. Retry with backoff
-	// until the new leader settles.
+	// of a few seconds, during which forwarded writes find no leader and
+	// NAS sends Registration Reject. Each retry is a fresh registration,
+	// not a replay of a possibly-committed write. Retry with backoff until
+	// the new leader settles.
 	const (
 		phase2Deadline = 30 * time.Second
 		phase2Backoff  = 2 * time.Second


### PR DESCRIPTION
# Description

Makes the Raft FSM halt instead of silently skipping unapplicable committed entries, and stops auto-retrying forwarded writes whose outcome is unknown.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
