### PR TITLE
test(ui): wait for the filtered rows before asserting the search result

### DIFF
--- a/ui/src/pages/Subscribers.test.tsx
+++ b/ui/src/pages/Subscribers.test.tsx
@@ -274,8 +274,11 @@ describe("Subscribers search", () => {
     await waitFor(() => expect(lastParams().get("search")).toBe("gate"), {
       timeout: 2000,
     });
-    expect(await screen.findByText(IMSIS[0])).toBeInTheDocument();
-    expect(screen.queryByText(IMSIS[1])).not.toBeInTheDocument();
+    await waitFor(
+      () => expect(screen.queryByText(IMSIS[1])).not.toBeInTheDocument(),
+      { timeout: 2000 },
+    );
+    expect(screen.getByText(IMSIS[0])).toBeInTheDocument();
   });
 
   it("caps the search input at the length the API accepts", async () => {


### PR DESCRIPTION
# Description

Fix a flaky UI unit test.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
