### PR TITLE
fix(tests): raise lifecycle timeouts

### DIFF
--- a/internal/tester/scenarios/common/connectivity.go
+++ b/internal/tester/scenarios/common/connectivity.go
@@ -23,7 +23,7 @@ import (
 const (
 	pduSessionType = fgs.PDUSessionTypeIPv4
 
-	registrationTimeout = 8 * time.Second
+	registrationTimeout = 15 * time.Second
 )
 
 // RegisterAndPingOpts: Key/OpC/SQN/PDUSessionID default to

--- a/internal/tester/scenarios/enb/timeouts.go
+++ b/internal/tester/scenarios/enb/timeouts.go
@@ -8,6 +8,6 @@ import "time"
 // Timeouts for the NG-eNB lifecycle procedures, named as in the gnb and s1enb
 // scenarios so every radio's scenarios read alike.
 const (
-	registrationTimeout = 8 * time.Second
-	releaseTimeout      = 2 * time.Second
+	registrationTimeout = 15 * time.Second
+	releaseTimeout      = 10 * time.Second
 )

--- a/internal/tester/scenarios/gnb/timeouts.go
+++ b/internal/tester/scenarios/gnb/timeouts.go
@@ -9,6 +9,6 @@ import "time"
 // the same way, so a 4G and a 5G scenario read alike; only the procedure names
 // differ, because 5GS registers where EPS attaches.
 const (
-	registrationTimeout = 8 * time.Second
-	releaseTimeout      = 2 * time.Second
+	registrationTimeout = 15 * time.Second
+	releaseTimeout      = 10 * time.Second
 )

--- a/internal/tester/scenarios/interworking/interworking.go
+++ b/internal/tester/scenarios/interworking/interworking.go
@@ -19,8 +19,8 @@ import (
 // Timeouts for the lifecycle procedures. s1enb scenarios spell theirs the same
 // way, so a 4G and a 5G scenario read alike.
 const (
-	registrationTimeout = 8 * time.Second
-	releaseTimeout      = 2 * time.Second
+	registrationTimeout = 15 * time.Second
+	releaseTimeout      = 10 * time.Second
 )
 
 const (


### PR DESCRIPTION
# Description

In #1585, we turned on fsync for the raft log, which makes writes slower, especially under load.

Raise the 5G registration and release budgets in the integration tests to the 15s/10s that s1enb already uses, giving 4G and 5G identical lifecycle timeouts.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
