### PR TITLE
fix(ha): re-run pin check after registration

### DIFF
--- a/internal/cluster/listener/listener.go
+++ b/internal/cluster/listener/listener.go
@@ -342,10 +342,6 @@ func (l *Listener) dispatch(ctx context.Context, conn net.Conn) {
 	l.trackConn(tlsConn)
 	defer l.untrackConn(tlsConn)
 
-	// CloseByPeerFingerprint only sees registered connections, so a pin
-	// dropped between the handshake and registration leaves a connection
-	// no scan can reach. Re-running the check after registration closes
-	// that window.
 	if err := verifyConnection(l.cfg.Pin)(tlsConn.ConnectionState()); err != nil {
 		logger.RaftLog.Warn("Cluster connection rejected after handshake",
 			zap.String("remote", conn.RemoteAddr().String()),

--- a/internal/cluster/listener/listener.go
+++ b/internal/cluster/listener/listener.go
@@ -342,6 +342,19 @@ func (l *Listener) dispatch(ctx context.Context, conn net.Conn) {
 	l.trackConn(tlsConn)
 	defer l.untrackConn(tlsConn)
 
+	// CloseByPeerFingerprint only sees registered connections, so a pin
+	// dropped between the handshake and registration leaves a connection
+	// no scan can reach. Re-running the check after registration closes
+	// that window.
+	if err := verifyConnection(l.cfg.Pin)(tlsConn.ConnectionState()); err != nil {
+		logger.RaftLog.Warn("Cluster connection rejected after handshake",
+			zap.String("remote", conn.RemoteAddr().String()),
+			zap.Error(err))
+		_ = conn.Close()
+
+		return
+	}
+
 	handler(conn)
 }
 

--- a/internal/cluster/listener/listener_pki_test.go
+++ b/internal/cluster/listener/listener_pki_test.go
@@ -147,3 +147,117 @@ func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration) {
 		t.Fatal("wg did not complete in time")
 	}
 }
+
+// TestListener_PinRemovedDuringHandshake_ConnClosed removes the peer's
+// pin while its handshake is still in flight, so CloseByPeerFingerprint
+// scans past a connection that is not registered yet.
+func TestListener_PinRemovedDuringHandshake_ConnClosed(t *testing.T) {
+	p := testutil.GenTestPKI(t, []int{1, 2})
+
+	base := p.PinFunc()
+	fp := pki.Fingerprint(p.Nodes[2].Cert)
+
+	var (
+		mu       sync.Mutex
+		unpinned bool
+	)
+
+	inHandshake := make(chan struct{})
+	release := make(chan struct{})
+	firstLookup := true
+
+	pin := func(fingerprint string) listener.PinResult {
+		if fingerprint == fp && firstLookup {
+			firstLookup = false
+
+			close(inHandshake)
+			<-release
+
+			// The handshake resolved the pin before it was removed.
+			return base(fingerprint)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if unpinned && fingerprint == fp {
+			return listener.PinResult{}
+		}
+
+		return base(fingerprint)
+	}
+
+	port := freePort(t)
+	addr1 := fmt.Sprintf("127.0.0.1:%d", port)
+
+	ln1 := listener.New(listener.Config{
+		BindAddress:      addr1,
+		AdvertiseAddress: addr1,
+		NodeID:           1,
+		Pin:              pin,
+		Leaf:             p.LeafFunc(1),
+	})
+
+	defer ln1.Stop()
+
+	handlerRan := make(chan struct{})
+
+	ln1.Register(listener.ALPNRaft, func(conn net.Conn) {
+		defer func() { _ = conn.Close() }()
+
+		close(handlerRan)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := ln1.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	ln2, _ := newTestListener(t, p, 2)
+	defer ln2.Stop()
+
+	dialed := make(chan *tls.Conn, 1)
+
+	go func() {
+		conn, err := ln2.Dial(ctx, addr1, 1, listener.ALPNRaft, 5*time.Second)
+		if err != nil {
+			dialed <- nil
+			return
+		}
+
+		dialed <- conn
+	}()
+
+	<-inHandshake
+
+	mu.Lock()
+	unpinned = true
+	mu.Unlock()
+
+	if closed := ln1.CloseByPeerFingerprint(fp); closed != 0 {
+		t.Fatalf("CloseByPeerFingerprint closed %d conns, want 0 for an unregistered handshake", closed)
+	}
+
+	close(release)
+
+	conn := <-dialed
+	if conn == nil {
+		return
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	if _, err := conn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("peer kept the connection after its pin was removed")
+	}
+
+	select {
+	case <-handlerRan:
+		t.Fatal("handler ran for a peer whose pin was removed")
+	default:
+	}
+}

--- a/internal/cluster/listener/listener_pki_test.go
+++ b/internal/cluster/listener/listener_pki_test.go
@@ -148,9 +148,6 @@ func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration) {
 	}
 }
 
-// TestListener_PinRemovedDuringHandshake_ConnClosed removes the peer's
-// pin while its handshake is still in flight, so CloseByPeerFingerprint
-// scans past a connection that is not registered yet.
 func TestListener_PinRemovedDuringHandshake_ConnClosed(t *testing.T) {
 	p := testutil.GenTestPKI(t, []int{1, 2})
 
@@ -173,7 +170,6 @@ func TestListener_PinRemovedDuringHandshake_ConnClosed(t *testing.T) {
 			close(inHandshake)
 			<-release
 
-			// The handshake resolved the pin before it was removed.
 			return base(fingerprint)
 		}
 


### PR DESCRIPTION
# Description

re-run pin check after registration

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
