### PR TITLE
perf: read DB config once per signaling event

### DIFF
--- a/internal/amf/config.go
+++ b/internal/amf/config.go
@@ -38,6 +38,32 @@ func (amf *AMF) OperatorInfo(ctx context.Context) (*OperatorInfo, error) {
 	return amf.operatorInfoFrom(operator)
 }
 
+type OperatorConfig struct {
+	op   *db.Operator
+	info *OperatorInfo
+}
+
+func (amf *AMF) Operator(ctx context.Context) (OperatorConfig, error) {
+	ctx, span := tracer.Start(ctx, "amf/get_operator")
+	defer span.End()
+
+	operator, err := amf.DBInstance.GetOperator(ctx)
+	if err != nil {
+		return OperatorConfig{}, fmt.Errorf("failed to get operator: %w", err)
+	}
+
+	info, err := amf.operatorInfoFrom(operator)
+	if err != nil {
+		return OperatorConfig{}, err
+	}
+
+	return OperatorConfig{op: operator, info: info}, nil
+}
+
+func (o OperatorConfig) Info() *OperatorInfo {
+	return o.info
+}
+
 func (amf *AMF) operatorInfoFrom(operator *db.Operator) (*OperatorInfo, error) {
 	supportedTAIs, err := getSupportedTAIs(operator)
 	if err != nil {

--- a/internal/amf/nas/handle_registration_complete.go
+++ b/internal/amf/nas/handle_registration_complete.go
@@ -33,7 +33,12 @@ func handleRegistrationComplete(ctx context.Context, amfInstance *amf.AMF, ue *a
 	amfInstance.CommitGUTIRealloc(ue)
 
 	// Configuration update command delivers the operator network name (TS 24.501).
-	amf.SendConfigurationUpdateCommand(ctx, amfInstance, ue, false)
+	operator, err := amfInstance.Operator(ctx)
+	if err != nil {
+		logger.From(ctx, logger.AmfLog).Error("cannot SendConfigurationUpdateCommand: failed to get operator", zap.Error(err))
+	} else {
+		amf.SendConfigurationUpdateCommand(ctx, amfInstance, ue, false, operator)
+	}
 
 	forPending := conn.RegistrationRequest.FOR
 

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -269,11 +269,13 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		return nasreply.Handled()
 	}
 
-	operatorInfo, err := amfInstance.OperatorInfo(ctx)
+	operator, err := amfInstance.Operator(ctx)
 	if err != nil {
 		logger.From(ctx, logger.AmfLog).Warn("error getting operator info", zap.Error(err))
 		return nasreply.Silent(nasreply.ReasonUnspecified)
 	}
+
+	operatorInfo := operator.Info()
 
 	initialContextSetup := ueConn.UeContextRequest && ueConn.ClaimICS()
 
@@ -413,7 +415,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 			return nasreply.Handled()
 		}
 
-		amf.SendConfigurationUpdateCommand(ctx, amfInstance, ue, true)
+		amf.SendConfigurationUpdateCommand(ctx, amfInstance, ue, true, operator)
 	} else if err := accept(nil); err != nil {
 		return nasreply.Handled()
 	}

--- a/internal/amf/nas/handle_service_request_test.go
+++ b/internal/amf/nas/handle_service_request_test.go
@@ -4,8 +4,10 @@
 package nas
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -495,6 +497,87 @@ func TestHandleServiceRequest_NASContainerServiceTypeData_ServiceAccept(t *testi
 
 	if ue.Conn().NASGuardForTest().Active() {
 		t.Fatalf("expected timer T3565 to be stopped and cleared")
+	}
+}
+
+type countingDBInstance struct {
+	*fakeDBInstance
+	operatorReads atomic.Int64
+}
+
+func (c *countingDBInstance) GetOperator(ctx context.Context) (*db.Operator, error) {
+	c.operatorReads.Add(1)
+
+	return c.fakeDBInstance.GetOperator(ctx)
+}
+
+func TestHandleServiceRequestMTReadsOperatorOnce(t *testing.T) {
+	dbInstance := &countingDBInstance{fakeDBInstance: &fakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}}
+
+	amfInstance := amf.New(
+		dbInstance,
+		&fakeAusf{
+			AvKgAka: &ausf.AuthResult{
+				Rand: hex.EncodeToString(make([]byte, 16)),
+				Autn: hex.EncodeToString(make([]byte, 16)),
+			},
+			Supi:  mustSUPIFromPrefixed("imsi-001019756139935"),
+			Kseaf: []byte("testkey"),
+		},
+		&fakeSmf{},
+	)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not build UE and radio: %v", err)
+	}
+
+	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
+
+	ue.ArmPagingForTest(6*time.Minute, 5)
+
+	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
+	ue.ForceStateForTest(amf.Registered)
+	ue.SetGutiForTest(oldguti)
+	ue.Tai = ue.Conn().Tai
+	ue.SetSecuredForTest(true)
+	{
+		ng := ue.NgKsiForTest()
+		ng.Ksi = 1
+		ue.SetNgKsiForTest(ng)
+	}
+
+	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
+	algo := nas.CipheringAES
+
+	ue.SetKnasEncForTest(key)
+	ue.SetKnasIntForTest(key)
+	ue.SetCipheringAlgForTest(algo)
+	ue.SetIntegrityAlgForTest(nas.IntegrityNull)
+
+	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), fgs.ServiceTypeMobileTerminatedServices)
+	if err != nil {
+		t.Fatalf("could not build service request: %v", err)
+	}
+
+	handleServiceRequest(t.Context(), amfInstance, ue, encSR(t, m), true)
+
+	if len(ngapSender.SentDownlinkNASTransport) < 2 {
+		t.Fatalf("expected a Service Accept and a Configuration Update Command, got %d downlinks", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	if ue.TmsiForTest() == oldguti.Tmsi {
+		t.Fatal("expected new GUTI to be allocated")
+	}
+
+	if got := dbInstance.operatorReads.Load(); got != 1 {
+		t.Fatalf("the mobile-terminated service request read the operator row %d times, want 1", got)
 	}
 }
 

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -462,7 +462,7 @@ func ResendRegistrationAccept(ctx context.Context, amfInstance *AMF, ue *UeConte
 	ArmRegistrationAcceptGuard(amfInstance, ue, plain)
 }
 
-func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe *UeContext, includeGUTI bool) {
+func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe *UeContext, includeGUTI bool, operator OperatorConfig) {
 	if amfUe == nil {
 		return
 	}
@@ -481,19 +481,7 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 		return
 	}
 
-	operator, err := amfInstance.DBInstance.GetOperator(ctx)
-	if err != nil {
-		logger.From(ctx, logger.AmfLog).Error("cannot SendConfigurationUpdateCommand: failed to get operator", zap.Error(err))
-		return
-	}
-
-	operatorInfo, err := amfInstance.operatorInfoFrom(operator)
-	if err != nil {
-		logger.From(ctx, logger.AmfLog).Error("cannot SendConfigurationUpdateCommand: failed to get operator info", zap.Error(err))
-		return
-	}
-
-	guti, err := amfInstance.Guti(operatorInfo.Guami, amfUe)
+	guti, err := amfInstance.Guti(operator.Info().Guami, amfUe)
 	if err != nil {
 		logger.From(ctx, logger.AmfLog).Error("cannot SendConfigurationUpdateCommand: failed to build 5G-GUTI", zap.Error(err))
 		return
@@ -507,7 +495,7 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 		networkTime = &built
 	}
 
-	plain, err := BuildConfigurationUpdateCommand(guti, operator.SpnFullName, operator.SpnShortName, networkTime, includeGUTI)
+	plain, err := BuildConfigurationUpdateCommand(guti, operator.op.SpnFullName, operator.op.SpnShortName, networkTime, includeGUTI)
 	if err != nil {
 		logger.From(ctx, logger.AmfLog).Error("error building ConfigurationUpdateCommand", zap.Error(err))
 

--- a/internal/mme/apn_selection_test.go
+++ b/internal/mme/apn_selection_test.go
@@ -6,8 +6,51 @@ package mme
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/udm"
 )
+
+type countingBearerStore struct {
+	fakeBearerStore
+	dataNetworkReads atomic.Int64
+}
+
+func (s *countingBearerStore) GetDataNetworkByID(ctx context.Context, id string) (*db.DataNetwork, error) {
+	s.dataNetworkReads.Add(1)
+
+	return s.fakeBearerStore.GetDataNetworkByID(ctx, id)
+}
+
+func TestResolveQoSByAPNReadsDataNetworkOnce(t *testing.T) {
+	for _, tc := range []struct {
+		apn      string
+		examined int64
+	}{
+		{apn: "internet", examined: 1},
+		{apn: "ims", examined: 2},
+	} {
+		t.Run(tc.apn, func(t *testing.T) {
+			store := &countingBearerStore{}
+			m := New(udm.New(newFakeCredStore(), noopKeyResolver), store, &fakeSessionManager{})
+
+			qos, err := ResolveQoSByAPN(context.Background(), m, testSubscriber.IMSI, tc.apn)
+			if err != nil {
+				t.Fatalf("ResolveQoSByAPN: %v", err)
+			}
+
+			if qos.APN != tc.apn {
+				t.Fatalf("APN = %q, want %q", qos.APN, tc.apn)
+			}
+
+			if got := store.dataNetworkReads.Load(); got != tc.examined {
+				t.Fatalf("read the data network %d times, want %d", got, tc.examined)
+			}
+		})
+	}
+}
 
 // TestResolveAttachQoSDefaultWhenNoAPN: with no requested APN the attach uses the
 // subscriber's default policy (TS 24.301 §6.5.1.3).

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -70,10 +70,9 @@ type fakeSessionManager struct {
 	ambrUplink      models.BitRate // records the last UpdateEPSSessionAMBR uplink value
 	ambrDownlink    models.BitRate
 	ambrErr         error // when set, UpdateEPSSessionAMBR fails with it
-	framedChanged   bool  // FramedRoutesChanged returns this
-	framedErr       error // when set, FramedRoutesChanged fails with it
-	staticIPChanged bool  // StaticIPChanged returns this
-	staticIPErr     error // when set, StaticIPChanged fails with it
+	framedChanged   bool  // EPSSubscriptionChanged reports this framed-route delta
+	staticIPChanged bool  // EPSSubscriptionChanged reports this static-IP delta
+	subscriptionErr error // when set, EPSSubscriptionChanged fails with it
 
 	suppressCalls         int // counts HandleEPSPagingFailure calls
 	clearSuppressionCalls int // counts ClearEPSPagingSuppression calls
@@ -172,12 +171,12 @@ func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) erro
 	return nil
 }
 
-func (f *fakeSessionManager) FramedRoutesChanged(_ context.Context, _ string) (bool, error) {
-	return f.framedChanged, f.framedErr
-}
+func (f *fakeSessionManager) EPSSubscriptionChanged(_ context.Context, _ string) (models.SubscriptionDelta, error) {
+	if f.subscriptionErr != nil {
+		return models.SubscriptionDelta{}, f.subscriptionErr
+	}
 
-func (f *fakeSessionManager) StaticIPChanged(_ context.Context, _ string) (bool, error) {
-	return f.staticIPChanged, f.staticIPErr
+	return models.SubscriptionDelta{FramedRoutes: f.framedChanged, StaticIP: f.staticIPChanged}, nil
 }
 
 // fakeBearerStore resolves a fixed default-bearer QoS (QCI 9, APN "internet",

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -38,8 +38,7 @@ type epsSessionManager interface {
 	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error
 	ClearEPSPagingSuppression(ctx context.Context, imsi string, ebi uint8) error
 	ReleaseEPSSession(ctx context.Context, ref string) error
-	FramedRoutesChanged(ctx context.Context, ref string) (bool, error)
-	StaticIPChanged(ctx context.Context, ref string) (bool, error)
+	EPSSubscriptionChanged(ctx context.Context, ref string) (models.SubscriptionDelta, error)
 }
 
 type credentialProvider interface {

--- a/internal/mme/nas/authentication.go
+++ b/internal/mme/nas/authentication.go
@@ -11,16 +11,25 @@ import (
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
 	"go.uber.org/zap"
 )
 
 func authenticateOrReject(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn) {
-	startAuthentication(ctx, m, ue, ueConn)
+	plmn, err := m.OperatorPLMN(ctx)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Info("attach rejected: cannot authenticate subscriber", zap.String("imsi", ue.IMSI()), zap.Error(err))
+		rejectAttach(ctx, m, ue, ueConn, authRejectCause(err))
+
+		return
+	}
+
+	startAuthentication(ctx, m, ue, ueConn, plmn)
 }
 
-func startAuthentication(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn) {
+func startAuthentication(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, servingPLMN models.PlmnID) {
 	// resyncTried scopes to one authentication exchange's consecutive synch
 	// failures, so a fresh procedure starts with a full budget (TS 24.301 §5.4.2.7).
 	ueConn.SetResyncTried(false)
@@ -29,7 +38,7 @@ func startAuthentication(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 	// its current context usable until the new one is taken into use (TS 24.301 §5.4.2.4).
 	ue.SetEksi(nas.KeySetIdentifier{Value: mme.NextEksi(ue.Eksi().Value)})
 
-	if err := sendAuthRequest(ctx, m, ue, ueConn, "", ""); err != nil {
+	if err := sendAuthRequest(ctx, m, ue, ueConn, servingPLMN, "", ""); err != nil {
 		logger.From(ctx, logger.MmeLog).Info("attach rejected: cannot authenticate subscriber", zap.String("imsi", ue.IMSI()), zap.Error(err))
 		rejectAttach(ctx, m, ue, ueConn, authRejectCause(err))
 	}
@@ -47,13 +56,8 @@ func authRejectCause(err error) eps.EMMCause {
 
 // sendAuthRequest sends an AUTHENTICATION REQUEST; a set resync pair drives an
 // AUTS re-synchronisation.
-func sendAuthRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, resyncAuts, resyncRand string) error {
-	op, err := m.OperatorPLMN(ctx)
-	if err != nil {
-		return err
-	}
-
-	plmn, err := mme.EncodePLMN(op)
+func sendAuthRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, servingPLMN models.PlmnID, resyncAuts, resyncRand string) error {
+	plmn, err := mme.EncodePLMN(servingPLMN)
 	if err != nil {
 		return fmt.Errorf("encode serving PLMN: %w", err)
 	}

--- a/internal/mme/nas/emm_test.go
+++ b/internal/mme/nas/emm_test.go
@@ -1069,3 +1069,41 @@ func TestAuthenticationSuccessMakesTheMMEServeTheUE(t *testing.T) {
 		t.Error("the MME does not serve a UE it has just authenticated, so no attach accept can be built for it")
 	}
 }
+
+func TestAttachReadsOperatorOnce(t *testing.T) {
+	m, store := newCountingMME(t)
+	cc := &captureConn{}
+	ue := newAttachUe(m, cc, 7)
+
+	esm, err := (&eps.PDNConnectivityRequest{PTI: 1, RequestType: 1, PDNType: 1}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attach := &eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		NASKeySetIdentifier: nas.KeySetIdentifier{Value: 7},
+		EPSMobileIdentity:   eps.IMSIIdentity(eps.IMSI(testSubscriber.IMSI)),
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70},
+		ESMMessageContainer: esm,
+	}
+
+	b, err := attach.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	HandleNAS(context.Background(), m, ue.Conn(), b)
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected one downlink (Authentication Request), got %d", len(cc.sent))
+	}
+
+	if mt, err := eps.PeekMessageType(decodeDownlinkNAS(t, cc.sent[0])); err != nil || mt != eps.MsgAuthenticationRequest {
+		t.Fatalf("expected Authentication Request, got mt=%#x err=%v", mt, err)
+	}
+
+	if got := store.reads.Load(); got != 1 {
+		t.Fatalf("attach read the operator row %d times, want 1", got)
+	}
+}

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ellanetworks/core/etsi"
@@ -169,12 +170,8 @@ func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, _ string) erro
 	return nil
 }
 
-func (f *fakeSessionManager) FramedRoutesChanged(_ context.Context, _ string) (bool, error) {
-	return false, nil
-}
-
-func (f *fakeSessionManager) StaticIPChanged(_ context.Context, _ string) (bool, error) {
-	return false, nil
+func (f *fakeSessionManager) EPSSubscriptionChanged(_ context.Context, _ string) (models.SubscriptionDelta, error) {
+	return models.SubscriptionDelta{}, nil
 }
 
 // fakeBearerStore resolves a fixed default-bearer QoS for any subscriber.
@@ -294,6 +291,27 @@ func newTestMME(t *testing.T) *mme.MME {
 	m.NAS = &nasHandler{m: m}
 
 	return m
+}
+
+type countingBearerStore struct {
+	fakeBearerStore
+	reads atomic.Int64
+}
+
+func (s *countingBearerStore) GetOperator(ctx context.Context) (*db.Operator, error) {
+	s.reads.Add(1)
+
+	return s.fakeBearerStore.GetOperator(ctx)
+}
+
+func newCountingMME(t *testing.T) (*mme.MME, *countingBearerStore) {
+	t.Helper()
+
+	store := &countingBearerStore{}
+	m := mme.New(udm.New(newFakeCredStore(), noopKeyResolver), store, &fakeSessionManager{})
+	m.NAS = &nasHandler{m: m}
+
+	return m, store
 }
 
 // nasHandler implements mme.NASHandler over the in-package handlers, so the

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -54,9 +54,15 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 		}
 	}
 
+	operator, err := m.Operator(ctx)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to read the operator configuration for attach", zap.Error(err))
+		return nasreply.Handled()
+	}
+
 	// The UE's serving cell must be in this MME's served area, or ATTACH REJECT #12
 	// (ServesTAI, TS 24.301 §5.5.1.2.5).
-	if served, err := m.ServesTAI(ctx, ueConn.ServingTAI); err != nil {
+	if served, err := operator.ServesTAI(ueConn.ServingTAI); err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to evaluate serving TAI for attach", zap.Error(err))
 		return nasreply.Handled()
 	} else if !served {
@@ -97,7 +103,7 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 
 	if imsi := req.EPSMobileIdentity.IMSI; imsi != nil {
 		m.SetIMSI(ue, string(*imsi))
-		authenticateOrReject(ctx, m, ue, ueConn)
+		startAuthentication(ctx, m, ue, ueConn, operator.PLMN())
 
 		return nasreply.Handled()
 	}

--- a/internal/mme/nas/handle_authentication_failure.go
+++ b/internal/mme/nas/handle_authentication_failure.go
@@ -56,7 +56,15 @@ func handleAuthenticationFailure(ctx context.Context, m *mme.MME, ue *mme.UeCont
 
 		logger.From(ctx, logger.MmeLog).Info("re-synchronising SQN, re-authenticating")
 
-		if err := sendAuthRequest(ctx, m, ue, ueConn, hex.EncodeToString(fail.AUTS), hex.EncodeToString(c.AuthVector.RAND[:])); err != nil {
+		plmn, err := m.OperatorPLMN(ctx)
+		if err != nil {
+			logger.From(ctx, logger.MmeLog).Warn("SQN re-synchronisation failed", zap.Error(err))
+			rejectAuthentication(ctx, m, ue, ueConn)
+
+			return nasreply.Handled()
+		}
+
+		if err := sendAuthRequest(ctx, m, ue, ueConn, plmn, hex.EncodeToString(fail.AUTS), hex.EncodeToString(c.AuthVector.RAND[:])); err != nil {
 			logger.From(ctx, logger.MmeLog).Warn("SQN re-synchronisation failed", zap.Error(err))
 			rejectAuthentication(ctx, m, ue, ueConn)
 		}

--- a/internal/mme/nas/handle_authentication_failure_test.go
+++ b/internal/mme/nas/handle_authentication_failure_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas/eps"
 )
@@ -72,7 +73,7 @@ func TestFreshAuthenticationResetsResyncBudget(t *testing.T) {
 	// A prior authentication exchange already spent its resync.
 	ue.Conn().SetResyncTried(true)
 
-	startAuthentication(context.Background(), m, ue, ue.Conn())
+	startAuthentication(context.Background(), m, ue, ue.Conn(), models.PlmnID{Mcc: "001", Mnc: "01"})
 
 	if ue.Conn().ResyncTried() {
 		t.Fatal("startAuthentication must reset resyncTried for a fresh authentication")

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -31,7 +31,13 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	if served, err := m.ServesTAI(ctx, ueConn.ServingTAI); err != nil {
+	operator, err := m.Operator(ctx)
+	if err != nil {
+		logger.From(ctx, logger.MmeLog).Error("failed to read the operator configuration for Tracking Area Update", zap.Error(err))
+		return nasreply.Handled()
+	}
+
+	if served, err := operator.ServesTAI(ueConn.ServingTAI); err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to evaluate serving TAI for Tracking Area Update", zap.Error(err))
 		return nasreply.Handled()
 	} else if !served {
@@ -83,7 +89,7 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	accept, err := buildTrackingAreaUpdateAccept(ctx, m, ue, tauAcceptOptions{
+	accept, err := buildTrackingAreaUpdateAccept(ctx, m, ue, operator, tauAcceptOptions{
 		combined: isCombinedUpdate(uint8(req.EPSUpdateType)),
 		bearerStatus: (req.EPSBearerContextStatus != nil || ue.LocalBearerDeactivationPending()) &&
 			len(m.SnapshotPDNs(ue)) > 0,
@@ -236,14 +242,9 @@ type tauAcceptOptions struct {
 // current TAI list and a reallocated GUTI (TS 24.301). A combined update includes
 // EMM cause #18, since the MME has no SGs interface, to stop the UE attempting CS
 // registration.
-func buildTrackingAreaUpdateAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext, opts tauAcceptOptions) (*eps.TrackingAreaUpdateAccept, error) {
+func buildTrackingAreaUpdateAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext, operator mme.OperatorConfig, opts tauAcceptOptions) (*eps.TrackingAreaUpdateAccept, error) {
 	if !m.ServesUeContext(ue) {
 		return nil, fmt.Errorf("refusing to build tracking area update accept: UE context is not indexed by IMSI")
-	}
-
-	operator, err := m.Operator(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	plmn := operator.PLMN()

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -704,3 +704,18 @@ func TestTrackingAreaUpdateRejectedWhen4GNotAllowed(t *testing.T) {
 		t.Fatalf("TAU Reject cause = %d, want %d (EPS services not allowed)", rej.Cause, eps.EMMCauseEPSServicesNotAllowed)
 	}
 }
+
+func TestTrackingAreaUpdateReadsOperatorOnce(t *testing.T) {
+	m, store := newCountingMME(t)
+	ue, cc := securedUE(t, m)
+
+	HandleNAS(context.Background(), m, ue.Conn(), trackingAreaUpdateNAS(t, ue, nil))
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected one downlink (TAU Accept), got %d", len(cc.sent))
+	}
+
+	if got := store.reads.Load(); got != 1 {
+		t.Fatalf("tracking area update read the operator row %d times, want 1", got)
+	}
+}

--- a/internal/mme/qos.go
+++ b/internal/mme/qos.go
@@ -90,7 +90,7 @@ func ResolveQoSByAPN(ctx context.Context, m *MME, imsi, apn string) (*EpsQoS, er
 		}
 
 		if dn.Name == apn {
-			return qosForPolicy(ctx, m, profile, &policies[i])
+			return qosForResolvedPolicy(ctx, m, profile, &policies[i], dn)
 		}
 	}
 
@@ -103,6 +103,10 @@ func qosForPolicy(ctx context.Context, m *MME, profile *db.Profile, pol *db.Poli
 		return nil, fmt.Errorf("get data network: %w", err)
 	}
 
+	return qosForResolvedPolicy(ctx, m, profile, pol, dn)
+}
+
+func qosForResolvedPolicy(ctx context.Context, m *MME, profile *db.Profile, pol *db.Policy, dn *db.DataNetwork) (*EpsQoS, error) {
 	snssai, err := snssaiForPolicy(ctx, m, pol)
 	if err != nil {
 		return nil, err

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -78,18 +78,18 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, ueConn *UeConn
 		return
 	}
 
-	// A framed-route change cannot be adopted in place: TS 23.501 §5.6.14 requires
-	// re-establishment. Checked before the QoS diff so a framed-only change still
-	// reactivates (framed routes are absent from the data-network fingerprint).
-	framedChanged, err := m.Session.FramedRoutesChanged(ctx, p.SessionRef)
+	delta, err := m.Session.EPSSubscriptionChanged(ctx, p.SessionRef)
 	if err != nil {
-		logger.From(ctx, logger.MmeLog).Warn("reconcile: failed to check framed routes; deferring to next sweep",
+		logger.From(ctx, logger.MmeLog).Warn("reconcile: failed to check the subscription; deferring to next sweep",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn), zap.Error(err))
 
 		return
 	}
 
-	if framedChanged {
+	// A framed-route change cannot be adopted in place: TS 23.501 §5.6.14 requires
+	// re-establishment. Checked before the QoS diff so a framed-only change still
+	// reactivates (framed routes are absent from the data-network fingerprint).
+	if delta.FramedRoutes {
 		logger.From(ctx, ueConn.Log).Info("framed routes changed; reactivating EPS bearer",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
 		m.reactivateBearer(ctx, ue, p)
@@ -99,15 +99,7 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, ueConn *UeConn
 
 	// The UE IP is fixed for the PDN connection lifetime (TS 23.401 §5.3.1.2.1);
 	// a reservation change requires reactivation, not in-place modification.
-	staticChanged, err := m.Session.StaticIPChanged(ctx, p.SessionRef)
-	if err != nil {
-		logger.From(ctx, logger.MmeLog).Warn("reconcile: failed to check static IP; deferring to next sweep",
-			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn), zap.Error(err))
-
-		return
-	}
-
-	if staticChanged {
+	if delta.StaticIP {
 		logger.From(ctx, ueConn.Log).Info("static IP changed; reactivating EPS bearer",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
 		m.reactivateBearer(ctx, ue, p)

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -186,12 +186,8 @@ func (f *fakeSessionManager) ReleaseEPSSession(_ context.Context, ref string) er
 	return nil
 }
 
-func (f *fakeSessionManager) FramedRoutesChanged(_ context.Context, _ string) (bool, error) {
-	return false, nil
-}
-
-func (f *fakeSessionManager) StaticIPChanged(_ context.Context, _ string) (bool, error) {
-	return false, nil
+func (f *fakeSessionManager) EPSSubscriptionChanged(_ context.Context, _ string) (models.SubscriptionDelta, error) {
+	return models.SubscriptionDelta{}, nil
 }
 
 // fakeBearerStore resolves a fixed default-bearer QoS for any subscriber.

--- a/internal/models/session_reconcile.go
+++ b/internal/models/session_reconcile.go
@@ -29,6 +29,11 @@ type SessionReconcileRequest struct {
 	Reason       SessionReconcileReason
 }
 
+type SubscriptionDelta struct {
+	FramedRoutes bool
+	StaticIP     bool
+}
+
 // SessionPolicyDelta holds the policy fields that affect an active session.
 type SessionPolicyDelta struct {
 	SessionAmbrUplink   string // e.g. "100 Mbps"

--- a/internal/smf/eps.go
+++ b/internal/smf/eps.go
@@ -255,24 +255,16 @@ func (s *SMF) dropHalf(ref string, by AccessType) bool {
 	return true
 }
 
-func (s *SMF) FramedRoutesChanged(ctx context.Context, ref string) (bool, error) {
-	return s.epsSubscriptionChanged(ctx, ref, s.framedRoutesChanged)
-}
-
-func (s *SMF) StaticIPChanged(ctx context.Context, ref string) (bool, error) {
-	return s.epsSubscriptionChanged(ctx, ref, s.staticIPChanged)
-}
-
-func (s *SMF) epsSubscriptionChanged(ctx context.Context, ref string, changed func(context.Context, *SMContext) (bool, error)) (bool, error) {
+func (s *SMF) EPSSubscriptionChanged(ctx context.Context, ref string) (models.SubscriptionDelta, error) {
 	smContext := s.GetSession(ref)
 	if smContext == nil {
-		return false, nil
+		return models.SubscriptionDelta{}, nil
 	}
 
 	smContext.Mutex.Lock()
 	defer smContext.Mutex.Unlock()
 
-	return changed(ctx, smContext)
+	return s.subscriptionChanged(ctx, smContext)
 }
 
 func (s *SMF) DeactivateEPSSession(ctx context.Context, ref string) error {

--- a/internal/smf/framed_routes_test.go
+++ b/internal/smf/framed_routes_test.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"net/netip"
 	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/smf"
 )
 
 func framedTestPrefixes(t *testing.T, cidrs ...string) []netip.Prefix {
@@ -73,7 +76,7 @@ func TestFramedRoutesChanged(t *testing.T) {
 
 	store.framedRoutes = framedTestPrefixes(t, "192.168.11.0/24", "192.168.10.0/24")
 
-	changed, err := s.FramedRoutesChanged(context.Background(), bearer.Ref)
+	changed, err := framedRoutesChanged(s, bearer.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +87,7 @@ func TestFramedRoutesChanged(t *testing.T) {
 
 	store.framedRoutes = framedTestPrefixes(t, "192.168.10.0/24")
 
-	changed, err = s.FramedRoutesChanged(context.Background(), bearer.Ref)
+	changed, err = framedRoutesChanged(s, bearer.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,12 +96,46 @@ func TestFramedRoutesChanged(t *testing.T) {
 		t.Fatal("a changed framed-route set was not detected")
 	}
 
-	changed, err = s.FramedRoutesChanged(context.Background(), "no-such-session")
+	changed, err = framedRoutesChanged(s, "no-such-session")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if changed {
 		t.Fatal("unknown session reported a framed-route change")
+	}
+}
+
+func framedRoutesChanged(s *smf.SMF, ref string) (bool, error) {
+	delta, err := s.EPSSubscriptionChanged(context.Background(), ref)
+
+	return delta.FramedRoutes, err
+}
+
+func TestEPSSubscriptionChangedResolvesDNNOnce(t *testing.T) {
+	store, upf := epsTestSMF()
+	store.framedRoutes = framedTestPrefixes(t, "192.168.10.0/24")
+	store.staticIPv4 = store.allocatedIP
+
+	s := newTestSMF(&fakePCF{}, store, upf, &fakeAMF{})
+
+	bearer, err := s.CreateEPSSession(context.Background(), epsRequest(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := store.dnnResolves()
+
+	delta, err := s.EPSSubscriptionChanged(context.Background(), bearer.Ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if delta != (models.SubscriptionDelta{}) {
+		t.Fatalf("subscription delta = %+v, want no change", delta)
+	}
+
+	if got := store.dnnResolves() - before; got != 1 {
+		t.Fatalf("the subscription check resolved the data network %d times, want 1", got)
 	}
 }

--- a/internal/smf/reconcile.go
+++ b/internal/smf/reconcile.go
@@ -133,13 +133,9 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 		}
 	}
 
-	// A framed-route change cannot be applied in place: TS 23.501 §5.6.14 requires
-	// the SMF to release the PDU session (framed routes are provisioned in the
-	// session's downlink PDRs) so the UE re-establishes with the new routes.
-	// Checked before the in-place QoS/AMBR path so a framed-only change releases.
-	framedChanged, err := s.framedRoutesChanged(ctx, smContext)
+	delta, err := s.subscriptionChanged(ctx, smContext)
 	if err != nil {
-		logger.SmfLog.Warn("failed to resolve framed routes during reconciliation; deferring to backstop",
+		logger.SmfLog.Warn("failed to evaluate the subscription during reconciliation; deferring to backstop",
 			logger.SUPI(smContext.Supi.String()),
 			logger.PDUSessionID(smContext.PDUSessionID),
 			zap.Error(err),
@@ -148,7 +144,11 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 		return nil
 	}
 
-	if framedChanged {
+	// A framed-route change cannot be applied in place: TS 23.501 §5.6.14 requires
+	// the SMF to release the PDU session (framed routes are provisioned in the
+	// session's downlink PDRs) so the UE re-establishes with the new routes.
+	// Checked before the in-place QoS/AMBR path so a framed-only change releases.
+	if delta.FramedRoutes {
 		logger.SmfLog.Info("framed routes changed, releasing session for re-establishment",
 			logger.SUPI(smContext.Supi.String()),
 			logger.PDUSessionID(smContext.PDUSessionID),
@@ -159,18 +159,7 @@ func (s *SMF) ReconcileSmContext(ctx context.Context, req *models.SessionReconci
 
 	// The UE IP is fixed for the session lifetime (TS 23.501 §5.8.2.2); a
 	// reservation change requires release, not in-place modification.
-	staticChanged, err := s.staticIPChanged(ctx, smContext)
-	if err != nil {
-		logger.SmfLog.Warn("failed to resolve static IP during reconciliation; deferring to backstop",
-			logger.SUPI(smContext.Supi.String()),
-			logger.PDUSessionID(smContext.PDUSessionID),
-			zap.Error(err),
-		)
-
-		return nil
-	}
-
-	if staticChanged {
+	if delta.StaticIP {
 		logger.SmfLog.Info("static IP changed, releasing session for re-establishment",
 			logger.SUPI(smContext.Supi.String()),
 			logger.PDUSessionID(smContext.PDUSessionID),
@@ -440,15 +429,33 @@ func (s *SMF) applySessionQERs(ctx context.Context, smContext *SMContext, policy
 	return s.applyDataPlane(ctx, smContext, next, policyID)
 }
 
+func (s *SMF) subscriptionChanged(ctx context.Context, smContext *SMContext) (models.SubscriptionDelta, error) {
+	dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
+	if err != nil {
+		return models.SubscriptionDelta{}, fmt.Errorf("resolve data network: %w", err)
+	}
+
+	framed, err := framedRoutesChanged(ctx, dn, smContext)
+	if err != nil {
+		return models.SubscriptionDelta{}, fmt.Errorf("framed routes: %w", err)
+	}
+
+	if framed {
+		return models.SubscriptionDelta{FramedRoutes: true}, nil
+	}
+
+	static, err := staticIPChanged(ctx, dn, smContext)
+	if err != nil {
+		return models.SubscriptionDelta{}, fmt.Errorf("static IP: %w", err)
+	}
+
+	return models.SubscriptionDelta{StaticIP: static}, nil
+}
+
 // framedRoutesChanged reports whether the subscriber's currently provisioned
 // framed routes differ from those installed on the session at establishment.
 // Caller holds smContext.Mutex.
-func (s *SMF) framedRoutesChanged(ctx context.Context, smContext *SMContext) (bool, error) {
-	dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
-	if err != nil {
-		return false, err
-	}
-
+func framedRoutesChanged(ctx context.Context, dn DNNStore, smContext *SMContext) (bool, error) {
 	current, err := dn.ListFramedRoutes(ctx, smContext.Supi.IMSI())
 	if err != nil {
 		return false, err
@@ -481,13 +488,8 @@ func framedRoutesEqual(a, b []netip.Prefix) bool {
 
 // staticIPChanged reports whether the subscriber's reserved static IP changed
 // since it was cached at establishment. Caller holds smContext.Mutex.
-func (s *SMF) staticIPChanged(ctx context.Context, smContext *SMContext) (bool, error) {
+func staticIPChanged(ctx context.Context, dn DNNStore, smContext *SMContext) (bool, error) {
 	imsi := smContext.Supi.IMSI()
-
-	dn, err := s.store.ResolveDNN(ctx, smContext.Dnn)
-	if err != nil {
-		return false, err
-	}
 
 	if smContext.PDUIPV4Address != nil {
 		changed, err := staticReservationChanged(ctx, dn, imsi, false, smContext.StaticIPv4)

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -40,10 +40,23 @@ type fakeStore struct {
 	staticIPErr     error
 	opLog           []string
 	allocSessionLog []uint8
+	dnnResolveCalls int
 }
 
 func (f *fakeStore) ResolveDNN(_ context.Context, _ string) (smf.DNNStore, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.dnnResolveCalls++
+
 	return f, nil
+}
+
+func (f *fakeStore) dnnResolves() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.dnnResolveCalls
 }
 
 // ops returns the IPv4 allocate/release calls in the order they arrived.

--- a/internal/smf/static_ip_test.go
+++ b/internal/smf/static_ip_test.go
@@ -9,7 +9,14 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/smf"
 )
+
+func staticIPChanged(s *smf.SMF, ref string) (bool, error) {
+	delta, err := s.EPSSubscriptionChanged(context.Background(), ref)
+
+	return delta.StaticIP, err
+}
 
 // TestStaticIPChanged covers the reconcile comparison used by the MME: a
 // reservation identical to the one cached at establishment is unchanged; a
@@ -26,7 +33,7 @@ func TestStaticIPChanged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changed, err := s.StaticIPChanged(context.Background(), bearer.Ref)
+	changed, err := staticIPChanged(s, bearer.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +45,7 @@ func TestStaticIPChanged(t *testing.T) {
 	// Repin to a different address.
 	store.staticIPv4 = netip.AddrFrom4([4]byte{10, 45, 0, 8})
 
-	changed, err = s.StaticIPChanged(context.Background(), bearer.Ref)
+	changed, err = staticIPChanged(s, bearer.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +57,7 @@ func TestStaticIPChanged(t *testing.T) {
 	// Delete the reservation.
 	store.staticIPv4 = netip.Addr{}
 
-	changed, err = s.StaticIPChanged(context.Background(), bearer.Ref)
+	changed, err = staticIPChanged(s, bearer.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +66,7 @@ func TestStaticIPChanged(t *testing.T) {
 		t.Fatal("a deleted static reservation was not detected")
 	}
 
-	changed, err = s.StaticIPChanged(context.Background(), "no-such-session")
+	changed, err = staticIPChanged(s, "no-such-session")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +89,7 @@ func TestStaticIPChangedCreatedOnDynamicSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changed, err := s.StaticIPChanged(context.Background(), bearer.Ref)
+	changed, err := staticIPChanged(s, bearer.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +101,7 @@ func TestStaticIPChangedCreatedOnDynamicSession(t *testing.T) {
 	// Operator pins a static IP mid-session.
 	store.staticIPv4 = netip.AddrFrom4([4]byte{10, 45, 0, 9})
 
-	changed, err = s.StaticIPChanged(context.Background(), bearer.Ref)
+	changed, err = staticIPChanged(s, bearer.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Description

Attach, tracking area update, and bearer reconciliation each now read the operator and data-network configuration a single time, cutting redundant database work.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
