### PR TITLE
fix(ha): barrier before the drain check on member removal

### DIFF
--- a/internal/api/server/api_cluster.go
+++ b/internal/api/server/api_cluster.go
@@ -205,6 +205,13 @@ func RemoveClusterMember(dbInstance *db.Database) http.Handler {
 			return
 		}
 
+		if err := dbInstance.ReadBarrier(); err != nil {
+			writeError(r.Context(), w, http.StatusServiceUnavailable,
+				"Cluster state has not settled after a leadership change; retry", err, logger.APILog)
+
+			return
+		}
+
 		member, err := dbInstance.GetClusterMember(r.Context(), nodeID)
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -406,6 +406,14 @@ func (db *Database) writeBarrier() error {
 	return classifyBarrierErr(db.raftManager.WriteBarrier(db.proposeTimeout))
 }
 
+func (db *Database) ReadBarrier() error {
+	if db.raftManager == nil || !db.raftManager.IsLeader() {
+		return nil
+	}
+
+	return db.writeBarrier()
+}
+
 // leaderCaptureAndPropose runs the capture→propose cycle on the leader.
 // proposeMu serialises captures so concurrent writers don't observe
 // the same pre-mutation state. minSchema is stamped on bytesPayload as


### PR DESCRIPTION
# Description

Removing a drained node right after a leadership change could be wrongly rejected with "node is not drained"; the new leader now catches up on cluster state before answering.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
