### PR TITLE
chore(ha): disable unused autopilot dead-server cleanup

### DIFF
--- a/internal/raft/autopilot.go
+++ b/internal/raft/autopilot.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/ellanetworks/core/internal/logger"
@@ -18,7 +17,14 @@ import (
 )
 
 const (
-	defaultCleanupDeadServers      = true
+	// defaultCleanupDeadServers is false: cluster membership is
+	// operator-driven, through the drain and remove endpoints in
+	// internal/api/server/api_cluster.go. A node evicted without an
+	// operator asking has no way back — it has Raft state, so it never
+	// re-runs discovery (Manager.discoveryPending) — and this deployment
+	// has no membership gossip that would put it back.
+	defaultCleanupDeadServers = false
+
 	defaultLastContactThreshold    = 10 * time.Second
 	defaultMaxTrailingLogs         = uint64(500)
 	defaultServerStabilizationTime = 10 * time.Second
@@ -28,20 +34,10 @@ const (
 // Raft configuration, with per-peer liveness supplied by the follower
 // tracker.
 type autopilotDelegate struct {
-	manager          *Manager
-	mu               sync.Mutex
-	inflightRemovals map[raft.ServerID]bool
+	manager *Manager
 }
 
 func (d *autopilotDelegate) AutopilotConfig() *autopilot.Config {
-	// Derive the floor on cluster size from the configured peers list
-	// (ceil(N/2)). Autopilot refuses to auto-remove dead servers below
-	// this count, protecting against quorum loss from over-eager cleanup.
-	minQuorum := uint((len(d.manager.config.Peers) + 1) / 2)
-	if minQuorum < 1 {
-		minQuorum = 1
-	}
-
 	lastContact := defaultLastContactThreshold
 	if d.manager.config.Autopilot.LastContactThreshold > 0 {
 		lastContact = d.manager.config.Autopilot.LastContactThreshold
@@ -56,7 +52,6 @@ func (d *autopilotDelegate) AutopilotConfig() *autopilot.Config {
 		CleanupDeadServers:      defaultCleanupDeadServers,
 		LastContactThreshold:    lastContact,
 		MaxTrailingLogs:         defaultMaxTrailingLogs,
-		MinQuorum:               minQuorum,
 		ServerStabilizationTime: stabilization,
 	}
 }
@@ -149,34 +144,14 @@ func (d *autopilotDelegate) KnownServers() map[raft.ServerID]*autopilot.Server {
 	return servers
 }
 
+// RemoveFailedServer satisfies autopilot.ApplicationIntegration.
+// pruneDeadServers returns before reaching it while CleanupDeadServers is
+// false, so a call here means the configuration and this delegate disagree.
 func (d *autopilotDelegate) RemoveFailedServer(srv *autopilot.Server) {
-	d.mu.Lock()
-	if d.inflightRemovals[srv.ID] {
-		d.mu.Unlock()
-		return
-	}
-
-	d.inflightRemovals[srv.ID] = true
-	d.mu.Unlock()
-
-	go func() {
-		logger.RaftLog.Info("Autopilot: removing failed server",
-			zap.String("id", string(srv.ID)),
-			zap.String("address", string(srv.Address)),
-		)
-
-		future := d.manager.raft.RemoveServer(srv.ID, 0, 0)
-		if err := future.Error(); err != nil {
-			logger.RaftLog.Error("Autopilot: failed to remove server",
-				zap.String("id", string(srv.ID)),
-				zap.Error(err),
-			)
-		}
-
-		d.mu.Lock()
-		delete(d.inflightRemovals, srv.ID)
-		d.mu.Unlock()
-	}()
+	logger.RaftLog.Warn("Autopilot asked to remove a failed server; membership changes are operator-driven",
+		zap.String("id", string(srv.ID)),
+		zap.String("address", string(srv.Address)),
+	)
 }
 
 func parseRaftStats(stats map[string]string) *autopilot.ServerStats {
@@ -207,10 +182,7 @@ type autopilotRunner struct {
 }
 
 func newAutopilotRunner(r *raft.Raft, m *Manager) *autopilotRunner {
-	delegate := &autopilotDelegate{
-		manager:          m,
-		inflightRemovals: make(map[raft.ServerID]bool),
-	}
+	delegate := &autopilotDelegate{manager: m}
 
 	opts := []autopilot.Option{
 		autopilot.WithLogger(hclog.NewNullLogger()),

--- a/internal/raft/autopilot.go
+++ b/internal/raft/autopilot.go
@@ -17,14 +17,7 @@ import (
 )
 
 const (
-	// defaultCleanupDeadServers is false: cluster membership is
-	// operator-driven, through the drain and remove endpoints in
-	// internal/api/server/api_cluster.go. A node evicted without an
-	// operator asking has no way back — it has Raft state, so it never
-	// re-runs discovery (Manager.discoveryPending) — and this deployment
-	// has no membership gossip that would put it back.
-	defaultCleanupDeadServers = false
-
+	defaultCleanupDeadServers      = false
 	defaultLastContactThreshold    = 10 * time.Second
 	defaultMaxTrailingLogs         = uint64(500)
 	defaultServerStabilizationTime = 10 * time.Second
@@ -144,9 +137,6 @@ func (d *autopilotDelegate) KnownServers() map[raft.ServerID]*autopilot.Server {
 	return servers
 }
 
-// RemoveFailedServer satisfies autopilot.ApplicationIntegration.
-// pruneDeadServers returns before reaching it while CleanupDeadServers is
-// false, so a call here means the configuration and this delegate disagree.
 func (d *autopilotDelegate) RemoveFailedServer(srv *autopilot.Server) {
 	logger.RaftLog.Warn("Autopilot asked to remove a failed server; membership changes are operator-driven",
 		zap.String("id", string(srv.ID)),


### PR DESCRIPTION
# Description

Disable unused autopilot dead-server cleanup.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
