### PR TITLE
fix: filter retired tables out of replayed changesets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,11 +115,9 @@ require (
 )
 
 // Fork of mattn/go-sqlite3 that exposes the SQLite session extension
-// (sqlite3session_*, sqlite3changeset_apply and its xFilter table filter).
-// Used by internal/db to replicate write-set changesets.
-//
-// LOCAL DEVELOPMENT REPLACE — repoint at a pushed pseudo-version before merge:
-//   go get github.com/ellanetworks/go-sqlite3@<sha> && go mod tidy
+// (sqlite3session_* / sqlite3changeset_apply) behind the sqlite_session
+// build tag. Used by internal/raft to replicate write-set changesets
+// rather than typed commands.
 replace github.com/mattn/go-sqlite3 => /home/guillaume/code/go-sqlite3
 
 replace github.com/ellanetworks/core/lppa => ./lppa

--- a/go.mod
+++ b/go.mod
@@ -115,10 +115,12 @@ require (
 )
 
 // Fork of mattn/go-sqlite3 that exposes the SQLite session extension
-// (sqlite3session_* / sqlite3changeset_apply) behind the sqlite_session
-// build tag. Used by internal/raft to replicate write-set changesets
-// rather than typed commands.
-replace github.com/mattn/go-sqlite3 => github.com/ellanetworks/go-sqlite3 v0.0.0-20260414212710-333ead4fa037
+// (sqlite3session_*, sqlite3changeset_apply and its xFilter table filter).
+// Used by internal/db to replicate write-set changesets.
+//
+// LOCAL DEVELOPMENT REPLACE — repoint at a pushed pseudo-version before merge:
+//   go get github.com/ellanetworks/go-sqlite3@<sha> && go mod tidy
+replace github.com/mattn/go-sqlite3 => /home/guillaume/code/go-sqlite3
 
 replace github.com/ellanetworks/core/lppa => ./lppa
 

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 // (sqlite3session_* / sqlite3changeset_apply) behind the sqlite_session
 // build tag. Used by internal/raft to replicate write-set changesets
 // rather than typed commands.
-replace github.com/mattn/go-sqlite3 => /home/guillaume/code/go-sqlite3
+replace github.com/mattn/go-sqlite3 => github.com/ellanetworks/go-sqlite3 v0.0.0-20260827160408-a9cbc9046963
 
 replace github.com/ellanetworks/core/lppa => ./lppa
 

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 // (sqlite3session_* / sqlite3changeset_apply) behind the sqlite_session
 // build tag. Used by internal/raft to replicate write-set changesets
 // rather than typed commands.
-replace github.com/mattn/go-sqlite3 => github.com/ellanetworks/go-sqlite3 v0.0.0-20260827160408-a9cbc9046963
+replace github.com/mattn/go-sqlite3 => github.com/ellanetworks/go-sqlite3 v0.0.0-20260827163036-c5b342dd0d66
 
 replace github.com/ellanetworks/core/lppa => ./lppa
 

--- a/go.mod
+++ b/go.mod
@@ -115,9 +115,8 @@ require (
 )
 
 // Fork of mattn/go-sqlite3 that exposes the SQLite session extension
-// (sqlite3session_* / sqlite3changeset_apply) behind the sqlite_session
-// build tag. Used by internal/raft to replicate write-set changesets
-// rather than typed commands.
+// (sqlite3session_*, sqlite3changeset_apply and its xFilter table filter).
+// Used by internal/db to replicate write-set changesets.
 replace github.com/mattn/go-sqlite3 => github.com/ellanetworks/go-sqlite3 v0.0.0-20260827163036-c5b342dd0d66
 
 replace github.com/ellanetworks/core/lppa => ./lppa

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/eapache/channels v1.1.0 h1:F1taHcn7/F0i8DYqKXJnyhJcVpp2kgFcNePxXtnyu4
 github.com/eapache/channels v1.1.0/go.mod h1:jMm2qB5Ubtg9zLd+inMZd2/NUvXgzmWXsDaLyQIGfH0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/ellanetworks/go-sqlite3 v0.0.0-20260414212710-333ead4fa037 h1:nVg+TaCQBY3LryKnt9XZFU6z2VXduf9jd4474s+pr/Q=
-github.com/ellanetworks/go-sqlite3 v0.0.0-20260414212710-333ead4fa037/go.mod h1:F5S0ejkRZ60w6ORkocJnAQKTZzGZf0PCSNdHHHjimuU=
+github.com/ellanetworks/go-sqlite3 v0.0.0-20260827160408-a9cbc9046963 h1:SCnkNvl9Q4KbUc0ZKUTODjd2MMTnFmuuHPKy5t+ppDs=
+github.com/ellanetworks/go-sqlite3 v0.0.0-20260827160408-a9cbc9046963/go.mod h1:F5S0ejkRZ60w6ORkocJnAQKTZzGZf0PCSNdHHHjimuU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/eapache/channels v1.1.0 h1:F1taHcn7/F0i8DYqKXJnyhJcVpp2kgFcNePxXtnyu4
 github.com/eapache/channels v1.1.0/go.mod h1:jMm2qB5Ubtg9zLd+inMZd2/NUvXgzmWXsDaLyQIGfH0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/ellanetworks/go-sqlite3 v0.0.0-20260827160408-a9cbc9046963 h1:SCnkNvl9Q4KbUc0ZKUTODjd2MMTnFmuuHPKy5t+ppDs=
-github.com/ellanetworks/go-sqlite3 v0.0.0-20260827160408-a9cbc9046963/go.mod h1:F5S0ejkRZ60w6ORkocJnAQKTZzGZf0PCSNdHHHjimuU=
+github.com/ellanetworks/go-sqlite3 v0.0.0-20260827163036-c5b342dd0d66 h1:9CvFX8V3xO8ABJ3H7KubI1L9sI/BQfzwgvHGtBABZvw=
+github.com/ellanetworks/go-sqlite3 v0.0.0-20260827163036-c5b342dd0d66/go.mod h1:F5S0ejkRZ60w6ORkocJnAQKTZzGZf0PCSNdHHHjimuU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=

--- a/internal/amf/eps_mapping_test.go
+++ b/internal/amf/eps_mapping_test.go
@@ -49,7 +49,7 @@ func TestMapSecurityContextToEPS(t *testing.T) {
 		t.Fatalf("EPS NAS algorithms = %+v, want the pair the UE was given", got.Context.Algorithms)
 	}
 
-	if want := (nas.AlgorithmSet(0xe0)); got.Context.UESecurityCapability.EEA != want {
+	if want := nas.AlgorithmSet(0xe0); got.Context.UESecurityCapability.EEA != want {
 		t.Fatalf("EPS security capability EEA = %08b, want %08b", got.Context.UESecurityCapability.EEA, want)
 	}
 

--- a/internal/api/server/cluster_http_forward_test.go
+++ b/internal/api/server/cluster_http_forward_test.go
@@ -25,13 +25,13 @@ import (
 func TestClusterPropose_HappyPath(t *testing.T) {
 	testDB := newLeaderTestDB(t)
 
-	payload, err := json.Marshal(map[string]string{"value": "1970-01-01"})
+	payload, err := json.Marshal(map[string]int64{"value": 30})
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
 	}
 
 	envelope, err := json.Marshal(ellaraft.ProposeForwardRequest{
-		Operation: "DeleteOldAuditLogs",
+		Operation: "DeleteOldDailyUsage",
 		Payload:   payload,
 	})
 	if err != nil {
@@ -151,7 +151,7 @@ func TestClusterPropose_MalformedPayloadRejected(t *testing.T) {
 	// in the handler must reject malformed envelopes before dispatch
 	// so a buggy (or malicious) follower can't crash the leader.
 	// An envelope with truncated JSON fails at envelope parse time.
-	badBody := []byte(`{"operation":"DeleteOldAuditLogs","payload":`)
+	badBody := []byte(`{"operation":"DeleteOldDailyUsage","payload":`)
 
 	req := httptest.NewRequestWithContext(context.Background(),
 		http.MethodPost, ellaraft.ProposeForwardPath, bytes.NewReader(badBody))

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -56,22 +56,12 @@ func (db *Database) ApplyCommand(ctx context.Context, cmd *ellaraft.Command, log
 
 		return result, applyErr
 
+	// Retired: audit_logs is local-only and each node prunes its own rows.
+	// Historical entries carry a cutoff another node computed; applying one
+	// would delete audit history this node owns. The type stays registered so
+	// the entry still decodes, and applies as a no-op.
 	case ellaraft.CmdDeleteOldAuditLogs:
-		if err := db.assertAppliedSchema(ctx, intentMinSchemaForCmd(cmd.Type), cmd.Type.String()); err != nil {
-			return nil, err
-		}
-
-		payload, err := unmarshalPayload[stringPayload](cmd.Payload)
-		if err != nil {
-			return nil, err
-		}
-
-		applyErr := db.applyDeleteOldAuditLogs(ctx, payload)
-		if applyErr == nil {
-			db.publishOpTopics(topicsForIntentCmd(cmd.Type), logIndex)
-		}
-
-		return nil, applyErr
+		return nil, nil
 
 	case ellaraft.CmdDeleteOldDailyUsage:
 		if err := db.assertAppliedSchema(ctx, intentMinSchemaForCmd(cmd.Type), cmd.Type.String()); err != nil {
@@ -760,15 +750,6 @@ func (db *Database) applyInsertAuditLog(ctx context.Context, p *auditLogPayload)
 	}
 
 	return nil, nil
-}
-
-func (db *Database) applyDeleteOldAuditLogs(ctx context.Context, p *stringPayload) error {
-	err := db.runner(ctx).Query(ctx, db.deleteOldAuditLogsStmt, cutoffArgs{Cutoff: p.Value}).Run()
-	if err != nil {
-		return fmt.Errorf("query failed: %w", err)
-	}
-
-	return nil
 }
 
 func (db *Database) applyCreateUser(ctx context.Context, u *User) (any, error) {

--- a/internal/db/applier.go
+++ b/internal/db/applier.go
@@ -56,10 +56,6 @@ func (db *Database) ApplyCommand(ctx context.Context, cmd *ellaraft.Command, log
 
 		return result, applyErr
 
-	// Retired: audit_logs is local-only and each node prunes its own rows.
-	// Historical entries carry a cutoff another node computed; applying one
-	// would delete audit history this node owns. The type stays registered so
-	// the entry still decodes, and applies as a no-op.
 	case ellaraft.CmdDeleteOldAuditLogs:
 		return nil, nil
 

--- a/internal/db/changeset_replication.go
+++ b/internal/db/changeset_replication.go
@@ -95,6 +95,60 @@ var localOnlyTables = []string{
 	PositioningSessionsTableName,
 }
 
+// retiredReplicatedTables were once in replicatedChangesetTables. Raft logs
+// written before their retirement still carry changesets that mutate them, and
+// applyChangeset filters those rows out by consulting replicatedTableSet.
+//
+// Retirement is not reversible by editing a list. A table demoted to
+// localOnlyTables becomes per-node state that restoreLocalOnlyTables carries
+// across a snapshot restore, so replaying a historical changeset collides with
+// rows the node already owns. That applies to the table's whole history, not to
+// entries past some cutover index, so the filter derives from the current
+// classification and not from a log position.
+//
+// Add an entry here in the same change that removes a table from
+// replicatedChangesetTables, and cover it in the snapshot-restore replay test.
+var retiredReplicatedTables = []string{
+	// Demoted to localOnlyTables.
+	AuditLogsTableName,
+	RoutesTableName,
+	BGPSettingsTableName,
+	BGPPeersTableName,
+	BGPImportPrefixesTableName,
+	N3SettingsTableName,
+	NATSettingsTableName,
+	FlowAccountingSettingsTableName,
+
+	// Dropped by migration v12. Named as literals because the constants went
+	// with them; the Raft log that mutated them outlives both.
+	"cluster_pki_roots",
+	"cluster_pki_intermediates",
+	"cluster_issued_certs",
+	"cluster_revoked_certs",
+	"cluster_pki_state",
+}
+
+// replicatedTableSet is replicatedChangesetTables as a lookup, and is the
+// authority on what a changeset is allowed to touch. Every other table in a
+// changeset — retired, dropped, or never classified — is skipped.
+var replicatedTableSet = func() map[string]struct{} {
+	set := make(map[string]struct{}, len(replicatedChangesetTables))
+	for _, t := range replicatedChangesetTables {
+		set[t] = struct{}{}
+	}
+
+	return set
+}()
+
+// isReplicatedTable is the xFilter passed to ApplyChangesetFiltered. SQLite
+// calls it once per table named in a changeset, so it must stay a pure
+// function of the name.
+func isReplicatedTable(table string) bool {
+	_, ok := replicatedTableSet[table]
+
+	return ok
+}
+
 // fsmInternalTables are managed directly by the FSM layer, not through
 // changeset replication or local-only backup/restore. The fsm_state table
 // tracks the Raft index of the last applied log entry. Its value must
@@ -158,6 +212,10 @@ func (db *Database) assertTableReplicationClassification(ctx context.Context) er
 // applyChangeset replays a captured changeset on the local SQLite and
 // advances fsm_state.lastApplied to logIndex in the same transaction.
 //
+// The apply is filtered through isReplicatedTable: a log entry is durable and
+// outlives the classification it was captured under, so only tables that are
+// replicated now may be written. See retiredReplicatedTables.
+//
 // The atomicity matters: a crash between the changeset commit and the
 // lastApplied write would let Raft replay re-apply this entry, and
 // changesets are not idempotent — duplicate INSERTs hit
@@ -202,7 +260,7 @@ func (db *Database) applyChangeset(ctx context.Context, payload *bytesPayload, l
 			_, _ = sqliteConn.ExecContext(context.Background(), "ROLLBACK", nil)
 		}
 
-		if err := sqliteConn.ApplyChangeset(ctx, payload.Value); err != nil {
+		if err := sqliteConn.ApplyChangesetFiltered(ctx, payload.Value, isReplicatedTable); err != nil {
 			rollback()
 			return fmt.Errorf("apply sqlite changeset: %w", err)
 		}

--- a/internal/db/changeset_replication.go
+++ b/internal/db/changeset_replication.go
@@ -95,21 +95,7 @@ var localOnlyTables = []string{
 	PositioningSessionsTableName,
 }
 
-// retiredReplicatedTables were once in replicatedChangesetTables. Raft logs
-// written before their retirement still carry changesets that mutate them, and
-// applyChangeset filters those rows out by consulting replicatedTableSet.
-//
-// Retirement is not reversible by editing a list. A table demoted to
-// localOnlyTables becomes per-node state that restoreLocalOnlyTables carries
-// across a snapshot restore, so replaying a historical changeset collides with
-// rows the node already owns. That applies to the table's whole history, not to
-// entries past some cutover index, so the filter derives from the current
-// classification and not from a log position.
-//
-// Add an entry here in the same change that removes a table from
-// replicatedChangesetTables, and cover it in the snapshot-restore replay test.
 var retiredReplicatedTables = []string{
-	// Demoted to localOnlyTables.
 	AuditLogsTableName,
 	RoutesTableName,
 	BGPSettingsTableName,
@@ -119,8 +105,6 @@ var retiredReplicatedTables = []string{
 	NATSettingsTableName,
 	FlowAccountingSettingsTableName,
 
-	// Dropped by migration v12. Named as literals because the constants went
-	// with them; the Raft log that mutated them outlives both.
 	"cluster_pki_roots",
 	"cluster_pki_intermediates",
 	"cluster_issued_certs",
@@ -128,9 +112,6 @@ var retiredReplicatedTables = []string{
 	"cluster_pki_state",
 }
 
-// replicatedTableSet is replicatedChangesetTables as a lookup, and is the
-// authority on what a changeset is allowed to touch. Every other table in a
-// changeset — retired, dropped, or never classified — is skipped.
 var replicatedTableSet = func() map[string]struct{} {
 	set := make(map[string]struct{}, len(replicatedChangesetTables))
 	for _, t := range replicatedChangesetTables {
@@ -140,9 +121,6 @@ var replicatedTableSet = func() map[string]struct{} {
 	return set
 }()
 
-// isReplicatedTable is the xFilter passed to ApplyChangesetFiltered. SQLite
-// calls it once per table named in a changeset, so it must stay a pure
-// function of the name.
 func isReplicatedTable(table string) bool {
 	_, ok := replicatedTableSet[table]
 
@@ -211,10 +189,6 @@ func (db *Database) assertTableReplicationClassification(ctx context.Context) er
 
 // applyChangeset replays a captured changeset on the local SQLite and
 // advances fsm_state.lastApplied to logIndex in the same transaction.
-//
-// The apply is filtered through isReplicatedTable: a log entry is durable and
-// outlives the classification it was captured under, so only tables that are
-// replicated now may be written. See retiredReplicatedTables.
 //
 // The atomicity matters: a crash between the changeset commit and the
 // lastApplied write would let Raft replay re-apply this entry, and

--- a/internal/db/changeset_retired_table_test.go
+++ b/internal/db/changeset_retired_table_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/mattn/go-sqlite3"
 )
 
-// captureChangesetOverTables records a changeset over an explicit table list,
-// standing in for a leader whose binary still held those tables in its
-// replicated set. The mutations are rolled back, matching captureChangeset.
 func captureChangesetOverTables(t *testing.T, database *Database, tables []string, stmts []string) []byte {
 	t.Helper()
 
@@ -93,12 +90,6 @@ func auditLogActor(t *testing.T, database *Database, id string) string {
 	return actor
 }
 
-// TestApplyChangeset_SkipsRetiredReplicatedTable replays an entry captured
-// while audit_logs was replicated against a node that already owns the same
-// row, which is what a snapshot restore leaves behind now that
-// restoreLocalOnlyTables carries audit_logs across the file swap. The retired
-// table must be filtered out, and the replicated table in the same entry must
-// still apply.
 func TestApplyChangeset_SkipsRetiredReplicatedTable(t *testing.T) {
 	database := newAtomicTestDB(t)
 	ctx := context.Background()
@@ -114,8 +105,6 @@ func TestApplyChangeset_SkipsRetiredReplicatedTable(t *testing.T) {
 			 VALUES ('01900000-0000-7000-8000-00000000aaaa', 1, '000001', 'changeset-regression')`,
 		})
 
-	// The row this node owns after restoreLocalOnlyTables carried its
-	// audit_logs across the snapshot restore.
 	if _, err := database.PlainDB().ExecContext(ctx,
 		`INSERT INTO audit_logs (id, timestamp, level, actor, action, ip, details)
 		 VALUES (?, '2026-08-27T10:00:00Z', 'INFO', 'local-node', 'login', '10.0.0.1', 'details')`,
@@ -146,9 +135,6 @@ func TestApplyChangeset_SkipsRetiredReplicatedTable(t *testing.T) {
 	}
 }
 
-// TestApplyChangeset_UnfilteredRetiredTableWouldConflict pins the reason the
-// filter exists: the same entry aborts the whole apply when every table is
-// accepted, which is what halts the FSM.
 func TestApplyChangeset_UnfilteredRetiredTableWouldConflict(t *testing.T) {
 	database := newAtomicTestDB(t)
 	ctx := context.Background()
@@ -189,12 +175,6 @@ func TestApplyChangeset_UnfilteredRetiredTableWouldConflict(t *testing.T) {
 	}
 }
 
-// TestApplyForwardedOperation_RejectsRetiredOps covers a follower on an older
-// binary forwarding an operation a leader cannot honor. Capturing
-// InsertAuditLog on the leader yields an empty changeset, since audit_logs is
-// unattached, and the propose path reads an empty changeset as a successful
-// no-op — so without an explicit rejection the follower is told its audit
-// record was written.
 func TestApplyForwardedOperation_RejectsRetiredOps(t *testing.T) {
 	database := newAtomicTestDB(t)
 
@@ -212,8 +192,6 @@ func TestApplyForwardedOperation_RejectsRetiredOps(t *testing.T) {
 	}
 }
 
-// TestApplyForwardedOperation_AcceptsLiveOps pins that the rejection is scoped
-// to retired names.
 func TestApplyForwardedOperation_AcceptsLiveOps(t *testing.T) {
 	database := newAtomicTestDB(t)
 

--- a/internal/db/changeset_retired_table_test.go
+++ b/internal/db/changeset_retired_table_test.go
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package db
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// captureChangesetOverTables records a changeset over an explicit table list,
+// standing in for a leader whose binary still held those tables in its
+// replicated set. The mutations are rolled back, matching captureChangeset.
+func captureChangesetOverTables(t *testing.T, database *Database, tables []string, stmts []string) []byte {
+	t.Helper()
+
+	ctx := context.Background()
+
+	conn, err := database.PlainDB().Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire conn: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	var changeset []byte
+
+	err = conn.Raw(func(raw any) error {
+		sqliteConn, ok := raw.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("unexpected sqlite driver conn type %T", raw)
+		}
+
+		if _, err := sqliteConn.ExecContext(ctx, "BEGIN IMMEDIATE", nil); err != nil {
+			return fmt.Errorf("begin capture: %w", err)
+		}
+
+		defer func() {
+			_, _ = sqliteConn.ExecContext(context.Background(), "ROLLBACK", nil)
+		}()
+
+		changeset, err = sqliteConn.CaptureChangeset(ctx, func() error {
+			for _, stmt := range stmts {
+				if _, err := sqliteConn.ExecContext(ctx, stmt, []driver.NamedValue{}); err != nil {
+					return fmt.Errorf("exec %q: %w", stmt, err)
+				}
+			}
+
+			return nil
+		}, tables)
+
+		return err
+	})
+	if err != nil {
+		t.Fatalf("capture changeset over %v: %v", tables, err)
+	}
+
+	if len(changeset) == 0 {
+		t.Fatalf("capture over %v returned zero bytes", tables)
+	}
+
+	return changeset
+}
+
+func countAuditLogs(t *testing.T, database *Database, id string) int {
+	t.Helper()
+
+	var n int
+
+	if err := database.PlainDB().QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM audit_logs WHERE id = ?", id).Scan(&n); err != nil {
+		t.Fatalf("count audit_logs: %v", err)
+	}
+
+	return n
+}
+
+func auditLogActor(t *testing.T, database *Database, id string) string {
+	t.Helper()
+
+	var actor string
+
+	if err := database.PlainDB().QueryRowContext(context.Background(),
+		"SELECT actor FROM audit_logs WHERE id = ?", id).Scan(&actor); err != nil {
+		t.Fatalf("read audit_logs actor: %v", err)
+	}
+
+	return actor
+}
+
+// TestApplyChangeset_SkipsRetiredReplicatedTable replays an entry captured
+// while audit_logs was replicated against a node that already owns the same
+// row, which is what a snapshot restore leaves behind now that
+// restoreLocalOnlyTables carries audit_logs across the file swap. The retired
+// table must be filtered out, and the replicated table in the same entry must
+// still apply.
+func TestApplyChangeset_SkipsRetiredReplicatedTable(t *testing.T) {
+	database := newAtomicTestDB(t)
+	ctx := context.Background()
+
+	const auditID = "01900000-0000-7000-8000-0000000000a1"
+
+	changeset := captureChangesetOverTables(t, database,
+		[]string{AuditLogsTableName, NetworkSlicesTableName},
+		[]string{
+			fmt.Sprintf(`INSERT INTO audit_logs (id, timestamp, level, actor, action, ip, details)
+			 VALUES ('%s', '2026-08-27T09:00:00Z', 'INFO', 'other-node', 'login', '10.0.0.2', 'details')`, auditID),
+			`INSERT INTO network_slices (id, sst, sd, name)
+			 VALUES ('01900000-0000-7000-8000-00000000aaaa', 1, '000001', 'changeset-regression')`,
+		})
+
+	// The row this node owns after restoreLocalOnlyTables carried its
+	// audit_logs across the snapshot restore.
+	if _, err := database.PlainDB().ExecContext(ctx,
+		`INSERT INTO audit_logs (id, timestamp, level, actor, action, ip, details)
+		 VALUES (?, '2026-08-27T10:00:00Z', 'INFO', 'local-node', 'login', '10.0.0.1', 'details')`,
+		auditID); err != nil {
+		t.Fatalf("seed local audit_logs row: %v", err)
+	}
+
+	setLastApplied(t, database, 41)
+
+	if _, err := database.applyChangeset(ctx, &bytesPayload{Value: changeset}, 42); err != nil {
+		t.Fatalf("apply changeset carrying a retired table: %v", err)
+	}
+
+	if got := countAuditLogs(t, database, auditID); got != 1 {
+		t.Fatalf("audit_logs rows for %s: got %d, want 1", auditID, got)
+	}
+
+	if got := auditLogActor(t, database, auditID); got != "local-node" {
+		t.Fatalf("audit_logs actor for %s: got %q, want %q", auditID, got, "local-node")
+	}
+
+	if got := countSlices(t, database); got != 1 {
+		t.Fatalf("network_slices rows named changeset-regression: got %d, want 1", got)
+	}
+
+	if got := readLastApplied(t, database); got != 42 {
+		t.Fatalf("fsm_state.lastApplied: got %d, want 42", got)
+	}
+}
+
+// TestApplyChangeset_UnfilteredRetiredTableWouldConflict pins the reason the
+// filter exists: the same entry aborts the whole apply when every table is
+// accepted, which is what halts the FSM.
+func TestApplyChangeset_UnfilteredRetiredTableWouldConflict(t *testing.T) {
+	database := newAtomicTestDB(t)
+	ctx := context.Background()
+
+	const auditID = "01900000-0000-7000-8000-0000000000a2"
+
+	changeset := captureChangesetOverTables(t, database,
+		[]string{AuditLogsTableName},
+		[]string{
+			fmt.Sprintf(`INSERT INTO audit_logs (id, timestamp, level, actor, action, ip, details)
+			 VALUES ('%s', '2026-08-27T09:00:00Z', 'INFO', 'other-node', 'login', '10.0.0.2', 'details')`, auditID),
+		})
+
+	if _, err := database.PlainDB().ExecContext(ctx,
+		`INSERT INTO audit_logs (id, timestamp, level, actor, action, ip, details)
+		 VALUES (?, '2026-08-27T10:00:00Z', 'INFO', 'local-node', 'login', '10.0.0.1', 'details')`,
+		auditID); err != nil {
+		t.Fatalf("seed local audit_logs row: %v", err)
+	}
+
+	conn, err := database.PlainDB().Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire conn: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	err = conn.Raw(func(raw any) error {
+		sqliteConn, ok := raw.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("unexpected sqlite driver conn type %T", raw)
+		}
+
+		return sqliteConn.ApplyChangeset(ctx, changeset)
+	})
+	if err == nil {
+		t.Fatal("unfiltered apply of a retired-table changeset succeeded, expected a conflict")
+	}
+}
+
+// TestApplyForwardedOperation_RejectsRetiredOps covers a follower on an older
+// binary forwarding an operation a leader cannot honor. Capturing
+// InsertAuditLog on the leader yields an empty changeset, since audit_logs is
+// unattached, and the propose path reads an empty changeset as a successful
+// no-op — so without an explicit rejection the follower is told its audit
+// record was written.
+func TestApplyForwardedOperation_RejectsRetiredOps(t *testing.T) {
+	database := newAtomicTestDB(t)
+
+	for _, opName := range []string{"InsertAuditLog", "DeleteOldAuditLogs"} {
+		t.Run(opName, func(t *testing.T) {
+			_, err := database.ApplyForwardedOperation(opName, []byte(`{}`))
+			if err == nil {
+				t.Fatalf("%s: forwarded retired operation returned success", opName)
+			}
+
+			if !errors.Is(err, ErrRetiredOperation) {
+				t.Fatalf("%s: got %v, want ErrRetiredOperation", opName, err)
+			}
+		})
+	}
+}
+
+// TestApplyForwardedOperation_AcceptsLiveOps pins that the rejection is scoped
+// to retired names.
+func TestApplyForwardedOperation_AcceptsLiveOps(t *testing.T) {
+	database := newAtomicTestDB(t)
+
+	_, err := database.ApplyForwardedOperation("CreateNetworkSlice", []byte(
+		`{"id":"01900000-0000-7000-8000-00000000abcd","sst":1,"sd":"000001","name":"forwarded-live"}`))
+	if err != nil && errors.Is(err, ErrRetiredOperation) {
+		t.Fatalf("live operation rejected as retired: %v", err)
+	}
+
+	if err != nil && errors.Is(err, ErrUnknownOperation) {
+		t.Fatalf("live operation reported as unknown: %v", err)
+	}
+}

--- a/internal/db/determinism_test.go
+++ b/internal/db/determinism_test.go
@@ -26,7 +26,7 @@ import (
 //
 // Any non-deterministic value must be captured at propose time (by the
 // leader, before Command.MarshalBinary) and carried into the applyX via its
-// payload — see applyDeleteOldAuditLogs's cutoff for an example.
+// payload — see applyDeleteOldDailyUsage's cutoff for an example.
 func TestIntentApplyFunctions_AreDeterministic(t *testing.T) {
 	// Package-qualified identifiers banned inside applyX bodies. Each entry
 	// is matched as a selector (pkg.Name) so unrelated uses like
@@ -70,7 +70,6 @@ func TestIntentApplyFunctions_AreDeterministic(t *testing.T) {
 	}
 
 	targetedApplyMethods := map[string]struct{}{
-		"applyDeleteOldAuditLogs":     {},
 		"applyDeleteOldDailyUsage":    {},
 		"applyDeleteExpiredSessions":  {},
 		"applyDeleteAllDynamicLeases": {},

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -25,6 +25,7 @@ var (
 	ErrJoinTokenNodeMismatch    = errors.New("join token is not registered to this node")
 	ErrJoinTokenExpired         = errors.New("join token expired")
 	ErrUnknownOperation         = errors.New("unknown forwarded operation")
+	ErrRetiredOperation         = errors.New("forwarded operation is retired")
 )
 
 func isUniqueNameError(err error) bool {

--- a/internal/db/migration_v11.go
+++ b/internal/db/migration_v11.go
@@ -134,7 +134,7 @@ func rebuildTableUUID(
 		args[0] = uuid.NewSHA1(idNamespace, []byte(table+":"+strconv.FormatInt(oldID, 10))).String()
 
 		for i, col := range columns {
-			val := *(values[i+1].(*any))
+			val := *values[i+1].(*any)
 
 			if fk, ok := fks[col]; ok {
 				rewritten, err := rewriteFK(fk, val)

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -519,6 +519,14 @@ func (db *Database) ApplyForwardedOperation(opName string, payload json.RawMessa
 		return nil, fmt.Errorf("cluster not enabled")
 	}
 
+	if _, ok := retiredChangesetOps[opName]; ok {
+		return nil, fmt.Errorf("%w: %s", ErrRetiredOperation, opName)
+	}
+
+	if _, ok := retiredIntentOps[opName]; ok {
+		return nil, fmt.Errorf("%w: %s", ErrRetiredOperation, opName)
+	}
+
 	if h, ok := changesetOps[opName]; ok {
 		return db.applyForwardedChangesetOp(opName, h, payload)
 	}

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -47,6 +47,25 @@ var (
 	_ = registerChangesetOp("InsertAuditLog", (*Database).applyInsertAuditLog)
 )
 
+// retiredChangesetOps and retiredIntentOps name operations that stay
+// registered — a follower on an older binary still forwards them by name — but
+// that a leader cannot honor: audit_logs is local-only, and a leader has no way
+// to write another node's rows.
+//
+// ApplyForwardedOperation rejects them. Capturing an InsertAuditLog on the
+// leader yields an empty changeset, since audit_logs is unattached, and the
+// propose path reads an empty changeset as a successful no-op — leaving the
+// forwarding node told that a discarded audit record was written.
+var (
+	retiredChangesetOps = map[string]struct{}{
+		"InsertAuditLog": {},
+	}
+
+	retiredIntentOps = map[string]struct{}{
+		"DeleteOldAuditLogs": {},
+	}
+)
+
 // Users
 var (
 	opCreateUser         = registerChangesetOp("CreateUser", (*Database).applyCreateUser)

--- a/internal/db/operations_register.go
+++ b/internal/db/operations_register.go
@@ -47,15 +47,6 @@ var (
 	_ = registerChangesetOp("InsertAuditLog", (*Database).applyInsertAuditLog)
 )
 
-// retiredChangesetOps and retiredIntentOps name operations that stay
-// registered — a follower on an older binary still forwards them by name — but
-// that a leader cannot honor: audit_logs is local-only, and a leader has no way
-// to write another node's rows.
-//
-// ApplyForwardedOperation rejects them. Capturing an InsertAuditLog on the
-// leader yields an empty changeset, since audit_logs is unattached, and the
-// propose path reads an empty changeset as a successful no-op — leaving the
-// forwarding node told that a discarded audit record was written.
 var (
 	retiredChangesetOps = map[string]struct{}{
 		"InsertAuditLog": {},

--- a/internal/db/table_classification_internal_test.go
+++ b/internal/db/table_classification_internal_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 )
 
-// Editing these pins is the deliberate act that reclassifying a table
-// requires.
 var (
 	pinnedReplicatedTables = []string{
 		"api_tokens",
@@ -143,9 +141,6 @@ func TestRetiredReplicatedTablesArePinned(t *testing.T) {
 	assertTableSetPinned(t, "retiredReplicatedTables", pinnedRetiredReplicatedTables, retiredReplicatedTables)
 }
 
-// A retired table must not still be replicated: isReplicatedTable is the
-// authority applyChangeset consults, and a table in both lists would keep
-// applying the very entries retirement exists to filter out.
 func TestRetiredTablesAreNotReplicated(t *testing.T) {
 	for _, table := range retiredReplicatedTables {
 		if isReplicatedTable(table) {
@@ -154,9 +149,6 @@ func TestRetiredTablesAreNotReplicated(t *testing.T) {
 	}
 }
 
-// Every demoted table must be local-only or gone. A retired table that is
-// neither is unclassified, which assertTableReplicationClassification rejects
-// at startup only if it still exists in sqlite_master.
 func TestRetiredTablesAreLocalOnlyOrDropped(t *testing.T) {
 	localOnly := make(map[string]struct{}, len(localOnlyTables))
 	for _, table := range localOnlyTables {
@@ -181,9 +173,6 @@ func TestRetiredTablesAreLocalOnlyOrDropped(t *testing.T) {
 	}
 }
 
-// isReplicatedTable must agree with replicatedChangesetTables, which is what
-// captureChangeset attaches: a table captured but not applied would be dropped
-// on every node, and a table applied but not captured cannot appear.
 func TestIsReplicatedTableMatchesCaptureSet(t *testing.T) {
 	for _, table := range replicatedChangesetTables {
 		if !isReplicatedTable(table) {

--- a/internal/db/table_classification_internal_test.go
+++ b/internal/db/table_classification_internal_test.go
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package db
+
+import (
+	"sort"
+	"testing"
+)
+
+// Editing these pins is the deliberate act that reclassifying a table
+// requires.
+var (
+	pinnedReplicatedTables = []string{
+		"api_tokens",
+		"cell_positions",
+		"cluster_join_hmac",
+		"cluster_join_tokens",
+		"cluster_members",
+		"cluster_node_certs",
+		"daily_usage",
+		"data_networks",
+		"home_network_keys",
+		"ip_leases",
+		"jwt_secret",
+		"network_rules",
+		"network_slices",
+		"operator",
+		"policies",
+		"profiles",
+		"retention_policies",
+		"schema_version",
+		"sessions",
+		"subscriber_framed_routes",
+		"subscribers",
+		"users",
+	}
+
+	pinnedLocalOnlyTables = []string{
+		"audit_logs",
+		"bgp_import_prefixes",
+		"bgp_peers",
+		"bgp_settings",
+		"flow_accounting_settings",
+		"flow_reports",
+		"local_switch_settings",
+		"n3_settings",
+		"nat_settings",
+		"network_logs",
+		"positioning_sessions",
+		"routes",
+	}
+
+	pinnedFSMInternalTables = []string{
+		"fsm_state",
+	}
+
+	pinnedRetiredReplicatedTables = []string{
+		"audit_logs",
+		"bgp_import_prefixes",
+		"bgp_peers",
+		"bgp_settings",
+		"cluster_issued_certs",
+		"cluster_pki_intermediates",
+		"cluster_pki_roots",
+		"cluster_pki_state",
+		"cluster_revoked_certs",
+		"flow_accounting_settings",
+		"n3_settings",
+		"nat_settings",
+		"routes",
+	}
+)
+
+const tableClassificationRule = `A table was added to, or removed from, a replication class.
+
+A Raft log entry is durable and is interpreted by whichever binary
+replays it, so the class a table holds today decides what every
+historical changeset is allowed to write. Demoting a table to
+localOnlyTables makes restoreLocalOnlyTables carry that table's rows
+across a snapshot restore, and replaying a changeset captured while it
+was replicated then collides with rows the node already owns — the FSM
+treats the conflict as fatal and the node crash-loops on every restart.
+
+Removing a table from replicatedChangesetTables therefore also requires
+adding it to retiredReplicatedTables, so applyChangeset keeps filtering
+its rows out of entries written before the demotion, and a case in
+TestApplyChangeset_SkipsRetiredReplicatedTable.
+
+Promoting a table is safe but ordered: entries written before the
+promotion never carried it.`
+
+func assertTableSetPinned(t *testing.T, label string, pinned, actual []string) {
+	t.Helper()
+
+	pinnedSet := make(map[string]struct{}, len(pinned))
+	for _, table := range pinned {
+		pinnedSet[table] = struct{}{}
+	}
+
+	actualSet := make(map[string]struct{}, len(actual))
+	for _, table := range actual {
+		actualSet[table] = struct{}{}
+	}
+
+	for _, table := range sortedKeys(pinnedSet) {
+		if _, ok := actualSet[table]; !ok {
+			t.Errorf("%s: %q is pinned but absent\n\n%s", label, table, tableClassificationRule)
+		}
+	}
+
+	for _, table := range sortedKeys(actualSet) {
+		if _, ok := pinnedSet[table]; !ok {
+			t.Errorf("%s: %q is present but not pinned\n\n%s", label, table, tableClassificationRule)
+		}
+	}
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+func TestReplicatedTablesArePinned(t *testing.T) {
+	assertTableSetPinned(t, "replicatedChangesetTables", pinnedReplicatedTables, replicatedChangesetTables)
+}
+
+func TestLocalOnlyTablesArePinned(t *testing.T) {
+	assertTableSetPinned(t, "localOnlyTables", pinnedLocalOnlyTables, localOnlyTables)
+}
+
+func TestFSMInternalTablesArePinned(t *testing.T) {
+	assertTableSetPinned(t, "fsmInternalTables", pinnedFSMInternalTables, fsmInternalTables)
+}
+
+func TestRetiredReplicatedTablesArePinned(t *testing.T) {
+	assertTableSetPinned(t, "retiredReplicatedTables", pinnedRetiredReplicatedTables, retiredReplicatedTables)
+}
+
+// A retired table must not still be replicated: isReplicatedTable is the
+// authority applyChangeset consults, and a table in both lists would keep
+// applying the very entries retirement exists to filter out.
+func TestRetiredTablesAreNotReplicated(t *testing.T) {
+	for _, table := range retiredReplicatedTables {
+		if isReplicatedTable(table) {
+			t.Errorf("%q is retired but isReplicatedTable reports it as replicated\n\n%s", table, tableClassificationRule)
+		}
+	}
+}
+
+// Every demoted table must be local-only or gone. A retired table that is
+// neither is unclassified, which assertTableReplicationClassification rejects
+// at startup only if it still exists in sqlite_master.
+func TestRetiredTablesAreLocalOnlyOrDropped(t *testing.T) {
+	localOnly := make(map[string]struct{}, len(localOnlyTables))
+	for _, table := range localOnlyTables {
+		localOnly[table] = struct{}{}
+	}
+
+	dropped := map[string]struct{}{
+		"cluster_pki_roots":         {},
+		"cluster_pki_intermediates": {},
+		"cluster_issued_certs":      {},
+		"cluster_revoked_certs":     {},
+		"cluster_pki_state":         {},
+	}
+
+	for _, table := range retiredReplicatedTables {
+		_, isLocal := localOnly[table]
+		_, isDropped := dropped[table]
+
+		if !isLocal && !isDropped {
+			t.Errorf("retired table %q is neither local-only nor dropped\n\n%s", table, tableClassificationRule)
+		}
+	}
+}
+
+// isReplicatedTable must agree with replicatedChangesetTables, which is what
+// captureChangeset attaches: a table captured but not applied would be dropped
+// on every node, and a table applied but not captured cannot appear.
+func TestIsReplicatedTableMatchesCaptureSet(t *testing.T) {
+	for _, table := range replicatedChangesetTables {
+		if !isReplicatedTable(table) {
+			t.Errorf("%q is attached at capture but isReplicatedTable rejects it\n\n%s", table, tableClassificationRule)
+		}
+	}
+
+	for _, table := range localOnlyTables {
+		if isReplicatedTable(table) {
+			t.Errorf("local-only %q is accepted by isReplicatedTable\n\n%s", table, tableClassificationRule)
+		}
+	}
+
+	for _, table := range fsmInternalTables {
+		if isReplicatedTable(table) {
+			t.Errorf("fsm-internal %q is accepted by isReplicatedTable\n\n%s", table, tableClassificationRule)
+		}
+	}
+}

--- a/internal/logger/fields.go
+++ b/internal/logger/fields.go
@@ -17,6 +17,7 @@ func TMSI(val string) zap.Field { return zap.String("tmsi", val) }
 
 // Session, NGAP & S1AP
 func AmfUeNgapID(val models.AmfUeNgapID) zap.Field { return zap.Int64("amf_ue_ngap_id", int64(val)) }
+
 func RanUeNgapID(val models.RanUeNgapID) zap.Field { return zap.Int64("ran_ue_ngap_id", int64(val)) }
 func MMEUeS1apID(val uint32) zap.Field             { return zap.Uint32("mme-ue-id", val) }
 func PDUSessionID(val uint8) zap.Field             { return zap.Uint8("pdu_session_id", val) }

--- a/internal/sctp/ipsock_linux.go
+++ b/internal/sctp/ipsock_linux.go
@@ -164,7 +164,7 @@ func (p *ipStackCapabilities) probe() {
 			continue
 		}
 
-		sa, err := sockaddr(&(probes[i].laddr), syscall.AF_INET6)
+		sa, err := sockaddr(&probes[i].laddr, syscall.AF_INET6)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
# Description

Fixes a crash loop where a node that had been offline could fail on startup after upgrading by no longer replaying old cluster history against records it now keeps per-node.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
