### PR TITLE
fix: handle SERVICE REQUEST received in 5GMM-CONNECTED mode

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -117,8 +117,6 @@ type DBer interface {
 
 type NASHandler interface {
 	HandleNAS(ctx context.Context, ue *UeConn, nasPdu []byte)
-	IsServiceRequest(nasPdu []byte) bool
-	HandleServiceRequest(ctx context.Context, ue *UeConn, nasPdu []byte)
 }
 
 // LPPHandler is called by the AMF when an UL NAS Transport carries an LPP payload.

--- a/internal/amf/nas/gmm_handler.go
+++ b/internal/amf/nas/gmm_handler.go
@@ -36,6 +36,8 @@ func HandleGmmMessage(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConte
 	switch msg := msg.(type) {
 	case *fgs.RegistrationRequest:
 		return handleRegistrationRequest(ctx, amfInstance, ue, msg, plain, integrityVerified, arrivedPlain)
+	case *fgs.ServiceRequest:
+		return handleServiceRequest(ctx, amfInstance, ue, plain, integrityVerified)
 	case *fgs.ULNASTransport:
 		return handleULNASTransport(ctx, amfInstance, ue, msg)
 	case *fgs.ConfigurationUpdateComplete:

--- a/internal/amf/nas/gmm_handler_test.go
+++ b/internal/amf/nas/gmm_handler_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
@@ -50,4 +52,67 @@ func TestHandleGmmMessage_DispatchesToStatus5GMM(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 
 	HandleGmmMessage(context.Background(), amfInstance, ue, uint8(fgs.MsgGMMStatus), buildTestStatus5gmmPlain(t), true, false)
+}
+
+// A SERVICE REQUEST is not confined to the first NAS message of a connection: TS 24.501
+// §5.6.1.1 cases b), e), h), i), j) and o) are sent in 5GMM-CONNECTED mode, and §5.6.1.7 a)
+// names that trigger explicitly. Such a request reaches the AMF in an NGAP UPLINK NAS
+// TRANSPORT (TS 38.413 §8.6.3.1), so HandleGmmMessage must dispatch it to the service
+// request procedure rather than answer 5GMM STATUS #97 (§7.4), whose cause is untrue of a
+// message type the AMF implements.
+func TestHandleGmmMessage_DispatchesToServiceRequest(t *testing.T) {
+	amfInstance := amf.New(
+		&fakeDBInstance{
+			Operator: &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: `["000001"]`},
+		},
+		nil,
+		nil,
+	)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.ForceStateForTest(amf.Registered)
+	ue.SetSecuredForTest(true)
+
+	plain := encSR(t, buildTestServiceRequest())
+
+	got := HandleGmmMessage(context.Background(), amfInstance, ue, uint8(fgs.MsgServiceRequest), plain, true, false)
+
+	if got.Action == nasreply.ActionStatus && got.Cause == nasreply.CauseMessageTypeNotImplemented {
+		t.Fatal("SERVICE REQUEST answered with 5GMM STATUS #97; it must run the service request procedure")
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlinks = %d, want 1 (SERVICE ACCEPT)", len(ngapSender.SentDownlinkNASTransport))
+	}
+}
+
+// The dispatch above does not weaken the integrity gate: SERVICE REQUEST is absent from the
+// TS 24.501 §4.4.4.3 list of messages the AMF processes without integrity protection, so one
+// arriving as plain NAS is discarded before it reaches the service request procedure.
+func TestHandleNAS_PlainServiceRequest_Discarded(t *testing.T) {
+	amfInstance := amf.New(
+		&fakeDBInstance{
+			Operator: &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: `["000001"]`},
+		},
+		nil,
+		nil,
+	)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	ue.ForceStateForTest(amf.Registered)
+	ue.SetSecuredForTest(true)
+
+	HandleNAS(context.Background(), amfInstance, ue.Conn(), encSR(t, buildTestServiceRequest()))
+
+	if len(ngapSender.SentDownlinkNASTransport) != 0 {
+		t.Fatalf("plain SERVICE REQUEST drew %d downlinks, want 0 (TS 24.501 §4.4.4.3)", len(ngapSender.SentDownlinkNASTransport))
+	}
 }

--- a/internal/amf/nas/gmm_handler_test.go
+++ b/internal/amf/nas/gmm_handler_test.go
@@ -55,11 +55,11 @@ func TestHandleGmmMessage_DispatchesToStatus5GMM(t *testing.T) {
 }
 
 // A SERVICE REQUEST is not confined to the first NAS message of a connection: TS 24.501
-// §5.6.1.1 cases b), e), h), i), j) and o) are sent in 5GMM-CONNECTED mode, and §5.6.1.7 a)
-// names that trigger explicitly. Such a request reaches the AMF in an NGAP UPLINK NAS
-// TRANSPORT (TS 38.413 §8.6.3.1), so HandleGmmMessage must dispatch it to the service
-// request procedure rather than answer 5GMM STATUS #97 (§7.4), whose cause is untrue of a
-// message type the AMF implements.
+// §5.6.1.1 cases b), e), h), i), j), k) and o) are sent in 5GMM-CONNECTED mode, and
+// §5.6.1.2.1 sets the NAS message container apart as the form used "from 5GMM-IDLE mode".
+// Such a request reaches the AMF in an NGAP UPLINK NAS TRANSPORT (TS 38.413 §8.6.3.1), so
+// HandleGmmMessage must dispatch it to the service request procedure rather than answer
+// 5GMM STATUS #97 (§7.4), whose cause is untrue of a message type the AMF implements.
 func TestHandleGmmMessage_DispatchesToServiceRequest(t *testing.T) {
 	amfInstance := amf.New(
 		&fakeDBInstance{

--- a/internal/amf/nas/gmm_handler_test.go
+++ b/internal/amf/nas/gmm_handler_test.go
@@ -54,12 +54,6 @@ func TestHandleGmmMessage_DispatchesToStatus5GMM(t *testing.T) {
 	HandleGmmMessage(context.Background(), amfInstance, ue, uint8(fgs.MsgGMMStatus), buildTestStatus5gmmPlain(t), true, false)
 }
 
-// A SERVICE REQUEST is not confined to the first NAS message of a connection: TS 24.501
-// §5.6.1.1 cases b), e), h), i), j), k) and o) are sent in 5GMM-CONNECTED mode, and
-// §5.6.1.2.1 sets the NAS message container apart as the form used "from 5GMM-IDLE mode".
-// Such a request reaches the AMF in an NGAP UPLINK NAS TRANSPORT (TS 38.413 §8.6.3.1), so
-// HandleGmmMessage must dispatch it to the service request procedure rather than answer
-// 5GMM STATUS #97 (§7.4), whose cause is untrue of a message type the AMF implements.
 func TestHandleGmmMessage_DispatchesToServiceRequest(t *testing.T) {
 	amfInstance := amf.New(
 		&fakeDBInstance{
@@ -90,9 +84,6 @@ func TestHandleGmmMessage_DispatchesToServiceRequest(t *testing.T) {
 	}
 }
 
-// The dispatch above does not weaken the integrity gate: SERVICE REQUEST is absent from the
-// TS 24.501 §4.4.4.3 list of messages the AMF processes without integrity protection, so one
-// arriving as plain NAS is discarded before it reaches the service request procedure.
 func TestHandleNAS_PlainServiceRequest_Discarded(t *testing.T) {
 	amfInstance := amf.New(
 		&fakeDBInstance{

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/ellanetworks/core/nas/fgs"
 	"github.com/ellanetworks/core/ngap"
 	"go.uber.org/zap"
@@ -161,35 +162,39 @@ func stagePendingN1(
 }
 
 // TS 24501 5.6.1
-func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, plain []byte, integrityVerified bool) {
+func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, plain []byte, integrityVerified bool) nasreply.Disposition {
+	ueConn := ue.Conn()
+	if ueConn == nil {
+		logger.From(ctx, logger.AmfLog).Warn("ue is not connected to RAN")
+		return nasreply.Silent(nasreply.ReasonNoContext)
+	}
+
 	msg, err := fgs.ParseServiceRequest(plain)
 	if !decoded(ctx, "ServiceRequest", err) {
+		// TS 24.501 §5.6.1.8 b): a SERVICE REQUEST carrying a protocol error is answered
+		// with a SERVICE REJECT #96, not a 5GMM STATUS.
 		logger.From(ctx, logger.AmfLog).Warn("failed to decode Service Request", zap.Error(err))
-		return
+		rejectService(ctx, ueConn, fgs.GMMCauseInvalidMandatoryInformation)
+
+		return nasreply.Handled()
 	}
 
 	state := ue.State()
 	if state != amf.Deregistered && state != amf.Registered {
 		logger.From(ctx, logger.AmfLog).Warn("state mismatch: receive Service Request message", zap.String("state", string(state)))
-		return
-	}
-
-	ueConn := ue.Conn()
-	if ueConn == nil {
-		logger.From(ctx, logger.AmfLog).Warn("ue is not connected to RAN")
-		return
+		return nasreply.Silent(nasreply.ReasonOutOfState)
 	}
 
 	// TS 24.501: reject service request from deregistered UE
 	if state == amf.Deregistered {
 		rejectService(ctx, ueConn, fgs.GMMCauseUEIdentityCannotBeDerived)
-		return
+		return nasreply.Handled()
 	}
 
 	conn := ue.Conn()
 	if conn == nil {
 		logger.From(ctx, logger.AmfLog).Warn("no active NAS connection")
-		return
+		return nasreply.Silent(nasreply.ReasonNoContext)
 	}
 
 	ue.StopPaging()
@@ -208,7 +213,9 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 			inner, err := fgs.ParseServiceRequest(contents)
 			if !decoded(ctx, "ServiceRequest", err) {
 				logger.From(ctx, logger.AmfLog).Warn("failed to decode service request NAS message container", zap.Error(err))
-				return
+				rejectService(ctx, ueConn, fgs.GMMCauseInvalidMandatoryInformation)
+
+				return nasreply.Handled()
 			}
 
 			msg = inner
@@ -226,7 +233,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 
 		rejectService(ctx, ueConn, fgs.GMMCauseUEIdentityCannotBeDerived)
 
-		return
+		return nasreply.Handled()
 	}
 
 	serviceType := msg.ServiceType
@@ -252,13 +259,13 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		logger.From(ctx, logger.AmfLog).Warn("emergency service is not supported; rejecting service request")
 		rejectService(ctx, ueConn, fgs.GMMCauseServicesNotAllowed)
 
-		return
+		return nasreply.Handled()
 	}
 
 	operatorInfo, err := amfInstance.OperatorInfo(ctx)
 	if err != nil {
 		logger.From(ctx, logger.AmfLog).Warn("error getting operator info", zap.Error(err))
-		return
+		return nasreply.Silent(nasreply.ReasonUnspecified)
 	}
 
 	if serviceType == fgs.ServiceTypeSignalling {
@@ -266,7 +273,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 			logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
 		}
 
-		return
+		return nasreply.Handled()
 	}
 
 	if requestData := ue.N1N2Message(); requestData != nil {
@@ -356,7 +363,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 			case requestData.Standalone():
 				if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, nil); err != nil {
 					logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-					return
+					return nasreply.Handled()
 				}
 
 			default:
@@ -365,7 +372,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 					ue.ClearN1N2Message()
 					logger.From(ctx, logger.AmfLog).Warn("service Request triggered by Network for pduSessionID that does not exist")
 
-					return
+					return nasreply.Silent(nasreply.ReasonNoContext)
 				}
 
 				ue.SetSmContextActive(requestData.PduSessionID)
@@ -381,7 +388,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 
 				if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, pending); err != nil {
 					logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-					return
+					return nasreply.Handled()
 				}
 
 				ue.ClearN1N2Message()
@@ -389,14 +396,14 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		} else {
 			if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, nil); err != nil {
 				logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-				return
+				return nasreply.Handled()
 			}
 		}
 
 		err := amfInstance.ReallocateGUTI(ctx, ue)
 		if err != nil {
 			logger.From(ctx, logger.AmfLog).Warn("error reallocating GUTI to UE", zap.Error(err))
-			return
+			return nasreply.Handled()
 		}
 
 		amf.SendConfigurationUpdateCommand(ctx, amfInstance, ue, true)
@@ -404,7 +411,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 	case fgs.ServiceTypeData, fgs.ServiceTypeHighPriorityAccess:
 		if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, nil); err != nil {
 			logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-			return
+			return nasreply.Handled()
 		}
 	default:
 		// TS 24.501 §5.6.1.5: a service request with an unsupported or unknown service type
@@ -412,12 +419,14 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		logger.From(ctx, logger.AmfLog).Warn("service type is not supported; rejecting", zap.Stringer("service_type", serviceType))
 		rejectService(ctx, ueConn, fgs.GMMCauseProtocolErrorUnspecified)
 
-		return
+		return nasreply.Handled()
 	}
 
 	if len(errPduSessionID) != 0 {
 		logger.From(ctx, logger.AmfLog).Info("", zap.Any("errPduSessionID", errPduSessionID), zap.Any("errCause", errCause))
 	}
+
+	return nasreply.Handled()
 }
 
 // rejectService answers a service request the AMF cannot accept with a SERVICE REJECT

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -30,6 +30,7 @@ func sendServiceAccept(
 	ctx context.Context,
 	ue *amf.UeContext,
 	ueConn *amf.UeConn,
+	initialContextSetup bool,
 	ctxList ngap.PDUSessionResourceSetupListCxtReq,
 	suList ngap.PDUSessionResourceSetupListSUReq,
 	pDUSessionStatus *[16]bool,
@@ -39,7 +40,10 @@ func sendServiceAccept(
 	supportedGUAMI *models.Guami,
 	pending *pendingN1,
 ) error {
-	if ueConn.UeContextRequest {
+	if initialContextSetup {
+		// TS 33.501 §6.8.1.2.2: KgNB is derived from the uplink NAS COUNT of the message that
+		// took the UE from CM-IDLE to CM-CONNECTED, and handed to the NG-RAN node in the
+		// INITIAL CONTEXT SETUP that carries the accept.
 		if err := ue.UpdateSecurityContext(); err != nil {
 			return fmt.Errorf("error updating security context: %v", err)
 		}
@@ -48,7 +52,7 @@ func sendServiceAccept(
 	sht := uint8(fgs.SHTIntegrityProtectedCiphered)
 
 	if pending != nil {
-		if err := stagePendingN1(ctx, ue, ueConn, pending, sht, &ctxList, &suList); err != nil {
+		if err := stagePendingN1(ctx, ue, initialContextSetup, pending, sht, &ctxList, &suList); err != nil {
 			amf.ReportProtectFailure(ctx, ue, "buffered N1 SM message", err)
 
 			return err
@@ -64,9 +68,7 @@ func sendServiceAccept(
 
 	if err := ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
 		switch {
-		case ueConn.UeContextRequest:
-			ueConn.MarkICSPending()
-
+		case initialContextSetup:
 			if err := ueConn.SendInitialContextSetup(
 				ctx,
 				ue.Ambr.Uplink,
@@ -117,14 +119,14 @@ func sendServiceAccept(
 func stagePendingN1(
 	ctx context.Context,
 	ue *amf.UeContext,
-	ueConn *amf.UeConn,
+	initialContextSetup bool,
 	pending *pendingN1,
 	sht uint8,
 	ctxList *ngap.PDUSessionResourceSetupListCxtReq,
 	suList *ngap.PDUSessionResourceSetupListSUReq,
 ) error {
 	stage := func(nasPdu []byte) error {
-		if ueConn.UeContextRequest {
+		if initialContextSetup {
 			item, err := amf.PDUSessionSetupItem(pending.pduSessionID, pending.snssai, nasPdu, pending.n2Info)
 			if err != nil {
 				logger.From(ctx, logger.AmfLog).Error("could not build PDU session setup item", zap.Error(err), zap.Uint8("pdu_session_id", pending.pduSessionID))
@@ -251,13 +253,23 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		ctxList ngap.PDUSessionResourceSetupListCxtReq
 	)
 
-	if serviceType == fgs.ServiceTypeEmergencyServices ||
-		serviceType == fgs.ServiceTypeEmergencyServicesFallback {
+	switch serviceType {
+	case fgs.ServiceTypeEmergencyServices, fgs.ServiceTypeEmergencyServicesFallback:
 		// Ella does not provide emergency services; the request cannot be accepted, so
 		// answer SERVICE REJECT #7 "5GS services not allowed" rather than silently dropping
 		// it (TS 24.501 §5.6.1.5).
 		logger.From(ctx, logger.AmfLog).Warn("emergency service is not supported; rejecting service request")
 		rejectService(ctx, ueConn, fgs.GMMCauseServicesNotAllowed)
+
+		return nasreply.Handled()
+	case fgs.ServiceTypeSignalling, fgs.ServiceTypeElevatedSignalling,
+		fgs.ServiceTypeData, fgs.ServiceTypeHighPriorityAccess,
+		fgs.ServiceTypeMobileTerminatedServices:
+	default:
+		// TS 24.501 §5.6.1.5: a service request with an unsupported or unknown service type
+		// cannot be accepted; answer SERVICE REJECT rather than silently dropping it.
+		logger.From(ctx, logger.AmfLog).Warn("service type is not supported; rejecting", zap.Stringer("service_type", serviceType))
+		rejectService(ctx, ueConn, fgs.GMMCauseProtocolErrorUnspecified)
 
 		return nasreply.Handled()
 	}
@@ -268,13 +280,12 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		return nasreply.Silent(nasreply.ReasonUnspecified)
 	}
 
-	if serviceType == fgs.ServiceTypeSignalling {
-		if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, nil, nil, nil, nil, operatorInfo.Guami, nil); err != nil {
-			logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-		}
-
-		return nasreply.Handled()
-	}
+	// The UE Context Request IE has the AMF trigger an Initial Context Setup (TS 38.413
+	// §8.6.1.2), and only that procedure carries the KgNB derived from this message's
+	// uplink NAS COUNT (TS 33.501 §6.8.1.2.2). A SERVICE REQUEST sent in 5GMM-CONNECTED
+	// mode is not the message that established the AS context, so the claim it loses
+	// routes its PDU sessions through a standalone PDU Session Resource Setup instead.
+	initialContextSetup := ueConn.UeContextRequest && ueConn.ClaimICS()
 
 	if requestData := ue.N1N2Message(); requestData != nil {
 		if requestData.N2Class == models.N2ClassSM && requestData.BinaryDataN2Information != nil {
@@ -310,7 +321,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 
 					ue.SetSmContextActive(pduSessionID)
 
-					if ueConn.UeContextRequest {
+					if initialContextSetup {
 						item, err := amf.PDUSessionSetupItem(pduSessionID, smContext.Snssai, nil, binaryDataN2SmInformation)
 						if err != nil {
 							logger.From(ctx, logger.AmfLog).Error("could not build PDU session setup item", zap.Error(err), zap.Uint8("pdu_session_id", pduSessionID))
@@ -351,74 +362,69 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		}
 	}
 
-	switch serviceType {
-	case fgs.ServiceTypeMobileTerminatedServices:
-		// TS 24.501 requires assigning a new GUTI after a successful Service Request
-		// triggered by a paging request.
-		if requestData := ue.N1N2Message(); requestData != nil {
-			n1Msg := requestData.BinaryDataN1Message
-			n2Info := requestData.BinaryDataN2Information
+	accept := func(pending *pendingN1) error {
+		err := sendServiceAccept(ctx, ue, ueConn, initialContextSetup, ctxList, suList, acceptPduSessionPsi,
+			reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, pending)
+		if err != nil {
+			logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
 
-			switch {
-			case requestData.Standalone():
-				if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, nil); err != nil {
-					logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-					return nasreply.Handled()
-				}
-
-			default:
-				_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
-				if !exist {
-					ue.ClearN1N2Message()
-					logger.From(ctx, logger.AmfLog).Warn("service Request triggered by Network for pduSessionID that does not exist")
-
-					return nasreply.Silent(nasreply.ReasonNoContext)
-				}
-
-				ue.SetSmContextActive(requestData.PduSessionID)
-
-				pending := &pendingN1{
-					pduSessionID: requestData.PduSessionID,
-					snssai:       requestData.SNssai,
-					n1Msg:        n1Msg,
-					n2Info:       n2Info,
-				}
-
-				logger.From(ctx, logger.AmfLog).Debug("sending service accept")
-
-				if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, pending); err != nil {
-					logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-					return nasreply.Handled()
-				}
-
-				ue.ClearN1N2Message()
-			}
-		} else {
-			if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, nil); err != nil {
-				logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-				return nasreply.Handled()
+			if initialContextSetup {
+				ueConn.ResetICS()
 			}
 		}
 
-		err := amfInstance.ReallocateGUTI(ctx, ue)
-		if err != nil {
+		return err
+	}
+
+	if serviceType == fgs.ServiceTypeMobileTerminatedServices {
+		// TS 24.501 requires assigning a new GUTI after a successful Service Request
+		// triggered by a paging request.
+		requestData := ue.N1N2Message()
+
+		switch {
+		case requestData == nil || requestData.Standalone():
+			if err := accept(nil); err != nil {
+				return nasreply.Handled()
+			}
+
+		default:
+			_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
+			if !exist {
+				ue.ClearN1N2Message()
+				logger.From(ctx, logger.AmfLog).Warn("service Request triggered by Network for pduSessionID that does not exist")
+
+				if initialContextSetup {
+					ueConn.ResetICS()
+				}
+
+				return nasreply.Silent(nasreply.ReasonNoContext)
+			}
+
+			ue.SetSmContextActive(requestData.PduSessionID)
+
+			pending := &pendingN1{
+				pduSessionID: requestData.PduSessionID,
+				snssai:       requestData.SNssai,
+				n1Msg:        requestData.BinaryDataN1Message,
+				n2Info:       requestData.BinaryDataN2Information,
+			}
+
+			logger.From(ctx, logger.AmfLog).Debug("sending service accept")
+
+			if err := accept(pending); err != nil {
+				return nasreply.Handled()
+			}
+
+			ue.ClearN1N2Message()
+		}
+
+		if err := amfInstance.ReallocateGUTI(ctx, ue); err != nil {
 			logger.From(ctx, logger.AmfLog).Warn("error reallocating GUTI to UE", zap.Error(err))
 			return nasreply.Handled()
 		}
 
 		amf.SendConfigurationUpdateCommand(ctx, amfInstance, ue, true)
-
-	case fgs.ServiceTypeData, fgs.ServiceTypeHighPriorityAccess:
-		if err := sendServiceAccept(ctx, ue, ueConn, ctxList, suList, acceptPduSessionPsi, reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, nil); err != nil {
-			logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
-			return nasreply.Handled()
-		}
-	default:
-		// TS 24.501 §5.6.1.5: a service request with an unsupported or unknown service type
-		// cannot be accepted; answer SERVICE REJECT rather than silently dropping it.
-		logger.From(ctx, logger.AmfLog).Warn("service type is not supported; rejecting", zap.Stringer("service_type", serviceType))
-		rejectService(ctx, ueConn, fgs.GMMCauseProtocolErrorUnspecified)
-
+	} else if err := accept(nil); err != nil {
 		return nasreply.Handled()
 	}
 
@@ -430,10 +436,46 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 }
 
 // rejectService answers a service request the AMF cannot accept with a SERVICE REJECT
-// carrying cause, then releases the RAN connection (TS 24.501 §5.6.1.5).
+// carrying cause (TS 24.501 §5.6.1.5), and releases the N1 NAS signalling connection only
+// when the UE expects the network to (§5.3.1.3).
 func rejectService(ctx context.Context, ueConn *amf.UeConn, cause fgs.GMMCause) {
 	amf.SendServiceReject(ctx, ueConn, cause)
 
+	if !releasesN1Connection(ueConn, cause) {
+		return
+	}
+
 	ueConn.ReleaseAction = amf.UeContextN2NormalRelease
 	ueConn.SendUEContextReleaseCommand(ctx, ngap.Cause{Group: ngap.CauseGroupNAS, Value: ngap.CauseNASNormalRelease})
+}
+
+// releasesN1Connection reports whether a SERVICE REJECT carrying cause is one on whose
+// receipt the UE starts T3540 to let the network release the N1 NAS signalling connection
+// (TS 24.501 §5.3.1.3 a) and d)). Any other cause is a protocol error, whose reject leaves
+// the AMF in its current 5GMM mode (§5.6.1.8 b)): the UE starts T3540 for it only when the
+// service request procedure was started from 5GMM-IDLE mode (§5.3.1.3 a1), §5.6.1.7 i)), so
+// a UE that sent the request in 5GMM-CONNECTED mode keeps its connection and user plane.
+func releasesN1Connection(ueConn *amf.UeConn, cause fgs.GMMCause) bool {
+	switch cause {
+	case fgs.GMMCauseServicesNotAllowed,
+		fgs.GMMCausePLMNNotAllowed,
+		fgs.GMMCauseTrackingAreaNotAllowed,
+		fgs.GMMCauseRoamingNotAllowedInThisTA,
+		fgs.GMMCauseNoSuitableCellsInTrackingArea,
+		fgs.GMMCauseN1ModeNotAllowed,
+		fgs.GMMCauseRedirectionToEPCRequired,
+		fgs.GMMCauseNoNetworkSlicesAvailable,
+		fgs.GMMCauseNon3GPPAccessNotAllowed,
+		fgs.GMMCauseServingNetworkNotAuthorized,
+		fgs.GMMCauseTemporarilyNotAuthorizedForThisSNPN,
+		fgs.GMMCausePermanentlyNotAuthorizedForThisSNPN,
+		fgs.GMMCauseNotAuthorizedForThisCAG,
+		fgs.GMMCausePLMNNotAllowedToOperateAtPresentUELocation,
+		fgs.GMMCauseUEIdentityCannotBeDerived,
+		fgs.GMMCauseImplicitlyDeregistered,
+		fgs.GMMCauseRestrictedServiceArea:
+		return true
+	}
+
+	return ueConn.SentFrom5GMMIdle()
 }

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -41,9 +41,6 @@ func sendServiceAccept(
 	pending *pendingN1,
 ) error {
 	if initialContextSetup {
-		// TS 33.501 §6.8.1.2.2: KgNB is derived from the uplink NAS COUNT of the message that
-		// took the UE from CM-IDLE to CM-CONNECTED, and handed to the NG-RAN node in the
-		// INITIAL CONTEXT SETUP that carries the accept.
 		if err := ue.UpdateSecurityContext(); err != nil {
 			return fmt.Errorf("error updating security context: %v", err)
 		}
@@ -173,8 +170,6 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 
 	msg, err := fgs.ParseServiceRequest(plain)
 	if !decoded(ctx, "ServiceRequest", err) {
-		// TS 24.501 §5.6.1.8 b): a SERVICE REQUEST carrying a protocol error is answered
-		// with a SERVICE REJECT #96, not a 5GMM STATUS.
 		logger.From(ctx, logger.AmfLog).Warn("failed to decode Service Request", zap.Error(err))
 		rejectService(ctx, ueConn, fgs.GMMCauseInvalidMandatoryInformation)
 
@@ -280,11 +275,6 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		return nasreply.Silent(nasreply.ReasonUnspecified)
 	}
 
-	// The UE Context Request IE has the AMF trigger an Initial Context Setup (TS 38.413
-	// §8.6.1.2), and only that procedure carries the KgNB derived from this message's
-	// uplink NAS COUNT (TS 33.501 §6.8.1.2.2). A SERVICE REQUEST sent in 5GMM-CONNECTED
-	// mode is not the message that established the AS context, so the claim it loses
-	// routes its PDU sessions through a standalone PDU Session Resource Setup instead.
 	initialContextSetup := ueConn.UeContextRequest && ueConn.ClaimICS()
 
 	if requestData := ue.N1N2Message(); requestData != nil {
@@ -436,8 +426,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 }
 
 // rejectService answers a service request the AMF cannot accept with a SERVICE REJECT
-// carrying cause (TS 24.501 §5.6.1.5), and releases the N1 NAS signalling connection only
-// when the UE expects the network to (§5.3.1.3).
+// carrying cause, releasing the RAN connection only when TS 24.501 §5.3.1.3 expects it.
 func rejectService(ctx context.Context, ueConn *amf.UeConn, cause fgs.GMMCause) {
 	amf.SendServiceReject(ctx, ueConn, cause)
 
@@ -449,12 +438,6 @@ func rejectService(ctx context.Context, ueConn *amf.UeConn, cause fgs.GMMCause) 
 	ueConn.SendUEContextReleaseCommand(ctx, ngap.Cause{Group: ngap.CauseGroupNAS, Value: ngap.CauseNASNormalRelease})
 }
 
-// releasesN1Connection reports whether a SERVICE REJECT carrying cause is one on whose
-// receipt the UE starts T3540 to let the network release the N1 NAS signalling connection
-// (TS 24.501 §5.3.1.3 a) and d)). Any other cause is a protocol error, whose reject leaves
-// the AMF in its current 5GMM mode (§5.6.1.8 b)): the UE starts T3540 for it only when the
-// service request procedure was started from 5GMM-IDLE mode (§5.3.1.3 a1), §5.6.1.7 i)), so
-// a UE that sent the request in 5GMM-CONNECTED mode keeps its connection and user plane.
 func releasesN1Connection(ueConn *amf.UeConn, cause fgs.GMMCause) bool {
 	switch cause {
 	case fgs.GMMCauseServicesNotAllowed,

--- a/internal/amf/nas/handle_service_request_connected_test.go
+++ b/internal/amf/nas/handle_service_request_connected_test.go
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/ausf"
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+type connectedModeFixture struct {
+	amf        *amf.AMF
+	ue         *amf.UeContext
+	ngapSender *fakeNGAPSender
+	key        [16]uint8
+	algo       nas.CipheringAlgorithm
+}
+
+func (f connectedModeFixture) conn() *amf.UeConn { return f.ue.Conn() }
+
+// serviceRequest encodes a ciphered SERVICE REQUEST of svcType for this fixture's UE.
+func (f connectedModeFixture) serviceRequest(t *testing.T, svcType fgs.ServiceType) []byte {
+	t.Helper()
+
+	m, err := buildTestServiceRequestCiphered(f.algo, f.key, f.ue.ULCount(), svcType)
+	if err != nil {
+		t.Fatalf("could not build service request: %v", err)
+	}
+
+	return encSR(t, m)
+}
+
+// connectedModeUe builds a registered, secured UE whose connection carries the UE Context
+// Request the gNB set on the INITIAL UE MESSAGE, with one PDU session (PSI 12 — the one
+// buildTestServiceRequestCiphered names in its Uplink data status IE).
+func connectedModeUe(t *testing.T, smf amf.SmfSbi) connectedModeFixture {
+	t.Helper()
+
+	amfInstance := amf.New(
+		&fakeDBInstance{
+			Operator: &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: `["000001"]`},
+		},
+		&fakeAusf{
+			AvKgAka: &ausf.AuthResult{Rand: hex.EncodeToString(make([]byte, 16)), Autn: hex.EncodeToString(make([]byte, 16))},
+			Supi:    mustSUPIFromPrefixed("imsi-001019756139935"),
+			Kseaf:   []byte("testkey"),
+		},
+		smf,
+	)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	snssai := models.Snssai{Sst: 1, Sd: "102030"}
+
+	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
+	setTestUESecurityCapability(ue)
+
+	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
+	ue.ForceStateForTest(amf.Registered)
+	ue.SetGutiForTest(mustTestGuti("001", "01", "cafe42", 0x00000001))
+	ue.Tai = ue.Conn().Tai
+	ue.SetSecuredForTest(true)
+
+	ng := ue.NgKsiForTest()
+	ng.Ksi = 1
+	ue.SetNgKsiForTest(ng)
+
+	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
+	algo := nas.CipheringAES
+
+	ue.SetKnasEncForTest(key)
+	ue.SetKnasIntForTest(key)
+	ue.SetCipheringAlgForTest(algo)
+	ue.SetIntegrityAlgForTest(nas.IntegrityNull)
+	ue.Ambr = &models.Ambr{Uplink: models.MustParseBitRate("100 Mbps"), Downlink: models.MustParseBitRate("100 Mbps")}
+
+	if err := ue.CreateSmContext(12, "testrefuplink", &snssai, "internet"); err != nil {
+		t.Fatalf("could not create sm context: %v", err)
+	}
+
+	ue.Conn().UeContextRequest = true
+	// The SERVICE REQUEST was integrity checked before dispatch, which is what establishes
+	// secure exchange on the connection (TS 24.501 §4.4.4.3).
+	ue.Conn().MarkSecureExchangeEstablished()
+
+	return connectedModeFixture{amf: amfInstance, ue: ue, ngapSender: ngapSender, key: key, algo: algo}
+}
+
+// The Initial Context Setup carries the KgNB derived from the uplink NAS COUNT of the NAS
+// message that took the UE from CM-IDLE to CM-CONNECTED (TS 33.501 §6.8.1.2.2), and the AMF
+// triggers it because the UE Context Request IE arrived on the INITIAL UE MESSAGE
+// (TS 38.413 §8.6.1.2). A SERVICE REQUEST the UE sends later in 5GMM-CONNECTED mode
+// (TS 24.501 §5.6.1.1 cases e) and j)) is not that message: it must neither repeat the
+// procedure nor re-derive the key, and its user-plane resources go up in a standalone PDU
+// Session Resource Setup instead.
+func TestHandleServiceRequest_ContextAlreadySetUp_NoSecondInitialContextSetup(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		connState func(*amf.UeConn)
+		wantICS   int
+		wantSUReq int
+	}{
+		{
+			name:      "5GMM-IDLE: the request that establishes the AS context",
+			connState: func(*amf.UeConn) {},
+			wantICS:   1,
+			wantSUReq: 0,
+		},
+		{
+			name:      "5GMM-CONNECTED: the AS context is already up",
+			connState: func(c *amf.UeConn) { c.MarkICSCompleted() },
+			wantICS:   0,
+			wantSUReq: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := connectedModeUe(t, &fakeSmf{})
+
+			tc.connState(f.conn())
+
+			before := append([]byte(nil), f.ue.Kgnb()...)
+
+			handleServiceRequest(t.Context(), f.amf, f.ue, f.serviceRequest(t, fgs.ServiceTypeData), true)
+
+			if got := len(f.ngapSender.SentInitialContextSetupRequest); got != tc.wantICS {
+				t.Fatalf("initial context setup requests = %d, want %d", got, tc.wantICS)
+			}
+
+			if got := len(f.ngapSender.SentPDUSessionResourceSetupRequest); got != tc.wantSUReq {
+				t.Fatalf("pdu session resource setup requests = %d, want %d", got, tc.wantSUReq)
+			}
+
+			if rederived := !bytes.Equal(before, f.ue.Kgnb()); rederived != (tc.wantICS == 1) {
+				t.Fatalf("KgNB re-derived = %v, want %v (TS 33.501 §6.8.1.2.2)", rederived, tc.wantICS == 1)
+			}
+		})
+	}
+}
+
+// TS 24.501 §5.6.1.8 b): a SERVICE REJECT for a protocol error leaves the AMF in its current
+// 5GMM mode. The UE starts T3540 to let the network release the N1 NAS signalling connection
+// only when it sent the request from 5GMM-IDLE mode (§5.3.1.3 a1), §5.6.1.7 i)) — a UE that
+// sent it in 5GMM-CONNECTED mode keeps its connection and its user plane.
+func TestHandleServiceRequest_ProtocolErrorReject_ReleasesOnlyFrom5GMMIdle(t *testing.T) {
+	const unassignedServiceType = fgs.ServiceType(0x07)
+
+	for _, tc := range []struct {
+		name        string
+		inboundNAS  int
+		wantRelease int
+	}{
+		{name: "started from 5GMM-IDLE", inboundNAS: 1, wantRelease: 1},
+		{name: "started from 5GMM-CONNECTED", inboundNAS: 2, wantRelease: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := connectedModeUe(t, &fakeSmf{})
+
+			for range tc.inboundNAS {
+				f.conn().NoteInboundNAS()
+			}
+
+			handleServiceRequest(t.Context(), f.amf, f.ue, f.serviceRequest(t, unassignedServiceType), true)
+
+			assertServiceReject(t, f, fgs.GMMCauseProtocolErrorUnspecified)
+
+			if got := len(f.ngapSender.SentUEContextReleaseCommand); got != tc.wantRelease {
+				t.Fatalf("UE context release commands = %d, want %d", got, tc.wantRelease)
+			}
+		})
+	}
+}
+
+// TS 24.501 §5.3.1.3 d): a SERVICE REJECT with 5GMM cause #9 has the UE start T3540 whatever
+// mode it sent the request from, so the network releases the connection either way.
+func TestHandleServiceRequest_Cause9Reject_ReleasesFrom5GMMConnected(t *testing.T) {
+	f := connectedModeUe(t, &fakeSmf{})
+
+	f.ue.ForceStateForTest(amf.Deregistered)
+	f.conn().NoteInboundNAS()
+	f.conn().NoteInboundNAS()
+
+	handleServiceRequest(t.Context(), f.amf, f.ue, f.serviceRequest(t, fgs.ServiceTypeData), true)
+
+	assertServiceReject(t, f, fgs.GMMCauseUEIdentityCannotBeDerived)
+
+	if len(f.ngapSender.SentUEContextReleaseCommand) != 1 {
+		t.Fatalf("UE context release commands = %d, want 1", len(f.ngapSender.SentUEContextReleaseCommand))
+	}
+}
+
+// TS 24.501 §5.6.1.4.1 conditions the AMF's user-plane re-establishment on the Uplink data
+// status IE being present, not on the service type, and §5.6.1.2.1 case c) has a UE with an
+// always-on PDU session include that IE alongside service type "signalling". Such a request
+// must re-establish the named PDU session and report the result in the SERVICE ACCEPT.
+func TestHandleServiceRequest_SignallingWithUplinkDataStatus_ReactivatesPDUSession(t *testing.T) {
+	f := connectedModeUe(t, &fakeSmf{})
+
+	f.conn().MarkICSCompleted()
+
+	handleServiceRequest(t.Context(), f.amf, f.ue, f.serviceRequest(t, fgs.ServiceTypeSignalling), true)
+
+	if len(f.ngapSender.SentPDUSessionResourceSetupRequest) != 1 {
+		t.Fatalf("pdu session resource setup requests = %d, want 1", len(f.ngapSender.SentPDUSessionResourceSetupRequest))
+	}
+
+	setup := f.ngapSender.SentPDUSessionResourceSetupRequest[0]
+	plain := decipherGmm(t, f.ue, *setup.NASPDU, uint8(fgs.MsgServiceAccept))
+
+	accept, err := fgs.ParseServiceAccept(plain)
+	if err != nil {
+		t.Fatalf("could not parse service accept: %v", err)
+	}
+
+	if accept.PDUSessionReactivationResult == nil {
+		t.Fatal("service accept carries no PDU session reactivation result IE (TS 24.501 §5.6.1.4.1)")
+	}
+
+	if psiSet(accept.PDUSessionReactivationResult, 12) {
+		t.Fatal("PDU session 12 reported as failed; it was re-established")
+	}
+
+	if accept.PDUSessionStatus == nil {
+		t.Fatal("service accept carries no PDU session status IE (TS 24.501 §5.6.1.4.1)")
+	}
+}
+
+// The N1 NAS signalling connection is established by the NGAP INITIAL UE MESSAGE that
+// carries a connection's first uplink NAS message (TS 38.413 §8.6.1.1, TS 24.501 §5.3.1.1),
+// so HandleNAS — the one entry point every uplink NAS PDU passes through — is where the AMF
+// learns which 5GMM mode the UE sent each message from.
+func TestHandleNAS_CountsTheConnectionsFirstMessageAsSentFrom5GMMIdle(t *testing.T) {
+	f := connectedModeUe(t, &fakeSmf{})
+
+	HandleNAS(t.Context(), f.amf, f.conn(), encSR(t, buildTestServiceRequest()))
+
+	if !f.conn().SentFrom5GMMIdle() {
+		t.Fatal("the connection's first NAS message must count as sent from 5GMM-IDLE mode")
+	}
+
+	HandleNAS(t.Context(), f.amf, f.conn(), encSR(t, buildTestServiceRequest()))
+
+	if f.conn().SentFrom5GMMIdle() {
+		t.Fatal("a later NAS message on the same connection was sent in 5GMM-CONNECTED mode")
+	}
+}
+
+func assertServiceReject(t *testing.T, f connectedModeFixture, want fgs.GMMCause) {
+	t.Helper()
+
+	if len(f.ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlink NAS transports = %d, want 1 (SERVICE REJECT)", len(f.ngapSender.SentDownlinkNASTransport))
+	}
+
+	plain := decipherGmm(t, f.ue, f.ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgServiceReject))
+
+	reject, err := fgs.ParseServiceReject(plain)
+	if err != nil {
+		t.Fatalf("could not parse service reject: %v", err)
+	}
+
+	if reject.Cause != want {
+		t.Fatalf("service reject cause = %v, want %v", reject.Cause, want)
+	}
+}

--- a/internal/amf/nas/handle_service_request_connected_test.go
+++ b/internal/amf/nas/handle_service_request_connected_test.go
@@ -26,7 +26,6 @@ type connectedModeFixture struct {
 
 func (f connectedModeFixture) conn() *amf.UeConn { return f.ue.Conn() }
 
-// serviceRequest encodes a ciphered SERVICE REQUEST of svcType for this fixture's UE.
 func (f connectedModeFixture) serviceRequest(t *testing.T, svcType fgs.ServiceType) []byte {
 	t.Helper()
 
@@ -38,9 +37,6 @@ func (f connectedModeFixture) serviceRequest(t *testing.T, svcType fgs.ServiceTy
 	return encSR(t, m)
 }
 
-// connectedModeUe builds a registered, secured UE whose connection carries the UE Context
-// Request the gNB set on the INITIAL UE MESSAGE, with one PDU session (PSI 12 — the one
-// buildTestServiceRequestCiphered names in its Uplink data status IE).
 func connectedModeUe(t *testing.T, smf amf.SmfSbi) connectedModeFixture {
 	t.Helper()
 
@@ -90,20 +86,11 @@ func connectedModeUe(t *testing.T, smf amf.SmfSbi) connectedModeFixture {
 	}
 
 	ue.Conn().UeContextRequest = true
-	// The SERVICE REQUEST was integrity checked before dispatch, which is what establishes
-	// secure exchange on the connection (TS 24.501 §4.4.4.3).
 	ue.Conn().MarkSecureExchangeEstablished()
 
 	return connectedModeFixture{amf: amfInstance, ue: ue, ngapSender: ngapSender, key: key, algo: algo}
 }
 
-// The Initial Context Setup carries the KgNB derived from the uplink NAS COUNT of the NAS
-// message that took the UE from CM-IDLE to CM-CONNECTED (TS 33.501 §6.8.1.2.2), and the AMF
-// triggers it because the UE Context Request IE arrived on the INITIAL UE MESSAGE
-// (TS 38.413 §8.6.1.2). A SERVICE REQUEST the UE sends later in 5GMM-CONNECTED mode
-// (TS 24.501 §5.6.1.1 cases e) and j)) is not that message: it must neither repeat the
-// procedure nor re-derive the key, and its user-plane resources go up in a standalone PDU
-// Session Resource Setup instead.
 func TestHandleServiceRequest_ContextAlreadySetUp_NoSecondInitialContextSetup(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -148,10 +135,6 @@ func TestHandleServiceRequest_ContextAlreadySetUp_NoSecondInitialContextSetup(t 
 	}
 }
 
-// TS 24.501 §5.6.1.8 b): a SERVICE REJECT for a protocol error leaves the AMF in its current
-// 5GMM mode. The UE starts T3540 to let the network release the N1 NAS signalling connection
-// only when it sent the request from 5GMM-IDLE mode (§5.3.1.3 a1), §5.6.1.7 i)) — a UE that
-// sent it in 5GMM-CONNECTED mode keeps its connection and its user plane.
 func TestHandleServiceRequest_ProtocolErrorReject_ReleasesOnlyFrom5GMMIdle(t *testing.T) {
 	const unassignedServiceType = fgs.ServiceType(0x07)
 
@@ -181,8 +164,6 @@ func TestHandleServiceRequest_ProtocolErrorReject_ReleasesOnlyFrom5GMMIdle(t *te
 	}
 }
 
-// TS 24.501 §5.3.1.3 d): a SERVICE REJECT with 5GMM cause #9 has the UE start T3540 whatever
-// mode it sent the request from, so the network releases the connection either way.
 func TestHandleServiceRequest_Cause9Reject_ReleasesFrom5GMMConnected(t *testing.T) {
 	f := connectedModeUe(t, &fakeSmf{})
 
@@ -199,10 +180,6 @@ func TestHandleServiceRequest_Cause9Reject_ReleasesFrom5GMMConnected(t *testing.
 	}
 }
 
-// TS 24.501 §5.6.1.4.1 conditions the AMF's user-plane re-establishment on the Uplink data
-// status IE being present, not on the service type, and §5.6.1.2.1 case c) has a UE with an
-// always-on PDU session include that IE alongside service type "signalling". Such a request
-// must re-establish the named PDU session and report the result in the SERVICE ACCEPT.
 func TestHandleServiceRequest_SignallingWithUplinkDataStatus_ReactivatesPDUSession(t *testing.T) {
 	f := connectedModeUe(t, &fakeSmf{})
 
@@ -235,10 +212,6 @@ func TestHandleServiceRequest_SignallingWithUplinkDataStatus_ReactivatesPDUSessi
 	}
 }
 
-// The N1 NAS signalling connection is established by the NGAP INITIAL UE MESSAGE that
-// carries a connection's first uplink NAS message (TS 38.413 §8.6.1.1, TS 24.501 §5.3.1.1),
-// so HandleNAS — the one entry point every uplink NAS PDU passes through — is where the AMF
-// learns which 5GMM mode the UE sent each message from.
 func TestHandleNAS_CountsTheConnectionsFirstMessageAsSentFrom5GMMIdle(t *testing.T) {
 	f := connectedModeUe(t, &fakeSmf{})
 

--- a/internal/amf/nas/handle_service_request_test.go
+++ b/internal/amf/nas/handle_service_request_test.go
@@ -318,8 +318,6 @@ func TestHandleServiceRequest_ServiceTypeReplies(t *testing.T) {
 		wantMsgType uint8
 	}{
 		{"high-priority access is accepted", uint8(fgs.ServiceTypeHighPriorityAccess), uint8(fgs.MsgServiceAccept)},
-		// TS 24.501 §5.6.1.2.1: a UE outside an allowed area sets this type to report a
-		// change of 3GPP PS data off status, so it is a request the AMF serves.
 		{"elevated signalling is accepted", uint8(fgs.ServiceTypeElevatedSignalling), uint8(fgs.MsgServiceAccept)},
 		{"emergency is rejected (unsupported)", uint8(fgs.ServiceTypeEmergencyServices), uint8(fgs.MsgServiceReject)},
 		{"emergency fallback is rejected", uint8(fgs.ServiceTypeEmergencyServicesFallback), uint8(fgs.MsgServiceReject)},

--- a/internal/amf/nas/handle_service_request_test.go
+++ b/internal/amf/nas/handle_service_request_test.go
@@ -318,6 +318,9 @@ func TestHandleServiceRequest_ServiceTypeReplies(t *testing.T) {
 		wantMsgType uint8
 	}{
 		{"high-priority access is accepted", uint8(fgs.ServiceTypeHighPriorityAccess), uint8(fgs.MsgServiceAccept)},
+		// TS 24.501 §5.6.1.2.1: a UE outside an allowed area sets this type to report a
+		// change of 3GPP PS data off status, so it is a request the AMF serves.
+		{"elevated signalling is accepted", uint8(fgs.ServiceTypeElevatedSignalling), uint8(fgs.MsgServiceAccept)},
 		{"emergency is rejected (unsupported)", uint8(fgs.ServiceTypeEmergencyServices), uint8(fgs.MsgServiceReject)},
 		{"emergency fallback is rejected", uint8(fgs.ServiceTypeEmergencyServicesFallback), uint8(fgs.MsgServiceReject)},
 		{"unknown service type is rejected", 0x07, uint8(fgs.MsgServiceReject)},

--- a/internal/amf/nas/nas_gate_test.go
+++ b/internal/amf/nas/nas_gate_test.go
@@ -17,7 +17,7 @@ import (
 
 // A SERVICE REQUEST that resolves no 5GMM context (e.g. the UE deregistered, or an unknown
 // 5G-S-TMSI) must be answered with a SERVICE REJECT #9, never dropped
-// (TS 24.501 §5.6.1.5, §4.4.4.3). The dedicated pre-context handler never mints a context.
+// (TS 24.501 §5.6.1.5, §4.4.4.3). The mint gate never mints a context for one.
 func TestHandleServiceRequest_NoContext_SendsServiceReject(t *testing.T) {
 	ngapSender := &fakeNGAPSender{}
 	amfInstance := amf.New(&fakeDBInstance{
@@ -31,7 +31,7 @@ func TestHandleServiceRequest_NoContext_SendsServiceReject(t *testing.T) {
 		t.Fatalf("could not create ueConn: %v", err)
 	}
 
-	HandleServiceRequest(context.Background(), amfInstance, ueConn, encodePlainServiceRequest(t))
+	HandleNAS(context.Background(), amfInstance, ueConn, encodePlainServiceRequest(t))
 
 	if ueConn.UeContext() != nil {
 		t.Fatal("no-context service request minted a UE context; the bare connection would leak")
@@ -57,7 +57,7 @@ func TestHandleServiceRequest_NoContext_SendsServiceReject(t *testing.T) {
 func TestHandleServiceRequest_ProtocolError_SendsServiceReject96(t *testing.T) {
 	malformed := []byte{0x7e, 0x00, 0x4c} // plain 5GMM, message type ServiceRequest, no IEs
 
-	if !IsServiceRequest(malformed) {
+	if !isServiceRequest(malformed) {
 		t.Fatal("a truncated plain SERVICE REQUEST must still be recognized by message type")
 	}
 
@@ -73,7 +73,7 @@ func TestHandleServiceRequest_ProtocolError_SendsServiceReject96(t *testing.T) {
 		t.Fatalf("could not create ueConn: %v", err)
 	}
 
-	HandleServiceRequest(context.Background(), amfInstance, ueConn, malformed)
+	HandleNAS(context.Background(), amfInstance, ueConn, malformed)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("expected 1 downlink (SERVICE REJECT), got %d", len(ngapSender.SentDownlinkNASTransport))

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -28,8 +28,8 @@ var nasTracer = otel.Tracer("ella-core/amf/nas")
 // it resolves to: a REGISTRATION REQUEST mints a fresh persistent context; a message the AMF
 // cannot process draws the STATUS the spec mandates (§7.4, §7.5.1) or an audited silence
 // (§4.4.4.3), never a bare drop; a message that establishes no context leaves the connection
-// bare for the NGAP layer to release. A SERVICE REQUEST is routed to HandleServiceRequest at
-// the NGAP layer, before HandleNAS.
+// bare for the NGAP layer to release. Every uplink NAS PDU enters here, whichever NGAP
+// procedure carried it.
 func HandleNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn, nasPdu []byte) {
 	if ue == nil {
 		logger.From(ctx, logger.AmfLog).Error("inbound NAS on a nil UE connection")
@@ -40,8 +40,6 @@ func HandleNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn, nasPdu
 }
 
 // dispositionForNAS resolves an inbound NAS PDU to the single outcome the finalizer applies.
-// A SERVICE REQUEST never reaches here — it is resolved-or-rejected by HandleServiceRequest,
-// routed at the NGAP layer before the mint gate.
 func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn, nasPdu []byte) nasreply.Disposition {
 	if nasPdu == nil {
 		logger.From(ctx, logger.AmfLog).Error("inbound NAS with a nil PDU")
@@ -56,10 +54,29 @@ func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn
 			// rather than dropping it. No secure exchange exists on a fresh connection, so
 			// §4.4.4.3's silent discard does not apply here.
 			logger.From(ctx, logger.AmfLog).Warn("failed to resolve UE context from mobile identity", zap.Error(err))
+
+			// A SERVICE REQUEST recognizable by message type but undecodable is a protocol
+			// error: §5.6.1.8 b) answers it with a SERVICE REJECT #96, not a STATUS.
+			if isServiceRequest(nasPdu) {
+				rejectBareServiceRequest(ctx, ue, fgs.GMMCauseInvalidMandatoryInformation)
+
+				return nasreply.Handled()
+			}
+
 			return dispositionForUnresolved(nasPdu)
 		}
 
 		if amfUe == nil {
+			// §4.4.4.3 admits a SERVICE REQUEST before secure exchange even when its MAC
+			// fails, but it never mints a context. With none resolved — or none the message
+			// authenticates against — the answer is a SERVICE REJECT #9, leaving the 5GMM
+			// and 5G NAS security contexts unchanged.
+			if isServiceRequest(nasPdu) {
+				rejectBareServiceRequest(ctx, ue, fgs.GMMCauseUEIdentityCannotBeDerived)
+
+				return nasreply.Handled()
+			}
+
 			// Mint a context only for an initial REGISTRATION REQUEST — the only message
 			// that establishes a fresh context. This keeps minting reserved to registration
 			// so an unauthenticated peer cannot leak a context per message. Any other message
@@ -161,48 +178,12 @@ func isRegistrationRequest(payload []byte) bool {
 	return ok && mt == uint8(fgs.MsgRegistrationRequest)
 }
 
-// IsServiceRequest reports whether a fresh connection's first NAS message is a SERVICE
-// REQUEST, so the NGAP layer can route it to HandleServiceRequest before the mint gate.
-func IsServiceRequest(payload []byte) bool {
+// isServiceRequest reports whether a fresh connection's first NAS message is a SERVICE
+// REQUEST, so the mint gate can answer it with a SERVICE REJECT instead of minting a
+// context or returning a 5GMM STATUS.
+func isServiceRequest(payload []byte) bool {
 	mt, ok := peekInitialGmmType(payload)
 	return ok && mt == uint8(fgs.MsgServiceRequest)
-}
-
-// HandleServiceRequest answers an initial SERVICE REQUEST, routed here from the NGAP layer
-// before the HandleNAS mint gate. It resolves the UE by the request's 5G-S-TMSI —
-// integrity-verified against the held context — and either dispatches the accept, or
-// answers a SERVICE REJECT (#96 for a protocol error per §5.6.1.8, else #9 when no context
-// can be derived per §5.6.1.5/§4.4.4.3). It never mints a context and leaves the
-// 5GMM/security context unchanged on rejection.
-func HandleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn, nasPdu []byte) {
-	amfUe, err := fetchUeContextWithMobileIdentity(ctx, amfInstance, nasPdu)
-	if err != nil {
-		// The SERVICE REQUEST is recognizable but could not be decoded (a protocol error,
-		// e.g. a missing mandatory IE). TS 24.501 §5.6.1.8 b): the AMF shall return a
-		// SERVICE REJECT with cause #96 "invalid mandatory information", not a silent drop.
-		logger.From(ctx, logger.AmfLog).Warn("malformed service request; rejecting", zap.Error(err))
-		rejectBareServiceRequest(ctx, ue, fgs.GMMCauseInvalidMandatoryInformation)
-
-		return
-	}
-
-	if amfUe == nil {
-		// The request decoded, but no 5GMM context exists for the cited 5G-S-TMSI (or it
-		// failed the integrity check): it cannot be accepted. SERVICE REJECT #9 without
-		// binding or mutating any context; the NGAP layer releases the bare connection.
-		rejectBareServiceRequest(ctx, ue, fgs.GMMCauseUEIdentityCannotBeDerived)
-		return
-	}
-
-	amfInstance.AttachUeConn(amfUe, ue)
-
-	result, err := amf.DecodeNASMessage(amfUe, nasPdu)
-	if err != nil {
-		amf.DispositionForDecodeError(err).Finalize(ctx, egress{ue: ue})
-		return
-	}
-
-	handleServiceRequest(ctx, amfInstance, amfUe, result.Plain, result.IntegrityVerified)
 }
 
 // peekInitialGmmType returns the GMM message type of a fresh connection's first NAS PDU by

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -28,8 +28,7 @@ var nasTracer = otel.Tracer("ella-core/amf/nas")
 // it resolves to: a REGISTRATION REQUEST mints a fresh persistent context; a message the AMF
 // cannot process draws the STATUS the spec mandates (§7.4, §7.5.1) or an audited silence
 // (§4.4.4.3), never a bare drop; a message that establishes no context leaves the connection
-// bare for the NGAP layer to release. Every uplink NAS PDU enters here, whichever NGAP
-// procedure carried it.
+// bare for the NGAP layer to release.
 func HandleNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn, nasPdu []byte) {
 	if ue == nil {
 		logger.From(ctx, logger.AmfLog).Error("inbound NAS on a nil UE connection")
@@ -57,11 +56,6 @@ func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn
 			// §4.4.4.3's silent discard does not apply here.
 			logger.From(ctx, logger.AmfLog).Warn("failed to resolve UE context from mobile identity", zap.Error(err))
 
-			// A SERVICE REQUEST recognizable by message type but undecodable is a protocol
-			// error: §5.6.1.8 b) answers it with a SERVICE REJECT #96, not a STATUS. One
-			// that decodes but whose identity the AMF could not look up is not the UE's
-			// protocol error, so it draws the #9 that leaves its contexts unchanged
-			// (§4.4.4.3) like any other unresolved request.
 			if isServiceRequest(nasPdu) {
 				cause := fgs.GMMCauseUEIdentityCannotBeDerived
 				if !decodesAsServiceRequest(ctx, nasPdu) {
@@ -77,10 +71,6 @@ func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn
 		}
 
 		if amfUe == nil {
-			// §4.4.4.3 admits a SERVICE REQUEST before secure exchange even when its MAC
-			// fails, but it never mints a context. With none resolved — or none the message
-			// authenticates against — the answer is a SERVICE REJECT #9, leaving the 5GMM
-			// and 5G NAS security contexts unchanged.
 			if isServiceRequest(nasPdu) {
 				rejectBareServiceRequest(ctx, ue, fgs.GMMCauseUEIdentityCannotBeDerived)
 
@@ -189,16 +179,12 @@ func isRegistrationRequest(payload []byte) bool {
 }
 
 // isServiceRequest reports whether a fresh connection's first NAS message is a SERVICE
-// REQUEST, so the mint gate can answer it with a SERVICE REJECT instead of minting a
-// context or returning a 5GMM STATUS.
+// REQUEST, so the mint gate can answer it with a SERVICE REJECT rather than mint a context.
 func isServiceRequest(payload []byte) bool {
 	mt, ok := peekInitialGmmType(payload)
 	return ok && mt == uint8(fgs.MsgServiceRequest)
 }
 
-// decodesAsServiceRequest reports whether a PDU already recognized as a SERVICE REQUEST by
-// message type also decodes, telling the protocol error §5.6.1.8 b) answers with cause #96
-// apart from a well-formed request the AMF simply could not resolve to a context.
 func decodesAsServiceRequest(ctx context.Context, payload []byte) bool {
 	body, ok := initialGmmBody(payload)
 	if !ok {
@@ -231,9 +217,6 @@ func peekInitialGmmType(payload []byte) (uint8, bool) {
 	return uint8(mt), true
 }
 
-// initialGmmBody returns the plain 5GMM message carried by a fresh connection's first NAS
-// PDU. ok is false for a non-5GMM, ciphered, or too-short PDU, none of which the AMF can
-// classify without a security context.
 func initialGmmBody(payload []byte) ([]byte, bool) {
 	sht, err := fgs.PeekSecurityHeaderType(payload)
 	if err != nil {

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -36,6 +36,8 @@ func HandleNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn, nasPdu
 		return
 	}
 
+	ue.NoteInboundNAS()
+
 	dispositionForNAS(ctx, amfInstance, ue, nasPdu).Finalize(ctx, egress{ue: ue})
 }
 
@@ -56,9 +58,17 @@ func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn
 			logger.From(ctx, logger.AmfLog).Warn("failed to resolve UE context from mobile identity", zap.Error(err))
 
 			// A SERVICE REQUEST recognizable by message type but undecodable is a protocol
-			// error: §5.6.1.8 b) answers it with a SERVICE REJECT #96, not a STATUS.
+			// error: §5.6.1.8 b) answers it with a SERVICE REJECT #96, not a STATUS. One
+			// that decodes but whose identity the AMF could not look up is not the UE's
+			// protocol error, so it draws the #9 that leaves its contexts unchanged
+			// (§4.4.4.3) like any other unresolved request.
 			if isServiceRequest(nasPdu) {
-				rejectBareServiceRequest(ctx, ue, fgs.GMMCauseInvalidMandatoryInformation)
+				cause := fgs.GMMCauseUEIdentityCannotBeDerived
+				if !decodesAsServiceRequest(ctx, nasPdu) {
+					cause = fgs.GMMCauseInvalidMandatoryInformation
+				}
+
+				rejectBareServiceRequest(ctx, ue, cause)
 
 				return nasreply.Handled()
 			}
@@ -186,6 +196,20 @@ func isServiceRequest(payload []byte) bool {
 	return ok && mt == uint8(fgs.MsgServiceRequest)
 }
 
+// decodesAsServiceRequest reports whether a PDU already recognized as a SERVICE REQUEST by
+// message type also decodes, telling the protocol error §5.6.1.8 b) answers with cause #96
+// apart from a well-formed request the AMF simply could not resolve to a context.
+func decodesAsServiceRequest(ctx context.Context, payload []byte) bool {
+	body, ok := initialGmmBody(payload)
+	if !ok {
+		return false
+	}
+
+	_, err := fgs.ParseServiceRequest(body)
+
+	return decoded(ctx, "ServiceRequest", err)
+}
+
 // peekInitialGmmType returns the GMM message type of a fresh connection's first NAS PDU by
 // reading the message-type octet directly (plain: octet 3; integrity-protected: octet 3 of
 // the inner plain message). It deliberately does NOT fully decode the body, so a
@@ -194,24 +218,8 @@ func isServiceRequest(payload []byte) bool {
 // not silently drop it. ok is false for a non-5GMM, ciphered, or too-short PDU. Mirrors the
 // MME's raw message-type peek.
 func peekInitialGmmType(payload []byte) (uint8, bool) {
-	sht, err := fgs.PeekSecurityHeaderType(payload)
-	if err != nil {
-		return 0, false
-	}
-
-	body := payload
-
-	switch sht {
-	case fgs.SHTPlain:
-	case fgs.SHTIntegrityProtected:
-		// The inner plain message follows the security header (EPD, SHT, MAC[4], seq).
-		spm, err := fgs.ParseSecurityProtectedMessage(payload)
-		if err != nil {
-			return 0, false
-		}
-
-		body = spm.UnverifiedPayload
-	default:
+	body, ok := initialGmmBody(payload)
+	if !ok {
 		return 0, false
 	}
 
@@ -221,6 +229,31 @@ func peekInitialGmmType(payload []byte) (uint8, bool) {
 	}
 
 	return uint8(mt), true
+}
+
+// initialGmmBody returns the plain 5GMM message carried by a fresh connection's first NAS
+// PDU. ok is false for a non-5GMM, ciphered, or too-short PDU, none of which the AMF can
+// classify without a security context.
+func initialGmmBody(payload []byte) ([]byte, bool) {
+	sht, err := fgs.PeekSecurityHeaderType(payload)
+	if err != nil {
+		return nil, false
+	}
+
+	switch sht {
+	case fgs.SHTPlain:
+		return payload, true
+	case fgs.SHTIntegrityProtected:
+		// The inner plain message follows the security header (EPD, SHT, MAC[4], seq).
+		spm, err := fgs.ParseSecurityProtectedMessage(payload)
+		if err != nil {
+			return nil, false
+		}
+
+		return spm.UnverifiedPayload, true
+	default:
+		return nil, false
+	}
 }
 
 // rejectBareServiceRequest answers a SERVICE REQUEST the AMF cannot accept with a SERVICE

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -59,9 +59,10 @@ func requiresNewContextSecurityHeader(plain []byte) bool {
 // plainNasAllowed reports whether a NAS message type may be processed without a verified
 // MAC before secure exchange (TS 24.501 §4.4.4.3, TS 33.501) — either sent as plain NAS,
 // or received integrity-protected with a failed MAC. SERVICE REQUEST is on the spec's
-// MAC-failed list but absent here: on a connection with no secure exchange it is verified
-// at context resolution and rejected with cause #9 on failure, and once secure exchange is
-// established §4.4.4.3 requires an unverified message to be discarded.
+// MAC-failed list but absent here: once secure exchange is established §4.4.4.3 requires an
+// unverified message to be discarded, and before it the request is verified at context
+// resolution, where a failed MAC resolves no context and draws the cause #9 §4.4.4.3
+// prescribes rather than being processed.
 func plainNasAllowed(msgType uint8) bool {
 	switch msgType {
 	case uint8(fgs.MsgRegistrationRequest),

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -59,8 +59,9 @@ func requiresNewContextSecurityHeader(plain []byte) bool {
 // plainNasAllowed reports whether a NAS message type may be processed without a verified
 // MAC before secure exchange (TS 24.501 §4.4.4.3, TS 33.501) — either sent as plain NAS,
 // or received integrity-protected with a failed MAC. SERVICE REQUEST is on the spec's
-// MAC-failed list but absent here: it is verified before context binding by the dedicated
-// HandleServiceRequest and rejected with cause #9 on failure, never admitted here.
+// MAC-failed list but absent here: on a connection with no secure exchange it is verified
+// at context resolution and rejected with cause #9 on failure, and once secure exchange is
+// established §4.4.4.3 requires an unverified message to be discarded.
 func plainNasAllowed(msgType uint8) bool {
 	switch msgType {
 	case uint8(fgs.MsgRegistrationRequest),

--- a/internal/amf/nas_classify.go
+++ b/internal/amf/nas_classify.go
@@ -59,10 +59,8 @@ func requiresNewContextSecurityHeader(plain []byte) bool {
 // plainNasAllowed reports whether a NAS message type may be processed without a verified
 // MAC before secure exchange (TS 24.501 §4.4.4.3, TS 33.501) — either sent as plain NAS,
 // or received integrity-protected with a failed MAC. SERVICE REQUEST is on the spec's
-// MAC-failed list but absent here: once secure exchange is established §4.4.4.3 requires an
-// unverified message to be discarded, and before it the request is verified at context
-// resolution, where a failed MAC resolves no context and draws the cause #9 §4.4.4.3
-// prescribes rather than being processed.
+// MAC-failed list but absent here: it is verified at context resolution and rejected with
+// cause #9 on failure, never admitted here.
 func plainNasAllowed(msgType uint8) bool {
 	switch msgType {
 	case uint8(fgs.MsgRegistrationRequest),

--- a/internal/amf/ngap/fixtures_test.go
+++ b/internal/amf/ngap/fixtures_test.go
@@ -409,24 +409,12 @@ type NASCall struct {
 // model a message that establishes none (undecodable, or an identity the network
 // cannot resolve), which the NGAP layer then releases.
 type fakeNASHandler struct {
-	Calls               []NASCall
-	LeavesBare          bool
-	ServiceRequest      bool // IsServiceRequest returns this (route to HandleServiceRequest)
-	ServiceRequestCalls []NASCall
+	Calls      []NASCall
+	LeavesBare bool
 }
 
 func (f *fakeNASHandler) HandleNAS(_ context.Context, ue *amf.UeConn, nasPdu []byte) {
 	f.Calls = append(f.Calls, NASCall{UeConn: ue, NASPDU: nasPdu})
-
-	if !f.LeavesBare && ue.UeContext() == nil {
-		ue.AMFForTest().AttachUeConn(amf.NewUeContext(), ue)
-	}
-}
-
-func (f *fakeNASHandler) IsServiceRequest(_ []byte) bool { return f.ServiceRequest }
-
-func (f *fakeNASHandler) HandleServiceRequest(_ context.Context, ue *amf.UeConn, nasPdu []byte) {
-	f.ServiceRequestCalls = append(f.ServiceRequestCalls, NASCall{UeConn: ue, NASPDU: nasPdu})
 
 	if !f.LeavesBare && ue.UeContext() == nil {
 		ue.AMFForTest().AttachUeConn(amf.NewUeContext(), ue)

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -45,8 +45,6 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		return
 	}
 
-	// TS 38.413 §8.6.1.2: the NAS-PDU is carried without interpretation. Which NAS message
-	// this is, and whether it may bind or mint a context, is the NAS layer's decision.
 	resumeExistingContext(ctx, amfInstance, ueConn, msg)
 
 	amfInstance.NAS.HandleNAS(ctx, ueConn, msg.NASPDU)

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -45,16 +45,11 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		return
 	}
 
-	// A SERVICE REQUEST is resolved and answered (accept, or SERVICE REJECT #9 when no
-	// context) by its dedicated handler, without the optimistic resume or the mint gate —
-	// it never mints a context.
-	if amfInstance.NAS.IsServiceRequest(msg.NASPDU) {
-		amfInstance.NAS.HandleServiceRequest(ctx, ueConn, msg.NASPDU)
-	} else {
-		resumeExistingContext(ctx, amfInstance, ueConn, msg)
+	// TS 38.413 §8.6.1.2: the NAS-PDU is carried without interpretation. Which NAS message
+	// this is, and whether it may bind or mint a context, is the NAS layer's decision.
+	resumeExistingContext(ctx, amfInstance, ueConn, msg)
 
-		amfInstance.NAS.HandleNAS(ctx, ueConn, msg.NASPDU)
-	}
+	amfInstance.NAS.HandleNAS(ctx, ueConn, msg.NASPDU)
 
 	// A NAS message that never established a UE context (undecodable, no usable mobile
 	// identity, not a registration request, or a service request the AMF has no context
@@ -69,10 +64,10 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 }
 
 // resumeExistingContext optimistically binds an existing, integrity-verified context to a
-// fresh connection when a non-service-request initial NAS message cites a known 5G-S-TMSI,
-// so the NAS layer need not re-resolve it. It binds nothing when the message cannot be
-// authenticated for the cited context (TS 24.501), leaving the NAS layer to register on a
-// fresh context.
+// fresh connection when an initial NAS message cites a known 5G-S-TMSI in the NGAP IE, so
+// the NAS layer need not re-resolve it. It binds nothing when the message cannot be
+// authenticated for the cited context (TS 24.501), leaving the NAS layer to resolve or
+// register on a fresh context.
 func resumeExistingContext(ctx context.Context, amfInstance *amf.AMF, ueConn *amf.UeConn, msg *ngap.InitialUEMessage) {
 	if msg.FiveGSTMSI == nil {
 		return

--- a/internal/amf/ngap/handle_initial_ue_message_servicereq_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_servicereq_test.go
@@ -14,23 +14,17 @@ import (
 )
 
 // realNASAdapter wires the actual NAS layer (not the fake) into the AMF, so a routing test
-// exercises the real IsServiceRequest peek and HandleServiceRequest reject end to end.
+// exercises the real mint gate and its SERVICE REJECT end to end.
 type realNASAdapter struct{ amf *amf.AMF }
 
 func (n *realNASAdapter) HandleNAS(ctx context.Context, ue *amf.UeConn, pdu []byte) {
 	amfnas.HandleNAS(ctx, n.amf, ue, pdu)
 }
 
-func (n *realNASAdapter) IsServiceRequest(pdu []byte) bool { return amfnas.IsServiceRequest(pdu) }
-
-func (n *realNASAdapter) HandleServiceRequest(ctx context.Context, ue *amf.UeConn, pdu []byte) {
-	amfnas.HandleServiceRequest(ctx, n.amf, ue, pdu)
-}
-
 // A truncated-but-recognizable plain SERVICE REQUEST arriving in an Initial UE Message (the
 // 3gpp-server Test5GServiceRequest_Fuzz "7e004c" case, sent verbatim) must be classified by
-// message type, routed to the dedicated handler, and answered with SERVICE REJECT #96 over
-// the whole NGAP→NAS path — never dropped in HandleNAS (TS 24.501 §5.6.1.8 b).
+// message type and answered with SERVICE REJECT #96 over the whole NGAP→NAS path — never
+// dropped (TS 24.501 §5.6.1.8 b).
 func TestHandleInitialUEMessage_MalformedServiceRequest_Rejects96(t *testing.T) {
 	amfInstance := newTestAMF()
 	amfInstance.NAS = &realNASAdapter{amf: amfInstance}

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -52,9 +52,8 @@ func TestHandleInitialUEMessage_CreatesNewUeConn(t *testing.T) {
 	}
 }
 
-// TS 38.413 §8.6.1.2: the NAS-PDU is carried without interpretation, so a SERVICE REQUEST
-// Initial UE Message goes through the same HandleNAS entry point as any other NAS message;
-// a request that binds no context leaves no bare RAN connection behind.
+// A SERVICE REQUEST Initial UE Message goes through the same HandleNAS entry point as any
+// other NAS message; a request that binds no context leaves no bare RAN connection behind.
 func TestHandleInitialUEMessage_ServiceRequestGoesThroughHandleNAS(t *testing.T) {
 	fakeNAS := &fakeNASHandler{LeavesBare: true}
 	amfInstance := newTestAMFWithNAS(fakeNAS)

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -52,11 +52,11 @@ func TestHandleInitialUEMessage_CreatesNewUeConn(t *testing.T) {
 	}
 }
 
-// A SERVICE REQUEST Initial UE Message is routed to the dedicated HandleServiceRequest,
-// never through the generic HandleNAS mint path (mirrors the MME's S1AP peek); a request
-// that binds no context leaves no bare RAN connection behind.
-func TestHandleInitialUEMessage_ServiceRequestRoutedToDedicatedHandler(t *testing.T) {
-	fakeNAS := &fakeNASHandler{ServiceRequest: true, LeavesBare: true}
+// TS 38.413 §8.6.1.2: the NAS-PDU is carried without interpretation, so a SERVICE REQUEST
+// Initial UE Message goes through the same HandleNAS entry point as any other NAS message;
+// a request that binds no context leaves no bare RAN connection behind.
+func TestHandleInitialUEMessage_ServiceRequestGoesThroughHandleNAS(t *testing.T) {
+	fakeNAS := &fakeNASHandler{LeavesBare: true}
 	amfInstance := newTestAMFWithNAS(fakeNAS)
 
 	ran := newTestRadio(amfInstance)
@@ -69,12 +69,8 @@ func TestHandleInitialUEMessage_ServiceRequestRoutedToDedicatedHandler(t *testin
 		NASPDU:      ngap.NASPDU(nasPDU),
 	})
 
-	if len(fakeNAS.ServiceRequestCalls) != 1 {
-		t.Fatalf("HandleServiceRequest calls = %d, want 1", len(fakeNAS.ServiceRequestCalls))
-	}
-
-	if len(fakeNAS.Calls) != 0 {
-		t.Fatalf("HandleNAS calls = %d, want 0 (a service request must not go through the mint gate)", len(fakeNAS.Calls))
+	if len(fakeNAS.Calls) != 1 {
+		t.Fatalf("HandleNAS calls = %d, want 1", len(fakeNAS.Calls))
 	}
 
 	if ran.NumUEsForTest() != 0 {

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -73,7 +73,11 @@ type UeConn struct {
 	// from the NGAP dispatch goroutine, the SMF N1N2 path, and the NAS-guard timer
 	// callback, so it is atomic; mutate it only through ICS()/ClaimICS()/MarkICS*/ResetICS.
 	ics atomic.Int32
-	Log *zap.Logger
+	// inboundNAS counts the uplink NAS messages dispatched on this connection; see
+	// NoteInboundNAS. Atomic like the other fields a UeConn exposes outside the NGAP
+	// dispatch goroutine that writes it.
+	inboundNAS atomic.Uint32
+	Log        *zap.Logger
 	// releasing gates a UE Context Release Command so a second one is not sent for the
 	// same RAN UE. Guarded by AMF.mu, like the conns registry it lives in.
 	releasing bool
@@ -288,6 +292,22 @@ func (ueConn *UeConn) MarkICSPending() {
 // MarkICSCompleted records that the InitialContextSetupResponse has been received.
 func (ueConn *UeConn) MarkICSCompleted() {
 	ueConn.ics.Store(int32(ICSCompleted))
+}
+
+// NoteInboundNAS records that an uplink NAS message is being dispatched on this connection.
+// The NGAP INITIAL UE MESSAGE carries the first one (TS 38.413 §8.6.1.1) and establishes the
+// N1 NAS signalling connection, which is what takes the UE to 5GMM-CONNECTED mode
+// (TS 24.501 §5.3.1.1).
+func (ueConn *UeConn) NoteInboundNAS() {
+	ueConn.inboundNAS.Add(1)
+}
+
+// SentFrom5GMMIdle reports whether the UE was in 5GMM-IDLE mode when it sent the uplink NAS
+// message now being dispatched — true for the connection's first message, false for every
+// later one, which the UE sent in 5GMM-CONNECTED mode over an already established N1 NAS
+// signalling connection.
+func (ueConn *UeConn) SentFrom5GMMIdle() bool {
+	return ueConn.inboundNAS.Load() <= 1
 }
 
 // ResetICS returns the connection to ICSNotStarted, rolling back a claim whose send

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -72,10 +72,7 @@ type UeConn struct {
 	// ics is the Initial Context Setup progress (an ICSState). It is read and written
 	// from the NGAP dispatch goroutine, the SMF N1N2 path, and the NAS-guard timer
 	// callback, so it is atomic; mutate it only through ICS()/ClaimICS()/MarkICS*/ResetICS.
-	ics atomic.Int32
-	// inboundNAS counts the uplink NAS messages dispatched on this connection; see
-	// NoteInboundNAS. Atomic like the other fields a UeConn exposes outside the NGAP
-	// dispatch goroutine that writes it.
+	ics        atomic.Int32
 	inboundNAS atomic.Uint32
 	Log        *zap.Logger
 	// releasing gates a UE Context Release Command so a second one is not sent for the
@@ -294,18 +291,10 @@ func (ueConn *UeConn) MarkICSCompleted() {
 	ueConn.ics.Store(int32(ICSCompleted))
 }
 
-// NoteInboundNAS records that an uplink NAS message is being dispatched on this connection.
-// The NGAP INITIAL UE MESSAGE carries the first one (TS 38.413 §8.6.1.1) and establishes the
-// N1 NAS signalling connection, which is what takes the UE to 5GMM-CONNECTED mode
-// (TS 24.501 §5.3.1.1).
 func (ueConn *UeConn) NoteInboundNAS() {
 	ueConn.inboundNAS.Add(1)
 }
 
-// SentFrom5GMMIdle reports whether the UE was in 5GMM-IDLE mode when it sent the uplink NAS
-// message now being dispatched — true for the connection's first message, false for every
-// later one, which the UE sent in 5GMM-CONNECTED mode over an already established N1 NAS
-// signalling connection.
 func (ueConn *UeConn) SentFrom5GMMIdle() bool {
 	return ueConn.inboundNAS.Load() <= 1
 }

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -186,7 +186,7 @@ func SendAuthenticationReject(ctx context.Context, ue *UeConn) {
 
 func SendServiceReject(ctx context.Context, ue *UeConn, cause fgs.GMMCause) {
 	sendGmm(ctx, ue, "nas/send_service_reject",
-		[]attribute.KeyValue{attribute.Int("cause", int(cause))}, uint8(fgs.SHTPlain),
+		[]attribute.KeyValue{attribute.Int("cause", int(cause))}, rejectSHT(ue),
 		func(_ *UeContext) ([]byte, error) { return BuildServiceReject(cause) })
 }
 
@@ -194,7 +194,7 @@ func SendServiceReject(ctx context.Context, ue *UeConn, cause fgs.GMMCause) {
 func SendRegistrationReject(ctx context.Context, ue *UeConn, cause5GMM fgs.GMMCause) {
 	sendGmm(ctx, ue, "nas/send_registration_reject",
 		[]attribute.KeyValue{attribute.Int("cause", int(cause5GMM))},
-		registrationRejectSHT(ue),
+		rejectSHT(ue),
 		func(_ *UeContext) ([]byte, error) {
 			return BuildRegistrationReject(int(ue.amf.T3502Value.Seconds()), cause5GMM)
 		})
@@ -253,7 +253,10 @@ func sendSecurityModeCommand(ctx context.Context, amfInstance *AMF, ue *UeConn, 
 	return nil
 }
 
-func registrationRejectSHT(ue *UeConn) uint8 {
+// rejectSHT selects the security header type for a REGISTRATION REJECT or SERVICE REJECT.
+// TS 24.501 §4.4.4.2 admits either unprotected only before the network has established
+// secure exchange on the connection; the UE discards one that arrives unprotected after.
+func rejectSHT(ue *UeConn) uint8 {
 	if ue.SecureExchangeEstablished() {
 		return uint8(fgs.SHTIntegrityProtectedCiphered)
 	}

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -253,9 +253,6 @@ func sendSecurityModeCommand(ctx context.Context, amfInstance *AMF, ue *UeConn, 
 	return nil
 }
 
-// rejectSHT selects the security header type for a REGISTRATION REJECT or SERVICE REJECT.
-// TS 24.501 §4.4.4.2 admits either unprotected only before the network has established
-// secure exchange on the connection; the UE discards one that arrives unprotected after.
 func rejectSHT(ue *UeConn) uint8 {
 	if ue.SecureExchangeEstablished() {
 		return uint8(fgs.SHTIntegrityProtectedCiphered)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -786,14 +786,6 @@ func (n *nasAdapter) HandleNAS(ctx context.Context, ue *amf.UeConn, nasPdu []byt
 	nas.HandleNAS(ctx, n.amf, ue, nasPdu)
 }
 
-func (n *nasAdapter) IsServiceRequest(nasPdu []byte) bool {
-	return nas.IsServiceRequest(nasPdu)
-}
-
-func (n *nasAdapter) HandleServiceRequest(ctx context.Context, ue *amf.UeConn, nasPdu []byte) {
-	nas.HandleServiceRequest(ctx, n.amf, ue, nasPdu)
-}
-
 // mmeNASAdapter injects the 4G EMM/ESM NAS layer (internal/mme/nas) into the MME
 // kernel so its S1AP layer dispatches uplink NAS without the kernel importing nas.
 type mmeNASAdapter struct {


### PR DESCRIPTION
# Description

When a phone that's already connected asked to reopen its data path, the core replied "unknown request" and the data stalled.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
