### PR TITLE
test: bump 5G signalling timeout in integration tests 

### DIFF
--- a/internal/tester/scenarios/defaults.go
+++ b/internal/tester/scenarios/defaults.go
@@ -3,6 +3,8 @@
 
 package scenarios
 
+import "time"
+
 // Defaults the integration suite provisions on Core and scenarios consume
 // directly, keeping a single source of truth for both.
 const (
@@ -48,4 +50,9 @@ const (
 
 	// DefaultProbePort is the TCP/UDP echo port exposed by the on-N6 responder.
 	DefaultProbePort = 34242
+
+	// NGSetupTimeout bounds the wait for an NG Setup outcome. The AMF reads
+	// operator configuration and network slices from storage before it can
+	// answer, so the wait has to absorb database latency on a loaded runner.
+	NGSetupTimeout = 5 * time.Second
 )

--- a/internal/tester/scenarios/enb/connectivity.go
+++ b/internal/tester/scenarios/enb/connectivity.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/enb"
 	"github.com/ellanetworks/core/internal/tester/gnb"
@@ -132,7 +131,7 @@ func runEnbConnectivity(ctx context.Context, env scenarios.Env, _ any) error {
 
 	defer ngeNB.Close()
 
-	_, err = ngeNB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = ngeNB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive SCTP frame: %v", err)
 	}

--- a/internal/tester/scenarios/enb/deregistration.go
+++ b/internal/tester/scenarios/enb/deregistration.go
@@ -58,7 +58,7 @@ func runEnbDeregistration(_ context.Context, env scenarios.Env, _ any) error {
 
 	defer ngeNB.Close()
 
-	_, err = ngeNB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = ngeNB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive SCTP frame: %v", err)
 	}

--- a/internal/tester/scenarios/enb/multi_ue_registration.go
+++ b/internal/tester/scenarios/enb/multi_ue_registration.go
@@ -6,7 +6,6 @@ package enb
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/enb"
 	"github.com/ellanetworks/core/internal/tester/gnb"
@@ -71,7 +70,7 @@ func runEnbMultiUERegistration(_ context.Context, env scenarios.Env, _ any) erro
 
 	defer ngeNB.Close()
 
-	_, err = ngeNB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = ngeNB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive SCTP frame: %v", err)
 	}

--- a/internal/tester/scenarios/enb/ng_setup.go
+++ b/internal/tester/scenarios/enb/ng_setup.go
@@ -6,7 +6,6 @@ package enb
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/enb"
 	"github.com/ellanetworks/core/internal/tester/gnb"
@@ -50,7 +49,7 @@ func runNgSetup(_ context.Context, env scenarios.Env, _ any) error {
 	if _, err := node.WaitForMessage(
 		gnb.Successful,
 		ngap.ProcNGSetup,
-		1*time.Second,
+		scenarios.NGSetupTimeout,
 	); err != nil {
 		return fmt.Errorf("wait NGSetupResponse: %w", err)
 	}

--- a/internal/tester/scenarios/gnb/authentication_wrong_key.go
+++ b/internal/tester/scenarios/gnb/authentication_wrong_key.go
@@ -57,7 +57,7 @@ func runAuthenticationWrongKey(_ context.Context, env scenarios.Env, _ any) erro
 
 	defer gNodeB.Close()
 
-	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("timeout waiting for NGSetupComplete: %v", err)
 	}

--- a/internal/tester/scenarios/gnb/connectivity_multi_pdu_session.go
+++ b/internal/tester/scenarios/gnb/connectivity_multi_pdu_session.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"time"
 
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/tester/gnb"
@@ -146,7 +145,7 @@ func runConnectivityMultiPDUSession(ctx context.Context, env scenarios.Env, _ an
 
 	defer gNodeB.Close()
 
-	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive NG Setup Response: %v", err)
 	}

--- a/internal/tester/scenarios/gnb/helpers.go
+++ b/internal/tester/scenarios/gnb/helpers.go
@@ -64,7 +64,7 @@ func startGNB(env scenarios.Env) (*gnb.GnodeB, error) {
 		return nil, fmt.Errorf("start gNB: %w", err)
 	}
 
-	if _, err := gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond); err != nil {
+	if _, err := gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout); err != nil {
 		gNodeB.Close()
 
 		return nil, fmt.Errorf("await NG Setup Response: %w", err)

--- a/internal/tester/scenarios/gnb/location.go
+++ b/internal/tester/scenarios/gnb/location.go
@@ -6,7 +6,6 @@ package gnb
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/client"
 	"github.com/ellanetworks/core/internal/tester/gnb"
@@ -87,7 +86,7 @@ func runLocationTest(ctx context.Context, env scenarios.Env, p *locationParams) 
 
 	defer gNodeB.Close()
 
-	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive NG Setup Response: %v", err)
 	}

--- a/internal/tester/scenarios/gnb/ng_reset.go
+++ b/internal/tester/scenarios/gnb/ng_reset.go
@@ -50,7 +50,7 @@ func runNGReset(_ context.Context, env scenarios.Env, _ any) error {
 	if _, err := node.WaitForMessage(
 		gnb.Successful,
 		ngaplib.ProcNGSetup,
-		200*time.Millisecond,
+		scenarios.NGSetupTimeout,
 	); err != nil {
 		return fmt.Errorf("wait NGSetupResponse: %w", err)
 	}

--- a/internal/tester/scenarios/gnb/ng_setup_failure.go
+++ b/internal/tester/scenarios/gnb/ng_setup_failure.go
@@ -6,7 +6,6 @@ package gnb
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
@@ -48,7 +47,7 @@ func runNGSetupFailureUnknownPLMN(_ context.Context, env scenarios.Env, _ any) e
 	frame, err := node.WaitForMessage(
 		gnb.Unsuccessful,
 		ngap.ProcNGSetup,
-		200*time.Millisecond,
+		scenarios.NGSetupTimeout,
 	)
 	if err != nil {
 		return fmt.Errorf("wait NGSetupFailure: %w", err)

--- a/internal/tester/scenarios/gnb/ran_configuration_update.go
+++ b/internal/tester/scenarios/gnb/ran_configuration_update.go
@@ -51,7 +51,7 @@ func runRANConfigurationUpdate(_ context.Context, env scenarios.Env, _ any) erro
 	if _, err := node.WaitForMessage(
 		gnb.Successful,
 		ngap.ProcNGSetup,
-		200*time.Millisecond,
+		scenarios.NGSetupTimeout,
 	); err != nil {
 		return fmt.Errorf("wait NGSetupResponse: %w", err)
 	}

--- a/internal/tester/scenarios/gnb/registration_success_multiple_data_networks.go
+++ b/internal/tester/scenarios/gnb/registration_success_multiple_data_networks.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
@@ -99,7 +98,7 @@ func runRegistrationSuccessMultipleDataNetworks(_ context.Context, env scenarios
 
 	defer gNodeB.Close()
 
-	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive SCTP frame: %v", err)
 	}

--- a/internal/tester/scenarios/gnb/registration_success_multiple_slices.go
+++ b/internal/tester/scenarios/gnb/registration_success_multiple_slices.go
@@ -136,7 +136,7 @@ func runRegistrationSuccessMultipleSlices(_ context.Context, env scenarios.Env, 
 
 	defer gNodeB.Close()
 
-	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive NG Setup Response: %v", err)
 	}

--- a/internal/tester/scenarios/gnb/registration_success_no_sd.go
+++ b/internal/tester/scenarios/gnb/registration_success_no_sd.go
@@ -6,7 +6,6 @@ package gnb
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
@@ -83,7 +82,7 @@ func runRegistrationSuccessNoSD(_ context.Context, env scenarios.Env, _ any) err
 
 	defer gNodeB.Close()
 
-	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond)
+	_, err = gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout)
 	if err != nil {
 		return fmt.Errorf("did not receive SCTP frame: %v", err)
 	}

--- a/internal/tester/scenarios/gnb/registration_success_profile_a.go
+++ b/internal/tester/scenarios/gnb/registration_success_profile_a.go
@@ -8,7 +8,6 @@ import (
 	"crypto/ecdh"
 	"encoding/hex"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/scenarios"
@@ -96,7 +95,7 @@ func runRegistrationSuccessProfileA(_ context.Context, env scenarios.Env, params
 	if _, err := gNodeB.WaitForMessage(
 		gnb.Successful,
 		ngap.ProcNGSetup,
-		200*time.Millisecond,
+		scenarios.NGSetupTimeout,
 	); err != nil {
 		return fmt.Errorf("wait NGSetupResponse: %w", err)
 	}

--- a/internal/tester/scenarios/gnb/sctp_basics.go
+++ b/internal/tester/scenarios/gnb/sctp_basics.go
@@ -6,7 +6,6 @@ package gnb
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ellanetworks/core/internal/tester/gnb"
 	"github.com/ellanetworks/core/internal/tester/logger"
@@ -50,7 +49,7 @@ func runSCTPBasic(ctx context.Context, env scenarios.Env, _ any) error {
 	fr, err := node.WaitForMessage(
 		gnb.Successful,
 		ngap.ProcNGSetup,
-		200*time.Millisecond,
+		scenarios.NGSetupTimeout,
 	)
 	if err != nil {
 		return fmt.Errorf("wait for NG Setup Response: %w", err)

--- a/internal/tester/scenarios/interworking/interworking.go
+++ b/internal/tester/scenarios/interworking/interworking.go
@@ -70,7 +70,7 @@ func startGNB(env scenarios.Env) (*gnb.GnodeB, error) {
 		return nil, fmt.Errorf("start gNB: %w", err)
 	}
 
-	if _, err := gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, 200*time.Millisecond); err != nil {
+	if _, err := gNodeB.WaitForMessage(gnb.Successful, ngap.ProcNGSetup, scenarios.NGSetupTimeout); err != nil {
 		gNodeB.Close()
 
 		return nil, fmt.Errorf("await NG Setup Response: %w", err)

--- a/internal/tester/scenarios/multi/cluster_traffic_5g.go
+++ b/internal/tester/scenarios/multi/cluster_traffic_5g.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/tester/gnb"
@@ -89,7 +88,7 @@ func runClusterTraffic(ctx context.Context, env scenarios.Env, p *clusterTraffic
 	if _, err := gNodeB.WaitForMessage(
 		gnb.Successful,
 		ngap.ProcNGSetup,
-		5*time.Second,
+		scenarios.NGSetupTimeout,
 	); err != nil {
 		return fmt.Errorf("NG Setup Response: %w", err)
 	}


### PR DESCRIPTION
# Description

Some integration tests can be flaky because of tight timeouts and slow runners. We increase timeouts.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
