### PR TITLE
fix: back off when authentication fails

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -704,8 +704,8 @@ func (a *AMF) NewUeConn(radio *Radio, ranUeNgapID models.RanUeNgapID) (*UeConn, 
 		conn:        radio.Conn,
 		radioName:   radio.name,
 		amf:         a,
-		Log:         radio.Log.With(logger.AmfUeNgapID(amfUeNgapID)),
 	}
+	ueConn.setLog(radio.Log.With(logger.AmfUeNgapID(amfUeNgapID)))
 
 	a.mu.Lock()
 	a.conns[int64(amfUeNgapID)] = ueConn

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -206,7 +206,7 @@ func (a *AMF) attachUeConnLocked(ue *UeContext, ueConn *UeConn) *UeConn {
 
 	if oldUeConn != nil && oldUeConn != ueConn {
 		if oldUeConn.ue.Load() == ue {
-			oldUeConn.Log.Info("Detached UeContext from previous UeConn")
+			oldUeConn.Log().Info("Detached UeContext from previous UeConn")
 			oldUeConn.ue.Store(nil)
 			displaced = oldUeConn
 		}

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -677,6 +677,24 @@ func (ue *UeContext) PagingActive() bool {
 	return ue.pagingTimer.Active()
 }
 
+func (ue *UeContext) SuspendRegistration(ctx context.Context) {
+	if conn := ue.Conn(); conn != nil {
+		conn.Release()
+	}
+
+	ue.endKeyChainProcs()
+
+	ue.mu.Lock()
+
+	ue.stopUeMuTimersLocked()
+
+	ue.transitionToLocked(Registered)
+
+	ue.mu.Unlock()
+
+	logger.From(ctx, logger.AmfLog).Debug("registration rejected with a back-off; UE context and PDU sessions retained", logger.SUPI(ue.supi.String()))
+}
+
 func (ue *UeContext) Deregister(ctx context.Context) {
 	if conn := ue.Conn(); conn != nil {
 		conn.Release()

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -692,7 +692,7 @@ func (ue *UeContext) SuspendRegistration(ctx context.Context) {
 
 	ue.mu.Unlock()
 
-	logger.From(ctx, logger.AmfLog).Debug("registration rejected with a back-off; UE context and PDU sessions retained", logger.SUPI(ue.supi.String()))
+	logger.From(ctx, logger.AmfLog).Debug("registration attempt abandoned on a transient failure; UE context and PDU sessions retained", logger.SUPI(ue.supi.String()))
 }
 
 func (ue *UeContext) Deregister(ctx context.Context) {

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -128,7 +128,7 @@ func BuildServiceReject(cause fgs.GMMCause) ([]byte, error) {
 	return (&fgs.ServiceReject{Cause: cause}).MarshalBinary()
 }
 
-func BuildRegistrationReject(t3502Value int, cause5GMM fgs.GMMCause, t3346Value time.Duration) ([]byte, error) {
+func BuildRegistrationReject(t3502Value int, cause5GMM fgs.GMMCause) ([]byte, error) {
 	m := &fgs.RegistrationReject{Cause: cause5GMM}
 
 	if t3502Value != 0 {
@@ -138,15 +138,6 @@ func BuildRegistrationReject(t3502Value int, cause5GMM fgs.GMMCause, t3346Value 
 		}
 
 		m.T3502 = &timer
-	}
-
-	if t3346Value != 0 {
-		timer, err := nas.GPRSTimer2FromDuration(t3346Value)
-		if err != nil {
-			return nil, err
-		}
-
-		m.T3346 = &timer
 	}
 
 	return m.MarshalBinary()

--- a/internal/amf/build.go
+++ b/internal/amf/build.go
@@ -128,8 +128,7 @@ func BuildServiceReject(cause fgs.GMMCause) ([]byte, error) {
 	return (&fgs.ServiceReject{Cause: cause}).MarshalBinary()
 }
 
-// T3346 timer are not supported
-func BuildRegistrationReject(t3502Value int, cause5GMM fgs.GMMCause) ([]byte, error) {
+func BuildRegistrationReject(t3502Value int, cause5GMM fgs.GMMCause, t3346Value time.Duration) ([]byte, error) {
 	m := &fgs.RegistrationReject{Cause: cause5GMM}
 
 	if t3502Value != 0 {
@@ -139,6 +138,15 @@ func BuildRegistrationReject(t3502Value int, cause5GMM fgs.GMMCause) ([]byte, er
 		}
 
 		m.T3502 = &timer
+	}
+
+	if t3346Value != 0 {
+		timer, err := nas.GPRSTimer2FromDuration(t3346Value)
+		if err != nil {
+			return nil, err
+		}
+
+		m.T3346 = &timer
 	}
 
 	return m.MarshalBinary()

--- a/internal/amf/build_registration_reject_test.go
+++ b/internal/amf/build_registration_reject_test.go
@@ -5,54 +5,34 @@ package amf_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
-	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
-// TS 24.501 §5.5.1.3.5
-func TestBuildRegistrationRejectCarriesT3346(t *testing.T) {
-	wire, err := amf.BuildRegistrationReject(720, fgs.GMMCauseCongestion, 10*time.Second)
-	if err != nil {
-		t.Fatalf("BuildRegistrationReject: %v", err)
-	}
+// TS 24.501 §5.5.1.2.5, §5.5.1.3.5
+func TestBuildRegistrationRejectNeverCarriesT3346(t *testing.T) {
+	for _, cause := range []fgs.GMMCause{fgs.GMMCauseIllegalUE, fgs.GMMCauseUEIdentityCannotBeDerived} {
+		wire, err := amf.BuildRegistrationReject(720, cause)
+		if err != nil {
+			t.Fatalf("BuildRegistrationReject: %v", err)
+		}
 
-	got, err := fgs.ParseRegistrationReject(wire)
-	if err != nil {
-		t.Fatalf("ParseRegistrationReject: %v", err)
-	}
+		got, err := fgs.ParseRegistrationReject(wire)
+		if err != nil {
+			t.Fatalf("ParseRegistrationReject: %v", err)
+		}
 
-	if got.Cause != fgs.GMMCauseCongestion {
-		t.Errorf("cause = %v, want %v", got.Cause, fgs.GMMCauseCongestion)
-	}
+		if got.Cause != cause {
+			t.Errorf("cause = %v, want %v", got.Cause, cause)
+		}
 
-	if got.T3346 == nil {
-		t.Fatal("T3346 not encoded")
-	}
+		if got.T3346 != nil {
+			t.Errorf("T3346 = %v, want nil; a back-off timer belongs to congestion control, which the AMF does not run", got.T3346)
+		}
 
-	if got.T3346.Unit != nas.GPRSTimer2Unit2Seconds || got.T3346.Value != 5 {
-		t.Errorf("T3346 = %v/%v, want %v/5", got.T3346.Unit, got.T3346.Value, nas.GPRSTimer2Unit2Seconds)
-	}
-
-	if got.T3502 == nil {
-		t.Error("T3502 not encoded")
-	}
-}
-
-func TestBuildRegistrationRejectOmitsT3346WhenZero(t *testing.T) {
-	wire, err := amf.BuildRegistrationReject(720, fgs.GMMCauseIllegalUE, 0)
-	if err != nil {
-		t.Fatalf("BuildRegistrationReject: %v", err)
-	}
-
-	got, err := fgs.ParseRegistrationReject(wire)
-	if err != nil {
-		t.Fatalf("ParseRegistrationReject: %v", err)
-	}
-
-	if got.T3346 != nil {
-		t.Errorf("T3346 = %v, want nil", got.T3346)
+		if got.T3502 == nil {
+			t.Error("T3502 not encoded")
+		}
 	}
 }

--- a/internal/amf/build_registration_reject_test.go
+++ b/internal/amf/build_registration_reject_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+// TS 24.501 §5.5.1.3.5
+func TestBuildRegistrationRejectCarriesT3346(t *testing.T) {
+	wire, err := amf.BuildRegistrationReject(720, fgs.GMMCauseCongestion, 10*time.Second)
+	if err != nil {
+		t.Fatalf("BuildRegistrationReject: %v", err)
+	}
+
+	got, err := fgs.ParseRegistrationReject(wire)
+	if err != nil {
+		t.Fatalf("ParseRegistrationReject: %v", err)
+	}
+
+	if got.Cause != fgs.GMMCauseCongestion {
+		t.Errorf("cause = %v, want %v", got.Cause, fgs.GMMCauseCongestion)
+	}
+
+	if got.T3346 == nil {
+		t.Fatal("T3346 not encoded")
+	}
+
+	if got.T3346.Unit != nas.GPRSTimer2Unit2Seconds || got.T3346.Value != 5 {
+		t.Errorf("T3346 = %v/%v, want %v/5", got.T3346.Unit, got.T3346.Value, nas.GPRSTimer2Unit2Seconds)
+	}
+
+	if got.T3502 == nil {
+		t.Error("T3502 not encoded")
+	}
+}
+
+func TestBuildRegistrationRejectOmitsT3346WhenZero(t *testing.T) {
+	wire, err := amf.BuildRegistrationReject(720, fgs.GMMCauseIllegalUE, 0)
+	if err != nil {
+		t.Fatalf("BuildRegistrationReject: %v", err)
+	}
+
+	got, err := fgs.ParseRegistrationReject(wire)
+	if err != nil {
+		t.Fatalf("ParseRegistrationReject: %v", err)
+	}
+
+	if got.T3346 != nil {
+		t.Errorf("T3346 = %v, want nil", got.T3346)
+	}
+}

--- a/internal/amf/decode_nas_message_test.go
+++ b/internal/amf/decode_nas_message_test.go
@@ -33,8 +33,8 @@ func newDecoderTestUE(t *testing.T) *UeContext {
 		amf:         radio.amf,
 		RanUeNgapID: 1,
 		AmfUeNgapID: 1,
-		Log:         zap.NewNop(),
 	}
+	ueConn.setLog(zap.NewNop())
 	ueConn.amf.AttachUeConn(ue, ueConn)
 
 	return ue

--- a/internal/amf/export_internal_test.go
+++ b/internal/amf/export_internal_test.go
@@ -22,7 +22,8 @@ func (nopNGAPSender) WriteMsg(b []byte, _ *sctp.SndRcvInfo) (int, error) { retur
 func TestExportUeContext_DetachedConnDoesNotPanic(t *testing.T) {
 	ue := NewUeContext()
 
-	conn := &UeConn{Log: zap.NewNop()}
+	conn := &UeConn{}
+	conn.setLog(zap.NewNop())
 	ue.active.Store(conn)
 	conn.ue.Store(nil)
 

--- a/internal/amf/handover.go
+++ b/internal/amf/handover.go
@@ -288,7 +288,7 @@ func handoverGuardExpiry(a *AMF, sourceUe, targetUe *UeConn) procedure.CancelFun
 			return procedure.Release, nil
 		}
 
-		logger.WithTrace(cctx, sourceUe.Log).Warn("N2 handover abandoned: target gNB did not complete it in time, releasing target")
+		logger.WithTrace(cctx, sourceUe.Log()).Warn("N2 handover abandoned: target gNB did not complete it in time, releasing target")
 
 		a.UnbindHandoverTarget(cctx, amfUe)
 

--- a/internal/amf/nas/authentication.go
+++ b/internal/amf/nas/authentication.go
@@ -5,15 +5,28 @@ package nas
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/fgs"
 )
+
+const authFailureBackoff = 10 * time.Second
+
+func registrationRejectForAuthFailure(err error) (fgs.GMMCause, time.Duration) {
+	if errors.Is(err, udm.ErrSubscriberUnknown) {
+		return fgs.GMMCauseIllegalUE, 0
+	}
+
+	return fgs.GMMCauseCongestion, authFailureBackoff
+}
 
 func sendUEAuthenticationAuthenticateRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, resyncInfo *ausf.ResyncInfo) (*ausf.AuthResult, error) {
 	if ue.Tai.PlmnID == nil {
@@ -22,7 +35,7 @@ func sendUEAuthenticationAuthenticateRequest(ctx context.Context, amfInstance *a
 
 	ueAuthenticationCtx, err := amfInstance.Ausf.Authenticate(ctx, ue.Suci, *ue.Tai.PlmnID, resyncInfo)
 	if err != nil {
-		return nil, fmt.Errorf("ausf UE amf.Authentication Authenticate Request failed: %s", err.Error())
+		return nil, fmt.Errorf("ausf UE amf.Authentication Authenticate Request failed: %w", err)
 	}
 
 	return ueAuthenticationCtx, nil
@@ -72,7 +85,7 @@ func authenticationProcedure(ctx context.Context, amfInstance *amf.AMF, ue *amf.
 
 	response, err := sendUEAuthenticationAuthenticateRequest(ctx, amfInstance, ue, nil)
 	if err != nil {
-		return false, fmt.Errorf("failed to send ue authentication request: %s", err)
+		return false, fmt.Errorf("failed to send ue authentication request: %w", err)
 	}
 
 	conn := ue.Conn()

--- a/internal/amf/nas/authentication.go
+++ b/internal/amf/nas/authentication.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/ausf"
@@ -18,14 +17,15 @@ import (
 	"github.com/ellanetworks/core/nas/fgs"
 )
 
-const authFailureBackoff = 10 * time.Second
-
-func registrationRejectForAuthFailure(err error) (fgs.GMMCause, time.Duration) {
-	if errors.Is(err, udm.ErrSubscriberUnknown) {
-		return fgs.GMMCauseIllegalUE, 0
+func registrationRejectCauseForAuthFailure(err error) (fgs.GMMCause, bool) {
+	switch {
+	case errors.Is(err, udm.ErrSUPIUnderivable):
+		return fgs.GMMCauseUEIdentityCannotBeDerived, true
+	case errors.Is(err, udm.ErrSubscriberUnknown):
+		return fgs.GMMCauseIllegalUE, true
+	default:
+		return 0, false
 	}
-
-	return fgs.GMMCauseCongestion, authFailureBackoff
 }
 
 func sendUEAuthenticationAuthenticateRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext, resyncInfo *ausf.ResyncInfo) (*ausf.AuthResult, error) {

--- a/internal/amf/nas/authentication_reject_cause_test.go
+++ b/internal/amf/nas/authentication_reject_cause_test.go
@@ -5,11 +5,15 @@ package nas
 
 import (
 	"context"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/ausf"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas/fgs"
@@ -18,50 +22,61 @@ import (
 // TS 24.501 §5.5.1.2.5, §5.5.1.3.5
 func TestRegistrationRejectForAuthFailure(t *testing.T) {
 	unknown := fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound)
+	underivable := fmt.Errorf("couldn't convert suci to supi: %w", fmt.Errorf("%w: %w", udm.ErrSUPIUnderivable, errors.New("profile A error: mac verification failed")))
 
 	tests := []struct {
-		name        string
-		err         error
-		wantCause   fgs.GMMCause
-		wantBackoff bool
+		name          string
+		err           error
+		wantCause     fgs.GMMCause
+		wantPermanent bool
 	}{
-		{"unknown subscriber", unknown, fgs.GMMCauseIllegalUE, false},
-		{"unknown subscriber wrapped by serving NFs", fmt.Errorf("failed to send ue authentication request: %w", fmt.Errorf("ausf UE amf.Authentication Authenticate Request failed: %w", unknown)), fgs.GMMCauseIllegalUE, false},
-		{"raft commit timeout", fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout), fgs.GMMCauseCongestion, true},
-		{"forwarded write outcome unknown", fmt.Errorf("advance sqn: %w", db.ErrOutcomeUnknown), fgs.GMMCauseCongestion, true},
-		{"migration pending", fmt.Errorf("advance sqn: %w", db.ErrMigrationPending), fgs.GMMCauseCongestion, true},
-		{"context cancelled", context.Canceled, fgs.GMMCauseCongestion, true},
-		{"opaque error defaults to transient", errors.New("boom"), fgs.GMMCauseCongestion, true},
+		{"unknown subscriber", unknown, fgs.GMMCauseIllegalUE, true},
+		{"unknown subscriber wrapped by serving NFs", fmt.Errorf("failed to send ue authentication request: %w", fmt.Errorf("ausf UE amf.Authentication Authenticate Request failed: %w", unknown)), fgs.GMMCauseIllegalUE, true},
+		{"suci does not deconceal", underivable, fgs.GMMCauseUEIdentityCannotBeDerived, true},
+		{"suci does not deconceal wrapped by serving NFs", fmt.Errorf("failed to send ue authentication request: %w", fmt.Errorf("ausf UE amf.Authentication Authenticate Request failed: %w", underivable)), fgs.GMMCauseUEIdentityCannotBeDerived, true},
+		{"raft commit timeout", fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout), 0, false},
+		{"forwarded write outcome unknown", fmt.Errorf("advance sqn: %w", db.ErrOutcomeUnknown), 0, false},
+		{"migration pending", fmt.Errorf("advance sqn: %w", db.ErrMigrationPending), 0, false},
+		{"context cancelled", context.Canceled, 0, false},
+		{"opaque error defaults to transient", errors.New("boom"), 0, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cause, backoff := registrationRejectForAuthFailure(tt.err)
+			cause, permanent := registrationRejectCauseForAuthFailure(tt.err)
+
+			if permanent != tt.wantPermanent {
+				t.Errorf("permanent = %v, want %v", permanent, tt.wantPermanent)
+			}
 
 			if cause != tt.wantCause {
 				t.Errorf("cause = %v, want %v", cause, tt.wantCause)
-			}
-
-			if got := backoff != 0; got != tt.wantBackoff {
-				t.Errorf("backoff = %v, want non-zero: %v", backoff, tt.wantBackoff)
 			}
 		})
 	}
 }
 
-func TestRegistrationRejectForAuthFailureNeverUsesIdentityCause(t *testing.T) {
+func TestRegistrationRejectForAuthFailureUsesIdentityCauseOnlyWhenSUPIUnderivable(t *testing.T) {
 	for _, err := range []error{
 		errors.New("boom"),
 		fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound),
 		db.ErrProposeTimeout,
+		db.ErrOutcomeUnknown,
+		db.ErrMigrationPending,
+		context.Canceled,
 	} {
-		if cause, _ := registrationRejectForAuthFailure(err); cause == fgs.GMMCauseUEIdentityCannotBeDerived {
-			t.Errorf("registrationRejectForAuthFailure(%v) = %v, which deregisters a UE on a mobility registration update", err, cause)
+		if cause, _ := registrationRejectCauseForAuthFailure(err); cause == fgs.GMMCauseUEIdentityCannotBeDerived {
+			t.Errorf("registrationRejectCauseForAuthFailure(%v) = %v, which deregisters a UE on a mobility registration update", err, cause)
 		}
+	}
+
+	underivable := fmt.Errorf("%w: %w", udm.ErrSUPIUnderivable, errors.New("home network key not found"))
+	if cause, _ := registrationRejectCauseForAuthFailure(underivable); cause != fgs.GMMCauseUEIdentityCannotBeDerived {
+		t.Errorf("registrationRejectCauseForAuthFailure(%v) = %v, want %v", underivable, cause, fgs.GMMCauseUEIdentityCannotBeDerived)
 	}
 }
 
-func registrationRejectOnAuthError(t *testing.T, ausfErr error) *fgs.RegistrationReject {
+func registrationOnAuth(t *testing.T, ausfInstance amf.Authenticator, suci string) *fakeNGAPSender {
 	t.Helper()
 
 	amfInstance := amf.New(&fakeDBInstance{
@@ -70,14 +85,14 @@ func registrationRejectOnAuthError(t *testing.T, ausfErr error) *fgs.Registratio
 			Mnc:           "01",
 			SupportedTACs: "[\"000001\"]",
 		},
-	}, &fakeAusf{Error: ausfErr}, nil)
+	}, ausfInstance, nil)
 
 	ue, ngapSender, err := buildUeAndRadio()
 	if err != nil {
 		t.Fatalf("could not create UE and radio: %v", err)
 	}
 
-	ue.Suci = "testsuci"
+	ue.Suci = suci
 	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
 
 	if err := amfInstance.CommitUEIdentity(t.Context(), ue, amf.MintAuthProofForRegistrationCommit()); err != nil {
@@ -90,6 +105,20 @@ func registrationRejectOnAuthError(t *testing.T, ausfErr error) *fgs.Registratio
 	}
 
 	handleRegistrationRequest(t.Context(), amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
+
+	return ngapSender
+}
+
+func registrationRejectOnAuthError(t *testing.T, ausfErr error) *fgs.RegistrationReject {
+	t.Helper()
+
+	return registrationRejectOnAuth(t, &fakeAusf{Error: ausfErr}, "testsuci")
+}
+
+func registrationRejectOnAuth(t *testing.T, ausfInstance amf.Authenticator, suci string) *fgs.RegistrationReject {
+	t.Helper()
+
+	ngapSender := registrationOnAuth(t, ausfInstance, suci)
 
 	if len(ngapSender.SentDownlinkNASTransport) != 1 {
 		t.Fatalf("sent %d downlink NAS messages, want 1", len(ngapSender.SentDownlinkNASTransport))
@@ -106,20 +135,15 @@ func registrationRejectOnAuthError(t *testing.T, ausfErr error) *fgs.Registratio
 	return reject
 }
 
-// TS 24.501 §5.5.1.3.5
-func TestHandleRegistrationRequest_TransientAuthFailureRejectsWithCongestion(t *testing.T) {
-	reject := registrationRejectOnAuthError(t, fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout))
+func TestHandleRegistrationRequest_TransientAuthFailureReleasesWithoutRejecting(t *testing.T) {
+	ngapSender := registrationOnAuth(t, &fakeAusf{Error: fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout)}, "testsuci")
 
-	if reject.Cause != fgs.GMMCauseCongestion {
-		t.Errorf("cause = %v, want %v", reject.Cause, fgs.GMMCauseCongestion)
+	if len(ngapSender.SentDownlinkNASTransport) != 0 {
+		t.Errorf("sent %d downlink NAS messages, want 0; an unprotected reject would strand the UE on a 15-30 minute T3346", len(ngapSender.SentDownlinkNASTransport))
 	}
 
-	if reject.T3346 == nil {
-		t.Fatal("T3346 absent; §5.5.1.3.5 makes #22 without it an abnormal case")
-	}
-
-	if reject.T3346.Value == 0 {
-		t.Error("T3346 is zero; §5.5.1.3.5 makes #22 with a zero timer an abnormal case")
+	if len(ngapSender.SentUEContextReleaseCommand) != 1 {
+		t.Errorf("sent %d UE Context Release Commands, want 1", len(ngapSender.SentUEContextReleaseCommand))
 	}
 }
 
@@ -131,6 +155,41 @@ func TestHandleRegistrationRequest_UnknownSubscriberRejectsWithIllegalUE(t *test
 
 	if reject.Cause != fgs.GMMCauseIllegalUE {
 		t.Errorf("cause = %v, want %v", reject.Cause, fgs.GMMCauseIllegalUE)
+	}
+
+	if reject.T3346 != nil {
+		t.Errorf("T3346 = %v, want nil on a permanent reject", reject.T3346)
+	}
+}
+
+type rejectingSubscriberStore struct{ t *testing.T }
+
+func (s *rejectingSubscriberStore) AdvanceSequenceNumber(_ context.Context, imsi, _, _ string) (*udm.AdvancedCredentials, error) {
+	s.t.Errorf("subscriber store queried for %q, but the SUCI never deconcealed", imsi)
+	return nil, errors.New("must not be reached")
+}
+
+func TestHandleRegistrationRequest_UndecipherableSUCIRejectsWithIdentityCause(t *testing.T) {
+	hnPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate home network key: %v", err)
+	}
+
+	schemeOutput := make([]byte, 45)
+	if _, err := rand.Read(schemeOutput); err != nil {
+		t.Fatalf("read scheme output: %v", err)
+	}
+
+	suci := fmt.Sprintf("suci-0-001-01-0000-1-0-%s", hex.EncodeToString(schemeOutput))
+
+	ausfInstance := ausf.New(&rejectingSubscriberStore{t: t}, func(scheme string, keyID int) (string, error) {
+		return hex.EncodeToString(hnPriv.Bytes()), nil
+	})
+
+	reject := registrationRejectOnAuth(t, ausfInstance, suci)
+
+	if reject.Cause != fgs.GMMCauseUEIdentityCannotBeDerived {
+		t.Errorf("cause = %v, want %v", reject.Cause, fgs.GMMCauseUEIdentityCannotBeDerived)
 	}
 
 	if reject.T3346 != nil {
@@ -174,16 +233,24 @@ func registeredUEWithSession(t *testing.T, ausfErr error) (*amf.UeContext, *fake
 	return ue, ngapSender
 }
 
-// TS 24.501 §5.5.1.3.5
-func TestTransientRejectRetainsRegistrationAndSessions(t *testing.T) {
-	ue, _ := registeredUEWithSession(t, fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout))
+// TS 24.501 §5.5.1.3.7 case e
+func TestTransientAuthFailureRetainsRegistrationAndSessions(t *testing.T) {
+	ue, ngapSender := registeredUEWithSession(t, fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout))
 
 	if got := ue.State(); got != amf.Registered {
-		t.Errorf("state = %v, want Registered; #22 leaves the UE 5GMM-REGISTERED", got)
+		t.Errorf("state = %v, want Registered; the UE stays 5GMM-REGISTERED and retries at T3511", got)
 	}
 
 	if _, ok := ue.SmContextFindByPDUSessionID(5); !ok {
-		t.Error("PDU session released on a transient reject; the UE still believes it exists")
+		t.Error("PDU session released on a transient failure; the UE still believes it exists")
+	}
+
+	if len(ngapSender.SentDownlinkNASTransport) != 0 {
+		t.Errorf("sent %d downlink NAS messages, want 0", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	if len(ngapSender.SentUEContextReleaseCommand) != 1 {
+		t.Errorf("sent %d UE Context Release Commands, want 1", len(ngapSender.SentUEContextReleaseCommand))
 	}
 }
 

--- a/internal/amf/nas/authentication_reject_cause_test.go
+++ b/internal/amf/nas/authentication_reject_cause_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/udm"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+// TS 24.501 §5.5.1.2.5, §5.5.1.3.5
+func TestRegistrationRejectForAuthFailure(t *testing.T) {
+	unknown := fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound)
+
+	tests := []struct {
+		name        string
+		err         error
+		wantCause   fgs.GMMCause
+		wantBackoff bool
+	}{
+		{"unknown subscriber", unknown, fgs.GMMCauseIllegalUE, false},
+		{"unknown subscriber wrapped by serving NFs", fmt.Errorf("failed to send ue authentication request: %w", fmt.Errorf("ausf UE amf.Authentication Authenticate Request failed: %w", unknown)), fgs.GMMCauseIllegalUE, false},
+		{"raft commit timeout", fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout), fgs.GMMCauseCongestion, true},
+		{"forwarded write outcome unknown", fmt.Errorf("advance sqn: %w", db.ErrOutcomeUnknown), fgs.GMMCauseCongestion, true},
+		{"migration pending", fmt.Errorf("advance sqn: %w", db.ErrMigrationPending), fgs.GMMCauseCongestion, true},
+		{"context cancelled", context.Canceled, fgs.GMMCauseCongestion, true},
+		{"opaque error defaults to transient", errors.New("boom"), fgs.GMMCauseCongestion, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cause, backoff := registrationRejectForAuthFailure(tt.err)
+
+			if cause != tt.wantCause {
+				t.Errorf("cause = %v, want %v", cause, tt.wantCause)
+			}
+
+			if got := backoff != 0; got != tt.wantBackoff {
+				t.Errorf("backoff = %v, want non-zero: %v", backoff, tt.wantBackoff)
+			}
+		})
+	}
+}
+
+func TestRegistrationRejectForAuthFailureNeverUsesIdentityCause(t *testing.T) {
+	for _, err := range []error{
+		errors.New("boom"),
+		fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound),
+		db.ErrProposeTimeout,
+	} {
+		if cause, _ := registrationRejectForAuthFailure(err); cause == fgs.GMMCauseUEIdentityCannotBeDerived {
+			t.Errorf("registrationRejectForAuthFailure(%v) = %v, which deregisters a UE on a mobility registration update", err, cause)
+		}
+	}
+}
+
+func registrationRejectOnAuthError(t *testing.T, ausfErr error) *fgs.RegistrationReject {
+	t.Helper()
+
+	amfInstance := amf.New(&fakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}, &fakeAusf{Error: ausfErr}, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	ue.Suci = "testsuci"
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+
+	if err := amfInstance.CommitUEIdentity(t.Context(), ue, amf.MintAuthProofForRegistrationCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	handleRegistrationRequest(t.Context(), amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
+
+	if len(ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("sent %d downlink NAS messages, want 1", len(ngapSender.SentDownlinkNASTransport))
+	}
+
+	resp := ngapSender.SentDownlinkNASTransport[0]
+	assertPlainGmm(t, resp.NASPDU, uint8(fgs.MsgRegistrationReject))
+
+	reject, err := fgs.ParseRegistrationReject(resp.NASPDU)
+	if err != nil {
+		t.Fatalf("ParseRegistrationReject: %v", err)
+	}
+
+	return reject
+}
+
+// TS 24.501 §5.5.1.3.5
+func TestHandleRegistrationRequest_TransientAuthFailureRejectsWithCongestion(t *testing.T) {
+	reject := registrationRejectOnAuthError(t, fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout))
+
+	if reject.Cause != fgs.GMMCauseCongestion {
+		t.Errorf("cause = %v, want %v", reject.Cause, fgs.GMMCauseCongestion)
+	}
+
+	if reject.T3346 == nil {
+		t.Fatal("T3346 absent; §5.5.1.3.5 makes #22 without it an abnormal case")
+	}
+
+	if reject.T3346.Value == 0 {
+		t.Error("T3346 is zero; §5.5.1.3.5 makes #22 with a zero timer an abnormal case")
+	}
+}
+
+// TS 24.501 §5.5.1.2.5
+func TestHandleRegistrationRequest_UnknownSubscriberRejectsWithIllegalUE(t *testing.T) {
+	unknown := fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound)
+
+	reject := registrationRejectOnAuthError(t, unknown)
+
+	if reject.Cause != fgs.GMMCauseIllegalUE {
+		t.Errorf("cause = %v, want %v", reject.Cause, fgs.GMMCauseIllegalUE)
+	}
+
+	if reject.T3346 != nil {
+		t.Errorf("T3346 = %v, want nil on a permanent reject", reject.T3346)
+	}
+}

--- a/internal/amf/nas/authentication_reject_cause_test.go
+++ b/internal/amf/nas/authentication_reject_cause_test.go
@@ -137,3 +137,67 @@ func TestHandleRegistrationRequest_UnknownSubscriberRejectsWithIllegalUE(t *test
 		t.Errorf("T3346 = %v, want nil on a permanent reject", reject.T3346)
 	}
 }
+
+func registeredUEWithSession(t *testing.T, ausfErr error) (*amf.UeContext, *fakeNGAPSender) {
+	t.Helper()
+
+	amfInstance := amf.New(&fakeDBInstance{
+		Operator: &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: "[\"000001\"]"},
+	}, &fakeAusf{Error: ausfErr}, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	ue.Suci = "testsuci"
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+
+	if err := amfInstance.CommitUEIdentity(t.Context(), ue, amf.MintAuthProofForRegistrationCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	if err := ue.CreateSmContext(5, "smref-5", nil, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	ue.TransitionTo(amf.RegistrationInitiated)
+	ue.TransitionTo(amf.Registered)
+
+	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	handleRegistrationRequest(t.Context(), amfInstance, ue, mustParseRegistrationRequest(t, m), m, true, false)
+
+	return ue, ngapSender
+}
+
+// TS 24.501 §5.5.1.3.5
+func TestTransientRejectRetainsRegistrationAndSessions(t *testing.T) {
+	ue, _ := registeredUEWithSession(t, fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout))
+
+	if got := ue.State(); got != amf.Registered {
+		t.Errorf("state = %v, want Registered; #22 leaves the UE 5GMM-REGISTERED", got)
+	}
+
+	if _, ok := ue.SmContextFindByPDUSessionID(5); !ok {
+		t.Error("PDU session released on a transient reject; the UE still believes it exists")
+	}
+}
+
+// TS 24.501 §5.5.1.3.5
+func TestPermanentRejectTearsDownRegistrationAndSessions(t *testing.T) {
+	unknown := fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound)
+
+	ue, _ := registeredUEWithSession(t, unknown)
+
+	if got := ue.State(); got != amf.Deregistered {
+		t.Errorf("state = %v, want Deregistered", got)
+	}
+
+	if _, ok := ue.SmContextFindByPDUSessionID(5); ok {
+		t.Error("PDU session retained on a permanent reject")
+	}
+}

--- a/internal/amf/nas/handle_authentication_failure.go
+++ b/internal/amf/nas/handle_authentication_failure.go
@@ -6,6 +6,7 @@ package nas
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/ausf"
@@ -101,7 +102,9 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 		}
 
 		if fail.AUTS == nil {
-			logger.From(ctx, logger.AmfLog).Warn("missing AuthenticationFailureParameter IE for SynchFailure")
+			abortRegistration(ctx, amfInstance, ue, "synch failure without AUTS",
+				errors.New("AUTHENTICATION FAILURE with 5GMM cause #21 omitted the Authentication failure parameter IE"))
+
 			return nasreply.Handled()
 		}
 
@@ -113,7 +116,21 @@ func handleAuthenticationFailure(ctx context.Context, amfInstance *amf.AMF, ue *
 
 		response, err := sendUEAuthenticationAuthenticateRequest(ctx, amfInstance, ue, resynchronizationInfo)
 		if err != nil {
-			logger.From(ctx, logger.AmfLog).Warn("send UE amf.Authentication Authenticate Request Error", zap.Error(err))
+			cause, permanent := registrationRejectCauseForAuthFailure(err)
+			if !permanent {
+				logger.From(ctx, logger.AmfLog).Warn("re-synchronised authentication vector unavailable on a transient error; releasing the NAS signalling connection so the UE retries when T3511 expires", zap.Error(err))
+
+				abortRegistration(ctx, amfInstance, ue, "transient authentication re-synchronisation failure", err)
+
+				return nasreply.Handled()
+			}
+
+			logger.From(ctx, logger.AmfLog).Warn("re-synchronised authentication vector unavailable, rejecting registration", zap.Error(err))
+
+			ue.Deregister(ctx)
+
+			amf.SendRegistrationReject(ctx, ueConn, cause)
+
 			return nasreply.Handled()
 		}
 

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -75,25 +75,23 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		contents := append([]byte(nil), req.NASMessageContainer...)
 
 		if err := ue.DecryptUplinkContents(contents); err != nil {
-			metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultReject)
+			logger.From(ctx, logger.AmfLog).Warn("could not decipher the NAS message container; proceeding with the cleartext IEs and requesting retransmission of the initial NAS message (TS 24.501 5.4.2.2)", zap.Error(err))
 
-			amf.SendRegistrationReject(ctx, ueConn, fgs.GMMCauseUEIdentityCannotBeDerived)
+			conn.SetRetransmissionOfInitialNASMsg(true)
+		} else {
+			inner, err := fgs.ParseRegistrationRequest(contents)
+			if !decoded(ctx, "RegistrationRequest", err) {
+				metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultReject)
 
-			return fmt.Errorf("failed to decrypt NAS message - sent registration reject: %v", err)
+				amf.SendRegistrationReject(ctx, ueConn, fgs.GMMCauseInvalidMandatoryInformation)
+
+				return fmt.Errorf("failed to decode NAS message - sent registration reject: %v", err)
+			}
+
+			req = inner
+
+			conn.SetRetransmissionOfInitialNASMsg(!integrityVerified)
 		}
-
-		inner, err := fgs.ParseRegistrationRequest(contents)
-		if !decoded(ctx, "RegistrationRequest", err) {
-			metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultReject)
-
-			amf.SendRegistrationReject(ctx, ueConn, fgs.GMMCauseUEIdentityCannotBeDerived)
-
-			return fmt.Errorf("failed to decode NAS message - sent registration reject: %v", err)
-		}
-
-		req = inner
-
-		conn.SetRetransmissionOfInitialNASMsg(!integrityVerified)
 	} else if req.NASMessageContainer != nil && !integrityVerified {
 		logger.From(ctx, logger.AmfLog).Info("Skipping NASMessageContainer decryption due to MAC verification failure, proceeding with cleartext IEs only")
 
@@ -282,7 +280,16 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 		if err != nil {
 			logger.From(ctx, logger.AmfLog).Warn("authentication procedure failed, rejecting registration", zap.Error(err))
 
-			defer ue.Deregister(ctx)
+			cause, backoff := registrationRejectForAuthFailure(err)
+
+			if backoff > 0 && state == amf.Registered {
+				defer func() {
+					ue.SuspendRegistration(ctx)
+					amfInstance.StartMobileReachable(ue)
+				}()
+			} else {
+				defer ue.Deregister(ctx)
+			}
 
 			var regType fgs.RegistrationType
 			if conn := ue.Conn(); conn != nil {
@@ -296,8 +303,6 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 				logger.From(ctx, logger.AmfLog).Warn("ue is not connected to RAN")
 				return nasreply.Handled()
 			}
-
-			cause, backoff := registrationRejectForAuthFailure(err)
 
 			amf.SendRegistrationRejectWithBackoff(ctx, ueConn, cause, backoff)
 

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -297,7 +297,9 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 				return nasreply.Handled()
 			}
 
-			amf.SendRegistrationReject(ctx, ueConn, fgs.GMMCauseUEIdentityCannotBeDerived)
+			cause, backoff := registrationRejectForAuthFailure(err)
+
+			amf.SendRegistrationRejectWithBackoff(ctx, ueConn, cause, backoff)
 
 			return nasreply.Handled()
 		}

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -278,18 +278,7 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 		pass, err := authenticationProcedure(ctx, amfInstance, ue)
 		if err != nil {
-			logger.From(ctx, logger.AmfLog).Warn("authentication procedure failed, rejecting registration", zap.Error(err))
-
-			cause, backoff := registrationRejectForAuthFailure(err)
-
-			if backoff > 0 && state == amf.Registered {
-				defer func() {
-					ue.SuspendRegistration(ctx)
-					amfInstance.StartMobileReachable(ue)
-				}()
-			} else {
-				defer ue.Deregister(ctx)
-			}
+			cause, permanent := registrationRejectCauseForAuthFailure(err)
 
 			var regType fgs.RegistrationType
 			if conn := ue.Conn(); conn != nil {
@@ -298,13 +287,29 @@ func handleRegistrationRequest(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 			metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(regType), metrics.ResultReject)
 
+			if !permanent {
+				logger.From(ctx, logger.AmfLog).Warn("authentication procedure failed on a transient error; releasing the NAS signalling connection so the UE retries when T3511 expires", zap.Error(err))
+
+				if state == amf.Registered {
+					abortRegistrationRetainingContext(ctx, amfInstance, ue)
+				} else {
+					abortRegistration(ctx, amfInstance, ue, "transient authentication failure", err)
+				}
+
+				return nasreply.Handled()
+			}
+
+			logger.From(ctx, logger.AmfLog).Warn("authentication procedure failed, rejecting registration", zap.Error(err))
+
+			defer ue.Deregister(ctx)
+
 			ueConn := ue.Conn()
 			if ueConn == nil {
 				logger.From(ctx, logger.AmfLog).Warn("ue is not connected to RAN")
 				return nasreply.Handled()
 			}
 
-			amf.SendRegistrationRejectWithBackoff(ctx, ueConn, cause, backoff)
+			amf.SendRegistrationReject(ctx, ueConn, cause)
 
 			return nasreply.Handled()
 		}

--- a/internal/amf/nas/nas_handler.go
+++ b/internal/amf/nas/nas_handler.go
@@ -115,7 +115,7 @@ func dispositionForNAS(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeConn
 	)
 	defer span.End()
 
-	ctx = logger.Into(ctx, ue.Log)
+	ctx = logger.Into(ctx, ue.Log())
 
 	logger.From(ctx, logger.AmfLog).Info(
 		"Received NAS message",

--- a/internal/amf/nas/nas_message_container_reject_test.go
+++ b/internal/amf/nas/nas_message_container_reject_test.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/ausf"
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func containerTestUE(t *testing.T, alg nas.CipheringAlgorithm, key [16]uint8) (*amf.AMF, *amf.UeContext, *fakeNGAPSender) {
+	t.Helper()
+
+	supi := mustSUPIFromPrefixed("imsi-001019756139935")
+
+	amfInstance := amf.New(&fakeDBInstance{
+		Operator: &db.Operator{Mcc: "001", Mnc: "01", SupportedTACs: "[\"000001\"]"},
+	}, &fakeAusf{
+		AvKgAka: &ausf.AuthResult{Rand: hex.EncodeToString(make([]byte, 16)), Autn: hex.EncodeToString(make([]byte, 16))},
+		Supi:    supi,
+		Kseaf:   []byte("testkey"),
+	}, nil)
+
+	ue, ngapSender, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	ue.Suci = "testsuci"
+	ue.SetSupiForTest(supi)
+
+	if err := amfInstance.CommitUEIdentity(t.Context(), ue, amf.MintAuthProofForRegistrationCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	ue.SetSecuredForTest(true)
+	ue.SetKnasEncForTest(key)
+	ue.SetCipheringAlgForTest(alg)
+
+	return amfInstance, ue, ngapSender
+}
+
+func rejectCauses(t *testing.T, sender *fakeNGAPSender) []fgs.GMMCause {
+	t.Helper()
+
+	var causes []fgs.GMMCause
+
+	for _, sent := range sender.SentDownlinkNASTransport {
+		if len(sent.NASPDU) < 3 || sent.NASPDU[2] != uint8(fgs.MsgRegistrationReject) {
+			continue
+		}
+
+		reject, err := fgs.ParseRegistrationReject(sent.NASPDU)
+		if err != nil {
+			t.Fatalf("ParseRegistrationReject: %v", err)
+		}
+
+		causes = append(causes, reject.Cause)
+	}
+
+	return causes
+}
+
+// TS 24.501 §5.4.2.2
+func TestHandleRegistrationRequestMessage_UndecipherableContainerDoesNotReject(t *testing.T) {
+	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
+
+	m, err := buildTestRegistrationRequestMessage(nas.CipheringAES, &key, 0)
+	if err != nil {
+		t.Fatalf("could not build registration request message: %v", err)
+	}
+
+	amfInstance, ue, ngapSender := containerTestUE(t, nas.CipheringZUC, key)
+
+	_ = handleRegistrationRequestMessage(t.Context(), amfInstance, ue, regReqFgs(t, m), m, true, false)
+
+	if causes := rejectCauses(t, ngapSender); len(causes) != 0 {
+		t.Errorf("sent REGISTRATION REJECT %v; §5.4.2.2 requires the AMF to proceed on the cleartext IEs", causes)
+	}
+
+	if !ue.Conn().RetransmissionOfInitialNASMsg {
+		t.Error("RINMR not set; the AMF must request retransmission of the initial NAS message")
+	}
+}
+
+// TS 24.501 §5.5.1.2.8, §5.5.1.3.8
+func TestHandleRegistrationRequestMessage_UndecodableContainerRejectsWithInvalidMandatoryInformation(t *testing.T) {
+	key := [16]uint8{0x0D, 0x0E, 0x0A, 0x0D, 0x0B, 0x0E, 0x0E, 0x0F, 0x0F, 0x0E, 0x0E, 0x0D, 0x0C, 0x0A, 0x0F, 0x0E}
+
+	ciph, err := nas.CipherFor(nas.CipheringAES)
+	if err != nil {
+		t.Fatalf("CipherFor: %v", err)
+	}
+
+	garbage, err := ciph.Apply(key, 0, nas.Bearer3GPP, nas.DirectionUplink, []byte{0xDE, 0xAD, 0xBE, 0xEF})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	outer := &fgs.RegistrationRequest{
+		RegistrationType:     fgs.RegistrationTypeInitial,
+		FOR:                  true,
+		NgKSI:                nas.KeySetIdentifier{Value: 0},
+		MobileIdentity:       testMobileIdentity(),
+		UESecurityCapability: &fgs.UESecurityCapability{EA: 0xc0, IA: 0xc0},
+		NASMessageContainer:  garbage,
+	}
+
+	m, err := outer.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+
+	amfInstance, ue, ngapSender := containerTestUE(t, nas.CipheringAES, key)
+
+	_ = handleRegistrationRequestMessage(t.Context(), amfInstance, ue, regReqFgs(t, m), m, true, false)
+
+	causes := rejectCauses(t, ngapSender)
+	if len(causes) != 1 {
+		t.Fatalf("sent %d REGISTRATION REJECT messages (%v), want 1", len(causes), causes)
+	}
+
+	if causes[0] != fgs.GMMCauseInvalidMandatoryInformation {
+		t.Errorf("cause = %v, want %v", causes[0], fgs.GMMCauseInvalidMandatoryInformation)
+	}
+
+	if causes[0] == fgs.GMMCauseUEIdentityCannotBeDerived {
+		t.Error("#9 deregisters a UE on a mobility registration update (§5.5.1.3.5)")
+	}
+}

--- a/internal/amf/nas/reg_initial.go
+++ b/internal/amf/nas/reg_initial.go
@@ -41,6 +41,21 @@ func releaseAbortedRegistration(ctx context.Context, ueConn *amf.UeConn) {
 	ueConn.SendUEContextReleaseCommand(ctx, ngap.Cause{Group: ngap.CauseGroupNAS, Value: ngap.CauseNASUnspecified})
 }
 
+func abortRegistrationRetainingContext(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) {
+	ueConn := ue.Conn()
+
+	ue.SuspendRegistration(ctx)
+
+	if ueConn == nil {
+		amfInstance.StartMobileReachable(ue)
+		return
+	}
+
+	ueConn.ReleaseAction = amf.UeContextN2NormalRelease
+
+	ueConn.SendUEContextReleaseCommand(ctx, ngap.Cause{Group: ngap.CauseGroupNAS, Value: ngap.CauseNASUnspecified})
+}
+
 func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) {
 	ue.ClearRegistrationData(ctx)
 

--- a/internal/amf/nas_count_order_test.go
+++ b/internal/amf/nas_count_order_test.go
@@ -108,8 +108,8 @@ func newDownlinkOrderUE(t *testing.T) (*UeContext, *downlinkOrderConn) {
 		amf:         radio.amf,
 		RanUeNgapID: 1,
 		AmfUeNgapID: 1,
-		Log:         zap.NewNop(),
 	}
+	ueConn.setLog(zap.NewNop())
 	ueConn.amf.AttachUeConn(ue, ueConn)
 
 	return ue, sender

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -20,7 +20,7 @@ func HandleHandoverCancel(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	logger.WithTrace(ctx, sourceUe.Log).Debug("Handle Handover Cancel", zap.Uint32("source-ran-ue-id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source-amf-ue-id", uint64(sourceUe.AmfUeNgapID)))
+	logger.WithTrace(ctx, sourceUe.Log()).Debug("Handle Handover Cancel", zap.Uint32("source-ran-ue-id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source-amf-ue-id", uint64(sourceUe.AmfUeNgapID)))
 	sourceUe.TouchLastSeen()
 
 	cause := ngap.Cause{
@@ -29,7 +29,7 @@ func HandleHandoverCancel(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	}
 
 	if msg.Cause != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Debug("Handover Cancel Cause", logger.Cause(msg.Cause.String()))
+		logger.WithTrace(ctx, sourceUe.Log()).Debug("Handover Cancel Cause", logger.Cause(msg.Cause.String()))
 
 		cause = *msg.Cause
 	}
@@ -37,7 +37,7 @@ func HandleHandoverCancel(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	amfUe := sourceUe.UeContext()
 
 	if target := amfInstance.HandoverTarget(amfUe); target != nil && target == sourceUe {
-		logger.WithTrace(ctx, sourceUe.Log).Info("ignoring a Handover Cancel from the prepared target")
+		logger.WithTrace(ctx, sourceUe.Log()).Info("ignoring a Handover Cancel from the prepared target")
 		sourceUe.SendHandoverCancelAcknowledge(ctx)
 
 		return
@@ -45,13 +45,13 @@ func HandleHandoverCancel(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	if id, toEPS := amfInstance.RelocationToEPS(amfUe); toEPS {
 		if err := amfInstance.CancelRelocationToEPS(ctx, amfUe, id); errors.Is(err, interworking.ErrRelocationTooLate) {
-			logger.WithTrace(ctx, sourceUe.Log).Info("the UE has already reached EPS; leaving the handover to complete",
+			logger.WithTrace(ctx, sourceUe.Log()).Info("the UE has already reached EPS; leaving the handover to complete",
 				zap.Error(err))
 			sourceUe.SendHandoverCancelAcknowledge(ctx)
 
 			return
 		} else if err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Info("the peer had no handover to cancel; unwinding locally",
+			logger.WithTrace(ctx, sourceUe.Log()).Info("the peer had no handover to cancel; unwinding locally",
 				zap.Error(err))
 		}
 	}

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -57,18 +57,18 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 		amfInstance.FailRelocationPreparation(amfUe,
 			interworking.TargetRefusal{Cause: amf.S1APHandoverFailureCause(failureCause)})
 	case sourceUe == nil:
-		logger.WithTrace(ctx, targetUe.Log).Error("N2 Handover between AMF has not been implemented yet")
+		logger.WithTrace(ctx, targetUe.Log()).Error("N2 Handover between AMF has not been implemented yet")
 	default:
 		amfInstance.ClearHandover(amfUe)
 
 		if sourceUe.Radio() == nil {
-			logger.WithTrace(ctx, targetUe.Log).Error("source UE radio is nil, cannot send handover preparation failure")
+			logger.WithTrace(ctx, targetUe.Log()).Error("source UE radio is nil, cannot send handover preparation failure")
 		} else {
 			sourceUe.SendHandoverPreparationFailure(ctx, failureCause, nil, msg.TargettoSourceFailureTransparentContainer)
 		}
 	}
 
 	if err := amfInstance.RemoveUeConn(ctx, targetUe); err != nil {
-		logger.WithTrace(ctx, targetUe.Log).Error("error removing target UE association", zap.Error(err))
+		logger.WithTrace(ctx, targetUe.Log()).Error("error removing target UE association", zap.Error(err))
 	}
 }

--- a/internal/amf/ngap/handle_handover_notify.go
+++ b/internal/amf/ngap/handle_handover_notify.go
@@ -21,7 +21,7 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	amfUe := targetUe.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, targetUe.Log).Error("UeContext is nil")
+		logger.WithTrace(ctx, targetUe.Log()).Error("UeContext is nil")
 		return
 	}
 
@@ -29,13 +29,13 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 
 	sourceUe := amfInstance.HandoverSource(amfUe)
 	if sourceUe == nil && !fromEPS {
-		logger.WithTrace(ctx, targetUe.Log).Error("N2 Handover between AMF has not been implemented yet")
+		logger.WithTrace(ctx, targetUe.Log()).Error("N2 Handover between AMF has not been implemented yet")
 		return
 	}
 
 	admitted, ok := amfInstance.MarkHandoverCommitting(amfUe, targetUe)
 	if !ok {
-		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Notify with no prepared handover for this target; dropping")
+		logger.WithTrace(ctx, targetUe.Log()).Warn("Handover Notify with no prepared handover for this target; dropping")
 		return
 	}
 
@@ -59,7 +59,7 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	})
 
 	if !amfInstance.FinishHandoverCommit(amfUe, targetUe) {
-		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Notify: UE released during the user-plane switch")
+		logger.WithTrace(ctx, targetUe.Log()).Warn("Handover Notify: UE released during the user-plane switch")
 
 		amfInstance.ClearHandover(amfUe)
 
@@ -70,7 +70,7 @@ func HandleHandoverNotify(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		targetUe.UpdateLocation(ctx, *msg.UserLocationInformation)
 	}
 
-	logger.WithTrace(ctx, targetUe.Log).Info("Handle Handover notification Finished")
+	logger.WithTrace(ctx, targetUe.Log()).Info("Handle Handover notification Finished")
 
 	if fromEPS {
 		amfInstance.CompleteRelocationFromEPS(ctx, amfUe)

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -44,12 +44,12 @@ func reportFailedSessionsToSmf(ctx context.Context, amfInstance *amf.AMF, target
 	for _, item := range failed {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
-			logger.WithTrace(ctx, targetUe.Log).Error("invalid PDU session ID in the failed-to-setup list", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+			logger.WithTrace(ctx, targetUe.Log()).Error("invalid PDU session ID in the failed-to-setup list", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
 			continue
 		}
 
 		if _, isAdmitted := admitted[pduSessionID]; isAdmitted {
-			logger.WithTrace(ctx, targetUe.Log).Warn("PDU session reported both admitted and failed to setup; keeping it handed over", zap.Uint8("pduSessionID", pduSessionID))
+			logger.WithTrace(ctx, targetUe.Log()).Warn("PDU session reported both admitted and failed to setup; keeping it handed over", zap.Uint8("pduSessionID", pduSessionID))
 			continue
 		}
 
@@ -59,7 +59,7 @@ func reportFailedSessionsToSmf(ctx context.Context, amfInstance *amf.AMF, target
 		}
 
 		if err := amfInstance.Session.UpdateSmContextN2HandoverFailed(ctx, smContext.Ref, item.Transfer); err != nil {
-			logger.WithTrace(ctx, targetUe.Log).Error("failed to hand the target's handover refusal to the SMF",
+			logger.WithTrace(ctx, targetUe.Log()).Error("failed to hand the target's handover refusal to the SMF",
 				zap.Error(err), zap.Uint8("pduSessionID", pduSessionID))
 		}
 	}
@@ -86,7 +86,7 @@ func releaseItems(ctx context.Context, targetUe *amf.UeConn, unadmitted []amf.Ha
 
 		item, err := toReleaseItemHOCmd(c.PDUSessionID, cause)
 		if err != nil {
-			logger.WithTrace(ctx, targetUe.Log).Error("failed to build PDU session to-release item", zap.Error(err), zap.Int64("pduSessionID", int64(c.PDUSessionID)))
+			logger.WithTrace(ctx, targetUe.Log()).Error("failed to build PDU session to-release item", zap.Error(err), zap.Int64("pduSessionID", int64(c.PDUSessionID)))
 			continue
 		}
 
@@ -111,11 +111,11 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 	}
 
 	targetUe.TouchLastSeen()
-	logger.WithTrace(ctx, targetUe.Log).Debug("Handle Handover Request Acknowledge", zap.Uint32("ran-ue-id", uint32(targetUe.RanUeNgapID)), zap.Uint64("amf-ue-id", uint64(targetUe.AmfUeNgapID)))
+	logger.WithTrace(ctx, targetUe.Log()).Debug("Handle Handover Request Acknowledge", zap.Uint32("ran-ue-id", uint32(targetUe.RanUeNgapID)), zap.Uint64("amf-ue-id", uint64(targetUe.AmfUeNgapID)))
 
 	amfUe := targetUe.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, targetUe.Log).Error("amfUe is nil")
+		logger.WithTrace(ctx, targetUe.Log()).Error("amfUe is nil")
 		return
 	}
 
@@ -123,17 +123,17 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 
 	sourceUe := amfInstance.HandoverSource(amfUe)
 	if sourceUe == nil && !fromEPS {
-		logger.WithTrace(ctx, targetUe.Log).Error("handover between different Ue has not been implement yet")
+		logger.WithTrace(ctx, targetUe.Log()).Error("handover between different Ue has not been implement yet")
 		return
 	}
 
 	if amfInstance.HandoverTarget(amfUe) != targetUe {
-		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Request Acknowledge from a radio that is not the prepared target; dropping")
+		logger.WithTrace(ctx, targetUe.Log()).Warn("Handover Request Acknowledge from a radio that is not the prepared target; dropping")
 		return
 	}
 
 	if !amfInstance.HandoverPreparing(amfUe) {
-		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Request Acknowledge for a handover past the preparing stage; dropping")
+		logger.WithTrace(ctx, targetUe.Log()).Warn("Handover Request Acknowledge for a handover past the preparing stage; dropping")
 		return
 	}
 
@@ -149,7 +149,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 	for _, item := range msg.PDUSessionResourceAdmittedList {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
-			logger.WithTrace(ctx, targetUe.Log).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+			logger.WithTrace(ctx, targetUe.Log()).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
 			continue
 		}
 
@@ -160,7 +160,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 
 		n2Rsp, err := amfInstance.Session.UpdateSmContextN2HandoverPrepared(ctx, smContext.Ref, item.Transfer)
 		if err != nil {
-			logger.WithTrace(ctx, targetUe.Log).Error("Send HandoverRequestAcknowledgeTransfer error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, targetUe.Log()).Error("Send HandoverRequestAcknowledgeTransfer error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			continue
 		}
 
@@ -176,7 +176,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 	reportFailedSessionsToSmf(ctx, amfInstance, targetUe, amfUe, msg.PDUSessionResourceFailedToSetup, admittedPDU)
 
 	if len(admitted) == 0 {
-		logger.WithTrace(ctx, targetUe.Log).Info("handle Handover Preparation Failure [HoFailure In Target5GC NgranNode Or TargetSystem]")
+		logger.WithTrace(ctx, targetUe.Log()).Info("handle Handover Preparation Failure [HoFailure In Target5GC NgranNode Or TargetSystem]")
 
 		amfInstance.UnbindHandoverTarget(ctx, amfUe)
 
@@ -187,7 +187,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 			amfInstance.ClearHandover(amfUe)
 
 			if sourceUe.Radio() == nil {
-				logger.WithTrace(ctx, targetUe.Log).Error("source UE radio is nil, cannot send handover preparation failure")
+				logger.WithTrace(ctx, targetUe.Log()).Error("source UE radio is nil, cannot send handover preparation failure")
 			} else {
 				sourceUe.SendHandoverPreparationFailure(ctx, causeHOFailureInTarget, nil, nil)
 			}
@@ -201,19 +201,19 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 
 	unadmitted, ok := amfInstance.MarkHandoverPrepared(amfUe, admittedPDU)
 	if !ok {
-		logger.WithTrace(ctx, targetUe.Log).Warn("Handover Request Acknowledge: handover advanced concurrently; dropping")
+		logger.WithTrace(ctx, targetUe.Log()).Warn("Handover Request Acknowledge: handover advanced concurrently; dropping")
 		return
 	}
 
 	if fromEPS {
-		logger.WithTrace(ctx, targetUe.Log).Info("Handover Request Acknowledge (EPS to 5GS)",
+		logger.WithTrace(ctx, targetUe.Log()).Info("Handover Request Acknowledge (EPS to 5GS)",
 			zap.Int("admitted", len(admitted)), zap.Int("not-handed-over", len(unadmitted)))
 		amfInstance.FinishRelocationPreparation(amfUe, msg.TargetToSourceTransparentContainer, unadmitted)
 
 		return
 	}
 
-	logger.WithTrace(ctx, targetUe.Log).Debug("handle handover request acknowledge", zap.Uint32("source-ran-ue-id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source-amf-ue-id", uint64(sourceUe.AmfUeNgapID)),
+	logger.WithTrace(ctx, targetUe.Log()).Debug("handle handover request acknowledge", zap.Uint32("source-ran-ue-id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source-amf-ue-id", uint64(sourceUe.AmfUeNgapID)),
 		zap.Uint32("target-ran-ue-id", uint32(targetUe.RanUeNgapID)), zap.Uint64("target-amf-ue-id", uint64(targetUe.AmfUeNgapID)))
 
 	sourceUe.SendHandoverCommand(ctx, admitted, releaseItems(ctx, targetUe, unadmitted, targetCauses), msg.TargetToSourceTransparentContainer)

--- a/internal/amf/ngap/handle_handover_required.go
+++ b/internal/amf/ngap/handle_handover_required.go
@@ -21,7 +21,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 	amfUe := sourceUe.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, sourceUe.Log).Error("Cannot find amfUE from sourceUE")
+		logger.WithTrace(ctx, sourceUe.Log()).Error("Cannot find amfUE from sourceUE")
 		return
 	}
 
@@ -29,12 +29,12 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 	conn := amfUe.Conn()
 	if conn == nil {
-		logger.WithTrace(ctx, sourceUe.Log).Error("no active NAS connection")
+		logger.WithTrace(ctx, sourceUe.Log()).Error("no active NAS connection")
 		return
 	}
 
 	if !amfUe.SecurityContextIsValid() {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [Authentication Failure]")
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [Authentication Failure]")
 
 		sourceUe.SendHandoverPreparationFailure(ctx, causeHandoverNoSecurity, nil, nil)
 
@@ -48,7 +48,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	}
 
 	if msg.HandoverType != ngap.HandoverTypeIntra5GS {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [unsupported Handover Type]",
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [unsupported Handover Type]",
 			zap.Uint8("handoverType", uint8(msg.HandoverType)))
 
 		sourceUe.SendHandoverPreparationFailure(ctx, causeHOTargetNotAllowed, nil, nil)
@@ -57,7 +57,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	}
 
 	if msg.TargetID.TargetRANNodeID == nil {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [Target ID is not an NG-RAN node]")
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [Target ID is not an NG-RAN node]")
 
 		sourceUe.SendHandoverPreparationFailure(ctx, causeUnknownTargetID, nil, nil)
 
@@ -68,7 +68,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 	targetRan, ok := amfInstance.FindRadioByRanID(targetRanNodeID)
 	if !ok {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [Unknown Target ID]", zap.Any("targetRanNodeID", targetRanNodeID))
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [Unknown Target ID]", zap.Any("targetRanNodeID", targetRanNodeID))
 
 		sourceUe.SendHandoverPreparationFailure(ctx, causeUnknownTargetID, nil, nil)
 
@@ -76,7 +76,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	}
 
 	if targetRan.Conn == ran.Conn {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [target gNB is the source]")
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [target gNB is the source]")
 
 		sourceUe.SendHandoverPreparationFailure(ctx, causeHOTargetNotAllowed, nil, nil)
 
@@ -97,7 +97,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	for _, item := range msg.PDUSessionResourceListHORqd {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
-			logger.WithTrace(ctx, sourceUe.Log).Error("invalid PDU session ID from gNB, reporting it as not handed over", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+			logger.WithTrace(ctx, sourceUe.Log()).Error("invalid PDU session ID from gNB, reporting it as not handed over", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
 			notOffered(item.PDUSessionID, causeUnknownPDUSessionID)
 
 			continue
@@ -105,7 +105,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 		smContext, exist := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !exist {
-			logger.WithTrace(ctx, sourceUe.Log).Error("no SM context for a PDU session the gNB asked to hand over", zap.Uint8("pduSessionID", pduSessionID))
+			logger.WithTrace(ctx, sourceUe.Log()).Error("no SM context for a PDU session the gNB asked to hand over", zap.Uint8("pduSessionID", pduSessionID))
 			notOffered(item.PDUSessionID, causeUnknownPDUSessionID)
 
 			continue
@@ -113,7 +113,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 		n2Rsp, err := amfInstance.Session.UpdateSmContextN2HandoverPreparing(ctx, smContext.Ref, item.Transfer)
 		if err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("SendUpdateSmContextN2HandoverPreparing Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, sourceUe.Log()).Error("SendUpdateSmContextN2HandoverPreparing Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			notOffered(item.PDUSessionID, causeHandoverCNReason)
 
 			continue
@@ -121,7 +121,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 		setupItem, err := amf.PDUSessionSetupItemHOReq(pduSessionID, smContext.Snssai, n2Rsp)
 		if err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("could not build the handover request item", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, sourceUe.Log()).Error("could not build the handover request item", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			notOffered(item.PDUSessionID, causeHandoverCNReason)
 
 			continue
@@ -132,7 +132,7 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	}
 
 	if len(sessions) == 0 {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [HoFailure In Target5GC NgranNode Or TargetSystem]")
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [HoFailure In Target5GC NgranNode Or TargetSystem]")
 
 		sourceUe.SendHandoverPreparationFailure(ctx, causeHOFailureInTarget, nil, nil)
 
@@ -141,13 +141,13 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 
 	operatorInfo, err := amfInstance.OperatorInfo(ctx)
 	if err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Error("Could not get operator info", zap.Error(err))
+		logger.WithTrace(ctx, sourceUe.Log()).Error("Could not get operator info", zap.Error(err))
 		return
 	}
 
 	snssaiList, err := amfInstance.ListOperatorSnssai(ctx)
 	if err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Error("Could not list operator SNSSAI", zap.Error(err))
+		logger.WithTrace(ctx, sourceUe.Log()).Error("Could not list operator SNSSAI", zap.Error(err))
 		return
 	}
 
@@ -178,11 +178,11 @@ func HandleHandoverRequired(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		ServingPLMN:          operatorInfo.Guami.PlmnID,
 	})
 	if err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Error("error sending handover request to target UE", zap.Error(err))
+		logger.WithTrace(ctx, sourceUe.Log()).Error("error sending handover request to target UE", zap.Error(err))
 		amfInstance.ClearHandover(amfUe)
 
 		if rerr := amfInstance.RemoveUeConn(ctx, targetUe); rerr != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Error("error removing target ue after failed handover request", zap.Error(rerr))
+			logger.WithTrace(ctx, sourceUe.Log()).Error("error removing target ue after failed handover request", zap.Error(rerr))
 		}
 
 		sourceUe.SendHandoverPreparationFailure(ctx, causeHOFailureInTarget, nil, nil)

--- a/internal/amf/ngap/handle_initial_context_setup_failure.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure.go
@@ -34,7 +34,7 @@ func HandleInitialContextSetupFailure(ctx context.Context, amfInstance *amf.AMF,
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("amfUe is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("amfUe is nil")
 		return
 	}
 
@@ -49,7 +49,7 @@ func HandleInitialContextSetupFailure(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Debug("Send PDUSessionResourceSetupUnsuccessfulTransfer to SMF")
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Send PDUSessionResourceSetupUnsuccessfulTransfer to SMF")
 
 	for _, item := range msg.PDUSessionResourceFailed {
 		pduSessionID := uint8(item.PDUSessionID)
@@ -57,13 +57,13 @@ func HandleInitialContextSetupFailure(ctx context.Context, amfInstance *amf.AMF,
 
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 			continue
 		}
 
 		err := amfInstance.Session.UpdateSmContextN2InfoPduResSetupFail(ctx, smContext.Ref, transfer)
 		if err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupUnsuccessfulTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupUnsuccessfulTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 		}
 	}
 }

--- a/internal/amf/ngap/handle_initial_context_setup_response.go
+++ b/internal/amf/ngap/handle_initial_context_setup_response.go
@@ -28,12 +28,12 @@ func HandleInitialContextSetupResponse(ctx context.Context, amfInstance *amf.AMF
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("amfUe is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("amfUe is nil")
 		return
 	}
 
 	if len(msg.PDUSessionResourceSetup) > 0 {
-		logger.WithTrace(ctx, ueConn.Log).Debug("Send PDUSessionResourceSetupResponseTransfer to SMF")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("Send PDUSessionResourceSetupResponseTransfer to SMF")
 
 		for _, item := range msg.PDUSessionResourceSetup {
 			pduSessionID := uint8(item.PDUSessionID)
@@ -41,19 +41,19 @@ func HandleInitialContextSetupResponse(ctx context.Context, amfInstance *amf.AMF
 
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 				continue
 			}
 
 			err := amfInstance.Session.UpdateSmContextN2InfoPduResSetupRsp(ctx, smContext.Ref, transfer)
 			if err != nil {
-				logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupResponseTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupResponseTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			}
 		}
 	}
 
 	if len(msg.PDUSessionResourceFailed) > 0 {
-		logger.WithTrace(ctx, ueConn.Log).Debug("Send PDUSessionResourceSetupUnsuccessfulTransfer to SMF")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("Send PDUSessionResourceSetupUnsuccessfulTransfer to SMF")
 
 		for _, item := range msg.PDUSessionResourceFailed {
 			pduSessionID := uint8(item.PDUSessionID)
@@ -61,13 +61,13 @@ func HandleInitialContextSetupResponse(ctx context.Context, amfInstance *amf.AMF
 
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 				continue
 			}
 
 			err := amfInstance.Session.UpdateSmContextN2InfoPduResSetupFail(ctx, smContext.Ref, transfer)
 			if err != nil {
-				logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupUnsuccessfulTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupUnsuccessfulTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			}
 		}
 	}

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -31,7 +31,7 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		return
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Debug("Added Ran UE to the pool", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Added Ran UE to the pool", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 
 	reportDiagnostics(ctx, ran, ngap.ProcInitialUEMessage, ngap.TriggeringInitiatingMessage,
 		ueAssociated(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), msg.RANUENGAPID), msg.Diagnostics())
@@ -41,7 +41,7 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	ueConn.UeContextRequest = msg.UEContextRequest != nil
 
 	if amfInstance.NAS == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("NAS handler not set")
+		logger.WithTrace(ctx, ueConn.Log()).Error("NAS handler not set")
 		return
 	}
 
@@ -56,7 +56,7 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 	// registration path.
 	if ueConn.UeContext() == nil {
 		if rerr := amfInstance.RemoveUeConn(ctx, ueConn); rerr != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("failed to release bare RAN UE", zap.Error(rerr))
+			logger.WithTrace(ctx, ueConn.Log()).Error("failed to release bare RAN UE", zap.Error(rerr))
 		}
 	}
 }
@@ -71,11 +71,11 @@ func resumeExistingContext(ctx context.Context, amfInstance *amf.AMF, ueConn *am
 		return
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Debug("Receive 5G-S-TMSI")
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Receive 5G-S-TMSI")
 
 	operatorInfo, err := amfInstance.OperatorInfo(ctx)
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("Could not get operator info", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Error("Could not get operator info", zap.Error(err))
 		return
 	}
 
@@ -84,7 +84,7 @@ func resumeExistingContext(ctx context.Context, amfInstance *amf.AMF, ueConn *am
 	// 5G-GUTI := <GUAMI><5G-TMSI>
 	region, _, _, err := util.AMFIDToNGAP(operatorInfo.Guami.AmfID)
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("invalid operator AMF id", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Error("invalid operator AMF id", zap.Error(err))
 		return
 	}
 
@@ -92,17 +92,17 @@ func resumeExistingContext(ctx context.Context, amfInstance *amf.AMF, ueConn *am
 
 	tmsi, err := etsi.NewTMSI(uint32(msg.FiveGSTMSI.FiveGTMSI))
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Warn("invalid tmsi", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Warn("invalid tmsi", zap.Error(err))
 	}
 
 	guti, err := etsi.NewGUTI5G(operatorInfo.Guami.PlmnID.Mcc, operatorInfo.Guami.PlmnID.Mnc, amfID, tmsi)
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Warn("invalid guti", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Warn("invalid guti", zap.Error(err))
 	}
 
 	amfUe, ok := amfInstance.LookupUeByGuti(operatorInfo.Guami, guti)
 	if !ok {
-		logger.WithTrace(ctx, ueConn.Log).Warn("Unknown UE", logger.GUTI(guti.String()))
+		logger.WithTrace(ctx, ueConn.Log()).Warn("Unknown UE", logger.GUTI(guti.String()))
 		return
 	}
 
@@ -110,14 +110,14 @@ func resumeExistingContext(ctx context.Context, amfInstance *amf.AMF, ueConn *am
 		// The message cites an existing context but is not authenticated for it. Do not
 		// bind to or mutate the live context; the NAS layer registers it on a fresh
 		// context pending authentication.
-		logger.WithTrace(ctx, ueConn.Log).Info("Initial UE Message cites a known GUTI but is not authenticated for that context; registering on a fresh context", logger.GUTI(guti.String()))
+		logger.WithTrace(ctx, ueConn.Log()).Info("Initial UE Message cites a known GUTI but is not authenticated for that context; registering on a fresh context", logger.GUTI(guti.String()))
 		return
 	}
 
 	if amfUe.Conn() != nil {
-		logger.WithTrace(ctx, ueConn.Log).Debug("Implicit Deregistration", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+		logger.WithTrace(ctx, ueConn.Log()).Debug("Implicit Deregistration", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Debug("UeContext Attach UeConn", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("UeContext Attach UeConn", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 	amfInstance.AttachUeConn(amfUe, ueConn)
 }

--- a/internal/amf/ngap/handle_location_report.go
+++ b/internal/amf/ngap/handle_location_report.go
@@ -33,47 +33,47 @@ func HandleLocationReport(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	// LocationReportingRequestType is ignore criticality, so §10.3.5 delivers a
 	// report without it; the location above is recorded either way.
 	if msg.LocationReportingRequestType == nil {
-		logger.WithTrace(ctx, ueConn.Log).Warn("Location Report carries no LocationReportingRequestType")
+		logger.WithTrace(ctx, ueConn.Log()).Warn("Location Report carries no LocationReportingRequestType")
 		return
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Debug("Handle Location Report",
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle Location Report",
 		zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)),
 		zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)),
 		zap.Int("report-area", int(msg.LocationReportingRequestType.ReportArea)))
 
 	switch msg.LocationReportingRequestType.EventType {
 	case ngap.EventTypeDirect:
-		logger.WithTrace(ctx, ueConn.Log).Debug("To report directly")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("To report directly")
 
 	case ngap.EventTypeChangeOfServeCell:
-		logger.WithTrace(ctx, ueConn.Log).Debug("To report upon change of serving cell")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("To report upon change of serving cell")
 
 	case ngap.EventTypeUEPresenceInAreaOfInterest:
 		// This AMF never requests area-of-interest reporting, so the library
 		// refuses an areaOfInterestList and there is nothing to match against;
 		// the presences are reported for the record only.
 		for _, item := range msg.UEPresenceInAreaOfInterestList {
-			logger.WithTrace(ctx, ueConn.Log).Debug("UE presence in an area this AMF did not request",
+			logger.WithTrace(ctx, ueConn.Log()).Debug("UE presence in an area this AMF did not request",
 				zap.Int("reference-id", int(item.LocationReportingReferenceID)),
 				zap.Int("ue-presence", int(item.UEPresence)))
 		}
 
 	case ngap.EventTypeStopChangeOfServeCell:
 		if err := ueConn.SendLocationReportingControl(ctx, msg.LocationReportingRequestType.EventType); err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("error sending location reporting control", zap.Error(err))
+			logger.WithTrace(ctx, ueConn.Log()).Error("error sending location reporting control", zap.Error(err))
 		}
 
 	case ngap.EventTypeStopUEPresenceInAreaOfInterest:
 		if msg.LocationReportingRequestType.LocationReportingReferenceIDToBeCancelled == nil {
-			logger.WithTrace(ctx, ueConn.Log).Warn("stop-ue-presence-in-area-of-interest with no reference id to cancel")
+			logger.WithTrace(ctx, ueConn.Log()).Warn("stop-ue-presence-in-area-of-interest with no reference id to cancel")
 			break
 		}
 
-		logger.WithTrace(ctx, ueConn.Log).Debug("To stop reporting UE presence in the area of interest",
+		logger.WithTrace(ctx, ueConn.Log()).Debug("To stop reporting UE presence in the area of interest",
 			zap.Int("reference-id", int(*msg.LocationReportingRequestType.LocationReportingReferenceIDToBeCancelled)))
 
 	case ngap.EventTypeCancelLocationReportingForTheUE:
-		logger.WithTrace(ctx, ueConn.Log).Debug("To cancel location reporting for the UE")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("To cancel location reporting for the UE")
 	}
 }

--- a/internal/amf/ngap/handle_nas_non_delivery_indication.go
+++ b/internal/amf/ngap/handle_nas_non_delivery_indication.go
@@ -35,5 +35,5 @@ func HandleNASNonDeliveryIndication(ctx context.Context, amfInstance *amf.AMF, r
 		fields = append(fields, logger.Cause(msg.Cause.String()))
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Debug("NAS Non Delivery Indication", fields...)
+	logger.WithTrace(ctx, ueConn.Log()).Debug("NAS Non Delivery Indication", fields...)
 }

--- a/internal/amf/ngap/handle_ng_reset.go
+++ b/internal/amf/ngap/handle_ng_reset.go
@@ -75,7 +75,7 @@ func releaseListedUEs(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio,
 		}
 
 		if err := amfInstance.RemoveUe(ctx, ueConn); err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("failed to remove UE named by NG Reset", zap.Error(err))
+			logger.WithTrace(ctx, ueConn.Log()).Error("failed to remove UE named by NG Reset", zap.Error(err))
 
 			continue
 		}

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -28,7 +28,7 @@ func appendPathSwitchReleasedItem(ctx context.Context, ueConn *amf.UeConn, list 
 		Cause: ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: causeValue},
 	}).Marshal()
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("failed to build PathSwitchRequestUnsuccessfulTransfer", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+		logger.WithTrace(ctx, ueConn.Log()).Error("failed to build PathSwitchRequestUnsuccessfulTransfer", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 		return
 	}
 
@@ -57,18 +57,18 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	}
 
 	ueConn.TouchLastSeen()
-	logger.WithTrace(ctx, ueConn.Log).Debug("Handle Path Switch Request", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle Path Switch Request", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("UeContext is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("UeContext is nil")
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
 
 		return
 	}
 
 	if !amfUe.SecurityContextIsValid() {
-		logger.WithTrace(ctx, ueConn.Log).Error("No Security Context", logger.SUPI(amfUe.Supi().String()))
+		logger.WithTrace(ctx, ueConn.Log()).Error("No Security Context", logger.SUPI(amfUe.Supi().String()))
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
 
 		return
@@ -77,7 +77,7 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	verifyUESecurityCapabilitiesOnPathSwitch(ctx, ueConn, amfUe, msg.UESecurityCapabilities)
 
 	if !amfUe.BeginKeyChainProc(procedure.PathSwitch) {
-		logger.WithTrace(ctx, ueConn.Log).Warn("Path Switch rejected: a key-changing procedure is in progress")
+		logger.WithTrace(ctx, ueConn.Log()).Warn("Path Switch rejected: a key-changing procedure is in progress")
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
 
 		return
@@ -88,24 +88,24 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	for _, item := range msg.PDUSessionResourceFailedToSetup {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+			logger.WithTrace(ctx, ueConn.Log()).Error("invalid PDU session ID from gNB, skipping", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
 			continue
 		}
 
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 			continue
 		}
 
 		if err := amfInstance.Session.UpdateSmContextXnHandoverFailed(ctx, smContext.Ref, item.Transfer); err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextXnHandoverFailed[PathSwitchRequestSetupFailedTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextXnHandoverFailed[PathSwitchRequestSetupFailedTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 		}
 	}
 
 	nh, ncc, err := amfUe.AdvancePathSwitchNH()
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("error advancing NH", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Error("error advancing NH", zap.Error(err))
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
 
 		return
@@ -113,7 +113,7 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 
 	snssaiList, err := amfInstance.ListOperatorSnssai(ctx)
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("List Operator SNSSAI Error", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Error("List Operator SNSSAI Error", zap.Error(err))
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
 
 		return
@@ -152,7 +152,7 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 	}
 
 	if !amfInstance.CommitPathSwitch(amfUe, ueConn, ran, models.RanUeNgapID(msg.RANUENGAPID), nh, ncc) {
-		logger.WithTrace(ctx, ueConn.Log).Warn("Path Switch Request: UE released during the user-plane switch")
+		logger.WithTrace(ctx, ueConn.Log()).Warn("Path Switch Request: UE released during the user-plane switch")
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnspecified)
 
 		return
@@ -193,13 +193,13 @@ func verifyUESecurityCapabilitiesOnPathSwitch(
 	case amf.VerifyMatch:
 		return
 	case amf.VerifyNoStoredValue:
-		logger.WithTrace(ctx, ueConn.Log).Warn(
+		logger.WithTrace(ctx, ueConn.Log()).Warn(
 			"received UE security capabilities in PathSwitchRequest but AMF has no stored capabilities for this UE",
 		)
 
 		return
 	case amf.VerifyMismatch:
-		logger.WithTrace(ctx, ueConn.Log).Warn(
+		logger.WithTrace(ctx, ueConn.Log()).Warn(
 			"UE 5G security capabilities reported by target gNB differ from locally stored values; ignoring received values (TS 33.501)",
 			zap.Stringer("stored", amfUe.UESecCap()),
 			zap.Stringer("received", reported),

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
@@ -25,12 +25,12 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 		ueConn.UpdateLocation(ctx, *msg.UserLocationInformation)
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Debug("UE Context", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("UE Context", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 	ueConn.TouchLastSeen()
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("UeContext is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("UeContext is nil")
 		return
 	}
 
@@ -44,7 +44,7 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 			failedList = appendFailedToModify(ctx, ueConn, failedList, item.PDUSessionID, ngap.CauseRadioNetworkUnknownPDUSessionID)
 
 			continue
@@ -52,7 +52,7 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 
 		confirmTransfer, err := amfInstance.Session.UpdateSmContextN2ModifyIndication(ctx, smContext.Ref, []byte(item.Transfer))
 		if err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("UpdateSmContextN2ModifyIndication error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("UpdateSmContextN2ModifyIndication error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			failedList = appendFailedToModify(ctx, ueConn, failedList, item.PDUSessionID, ngap.CauseRadioNetworkUnspecified)
 
 			continue
@@ -83,7 +83,7 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 
 	pkt, err := confirm.Marshal()
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("error building pdu session resource modify confirm", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Error("error building pdu session resource modify confirm", zap.Error(err))
 		return
 	}
 
@@ -100,7 +100,7 @@ func appendFailedToModify(ctx context.Context, ueConn *amf.UeConn, list ngap.PDU
 
 	transfer, err := t.Marshal()
 	if err != nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("encode modify indication unsuccessful transfer", zap.Error(err))
+		logger.WithTrace(ctx, ueConn.Log()).Error("encode modify indication unsuccessful transfer", zap.Error(err))
 		return list
 	}
 

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_response.go
@@ -34,13 +34,13 @@ func HandlePDUSessionResourceModifyResponse(ctx context.Context, amfInstance *am
 	}
 
 	ueConn.TouchLastSeen()
-	logger.WithTrace(ctx, ueConn.Log).Debug("Handle PDUSessionResourceModifyResponse", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle PDUSessionResourceModifyResponse", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
 
 	// The transfer carries the NG-RAN node's cause but is opaque here, so the
 	// rejection is surfaced by session id: without it a modification the RAN
 	// refused is indistinguishable from one it applied.
 	for _, item := range msg.PDUSessionResourceFailed {
-		logger.WithTrace(ctx, ueConn.Log).Warn("NG-RAN node did not modify a PDU session",
+		logger.WithTrace(ctx, ueConn.Log()).Warn("NG-RAN node did not modify a PDU session",
 			zap.Uint8("pdu-session-id", uint8(item.PDUSessionID)))
 	}
 }

--- a/internal/amf/ngap/handle_pdu_session_resource_notify.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_notify.go
@@ -28,11 +28,11 @@ func HandlePDUSessionResourceNotify(ctx context.Context, amfInstance *amf.AMF, r
 	reportDiagnostics(ctx, ran, ngap.ProcPDUSessionResourceNotify, ngap.TriggeringInitiatingMessage, ueAssociated(msg.AMFUENGAPID, msg.RANUENGAPID), msg.Diagnostics())
 
 	ueConn.TouchLastSeen()
-	logger.WithTrace(ctx, ueConn.Log).Debug("Handle PDUSessionResourceNotify", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle PDUSessionResourceNotify", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("amfUe is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("amfUe is nil")
 		return
 	}
 
@@ -41,7 +41,7 @@ func HandlePDUSessionResourceNotify(ctx context.Context, amfInstance *amf.AMF, r
 	}
 
 	for _, item := range msg.PDUSessionResourceNotify {
-		logger.WithTrace(ctx, ueConn.Log).Warn("QoS flow status change not forwarded to the SMF (TS 38.413 §8.2.4.2)",
+		logger.WithTrace(ctx, ueConn.Log()).Warn("QoS flow status change not forwarded to the SMF (TS 38.413 §8.2.4.2)",
 			zap.Uint8("pdu-session-id", uint8(item.PDUSessionID)))
 	}
 
@@ -50,18 +50,18 @@ func HandlePDUSessionResourceNotify(ctx context.Context, amfInstance *amf.AMF, r
 
 		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 			continue
 		}
 
 		err := amfInstance.Session.DeactivateSmContext(ctx, smContext.Ref)
 		if err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("DeactivateSmContext failed", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+			logger.WithTrace(ctx, ueConn.Log()).Error("DeactivateSmContext failed", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			continue
 		}
 
 		amfUe.SetSmContextInactive(pduSessionID)
 
-		logger.WithTrace(ctx, ueConn.Log).Info("deactivated PDU session released by gNB", zap.Uint8("PduSessionID", pduSessionID))
+		logger.WithTrace(ctx, ueConn.Log()).Info("deactivated PDU session released by gNB", zap.Uint8("PduSessionID", pduSessionID))
 	}
 }

--- a/internal/amf/ngap/handle_pdu_session_resource_release_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_release_response.go
@@ -33,26 +33,26 @@ func HandlePDUSessionResourceReleaseResponse(ctx context.Context, amfInstance *a
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("amfUe is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("amfUe is nil")
 		return
 	}
 
 	if len(msg.PDUSessionResourceReleased) > 0 {
-		logger.WithTrace(ctx, ueConn.Log).Debug("Send PDUSessionResourceReleaseResponseTransfer to SMF")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("Send PDUSessionResourceReleaseResponseTransfer to SMF")
 
 		for _, item := range msg.PDUSessionResourceReleased {
 			pduSessionID := uint8(item.PDUSessionID)
 
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				logger.WithTrace(ctx, ueConn.Log).Warn("SmContext not found during release response (may already be removed by SMF)",
+				logger.WithTrace(ctx, ueConn.Log()).Warn("SmContext not found during release response (may already be removed by SMF)",
 					zap.Uint8("PduSessionID", pduSessionID))
 			}
 
 			if smContext != nil {
 				err := amfInstance.Session.UpdateSmContextN2InfoPduResRelRsp(ctx, smContext.Ref)
 				if err != nil {
-					logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextN2InfoPduResRelRsp failed", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+					logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2InfoPduResRelRsp failed", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 				}
 			}
 

--- a/internal/amf/ngap/handle_pdu_session_resource_setup_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_setup_response.go
@@ -32,12 +32,12 @@ func HandlePDUSessionResourceSetupResponse(ctx context.Context, amfInstance *amf
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("amfUe is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("amfUe is nil")
 		return
 	}
 
 	if len(msg.PDUSessionResourceSetup) > 0 {
-		logger.WithTrace(ctx, ueConn.Log).Debug("Send PDUSessionResourceSetupResponseTransfer to SMF")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("Send PDUSessionResourceSetupResponseTransfer to SMF")
 
 		for _, item := range msg.PDUSessionResourceSetup {
 			pduSessionID := uint8(item.PDUSessionID)
@@ -45,19 +45,19 @@ func HandlePDUSessionResourceSetupResponse(ctx context.Context, amfInstance *amf
 
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 				continue
 			}
 
 			err := amfInstance.Session.UpdateSmContextN2InfoPduResSetupRsp(ctx, smContext.Ref, transfer)
 			if err != nil {
-				logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupResponseTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupResponseTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			}
 		}
 	}
 
 	if len(msg.PDUSessionResourceFailed) > 0 {
-		logger.WithTrace(ctx, ueConn.Log).Debug("Send PDUSessionResourceSetupUnsuccessfulTransfer to SMF")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("Send PDUSessionResourceSetupUnsuccessfulTransfer to SMF")
 
 		for _, item := range msg.PDUSessionResourceFailed {
 			pduSessionID := uint8(item.PDUSessionID)
@@ -65,13 +65,13 @@ func HandlePDUSessionResourceSetupResponse(ctx context.Context, amfInstance *amf
 
 			smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 			if !ok {
-				logger.WithTrace(ctx, ueConn.Log).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SmContext not found", zap.Uint8("PduSessionID", pduSessionID))
 				continue
 			}
 
 			err := amfInstance.Session.UpdateSmContextN2InfoPduResSetupFail(ctx, smContext.Ref, transfer)
 			if err != nil {
-				logger.WithTrace(ctx, ueConn.Log).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupUnsuccessfulTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+				logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupUnsuccessfulTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 			}
 		}
 	}

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -28,7 +28,7 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 	reportDiagnostics(ctx, ran, ngap.ProcUEContextReleaseRequest, ngap.TriggeringInitiatingMessage, ueAssociated(msg.AMFUENGAPID, msg.RANUENGAPID), msg.Diagnostics())
 
 	ueConn.TouchLastSeen()
-	logger.WithTrace(ctx, ueConn.Log).Debug("Handle UE Context Release Request", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle UE Context Release Request", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 
 	// An omitted Cause is an ignore-criticality absence: the NG-RAN node has
 	// dropped the radio connection either way, so the release proceeds under a
@@ -43,13 +43,13 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 			fields = append(fields, logger.SUPI(ueConn.UeContext().Supi().String()))
 		}
 
-		logger.WithTrace(ctx, ueConn.Log).Info("UE Context Release Cause", fields...)
+		logger.WithTrace(ctx, ueConn.Log()).Info("UE Context Release Cause", fields...)
 	}
 
 	amfUe := ueConn.UeContext()
 	if amfUe != nil {
 		if amfUe.State() == amf.Registered {
-			logger.WithTrace(ctx, ueConn.Log).Info("Ue Context in GMM-Registered")
+			logger.WithTrace(ctx, ueConn.Log()).Info("Ue Context in GMM-Registered")
 
 			if msg.PDUSessionResourceList != nil {
 				for _, item := range msg.PDUSessionResourceList {
@@ -57,7 +57,7 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 					smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
 					if !ok {
-						logger.WithTrace(ctx, ueConn.Log).Warn("no SM context for a PDU session the NG-RAN node reported as established",
+						logger.WithTrace(ctx, ueConn.Log()).Warn("no SM context for a PDU session the NG-RAN node reported as established",
 							zap.Uint8("PduSessionID", pduSessionID))
 
 						continue
@@ -65,26 +65,26 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 					err := amfInstance.Session.DeactivateSmContext(ctx, smContext.Ref)
 					if err != nil {
-						logger.WithTrace(ctx, ueConn.Log).Error("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+						logger.WithTrace(ctx, ueConn.Log()).Error("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
 					}
 				}
 			} else {
-				logger.WithTrace(ctx, ueConn.Log).Info("Pdu Session IDs not received from gNB, Releasing the UE Context with SMF using local context")
+				logger.WithTrace(ctx, ueConn.Log()).Info("Pdu Session IDs not received from gNB, Releasing the UE Context with SMF using local context")
 
 				for _, sr := range amfUe.SmContextRefs() {
 					if sr.Inactive {
-						logger.WithTrace(ctx, ueConn.Log).Info("Pdu Session is inactive so not sending deactivate to SMF", logger.PDUSessionID(sr.PduSessionID))
+						logger.WithTrace(ctx, ueConn.Log()).Info("Pdu Session is inactive so not sending deactivate to SMF", logger.PDUSessionID(sr.PduSessionID))
 						continue
 					}
 
 					err := amfInstance.Session.DeactivateSmContext(ctx, sr.Ref)
 					if err != nil {
-						logger.WithTrace(ctx, ueConn.Log).Warn("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
+						logger.WithTrace(ctx, ueConn.Log()).Warn("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
 					}
 				}
 			}
 		} else {
-			logger.WithTrace(ctx, ueConn.Log).Info("Ue Context in Non GMM-Registered")
+			logger.WithTrace(ctx, ueConn.Log()).Info("Ue Context in Non GMM-Registered")
 			ueConn.ReleaseAction = amf.UeContextReleaseUeContext
 
 			ueConn.SendUEContextReleaseCommand(ctx, cause)
@@ -92,7 +92,7 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 			for _, sr := range amfUe.SmContextRefs() {
 				err := amfInstance.Session.ReleaseSmContext(ctx, sr.Ref)
 				if err != nil {
-					logger.WithTrace(ctx, ueConn.Log).Error("error sending release sm context request", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
+					logger.WithTrace(ctx, ueConn.Log()).Error("error sending release sm context request", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
 				}
 			}
 

--- a/internal/amf/ngap/handle_ue_radio_capability_info_indication.go
+++ b/internal/amf/ngap/handle_ue_radio_capability_info_indication.go
@@ -32,7 +32,7 @@ func HandleUERadioCapabilityInfoIndication(ctx context.Context, amfInstance *amf
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("amfUe is nil")
+		logger.WithTrace(ctx, ueConn.Log()).Error("amfUe is nil")
 		return
 	}
 
@@ -55,6 +55,6 @@ func HandleUERadioCapabilityInfoIndication(ctx context.Context, amfInstance *amf
 		amfUe.RadioCapabilityForPaging = stored
 	}
 
-	logger.WithTrace(ctx, ueConn.Log).Info("stored UE Radio Capability",
+	logger.WithTrace(ctx, ueConn.Log()).Info("stored UE Radio Capability",
 		zap.Int("bytes", len(amfUe.RadioCapability)))
 }

--- a/internal/amf/ngap/handle_uplink_nas_transport.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport.go
@@ -27,10 +27,10 @@ func HandleUplinkNASTransport(ctx context.Context, amfInstance *amf.AMF, ran *am
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
 		if err := amfInstance.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error("error removing ran ue context", zap.Error(err))
+			logger.WithTrace(ctx, ueConn.Log()).Error("error removing ran ue context", zap.Error(err))
 		}
 
-		logger.WithTrace(ctx, ueConn.Log).Error("No UE Context of UeConn",
+		logger.WithTrace(ctx, ueConn.Log()).Error("No UE Context of UeConn",
 			zap.Uint64("amf-ue-id", uint64(msg.AMFUENGAPID)),
 			zap.Uint32("ran-ue-id", uint32(msg.RANUENGAPID)))
 
@@ -45,7 +45,7 @@ func HandleUplinkNASTransport(ctx context.Context, amfInstance *amf.AMF, ran *am
 	}
 
 	if amfInstance.NAS == nil {
-		logger.WithTrace(ctx, ueConn.Log).Error("NAS handler not set")
+		logger.WithTrace(ctx, ueConn.Log()).Error("NAS handler not set")
 		return
 	}
 

--- a/internal/amf/ngap/handle_uplink_ran_status_transfer.go
+++ b/internal/amf/ngap/handle_uplink_ran_status_transfer.go
@@ -25,7 +25,7 @@ func HandleUplinkRanStatusTransfer(ctx context.Context, amfInstance *amf.AMF, ra
 
 	target := amfInstance.HandoverTarget(ueConn.UeContext())
 	if target == nil {
-		logger.WithTrace(ctx, ueConn.Log).Warn("RAN Status Transfer with no handover in progress")
+		logger.WithTrace(ctx, ueConn.Log()).Warn("RAN Status Transfer with no handover in progress")
 		return
 	}
 

--- a/internal/amf/ngap/handover_to_eps.go
+++ b/internal/amf/ngap/handover_to_eps.go
@@ -16,7 +16,7 @@ import (
 
 func handoverRequiredToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *amf.UeConn, amfUe *amf.UeContext, msg *ngap.HandoverRequired) {
 	if msg.TargetID.TargeteNBID == nil {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [Target ID is not an eNB]")
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [Target ID is not an eNB]")
 		sourceUe.SendHandoverPreparationFailure(ctx, causeUnknownTargetID, nil, nil)
 
 		return
@@ -24,7 +24,7 @@ func handoverRequiredToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 
 	target, err := amf.ENBIdentityFromNGAP(*msg.TargetID.TargeteNBID)
 	if err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [unusable eNB identity]", zap.Error(err))
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [unusable eNB identity]", zap.Error(err))
 		sourceUe.SendHandoverPreparationFailure(ctx, causeUnknownTargetID, nil, nil)
 
 		return
@@ -37,7 +37,7 @@ func handoverRequiredToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 	for _, item := range msg.PDUSessionResourceListHORqd {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
-			logger.WithTrace(ctx, sourceUe.Log).Error("invalid PDU session ID from gNB, reporting it as not handed over",
+			logger.WithTrace(ctx, sourceUe.Log()).Error("invalid PDU session ID from gNB, reporting it as not handed over",
 				zap.Int64("pduSessionID", int64(item.PDUSessionID)))
 
 			cause := causeUnknownPDUSessionID
@@ -53,7 +53,7 @@ func handoverRequiredToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 
 	prep, err := amfInstance.PrepareHandoverToEPS(amfUe, sourceUe, target, msg.SourceToTargetTransparentContainer, requested, msg.Cause)
 	if err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Info("handle Handover Preparation Failure [handover to EPS could not be prepared]", zap.Error(err))
+		logger.WithTrace(ctx, sourceUe.Log()).Info("handle Handover Preparation Failure [handover to EPS could not be prepared]", zap.Error(err))
 		sourceUe.SendHandoverPreparationFailure(ctx, preparationFailureCause(err), nil, nil)
 
 		return
@@ -65,7 +65,7 @@ func handoverRequiredToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 func completeHandoverToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *amf.UeConn, amfUe *amf.UeContext, prep *amf.RelocationPreparation, unusable []amf.HandoverCandidate) {
 	resp, err := amfInstance.RequestRelocationToEPS(ctx, prep.Request)
 	if err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Warn("the EPS peer could not prepare the handover", zap.Error(err))
+		logger.WithTrace(ctx, sourceUe.Log()).Warn("the EPS peer could not prepare the handover", zap.Error(err))
 
 		if amfInstance.AbandonHandoverToEPS(ctx, amfUe, prep.Request.ID) {
 			sourceUe.SendHandoverPreparationFailure(ctx, handoverToEPSFailureCause(err), nil, nil)
@@ -81,10 +81,10 @@ func completeHandoverToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 
 	notHandedOver, ok := amfInstance.MarkHandoverPrepared(amfUe, admitted)
 	if !ok {
-		logger.WithTrace(ctx, sourceUe.Log).Warn("the handover to EPS was abandoned while the peer prepared it")
+		logger.WithTrace(ctx, sourceUe.Log()).Warn("the handover to EPS was abandoned while the peer prepared it")
 
 		if err := amfInstance.CancelRelocationToEPS(ctx, amfUe, prep.Request.ID); err != nil {
-			logger.WithTrace(ctx, sourceUe.Log).Info("the peer had no handover to cancel", zap.Error(err))
+			logger.WithTrace(ctx, sourceUe.Log()).Info("the peer had no handover to cancel", zap.Error(err))
 		}
 
 		return
@@ -92,7 +92,7 @@ func completeHandoverToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 
 	container, err := prep.Container.MarshalBinary()
 	if err != nil {
-		logger.WithTrace(ctx, sourceUe.Log).Error("failed to encode the N1 mode to S1 mode NAS transparent container", zap.Error(err))
+		logger.WithTrace(ctx, sourceUe.Log()).Error("failed to encode the N1 mode to S1 mode NAS transparent container", zap.Error(err))
 
 		if amfInstance.AbandonHandoverToEPS(ctx, amfUe, prep.Request.ID) {
 			sourceUe.SendHandoverPreparationFailure(ctx, causeHOFailureInTarget, nil, nil)
@@ -101,7 +101,7 @@ func completeHandoverToEPS(ctx context.Context, amfInstance *amf.AMF, sourceUe *
 		return
 	}
 
-	logger.WithTrace(ctx, sourceUe.Log).Info("Handover Command (5GS to EPS)",
+	logger.WithTrace(ctx, sourceUe.Log()).Info("Handover Command (5GS to EPS)",
 		zap.Int("admitted", len(admitted)),
 		zap.Int("not-handed-over", len(notHandedOver)))
 

--- a/internal/amf/ngap/path_switch_failure.go
+++ b/internal/amf/ngap/path_switch_failure.go
@@ -19,7 +19,7 @@ func pathSwitchSessions(ctx context.Context, ueConn *amf.UeConn, items ngap.PDUS
 	for _, item := range items {
 		pduSessionID, ok := validPDUSessionID(int64(item.PDUSessionID))
 		if !ok {
-			logger.WithTrace(ctx, ueConn.Log).Error("invalid PDU session ID from gNB, not switched", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
+			logger.WithTrace(ctx, ueConn.Log()).Error("invalid PDU session ID from gNB, not switched", zap.Int64("pduSessionID", int64(item.PDUSessionID)))
 
 			undecodable = append(undecodable, uint8(item.PDUSessionID))
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -74,7 +74,7 @@ type UeConn struct {
 	// callback, so it is atomic; mutate it only through ICS()/ClaimICS()/MarkICS*/ResetICS.
 	ics        atomic.Int32
 	inboundNAS atomic.Uint32
-	Log        *zap.Logger
+	log        atomic.Pointer[zap.Logger]
 	// releasing gates a UE Context Release Command so a second one is not sent for the
 	// same RAN UE. Guarded by AMF.mu, like the conns registry it lives in.
 	releasing bool
@@ -140,6 +140,18 @@ func (a *EPSArrival) ArrivingSessions() *interworking.ArrivingSessions {
 	}
 
 	return a.Sessions
+}
+
+func (ueConn *UeConn) Log() *zap.Logger {
+	if l := ueConn.log.Load(); l != nil {
+		return l
+	}
+
+	return logger.AmfLog
+}
+
+func (ueConn *UeConn) setLog(l *zap.Logger) {
+	ueConn.log.Store(l)
 }
 
 // Parent returns the UeContext this connection is bound to, or nil when bare.
@@ -447,7 +459,7 @@ func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.From(ctx, ueConn.Log).Error(err.Error())
+			logger.From(ctx, ueConn.Log()).Error(err.Error())
 		}
 
 		return
@@ -456,7 +468,7 @@ func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
 	if amfUe.State() == Registered {
 		for _, sr := range amfUe.SmContextRefs() {
 			if err := a.Session.DeactivateSmContext(ctx, sr.Ref); err != nil {
-				logger.From(ctx, ueConn.Log).Warn("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
+				logger.From(ctx, ueConn.Log()).Warn("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
 			}
 		}
 
@@ -466,11 +478,11 @@ func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
 	switch ueConn.ReleaseAction {
 	case UeContextN2NormalRelease:
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.From(ctx, ueConn.Log).Error(err.Error())
+			logger.From(ctx, ueConn.Log()).Error(err.Error())
 		}
 	case UeContextReleaseUeContext:
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.From(ctx, ueConn.Log).Error(err.Error())
+			logger.From(ctx, ueConn.Log()).Error(err.Error())
 		}
 
 		// A UE without a valid security context (never fully registered) has its AMF UE
@@ -480,7 +492,7 @@ func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
 		}
 	case UeContextReleaseDueToNwInitiatedDeregistraion:
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.From(ctx, ueConn.Log).Error(err.Error())
+			logger.From(ctx, ueConn.Log()).Error(err.Error())
 		}
 
 		a.DeregisterAndRemoveUeContext(ctx, amfUe)
@@ -488,7 +500,7 @@ func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
 		// A mid-registration UE is never "keep-context, go idle": delete unconditionally,
 		// even if it is Secured (a post-SMC registration failure).
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.From(ctx, ueConn.Log).Error(err.Error())
+			logger.From(ctx, ueConn.Log()).Error(err.Error())
 		}
 
 		a.DeregisterAndRemoveUeContext(ctx, amfUe)
@@ -496,14 +508,14 @@ func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
 		a.ClearHandover(amfUe)
 
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.From(ctx, ueConn.Log).Error(err.Error())
+			logger.From(ctx, ueConn.Log()).Error(err.Error())
 		}
 	case UeContextReleaseToEPS:
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.From(ctx, ueConn.Log).Error(err.Error())
+			logger.From(ctx, ueConn.Log()).Error(err.Error())
 		}
 	default:
-		logger.From(ctx, ueConn.Log).Error("Invalid Release Action", zap.Any("ReleaseAction", ueConn.ReleaseAction))
+		logger.From(ctx, ueConn.Log()).Error("Invalid Release Action", zap.Any("ReleaseAction", ueConn.ReleaseAction))
 	}
 }
 
@@ -533,7 +545,7 @@ func (ueConn *UeConn) abortHandoverOnRemoval(ctx context.Context) {
 			a.dropRelocationFromEPS(ctx, ue)
 		}
 
-		logger.WithTrace(ctx, ueConn.Log).Info("aborted in-flight N2 handover: target association removed")
+		logger.WithTrace(ctx, ueConn.Log()).Info("aborted in-flight N2 handover: target association removed")
 	case source:
 		a.ClearHandover(ue)
 		a.UnbindHandoverTarget(ctx, ue)
@@ -545,7 +557,7 @@ func (ueConn *UeConn) abortHandoverOnRemoval(ctx context.Context) {
 				ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkRadioConnectionWithUELost})
 		}
 
-		logger.WithTrace(ctx, ueConn.Log).Info("released prepared N2 handover target: source association removed")
+		logger.WithTrace(ctx, ueConn.Log()).Info("released prepared N2 handover target: source association removed")
 	}
 }
 
@@ -568,12 +580,12 @@ func (a *AMF) DropStaleUe(ctx context.Context, radio *Radio, ranUeNgapID models.
 	a.mu.Unlock()
 
 	for _, ueConn := range stale {
-		logger.WithTrace(ctx, ueConn.Log).Debug("RAN UE NGAP ID reused in InitialUEMessage, removing stale UeConn",
+		logger.WithTrace(ctx, ueConn.Log()).Debug("RAN UE NGAP ID reused in InitialUEMessage, removing stale UeConn",
 			zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)),
 			zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
 
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
-			logger.WithTrace(ctx, ueConn.Log).Error(err.Error())
+			logger.WithTrace(ctx, ueConn.Log()).Error(err.Error())
 		}
 	}
 }
@@ -629,8 +641,8 @@ func (a *AMF) CommitPathSwitch(ue *UeContext, ueConn *UeConn, ran *Radio, ranUeN
 
 	a.mu.Unlock()
 
-	ueConn.Log = ran.Log.With(logger.AmfUeNgapID(ueConn.AmfUeNgapID))
-	ueConn.Log.Info("ran ue switched to new Ran", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	ueConn.setLog(ran.Log.With(logger.AmfUeNgapID(ueConn.AmfUeNgapID)))
+	ueConn.Log().Info("ran ue switched to new Ran", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 
 	return true
 }
@@ -650,8 +662,8 @@ func NewUeConnForTest(radio *Radio, ranUeNgapID models.RanUeNgapID, amfUeNgapID 
 		conn:        radio.Conn,
 		radioName:   radio.name,
 		amf:         radio.amf,
-		Log:         log,
 	}
+	ueConn.setLog(log)
 
 	radio.amf.mu.Lock()
 

--- a/internal/amf/ran_ue_log_race_test.go
+++ b/internal/amf/ran_ue_log_race_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+)
+
+func TestUeConnLogConcurrentAccessNoRace(t *testing.T) {
+	a := New(nil, nil, nil)
+	target := &Radio{amf: a, name: "target", Log: logger.AmfLog}
+
+	ueConn := &UeConn{AmfUeNgapID: 1, amf: a}
+	ueConn.setLog(logger.AmfLog)
+
+	ue := NewUeContext()
+	ueConn.ue.Store(ue)
+
+	a.mu.Lock()
+	a.conns[int64(ueConn.AmfUeNgapID)] = ueConn
+	a.mu.Unlock()
+
+	var (
+		wg      sync.WaitGroup
+		commits atomic.Int64
+	)
+
+	for _, op := range []func(){
+		func() {
+			if a.CommitPathSwitch(ue, ueConn, target, models.RanUeNgapID(7), [32]uint8{}, 0) {
+				commits.Add(1)
+			}
+		},
+		func() { _ = ueConn.Log() },
+	} {
+		wg.Add(1)
+
+		go func(f func()) {
+			defer wg.Done()
+
+			for range 500 {
+				f()
+			}
+		}(op)
+	}
+
+	wg.Wait()
+
+	if commits.Load() == 0 {
+		t.Fatal("CommitPathSwitch never committed; the logger write was not exercised")
+	}
+}

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -191,15 +191,11 @@ func SendServiceReject(ctx context.Context, ue *UeConn, cause fgs.GMMCause) {
 }
 
 func SendRegistrationReject(ctx context.Context, ue *UeConn, cause5GMM fgs.GMMCause) {
-	SendRegistrationRejectWithBackoff(ctx, ue, cause5GMM, 0)
-}
-
-func SendRegistrationRejectWithBackoff(ctx context.Context, ue *UeConn, cause5GMM fgs.GMMCause, t3346Value time.Duration) {
 	sendGmm(ctx, ue, "nas/send_registration_reject",
 		[]attribute.KeyValue{attribute.Int("cause", int(cause5GMM))},
 		rejectSHT(ue),
 		func(_ *UeContext) ([]byte, error) {
-			return BuildRegistrationReject(int(ue.amf.T3502Value.Seconds()), cause5GMM, t3346Value)
+			return BuildRegistrationReject(int(ue.amf.T3502Value.Seconds()), cause5GMM)
 		})
 }
 

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -190,13 +190,16 @@ func SendServiceReject(ctx context.Context, ue *UeConn, cause fgs.GMMCause) {
 		func(_ *UeContext) ([]byte, error) { return BuildServiceReject(cause) })
 }
 
-// T3502: This IE may be included to indicate a value for timer T3502 during the initial registration
 func SendRegistrationReject(ctx context.Context, ue *UeConn, cause5GMM fgs.GMMCause) {
+	SendRegistrationRejectWithBackoff(ctx, ue, cause5GMM, 0)
+}
+
+func SendRegistrationRejectWithBackoff(ctx context.Context, ue *UeConn, cause5GMM fgs.GMMCause, t3346Value time.Duration) {
 	sendGmm(ctx, ue, "nas/send_registration_reject",
 		[]attribute.KeyValue{attribute.Int("cause", int(cause5GMM))},
 		rejectSHT(ue),
 		func(_ *UeContext) ([]byte, error) {
-			return BuildRegistrationReject(int(ue.amf.T3502Value.Seconds()), cause5GMM)
+			return BuildRegistrationReject(int(ue.amf.T3502Value.Seconds()), cause5GMM, t3346Value)
 		})
 }
 

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -34,16 +34,16 @@ func armNASGuard(conn *UeConn, ueConn *UeConn, cfg guard.TimerValue, name string
 
 	conn.armNASGuardWith(cfg, name,
 		func(attempt int32) {
-			logger.AmfLog.Warn("retransmitting NAS request", zap.String("timer", name), zap.Int32("attempt", attempt))
+			conn.Log().Warn("retransmitting NAS request", zap.String("timer", name), zap.Int32("attempt", attempt))
 
 			if err := ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
 				return ueConn.SendDownlinkNASTransport(context.Background(), wire)
 			}); err != nil {
-				logger.AmfLog.Error("failed to retransmit NAS request", zap.String("timer", name), zap.Error(err))
+				ueConn.Log().Error("failed to retransmit NAS request", zap.String("timer", name), zap.Error(err))
 			}
 		},
 		func() {
-			logger.AmfLog.Warn("NAS guard exhausted, aborting procedure", zap.String("timer", name))
+			conn.Log().Warn("NAS guard exhausted, aborting procedure", zap.String("timer", name))
 			onExhausted()
 		},
 	)
@@ -364,7 +364,7 @@ func SendRegistrationAccept(
 		conn.armNASGuardWith(cfg, "T3550 (Registration Accept)", func(expireTimes int32) {
 			retryUeConn := ue.Conn()
 			if retryUeConn == nil {
-				logger.From(ctx, logger.AmfLog).Warn("[NAS] UE Context released, abort retransmission of Registration Accept")
+				logger.From(ctx, conn.Log()).Warn("[NAS] UE Context released, abort retransmission of Registration Accept")
 
 				return
 			}
@@ -384,30 +384,30 @@ func SendRegistrationAccept(
 						pduSessionResourceSetupList,
 						supportedGUAMI,
 					); err != nil {
-						logger.From(ctx, logger.AmfLog).Error("could not send initial context setup request", zap.Error(err))
+						logger.From(ctx, retryUeConn.Log()).Error("could not send initial context setup request", zap.Error(err))
 					}
 
 					retryUeConn.MarkICSPending()
 
-					logger.From(ctx, logger.AmfLog).Info("Sent NGAP initial context setup request")
+					logger.From(ctx, retryUeConn.Log()).Info("Sent NGAP initial context setup request")
 
 					return nil
 				}
 
-				logger.From(ctx, logger.AmfLog).Warn("T3550 expires, retransmit Registration Accept", zap.Any("expireTimes", expireTimes))
+				logger.From(ctx, retryUeConn.Log()).Warn("T3550 expires, retransmit Registration Accept", zap.Any("expireTimes", expireTimes))
 
 				if err := retryUeConn.SendDownlinkNASTransport(context.Background(), wire); err != nil {
-					logger.From(ctx, logger.AmfLog).Error("could not send downlink NAS transport message", zap.Error(err))
+					logger.From(ctx, retryUeConn.Log()).Error("could not send downlink NAS transport message", zap.Error(err))
 				}
 
-				logger.From(ctx, logger.AmfLog).Info("Sent GMM registration accept")
+				logger.From(ctx, retryUeConn.Log()).Info("Sent GMM registration accept")
 
 				return nil
 			}); err != nil {
-				logger.From(ctx, logger.AmfLog).Error("could not retransmit Registration Accept", zap.Error(err))
+				logger.From(ctx, retryUeConn.Log()).Error("could not retransmit Registration Accept", zap.Error(err))
 			}
 		}, func() {
-			logger.From(ctx, logger.AmfLog).Warn("T3550 Expires, abort retransmission of Registration Accept", zap.Any("expireTimes", cfg.MaxRetryTimes))
+			logger.From(ctx, conn.Log()).Warn("T3550 Expires, abort retransmission of Registration Accept", zap.Any("expireTimes", cfg.MaxRetryTimes))
 
 			amfInstance.MarkRegistered(context.Background(), ue)
 			ue.ClearRegistrationRequestData()
@@ -429,19 +429,19 @@ func ArmRegistrationAcceptGuard(amfInstance *AMF, ue *UeContext, plain []byte) {
 	conn.armNASGuardWith(cfg, "T3550 (Registration Accept)", func(expireTimes int32) {
 		retryUeConn := ue.Conn()
 		if retryUeConn == nil {
-			logger.AmfLog.Warn("UE context released, abort retransmission of Registration Accept")
+			conn.Log().Warn("UE context released, abort retransmission of Registration Accept")
 			return
 		}
 
-		logger.AmfLog.Warn("T3550 expires, retransmit Registration Accept", zap.Any("expireTimes", expireTimes))
+		retryUeConn.Log().Warn("T3550 expires, retransmit Registration Accept", zap.Any("expireTimes", expireTimes))
 
 		if err := ue.SendDownlinkNAS(plain, uint8(fgs.SHTIntegrityProtectedCiphered), func(wire []byte) error {
 			return retryUeConn.SendDownlinkNASTransport(context.Background(), wire)
 		}); err != nil {
-			logger.AmfLog.Error("could not retransmit Registration Accept", zap.Error(err))
+			retryUeConn.Log().Error("could not retransmit Registration Accept", zap.Error(err))
 		}
 	}, func() {
-		logger.AmfLog.Warn("T3550 Expires, abort retransmission of Registration Accept", zap.Any("expireTimes", cfg.MaxRetryTimes))
+		conn.Log().Warn("T3550 Expires, abort retransmission of Registration Accept", zap.Any("expireTimes", cfg.MaxRetryTimes))
 
 		amfInstance.MarkRegistered(context.Background(), ue)
 		ue.ClearRegistrationRequestData()
@@ -528,27 +528,27 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 		}
 
 		conn.armNASGuardWith(cfg, "T3555 (Configuration Update)", func(expireTimes int32) {
-			logger.From(ctx, logger.AmfLog).Warn("timer T3555 expired, retransmit Configuration Update Command", zap.Int32("retry", expireTimes))
+			logger.From(ctx, conn.Log()).Warn("timer T3555 expired, retransmit Configuration Update Command", zap.Int32("retry", expireTimes))
 
 			retryUeConn := amfUe.Conn()
 			if retryUeConn == nil {
-				logger.From(ctx, logger.AmfLog).Warn("UE Context released, abort retransmission of Configuration Update Command")
+				logger.From(ctx, conn.Log()).Warn("UE Context released, abort retransmission of Configuration Update Command")
 
 				return
 			}
 
 			if retryUeConn.Radio() == nil {
-				logger.From(ctx, logger.AmfLog).Warn("Radio is nil, abort retransmission of Configuration Update Command")
+				logger.From(ctx, retryUeConn.Log()).Warn("Radio is nil, abort retransmission of Configuration Update Command")
 				return
 			}
 
 			if err := amfUe.SendDownlinkNAS(plain, sht, func(wire []byte) error {
 				return retryUeConn.SendDownlinkNASTransport(context.Background(), wire)
 			}); err != nil {
-				logger.From(ctx, logger.AmfLog).Error("could not send configuration update command", zap.Error(err))
+				logger.From(ctx, retryUeConn.Log()).Error("could not send configuration update command", zap.Error(err))
 			}
 		}, func() {
-			logger.From(ctx, logger.AmfLog).Warn("timer T3555 expired too many times, aborting configuration update procedure", zap.Int32("maximum retries", cfg.MaxRetryTimes))
+			logger.From(ctx, conn.Log()).Warn("timer T3555 expired too many times, aborting configuration update procedure", zap.Int32("maximum retries", cfg.MaxRetryTimes))
 		},
 		)
 	}
@@ -558,7 +558,7 @@ func SendConfigurationUpdateCommand(ctx context.Context, amfInstance *AMF, amfUe
 func (ueConn *UeConn) SendNGAP(ctx context.Context, msgType NGAPProcedure, pkt []byte) {
 	amfInstance, conn, err := ueConn.sendTarget()
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to resolve NGAP send target", zap.String("procedure", string(msgType)), zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to resolve NGAP send target", zap.String("procedure", string(msgType)), zap.Error(err))
 		return
 	}
 
@@ -639,7 +639,7 @@ func ueContextReleaseCommandBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAPID
 func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause ngap.Cause) {
 	amfInstance, conn, err := ueConn.sendTarget()
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to resolve send target for UE Context Release Command", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to resolve send target for UE Context Release Command", zap.Error(err))
 		return
 	}
 
@@ -647,7 +647,7 @@ func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause nga
 	// racing a NAS-guard timeout, or two handover-abort paths) must not send a second
 	// UE Context Release Command.
 	if !amfInstance.claimRelease(ueConn) {
-		logger.WithTrace(ctx, ueConn.Log).Debug("UE Context Release already in progress; suppressing duplicate")
+		logger.WithTrace(ctx, ueConn.Log()).Debug("UE Context Release already in progress; suppressing duplicate")
 		return
 	}
 
@@ -655,7 +655,7 @@ func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause nga
 	if err != nil {
 		// The command cannot be sent, so no Release Complete will arrive; release
 		// locally now to avoid leaking the UeConn and its claim.
-		logger.From(ctx, ueConn.Log).Error("failed to build UE Context Release Command", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to build UE Context Release Command", zap.Error(err))
 		amfInstance.ReleaseUeConn(ctx, ueConn)
 
 		return
@@ -940,7 +940,7 @@ func handoverPreparationFailureBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGA
 func (ueConn *UeConn) SendHandoverPreparationFailure(ctx context.Context, cause ngap.Cause, criticalityDiagnostics *ngap.CriticalityDiagnostics, targetFailure ngap.TargettoSourceFailureTransparentContainer) {
 	pkt, err := handoverPreparationFailureBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), cause, criticalityDiagnostics, targetFailure)
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to build Handover Preparation Failure", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to build Handover Preparation Failure", zap.Error(err))
 		return
 	}
 
@@ -961,7 +961,7 @@ func handoverCancelAcknowledgeBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAP
 func (ueConn *UeConn) SendHandoverCancelAcknowledge(ctx context.Context) {
 	pkt, err := handoverCancelAcknowledgeBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID))
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to build Handover Cancel Acknowledge", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to build Handover Cancel Acknowledge", zap.Error(err))
 		return
 	}
 
@@ -1111,7 +1111,7 @@ func (ueConn *UeConn) SendHandoverCommand(
 		ueConn.HandOverType, admitted, toRelease, targetToSource, nil,
 	)
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to build Handover Command", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to build Handover Command", zap.Error(err))
 		return
 	}
 
@@ -1129,7 +1129,7 @@ func (ueConn *UeConn) SendHandoverCommandToEPS(
 		ngap.HandoverTypeFiveGSToEPS, nil, toRelease, targetToSource, nasSecurityParameters,
 	)
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to build Handover Command to EPS", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to build Handover Command to EPS", zap.Error(err))
 		return
 	}
 
@@ -1169,7 +1169,7 @@ func downlinkRANStatusTransferBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAP
 func (ueConn *UeConn) SendDownlinkRANStatusTransfer(ctx context.Context, container ngap.StatusTransferContainer) {
 	pkt, err := downlinkRANStatusTransferBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), container)
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to build Downlink RAN Status Transfer", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to build Downlink RAN Status Transfer", zap.Error(err))
 		return
 	}
 
@@ -1224,7 +1224,7 @@ func (ueConn *UeConn) SendPathSwitchRequestAcknowledge(
 ) {
 	allowed, err := util.AllowedNSSAIToNGAP(snssaiList)
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("could not convert Allowed NSSAI", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("could not convert Allowed NSSAI", zap.Error(err))
 		return
 	}
 
@@ -1233,7 +1233,7 @@ func (ueConn *UeConn) SendPathSwitchRequestAcknowledge(
 		ueSecurityCapability, ncc, nh, switched, released, allowed,
 	)
 	if err != nil {
-		logger.From(ctx, ueConn.Log).Error("failed to build Path Switch Request Acknowledge", zap.Error(err))
+		logger.From(ctx, ueConn.Log()).Error("failed to build Path Switch Request Acknowledge", zap.Error(err))
 		return
 	}
 

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -266,7 +266,7 @@ func (f *fakeCredStore) GetSubscriber(_ context.Context, imsi string) (*udm.Subs
 
 	s, ok := f.subs[imsi]
 	if !ok {
-		return nil, fmt.Errorf("subscriber %s not found", imsi)
+		return nil, fmt.Errorf("subscriber %s: %w", imsi, udm.ErrSubscriberUnknown)
 	}
 
 	cp := *s
@@ -313,7 +313,7 @@ func (f *fakeCredStore) AdvanceSequenceNumber(_ context.Context, imsi, resyncAut
 
 	sub, ok := f.subs[imsi]
 	if !ok {
-		return nil, fmt.Errorf("subscriber %s not found", imsi)
+		return nil, fmt.Errorf("subscriber %s: %w", imsi, udm.ErrSubscriberUnknown)
 	}
 
 	next, err := sqn.Next(sub.SequenceNumber, sub.Opc, sub.PermanentKey, resyncAuts, resyncRand)

--- a/internal/mme/detach.go
+++ b/internal/mme/detach.go
@@ -50,7 +50,7 @@ func (m *MME) DetachSubscriber(ctx context.Context, imsi string) {
 
 	ue.TransitionTo(EMMDeregistrationInitiated)
 
-	logger.From(ctx, ueConn.Log).Info("network-initiated detach (subscriber deleted)",
+	logger.From(ctx, ueConn.Log()).Info("network-initiated detach (subscriber deleted)",
 		zap.String("imsi", imsi))
 
 	plain, err := (&eps.DetachRequestNetwork{TypeOfDetach: eps.DetachTypeReattachNotRequired}).MarshalBinary()

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -92,7 +92,7 @@ func (m *MME) PrepareHandover(ue *UeContext, target S1APWriter, reqMMEID s1ap.MM
 
 	targetConn := &UeConn{m: m, MMEUES1APID: s1ap.MMEUES1APID(tid), ue: ue}
 	targetConn.setConn(target)
-	targetConn.Log = m.nodeLogLocked(target).With(logger.MMEUeS1apID(uint32(targetConn.MMEUES1APID)))
+	targetConn.setLog(m.nodeLogLocked(target).With(logger.MMEUeS1apID(uint32(targetConn.MMEUES1APID))))
 	m.conns[tid] = targetConn
 
 	ho := &handoverContext{
@@ -222,7 +222,7 @@ func (m *MME) prepareRelocation(ue *UeContext, target S1APWriter, candidates []H
 
 	targetConn := &UeConn{m: m, MMEUES1APID: s1ap.MMEUES1APID(tid), ue: ue}
 	targetConn.setConn(target)
-	targetConn.Log = m.nodeLogLocked(target).With(logger.MMEUeS1apID(uint32(targetConn.MMEUES1APID)))
+	targetConn.setLog(m.nodeLogLocked(target).With(logger.MMEUeS1apID(uint32(targetConn.MMEUES1APID))))
 	m.conns[tid] = targetConn
 
 	delivery := make(chan relocationOutcome, 1)
@@ -470,6 +470,7 @@ func (m *MME) CommitPathSwitch(ue *UeContext, conn S1APWriter, enbUEID s1ap.ENBU
 
 	ue.Conn().setConn(conn)
 	ue.Conn().ENBUES1APID = enbUEID
+	ue.Conn().setLog(m.nodeLogLocked(conn).With(logger.MMEUeS1apID(uint32(ue.Conn().MMEUES1APID))))
 
 	ue.mu.Lock()
 	ue.nh = newNH

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -546,7 +546,7 @@ func (m *MME) NewUeConn(conn S1APWriter, enbUEID s1ap.ENBUES1APID) *UeConn {
 
 	c := &UeConn{m: m, ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id)}
 	c.setConn(conn)
-	c.Log = m.nodeLogLocked(conn).With(logger.MMEUeS1apID(uint32(c.MMEUES1APID)))
+	c.setLog(m.nodeLogLocked(conn).With(logger.MMEUeS1apID(uint32(c.MMEUES1APID))))
 	m.conns[id] = c
 
 	return c

--- a/internal/mme/nas/attach_reject_test.go
+++ b/internal/mme/nas/attach_reject_test.go
@@ -5,13 +5,58 @@ package nas
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
 	"github.com/ellanetworks/core/s1ap"
 )
+
+type transientCredStore struct{ err error }
+
+func (s transientCredStore) AdvanceSequenceNumber(_ context.Context, _, _, _ string) (*udm.AdvancedCredentials, error) {
+	return nil, s.err
+}
+
+func TestAttachTransientCredentialFailureReleasesWithoutRejecting(t *testing.T) {
+	store := transientCredStore{err: fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout)}
+
+	m := mme.New(udm.New(store, noopKeyResolver), fakeBearerStore{}, &fakeSessionManager{})
+	m.NAS = &nasHandler{m: m}
+
+	cc := &captureConn{}
+	ue := newAttachUe(m, cc, 7)
+
+	esm, err := (&eps.PDNConnectivityRequest{PTI: 1, RequestType: 1, PDNType: 1}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attach := &eps.AttachRequest{
+		EPSAttachType:       eps.AttachTypeEPS,
+		NASKeySetIdentifier: nas.KeySetIdentifier{Value: 7},
+		EPSMobileIdentity:   eps.IMSIIdentity(eps.IMSI(testSubscriber.IMSI)),
+		UENetworkCapability: eps.UENetworkCapability{EEA: 0xf0, EIA: 0x70},
+		ESMMessageContainer: esm,
+	}
+
+	b, err := attach.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	HandleNAS(context.Background(), m, ue.Conn(), b)
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("expected only a UE Context Release Command, got %d S1AP messages", len(cc.sent))
+	}
+
+	parseUEContextReleaseCommand(t, cc.sent[0])
+}
 
 // TestAttachTrackingAreaNotAllowed checks an Attach from a serving cell outside the
 // served area is rejected with ATTACH REJECT #12 and the S1 context released, without
@@ -98,7 +143,7 @@ func TestAttachProtocolError(t *testing.T) {
 }
 
 // TestAttachUnknownIMSI checks that an Attach Request from an unprovisioned IMSI
-// is rejected with ATTACH REJECT #2 ("IMSI unknown in HSS") and the S1 context
+// is rejected with ATTACH REJECT #3 ("Illegal UE") and the S1 context
 // is released, without starting authentication.
 func TestAttachUnknownIMSI(t *testing.T) {
 	m := newTestMME(t)
@@ -134,8 +179,8 @@ func TestAttachUnknownIMSI(t *testing.T) {
 		t.Fatalf("not an Attach Reject: %v", err)
 	}
 
-	if rej.Cause != eps.EMMCauseIMSIUnknownInHSS {
-		t.Fatalf("Attach Reject cause = %d, want %d", rej.Cause, eps.EMMCauseIMSIUnknownInHSS)
+	if rej.Cause != eps.EMMCauseIllegalUE {
+		t.Fatalf("Attach Reject cause = %d, want %d", rej.Cause, eps.EMMCauseIllegalUE)
 	}
 
 	// The reject carries the T3402 back-off (12 min), mirroring the AMF's T3502.

--- a/internal/mme/nas/auth_reject_cause_test.go
+++ b/internal/mme/nas/auth_reject_cause_test.go
@@ -4,39 +4,38 @@
 package nas
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas/eps"
 )
 
+// TS 24.301 §5.5.1.2.5, §5.5.3.2.5
 func TestAuthRejectCause(t *testing.T) {
-	for _, tc := range []struct {
+	unknown := fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound)
+
+	tests := []struct {
 		name string
 		err  error
 		want eps.EMMCause
 	}{
-		{
-			name: "propose timeout",
-			err:  fmt.Errorf("couldn't update subscriber 001010000000001: %w", db.ErrProposeTimeout),
-			want: eps.EMMCauseNetworkFailure,
-		},
-		{
-			name: "migration pending",
-			err:  fmt.Errorf("SQN advance failed: %w", db.ErrMigrationPending),
-			want: eps.EMMCauseNetworkFailure,
-		},
-		{
-			name: "subscriber missing",
-			err:  errors.New("subscriber not found"),
-			want: eps.EMMCauseIMSIUnknownInHSS,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := authRejectCause(tc.err); got != tc.want {
-				t.Fatalf("authRejectCause(%v): want %d, got %d", tc.err, tc.want, got)
+		{"unknown subscriber", unknown, eps.EMMCauseIMSIUnknownInHSS},
+		{"unknown subscriber wrapped", fmt.Errorf("generate EPS vector: %w", unknown), eps.EMMCauseIMSIUnknownInHSS},
+		{"raft commit timeout", fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout), eps.EMMCauseNetworkFailure},
+		{"forwarded outcome unknown", fmt.Errorf("advance sqn: %w", db.ErrOutcomeUnknown), eps.EMMCauseNetworkFailure},
+		{"migration pending", fmt.Errorf("advance sqn: %w", db.ErrMigrationPending), eps.EMMCauseNetworkFailure},
+		{"context cancelled", context.Canceled, eps.EMMCauseNetworkFailure},
+		{"opaque error defaults to network failure", errors.New("boom"), eps.EMMCauseNetworkFailure},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authRejectCause(tt.err); got != tt.want {
+				t.Errorf("authRejectCause(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/internal/mme/nas/auth_reject_cause_test.go
+++ b/internal/mme/nas/auth_reject_cause_test.go
@@ -14,29 +14,72 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// TS 24.301 §5.5.1.2.5, §5.5.3.2.5
-func TestAuthRejectCause(t *testing.T) {
+// TS 24.301 §5.5.1.2.5
+func TestAttachRejectCauseForAuthFailure(t *testing.T) {
 	unknown := fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound)
 
 	tests := []struct {
-		name string
-		err  error
-		want eps.EMMCause
+		name          string
+		err           error
+		want          eps.EMMCause
+		wantPermanent bool
 	}{
-		{"unknown subscriber", unknown, eps.EMMCauseIMSIUnknownInHSS},
-		{"unknown subscriber wrapped", fmt.Errorf("generate EPS vector: %w", unknown), eps.EMMCauseIMSIUnknownInHSS},
-		{"raft commit timeout", fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout), eps.EMMCauseNetworkFailure},
-		{"forwarded outcome unknown", fmt.Errorf("advance sqn: %w", db.ErrOutcomeUnknown), eps.EMMCauseNetworkFailure},
-		{"migration pending", fmt.Errorf("advance sqn: %w", db.ErrMigrationPending), eps.EMMCauseNetworkFailure},
-		{"context cancelled", context.Canceled, eps.EMMCauseNetworkFailure},
-		{"opaque error defaults to network failure", errors.New("boom"), eps.EMMCauseNetworkFailure},
+		{"unknown subscriber", unknown, eps.EMMCauseIllegalUE, true},
+		{"unknown subscriber wrapped", fmt.Errorf("generate EPS vector: %w", unknown), eps.EMMCauseIllegalUE, true},
+		{"raft commit timeout", fmt.Errorf("advance sqn: %w", db.ErrProposeTimeout), 0, false},
+		{"forwarded outcome unknown", fmt.Errorf("advance sqn: %w", db.ErrOutcomeUnknown), 0, false},
+		{"migration pending", fmt.Errorf("advance sqn: %w", db.ErrMigrationPending), 0, false},
+		{"context cancelled", context.Canceled, 0, false},
+		{"opaque error defaults to transient", errors.New("boom"), 0, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := authRejectCause(tt.err); got != tt.want {
-				t.Errorf("authRejectCause(%v) = %v, want %v", tt.err, got, tt.want)
+			got, permanent := attachRejectCauseForAuthFailure(tt.err)
+
+			if permanent != tt.wantPermanent {
+				t.Errorf("permanent = %v, want %v", permanent, tt.wantPermanent)
+			}
+
+			if got != tt.want {
+				t.Errorf("attachRejectCauseForAuthFailure(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAttachRejectCauseIsAnAttachRejectCause(t *testing.T) {
+	listed := map[eps.EMMCause]bool{
+		eps.EMMCauseIllegalUE:                                  true,
+		eps.EMMCauseIllegalME:                                  true,
+		eps.EMMCauseEPSAndNonEPSServicesNotAllowed:             true,
+		eps.EMMCauseEPSServicesNotAllowed:                      true,
+		eps.EMMCausePLMNNotAllowed:                             true,
+		eps.EMMCauseTrackingAreaNotAllowed:                     true,
+		eps.EMMCauseRoamingNotAllowedInThisTA:                  true,
+		eps.EMMCauseEPSServicesNotAllowedInThisPLMN:            true,
+		eps.EMMCauseNoSuitableCellsInTrackingArea:              true,
+		eps.EMMCauseCongestion:                                 true,
+		eps.EMMCauseNotAuthorizedForThisCSG:                    true,
+		eps.EMMCauseRedirectionTo5GCNRequired:                  true,
+		eps.EMMCauseServiceOptionNotAuthorizedInPLMN:           true,
+		eps.EMMCauseIABNodeOperationNotAuthorized:              true,
+		eps.EMMCauseSevereNetworkFailure:                       true,
+		eps.EMMCausePLMNNotAllowedToOperateAtPresentUELocation: true,
+	}
+
+	for _, err := range []error{
+		fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, db.ErrNotFound),
+		errors.New("boom"),
+		db.ErrProposeTimeout,
+	} {
+		cause, permanent := attachRejectCauseForAuthFailure(err)
+		if !permanent {
+			continue
+		}
+
+		if !listed[cause] {
+			t.Errorf("attachRejectCauseForAuthFailure(%v) = %v, which TS 24.301 §5.5.1.2.5 does not define for an ATTACH REJECT", err, cause)
+		}
 	}
 }

--- a/internal/mme/nas/authentication.go
+++ b/internal/mme/nas/authentication.go
@@ -8,10 +8,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/nas/eps"
 	"go.uber.org/zap"
@@ -45,13 +45,11 @@ func startAuthentication(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 }
 
 func authRejectCause(err error) eps.EMMCause {
-	if errors.Is(err, db.ErrProposeTimeout) ||
-		errors.Is(err, db.ErrOutcomeUnknown) ||
-		errors.Is(err, db.ErrMigrationPending) {
-		return eps.EMMCauseNetworkFailure
+	if errors.Is(err, udm.ErrSubscriberUnknown) {
+		return eps.EMMCauseIMSIUnknownInHSS
 	}
 
-	return eps.EMMCauseIMSIUnknownInHSS
+	return eps.EMMCauseNetworkFailure
 }
 
 // sendAuthRequest sends an AUTHENTICATION REQUEST; a set resync pair drives an

--- a/internal/mme/nas/authentication.go
+++ b/internal/mme/nas/authentication.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/metrics"
 	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/udm"
@@ -20,8 +21,7 @@ import (
 func authenticateOrReject(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn) {
 	plmn, err := m.OperatorPLMN(ctx)
 	if err != nil {
-		logger.From(ctx, logger.MmeLog).Info("attach rejected: cannot authenticate subscriber", zap.String("imsi", ue.IMSI()), zap.Error(err))
-		rejectAttach(ctx, m, ue, ueConn, authRejectCause(err))
+		failAuthentication(ctx, m, ue, ueConn, err)
 
 		return
 	}
@@ -39,17 +39,34 @@ func startAuthentication(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 	ue.SetEksi(nas.KeySetIdentifier{Value: mme.NextEksi(ue.Eksi().Value)})
 
 	if err := sendAuthRequest(ctx, m, ue, ueConn, servingPLMN, "", ""); err != nil {
-		logger.From(ctx, logger.MmeLog).Info("attach rejected: cannot authenticate subscriber", zap.String("imsi", ue.IMSI()), zap.Error(err))
-		rejectAttach(ctx, m, ue, ueConn, authRejectCause(err))
+		failAuthentication(ctx, m, ue, ueConn, err)
 	}
 }
 
-func authRejectCause(err error) eps.EMMCause {
-	if errors.Is(err, udm.ErrSubscriberUnknown) {
-		return eps.EMMCauseIMSIUnknownInHSS
+func failAuthentication(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, err error) {
+	cause, permanent := attachRejectCauseForAuthFailure(err)
+	if !permanent {
+		logger.From(ctx, logger.MmeLog).Info("attach aborted on a transient error: cannot authenticate subscriber; releasing the NAS signalling connection so the UE retries when T3411 expires",
+			zap.String("imsi", ue.IMSI()), zap.Error(err))
+
+		metrics.RegistrationAttempt(metrics.RAT4G, attachTypeName(ue), metrics.ResultReject)
+		ueConn.StopNASGuard()
+
+		m.ReleaseUEContext(ctx, ue, mme.CauseNASUnspecified)
+
+		return
 	}
 
-	return eps.EMMCauseNetworkFailure
+	logger.From(ctx, logger.MmeLog).Info("attach rejected: cannot authenticate subscriber", zap.String("imsi", ue.IMSI()), zap.Error(err))
+	rejectAttach(ctx, m, ue, ueConn, cause)
+}
+
+func attachRejectCauseForAuthFailure(err error) (eps.EMMCause, bool) {
+	if errors.Is(err, udm.ErrSubscriberUnknown) {
+		return eps.EMMCauseIllegalUE, true
+	}
+
+	return 0, false
 }
 
 // sendAuthRequest sends an AUTHENTICATION REQUEST; a set resync pair drives an

--- a/internal/mme/nas/emm.go
+++ b/internal/mme/nas/emm.go
@@ -63,9 +63,7 @@ func dispositionForNAS(ctx context.Context, m *mme.MME, conn *mme.UeConn, pdu []
 		return nasreply.Silent(nasreply.ReasonNoContext)
 	}
 
-	if ueConn.Log != nil {
-		ctx = logger.Into(ctx, ueConn.Log)
-	}
+	ctx = logger.Into(ctx, ueConn.Log())
 
 	pd, err := eps.PeekProtocolDiscriminator(pdu)
 	if err != nil {

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -261,7 +261,7 @@ func (f *fakeCredStore) GetSubscriber(_ context.Context, imsi string) (*udm.Subs
 
 	s, ok := f.subs[imsi]
 	if !ok {
-		return nil, fmt.Errorf("subscriber %s not found", imsi)
+		return nil, fmt.Errorf("subscriber %s: %w", imsi, udm.ErrSubscriberUnknown)
 	}
 
 	cp := *s
@@ -405,7 +405,7 @@ func (f *fakeCredStore) AdvanceSequenceNumber(_ context.Context, imsi, resyncAut
 
 	sub, ok := f.subs[imsi]
 	if !ok {
-		return nil, fmt.Errorf("subscriber %s not found", imsi)
+		return nil, fmt.Errorf("subscriber %s: %w", imsi, udm.ErrSubscriberUnknown)
 	}
 
 	next, err := sqn.Next(sub.SequenceNumber, sub.Opc, sub.PermanentKey, resyncAuts, resyncRand)

--- a/internal/mme/nas/handle_modify_bearer_accept.go
+++ b/internal/mme/nas/handle_modify_bearer_accept.go
@@ -20,7 +20,7 @@ func handleModifyBearerAccept(m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 	m.StopESMGuard(p)
 
 	if cause, ok := fiveGSMCauseFromPCOs(accept.ProtocolConfigurationOptions, accept.ExtendedProtocolConfigurationOptions); ok {
-		ueConn.Log.Warn("UE discarded the mapped 5GS QoS parameters of the bearer modification",
+		ueConn.Log().Warn("UE discarded the mapped 5GS QoS parameters of the bearer modification",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn), zap.Uint8("5gsm-cause", cause))
 	}
 
@@ -28,7 +28,7 @@ func handleModifyBearerAccept(m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 		return nasreply.Silent(nasreply.ReasonOutOfState)
 	}
 
-	ueConn.Log.Info("EPS bearer modified in place", zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
+	ueConn.Log().Info("EPS bearer modified in place", zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
 
 	return nasreply.Handled()
 }

--- a/internal/mme/nas/handle_modify_bearer_reject.go
+++ b/internal/mme/nas/handle_modify_bearer_reject.go
@@ -20,7 +20,7 @@ func handleModifyBearerReject(m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn,
 		ue.ClearPendingModify(p)
 	}
 
-	ueConn.Log.Warn("UE rejected EPS bearer modification", zap.String("imsi", ue.IMSI()))
+	ueConn.Log().Warn("UE rejected EPS bearer modification", zap.String("imsi", ue.IMSI()))
 
 	return nasreply.Handled()
 }

--- a/internal/mme/nas_guard.go
+++ b/internal/mme/nas_guard.go
@@ -169,12 +169,10 @@ func (c *UeConn) retransmitNASGuard(ue *UeContext, name string, plain []byte, sh
 		return
 	}
 
-	mmeUEID := c.MMEUES1APID
-
 	m.mu.Unlock()
 
-	logger.MmeLog.Info("retransmitting NAS message",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("procedure", name), zap.Int("attempt", int(attempt)))
+	c.Log().Info("retransmitting NAS message",
+		zap.String("procedure", name), zap.Int("attempt", int(attempt)))
 
 	// Retransmission is timer-driven, outside the original request; start a fresh root.
 	ctx := context.Background()
@@ -199,21 +197,18 @@ func (c *UeConn) expireNASGuard(ue *UeContext, name string, onAbort func()) {
 		return
 	}
 
-	mmeUEID := c.MMEUES1APID
-
 	m.mu.Unlock()
 
 	if onAbort != nil {
-		logger.MmeLog.Info("NAS procedure timed out, aborting (UE stays connected)",
-			zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("procedure", name))
+		c.Log().Info("NAS procedure timed out, aborting (UE stays connected)",
+			zap.String("procedure", name))
 
 		onAbort()
 
 		return
 	}
 
-	logger.MmeLog.Info("NAS procedure timed out, releasing UE",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("procedure", name))
+	c.Log().Info("NAS procedure timed out, releasing UE", zap.String("procedure", name))
 	// The guard fires from a timer outside any request; start a fresh root.
 	m.ReleaseUEContext(context.Background(), ue, CauseNASUnspecified)
 }

--- a/internal/mme/reconcile.go
+++ b/internal/mme/reconcile.go
@@ -90,7 +90,7 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, ueConn *UeConn
 	// re-establishment. Checked before the QoS diff so a framed-only change still
 	// reactivates (framed routes are absent from the data-network fingerprint).
 	if delta.FramedRoutes {
-		logger.From(ctx, ueConn.Log).Info("framed routes changed; reactivating EPS bearer",
+		logger.From(ctx, ueConn.Log()).Info("framed routes changed; reactivating EPS bearer",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
 		m.reactivateBearer(ctx, ue, p)
 
@@ -100,7 +100,7 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, ueConn *UeConn
 	// The UE IP is fixed for the PDN connection lifetime (TS 23.401 §5.3.1.2.1);
 	// a reservation change requires reactivation, not in-place modification.
 	if delta.StaticIP {
-		logger.From(ctx, ueConn.Log).Info("static IP changed; reactivating EPS bearer",
+		logger.From(ctx, ueConn.Log()).Info("static IP changed; reactivating EPS bearer",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
 		m.reactivateBearer(ctx, ue, p)
 
@@ -114,7 +114,7 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, ueConn *UeConn
 		// §5.4.4.1), symmetric with the 5G release on an unresolvable policy. Other
 		// errors are transient (DB/infra); skip and let the backstop retry.
 		if errors.Is(err, ErrUnknownAPN) {
-			logger.From(ctx, ueConn.Log).Info("APN no longer authorized; reactivating EPS bearer",
+			logger.From(ctx, ueConn.Log()).Info("APN no longer authorized; reactivating EPS bearer",
 				zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
 			m.reactivateBearer(ctx, ue, p)
 
@@ -142,14 +142,14 @@ func (m *MME) reconcileBearer(ctx context.Context, ue *UeContext, ueConn *UeConn
 	// An IP-pool or MTU change cannot be adopted in place; reactivate so the UE
 	// re-establishes (the new bearer also picks up the new QoS/Session-AMBR).
 	if dnChanged && !dnsOnlyChange(curDNConfig, newFingerprint) {
-		logger.From(ctx, ueConn.Log).Info("data-network configuration changed; reactivating EPS bearer",
+		logger.From(ctx, ueConn.Log()).Info("data-network configuration changed; reactivating EPS bearer",
 			zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn))
 		m.reactivateBearer(ctx, ue, p)
 
 		return
 	}
 
-	logger.From(ctx, ueConn.Log).Info("policy/data-network changed; modifying EPS bearer in place",
+	logger.From(ctx, ueConn.Log()).Info("policy/data-network changed; modifying EPS bearer in place",
 		zap.String("imsi", ue.IMSI()), zap.String("apn", p.Apn),
 		zap.Bool("dns", dnChanged), zap.Bool("session-ambr", ambrChanged), zap.Bool("qos", qosChanged))
 	m.modifyBearer(ctx, ue, ueConn, p, qos, dnChanged, ambrChanged, qosChanged)

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/guard"
 	"github.com/ellanetworks/core/internal/interworking"
+	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/udm"
 	"github.com/ellanetworks/core/nas/eps"
@@ -37,7 +38,7 @@ type UeConn struct {
 	ENBUES1APID               s1ap.ENBUES1APID
 	MMEUES1APID               s1ap.MMEUES1APID
 	conn                      atomic.Pointer[S1APWriter]
-	Log                       *zap.Logger
+	log                       atomic.Pointer[zap.Logger]
 	ue                        *UeContext
 	ServingTAI                s1ap.TAI
 	Location                  models.UserLocation
@@ -65,6 +66,22 @@ type FiveGSArrival struct {
 	Sessions *interworking.ArrivingSessions
 
 	RemappedHeldContext bool
+}
+
+func (c *UeConn) Log() *zap.Logger {
+	if c == nil {
+		return logger.MmeLog
+	}
+
+	if l := c.log.Load(); l != nil {
+		return l
+	}
+
+	return logger.MmeLog
+}
+
+func (c *UeConn) setLog(l *zap.Logger) {
+	c.log.Store(l)
 }
 
 func (c *UeConn) ArrivedFrom5GS() bool {

--- a/internal/mme/s1_conn_log_test.go
+++ b/internal/mme/s1_conn_log_test.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func observeMmeLogAt(t *testing.T, lvl zapcore.Level) *observer.ObservedLogs {
+	t.Helper()
+
+	core, logs := observer.New(lvl)
+	saved := logger.MmeLog
+	logger.MmeLog = zap.New(core)
+
+	t.Cleanup(func() { logger.MmeLog = saved })
+
+	return logs
+}
+
+func trackRadioAt(m *MME, w S1APWriter, address string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.radios[w] = &Radio{m: m, address: address, Log: logger.MmeLog.With(logger.RanAddr(address))}
+}
+
+func ranAddrOf(t *testing.T, e observer.LoggedEntry) string {
+	t.Helper()
+
+	for k, v := range e.ContextMap() {
+		if k == "ran_addr" {
+			s, _ := v.(string)
+			return s
+		}
+	}
+
+	return ""
+}
+
+// TS 36.413 §8.6.1
+func TestCommitPathSwitchRebindsConnLoggerToTargetENB(t *testing.T) {
+	logs := observeMmeLogAt(t, zapcore.InfoLevel)
+
+	m := New(nil, nil, nil)
+
+	source, target := &captureConn{}, &captureConn{}
+	trackRadioAt(m, source, "10.0.0.1:36412")
+	trackRadioAt(m, target, "10.0.0.2:36412")
+
+	c := m.NewUeConn(source, 5)
+
+	ue := &UeContext{}
+	ue.active.Store(c)
+	c.ue = ue
+
+	c.Log().Info("before")
+
+	if _, ok := m.CommitPathSwitch(ue, target, 7, [32]byte{}, 0); !ok {
+		t.Fatal("CommitPathSwitch did not commit")
+	}
+
+	c.Log().Info("after")
+
+	entries := logs.All()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(entries))
+	}
+
+	if got := ranAddrOf(t, entries[0]); got != "10.0.0.1:36412" {
+		t.Fatalf("before path switch: ran_addr = %q, want the source eNB", got)
+	}
+
+	if got := ranAddrOf(t, entries[1]); got != "10.0.0.2:36412" {
+		t.Fatalf("after path switch: ran_addr = %q, want the target eNB", got)
+	}
+}
+
+func TestUeConnLogConcurrentAccessNoRace(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	source, target := &captureConn{}, &captureConn{}
+	trackRadioAt(m, source, "10.0.0.1:36412")
+	trackRadioAt(m, target, "10.0.0.2:36412")
+
+	c := m.NewUeConn(source, 5)
+
+	ue := &UeContext{}
+	ue.active.Store(c)
+	c.ue = ue
+
+	var (
+		wg      sync.WaitGroup
+		commits atomic.Int64
+	)
+
+	for _, op := range []func(){
+		func() {
+			if _, ok := m.CommitPathSwitch(ue, target, 7, [32]byte{}, 0); ok {
+				commits.Add(1)
+			}
+		},
+		func() { _ = c.Log() },
+	} {
+		wg.Add(1)
+
+		go func(f func()) {
+			defer wg.Done()
+
+			for range 500 {
+				f()
+			}
+		}(op)
+	}
+
+	wg.Wait()
+
+	if commits.Load() == 0 {
+		t.Fatal("CommitPathSwitch never committed; the logger write was not exercised")
+	}
+}

--- a/internal/mme/s1ap/handle_erab_release_response.go
+++ b/internal/mme/s1ap/handle_erab_release_response.go
@@ -32,7 +32,7 @@ func HandleERABReleaseResponse(m *mme.MME, ctx context.Context, radio *mme.Radio
 	captureUserLocation(ueConn, msg.UserLocationInformation)
 
 	for _, erab := range msg.ERABReleased {
-		ueConn.Log.Info("E-RAB released at eNB",
+		ueConn.Log().Info("E-RAB released at eNB",
 			zap.String("imsi", ue.IMSI()),
 			zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 	}

--- a/internal/mme/s1ap/handle_initial_ue_message.go
+++ b/internal/mme/s1ap/handle_initial_ue_message.go
@@ -53,7 +53,7 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 		c.UpdateLocation(*msg.EUTRANCGI, msg.TAI)
 	}
 
-	logger.From(ctx, c.Log).Info("Initial UE Message",
+	logger.From(ctx, c.Log()).Info("Initial UE Message",
 		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),
 	)
 
@@ -65,7 +65,7 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 	if len(nas) > 0 && nas[0]>>4 != uint8(eps.SHTPlain) && msg.STMSI != nil {
 		if ue, ok := m.LookupUeByMTMSI(uint32(msg.STMSI.MTMSI)); ok && ue.EMMState() == mme.EMMRegistered && ue.Secured() {
 			if _, _, err := ue.TryUnprotectUplink(nas); err == nil {
-				logger.From(ctx, c.Log).Debug("Initial UE Message: resuming held context",
+				logger.From(ctx, c.Log()).Debug("Initial UE Message: resuming held context",
 					zap.Uint32("m-tmsi", uint32(msg.STMSI.MTMSI)))
 				m.AttachUeConn(ue, c)
 			}

--- a/internal/mme/s1ap/handle_path_switch_request.go
+++ b/internal/mme/s1ap/handle_path_switch_request.go
@@ -65,7 +65,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	// Nil in ECM-IDLE, and a concurrent detach can nil it at any point.
 	ueLog := logger.MmeLog
 	if c := ue.Conn(); c != nil {
-		ueLog = c.Log
+		ueLog = c.Log()
 	}
 
 	if !ue.Secured() || !ue.HasKASME() {

--- a/internal/mme/s1ap/handle_ue_capability_info_indication.go
+++ b/internal/mme/s1ap/handle_ue_capability_info_indication.go
@@ -39,7 +39,7 @@ func handleUECapabilityInfoIndication(m *mme.MME, ctx context.Context, radio *mm
 		ue.RadioCapabilityForPaging = msg.UERadioCapabilityForPaging
 	}
 
-	ueConn.Log.Info("stored UE Radio Capability",
+	ueConn.Log().Info("stored UE Radio Capability",
 		zap.Int("bytes", len(ue.RadioCapability)),
 		zap.Int("paging-bytes", len(ue.RadioCapabilityForPaging)))
 }

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -64,10 +64,10 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 			icsReceived = p.EnbFTEID.TEID != 0
 		}
 
-		logger.From(ctx, ueConn.Log).Warn("UE Context Release Request aborted an in-progress attach",
+		logger.From(ctx, ueConn.Log()).Warn("UE Context Release Request aborted an in-progress attach",
 			append(fields, zap.Bool("ics-response-received", icsReceived))...)
 	} else {
-		logger.From(ctx, ueConn.Log).Info("UE Context Release Request", fields...)
+		logger.From(ctx, ueConn.Log()).Info("UE Context Release Request", fields...)
 	}
 
 	m.ReleaseUEContext(ctx, ue, cause)

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -34,8 +34,7 @@ func (m *MME) releaseSupersededConn(ctx context.Context, c *UeConn) {
 func (m *MME) guardDetachedRelease(c *UeConn) {
 	c.releaseGuard.Arm(releaseGuardTimeout, 0, nil, func() {
 		if m.ReleaseDetachedConn(c.Conn(), c.MMEUES1APID, c.ENBUES1APID) {
-			logger.MmeLog.Info("reaped detached S1 connection after release timeout",
-				zap.Uint32("mme-ue-id", uint32(c.MMEUES1APID)))
+			c.Log().Info("reaped detached S1 connection after release timeout")
 		}
 	})
 }
@@ -101,7 +100,7 @@ func (c *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause s1ap.Cau
 		return
 	}
 
-	logger.From(ctx, c.Log).Info("UE Context Release Command")
+	logger.From(ctx, c.Log()).Info("UE Context Release Command")
 	c.SendS1AP(ctx, S1APProcedureUEContextReleaseCommand, b)
 }
 

--- a/internal/tester/scenarios/gnb/registration_reject_unknown_ue.go
+++ b/internal/tester/scenarios/gnb/registration_reject_unknown_ue.go
@@ -87,7 +87,7 @@ func runRegistrationRejectUnknownUE(_ context.Context, env scenarios.Env, _ any)
 		return fmt.Errorf("did not receive Registration Reject: %v", err)
 	}
 
-	err = validateRegistrationReject(msg, 9 /* 5GMM cause #9: UE identity cannot be derived by the network */)
+	err = validateRegistrationReject(msg, 3 /* 5GMM cause #3: Illegal UE */)
 	if err != nil {
 		return fmt.Errorf("NAS PDU validation failed: %v", err)
 	}

--- a/internal/tester/scenarios/s1enb/attach_reject_unknown_imsi.go
+++ b/internal/tester/scenarios/s1enb/attach_reject_unknown_imsi.go
@@ -43,9 +43,9 @@ func runS1ENBAttachRejectUnknownIMSI(_ context.Context, env scenarios.Env, _ any
 		return fmt.Errorf("attach: %w", err)
 	}
 
-	// EMM cause #2, IMSI unknown in HSS (TS 24.301 §9.9.3.9).
-	if cause != 2 {
-		return fmt.Errorf("expected Attach Reject cause #2 (IMSI unknown in HSS), got #%d", cause)
+	// EMM cause #3, Illegal UE (TS 24.301 §9.9.3.9).
+	if cause != 3 {
+		return fmt.Errorf("expected Attach Reject cause #3 (Illegal UE), got #%d", cause)
 	}
 
 	return nil

--- a/internal/udm/credential.go
+++ b/internal/udm/credential.go
@@ -12,10 +12,13 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/ellanetworks/core/etsi"
 )
+
+var ErrSubscriberUnknown = errors.New("subscriber unknown")
 
 // Subscriber holds the authentication material the credential authority needs.
 type Subscriber struct {

--- a/internal/udm/suci.go
+++ b/internal/udm/suci.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"math/bits"
@@ -332,7 +333,18 @@ func schemeIDToLetter(schemeID string) (string, error) {
 // scheme is "A" or "B". keyIdentifier is 0-255.
 type KeyResolver func(scheme string, keyIdentifier int) (string, error)
 
+var ErrSUPIUnderivable = errors.New("supi cannot be derived from suci")
+
 func ToSupi(suci string, resolveKey KeyResolver) (etsi.SUPI, error) {
+	supi, err := toSupi(suci, resolveKey)
+	if err != nil {
+		return etsi.InvalidSUPI, fmt.Errorf("%w: %w", ErrSUPIUnderivable, err)
+	}
+
+	return supi, nil
+}
+
+func toSupi(suci string, resolveKey KeyResolver) (etsi.SUPI, error) {
 	suciPart := strings.Split(suci, "-")
 	suciPrefix := suciPart[0]
 

--- a/internal/udm/suci_test.go
+++ b/internal/udm/suci_test.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -436,6 +437,55 @@ func TestToSupi_MalformedSuci(t *testing.T) {
 	_, err := ToSupi("suci-0-001-01", nil)
 	if err == nil {
 		t.Fatal("expected error for malformed SUCI")
+	}
+}
+
+func TestToSupi_FailuresWrapErrSUPIUnderivable(t *testing.T) {
+	hnPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	otherPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	schemeOutput, err := buildProfileASchemeOutput("0000000002", hex.EncodeToString(otherPriv.PublicKey().Bytes()), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolveHN := func(scheme string, keyID int) (string, error) {
+		return hex.EncodeToString(hnPriv.Bytes()), nil
+	}
+
+	tests := []struct {
+		name    string
+		suci    string
+		resolve KeyResolver
+	}{
+		{"unknown prefix", "msisdn-001010000000001", nil},
+		{"malformed suci", "suci-0-001-01", nil},
+		{"unparsable key identifier", "suci-0-001-01-0000-1-notanumber-0000000001", resolveHN},
+		{"unsupported protection scheme", "suci-0-001-01-0000-3-0-0000000001", resolveHN},
+		{"home network key identifier not provisioned", "suci-0-001-01-0000-1-7-0000000001", func(scheme string, keyID int) (string, error) {
+			return "", fmt.Errorf("no key for identifier %d", keyID)
+		}},
+		{"scheme output encrypted with another home network key", fmt.Sprintf("suci-0-001-01-0000-1-0-%s", schemeOutput), resolveHN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ToSupi(tt.suci, tt.resolve)
+			if err == nil {
+				t.Fatal("ToSupi succeeded, want an error")
+			}
+
+			if !errors.Is(err, ErrSUPIUnderivable) {
+				t.Errorf("error %v does not wrap ErrSUPIUnderivable", err)
+			}
+		})
 	}
 }
 

--- a/pkg/runtime/ausf_adapter_test.go
+++ b/pkg/runtime/ausf_adapter_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/udm"
+)
+
+func TestAusfDBAdapterAdvanceSequenceNumberUnknownSubscriber(t *testing.T) {
+	ctx := context.Background()
+
+	database, err := db.NewDatabaseWithoutRaft(ctx, filepath.Join(t.TempDir(), "db.sqlite3"))
+	if err != nil {
+		t.Fatalf("NewDatabaseWithoutRaft: %s", err)
+	}
+
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Fatalf("Close: %s", err)
+		}
+	})
+
+	adapter := &ausfDBAdapter{db: database}
+
+	_, err = adapter.AdvanceSequenceNumber(ctx, "001019999999999", "", "")
+	if err == nil {
+		t.Fatal("AdvanceSequenceNumber succeeded for an unprovisioned subscriber")
+	}
+
+	if !errors.Is(err, udm.ErrSubscriberUnknown) {
+		t.Errorf("error %v does not wrap udm.ErrSubscriberUnknown", err)
+	}
+
+	if !errors.Is(err, db.ErrNotFound) {
+		t.Errorf("error %v no longer wraps db.ErrNotFound", err)
+	}
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -831,6 +831,10 @@ type ausfDBAdapter struct {
 func (a *ausfDBAdapter) AdvanceSequenceNumber(ctx context.Context, imsi, resyncAuts, resyncRand string) (*udm.AdvancedCredentials, error) {
 	creds, err := a.db.AdvanceSubscriberSQN(ctx, imsi, resyncAuts, resyncRand)
 	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, fmt.Errorf("%w: %w", udm.ErrSubscriberUnknown, err)
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

If a transient core-side failure interrupts authentication (ex. during HA leader election), connecting subscribers are now given a standards-compliant retry signal.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
