### PR TITLE
fix: decouple startup from raft leadership

### DIFF
--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -54,7 +54,7 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
     - `peers` (list of strings): `host:port` of every node in the cluster. Host may be an IP or DNS name. Must include this node's own `advertise-address` (or `bind-address` if `advertise-address` is unset) as the same string.
     - `join-token` (string, optional): Single-use token minted on an existing voter via `POST /api/v1/cluster/pki/join-tokens`. Required on the first boot of a node joining an existing cluster; consumed and ignored on subsequent starts. Its presence also tells the daemon that this node is a joiner, not the founder.
     - `initial-suffrage` (string, optional): `voter` or `nonvoter`. Defaults to `voter`.
-    - `join-timeout` (duration string, optional): Maximum wait for cluster formation during discovery.
+    - `join-timeout` (duration string, optional): Wait for cluster formation after which discovery starts logging that it is slow. Discovery keeps retrying past it.
     - `propose-timeout` (duration string, optional): Maximum wait for a Raft commit before the API returns 503.
     - `snapshot-interval` (duration string, optional): Minimum interval between automatic Raft snapshots.
     - `snapshot-threshold` (int, optional): Minimum number of applied log entries between automatic snapshots.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -218,8 +218,8 @@ func StartDiscovery(ctx context.Context, dbInstance *db.Database, cfg config.Con
 }
 
 // Upgrade swaps the discovery-only handler for the full API handler. It
-// must be called after cluster formation and database initialization so
-// that the JWT secret and all settings are available.
+// must be called after Initialize has seeded the replicated JWT secret on
+// this node; it does not require a leader or a formed cluster.
 func (s *Server) Upgrade(ctx context.Context, opts UpgradeConfig) error {
 	jwtSecretBytes, err := opts.DB.GetJWTSecret(ctx)
 	if err != nil {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -59,9 +59,13 @@ func TestStartServerStandup(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
 
-	testdb, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	testdb, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("could not create new database: %v", err)
+	}
+
+	if err := testdb.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	port := freePort(t)

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -100,8 +100,12 @@ func setupServer(filepath string) (testEnv, error) {
 // setupServerWithRaft is the slow path for tests that exercise cluster /
 // restore behavior and therefore need a live Raft manager.
 func setupServerWithRaft(filepath string) (testEnv, error) {
-	testdb, err := db.NewDatabase(context.Background(), filepath, ellaraft.ClusterConfig{})
+	testdb, err := db.NewDatabase(context.Background(), filepath, ellaraft.FastTestConfig())
 	if err != nil {
+		return testEnv{}, err
+	}
+
+	if err := testdb.WaitUntilReady(context.Background()); err != nil {
 		return testEnv{}, err
 	}
 

--- a/internal/api/server/api_pki.go
+++ b/internal/api/server/api_pki.go
@@ -24,13 +24,14 @@ const (
 
 // pkiAdminEndpoint resolves the pkiissuer.Service at request time and
 // dispatches to build. Returns 503 until the issuer service has been
-// installed by runtime.
+// installed by runtime and its join-HMAC key is committed; both are
+// transient startup states, so the caller should retry.
 func pkiAdminEndpoint(build func(*pkiissuer.Service) http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		svc := loadPKIIssuer()
-		if svc == nil {
+		if svc == nil || !svc.Ready(r.Context()) {
 			writeError(r.Context(), w, http.StatusServiceUnavailable,
-				"pki issuer not yet installed", nil, logger.APILog)
+				"pki issuer not yet ready", nil, logger.APILog)
 
 			return
 		}

--- a/internal/api/server/api_pki.go
+++ b/internal/api/server/api_pki.go
@@ -24,8 +24,7 @@ const (
 
 // pkiAdminEndpoint resolves the pkiissuer.Service at request time and
 // dispatches to build. Returns 503 until the issuer service has been
-// installed by runtime and its join-HMAC key is committed; both are
-// transient startup states, so the caller should retry.
+// installed by runtime and its join-HMAC key is committed.
 func pkiAdminEndpoint(build func(*pkiissuer.Service) http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		svc := loadPKIIssuer()

--- a/internal/api/server/api_pki_test.go
+++ b/internal/api/server/api_pki_test.go
@@ -137,10 +137,6 @@ func TestPKIAdminEndpoints_MintToken(t *testing.T) {
 	}
 }
 
-// TestPKIAdminEndpoints_InstalledButNotBootstrapped503 covers the startup
-// window where the issuer handle is published before its join-HMAC key is
-// committed. The condition is transient, so it must read as a retryable 503
-// rather than a 500 from deep inside MintJoinToken.
 func TestPKIAdminEndpoints_InstalledButNotBootstrapped503(t *testing.T) {
 	env, err := setupServer(filepath.Join(t.TempDir(), "ella.db"))
 	if err != nil {
@@ -153,7 +149,6 @@ func TestPKIAdminEndpoints_InstalledButNotBootstrapped503(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Installed, but deliberately never bootstrapped.
 	server.SetPKIIssuer(pkiissuer.New(env.DB))
 	t.Cleanup(func() { server.SetPKIIssuer(nil) })
 

--- a/internal/api/server/api_pki_test.go
+++ b/internal/api/server/api_pki_test.go
@@ -136,3 +136,45 @@ func TestPKIAdminEndpoints_MintToken(t *testing.T) {
 		t.Fatal("empty expiresAt")
 	}
 }
+
+// TestPKIAdminEndpoints_InstalledButNotBootstrapped503 covers the startup
+// window where the issuer handle is published before its join-HMAC key is
+// committed. The condition is transient, so it must read as a retryable 503
+// rather than a 500 from deep inside MintJoinToken.
+func TestPKIAdminEndpoints_InstalledButNotBootstrapped503(t *testing.T) {
+	env, err := setupServer(filepath.Join(t.TempDir(), "ella.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() { _ = env.DB.Close() }()
+
+	if err := env.DB.UpdateOperatorClusterID(context.Background(), "test-cluster"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Installed, but deliberately never bootstrapped.
+	server.SetPKIIssuer(pkiissuer.New(env.DB))
+	t.Cleanup(func() { server.SetPKIIssuer(nil) })
+
+	admin, err := initializeAndRefresh(env.Server.URL, env.Server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		env.Server.URL+"/api/v1/cluster/pki/join-tokens", strings.NewReader(`{"nodeID": 5}`))
+	req.Header.Set("Authorization", "Bearer "+admin)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.Server.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("got %d, want 503 while the issuer is installed but not yet bootstrapped", resp.StatusCode)
+	}
+}

--- a/internal/api/server/api_status.go
+++ b/internal/api/server/api_status.go
@@ -95,7 +95,7 @@ func GetStatus(dbInstance *db.Database, ready *atomic.Bool, datapathMode func() 
 			Version:       ver.Version,
 			Revision:      ver.Revision,
 			Initialized:   initialized,
-			Ready:         ready.Load(),
+			Ready:         ready.Load() && dbInstance.HasLeader() && dbInstance.IsOperatorInitialized(ctx),
 			SchemaVersion: db.SchemaVersion(),
 		}
 

--- a/internal/api/server/cluster_http_mux.go
+++ b/internal/api/server/cluster_http_mux.go
@@ -100,9 +100,7 @@ func newClusterMux(dbInstance *db.Database) *http.ServeMux {
 }
 
 // pkiEndpoint resolves the current pkiissuer.Service at request time
-// and dispatches. Returns 503 until the service is installed and its
-// join-HMAC key is committed; both are transient startup states, so the
-// caller should retry rather than treat them as a failed request.
+// and dispatches. Returns 503 until the service is installed and ready.
 func pkiEndpoint(build func(*pkiissuer.Service) http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		svc := loadPKIIssuer()

--- a/internal/api/server/cluster_http_mux.go
+++ b/internal/api/server/cluster_http_mux.go
@@ -100,13 +100,15 @@ func newClusterMux(dbInstance *db.Database) *http.ServeMux {
 }
 
 // pkiEndpoint resolves the current pkiissuer.Service at request time
-// and dispatches. Returns 503 if the service is not yet installed.
+// and dispatches. Returns 503 until the service is installed and its
+// join-HMAC key is committed; both are transient startup states, so the
+// caller should retry rather than treat them as a failed request.
 func pkiEndpoint(build func(*pkiissuer.Service) http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		svc := loadPKIIssuer()
-		if svc == nil {
+		if svc == nil || !svc.Ready(r.Context()) {
 			writeError(r.Context(), w, http.StatusServiceUnavailable,
-				"pki issuer not yet installed", nil, logger.APILog)
+				"pki issuer not yet ready", nil, logger.APILog)
 
 			return
 		}

--- a/internal/api/server/cluster_http_mux_test.go
+++ b/internal/api/server/cluster_http_mux_test.go
@@ -23,9 +23,13 @@ func newTestDB(t *testing.T) *db.Database {
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 
-	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("create test db: %v", err)
+	}
+
+	if err := testDB.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	t.Cleanup(func() { _ = testDB.Close() })

--- a/internal/api/server/cluster_http_test.go
+++ b/internal/api/server/cluster_http_test.go
@@ -54,9 +54,13 @@ func TestClusterHTTP_Status(t *testing.T) {
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 
-	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("create test db: %v", err)
+	}
+
+	if err := testDB.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	stopCluster := server.StartClusterHTTP(testDB, serverLn)
@@ -157,9 +161,13 @@ func clusterTestServer(t *testing.T, pki *testutil.PKI, peerNodeIDs []int) (serv
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 
-	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	testDB, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("create test db: %v", err)
+	}
+
+	if err := testDB.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	stopCluster := server.StartClusterHTTP(testDB, serverLn)

--- a/internal/db/api_tokens.go
+++ b/internal/db/api_tokens.go
@@ -125,7 +125,7 @@ func (db *Database) CreateAPIToken(ctx context.Context, apiToken *APIToken) erro
 		apiToken.ID = id.String()
 	}
 
-	_, err := opCreateAPIToken.Invoke(db, apiToken)
+	_, err := opCreateAPIToken.Invoke(ctx, db, apiToken)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -194,7 +194,7 @@ func (db *Database) DeleteAPIToken(ctx context.Context, id string) error {
 
 	DBQueriesTotal.WithLabelValues(APITokensTableName, "delete").Inc()
 
-	_, err := opDeleteAPIToken.Invoke(db, &stringPayload{Value: id})
+	_, err := opDeleteAPIToken.Invoke(ctx, db, &stringPayload{Value: id})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/backup_test.go
+++ b/internal/db/backup_test.go
@@ -20,9 +20,13 @@ func TestDatabaseBackup(t *testing.T) {
 
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
 
-	database, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("Couldn't initialize NewDatabase: %s", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {

--- a/internal/db/changeset_apply_atomic_test.go
+++ b/internal/db/changeset_apply_atomic_test.go
@@ -82,9 +82,13 @@ func newAtomicTestDB(t *testing.T) *Database {
 	tmp := t.TempDir()
 
 	database, err := NewDatabase(context.Background(),
-		filepath.Join(tmp, "db.sqlite3"), ellaraft.ClusterConfig{})
+		filepath.Join(tmp, "db.sqlite3"), ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	t.Cleanup(func() { _ = database.Close() })

--- a/internal/db/cluster_members.go
+++ b/internal/db/cluster_members.go
@@ -149,7 +149,7 @@ func (db *Database) UpsertClusterMember(ctx context.Context, member *ClusterMemb
 
 	DBQueriesTotal.WithLabelValues(ClusterMembersTableName, "upsert").Inc()
 
-	_, err := opUpsertClusterMember.Invoke(db, member)
+	_, err := opUpsertClusterMember.Invoke(ctx, db, member)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -180,7 +180,7 @@ func (db *Database) DeleteClusterMember(ctx context.Context, nodeID int) error {
 
 	DBQueriesTotal.WithLabelValues(ClusterMembersTableName, "delete").Inc()
 
-	_, err := opDeleteClusterMember.Invoke(db, &intPayload{Value: nodeID})
+	_, err := opDeleteClusterMember.Invoke(ctx, db, &intPayload{Value: nodeID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -223,7 +223,7 @@ func (db *Database) SetDrainState(ctx context.Context, nodeID int, state string)
 		DrainUpdatedAt: time.Now().Unix(),
 	}
 
-	_, err := opSetDrainState.Invoke(db, member)
+	_, err := opSetDrainState.Invoke(ctx, db, member)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/cluster_pki.go
+++ b/internal/db/cluster_pki.go
@@ -183,7 +183,7 @@ func (db *Database) GetClusterNodeCertByFingerprint(ctx context.Context, fingerp
 // UpsertClusterNodeCert pins (or re-pins on rotation) a node's cert.
 // The leader's /cluster/pki/register handler drives this.
 func (db *Database) UpsertClusterNodeCert(ctx context.Context, r *ClusterNodeCert) error {
-	_, err := opUpsertNodeCert.Invoke(db, r)
+	_, err := opUpsertNodeCert.Invoke(ctx, db, r)
 
 	return err
 }
@@ -192,7 +192,7 @@ func (db *Database) UpsertClusterNodeCert(ctx context.Context, r *ClusterNodeCer
 // RemoveClusterMember; once the deletion replicates, peers reject
 // the removed node's handshakes.
 func (db *Database) DeleteClusterNodeCert(ctx context.Context, nodeID int) error {
-	_, err := opDeleteNodeCert.Invoke(db, &ClusterNodeCert{NodeID: nodeID})
+	_, err := opDeleteNodeCert.Invoke(ctx, db, &ClusterNodeCert{NodeID: nodeID})
 
 	return err
 }
@@ -201,7 +201,7 @@ func (db *Database) DeleteClusterNodeCert(ctx context.Context, nodeID int) error
 // token can be checked for single-use. The token string itself is
 // emitted by pki.MintJoinToken; this row only carries metadata.
 func (db *Database) MintJoinTokenRecord(ctx context.Context, r *ClusterJoinToken) error {
-	_, err := opMintJoinToken.Invoke(db, r)
+	_, err := opMintJoinToken.Invoke(ctx, db, r)
 
 	return err
 }
@@ -226,7 +226,7 @@ func (db *Database) GetJoinToken(ctx context.Context, id string) (*ClusterJoinTo
 // UPDATE only matches unconsumed rows, so a second caller on a different
 // voter (post-replication) finds nothing to update.
 func (db *Database) ConsumeJoinToken(ctx context.Context, id string, nodeID int) error {
-	_, err := opConsumeJoinToken.Invoke(db, &ClusterJoinToken{
+	_, err := opConsumeJoinToken.Invoke(ctx, db, &ClusterJoinToken{
 		ID:         id,
 		ConsumedAt: time.Now().Unix(),
 		ConsumedBy: nodeID,
@@ -240,7 +240,7 @@ func (db *Database) ConsumeJoinToken(ctx context.Context, id string, nodeID int)
 func (db *Database) DeleteStaleJoinTokens(ctx context.Context, now time.Time) error {
 	cutoffConsumed := now.Add(-time.Hour).Unix()
 
-	_, err := opDeleteStaleJoinTokens.Invoke(db, &ClusterJoinToken{
+	_, err := opDeleteStaleJoinTokens.Invoke(ctx, db, &ClusterJoinToken{
 		ExpiresAt:  now.Unix(),
 		ConsumedAt: cutoffConsumed,
 	})
@@ -269,7 +269,7 @@ func (db *Database) GetClusterJoinHMACKey(ctx context.Context) ([]byte, error) {
 // leader promotion. Subsequent calls are no-ops (ON CONFLICT DO
 // NOTHING) so the key is fixed for the cluster's lifetime.
 func (db *Database) InitClusterJoinHMACKey(ctx context.Context, key []byte) error {
-	_, err := opInitJoinHMAC.Invoke(db, &ClusterJoinHMAC{HMACKey: key})
+	_, err := opInitJoinHMAC.Invoke(ctx, db, &ClusterJoinHMAC{HMACKey: key})
 
 	return err
 }

--- a/internal/db/daily_usage.go
+++ b/internal/db/daily_usage.go
@@ -120,7 +120,7 @@ func (db *Database) IncrementDailyUsage(ctx context.Context, usage DailyUsage) e
 
 	DBQueriesTotal.WithLabelValues(DailyUsageTableName, "insert").Inc()
 
-	_, err := opIncrementDailyUsage.Invoke(db, &usage)
+	_, err := opIncrementDailyUsage.Invoke(ctx, db, &usage)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -247,7 +247,7 @@ func (db *Database) ClearDailyUsage(ctx context.Context) error {
 
 	DBQueriesTotal.WithLabelValues(DailyUsageTableName, "delete").Inc()
 
-	_, err := opClearDailyUsage.Invoke(db, &emptyPayload{})
+	_, err := opClearDailyUsage.Invoke(ctx, db, &emptyPayload{})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -284,7 +284,7 @@ func (db *Database) DeleteOldDailyUsage(ctx context.Context, days int) error {
 	// desync replicas.
 	cutoffDay := time.Now().UTC().AddDate(0, 0, -days).Unix() / 86400
 
-	_, err := opDeleteOldDailyUsage.Invoke(db, &int64Payload{Value: cutoffDay})
+	_, err := opDeleteOldDailyUsage.Invoke(ctx, db, &int64Payload{Value: cutoffDay})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/data_networks.go
+++ b/internal/db/data_networks.go
@@ -245,7 +245,7 @@ func (db *Database) CreateDataNetwork(ctx context.Context, dataNetwork *DataNetw
 		dataNetwork.ID = id.String()
 	}
 
-	_, err := opCreateDataNetwork.Invoke(db, dataNetwork)
+	_, err := opCreateDataNetwork.Invoke(ctx, db, dataNetwork)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -276,7 +276,7 @@ func (db *Database) UpdateDataNetwork(ctx context.Context, dataNetwork *DataNetw
 
 	DBQueriesTotal.WithLabelValues(DataNetworksTableName, "update").Inc()
 
-	_, err := opUpdateDataNetwork.Invoke(db, dataNetwork)
+	_, err := opUpdateDataNetwork.Invoke(ctx, db, dataNetwork)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -307,7 +307,7 @@ func (db *Database) DeleteDataNetwork(ctx context.Context, name string) error {
 
 	DBQueriesTotal.WithLabelValues(DataNetworksTableName, "delete").Inc()
 
-	_, err := opDeleteDataNetwork.Invoke(db, &stringPayload{Value: name})
+	_, err := opDeleteDataNetwork.Invoke(ctx, db, &stringPayload{Value: name})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1042,19 +1042,15 @@ func (db *Database) RemoveServer(nodeID int) error {
 	return db.raftManager.RemoveServer(nodeID)
 }
 
-// RunDiscovery performs cluster formation for HA mode. Must be called after
-// the HTTP server starts so peers can reach this node's API.
-// After discovery, the leader generates a cluster ID if none exists yet.
-func (db *Database) RunDiscovery(ctx context.Context) error {
+// StartDiscovery performs cluster formation for HA mode in the background.
+// Must be called after the HTTP server starts so peers can reach this
+// node's API.
+func (db *Database) StartDiscovery(ctx context.Context) {
 	if db.raftManager == nil {
-		return nil
+		return
 	}
 
-	if err := db.raftManager.RunDiscovery(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	db.raftManager.StartDiscovery(ctx)
 }
 
 // ensureClusterID populates the operator row's ClusterID if empty.
@@ -1205,21 +1201,20 @@ func NewDatabase(ctx context.Context, dbPath string, raftCfg ellaraft.ClusterCon
 	// Local-only singleton tables (NAT, flow accounting, BGP, N3) seed
 	// their default rows here on every node — leader, follower, standalone.
 	// Local-only writes don't go through Raft, so no leader is required
-	// and this is safe to run before RunDiscovery. Each Initialize* is
+	// and this is safe to run before cluster discovery. Each Initialize* is
 	// idempotent: an existing row (default or operator-set) is preserved.
 	if err := db.InitializeLocalSettings(ctx); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("seed local-only settings: %w", err)
 	}
 
-	// In HA mode, defer Initialize() until RunDiscovery has formed or
-	// joined the cluster and a leader exists — otherwise every propose()
-	// here would fail with ErrNotLeader on a fresh follower. Callers must
-	// invoke Initialize explicitly after RunDiscovery.
+	// Replicated singleton rows (JWT secret, operator, admin user) are
+	// seeded on leadership, not here: Initialize proposes through Raft and
+	// no node is leader this early. HA mode seeds through runLeaderInit in
+	// pkg/runtime; standalone seeds through the callback registered below.
 	if !raftCfg.Enabled {
-		if err := db.Initialize(ctx); err != nil {
-			_ = db.Close()
-			return nil, fmt.Errorf("failed to initialize database: %w", err)
+		if observer := raftMgr.LeaderObserver(); observer != nil {
+			observer.Register(newStandaloneInitializer(db, workerCtx))
 		}
 	}
 
@@ -1580,10 +1575,18 @@ func (db *Database) PrepareStatements() error {
 	return nil
 }
 
-// WaitForInitialization polls until the leader's Initialize data has
-// replicated to this follower (operator row exists), or ctx is cancelled.
+// WaitForInitialization polls until the replicated initial settings are
+// visible on this node (the operator row exists), ctx is cancelled, or
+// timeout elapses. A timeout of zero or less waits indefinitely.
 func (db *Database) WaitForInitialization(ctx context.Context, timeout time.Duration) error {
-	deadline := time.After(timeout)
+	var deadline <-chan time.Time
+
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+
+		deadline = timer.C
+	}
 
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
@@ -1611,7 +1614,7 @@ func (db *Database) WaitForInitialization(ctx context.Context, timeout time.Dura
 //
 // Runs on every node — leader, follower, standalone — from NewDatabase.
 // Local-only writes do not go through Raft, so this is safe to call
-// before RunDiscovery / leader election.
+// before cluster discovery / leader election.
 //
 // Invariant: every singleton table in localOnlyTables (see
 // changeset_replication.go) MUST have its initializer registered here.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -835,7 +835,7 @@ func (db *Database) CheckPendingMigrations(ctx context.Context) error {
 		logger.WithTrace(ctx, logger.DBLog).Info("Proposing migration over Raft",
 			zap.Int("targetVersion", v))
 
-		if _, err := opMigrateShared.Invoke(db, migrateSharedPayload{TargetVersion: v}); err != nil {
+		if _, err := opMigrateShared.Invoke(ctx, db, migrateSharedPayload{TargetVersion: v}); err != nil {
 			return fmt.Errorf("propose migration %d: %w", v, err)
 		}
 	}
@@ -1659,44 +1659,6 @@ func (db *Database) Initialize(ctx context.Context) error {
 		}
 	}
 
-	if !db.IsOperatorInitialized(ctx) {
-		initialOp, err := generateOperatorCode()
-		if err != nil {
-			return fmt.Errorf("couldn't generate operator code: %w", err)
-		}
-
-		initialOperator := &Operator{
-			Mcc:          InitialMcc,
-			Mnc:          InitialMnc,
-			OperatorCode: initialOp,
-		}
-
-		err = initialOperator.SetSupportedTacs(InitialSupportedTacs)
-		if err != nil {
-			return fmt.Errorf("failed to set supported TACs: %w", err)
-		}
-
-		// RAT-neutral NAS algorithm identities (AES preferred, SNOW3G fallback),
-		// shared by EPS (EEA/EIA) and 5G (NEA/NIA) — TS 24.301 §9.9.3.23 ≡
-		// TS 24.501 §9.11.3.34.
-		if err = initialOperator.SetCiphering([]string{"AES", "SNOW3G"}); err != nil {
-			return fmt.Errorf("failed to set default ciphering: %w", err)
-		}
-
-		if err = initialOperator.SetIntegrity([]string{"AES", "SNOW3G"}); err != nil {
-			return fmt.Errorf("failed to set default integrity: %w", err)
-		}
-
-		err = db.InitializeOperator(ctx, initialOperator)
-		if err != nil {
-			return fmt.Errorf("failed to initialize network configuration: %v", err)
-		}
-	}
-
-	if err := db.ensureClusterID(ctx); err != nil {
-		return fmt.Errorf("failed to ensure cluster ID: %w", err)
-	}
-
 	numKeys, err := db.CountHomeNetworkKeys(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to count home network keys: %w", err)
@@ -1846,6 +1808,44 @@ func (db *Database) Initialize(ctx context.Context) error {
 		if err := db.SetDefaultPolicy(ctx, profile.ID, initialPolicy.Name); err != nil {
 			return fmt.Errorf("failed to set default policy: %v", err)
 		}
+	}
+
+	if !db.IsOperatorInitialized(ctx) {
+		initialOp, err := generateOperatorCode()
+		if err != nil {
+			return fmt.Errorf("couldn't generate operator code: %w", err)
+		}
+
+		initialOperator := &Operator{
+			Mcc:          InitialMcc,
+			Mnc:          InitialMnc,
+			OperatorCode: initialOp,
+		}
+
+		err = initialOperator.SetSupportedTacs(InitialSupportedTacs)
+		if err != nil {
+			return fmt.Errorf("failed to set supported TACs: %w", err)
+		}
+
+		// RAT-neutral NAS algorithm identities (AES preferred, SNOW3G fallback),
+		// shared by EPS (EEA/EIA) and 5G (NEA/NIA) — TS 24.301 §9.9.3.23 ≡
+		// TS 24.501 §9.11.3.34.
+		if err = initialOperator.SetCiphering([]string{"AES", "SNOW3G"}); err != nil {
+			return fmt.Errorf("failed to set default ciphering: %w", err)
+		}
+
+		if err = initialOperator.SetIntegrity([]string{"AES", "SNOW3G"}); err != nil {
+			return fmt.Errorf("failed to set default integrity: %w", err)
+		}
+
+		err = db.InitializeOperator(ctx, initialOperator)
+		if err != nil {
+			return fmt.Errorf("failed to initialize network configuration: %v", err)
+		}
+	}
+
+	if err := db.ensureClusterID(ctx); err != nil {
+		return fmt.Errorf("failed to ensure cluster ID: %w", err)
 	}
 
 	return nil

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1820,6 +1820,7 @@ func (db *Database) Initialize(ctx context.Context) error {
 			Mcc:          InitialMcc,
 			Mnc:          InitialMnc,
 			OperatorCode: initialOp,
+			ClusterID:    uuid.New().String(),
 		}
 
 		err = initialOperator.SetSupportedTacs(InitialSupportedTacs)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1576,8 +1576,7 @@ func (db *Database) PrepareStatements() error {
 }
 
 // WaitForInitialization polls until the replicated initial settings are
-// visible on this node (the operator row exists), ctx is cancelled, or
-// timeout elapses. A timeout of zero or less waits indefinitely.
+// visible here, ctx is cancelled, or timeout elapses. Zero waits forever.
 func (db *Database) WaitForInitialization(ctx context.Context, timeout time.Duration) error {
 	var deadline <-chan time.Time
 

--- a/internal/db/framed_routes.go
+++ b/internal/db/framed_routes.go
@@ -67,7 +67,7 @@ func (db *Database) ReplaceFramedRoutes(ctx context.Context, imsi, dataNetworkID
 		normalized = append(normalized, p.Masked().String())
 	}
 
-	_, err := opReplaceFramedRoutes.Invoke(db, &framedRoutesPayload{
+	_, err := opReplaceFramedRoutes.Invoke(ctx, db, &framedRoutesPayload{
 		Imsi:          imsi,
 		DataNetworkID: dataNetworkID,
 		Prefixes:      normalized,

--- a/internal/db/home_network_key.go
+++ b/internal/db/home_network_key.go
@@ -224,7 +224,7 @@ func (db *Database) CreateHomeNetworkKey(ctx context.Context, key *HomeNetworkKe
 		return fmt.Errorf("CreateHomeNetworkKey: ID must be set by the caller")
 	}
 
-	_, err := opCreateHomeNetworkKey.Invoke(db, key)
+	_, err := opCreateHomeNetworkKey.Invoke(ctx, db, key)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -256,7 +256,7 @@ func (db *Database) DeleteHomeNetworkKey(ctx context.Context, id string) error {
 
 	DBQueriesTotal.WithLabelValues(HomeNetworkKeysTableName, "delete").Inc()
 
-	_, err := opDeleteHomeNetworkKey.Invoke(db, &stringPayload{Value: id})
+	_, err := opDeleteHomeNetworkKey.Invoke(ctx, db, &stringPayload{Value: id})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/initializer.go
+++ b/internal/db/initializer.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package db
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"go.uber.org/zap"
+)
+
+const (
+	initializerInitialBackoff = 500 * time.Millisecond
+	initializerMaxBackoff     = 30 * time.Second
+)
+
+type standaloneInitializer struct {
+	db        *Database
+	parentCtx context.Context
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   bool
+}
+
+func newStandaloneInitializer(db *Database, parentCtx context.Context) *standaloneInitializer {
+	return &standaloneInitializer{db: db, parentCtx: parentCtx}
+}
+
+func (s *standaloneInitializer) OnBecameLeader() {
+	s.mu.Lock()
+
+	if s.done {
+		s.mu.Unlock()
+		return
+	}
+
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	ctx, cancel := context.WithCancel(s.parentCtx)
+	s.cancel = cancel
+	s.mu.Unlock()
+
+	go s.run(ctx)
+}
+
+func (s *standaloneInitializer) OnLostLeadership() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+}
+
+func (s *standaloneInitializer) run(ctx context.Context) {
+	backoff := initializerInitialBackoff
+
+	for {
+		err := s.db.Initialize(ctx)
+		if err == nil {
+			s.mu.Lock()
+			s.done = true
+			s.mu.Unlock()
+
+			return
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		logger.DBLog.Warn("database initialization failed; retrying",
+			zap.Error(err),
+			zap.Duration("next_backoff", backoff))
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > initializerMaxBackoff {
+			backoff = initializerMaxBackoff
+		}
+	}
+}

--- a/internal/db/ip_leases.go
+++ b/internal/db/ip_leases.go
@@ -104,7 +104,7 @@ func (db *Database) AllocateIPLease(ctx context.Context, poolID string, poolType
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "allocate").Inc()
 
-	addrStr, err := opAllocateIPLease.Invoke(db, &allocateIPLeasePayload{
+	addrStr, err := opAllocateIPLease.Invoke(ctx, db, &allocateIPLeasePayload{
 		PoolID:    poolID,
 		PoolType:  poolType,
 		IMSI:      imsi,
@@ -155,7 +155,7 @@ func (db *Database) AllocateIPv6Lease(ctx context.Context, poolID string, poolTy
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "allocate_ipv6").Inc()
 
-	addrStr, err := opAllocateIPv6Lease.Invoke(db, &allocateIPLeasePayload{
+	addrStr, err := opAllocateIPv6Lease.Invoke(ctx, db, &allocateIPLeasePayload{
 		PoolID:    poolID,
 		PoolType:  poolType,
 		IMSI:      imsi,
@@ -207,7 +207,7 @@ func (db *Database) CreateLease(ctx context.Context, lease *IPLease, address net
 	b := address.As16()
 	lease.AddressBin = b[:]
 
-	_, err := opCreateLease.Invoke(db, lease)
+	_, err := opCreateLease.Invoke(ctx, db, lease)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -280,7 +280,7 @@ func (db *Database) UpdateLeaseSession(ctx context.Context, leaseID string, sess
 
 	lease := &IPLease{ID: leaseID, SessionID: &sessionID}
 
-	_, err := opUpdateLeaseSession.Invoke(db, lease)
+	_, err := opUpdateLeaseSession.Invoke(ctx, db, lease)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -311,7 +311,7 @@ func (db *Database) ReleaseIPLease(ctx context.Context, poolID string, poolType 
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "release").Inc()
 
-	addrStr, err := opReleaseIPLease.Invoke(db, &releaseIPLeasePayload{
+	addrStr, err := opReleaseIPLease.Invoke(ctx, db, &releaseIPLeasePayload{
 		PoolID:    poolID,
 		PoolType:  poolType,
 		IMSI:      imsi,
@@ -362,7 +362,7 @@ func (db *Database) DeleteDynamicLease(ctx context.Context, leaseID string) erro
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "delete").Inc()
 
-	_, err := opDeleteDynamicLease.Invoke(db, &stringPayload{Value: leaseID})
+	_, err := opDeleteDynamicLease.Invoke(ctx, db, &stringPayload{Value: leaseID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -395,7 +395,7 @@ func (db *Database) DeleteAllDynamicLeases(ctx context.Context) error {
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "delete").Inc()
 
-	_, err := opDeleteAllDynamicLeases.Invoke(db, nil)
+	_, err := opDeleteAllDynamicLeases.Invoke(ctx, db, nil)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -430,7 +430,7 @@ func (db *Database) DeleteDynamicLeasesByNode(ctx context.Context, nodeID int) e
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "delete").Inc()
 
-	_, err := opDeleteDynamicLeasesByNode.Invoke(db, &intPayload{Value: nodeID})
+	_, err := opDeleteDynamicLeasesByNode.Invoke(ctx, db, &intPayload{Value: nodeID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -465,7 +465,7 @@ func (db *Database) UpdateLeaseNode(ctx context.Context, leaseID string, nodeID 
 
 	lease := &IPLease{ID: leaseID, NodeID: nodeID, SessionID: &sessionID}
 
-	_, err := opUpdateLeaseNode.Invoke(db, lease)
+	_, err := opUpdateLeaseNode.Invoke(ctx, db, lease)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -922,7 +922,7 @@ func (db *Database) CreateStaticLease(ctx context.Context, imsi, poolID, poolTyp
 		IMSI:       imsi,
 	}
 
-	_, err := opCreateStaticLease.Invoke(db, lease)
+	_, err := opCreateStaticLease.Invoke(ctx, db, lease)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -1076,7 +1076,7 @@ func (db *Database) ClearStaticLeaseSession(ctx context.Context, leaseID string)
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "update").Inc()
 
-	_, err := opUpdateLeaseSession.Invoke(db, &IPLease{ID: leaseID})
+	_, err := opUpdateLeaseSession.Invoke(ctx, db, &IPLease{ID: leaseID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -1112,7 +1112,7 @@ func (db *Database) UpdateStaticLeaseAddress(ctx context.Context, leaseID string
 
 	b := addr.As16()
 
-	_, err := opUpdateStaticLeaseAddress.Invoke(db, &IPLease{ID: leaseID, AddressBin: b[:]})
+	_, err := opUpdateStaticLeaseAddress.Invoke(ctx, db, &IPLease{ID: leaseID, AddressBin: b[:]})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -1145,7 +1145,7 @@ func (db *Database) DeleteStaticLease(ctx context.Context, leaseID string) error
 
 	DBQueriesTotal.WithLabelValues(IPLeasesTableName, "delete").Inc()
 
-	_, err := opDeleteStaticLease.Invoke(db, &stringPayload{Value: leaseID})
+	_, err := opDeleteStaticLease.Invoke(ctx, db, &stringPayload{Value: leaseID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/jwt_secret.go
+++ b/internal/db/jwt_secret.go
@@ -104,7 +104,7 @@ func (db *Database) SetJWTSecret(ctx context.Context, secret []byte) error {
 
 	DBQueriesTotal.WithLabelValues(JWTSecretTableName, "update").Inc()
 
-	_, err := opSetJWTSecret.Invoke(db, &bytesPayload{Value: secret})
+	_, err := opSetJWTSecret.Invoke(ctx, db, &bytesPayload{Value: secret})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/jwt_secret_test.go
+++ b/internal/db/jwt_secret_test.go
@@ -90,9 +90,13 @@ func TestJWTSecretPersistsAcrossReopen(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
 
-	database, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("Couldn't complete NewDatabase: %s", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	secret, err := database.GetJWTSecret(context.Background())
@@ -105,9 +109,13 @@ func TestJWTSecretPersistsAcrossReopen(t *testing.T) {
 	}
 
 	// Re-open the same database file.
-	database2, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	database2, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("Couldn't complete NewDatabase on reopen: %s", err)
+	}
+
+	if err := database2.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {

--- a/internal/db/leader_wait.go
+++ b/internal/db/leader_wait.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const readyWaitTimeout = 30 * time.Second
+
+func (db *Database) HasLeader() bool {
+	if db.raftManager == nil {
+		return true
+	}
+
+	return db.raftManager.HasLeader()
+}
+
+func (db *Database) WaitForLeader(ctx context.Context) error {
+	if db.raftManager == nil {
+		return nil
+	}
+
+	return db.raftManager.WaitForLeader(ctx)
+}
+
+func (db *Database) WaitUntilReady(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, readyWaitTimeout)
+	defer cancel()
+
+	if db.raftManager != nil {
+		if err := db.raftManager.HoldForLeader(ctx, readyWaitTimeout); err != nil {
+			return fmt.Errorf("wait for raft leader: %w", err)
+		}
+	}
+
+	return db.WaitForInitialization(ctx, 0)
+}
+
+func (db *Database) holdForLeader() {
+	if db.raftManager == nil || db.raftManager.HasLeader() {
+		return
+	}
+
+	timeout := db.proposeTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	_ = db.raftManager.HoldForLeader(context.Background(), timeout)
+}

--- a/internal/db/leader_wait.go
+++ b/internal/db/leader_wait.go
@@ -9,7 +9,10 @@ import (
 	"time"
 )
 
-const readyWaitTimeout = 30 * time.Second
+const (
+	readyWaitTimeout            = 30 * time.Second
+	defaultHoldForLeaderTimeout = 5 * time.Second
+)
 
 func (db *Database) HasLeader() bool {
 	if db.raftManager == nil {
@@ -27,6 +30,18 @@ func (db *Database) WaitForLeader(ctx context.Context) error {
 	return db.raftManager.WaitForLeader(ctx)
 }
 
+// WaitForFSMCatchUp blocks until local reads reflect every committed write.
+// A standalone node is the only voter, so it always elects itself and the
+// post-leadership barrier is guaranteed to land. An HA follower has no way to
+// force its FSM forward, so it does not wait; its leader barriers on election.
+func (db *Database) WaitForFSMCatchUp(ctx context.Context) error {
+	if db.raftManager == nil || db.raftManager.ClusterEnabled() {
+		return nil
+	}
+
+	return db.raftManager.WaitForLeaderBarrier(ctx)
+}
+
 func (db *Database) WaitUntilReady(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, readyWaitTimeout)
 	defer cancel()
@@ -40,15 +55,25 @@ func (db *Database) WaitUntilReady(ctx context.Context) error {
 	return db.WaitForInitialization(ctx, 0)
 }
 
-func (db *Database) holdForLeader() {
+// holdForLeader waits out an in-progress election before a write is
+// dispatched. It is a pure wait with no side effects, so it honours the
+// caller's context: a client that has gone away, or a shutdown, stops the
+// wait instead of pinning the request for the full budget. Exhausting the
+// budget is reported as a transient failure so the caller does not go on to
+// spend a second budget forwarding to a leader that does not exist.
+func (db *Database) holdForLeader(ctx context.Context) error {
 	if db.raftManager == nil || db.raftManager.HasLeader() {
-		return
+		return nil
 	}
 
 	timeout := db.proposeTimeout
 	if timeout <= 0 {
-		timeout = 5 * time.Second
+		timeout = defaultHoldForLeaderTimeout
 	}
 
-	_ = db.raftManager.HoldForLeader(context.Background(), timeout)
+	if err := db.raftManager.HoldForLeader(ctx, timeout); err != nil {
+		return fmt.Errorf("%w: no raft leader: %v", ErrProposeTimeout, err)
+	}
+
+	return nil
 }

--- a/internal/db/leader_wait.go
+++ b/internal/db/leader_wait.go
@@ -30,10 +30,6 @@ func (db *Database) WaitForLeader(ctx context.Context) error {
 	return db.raftManager.WaitForLeader(ctx)
 }
 
-// WaitForFSMCatchUp blocks until local reads reflect every committed write.
-// A standalone node is the only voter, so it always elects itself and the
-// post-leadership barrier is guaranteed to land. An HA follower has no way to
-// force its FSM forward, so it does not wait; its leader barriers on election.
 func (db *Database) WaitForFSMCatchUp(ctx context.Context) error {
 	if db.raftManager == nil || db.raftManager.ClusterEnabled() {
 		return nil
@@ -55,12 +51,6 @@ func (db *Database) WaitUntilReady(ctx context.Context) error {
 	return db.WaitForInitialization(ctx, 0)
 }
 
-// holdForLeader waits out an in-progress election before a write is
-// dispatched. It is a pure wait with no side effects, so it honours the
-// caller's context: a client that has gone away, or a shutdown, stops the
-// wait instead of pinning the request for the full budget. Exhausting the
-// budget is reported as a transient failure so the caller does not go on to
-// spend a second budget forwarding to a leader that does not exist.
 func (db *Database) holdForLeader(ctx context.Context) error {
 	if db.raftManager == nil || db.raftManager.HasLeader() {
 		return nil

--- a/internal/db/metrics_test.go
+++ b/internal/db/metrics_test.go
@@ -25,9 +25,13 @@ func TestDatabaseMetrics(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "db.sqlite3")
 
-	database, err := db.NewDatabase(context.Background(), dbPath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("Couldn't initialize NewDatabase: %s", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {

--- a/internal/db/migration_gate_internal_test.go
+++ b/internal/db/migration_gate_internal_test.go
@@ -19,9 +19,13 @@ func newStandaloneDB(t *testing.T) *Database {
 
 	tmp := t.TempDir()
 
-	database, err := NewDatabase(context.Background(), filepath.Join(tmp, "db.sqlite3"), ellaraft.ClusterConfig{})
+	database, err := NewDatabase(context.Background(), filepath.Join(tmp, "db.sqlite3"), ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	t.Cleanup(func() { _ = database.Close() })

--- a/internal/db/network_rules.go
+++ b/internal/db/network_rules.go
@@ -81,7 +81,7 @@ func (db *Database) CreateNetworkRule(ctx context.Context, nr *NetworkRule) (str
 		nr.ID = id.String()
 	}
 
-	_, err := opCreateNetworkRule.Invoke(db, nr)
+	_, err := opCreateNetworkRule.Invoke(ctx, db, nr)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -154,7 +154,7 @@ func (db *Database) UpdateNetworkRule(ctx context.Context, nr *NetworkRule) erro
 
 	nr.UpdatedAt = time.Now().UTC()
 
-	_, err := opUpdateNetworkRule.Invoke(db, nr)
+	_, err := opUpdateNetworkRule.Invoke(ctx, db, nr)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -286,7 +286,7 @@ func (db *Database) DeleteNetworkRule(ctx context.Context, id string) error {
 
 	DBQueriesTotal.WithLabelValues(NetworkRulesTableName, "delete").Inc()
 
-	_, err := opDeleteNetworkRule.Invoke(db, &stringPayload{Value: id})
+	_, err := opDeleteNetworkRule.Invoke(ctx, db, &stringPayload{Value: id})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -359,7 +359,7 @@ func (db *Database) DeleteNetworkRulesByPolicyID(ctx context.Context, policyID s
 
 	DBQueriesTotal.WithLabelValues(NetworkRulesTableName, "delete").Inc()
 
-	_, err := opDeleteNetworkRulesByPolicy.Invoke(db, &stringPayload{Value: policyID})
+	_, err := opDeleteNetworkRulesByPolicy.Invoke(ctx, db, &stringPayload{Value: policyID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/network_rules_test.go
+++ b/internal/db/network_rules_test.go
@@ -975,9 +975,13 @@ func TestUpdatePolicyWithRules_AllZeroRule_Raft(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "data")
 
-	database, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {
@@ -1088,9 +1092,13 @@ func TestUpdatePolicyWithRules_Raft_SurviveRestart(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "data")
 
-	database, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	// Create prerequisite entities.
@@ -1157,9 +1165,13 @@ func TestUpdatePolicyWithRules_Raft_SurviveRestart(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	database2, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	database2, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("NewDatabase (reopen): %v", err)
+	}
+
+	if err := database2.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {
@@ -1207,9 +1219,13 @@ func TestUpdatePolicyWithRules_SnapshotRestore_SurviveRestart(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "data")
 
-	database, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	// Create prerequisite entities.
@@ -1286,9 +1302,13 @@ func TestUpdatePolicyWithRules_SnapshotRestore_SurviveRestart(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	database2, err := db.NewDatabase(ctx, dbPath, ellaraft.ClusterConfig{})
+	database2, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("NewDatabase (reopen): %v", err)
+	}
+
+	if err := database2.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {

--- a/internal/db/network_slices.go
+++ b/internal/db/network_slices.go
@@ -239,7 +239,7 @@ func (db *Database) CreateNetworkSlice(ctx context.Context, slice *NetworkSlice)
 		slice.ID = id.String()
 	}
 
-	_, err := opCreateNetworkSlice.Invoke(db, slice)
+	_, err := opCreateNetworkSlice.Invoke(ctx, db, slice)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -270,7 +270,7 @@ func (db *Database) UpdateNetworkSlice(ctx context.Context, slice *NetworkSlice)
 
 	DBQueriesTotal.WithLabelValues(NetworkSlicesTableName, "update").Inc()
 
-	_, err := opUpdateNetworkSlice.Invoke(db, slice)
+	_, err := opUpdateNetworkSlice.Invoke(ctx, db, slice)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -301,7 +301,7 @@ func (db *Database) DeleteNetworkSlice(ctx context.Context, name string) error {
 
 	DBQueriesTotal.WithLabelValues(NetworkSlicesTableName, "delete").Inc()
 
-	_, err := opDeleteNetworkSlice.Invoke(db, &stringPayload{Value: name})
+	_, err := opDeleteNetworkSlice.Invoke(ctx, db, &stringPayload{Value: name})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -256,7 +256,7 @@ func narrowResult[R any](opName string, raw any) (R, error) {
 	}
 }
 
-func (op *ChangesetOp[P, R]) Invoke(db *Database, payload *P) (R, error) {
+func (op *ChangesetOp[P, R]) Invoke(ctx context.Context, db *Database, payload *P) (R, error) {
 	var zero R
 
 	if err := db.checkOpSchema(op.minSchema); err != nil {
@@ -274,7 +274,9 @@ func (op *ChangesetOp[P, R]) Invoke(db *Database, payload *P) (R, error) {
 		return narrowResult[R](op.name, result)
 	}
 
-	db.holdForLeader()
+	if err := db.holdForLeader(ctx); err != nil {
+		return zero, err
+	}
 
 	if db.IsLeader() {
 		result, err := db.leaderCaptureAndPropose(op.name, op.minSchema, func(ctx context.Context) (any, error) {
@@ -308,7 +310,7 @@ func (op *ChangesetOp[P, R]) invokeFollower(db *Database, payload *P) (R, error)
 	return narrowResult[R](op.name, result.Value)
 }
 
-func (op intentOp[R]) Invoke(db *Database, payload any) (R, error) {
+func (op intentOp[R]) Invoke(ctx context.Context, db *Database, payload any) (R, error) {
 	var zero R
 
 	if err := db.checkOpSchema(op.minSchema); err != nil {
@@ -329,7 +331,9 @@ func (op intentOp[R]) Invoke(db *Database, payload any) (R, error) {
 		return narrowResult[R](op.name, result)
 	}
 
-	db.holdForLeader()
+	if err := db.holdForLeader(ctx); err != nil {
+		return zero, err
+	}
 
 	if db.IsLeader() {
 		data, err := cmd.MarshalBinary()

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -274,6 +274,8 @@ func (op *ChangesetOp[P, R]) Invoke(db *Database, payload *P) (R, error) {
 		return narrowResult[R](op.name, result)
 	}
 
+	db.holdForLeader()
+
 	if db.IsLeader() {
 		result, err := db.leaderCaptureAndPropose(op.name, op.minSchema, func(ctx context.Context) (any, error) {
 			return op.apply(db, ctx, payload)
@@ -326,6 +328,8 @@ func (op intentOp[R]) Invoke(db *Database, payload any) (R, error) {
 
 		return narrowResult[R](op.name, result)
 	}
+
+	db.holdForLeader()
 
 	if db.IsLeader() {
 		data, err := cmd.MarshalBinary()

--- a/internal/db/operator.go
+++ b/internal/db/operator.go
@@ -31,7 +31,7 @@ const (
 	updateOperatorSPNStmtConst                = "UPDATE %s SET spnFullName=$Operator.spnFullName, spnShortName=$Operator.spnShortName WHERE id=1"
 	updateOperatorAMFIdentityStmtConst        = "UPDATE %s SET amfRegionID=$Operator.amfRegionID, amfSetID=$Operator.amfSetID WHERE id=1"
 	updateOperatorClusterIDStmtConst          = "UPDATE %s SET clusterID=$Operator.clusterID WHERE id=1"
-	initializeOperatorStmt                    = "INSERT INTO %s (mcc, mnc, operatorCode, supportedTACs, ciphering, integrity) VALUES ($Operator.mcc, $Operator.mnc, $Operator.operatorCode, $Operator.supportedTACs, $Operator.ciphering, $Operator.integrity)"
+	initializeOperatorStmt                    = "INSERT INTO %s (mcc, mnc, operatorCode, supportedTACs, ciphering, integrity, clusterID) VALUES ($Operator.mcc, $Operator.mnc, $Operator.operatorCode, $Operator.supportedTACs, $Operator.ciphering, $Operator.integrity, $Operator.clusterID)"
 )
 
 type Operator struct {

--- a/internal/db/operator.go
+++ b/internal/db/operator.go
@@ -210,7 +210,7 @@ func (db *Database) InitializeOperator(ctx context.Context, initialOperator *Ope
 
 	DBQueriesTotal.WithLabelValues(OperatorTableName, "insert").Inc()
 
-	_, err := opInitializeOperator.Invoke(db, initialOperator)
+	_, err := opInitializeOperator.Invoke(ctx, db, initialOperator)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -286,7 +286,7 @@ func (db *Database) UpdateOperatorTracking(ctx context.Context, supportedTACs []
 		return fmt.Errorf("failed to set supported TACs: %w", err)
 	}
 
-	_, err = opUpdateOperatorTracking.Invoke(db, op)
+	_, err = opUpdateOperatorTracking.Invoke(ctx, db, op)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -320,7 +320,7 @@ func (db *Database) UpdateOperatorID(ctx context.Context, mcc, mnc string) error
 
 	op := &Operator{Mcc: mcc, Mnc: mnc}
 
-	_, err := opUpdateOperatorID.Invoke(db, op)
+	_, err := opUpdateOperatorID.Invoke(ctx, db, op)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -388,7 +388,7 @@ func (db *Database) UpdateOperatorCode(ctx context.Context, operatorCode string)
 
 	op := &Operator{OperatorCode: operatorCode}
 
-	_, err := opUpdateOperatorCode.Invoke(db, op)
+	_, err := opUpdateOperatorCode.Invoke(ctx, db, op)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -438,7 +438,7 @@ func (db *Database) UpdateOperatorSecurityAlgorithms(ctx context.Context, cipher
 		return fmt.Errorf("failed to set integrity order: %w", err)
 	}
 
-	_, err = opUpdateOperatorSecurityAlgorithms.Invoke(db, op)
+	_, err = opUpdateOperatorSecurityAlgorithms.Invoke(ctx, db, op)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -472,7 +472,7 @@ func (db *Database) UpdateOperatorSPN(ctx context.Context, spnFullName, spnShort
 
 	op := &Operator{SpnFullName: spnFullName, SpnShortName: spnShortName}
 
-	_, err := opUpdateOperatorSPN.Invoke(db, op)
+	_, err := opUpdateOperatorSPN.Invoke(ctx, db, op)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -515,7 +515,7 @@ func (db *Database) UpdateOperatorAMFIdentity(ctx context.Context, regionID, set
 
 	op := &Operator{AmfRegionID: regionID, AmfSetID: setID}
 
-	_, err := opUpdateOperatorAMFIdentity.Invoke(db, op)
+	_, err := opUpdateOperatorAMFIdentity.Invoke(ctx, db, op)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -549,7 +549,7 @@ func (db *Database) UpdateOperatorClusterID(ctx context.Context, clusterID strin
 
 	op := &Operator{ClusterID: clusterID}
 
-	_, err := opUpdateOperatorClusterID.Invoke(db, op)
+	_, err := opUpdateOperatorClusterID.Invoke(ctx, db, op)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/policies.go
+++ b/internal/db/policies.go
@@ -360,7 +360,7 @@ func (db *Database) SetDefaultPolicy(ctx context.Context, profileID, name string
 
 	DBQueriesTotal.WithLabelValues(PoliciesTableName, "update").Inc()
 
-	_, err := opSetDefaultPolicy.Invoke(db, &Policy{ProfileID: profileID, Name: name})
+	_, err := opSetDefaultPolicy.Invoke(ctx, db, &Policy{ProfileID: profileID, Name: name})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -553,7 +553,7 @@ func (db *Database) CreatePolicy(ctx context.Context, policy *Policy) error {
 		policy.ID = id.String()
 	}
 
-	_, err := opCreatePolicy.Invoke(db, policy)
+	_, err := opCreatePolicy.Invoke(ctx, db, policy)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -584,7 +584,7 @@ func (db *Database) UpdatePolicy(ctx context.Context, policy *Policy) error {
 
 	DBQueriesTotal.WithLabelValues(PoliciesTableName, "update").Inc()
 
-	_, err := opUpdatePolicy.Invoke(db, policy)
+	_, err := opUpdatePolicy.Invoke(ctx, db, policy)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -615,7 +615,7 @@ func (db *Database) DeletePolicy(ctx context.Context, name string) error {
 
 	DBQueriesTotal.WithLabelValues(PoliciesTableName, "delete").Inc()
 
-	_, err := opDeletePolicy.Invoke(db, &stringPayload{Value: name})
+	_, err := opDeletePolicy.Invoke(ctx, db, &stringPayload{Value: name})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/policy_rules_ops.go
+++ b/internal/db/policy_rules_ops.go
@@ -40,13 +40,13 @@ func (db *Database) CreatePolicyWithRules(ctx context.Context, policy *Policy, r
 		policy.ID = id.String()
 	}
 
-	_, err := opCreatePolicyWithRules.Invoke(db, &policyWithRulesPayload{Policy: *policy, Rules: rules})
+	_, err := opCreatePolicyWithRules.Invoke(ctx, db, &policyWithRulesPayload{Policy: *policy, Rules: rules})
 
 	return err
 }
 
 func (db *Database) UpdatePolicyWithRules(ctx context.Context, policy *Policy, rules *PolicyRulesInput) error {
-	_, err := opUpdatePolicyWithRules.Invoke(db, &policyWithRulesPayload{Policy: *policy, Rules: rules})
+	_, err := opUpdatePolicyWithRules.Invoke(ctx, db, &policyWithRulesPayload{Policy: *policy, Rules: rules})
 
 	return err
 }

--- a/internal/db/profiles.go
+++ b/internal/db/profiles.go
@@ -200,7 +200,7 @@ func (db *Database) CreateProfile(ctx context.Context, profile *Profile) error {
 		profile.ID = id.String()
 	}
 
-	_, err := opCreateProfile.Invoke(db, profile)
+	_, err := opCreateProfile.Invoke(ctx, db, profile)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -231,7 +231,7 @@ func (db *Database) UpdateProfile(ctx context.Context, profile *Profile) error {
 
 	DBQueriesTotal.WithLabelValues(ProfilesTableName, "update").Inc()
 
-	_, err := opUpdateProfile.Invoke(db, profile)
+	_, err := opUpdateProfile.Invoke(ctx, db, profile)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -262,7 +262,7 @@ func (db *Database) DeleteProfile(ctx context.Context, name string) error {
 
 	DBQueriesTotal.WithLabelValues(ProfilesTableName, "delete").Inc()
 
-	_, err := opDeleteProfile.Invoke(db, &stringPayload{Value: name})
+	_, err := opDeleteProfile.Invoke(ctx, db, &stringPayload{Value: name})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/propose_apply_test.go
+++ b/internal/db/propose_apply_test.go
@@ -26,9 +26,13 @@ func TestProposeApply_RoundTrip_WritesShowUpAndAdvanceAppliedIndex(t *testing.T)
 	ctx := context.Background()
 	tempDir := t.TempDir()
 
-	database, err := db.NewDatabase(ctx, filepath.Join(tempDir, "data"), ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(ctx, filepath.Join(tempDir, "data"), ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("new database: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {
@@ -83,9 +87,13 @@ func TestProposeApply_ApplierErrorSurfacesToCaller(t *testing.T) {
 	ctx := context.Background()
 	tempDir := t.TempDir()
 
-	database, err := db.NewDatabase(ctx, filepath.Join(tempDir, "data"), ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(ctx, filepath.Join(tempDir, "data"), ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("new database: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {

--- a/internal/db/restore_test.go
+++ b/internal/db/restore_test.go
@@ -24,9 +24,13 @@ func TestRestore(t *testing.T) {
 
 	databasePath := filepath.Join(tempDir, "db.sqlite3")
 
-	database, err := db.NewDatabase(context.Background(), databasePath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), databasePath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {
@@ -81,9 +85,13 @@ func TestRestore_InvalidFile(t *testing.T) {
 	tempDir := t.TempDir()
 	databasePath := filepath.Join(tempDir, "db.sqlite3")
 
-	database, err := db.NewDatabase(context.Background(), databasePath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), databasePath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {
@@ -135,9 +143,13 @@ func TestRestore_ConcurrentRestore(t *testing.T) {
 	tempDir := t.TempDir()
 	databasePath := filepath.Join(tempDir, "db.sqlite3")
 
-	database, err := db.NewDatabase(context.Background(), databasePath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), databasePath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {
@@ -235,9 +247,13 @@ func TestRestore_RoundTripPreservesData(t *testing.T) {
 	databasePath := filepath.Join(tempDir, "data")
 	ctx := context.Background()
 
-	database, err := db.NewDatabase(ctx, databasePath, ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(ctx, databasePath, ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {

--- a/internal/db/retention_policies.go
+++ b/internal/db/retention_policies.go
@@ -151,7 +151,7 @@ func (db *Database) SetRetentionPolicy(ctx context.Context, policy *RetentionPol
 		policy.ID = id.String()
 	}
 
-	_, err := opSetRetentionPolicy.Invoke(db, policy)
+	_, err := opSetRetentionPolicy.Invoke(ctx, db, policy)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -79,7 +79,7 @@ func (db *Database) CreateSession(ctx context.Context, session *Session) error {
 		session.ID = id.String()
 	}
 
-	_, err := opCreateSession.Invoke(db, session)
+	_, err := opCreateSession.Invoke(ctx, db, session)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -148,7 +148,7 @@ func (db *Database) DeleteSessionByTokenHash(ctx context.Context, tokenHash []by
 
 	DBQueriesTotal.WithLabelValues(SessionsTableName, "delete").Inc()
 
-	_, err := opDeleteSessionByTokenHash.Invoke(db, &bytesPayload{Value: tokenHash})
+	_, err := opDeleteSessionByTokenHash.Invoke(ctx, db, &bytesPayload{Value: tokenHash})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -181,7 +181,7 @@ func (db *Database) DeleteExpiredSessions(ctx context.Context) (int, error) {
 
 	nowUnix := time.Now().Unix()
 
-	count, err := opDeleteExpiredSessions.Invoke(db, &int64Payload{Value: nowUnix})
+	count, err := opDeleteExpiredSessions.Invoke(ctx, db, &int64Payload{Value: nowUnix})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -247,7 +247,7 @@ func (db *Database) DeleteOldestSessions(ctx context.Context, userID string, lim
 
 	DBQueriesTotal.WithLabelValues(SessionsTableName, "delete").Inc()
 
-	_, err := opDeleteOldestSessions.Invoke(db, &DeleteOldestArgs{UserID: userID, Limit: limit})
+	_, err := opDeleteOldestSessions.Invoke(ctx, db, &DeleteOldestArgs{UserID: userID, Limit: limit})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -278,7 +278,7 @@ func (db *Database) DeleteAllSessionsForUser(ctx context.Context, userID string)
 
 	DBQueriesTotal.WithLabelValues(SessionsTableName, "delete").Inc()
 
-	_, err := opDeleteAllSessionsForUser.Invoke(db, &stringPayload{Value: userID})
+	_, err := opDeleteAllSessionsForUser.Invoke(ctx, db, &stringPayload{Value: userID})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -309,7 +309,7 @@ func (db *Database) DeleteAllSessions(ctx context.Context) error {
 
 	DBQueriesTotal.WithLabelValues(SessionsTableName, "delete").Inc()
 
-	_, err := opDeleteAllSessions.Invoke(db, &emptyPayload{})
+	_, err := opDeleteAllSessions.Invoke(ctx, db, &emptyPayload{})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/startup_test.go
+++ b/internal/db/startup_test.go
@@ -5,6 +5,7 @@ package db_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -87,5 +88,117 @@ func TestWriteIssuedBeforeElectionHoldsForLeader(t *testing.T) {
 
 	if err := database.InitializeJWTSecret(context.Background()); err != nil {
 		t.Fatalf("write before election should hold for the leader, got: %v", err)
+	}
+}
+
+func TestWaitForInitializationImpliesJWTSecret(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.NewDatabase(context.Background(), filepath.Join(t.TempDir(), "db.sqlite3"), ellaraft.FastTestConfig())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	defer func() { _ = database.Close() }()
+
+	if err := database.WaitForInitialization(t.Context(), 30*time.Second); err != nil {
+		t.Fatalf("initial settings never landed: %v", err)
+	}
+
+	secret, err := database.GetJWTSecret(t.Context())
+	if err != nil {
+		t.Fatalf("the API upgrade gate gets past WaitForInitialization, so the JWT secret must already be seeded: %v", err)
+	}
+
+	if len(secret) == 0 {
+		t.Fatal("expected a non-empty JWT secret")
+	}
+}
+
+func TestInitializationSignalMeansSeedingFinished(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.NewDatabase(context.Background(), filepath.Join(t.TempDir(), "db.sqlite3"), ellaraft.FastTestConfig())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	defer func() { _ = database.Close() }()
+
+	deadline := time.Now().Add(30 * time.Second)
+	for !database.IsOperatorInitialized(t.Context()) {
+		if time.Now().After(deadline) {
+			t.Fatal("initial settings never landed")
+		}
+	}
+
+	checks := []struct {
+		name string
+		fn   func() error
+	}{
+		{"jwt secret", func() error { _, err := database.GetJWTSecret(t.Context()); return err }},
+		{"operator", func() error { _, err := database.GetOperator(t.Context()); return err }},
+		{"default data network", func() error { _, err := database.GetDataNetwork(t.Context(), db.InitialDataNetworkName); return err }},
+		{"default profile", func() error { _, err := database.GetProfile(t.Context(), db.InitialProfileName); return err }},
+		{"default policy", func() error { _, err := database.GetPolicy(t.Context(), db.InitialPolicyName); return err }},
+		{"default network slice", func() error { _, err := database.GetNetworkSlice(t.Context(), db.InitialSliceName); return err }},
+	}
+
+	for _, c := range checks {
+		if err := c.fn(); err != nil {
+			t.Errorf("%s missing the moment the readiness signal flipped; the operator row must be the last thing Initialize writes: %v", c.name, err)
+		}
+	}
+
+	numKeys, err := database.CountHomeNetworkKeys(t.Context())
+	if err != nil {
+		t.Fatalf("CountHomeNetworkKeys: %v", err)
+	}
+
+	if numKeys == 0 {
+		t.Error("home network key missing the moment the readiness signal flipped")
+	}
+}
+
+func TestWriteHonoursCallerCancellationWhileHoldingForLeader(t *testing.T) {
+	t.Parallel()
+
+	cfg := ellaraft.FastTestConfig()
+	cfg.ElectionTimeout = 10 * time.Second
+	cfg.HeartbeatTimeout = 10 * time.Second
+	cfg.LeaderLeaseTimeout = 5 * time.Second
+
+	database, err := db.NewDatabase(context.Background(), filepath.Join(t.TempDir(), "db.sqlite3"), cfg)
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	defer func() { _ = database.Close() }()
+
+	if database.HasLeader() {
+		t.Fatal("no leader should exist this early; the hold cannot be exercised")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err = database.InitializeJWTSecret(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the write to fail once the caller went away")
+	}
+
+	if !errors.Is(err, db.ErrProposeTimeout) {
+		t.Errorf("want a transient ErrProposeTimeout the API maps to 503, got %v", err)
+	}
+
+	if elapsed > 2*time.Second {
+		t.Errorf("write ignored caller cancellation and burned the full budget: took %s", elapsed)
 	}
 }

--- a/internal/db/startup_test.go
+++ b/internal/db/startup_test.go
@@ -150,6 +150,15 @@ func TestInitializationSignalMeansSeedingFinished(t *testing.T) {
 		}
 	}
 
+	op, err := database.GetOperator(t.Context())
+	if err != nil {
+		t.Fatalf("GetOperator: %v", err)
+	}
+
+	if op.ClusterID == "" {
+		t.Error("cluster ID missing the moment the readiness signal flipped; it must be written with the operator row, not after it")
+	}
+
 	numKeys, err := database.CountHomeNetworkKeys(t.Context())
 	if err != nil {
 		t.Fatalf("CountHomeNetworkKeys: %v", err)

--- a/internal/db/startup_test.go
+++ b/internal/db/startup_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package db_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/db"
+	ellaraft "github.com/ellanetworks/core/internal/raft"
+)
+
+func TestNewDatabaseDoesNotWaitForElection(t *testing.T) {
+	t.Parallel()
+
+	cfg := ellaraft.FastTestConfig()
+	cfg.ElectionTimeout = 10 * time.Second
+	cfg.HeartbeatTimeout = 10 * time.Second
+	cfg.LeaderLeaseTimeout = 5 * time.Second
+
+	start := time.Now()
+
+	database, err := db.NewDatabase(context.Background(), filepath.Join(t.TempDir(), "db.sqlite3"), cfg)
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	defer func() { _ = database.Close() }()
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("NewDatabase blocked for %s waiting on leadership", elapsed)
+	}
+
+	if database.HasLeader() {
+		t.Fatal("no leader should exist this early")
+	}
+
+	if database.IsOperatorInitialized(context.Background()) {
+		t.Fatal("replicated settings cannot be seeded before an election")
+	}
+}
+
+func TestStandaloneSeedsInitialSettingsAfterElection(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.NewDatabase(context.Background(), filepath.Join(t.TempDir(), "db.sqlite3"), ellaraft.FastTestConfig())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	defer func() { _ = database.Close() }()
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
+	}
+
+	if !database.IsOperatorInitialized(context.Background()) {
+		t.Fatal("expected operator row to be seeded once leadership was acquired")
+	}
+
+	op, err := database.GetOperator(context.Background())
+	if err != nil {
+		t.Fatalf("GetOperator: %v", err)
+	}
+
+	if op.ClusterID == "" {
+		t.Error("expected a cluster ID to be generated during seeding")
+	}
+}
+
+func TestWriteIssuedBeforeElectionHoldsForLeader(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.NewDatabase(context.Background(), filepath.Join(t.TempDir(), "db.sqlite3"), ellaraft.FastTestConfig())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	defer func() { _ = database.Close() }()
+
+	if database.HasLeader() {
+		t.Skip("election already completed; nothing to hold for")
+	}
+
+	if err := database.InitializeJWTSecret(context.Background()); err != nil {
+		t.Fatalf("write before election should hold for the leader, got: %v", err)
+	}
+}

--- a/internal/db/subscriber_sqn.go
+++ b/internal/db/subscriber_sqn.go
@@ -98,7 +98,7 @@ func (db *Database) applyAdvanceSubscriberSQN(ctx context.Context, payload *Adva
 }
 
 func (db *Database) AdvanceSubscriberSQN(ctx context.Context, imsi, resyncAuts, resyncRand string) (*AdvancedCredentials, error) {
-	creds, err := opAdvanceSubscriberSQN.Invoke(db, &AdvanceSQNPayload{
+	creds, err := opAdvanceSubscriberSQN.Invoke(ctx, db, &AdvanceSQNPayload{
 		IMSI:       imsi,
 		ResyncAuts: resyncAuts,
 		ResyncRand: resyncRand,

--- a/internal/db/subscribers.go
+++ b/internal/db/subscribers.go
@@ -219,7 +219,7 @@ func (db *Database) CreateSubscriber(ctx context.Context, subscriber *Subscriber
 		subscriber.ID = id.String()
 	}
 
-	_, err := opCreateSubscriber.Invoke(db, subscriber)
+	_, err := opCreateSubscriber.Invoke(ctx, db, subscriber)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -250,7 +250,7 @@ func (db *Database) UpdateSubscriberProfile(ctx context.Context, subscriber *Sub
 
 	DBQueriesTotal.WithLabelValues(SubscribersTableName, "update").Inc()
 
-	_, err := opUpdateSubscriberProfile.Invoke(db, subscriber)
+	_, err := opUpdateSubscriberProfile.Invoke(ctx, db, subscriber)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -286,7 +286,7 @@ func (db *Database) EditSubscriberSequenceNumber(ctx context.Context, imsi strin
 		SequenceNumber: sequenceNumber,
 	}
 
-	_, err := opEditSubscriberSeqNum.Invoke(db, subscriber)
+	_, err := opEditSubscriberSeqNum.Invoke(ctx, db, subscriber)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -317,7 +317,7 @@ func (db *Database) DeleteSubscriber(ctx context.Context, imsi string) error {
 
 	DBQueriesTotal.WithLabelValues(SubscribersTableName, "delete").Inc()
 
-	_, err := opDeleteSubscriber.Invoke(db, &stringPayload{Value: imsi})
+	_, err := opDeleteSubscriber.Invoke(ctx, db, &stringPayload{Value: imsi})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -210,7 +210,7 @@ func (db *Database) CreateUser(ctx context.Context, user *User) (string, error) 
 		user.ID = id.String()
 	}
 
-	if _, err := opCreateUser.Invoke(db, user); err != nil {
+	if _, err := opCreateUser.Invoke(ctx, db, user); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -246,7 +246,7 @@ func (db *Database) UpdateUser(ctx context.Context, email string, roleID RoleID)
 		RoleID: roleID,
 	}
 
-	_, err := opUpdateUser.Invoke(db, user)
+	_, err := opUpdateUser.Invoke(ctx, db, user)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -283,7 +283,7 @@ func (db *Database) UpdateUserPassword(ctx context.Context, email string, hashed
 		HashedPassword: hashedPassword,
 	}
 
-	_, err := opUpdateUserPassword.Invoke(db, user)
+	_, err := opUpdateUserPassword.Invoke(ctx, db, user)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -315,7 +315,7 @@ func (db *Database) DeleteUser(ctx context.Context, email string) error {
 
 	DBQueriesTotal.WithLabelValues(UsersTableName, "delete").Inc()
 
-	_, err := opDeleteUser.Invoke(db, &stringPayload{Value: email})
+	_, err := opDeleteUser.Invoke(ctx, db, &stringPayload{Value: email})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/raft/discovery.go
+++ b/internal/raft/discovery.go
@@ -28,10 +28,6 @@ const (
 	discoveryErrLogInterval = 30 * time.Second
 )
 
-// ErrDiscoveryFatal marks a cluster-formation failure that retrying cannot
-// resolve, such as a duplicate node-id. Transient conditions (unreachable
-// peers, a cluster that has not formed yet) are retried indefinitely and
-// never carry it.
 var ErrDiscoveryFatal = errors.New("fatal cluster discovery error")
 
 type peerState int
@@ -58,10 +54,9 @@ type statusResponse struct {
 	Result statusResult `json:"result"`
 }
 
-// StartDiscovery performs cluster formation for HA mode in the background. It
-// must be called after the cluster listener starts so peers can reach this
-// node's cluster port. In standalone mode or when resuming existing Raft
-// state, it is a no-op.
+// StartDiscovery performs cluster formation for HA mode in the background.
+// It must be called after the cluster listener starts so peers can reach
+// this node's cluster port. Standalone or resumed state makes it a no-op.
 func (m *Manager) StartDiscovery(ctx context.Context) {
 	if !m.discoveryPending.Load() {
 		return
@@ -75,9 +70,6 @@ func (m *Manager) StartDiscovery(ctx context.Context) {
 	go m.runDiscovery(ctx)
 }
 
-// setDiscoveryFatal records a misconfiguration that retrying cannot resolve.
-// Discovery stops, the node stays up and unready, and the reason is reported
-// through the status endpoint so an operator sees it without reading logs.
 func (m *Manager) setDiscoveryFatal(err error) {
 	msg := err.Error()
 	m.discoveryFatal.Store(&msg)
@@ -88,8 +80,6 @@ func (m *Manager) setDiscoveryFatal(err error) {
 	)
 }
 
-// DiscoveryError reports a terminal cluster-formation failure, or "" when
-// discovery is progressing or already complete.
 func (m *Manager) DiscoveryError() string {
 	if msg := m.discoveryFatal.Load(); msg != nil {
 		return *msg

--- a/internal/raft/discovery.go
+++ b/internal/raft/discovery.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,6 +27,12 @@ const (
 
 	discoveryErrLogInterval = 30 * time.Second
 )
+
+// ErrDiscoveryFatal marks a cluster-formation failure that retrying cannot
+// resolve, such as a duplicate node-id. Transient conditions (unreachable
+// peers, a cluster that has not formed yet) are retried indefinitely and
+// never carry it.
+var ErrDiscoveryFatal = errors.New("fatal cluster discovery error")
 
 type peerState int
 
@@ -61,11 +68,34 @@ func (m *Manager) StartDiscovery(ctx context.Context) {
 	}
 
 	if m.clusterListener == nil {
-		logger.RaftLog.Error("Cluster discovery requires a cluster listener (mTLS); node will stay unready")
+		m.setDiscoveryFatal(fmt.Errorf("%w: cluster discovery requires a cluster listener (mTLS)", ErrDiscoveryFatal))
 		return
 	}
 
 	go m.runDiscovery(ctx)
+}
+
+// setDiscoveryFatal records a misconfiguration that retrying cannot resolve.
+// Discovery stops, the node stays up and unready, and the reason is reported
+// through the status endpoint so an operator sees it without reading logs.
+func (m *Manager) setDiscoveryFatal(err error) {
+	msg := err.Error()
+	m.discoveryFatal.Store(&msg)
+
+	logger.RaftLog.Error("Cluster discovery cannot continue; fix the configuration and restart",
+		zap.Int("node_id", m.nodeID),
+		zap.Error(err),
+	)
+}
+
+// DiscoveryError reports a terminal cluster-formation failure, or "" when
+// discovery is progressing or already complete.
+func (m *Manager) DiscoveryError() string {
+	if msg := m.discoveryFatal.Load(); msg != nil {
+		return *msg
+	}
+
+	return ""
 }
 
 func (m *Manager) runDiscovery(ctx context.Context) {
@@ -91,6 +121,12 @@ func (m *Manager) runDiscovery(ctx context.Context) {
 
 	for {
 		joined, err := m.discoveryTick(ctx)
+
+		if errors.Is(err, ErrDiscoveryFatal) {
+			m.setDiscoveryFatal(err)
+			return
+		}
+
 		if err != nil && time.Since(lastErrLog) >= discoveryErrLogInterval {
 			lastErrLog = time.Now()
 
@@ -149,7 +185,11 @@ func (m *Manager) discoveryTick(ctx context.Context) (bool, error) {
 			zap.Int("node_id", m.nodeID),
 		)
 
-		return true, m.bootstrapCluster()
+		if err := m.bootstrapCluster(); err != nil {
+			return false, fmt.Errorf("%w: %w", ErrDiscoveryFatal, err)
+		}
+
+		return true, nil
 	}
 
 	for _, peerAddr := range m.config.Peers {
@@ -169,7 +209,7 @@ func (m *Manager) discoveryTick(ctx context.Context) (bool, error) {
 		// so the operator fixes cluster.node-id rather than letting the
 		// cluster form silently wrong.
 		if nodeID > 0 && nodeID == m.nodeID {
-			return false, fmt.Errorf("peer %s advertises the same node-id (%d) as this node; check cluster.node-id configuration", peerAddr, nodeID)
+			return false, fmt.Errorf("%w: peer %s advertises the same node-id (%d) as this node; check cluster.node-id configuration", ErrDiscoveryFatal, peerAddr, nodeID)
 		}
 
 		if state != peerFormed {

--- a/internal/raft/discovery.go
+++ b/internal/raft/discovery.go
@@ -23,6 +23,8 @@ const (
 	discoveryPollInterval = 1 * time.Second
 	defaultJoinTimeout    = 2 * time.Minute
 	discoveryHTTPTimeout  = 5 * time.Second
+
+	discoveryErrLogInterval = 30 * time.Second
 )
 
 type peerState int
@@ -49,55 +51,80 @@ type statusResponse struct {
 	Result statusResult `json:"result"`
 }
 
-// RunDiscovery performs cluster formation for HA mode. It must be called after
-// the cluster listener starts so peers can reach this node's cluster port. In
-// standalone mode or when resuming existing Raft state, it returns immediately.
-func (m *Manager) RunDiscovery(ctx context.Context) error {
-	if !m.needsDiscovery {
-		return nil
+// StartDiscovery performs cluster formation for HA mode in the background. It
+// must be called after the cluster listener starts so peers can reach this
+// node's cluster port. In standalone mode or when resuming existing Raft
+// state, it is a no-op.
+func (m *Manager) StartDiscovery(ctx context.Context) {
+	if !m.discoveryPending.Load() {
+		return
 	}
 
 	if m.clusterListener == nil {
-		return fmt.Errorf("cluster discovery requires a cluster listener (mTLS)")
+		logger.RaftLog.Error("Cluster discovery requires a cluster listener (mTLS); node will stay unready")
+		return
 	}
 
-	timeout := m.config.JoinTimeout
-	if timeout == 0 {
-		timeout = defaultJoinTimeout
-	}
+	go m.runDiscovery(ctx)
+}
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+func (m *Manager) runDiscovery(ctx context.Context) {
+	slowAfter := m.config.JoinTimeout
+	if slowAfter == 0 {
+		slowAfter = defaultJoinTimeout
+	}
 
 	logger.RaftLog.Info("Starting cluster discovery",
 		zap.Int("node_id", m.nodeID),
 		zap.Bool("has_join_token", m.config.HasJoinToken),
 		zap.Int("peers", len(m.config.Peers)),
-		zap.Duration("join_timeout", timeout),
+		zap.Duration("warn_after", slowAfter),
 	)
+
+	started := time.Now()
+	warned := false
+
+	var lastErrLog time.Time
 
 	ticker := time.NewTicker(discoveryPollInterval)
 	defer ticker.Stop()
 
 	for {
 		joined, err := m.discoveryTick(ctx)
-		if err != nil {
-			return err
+		if err != nil && time.Since(lastErrLog) >= discoveryErrLogInterval {
+			lastErrLog = time.Now()
+
+			logger.RaftLog.Error("Cluster discovery attempt failed; retrying",
+				zap.Int("node_id", m.nodeID),
+				zap.Error(err),
+			)
 		}
 
-		if joined {
-			m.needsDiscovery = false
+		if err == nil && joined {
+			m.discoveryPending.Store(false)
 
-			if err := m.waitForLeader(ctx); err != nil {
-				return err
-			}
+			logger.RaftLog.Info("Cluster formation complete",
+				zap.Int("node_id", m.nodeID),
+				zap.Duration("took", time.Since(started)),
+			)
 
-			return nil
+			return
+		}
+
+		if !warned && time.Since(started) > slowAfter {
+			warned = true
+
+			logger.RaftLog.Warn("Cluster formation is taking longer than expected; still retrying",
+				zap.Int("node_id", m.nodeID),
+				zap.Duration("elapsed", time.Since(started)),
+				zap.Strings("peers", m.config.Peers),
+			)
 		}
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("cluster discovery timed out after %s", timeout)
+			logger.RaftLog.Info("Cluster discovery stopped", zap.Error(ctx.Err()))
+			return
 		case <-ticker.C:
 		}
 	}

--- a/internal/raft/discovery_fatal_test.go
+++ b/internal/raft/discovery_fatal_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package raft
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/cluster/listener"
+	"github.com/ellanetworks/core/internal/cluster/listener/testutil"
+)
+
+func TestStartDiscoveryWithoutClusterListenerIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	m := &Manager{nodeID: 3}
+	m.discoveryPending.Store(true)
+
+	m.StartDiscovery(context.Background())
+
+	if got := m.DiscoveryError(); got == "" {
+		t.Fatal("a missing cluster listener can never resolve by retrying; it must be reported as terminal")
+	}
+
+	if !strings.Contains(m.DiscoveryError(), "cluster listener") {
+		t.Errorf("discovery error should name the missing listener, got %q", m.DiscoveryError())
+	}
+}
+
+func TestRunDiscoveryStopsOnTerminalError(t *testing.T) {
+	t.Parallel()
+
+	applier := newTestApplier(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mgr, err := NewManager(ctx, FastTestConfig(), applier, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	t.Cleanup(func() { _ = mgr.Shutdown() })
+
+	if err := mgr.WaitForLeaderBarrier(ctx); err != nil {
+		t.Fatalf("barrier: %v", err)
+	}
+
+	// The node is already bootstrapped, so the founder path cannot bootstrap
+	// again. Retrying that at 1 Hz forever would hide the problem.
+	mgr.config.HasJoinToken = false
+	mgr.discoveryPending.Store(true)
+
+	pki := testutil.GenTestPKI(t, []int{1})
+
+	mgr.attachClusterListener(listener.New(listener.Config{
+		BindAddress:      "127.0.0.1:0",
+		AdvertiseAddress: "127.0.0.1:0",
+		NodeID:           1,
+		Pin:              pki.PinFunc(),
+		Leaf:             pki.LeafFunc(1),
+	}))
+
+	mgr.StartDiscovery(ctx)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for mgr.DiscoveryError() == "" {
+		if time.Now().After(deadline) {
+			t.Fatal("discovery kept retrying an error that can never succeed instead of stopping")
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !strings.Contains(mgr.DiscoveryError(), "bootstrap") {
+		t.Errorf("discovery error should explain the bootstrap failure, got %q", mgr.DiscoveryError())
+	}
+}

--- a/internal/raft/discovery_fatal_test.go
+++ b/internal/raft/discovery_fatal_test.go
@@ -49,8 +49,6 @@ func TestRunDiscoveryStopsOnTerminalError(t *testing.T) {
 		t.Fatalf("barrier: %v", err)
 	}
 
-	// The node is already bootstrapped, so the founder path cannot bootstrap
-	// again. Retrying that at 1 Hz forever would hide the problem.
 	mgr.config.HasJoinToken = false
 	mgr.discoveryPending.Store(true)
 

--- a/internal/raft/discovery_retry_test.go
+++ b/internal/raft/discovery_retry_test.go
@@ -57,6 +57,10 @@ func TestStartDiscoveryRetriesPastJoinTimeout(t *testing.T) {
 	if !m.discoveryPending.Load() {
 		t.Error("discovery must still be pending, not abandoned")
 	}
+
+	if got := m.DiscoveryError(); got != "" {
+		t.Errorf("an unreachable peer is transient and must never be treated as terminal, got %q", got)
+	}
 }
 
 func TestStartDiscoveryStopsOnContextCancel(t *testing.T) {

--- a/internal/raft/discovery_retry_test.go
+++ b/internal/raft/discovery_retry_test.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package raft
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/cluster/listener"
+	"github.com/ellanetworks/core/internal/cluster/listener/testutil"
+)
+
+func newDiscoveryTestManager(t *testing.T, peers []string) *Manager {
+	t.Helper()
+
+	pki := testutil.GenTestPKI(t, []int{1, 2})
+
+	ln := listener.New(listener.Config{
+		BindAddress:      "127.0.0.1:0",
+		AdvertiseAddress: "127.0.0.1:0",
+		NodeID:           2,
+		Pin:              pki.PinFunc(),
+		Leaf:             pki.LeafFunc(2),
+	})
+
+	m := &Manager{
+		nodeID:          2,
+		clusterListener: ln,
+		config: ClusterConfig{
+			Peers:            peers,
+			AdvertiseAddress: "127.0.0.1:9999",
+			HasJoinToken:     true,
+			SchemaVersion:    9,
+			JoinTimeout:      50 * time.Millisecond,
+		},
+	}
+
+	m.discoveryPending.Store(true)
+
+	return m
+}
+
+func TestStartDiscoveryRetriesPastJoinTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := newDiscoveryTestManager(t, []string{"127.0.0.1:1"})
+
+	m.StartDiscovery(ctx)
+
+	time.Sleep(300 * time.Millisecond)
+
+	if !m.discoveryPending.Load() {
+		t.Error("discovery must still be pending, not abandoned")
+	}
+}
+
+func TestStartDiscoveryStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	m := newDiscoveryTestManager(t, []string{"127.0.0.1:1"})
+
+	m.StartDiscovery(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	time.Sleep(200 * time.Millisecond)
+
+	if !m.discoveryPending.Load() {
+		t.Error("cancelling must not mark discovery successful")
+	}
+}

--- a/internal/raft/leader_barrier_test.go
+++ b/internal/raft/leader_barrier_test.go
@@ -61,9 +61,6 @@ func TestStandaloneRestartBarriersBeforeReadsAreServed(t *testing.T) {
 	}
 }
 
-// TestBarrierForLeadershipAbortsOnShutdown pins the ordering hazard in
-// Manager.Shutdown: it stops the observer before shutting raft down, so a
-// leadership barrier still waiting on the FSM would hold shutdown open.
 func TestBarrierForLeadershipAbortsOnShutdown(t *testing.T) {
 	t.Parallel()
 
@@ -81,8 +78,6 @@ func TestBarrierForLeadershipAbortsOnShutdown(t *testing.T) {
 		t.Fatalf("barrier: %v", err)
 	}
 
-	// Install a barrier attempt that never completes, standing in for an FSM
-	// still draining a large replay backlog.
 	mgr.barrieredTerm.Store(0)
 
 	mgr.barrierMu.Lock()
@@ -93,7 +88,6 @@ func TestBarrierForLeadershipAbortsOnShutdown(t *testing.T) {
 
 	go func() { done <- mgr.barrierForLeadership() }()
 
-	// Let the waiter park on the barrier before shutdown overtakes it.
 	time.Sleep(200 * time.Millisecond)
 
 	if err := mgr.Shutdown(); err != nil {

--- a/internal/raft/leader_barrier_test.go
+++ b/internal/raft/leader_barrier_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package raft
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStandaloneRestartBarriersBeforeReadsAreServed(t *testing.T) {
+	t.Parallel()
+
+	applier := newTestApplier(t)
+	dataDir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	first, err := NewManager(ctx, FastTestConfig(), applier, dataDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	if err := first.WaitForLeaderBarrier(ctx); err != nil {
+		t.Fatalf("first barrier: %v", err)
+	}
+
+	for i := range 500 {
+		cmd, err := NewCommand(CmdChangeset, map[string]int{"n": i})
+		if err != nil {
+			t.Fatalf("NewCommand: %v", err)
+		}
+
+		if _, err := first.Propose(cmd, first.ProposeTimeout()); err != nil {
+			t.Fatalf("propose %d: %v", i, err)
+		}
+	}
+
+	committed := first.AppliedIndex()
+
+	if err := first.Shutdown(); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	second, err := NewManager(ctx, FastTestConfig(), applier, dataDir)
+	if err != nil {
+		t.Fatalf("NewManager (reopen): %v", err)
+	}
+
+	t.Cleanup(func() { _ = second.Shutdown() })
+
+	if err := second.WaitForLeaderBarrier(ctx); err != nil {
+		t.Fatalf("post-restart barrier never completed: %v", err)
+	}
+
+	if got := second.AppliedIndex(); got < committed {
+		t.Fatalf("FSM still lags the committed log after the barrier: applied %d, committed before restart %d", got, committed)
+	}
+}

--- a/internal/raft/leader_barrier_test.go
+++ b/internal/raft/leader_barrier_test.go
@@ -5,6 +5,7 @@ package raft
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -57,5 +58,54 @@ func TestStandaloneRestartBarriersBeforeReadsAreServed(t *testing.T) {
 
 	if got := second.AppliedIndex(); got < committed {
 		t.Fatalf("FSM still lags the committed log after the barrier: applied %d, committed before restart %d", got, committed)
+	}
+}
+
+// TestBarrierForLeadershipAbortsOnShutdown pins the ordering hazard in
+// Manager.Shutdown: it stops the observer before shutting raft down, so a
+// leadership barrier still waiting on the FSM would hold shutdown open.
+func TestBarrierForLeadershipAbortsOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	applier := newTestApplier(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mgr, err := NewManager(ctx, FastTestConfig(), applier, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	if err := mgr.WaitForLeaderBarrier(ctx); err != nil {
+		t.Fatalf("barrier: %v", err)
+	}
+
+	// Install a barrier attempt that never completes, standing in for an FSM
+	// still draining a large replay backlog.
+	mgr.barrieredTerm.Store(0)
+
+	mgr.barrierMu.Lock()
+	mgr.barrier = &barrierAttempt{term: mgr.raft.CurrentTerm(), done: make(chan struct{})}
+	mgr.barrierMu.Unlock()
+
+	done := make(chan error, 1)
+
+	go func() { done <- mgr.barrierForLeadership() }()
+
+	// Let the waiter park on the barrier before shutdown overtakes it.
+	time.Sleep(200 * time.Millisecond)
+
+	if err := mgr.Shutdown(); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, errShuttingDown) {
+			t.Fatalf("want errShuttingDown, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("barrier ignored shutdown; Manager.Shutdown stops the observer first, so this deadlocks shutdown")
 	}
 }

--- a/internal/raft/leader_notify_test.go
+++ b/internal/raft/leader_notify_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package raft
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWaitForLeaderDoesNotConsumeLeaderCh(t *testing.T) {
+	t.Parallel()
+
+	applier := newTestApplier(t)
+
+	cfg := ClusterConfig{
+		HeartbeatTimeout:   2 * time.Second,
+		ElectionTimeout:    2 * time.Second,
+		LeaderLeaseTimeout: 1 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mgr, err := NewManager(ctx, cfg, applier, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	t.Cleanup(func() { _ = mgr.Shutdown() })
+
+	mgr.LeaderObserver().Stop()
+
+	if err := mgr.WaitForLeader(ctx); err != nil {
+		t.Fatalf("WaitForLeader: %v", err)
+	}
+
+	select {
+	case isLeader := <-mgr.raft.LeaderCh():
+		if !isLeader {
+			t.Fatal("expected the pending notification to report leadership")
+		}
+	default:
+		t.Fatal("waitForLeader took the transition off raft.LeaderCh(); raft delivers each value to exactly one receiver, so LeaderObserver must be its sole consumer or leadership callbacks are lost")
+	}
+}

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -95,8 +95,12 @@ const (
 
 	leaderPollInterval = 25 * time.Millisecond
 
-	leaderBarrierTimeout = 2 * time.Minute
+	leaderBarrierRetryInterval = 1 * time.Second
 )
+
+// errShuttingDown aborts a wait that the manager's own shutdown has
+// overtaken. It never reaches a caller outside this package.
+var errShuttingDown = errors.New("raft manager shutting down")
 
 // closeTransport best-effort closes a raft.Transport. The interface itself
 // has no Close method, but concrete transports (TCP, in-mem) implement
@@ -134,6 +138,9 @@ type Manager struct {
 
 	leaderBarrier     chan struct{}
 	leaderBarrierOnce sync.Once
+
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
 }
 
 // leaderBarrierCallback applies a raft barrier on every leadership
@@ -147,14 +154,51 @@ type leaderBarrierCallback struct {
 func (c leaderBarrierCallback) OnLostLeadership() {}
 
 func (c leaderBarrierCallback) OnBecameLeader() {
-	if err := c.m.WriteBarrier(leaderBarrierTimeout); err != nil {
-		logger.RaftLog.Error("Post-leadership barrier failed; reads may lag the committed log",
+	for {
+		err := c.m.barrierForLeadership()
+		if err == nil {
+			c.m.leaderBarrierOnce.Do(func() { close(c.m.leaderBarrier) })
+			return
+		}
+
+		if errors.Is(err, errShuttingDown) || c.m.raft.State() != raft.Leader {
+			logger.RaftLog.Warn("Post-leadership barrier abandoned", zap.Error(err))
+			return
+		}
+
+		logger.RaftLog.Error("Post-leadership barrier failed; retrying before leader initialization runs",
 			zap.Error(err))
 
-		return
+		select {
+		case <-c.m.shutdownCh:
+			return
+		case <-time.After(leaderBarrierRetryInterval):
+		}
+	}
+}
+
+// barrierForLeadership waits out the shared per-term barrier with no deadline
+// of its own: raft.Barrier already ends when the FSM catches up or raft shuts
+// down, and a deadline here would only strand the waiter while the barrier it
+// abandoned went on to succeed.
+func (m *Manager) barrierForLeadership() error {
+	term := m.raft.CurrentTerm()
+	if term != 0 && m.barrieredTerm.Load() == term {
+		return nil
 	}
 
-	c.m.leaderBarrierOnce.Do(func() { close(c.m.leaderBarrier) })
+	if m.raft.State() != raft.Leader {
+		return raft.ErrNotLeader
+	}
+
+	att := m.barrierFor(term)
+
+	select {
+	case <-att.done:
+		return att.err
+	case <-m.shutdownCh:
+		return errShuttingDown
+	}
 }
 
 // WaitForLeaderBarrier blocks until this node has completed a post-leadership
@@ -340,6 +384,7 @@ func NewManager(_ context.Context, cfg ClusterConfig, applier Applier, dataDir s
 		observer:      observer,
 		boltNoSync:    false,
 		leaderBarrier: make(chan struct{}),
+		shutdownCh:    make(chan struct{}),
 	}
 
 	observer.Register(leaderBarrierCallback{m: m})
@@ -770,6 +815,8 @@ func (m *Manager) MemberIDs() []int {
 
 // Shutdown gracefully shuts down the Raft node.
 func (m *Manager) Shutdown() error {
+	m.shutdownOnce.Do(func() { close(m.shutdownCh) })
+
 	if m.observer != nil {
 		m.observer.Stop()
 	}

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -98,8 +98,6 @@ const (
 	leaderBarrierRetryInterval = 1 * time.Second
 )
 
-// errShuttingDown aborts a wait that the manager's own shutdown has
-// overtaken. It never reaches a caller outside this package.
 var errShuttingDown = errors.New("raft manager shutting down")
 
 // closeTransport best-effort closes a raft.Transport. The interface itself
@@ -143,10 +141,6 @@ type Manager struct {
 	shutdownOnce sync.Once
 }
 
-// leaderBarrierCallback applies a raft barrier on every leadership
-// acquisition, so the FSM has drained every entry committed before this term
-// before anything reads it. Post-snapshot entries are applied asynchronously,
-// so on a restart the FSM lags the durable log until this completes.
 type leaderBarrierCallback struct {
 	m *Manager
 }
@@ -177,10 +171,6 @@ func (c leaderBarrierCallback) OnBecameLeader() {
 	}
 }
 
-// barrierForLeadership waits out the shared per-term barrier with no deadline
-// of its own: raft.Barrier already ends when the FSM catches up or raft shuts
-// down, and a deadline here would only strand the waiter while the barrier it
-// abandoned went on to succeed.
 func (m *Manager) barrierForLeadership() error {
 	term := m.raft.CurrentTerm()
 	if term != 0 && m.barrieredTerm.Load() == term {
@@ -201,8 +191,6 @@ func (m *Manager) barrierForLeadership() error {
 	}
 }
 
-// WaitForLeaderBarrier blocks until this node has completed a post-leadership
-// barrier, so local reads reflect every committed write.
 func (m *Manager) WaitForLeaderBarrier(ctx context.Context) error {
 	select {
 	case <-m.leaderBarrier:
@@ -866,10 +854,9 @@ func (m *Manager) HoldForLeader(ctx context.Context, timeout time.Duration) erro
 }
 
 // waitForLeader blocks until the cluster has an elected leader or ctx is
-// cancelled. It polls LeaderWithID rather than selecting on LeaderCh:
-// LeaderCh only reports this node's own leadership transitions, and raft
-// delivers each of its values to exactly one receiver, so LeaderObserver
-// must stay its sole consumer or leadership callbacks are silently lost.
+// cancelled. It polls LeaderWithID rather than selecting on LeaderCh, which
+// only reports this node's own transitions and delivers each value to exactly
+// one receiver, so LeaderObserver must stay its sole consumer.
 func (m *Manager) waitForLeader(ctx context.Context) error {
 	if addr, _ := m.raft.LeaderWithID(); addr != "" {
 		return nil

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -92,6 +92,10 @@ const (
 	// persists when neither config, environment, nor a previously written
 	// node-id file supplies one.
 	defaultStandaloneNodeID = 1
+
+	leaderPollInterval = 25 * time.Millisecond
+
+	leaderBarrierTimeout = 2 * time.Minute
 )
 
 // closeTransport best-effort closes a raft.Transport. The interface itself
@@ -122,10 +126,46 @@ type Manager struct {
 	leaderClient *leaderHTTPClient
 
 	discoveryPending atomic.Bool
+	discoveryFatal   atomic.Pointer[string]
 
 	barrieredTerm atomic.Uint64
 	barrierMu     sync.Mutex
 	barrier       *barrierAttempt
+
+	leaderBarrier     chan struct{}
+	leaderBarrierOnce sync.Once
+}
+
+// leaderBarrierCallback applies a raft barrier on every leadership
+// acquisition, so the FSM has drained every entry committed before this term
+// before anything reads it. Post-snapshot entries are applied asynchronously,
+// so on a restart the FSM lags the durable log until this completes.
+type leaderBarrierCallback struct {
+	m *Manager
+}
+
+func (c leaderBarrierCallback) OnLostLeadership() {}
+
+func (c leaderBarrierCallback) OnBecameLeader() {
+	if err := c.m.WriteBarrier(leaderBarrierTimeout); err != nil {
+		logger.RaftLog.Error("Post-leadership barrier failed; reads may lag the committed log",
+			zap.Error(err))
+
+		return
+	}
+
+	c.m.leaderBarrierOnce.Do(func() { close(c.m.leaderBarrier) })
+}
+
+// WaitForLeaderBarrier blocks until this node has completed a post-leadership
+// barrier, so local reads reflect every committed write.
+func (m *Manager) WaitForLeaderBarrier(ctx context.Context) error {
+	select {
+	case <-m.leaderBarrier:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 type barrierAttempt struct {
@@ -289,17 +329,20 @@ func NewManager(_ context.Context, cfg ClusterConfig, applier Applier, dataDir s
 	observer := NewLeaderObserver()
 
 	m := &Manager{
-		raft:       r,
-		fsm:        fsm,
-		transport:  transport,
-		logStore:   boltStore,
-		snaps:      snapshotStore,
-		config:     cfg,
-		nodeID:     nodeID,
-		dataDir:    dataDir,
-		observer:   observer,
-		boltNoSync: false,
+		raft:          r,
+		fsm:           fsm,
+		transport:     transport,
+		logStore:      boltStore,
+		snaps:         snapshotStore,
+		config:        cfg,
+		nodeID:        nodeID,
+		dataDir:       dataDir,
+		observer:      observer,
+		boltNoSync:    false,
+		leaderBarrier: make(chan struct{}),
 	}
+
+	observer.Register(leaderBarrierCallback{m: m})
 
 	m.discoveryPending.Store(!singleServer && !hasState && !recovered)
 
@@ -776,25 +819,22 @@ func (m *Manager) HoldForLeader(ctx context.Context, timeout time.Duration) erro
 }
 
 // waitForLeader blocks until the cluster has an elected leader or ctx is
-// cancelled. On the bootstrapper LeaderCh fires quickly; on joiners we
-// poll LeaderWithID because LeaderCh only signals this node's own
-// leadership transitions.
+// cancelled. It polls LeaderWithID rather than selecting on LeaderCh:
+// LeaderCh only reports this node's own leadership transitions, and raft
+// delivers each of its values to exactly one receiver, so LeaderObserver
+// must stay its sole consumer or leadership callbacks are silently lost.
 func (m *Manager) waitForLeader(ctx context.Context) error {
 	if addr, _ := m.raft.LeaderWithID(); addr != "" {
 		return nil
 	}
 
-	ticker := time.NewTicker(200 * time.Millisecond)
+	ticker := time.NewTicker(leaderPollInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case isLeader := <-m.raft.LeaderCh():
-			if isLeader {
-				return nil
-			}
 		case <-ticker.C:
 			if addr, _ := m.raft.LeaderWithID(); addr != "" {
 				return nil

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -18,10 +18,12 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/cluster/listener"
+	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/osutil"
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
+	"go.uber.org/zap"
 )
 
 var ErrBarrierTimeout = errors.New("raft barrier timed out")
@@ -46,11 +48,12 @@ type ClusterConfig struct {
 	SnapshotInterval  time.Duration
 	SnapshotThreshold uint64
 
-	// PerformanceMultiplier scales heartbeat/election/leader-lease timeouts
-	// in HA mode. Trading a
-	// slower election for tolerance of real-network jitter. Ignored in
-	// single-server mode, which uses fixed fast timeouts.
 	PerformanceMultiplier int
+
+	HeartbeatTimeout   time.Duration
+	ElectionTimeout    time.Duration
+	LeaderLeaseTimeout time.Duration
+	CommitTimeout      time.Duration
 
 	// TrailingLogs bounds the number of Raft log entries retained after a
 	// snapshot. Lower values shrink BoltDB at the cost of forcing full
@@ -77,14 +80,7 @@ const (
 	// applied to the library's default timeouts when running in HA mode.
 	defaultPerformanceMultiplier = 5
 
-	// standaloneHeartbeatTimeout and friends govern the single-server bootstrap
-	// path. Aggressive values are safe because there are no peers to time
-	// out against — the timeout is a ceiling, not a floor, and the real
-	// election completes in microseconds over the loopback listener.
-	standaloneHeartbeatTimeout   = 50 * time.Millisecond
-	standaloneElectionTimeout    = 50 * time.Millisecond
-	standaloneLeaderLeaseTimeout = 50 * time.Millisecond
-	standaloneCommitTimeout      = 5 * time.Millisecond
+	standalonePerformanceMultiplier = 1
 
 	// defaultProposeTimeout caps how long a write waits for Raft commit
 	// before the API layer returns 503. 5 s is generous for single-server
@@ -96,8 +92,6 @@ const (
 	// persists when neither config, environment, nor a previously written
 	// node-id file supplies one.
 	defaultStandaloneNodeID = 1
-
-	standaloneLeaderTimeout = 60 * time.Second
 )
 
 // closeTransport best-effort closes a raft.Transport. The interface itself
@@ -120,13 +114,14 @@ type Manager struct {
 	nodeID          int
 	dataDir         string
 	observer        *LeaderObserver
-	needsDiscovery  bool
 	autopilot       *autopilotRunner
 	followerTracker *followerTracker
 	boltNoSync      bool
 	clusterListener *listener.Listener
 
 	leaderClient *leaderHTTPClient
+
+	discoveryPending atomic.Bool
 
 	barrieredTerm atomic.Uint64
 	barrierMu     sync.Mutex
@@ -149,15 +144,8 @@ const defaultStandaloneBindAddress = "127.0.0.1:0"
 // NewManager creates and starts a Raft node over a real TCP transport. The
 // applier is called by the FSM for every committed log entry.
 //
-// When cfg.Enabled is false, the manager runs as a single-server cluster:
-// fast timeouts, auto-bootstrap on fresh state, and a synchronous wait for
-// self-election. This is the shipping standalone mode. Tests that want an
-// in-memory transport should use NewTestManager instead.
-//
-// When cfg.Enabled is true, the manager runs in HA mode: library default
-// timeouts scaled by PerformanceMultiplier, and no auto-bootstrap (operators
-// drive cluster formation explicitly).
-func NewManager(ctx context.Context, cfg ClusterConfig, applier Applier, dataDir string, opts ...ManagerOption) (*Manager, error) {
+// Tests that want an in-memory transport should use NewTestManager instead.
+func NewManager(_ context.Context, cfg ClusterConfig, applier Applier, dataDir string, opts ...ManagerOption) (*Manager, error) {
 	options := managerOptions{}
 	for _, opt := range opts {
 		opt(&options)
@@ -301,18 +289,19 @@ func NewManager(ctx context.Context, cfg ClusterConfig, applier Applier, dataDir
 	observer := NewLeaderObserver()
 
 	m := &Manager{
-		raft:           r,
-		fsm:            fsm,
-		transport:      transport,
-		logStore:       boltStore,
-		snaps:          snapshotStore,
-		config:         cfg,
-		nodeID:         nodeID,
-		dataDir:        dataDir,
-		observer:       observer,
-		needsDiscovery: !singleServer && !hasState && !recovered,
-		boltNoSync:     false,
+		raft:       r,
+		fsm:        fsm,
+		transport:  transport,
+		logStore:   boltStore,
+		snaps:      snapshotStore,
+		config:     cfg,
+		nodeID:     nodeID,
+		dataDir:    dataDir,
+		observer:   observer,
+		boltNoSync: false,
 	}
+
+	m.discoveryPending.Store(!singleServer && !hasState && !recovered)
 
 	m.attachClusterListener(options.clusterListener)
 
@@ -326,39 +315,7 @@ func NewManager(ctx context.Context, cfg ClusterConfig, applier Applier, dataDir
 	}
 
 	if singleServer {
-		leaderCtx, cancelLeader := context.WithTimeout(ctx, standaloneLeaderTimeout)
-		leaderErr := m.waitForLeader(leaderCtx)
-
-		cancelLeader()
-
-		if leaderErr != nil {
-			servers := describeServers(r)
-
-			_ = r.Shutdown().Error()
-
-			closeTransport(transport)
-
-			_ = boltStore.Close()
-
-			return nil, fmt.Errorf("standalone node %d did not become raft leader (%w); the raft "+
-				"state in %s lists servers [%s], and a standalone node can only elect itself when "+
-				"it is the sole voter; write a peers.json recovery file into that directory to "+
-				"reset the server configuration",
-				nodeID, leaderErr, raftDir, servers)
-		}
-
-		// Post-snapshot committed entries are applied asynchronously,
-		// so the FSM can lag the durable log on startup. Barrier
-		// requires leadership, just confirmed by waitForLeader.
-		if err := m.raft.Barrier(m.ProposeTimeout()).Error(); err != nil {
-			_ = r.Shutdown().Error()
-
-			closeTransport(transport)
-
-			_ = boltStore.Close()
-
-			return nil, fmt.Errorf("post-startup barrier: %w", err)
-		}
+		warnOnMultiServerStandaloneState(r, nodeID, raftDir)
 	}
 
 	go observer.Run(r)
@@ -385,6 +342,24 @@ func describeServers(r *raft.Raft) string {
 	return strings.Join(ids, ", ")
 }
 
+func warnOnMultiServerStandaloneState(r *raft.Raft, nodeID int, raftDir string) {
+	future := r.GetConfiguration()
+	if err := future.Error(); err != nil {
+		return
+	}
+
+	if len(future.Configuration().Servers) <= 1 {
+		return
+	}
+
+	logger.RaftLog.Error("Standalone node cannot elect itself: on-disk raft state lists multiple servers",
+		zap.Int("node_id", nodeID),
+		zap.String("raft_dir", raftDir),
+		zap.String("servers", describeServers(r)),
+		zap.String("remedy", "write a peers.json recovery file into the raft directory to reset the server configuration"),
+	)
+}
+
 // resolveNodeIDForMode picks the Raft server ID. Both modes go through the
 // same config/env/file chain, which persists the ID on first boot and
 // rejects later mismatches that would invalidate issued GUTIs. Single-server
@@ -405,38 +380,35 @@ func resolveNodeIDForMode(cfg ClusterConfig, singleServer bool, dataDir string) 
 }
 
 // applyTimeouts configures heartbeat / election / leader-lease / commit
-// timeouts based on whether the manager is single-server or HA.
-//
-// Single-server mode uses fixed 50 ms timeouts: with no peers to negotiate
-// with the library defaults are pure dead time during bootstrap.
-//
-// HA mode scales the library defaults by PerformanceMultiplier (default 5)
-// from day one — including on fresh boot. We used to override freshBoot
-// nodes with the 50 ms standalone values to accelerate the first election,
-// but LeaderLeaseTimeout is not runtime-reloadable, so it then stayed at
-// 50 ms forever. Any operation that stalled a follower's FSM for longer
-// than 50 ms (snapshot install, raft.Restore, a slow Apply) caused the
-// leader to drop its lease and step down, triggering a leadership
-// oscillation that could not recover. Paying the one-time 1–5 s first
-// election cost is the correct tradeoff for a multi-node cluster.
+// timeouts.
 func applyTimeouts(rc *raft.Config, cfg ClusterConfig, singleServer bool) {
-	if singleServer {
-		rc.HeartbeatTimeout = standaloneHeartbeatTimeout
-		rc.ElectionTimeout = standaloneElectionTimeout
-		rc.LeaderLeaseTimeout = standaloneLeaderLeaseTimeout
-		rc.CommitTimeout = standaloneCommitTimeout
-
-		return
-	}
-
 	multiplier := cfg.PerformanceMultiplier
 	if multiplier <= 0 {
 		multiplier = defaultPerformanceMultiplier
+		if singleServer {
+			multiplier = standalonePerformanceMultiplier
+		}
 	}
 
 	rc.HeartbeatTimeout *= time.Duration(multiplier)
 	rc.ElectionTimeout *= time.Duration(multiplier)
 	rc.LeaderLeaseTimeout *= time.Duration(multiplier)
+
+	if cfg.HeartbeatTimeout > 0 {
+		rc.HeartbeatTimeout = cfg.HeartbeatTimeout
+	}
+
+	if cfg.ElectionTimeout > 0 {
+		rc.ElectionTimeout = cfg.ElectionTimeout
+	}
+
+	if cfg.LeaderLeaseTimeout > 0 {
+		rc.LeaderLeaseTimeout = cfg.LeaderLeaseTimeout
+	}
+
+	if cfg.CommitTimeout > 0 {
+		rc.CommitTimeout = cfg.CommitTimeout
+	}
 }
 
 // Propose serializes a command and applies it through Raft consensus.
@@ -781,6 +753,26 @@ func (m *Manager) Shutdown() error {
 	}
 
 	return nil
+}
+
+func (m *Manager) HasLeader() bool {
+	addr, _ := m.raft.LeaderWithID()
+	return addr != ""
+}
+
+func (m *Manager) WaitForLeader(ctx context.Context) error {
+	return m.waitForLeader(ctx)
+}
+
+func (m *Manager) HoldForLeader(ctx context.Context, timeout time.Duration) error {
+	if m.HasLeader() {
+		return nil
+	}
+
+	holdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return m.waitForLeader(holdCtx)
 }
 
 // waitForLeader blocks until the cluster has an elected leader or ctx is

--- a/internal/raft/manager_bolt_fsync_test.go
+++ b/internal/raft/manager_bolt_fsync_test.go
@@ -17,7 +17,7 @@ func TestManagerBoltFsyncStandalone(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	mgr, err := NewManager(ctx, ClusterConfig{}, applier, t.TempDir())
+	mgr, err := NewManager(ctx, FastTestConfig(), applier, t.TempDir())
 	if err != nil {
 		t.Fatalf("NewManager standalone: %v", err)
 	}

--- a/internal/raft/manager_standalone_leader_test.go
+++ b/internal/raft/manager_standalone_leader_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -64,7 +63,7 @@ func seedMultiServerRaftState(t testing.TB, dataDir string) {
 	}
 }
 
-func TestNewManagerStandaloneFailsOnMultiServerState(t *testing.T) {
+func TestNewManagerStandaloneStartsWithMultiServerState(t *testing.T) {
 	t.Parallel()
 
 	applier := newTestApplier(t)
@@ -72,33 +71,113 @@ func TestNewManagerStandaloneFailsOnMultiServerState(t *testing.T) {
 
 	seedMultiServerRaftState(t, dataDir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	mgr, err := NewManager(ctx, ClusterConfig{}, applier, dataDir)
-	if err == nil {
-		_ = mgr.Shutdown()
-
-		t.Fatal("expected NewManager to fail when standalone state lists multiple servers")
+	mgr, err := NewManager(ctx, FastTestConfig(), applier, dataDir)
+	if err != nil {
+		t.Fatalf("NewManager must start even when it can never elect itself: %v", err)
 	}
 
-	for _, want := range []string{"did not become raft leader", "lists servers", "peers.json"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error missing %q; got: %v", want, err)
-		}
-	}
+	t.Cleanup(func() { _ = mgr.Shutdown() })
 
-	for _, id := range []string{"1", "2", "3"} {
-		if !strings.Contains(err.Error(), id) {
-			t.Fatalf("error does not name server %q; got: %v", id, err)
-		}
+	if mgr.HasLeader() {
+		t.Fatal("node with a stale three-server configuration must not report a leader")
 	}
 }
 
-func TestStandaloneLeaderTimeoutIsBounded(t *testing.T) {
+func TestNewManagerStandaloneDoesNotBlockOnElection(t *testing.T) {
 	t.Parallel()
 
-	if standaloneLeaderTimeout <= 0 || standaloneLeaderTimeout > 5*time.Minute {
-		t.Fatalf("standaloneLeaderTimeout must be a sane positive bound on startup, got %s", standaloneLeaderTimeout)
+	applier := newTestApplier(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cfg := ClusterConfig{
+		ElectionTimeout:    10 * time.Second,
+		HeartbeatTimeout:   10 * time.Second,
+		LeaderLeaseTimeout: 5 * time.Second,
+	}
+
+	start := time.Now()
+
+	mgr, err := NewManager(ctx, cfg, applier, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	t.Cleanup(func() { _ = mgr.Shutdown() })
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("NewManager blocked for %s; startup must not wait for leadership", elapsed)
+	}
+}
+
+func TestApplyTimeoutsUsesLibraryDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		cfg          ClusterConfig
+		singleServer bool
+		heartbeat    time.Duration
+		election     time.Duration
+		lease        time.Duration
+	}{
+		{
+			name:         "standalone",
+			singleServer: true,
+			heartbeat:    1000 * time.Millisecond,
+			election:     1000 * time.Millisecond,
+			lease:        500 * time.Millisecond,
+		},
+		{
+			name:      "ha",
+			cfg:       ClusterConfig{Enabled: true},
+			heartbeat: 5000 * time.Millisecond,
+			election:  5000 * time.Millisecond,
+			lease:     2500 * time.Millisecond,
+		},
+		{
+			name:      "ha with multiplier",
+			cfg:       ClusterConfig{Enabled: true, PerformanceMultiplier: 2},
+			heartbeat: 2000 * time.Millisecond,
+			election:  2000 * time.Millisecond,
+			lease:     1000 * time.Millisecond,
+		},
+		{
+			name:         "explicit overrides win",
+			singleServer: true,
+			cfg: ClusterConfig{
+				HeartbeatTimeout:   7 * time.Millisecond,
+				ElectionTimeout:    8 * time.Millisecond,
+				LeaderLeaseTimeout: 9 * time.Millisecond,
+			},
+			heartbeat: 7 * time.Millisecond,
+			election:  8 * time.Millisecond,
+			lease:     9 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rc := raft.DefaultConfig()
+			applyTimeouts(rc, tt.cfg, tt.singleServer)
+
+			if rc.HeartbeatTimeout != tt.heartbeat {
+				t.Errorf("HeartbeatTimeout = %s, want %s", rc.HeartbeatTimeout, tt.heartbeat)
+			}
+
+			if rc.ElectionTimeout != tt.election {
+				t.Errorf("ElectionTimeout = %s, want %s", rc.ElectionTimeout, tt.election)
+			}
+
+			if rc.LeaderLeaseTimeout != tt.lease {
+				t.Errorf("LeaderLeaseTimeout = %s, want %s", rc.LeaderLeaseTimeout, tt.lease)
+			}
+		})
 	}
 }

--- a/internal/raft/testing.go
+++ b/internal/raft/testing.go
@@ -18,6 +18,15 @@ import (
 	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
 )
 
+func FastTestConfig() ClusterConfig {
+	return ClusterConfig{
+		HeartbeatTimeout:   50 * time.Millisecond,
+		ElectionTimeout:    50 * time.Millisecond,
+		LeaderLeaseTimeout: 50 * time.Millisecond,
+		CommitTimeout:      5 * time.Millisecond,
+	}
+}
+
 // NewTestManager spins up a single-node Raft cluster over an in-memory
 // transport, tuned for fast unit tests. No TCP bind, small trailing-log window, low snapshot
 // threshold. Tests reach leader in milliseconds and don't compete for ports.

--- a/internal/raft/testing.go
+++ b/internal/raft/testing.go
@@ -128,7 +128,11 @@ func NewTestManager(t testing.TB, applier Applier) (*Manager, func()) {
 		nodeID:    1,
 		dataDir:   dataDir,
 		observer:  observer,
+
+		leaderBarrier: make(chan struct{}),
 	}
+
+	observer.Register(leaderBarrierCallback{m: m})
 
 	if err := waitForLeaderTest(t, m); err != nil {
 		_ = r.Shutdown().Error()
@@ -170,14 +174,18 @@ func waitForLeaderTest(t testing.TB, m *Manager) error {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
+	ticker := time.NewTicker(leaderPollInterval)
+	defer ticker.Stop()
+
 	for {
+		if m.raft.State() == raft.Leader {
+			return nil
+		}
+
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("no leader elected: %w", ctx.Err())
-		case isLeader := <-m.raft.LeaderCh():
-			if isLeader {
-				return nil
-			}
+		case <-ticker.C:
 		}
 	}
 }

--- a/internal/raft/testing.go
+++ b/internal/raft/testing.go
@@ -130,6 +130,7 @@ func NewTestManager(t testing.TB, applier Applier) (*Manager, func()) {
 		observer:  observer,
 
 		leaderBarrier: make(chan struct{}),
+		shutdownCh:    make(chan struct{}),
 	}
 
 	observer.Register(leaderBarrierCallback{m: m})

--- a/internal/raft/testing_cluster.go
+++ b/internal/raft/testing_cluster.go
@@ -309,7 +309,11 @@ func createTestNode(t testing.TB, nodeID, port int, pki *testutil.PKI, applier A
 		nodeID:    nodeID,
 		dataDir:   dataDir,
 		observer:  observer,
+
+		leaderBarrier: make(chan struct{}),
 	}
+
+	observer.Register(leaderBarrierCallback{m: m})
 
 	m.attachClusterListener(ln)
 

--- a/internal/raft/testing_cluster.go
+++ b/internal/raft/testing_cluster.go
@@ -311,6 +311,7 @@ func createTestNode(t testing.TB, nodeID, port int, pki *testutil.PKI, applier A
 		observer:  observer,
 
 		leaderBarrier: make(chan struct{}),
+		shutdownCh:    make(chan struct{}),
 	}
 
 	observer.Register(leaderBarrierCallback{m: m})

--- a/internal/smf/policy_fetch_test.go
+++ b/internal/smf/policy_fetch_test.go
@@ -17,9 +17,13 @@ import (
 func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 	tempDir := t.TempDir()
 
-	database, err := db.NewDatabase(context.Background(), filepath.Join(tempDir, "db.sqlite3"), ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), filepath.Join(tempDir, "db.sqlite3"), ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("couldn't create test database: %s", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {
@@ -240,9 +244,13 @@ func TestGetSessionPolicy_FetchesNetworkRules(t *testing.T) {
 func TestGetSessionPolicy_NoNetworkRules(t *testing.T) {
 	tempDir := t.TempDir()
 
-	database, err := db.NewDatabase(context.Background(), filepath.Join(tempDir, "db.sqlite3"), ellaraft.ClusterConfig{})
+	database, err := db.NewDatabase(context.Background(), filepath.Join(tempDir, "db.sqlite3"), ellaraft.FastTestConfig())
 	if err != nil {
 		t.Fatalf("couldn't create test database: %s", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %v", err)
 	}
 
 	defer func() {

--- a/pkg/runtime/converge.go
+++ b/pkg/runtime/converge.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/logger"
+	"go.uber.org/zap"
+)
+
+const (
+	leaseReleaseInitialBackoff = 1 * time.Second
+	leaseReleaseMaxBackoff     = 30 * time.Second
+)
+
+func awaitInitialSettings(ctx context.Context, dbInstance *db.Database, pki *pkiState) {
+	logger.EllaLog.Info("Waiting for a raft leader")
+
+	if err := dbInstance.WaitForLeader(ctx); err != nil {
+		logger.EllaLog.Info("Stopped waiting for a raft leader", zap.Error(err))
+		return
+	}
+
+	logger.EllaLog.Info("Waiting for initial settings")
+
+	if err := dbInstance.WaitForInitialization(ctx, 0); err != nil {
+		logger.EllaLog.Info("Stopped waiting for initial settings", zap.Error(err))
+		return
+	}
+
+	logger.EllaLog.Info("Initial settings available")
+
+	releaseStaleLeases(ctx, dbInstance)
+
+	if pki != nil {
+		pki.ensureIssuer(dbInstance)
+	}
+}
+
+func releaseStaleLeases(ctx context.Context, dbInstance *db.Database) {
+	backoff := leaseReleaseInitialBackoff
+
+	for {
+		err := clearStaleDynamicLeases(ctx, dbInstance)
+		if err == nil {
+			return
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		logger.EllaLog.Warn("could not release this node's stale dynamic leases; retrying",
+			zap.Error(err),
+			zap.Duration("next_backoff", backoff))
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > leaseReleaseMaxBackoff {
+			backoff = leaseReleaseMaxBackoff
+		}
+	}
+}

--- a/pkg/runtime/pki.go
+++ b/pkg/runtime/pki.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/ellanetworks/core/internal/api/server"
 	"github.com/ellanetworks/core/internal/cluster/listener"
 	"github.com/ellanetworks/core/internal/cluster/pkiagent"
 	"github.com/ellanetworks/core/internal/cluster/pkiissuer"
@@ -31,7 +33,19 @@ type pkiState struct {
 	agent  *pkiagent.Agent
 	issuer *pkiissuer.Service
 
+	issuerMu sync.Mutex
+
 	pins atomic.Pointer[map[string]int]
+}
+
+func (p *pkiState) ensureIssuer(dbInstance *db.Database) {
+	p.issuerMu.Lock()
+	defer p.issuerMu.Unlock()
+
+	if p.issuer == nil {
+		p.issuer = pkiissuer.New(dbInstance)
+		server.SetPKIIssuer(p.issuer)
+	}
 }
 
 func newPKIState(nodeID int, clusterID, dataDir string) *pkiState {

--- a/pkg/runtime/pki.go
+++ b/pkg/runtime/pki.go
@@ -35,19 +35,10 @@ type pkiState struct {
 
 	issuerMu sync.Mutex
 
-	// Pins come from two independent sources. bootstrapPins is the
-	// disk-resident snapshot written by JoinFlow: it is all a fresh joiner
-	// has until cluster_node_certs replicates, and replication must never
-	// destroy it. pins mirrors that replicated table and is authoritative
-	// once it holds anything, so a revoked cert stops being honoured as
-	// soon as the removal replicates.
 	bootstrapPins atomic.Pointer[map[string]int]
 	pins          atomic.Pointer[map[string]int]
 }
 
-// activePins resolves the two sources. The replicated table wins whenever it
-// has landed; the bootstrap snapshot covers only the window before that, so
-// neither source can be emptied by a refresh racing cluster formation.
 func (p *pkiState) activePins() map[string]int {
 	if m := p.pins.Load(); m != nil && len(*m) > 0 {
 		return *m
@@ -129,8 +120,6 @@ func (p *pkiState) SeedPinsFromAgentDisk() {
 }
 
 // RefreshPins reads cluster_node_certs and replaces the replicated pin set.
-// An empty table means replication has not landed yet, not that every peer
-// became untrusted, so the bootstrap snapshot stays in effect until it does.
 func (p *pkiState) RefreshPins(ctx context.Context, dbInstance *db.Database) error {
 	rows, err := dbInstance.ListClusterNodeCerts(ctx)
 	if err != nil {

--- a/pkg/runtime/pki.go
+++ b/pkg/runtime/pki.go
@@ -35,7 +35,29 @@ type pkiState struct {
 
 	issuerMu sync.Mutex
 
-	pins atomic.Pointer[map[string]int]
+	// Pins come from two independent sources. bootstrapPins is the
+	// disk-resident snapshot written by JoinFlow: it is all a fresh joiner
+	// has until cluster_node_certs replicates, and replication must never
+	// destroy it. pins mirrors that replicated table and is authoritative
+	// once it holds anything, so a revoked cert stops being honoured as
+	// soon as the removal replicates.
+	bootstrapPins atomic.Pointer[map[string]int]
+	pins          atomic.Pointer[map[string]int]
+}
+
+// activePins resolves the two sources. The replicated table wins whenever it
+// has landed; the bootstrap snapshot covers only the window before that, so
+// neither source can be emptied by a refresh racing cluster formation.
+func (p *pkiState) activePins() map[string]int {
+	if m := p.pins.Load(); m != nil && len(*m) > 0 {
+		return *m
+	}
+
+	if m := p.bootstrapPins.Load(); m != nil {
+		return *m
+	}
+
+	return nil
 }
 
 func (p *pkiState) ensureIssuer(dbInstance *db.Database) {
@@ -62,22 +84,22 @@ func (p *pkiState) LeafFunc() listener.LeafFunc {
 // fingerprint against the cached pin map.
 func (p *pkiState) PinFunc() listener.PinFunc {
 	return func(fingerprint string) listener.PinResult {
-		m := p.pins.Load()
+		m := p.activePins()
 		if m == nil {
 			return listener.PinResult{}
 		}
 
-		nid, ok := (*m)[fingerprint]
+		nid, ok := m[fingerprint]
 
-		known := make([]int, 0, len(*m))
-		for _, n := range *m {
+		known := make([]int, 0, len(m))
+		for _, n := range m {
 			known = append(known, n)
 		}
 
 		return listener.PinResult{
 			Found:        ok,
 			NodeID:       nid,
-			CacheSize:    len(*m),
+			CacheSize:    len(m),
 			KnownNodeIDs: known,
 		}
 	}
@@ -86,8 +108,7 @@ func (p *pkiState) PinFunc() listener.PinFunc {
 // SeedPinsFromAgentDisk installs the disk-resident pin map (the
 // local node's own pin plus the peer-pins.json snapshot saved by
 // the most recent JoinFlow / register call) so the listener can
-// verify peers during the startup window before the first
-// RefreshPins reads the replicated table.
+// verify peers for as long as the replicated table has not landed.
 func (p *pkiState) SeedPinsFromAgentDisk() {
 	m, err := p.agent.LoadPeerPins()
 	if err != nil {
@@ -104,10 +125,12 @@ func (p *pkiState) SeedPinsFromAgentDisk() {
 		return
 	}
 
-	p.pins.Store(&m)
+	p.bootstrapPins.Store(&m)
 }
 
-// RefreshPins reads cluster_node_certs and replaces the cache.
+// RefreshPins reads cluster_node_certs and replaces the replicated pin set.
+// An empty table means replication has not landed yet, not that every peer
+// became untrusted, so the bootstrap snapshot stays in effect until it does.
 func (p *pkiState) RefreshPins(ctx context.Context, dbInstance *db.Database) error {
 	rows, err := dbInstance.ListClusterNodeCerts(ctx)
 	if err != nil {

--- a/pkg/runtime/pki_leader.go
+++ b/pkg/runtime/pki_leader.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ellanetworks/core/internal/api/server"
 	"github.com/ellanetworks/core/internal/cluster/listener"
-	"github.com/ellanetworks/core/internal/cluster/pkiissuer"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/pki"
@@ -198,9 +197,7 @@ func setupLeaderPKI(ctx context.Context, p *pkiState, dbInstance *db.Database, n
 
 	// Step 2: install the issuer so the leader can mint join tokens
 	// and accept register requests.
-	if p.issuer == nil {
-		p.issuer = pkiissuer.New(dbInstance)
-	}
+	p.ensureIssuer(dbInstance)
 
 	if err := p.issuer.Bootstrap(ctx); err != nil {
 		return fmt.Errorf("issuer bootstrap: %w", err)
@@ -223,8 +220,6 @@ func setupLeaderPKI(ctx context.Context, p *pkiState, dbInstance *db.Database, n
 	if err := p.RefreshPins(ctx, dbInstance); err != nil {
 		return fmt.Errorf("refresh pin cache: %w", err)
 	}
-
-	server.SetPKIIssuer(p.issuer)
 
 	return nil
 }

--- a/pkg/runtime/pki_pins_test.go
+++ b/pkg/runtime/pki_pins_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/db"
+)
+
+func newPinState(bootstrap map[string]int) *pkiState {
+	p := &pkiState{}
+	if bootstrap != nil {
+		p.bootstrapPins.Store(&bootstrap)
+	}
+
+	return p
+}
+
+// TestRefreshPinsDoesNotWipeBootstrapPins covers a fresh joiner: the pin
+// subscriber refreshes from cluster_node_certs the moment it starts, long
+// before that table has replicated. An empty table means "not replicated
+// yet", and treating it as the truth leaves the node unable to complete any
+// cluster TLS handshake — including the ones replication itself needs.
+func TestRefreshPinsDoesNotWipeBootstrapPins(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	database, err := db.NewDatabaseWithoutRaft(ctx, filepath.Join(t.TempDir(), "db.sqlite3"))
+	if err != nil {
+		t.Fatalf("NewDatabaseWithoutRaft: %v", err)
+	}
+
+	defer func() { _ = database.Close() }()
+
+	p := newPinState(map[string]int{"leader-fp": 1, "self-fp": 2})
+
+	if err := p.RefreshPins(ctx, database); err != nil {
+		t.Fatalf("RefreshPins: %v", err)
+	}
+
+	got := p.PinFunc()("leader-fp")
+	if !got.Found {
+		t.Fatal("bootstrap pin was destroyed by a refresh against a table that has not replicated yet")
+	}
+
+	if got.NodeID != 1 {
+		t.Errorf("NodeID = %d, want 1", got.NodeID)
+	}
+}
+
+// TestReplicatedPinsSupersedeBootstrap is the other half: once the replicated
+// table has landed it is authoritative, so a pin it no longer lists must stop
+// being honoured. Otherwise a revoked certificate would live on in the
+// bootstrap snapshot forever.
+func TestReplicatedPinsSupersedeBootstrap(t *testing.T) {
+	t.Parallel()
+
+	p := newPinState(map[string]int{"revoked-fp": 9})
+
+	replicated := map[string]int{"live-fp": 1}
+	p.pins.Store(&replicated)
+
+	if p.PinFunc()("revoked-fp").Found {
+		t.Error("bootstrap pin must not outlive the replicated set that omits it")
+	}
+
+	if !p.PinFunc()("live-fp").Found {
+		t.Error("replicated pin should resolve")
+	}
+}
+
+func TestActivePinsWithNoSourcesIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := newPinState(nil).PinFunc()("anything"); got.Found || got.CacheSize != 0 {
+		t.Errorf("want an empty result with no pin sources, got %+v", got)
+	}
+}

--- a/pkg/runtime/pki_pins_test.go
+++ b/pkg/runtime/pki_pins_test.go
@@ -20,11 +20,6 @@ func newPinState(bootstrap map[string]int) *pkiState {
 	return p
 }
 
-// TestRefreshPinsDoesNotWipeBootstrapPins covers a fresh joiner: the pin
-// subscriber refreshes from cluster_node_certs the moment it starts, long
-// before that table has replicated. An empty table means "not replicated
-// yet", and treating it as the truth leaves the node unable to complete any
-// cluster TLS handshake — including the ones replication itself needs.
 func TestRefreshPinsDoesNotWipeBootstrapPins(t *testing.T) {
 	t.Parallel()
 
@@ -53,10 +48,6 @@ func TestRefreshPinsDoesNotWipeBootstrapPins(t *testing.T) {
 	}
 }
 
-// TestReplicatedPinsSupersedeBootstrap is the other half: once the replicated
-// table has landed it is authoritative, so a pin it no longer lists must stop
-// being honoured. Otherwise a revoked certificate would live on in the
-// bootstrap snapshot forever.
 func TestReplicatedPinsSupersedeBootstrap(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -528,12 +528,8 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 	}())
 	mmeReconciler.Start()
 
-	// --- Phase B: upgrade the API server to serve all routes. The full
-	// handler needs the replicated JWT secret, which the leader seeds
-	// through Initialize, so hold here until that row is visible on this
-	// node. Phase A keeps answering status, metrics and the 503 fallback
-	// meanwhile, and cluster formation runs on the cluster port, so a node
-	// that never sees a leader stays up and unready instead of exiting. ---
+	// --- Phase B: upgrade the API server to serve all routes once the
+	// replicated initial settings are visible on this node. ---
 	logger.EllaLog.Info("Waiting for initial settings before serving the full API")
 
 	if err := dbInstance.WaitForFSMCatchUp(ctx); err != nil {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/bgp"
 	"github.com/ellanetworks/core/internal/cluster/listener"
-	"github.com/ellanetworks/core/internal/cluster/pkiissuer"
 	"github.com/ellanetworks/core/internal/config"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/dbwriter"
@@ -55,16 +54,26 @@ import (
 
 var getInterfaceIPs = config.GetInterfaceIPs
 
-var staleLeaseCleanup sync.Once
+var staleLeaseCleanup struct {
+	mu   sync.Mutex
+	done bool
+}
 
 func clearStaleDynamicLeases(ctx context.Context, dbInstance *db.Database) error {
-	var err error
+	staleLeaseCleanup.mu.Lock()
+	defer staleLeaseCleanup.mu.Unlock()
 
-	staleLeaseCleanup.Do(func() {
-		err = dbInstance.DeleteDynamicLeasesByNode(ctx, dbInstance.NodeID())
-	})
+	if staleLeaseCleanup.done {
+		return nil
+	}
 
-	return err
+	if err := dbInstance.DeleteDynamicLeasesByNode(ctx, dbInstance.NodeID()); err != nil {
+		return err
+	}
+
+	staleLeaseCleanup.done = true
+
+	return nil
 }
 
 type RuntimeConfig struct {
@@ -239,41 +248,13 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		}
 	}
 
-	if err := dbInstance.RunDiscovery(ctx); err != nil {
-		return fmt.Errorf("cluster discovery failed: %w", err)
-	}
-
-	// Leader-side init runs from runLeaderInit via the OnBecameLeader
-	// callback registered below. Followers block here until the
-	// leader's Initialize replicates. Standalone runs Initialize from
-	// NewDatabase.
-	if cfg.Cluster.Enabled {
-		if !dbInstance.IsLeader() {
-			logger.EllaLog.Info("Waiting for leader initialization to replicate")
-
-			if err := dbInstance.WaitForInitialization(ctx, 30*time.Second); err != nil {
-				return fmt.Errorf("follower couldn't sync initial settings: %w", err)
-			}
-
-			logger.EllaLog.Info("Leader initialization replicated successfully")
-
-			if err := clearStaleDynamicLeases(ctx, dbInstance); err != nil {
-				logger.EllaLog.Warn("could not release this node's stale dynamic leases; they will hold addresses until the next successful start",
-					zap.Error(err))
-			}
-
-			if pki != nil {
-				pki.issuer = pkiissuer.New(dbInstance)
-				server.SetPKIIssuer(pki.issuer)
-			}
-		}
-	} else {
-		if err := clearStaleDynamicLeases(ctx, dbInstance); err != nil {
-			return fmt.Errorf("couldn't release all dynamic leases: %w", err)
-		}
-	}
+	dbInstance.StartDiscovery(ctx)
 
 	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		awaitInitialSettings(ctx, dbInstance, pki)
+	})
 
 	if observer := dbInstance.LeaderObserver(); observer != nil {
 		observer.Register(server.NewLeadershipAuditCallback(dbInstance.NodeID()))

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -528,8 +528,22 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 	}())
 	mmeReconciler.Start()
 
-	// --- Phase B: upgrade the API server to serve all routes now that
-	// the cluster is formed, settings are seeded, and NFs are running. ---
+	// --- Phase B: upgrade the API server to serve all routes. The full
+	// handler needs the replicated JWT secret, which the leader seeds
+	// through Initialize, so hold here until that row is visible on this
+	// node. Phase A keeps answering status, metrics and the 503 fallback
+	// meanwhile, and cluster formation runs on the cluster port, so a node
+	// that never sees a leader stays up and unready instead of exiting. ---
+	logger.EllaLog.Info("Waiting for initial settings before serving the full API")
+
+	if err := dbInstance.WaitForFSMCatchUp(ctx); err != nil {
+		return fmt.Errorf("couldn't wait for the state machine to catch up: %w", err)
+	}
+
+	if err := dbInstance.WaitForInitialization(ctx, 0); err != nil {
+		return fmt.Errorf("couldn't wait for initial settings: %w", err)
+	}
+
 	if err := apiServer.Upgrade(ctx, api.UpgradeConfig{
 		DB:                  dbInstance,
 		Sessions:            smfInstance,


### PR DESCRIPTION
# Description

Ella Core no longer refuses to start when it can't immediately reach a Raft leader. It comes up, reports itself not-ready, and keeps trying in the background until the cluster settles.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
