### PR TITLE
fix: refuse 5G->4G idle-mode interworking that carries no session

### DIFF
--- a/internal/amf/fivegs_idle_mobility.go
+++ b/internal/amf/fivegs_idle_mobility.go
@@ -70,12 +70,16 @@ func (a *AMF) EPSContext(ctx context.Context, req interworking.EPSContextRequest
 		return none, fmt.Errorf("%w: %w", interworking.ErrIntegrityCheckFailed, err)
 	}
 
+	sessions := ue.AllTransferableEPSSessions()
+	if len(sessions) == 0 && ue.State() == Registered {
+		return none, fmt.Errorf("%w: no PDU session of 5G-GUTI %s can become a PDN connection",
+			interworking.ErrNoTransferableSessions, presented.String())
+	}
+
 	security, err := ue.MapSecurityContextToEPSOnIdleMobility()
 	if err != nil {
 		return none, err
 	}
-
-	sessions := ue.AllTransferableEPSSessions()
 
 	logger.From(ctx, logger.AmfLog).Info("handing the UE's context to EPS for an idle-mode change",
 		logger.SUPI(ue.Supi().String()), zap.Int("pdu-sessions", len(sessions)))

--- a/internal/amf/fivegs_idle_mobility_test.go
+++ b/internal/amf/fivegs_idle_mobility_test.go
@@ -532,3 +532,42 @@ func TestEPSContextReadsTheAmbrUnderTheLock(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TS 29.274 §7.3.6
+func TestEPSContextRefusesARegisteredUEWithNoTransferableSession(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		strip func(*UeContext)
+	}{
+		{
+			name:  "the UE holds no PDU session",
+			strip: func(ue *UeContext) { ue.DeleteSmContext(3) },
+		},
+		{
+			name:  "the UE's only PDU session has no EPS bearer identity",
+			strip: func(ue *UeContext) { ue.SetEPSBearerIdentity(3, 0) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := idleMobilityAMF()
+			guti := idleMobilityGUTI(t)
+			ue := leavingUE(t, a, guti)
+
+			tc.strip(ue)
+
+			count, err := ue.ulCount.Estimate(0)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = a.EPSContext(context.Background(), mappedRequest(t, ue, guti, count))
+			if !errors.Is(err, interworking.ErrNoTransferableSessions) {
+				t.Fatalf("EPSContext returned %v, want a refusal the MME can answer with EMM cause #40", err)
+			}
+
+			if ue.State() != Registered {
+				t.Errorf("the refused UE is %s, want it still Registered in 5GS", ue.State())
+			}
+		})
+	}
+}

--- a/internal/interworking/context_transfer.go
+++ b/internal/interworking/context_transfer.go
@@ -13,8 +13,9 @@ import (
 )
 
 var (
-	ErrUnknownUEContext     = errors.New("interworking: the peer holds no context for this identity")
-	ErrIntegrityCheckFailed = errors.New("interworking: the peer could not verify the enclosed NAS message")
+	ErrUnknownUEContext       = errors.New("interworking: the peer holds no context for this identity")
+	ErrIntegrityCheckFailed   = errors.New("interworking: the peer could not verify the enclosed NAS message")
+	ErrNoTransferableSessions = errors.New("interworking: the peer holds no session the target system can adopt")
 )
 
 type MMContextRequest struct {

--- a/internal/mme/nas/idle_mobility_from_5gs.go
+++ b/internal/mme/nas/idle_mobility_from_5gs.go
@@ -5,6 +5,7 @@ package nas
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/logger"
@@ -37,6 +38,11 @@ func recoverContextFrom5GS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pd
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Info("the 5GS peer returned no context for an inter-system change; the update is rejected",
 			zap.Error(err))
+
+		if errors.Is(err, interworking.ErrNoTransferableSessions) {
+			cause := eps.EMMCauseNoEPSBearerContextActivated
+			conn.TauRejectCause = &cause
+		}
 
 		return nil, nil
 	}

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/udm"
+	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
 )
@@ -51,6 +52,7 @@ type UeConn struct {
 	TauRequestPlain           []byte
 	TauAcceptPlain            []byte
 	TauReleaseOnComplete      bool
+	TauRejectCause            *eps.EMMCause
 	FiveGSArrival             *FiveGSArrival
 	DeferredTAUPlain          []byte
 	nasGuard                  guard.Guard

--- a/internal/mme/s1ap/handle_initial_ue_message.go
+++ b/internal/mme/s1ap/handle_initial_ue_message.go
@@ -79,14 +79,20 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 	}
 
 	// No context was bound. A protected TRACKING AREA UPDATE the MME cannot resolve is
-	// rejected with EMM cause #9 so the UE re-attaches at once without waiting out T3430
-	// (TS 24.301 §5.5.3.2.5); any other message is dropped. The bare connection is
+	// rejected so the UE re-attaches at once without waiting out T3430 (TS 24.301
+	// §5.5.3.2.5), carrying the cause the NAS layer recorded for the connection or #9
+	// when it recorded none; any other message is dropped. The bare connection is
 	// released either way.
 	if isTrackingAreaUpdate(nas) {
+		cause := eps.EMMCauseUEIdentityCannotBeDerived
+		if c.TauRejectCause != nil {
+			cause = *c.TauRejectCause
+		}
+
 		metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
 		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update rejected; UE will re-attach",
-			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
-		c.SendDownlinkMessage(ctx, &eps.TrackingAreaUpdateReject{Cause: eps.EMMCauseUEIdentityCannotBeDerived})
+			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)), zap.Stringer("cause", cause))
+		c.SendDownlinkMessage(ctx, &eps.TrackingAreaUpdateReject{Cause: cause})
 
 		m.ReleaseAnsweredBareConn(ctx, c, mme.CauseNASUnspecified)
 

--- a/internal/mme/s1ap/idle_mobility_from_5gs_test.go
+++ b/internal/mme/s1ap/idle_mobility_from_5gs_test.go
@@ -46,11 +46,17 @@ func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 		err         error
 		noPeer      bool
 		unprotected bool
+		wantCause   eps.EMMCause
 	}{
-		{name: "the 5GS peer holds no context", err: interworking.ErrUnknownUEContext},
-		{name: "the 5GS peer could not verify the update", err: interworking.ErrIntegrityCheckFailed},
-		{name: "the update carries no integrity protection", err: interworking.ErrIntegrityCheckFailed, unprotected: true},
-		{name: "the operator configured no 5GS peer", noPeer: true},
+		{name: "the 5GS peer holds no context", err: interworking.ErrUnknownUEContext, wantCause: eps.EMMCauseUEIdentityCannotBeDerived},
+		{name: "the 5GS peer could not verify the update", err: interworking.ErrIntegrityCheckFailed, wantCause: eps.EMMCauseUEIdentityCannotBeDerived},
+		{name: "the update carries no integrity protection", err: interworking.ErrIntegrityCheckFailed, unprotected: true, wantCause: eps.EMMCauseUEIdentityCannotBeDerived},
+		{name: "the operator configured no 5GS peer", noPeer: true, wantCause: eps.EMMCauseUEIdentityCannotBeDerived},
+		{
+			name:      "the 5GS peer holds no session EPS can adopt",
+			err:       interworking.ErrNoTransferableSessions,
+			wantCause: eps.EMMCauseNoEPSBearerContextActivated,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newTestMME(t)
@@ -105,8 +111,8 @@ func TestInterSystemTAUWithNoRecoverableContextIsRejected(t *testing.T) {
 				t.Fatalf("parse TAU Reject: %v", err)
 			}
 
-			if rej.Cause != eps.EMMCauseUEIdentityCannotBeDerived {
-				t.Fatalf("TAU Reject cause = %d, want #%d", rej.Cause, eps.EMMCauseUEIdentityCannotBeDerived)
+			if rej.Cause != tc.wantCause {
+				t.Fatalf("TAU Reject cause = %d, want #%d", rej.Cause, tc.wantCause)
 			}
 
 			// TS 24.301 §5.3.1.2.1 d)


### PR DESCRIPTION
# Description

When a phone drifts from 5G to 4G coverage with no data session left to carry over, the 5G side now declines the handover up front instead of passing the 4G side an empty context, so the phone gets told exactly why and re-attaches while keeping the credentials that make its next trip back to 5G fast.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
