### PR TITLE
test(ha): extend integration test depth and coverage

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 )
 
 type ClusterMember struct {
@@ -148,15 +149,17 @@ func (c *Client) PromoteClusterMember(ctx context.Context, nodeID int) error {
 // RAN connections uncleaned until the removal itself triggers the usual
 // post-remove purge).
 func (c *Client) RemoveClusterMember(ctx context.Context, nodeID int, force bool) error {
-	path := fmt.Sprintf("api/v1/cluster/members/%d", nodeID)
+	var query url.Values
+
 	if force {
-		path += "?force=true"
+		query = url.Values{"force": {"true"}}
 	}
 
 	_, err := c.Requester.Do(ctx, &RequestOptions{
 		Type:   SyncRequest,
 		Method: "DELETE",
-		Path:   path,
+		Path:   fmt.Sprintf("api/v1/cluster/members/%d", nodeID),
+		Query:  query,
 	})
 	if err != nil {
 		return err

--- a/client/cluster_test.go
+++ b/client/cluster_test.go
@@ -197,8 +197,12 @@ func TestRemoveClusterMember_Force(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if fake.lastOpts.Path != "api/v1/cluster/members/2?force=true" {
-		t.Errorf("expected force query string, got %s", fake.lastOpts.Path)
+	if fake.lastOpts.Path != "api/v1/cluster/members/2" {
+		t.Errorf("expected a clean path, got %s", fake.lastOpts.Path)
+	}
+
+	if got := fake.lastOpts.Query.Get("force"); got != "true" {
+		t.Errorf("expected force=true in the query, got %q", got)
 	}
 }
 

--- a/docs/explanation/high_availability.md
+++ b/docs/explanation/high_availability.md
@@ -19,14 +19,14 @@ Deploy three or five nodes. A *voter* is a node that counts toward quorum, and a
 
 Two things HA does not handle automatically:
 
-- **Loss of quorum.** If more than half the voters fail at the same time, the cluster loses quorum and writes stall until enough nodes return — or the cluster is restored from backup via [Disaster recovery](#disaster-recovery).
+- **Loss of quorum.** If a majority of voters is lost, the cluster loses quorum and writes stall until enough nodes return — or the cluster is restored from backup via [Disaster recovery](#disaster-recovery).
 - **In-flight UE sessions.** Sessions on a dead node drop; those UEs re-register on a surviving node.
 
 ## What replicates, and what does not
 
 Network-wide resources — subscribers, profiles, policies, slices, data networks, network rules, IP leases, users, API tokens, the operator configuration — replicate across the cluster. Every replicated record carries a globally-unique ID, so rows created on different nodes never collide. If a node dies, the survivors hold the same state, automatically elect a new leader, and keep accepting writes.
 
-Per-node configuration does not replicate. This covers the local data-plane and routing settings each node owns: static routes, BGP settings, BGP peers and import prefixes, NAT, the N3 external address, and flow accounting. To configure these on an HA cluster, hit each node's API directly — a change made on one node does not propagate to its peers. This lets nodes in different racks or AZs run with different upstream gateways and BGP topologies.
+Per-node configuration does not replicate. This covers the local data-plane and routing settings each node owns: static routes, BGP settings, BGP peers and import prefixes, NAT, the N3 external address, local switching, and flow accounting. To configure these on an HA cluster, hit each node's API directly — a change made on one node does not propagate to its peers. This lets nodes in different racks or AZs run with different upstream gateways and BGP topologies.
 
 Runtime state tied to a specific connection or session also does not replicate: SCTP associations with radios, UE contexts, active sessions and their User Plane state, GTP-U tunnels, and active BGP adjacencies.
 
@@ -36,7 +36,7 @@ Observability is per-node: each instance exposes its own Prometheus endpoint, ra
 
 A UE's user-plane traffic flows through the node that handled its registration — that node runs its User Plane and terminates its GTP-U tunnel. Each data network has one cluster-wide IP pool; the replicated lease table guarantees no two UEs receive the same address, and each lease records the node currently serving it.
 
-When BGP is enabled, each node advertises a `/32` route for every UE session it hosts (see [Advertising routes via BGP](bgp.md)). When a UE re-registers on a different node after failover, the lease's owning node is updated in place — the UE keeps its IP — and the new node's speaker begins advertising the same `/32` from its N6. The dead node's BGP session times out after the hold timer (90 s by default, configurable per peer), its routes are withdrawn, and upstream routing converges on the survivor without operator action.
+When BGP is enabled, each node advertises a `/32` (IPv4) or `/64` (IPv6) route for every UE session it hosts (see [Advertising routes via BGP](bgp.md)). When a UE re-registers on a different node after failover, the lease's owning node is updated in place — the UE keeps its IP — and the new node's speaker begins advertising the same prefix from its N6. The dead node's BGP session times out after the hold timer (90 s by default, configurable per peer), its routes are withdrawn, and upstream routing converges on the survivor without operator action.
 
 ## Failover and timing
 
@@ -70,7 +70,7 @@ Useful for site- or tenant-partitioned deployments. Network-wide state still rep
 
 Draining prepares a node for removal without disrupting traffic on its peers. A drained node hands Raft leadership to another voter if it held it, signals connected radios that it is unavailable so new UEs attach elsewhere, and stops advertising user-plane routes so upstream routing shifts to the survivors. Existing flows keep running until the node is removed or shut down.
 
-Drain is triggered by an operator via the cluster API. Removal requires a drained node.
+Drain is triggered by an operator via the cluster API. Removal requires a drained node, unless it is forced.
 
 ## Scaling the cluster
 

--- a/docs/explanation/high_availability.md
+++ b/docs/explanation/high_availability.md
@@ -40,9 +40,9 @@ When BGP is enabled, each node advertises a `/32` route for every UE session it 
 
 ## Failover and timing
 
-Leader re-election completes within a few seconds; surviving nodes continue accepting NGAP, S1AP, and API calls the whole time.
+Leader re-election completes within a few seconds.
 
-Each Ella Core node presents as a distinct AMF in the same AMF Set (5G) and a distinct MME — a distinct GUMMEI — in a single MME Pool (4G). A UE's GUTI pins it to the node that handled its registration, and new UEs distribute across the nodes by advertised capacity. When a node dies, radios detect the loss via SCTP heartbeat timeout and reselect a surviving AMF/MME. UEs that were attached to the dead node then re-register from scratch, including a fresh authentication and a new session.
+Each Ella Core node presents as a distinct AMF in the same AMF Set (5G) and a distinct MME — a distinct GUMMEI — in a single MME Pool (4G). A UE's GUTI pins it to the node that handled its registration. When a node dies, radios detect the loss via SCTP heartbeat timeout and reselect a surviving AMF/MME. UEs that were attached to the dead node then re-register from scratch, including a fresh authentication and a new session.
 
 ## Deployment scenarios
 

--- a/docs/how_to/backup_and_restore.md
+++ b/docs/how_to/backup_and_restore.md
@@ -36,18 +36,37 @@ Ella Core stores all persistent data in an embedded database. You can create bac
 
 ## Disaster recovery for HA clusters
 
-1. Stop every voter in the cluster.
-2. On one node, drop the backup archive into the data directory as `restore.bundle`:
+Paths below assume the default data directory `/var/snap/ella-core/common/data` (the directory holding `db.path`).
+
+1. Stop the daemon on every node in the cluster:
 
     ```shell
-    sudo mv backup.tar.gz /var/snap/ella-core/common/restore.bundle
-    sudo chmod 600 /var/snap/ella-core/common/restore.bundle
+    sudo snap stop ella-core.cored
     ```
 
-3. Start the daemon on that node:
+2. On the node you seed from the backup, delete the old cluster state:
+
+    ```shell
+    sudo rm -rf /var/snap/ella-core/common/data/ella.db \
+                /var/snap/ella-core/common/data/ella.db-wal \
+                /var/snap/ella-core/common/data/ella.db-shm \
+                /var/snap/ella-core/common/data/raft \
+                /var/snap/ella-core/common/data/cluster-tls
+    ```
+
+3. Remove `cluster.join-token` from that node's `core.yaml` if it is set.
+
+4. Drop the backup archive into the data directory as `restore.bundle`:
+
+    ```shell
+    sudo mv backup.tar.gz /var/snap/ella-core/common/data/restore.bundle
+    sudo chmod 600 /var/snap/ella-core/common/data/restore.bundle
+    ```
+
+5. Start the daemon on that node:
 
     ```shell
     sudo snap start --enable ella-core.cored
     ```
 
-4. Add the remaining nodes via the [join-token flow](deploy_ha_cluster.md).
+6. On each remaining node, repeat step 2, then add it via the [join-token flow](deploy_ha_cluster.md).

--- a/docs/how_to/deploy_ha_cluster.md
+++ b/docs/how_to/deploy_ha_cluster.md
@@ -24,7 +24,7 @@ logging:
   audit:
     output: "stdout"
 db:
-  path: "/var/snap/ella-core/common/ella.db"
+  path: "/var/snap/ella-core/common/data/ella.db"
 interfaces:
   n2:
     address: "10.0.0.1"

--- a/docs/how_to/rolling_upgrade.md
+++ b/docs/how_to/rolling_upgrade.md
@@ -14,20 +14,21 @@ This guide walks through upgrading every node in a running Ella Core high-availa
 
 ## Upgrade one node
 
-Repeat these steps for each node, **upgrading the leader last**.
+Repeat these steps for each node, **upgrading the leader last**. **Drain** and **Resume** must be clicked on the leader's **Cluster** page.
 
-1. Identify the leader on the **Cluster** page of any healthy node.
-2. Pick the next node to upgrade — a follower, unless this is the last pass.
-3. Click **Drain** next to that node. Wait until its **Drain State** is `drained`.
-4. On that host, refresh the snap:
+1. Open the **Cluster** page on any healthy node and note which node carries the **Leader** chip. Its **API Address** column gives the URL.
+2. Open the **Cluster** page on the leader.
+3. Pick the next node to upgrade — a follower, unless this is the last pass.
+4. Click **Drain** next to that node. Wait until its **Drain State** is `drained`.
+5. On that host, refresh the snap:
 
     ```shell
     sudo snap refresh ella-core
     ```
 
-5. On the **Cluster** page, wait for the node to return to **Healthy**.
-6. Click **Resume** next to the node. Wait for **Drain State** to clear back to `active`.
-7. Move to the next node.
+6. On the **Cluster** page, wait for the node to return to **Healthy**.
+7. On the last pass, reopen the **Cluster** page on the new leader. Click **Resume** next to the node. Wait for **Drain State** to clear back to `active`.
+8. Move to the next node.
 
 ## Verify the upgrade
 

--- a/docs/how_to/scale_up_ha_cluster.md
+++ b/docs/how_to/scale_up_ha_cluster.md
@@ -14,9 +14,10 @@ This guide walks through adding a node to an existing Ella Core high-availabilit
 
 ## Add a node
 
-1. On any existing node, open the Ella Core UI and navigate to the **Cluster** page.
-2. Click **Add Node**, select the next free node ID (for example `4`), click **Mint Token**, and copy the token.
-3. On the new host, create `core.yaml` using the same shape as the other nodes. List every node — including the new one — in `peers`, and paste the token into `join-token`:
+1. On any existing node, open the Ella Core UI and navigate to the **Cluster** page. Note which node carries the **Leader** chip.
+2. Open the **Cluster** page on the leader.
+3. Click **Add Node**, select the next free node ID (for example `4`), click **Mint Token**, and copy the token.
+4. On the new host, create `core.yaml` using the same shape as the other nodes. List every node — including the new one — in `peers`, and paste the token into `join-token`:
 
     ```yaml title="core.yaml (new node)"
     cluster:
@@ -31,13 +32,13 @@ This guide walks through adding a node to an existing Ella Core high-availabilit
       join-token: "ejYM..."
     ```
 
-4. Start Ella Core on the new host:
+5. Start Ella Core on the new host:
 
     ```shell
     sudo snap start --enable ella-core.cored
     ```
 
-5. On the **Cluster** page, verify the new node appears and is shown as a **Voter** and **Healthy**. It joins the voting set directly.
+6. On the **Cluster** page, verify the new node appears and is shown as a **Voter** and **Healthy**. It joins the voting set directly.
 
 ## Verify the new cluster size
 

--- a/docs/reference/api/cluster.md
+++ b/docs/reference/api/cluster.md
@@ -47,7 +47,7 @@ None
 
 ## Remove a Cluster Member
 
-This path removes a node from the Raft cluster. The node must be drained first (`drainState == "drained"`) unless `force=true` is set. The current leader cannot be removed regardless of `force`. Requires admin privileges.
+This path removes a node from the Raft cluster. The node must be drained first (`drainState == "drained"`) unless `force=true` is set. The current leader cannot be removed regardless of `force`. Must be sent to the leader. Requires admin privileges.
 
 | Method | Path                            |
 | ------ | ------------------------------- |
@@ -71,7 +71,7 @@ This path removes a node from the Raft cluster. The node must be drained first (
 
 ## Promote a Cluster Member
 
-This path promotes a nonvoter node to a voter in the Raft cluster. Autopilot promotes healthy nonvoters automatically; use this endpoint to promote immediately. Requires admin privileges.
+This path promotes a nonvoter node to a voter in the Raft cluster. Autopilot promotes healthy nonvoters automatically; use this endpoint to promote immediately. Must be sent to the leader. Requires admin privileges.
 
 | Method | Path                                    |
 | ------ | --------------------------------------- |
@@ -138,7 +138,7 @@ None
 
 ## Drain Cluster Member
 
-This path drains a node and persists `drainState=drained`. The server runs the local drain side-effects on the target: signals connected RANs that this AMF's GUAMI is unavailable, stops the local BGP speaker, and transfers Raft leadership when the target is the current leader. A node must be drained before it can be removed. Requires admin privileges.
+This path drains a node and persists `drainState=drained`. The server runs the local drain side-effects on the target: signals connected RANs that this AMF's GUAMI is unavailable, stops the local BGP speaker, and transfers Raft leadership when the target is the current leader. A node must be drained before it can be removed. Must be sent to the leader. Requires admin privileges.
 
 | Method | Path                                            |
 | ------ | ----------------------------------------------- |
@@ -160,7 +160,7 @@ None.
 
 ## Resume Cluster Member
 
-This path reverses drain on a node: restarts the local BGP speaker (if BGP is enabled) and clears `drainState` back to `active`. RAN unavailability and transferred leadership are not reversed. Idempotent. Requires admin privileges.
+This path reverses drain on a node: restarts the local BGP speaker (if BGP is enabled) and clears `drainState` back to `active`. RAN unavailability and transferred leadership are not reversed. Idempotent. Must be sent to the leader. Requires admin privileges.
 
 | Method | Path                                            |
 | ------ | ----------------------------------------------- |
@@ -182,7 +182,7 @@ None
 
 ## Mint Join Token
 
-This path mints a single-use HMAC token authorising `nodeID` to register its self-signed cluster certificate with the leader. The leader's own pinned certificate fingerprint is embedded in the token, so the joining node pins the bootstrap TLS handshake directly to the leader's certificate. Requires admin privileges.
+This path mints a single-use HMAC token authorising `nodeID` to register its self-signed cluster certificate with the leader. The leader's own pinned certificate fingerprint is embedded in the token, so the joining node pins the bootstrap TLS handshake directly to the leader's certificate. Must be sent to the leader. Requires admin privileges.
 
 | Method | Path                               |
 | ------ | ---------------------------------- |

--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -52,7 +52,7 @@ Start Ella core with the `--config` flag to specify the path to the configuratio
     - `bind-address` (string): `host:port` the cluster listener binds to. Carries Raft consensus and cluster HTTP over mTLS.
     - `advertise-address` (string, optional): `host:port` peers use to reach this node. Host may be an IP or DNS name. Defaults to `bind-address`. Must appear in `peers` and must not use an unspecified IP.
     - `peers` (list of strings): `host:port` of every node in the cluster. Host may be an IP or DNS name. Must include this node's own `advertise-address` (or `bind-address` if `advertise-address` is unset) as the same string.
-    - `join-token` (string, optional): Single-use token minted on an existing voter via `POST /api/v1/cluster/pki/join-tokens`. Required on the first boot of a node joining an existing cluster; consumed and ignored on subsequent starts. Its presence also tells the daemon that this node is a joiner, not the founder.
+    - `join-token` (string, optional): Single-use token minted on the cluster leader via `POST /api/v1/cluster/pki/join-tokens`. Required on the first boot of a node joining an existing cluster; consumed and ignored on subsequent starts. Its presence also tells the daemon that this node is a joiner, not the founder.
     - `initial-suffrage` (string, optional): `voter` or `nonvoter`. Defaults to `voter`.
     - `join-timeout` (duration string, optional): Wait for cluster formation after which discovery starts logging that it is slow. Discovery keeps retrying past it.
     - `propose-timeout` (duration string, optional): Maximum wait for a Raft commit before the API returns 503.

--- a/integration/ha_force_remove_test.go
+++ b/integration/ha_force_remove_test.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+)
+
+func TestIntegrationHAForceRemoveUnreachableMember(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	beginHATest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	dockerClient, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dockerClient.Close(); err != nil {
+			HALogf(t, "failed to close docker client: %v", err)
+		}
+	}()
+
+	composeFile := ComposeFile()
+
+	clients, err := bringUpHACluster(t, ctx, dockerClient)
+	if err != nil {
+		t.Fatalf("bring up HA cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		diagCtx, diagCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer diagCancel()
+
+		dumpClusterDiagnostics(t, diagCtx, dockerClient, haComposeDir, haNodeServices, clients)
+	})
+
+	_, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("find leader: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("nodes not ready: %v", err)
+	}
+
+	doomedID, _, err := findFollower(ctx, clients)
+	if err != nil {
+		t.Fatalf("find follower: %v", err)
+	}
+
+	doomedIdx := doomedID - 1
+	doomedService := haNodeServices[doomedIdx]
+
+	survivors := make([]*client.Client, 0, len(clients)-1)
+
+	for i, c := range clients {
+		if i != doomedIdx {
+			survivors = append(survivors, c)
+		}
+	}
+
+	HALogf(t, "stopping follower %s (node %d) so it can no longer be drained", doomedService, doomedID)
+
+	if err := dockerClient.ComposeStopWithFile(ctx, haComposeDir, composeFile, doomedService); err != nil {
+		t.Fatalf("stop %s: %v", doomedService, err)
+	}
+
+	err = leader.RemoveClusterMember(ctx, doomedID, false)
+	if err == nil {
+		t.Fatal("unforced RemoveClusterMember succeeded on a node that was never drained; the drain precondition is not enforced")
+	}
+
+	if !strings.Contains(strings.ToLower(err.Error()), "drain") {
+		t.Fatalf("unforced removal was refused, but not for the drain precondition: %v", err)
+	}
+
+	HALogf(t, "unforced removal correctly refused: %v", err)
+
+	members, err := leader.ListClusterMembers(ctx)
+	if err != nil {
+		t.Fatalf("list members after refused removal: %v", err)
+	}
+
+	if len(members) != 3 {
+		t.Fatalf("refused removal still changed membership: got %d members, want 3", len(members))
+	}
+
+	HALogf(t, "membership intact after refusal; force-removing node %d", doomedID)
+
+	if err := leader.RemoveClusterMember(ctx, doomedID, true); err != nil {
+		t.Fatalf("force RemoveClusterMember(%d): %v", doomedID, err)
+	}
+
+	if err := waitForMemberCount(ctx, leader, 2, 60*time.Second); err != nil {
+		t.Fatalf("cluster did not shrink to 2 members after force removal: %v", err)
+	}
+
+	members, err = leader.ListClusterMembers(ctx)
+	if err != nil {
+		t.Fatalf("list members after force removal: %v", err)
+	}
+
+	for _, m := range members {
+		if m.NodeID == doomedID {
+			t.Fatalf("force-removed node %d is still present in cluster members", doomedID)
+		}
+	}
+
+	const postRemoveIMSI = "001019756170000"
+
+	if err := leader.CreateSubscriber(ctx, &client.CreateSubscriberOptions{
+		Imsi:           postRemoveIMSI,
+		Key:            "0eefb0893e6f1c2855a3a244c6db1277",
+		OPc:            "98da19bbc55e2a5b53857d10557b1d26",
+		SequenceNumber: "000000000022",
+		ProfileName:    "default",
+	}); err != nil {
+		t.Fatalf("write on the 2-node cluster after force removal: %v", err)
+	}
+
+	idx, err := leaderAppliedIndex(ctx, leader)
+	if err != nil {
+		t.Fatalf("leader applied index: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, survivors, idx); err != nil {
+		t.Fatalf("surviving follower did not converge after force removal: %v", err)
+	}
+
+	for i, c := range survivors {
+		sub, err := c.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: postRemoveIMSI})
+		if err != nil {
+			t.Fatalf("read post-removal subscriber from survivor %d: %v", i+1, err)
+		}
+
+		if sub.Imsi != postRemoveIMSI {
+			t.Fatalf("survivor %d returned IMSI %q, want %q", i+1, sub.Imsi, postRemoveIMSI)
+		}
+	}
+
+	assertMembershipConsistent(t, ctx, survivors)
+}

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -366,18 +366,49 @@ func waitForClusterReadyWithin(ctx context.Context, clients []*client.Client, ti
 
 // findLeader returns the index and client of the current leader node.
 func findLeader(ctx context.Context, clients []*client.Client) (int, *client.Client, error) {
-	for i, c := range clients {
-		status, err := c.GetStatus(ctx)
-		if err != nil {
-			continue
+	const timeout = 30 * time.Second
+
+	deadline := time.Now().Add(timeout)
+
+	var lastState string
+
+	for {
+		leaderIdxs := make([]int, 0, len(clients))
+		claims := make([]string, 0, len(clients))
+
+		for i, c := range clients {
+			status, err := c.GetStatus(ctx)
+			if err != nil {
+				continue
+			}
+
+			if status.Cluster != nil && status.Cluster.Role == "Leader" {
+				leaderIdxs = append(leaderIdxs, i)
+				claims = append(claims, fmt.Sprintf("node %d", status.Cluster.NodeID))
+			}
 		}
 
-		if status.Cluster != nil && status.Cluster.Role == "Leader" {
-			return i, c, nil
+		if len(leaderIdxs) == 1 {
+			return leaderIdxs[0], clients[leaderIdxs[0]], nil
+		}
+
+		if len(leaderIdxs) == 0 {
+			lastState = "no node reports the Leader role"
+		} else {
+			lastState = fmt.Sprintf("%d nodes claim leadership at once (%s)",
+				len(leaderIdxs), strings.Join(claims, ", "))
+		}
+
+		if !time.Now().Before(deadline) {
+			return -1, nil, fmt.Errorf("no single leader after %v: %s", timeout, lastState)
+		}
+
+		select {
+		case <-ctx.Done():
+			return -1, nil, fmt.Errorf("waiting for a single leader: %w", ctx.Err())
+		case <-time.After(time.Second):
 		}
 	}
-
-	return -1, nil, fmt.Errorf("no leader found")
 }
 
 func waitForNewLeader(ctx context.Context, survivors []*client.Client) (*client.Client, error) {

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -700,10 +700,6 @@ func dumpClusterDiagnostics(t *testing.T, ctx context.Context, dc *DockerClient,
 	}
 }
 
-// assertMembershipConsistent fails if clients return different
-// cluster_members sets. Polls 10s — callers should already be past
-// any settle wait (waitForFollowerConvergence etc.); this catches
-// persistent divergence, not apply-path race.
 func subscriberIMSIsOn(ctx context.Context, c *client.Client) (map[string]struct{}, error) {
 	const perPage = 100
 
@@ -786,6 +782,10 @@ func assertAckedWritesDurable(t *testing.T, ctx context.Context, clients []*clie
 		len(report.acked), len(clients), len(report.unknown))
 }
 
+// assertMembershipConsistent fails if clients return different
+// cluster_members sets. Polls 10s — callers should already be past
+// any settle wait (waitForFollowerConvergence etc.); this catches
+// persistent divergence, not apply-path race.
 func assertMembershipConsistent(t *testing.T, ctx context.Context, clients []*client.Client) {
 	t.Helper()
 

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -673,6 +673,88 @@ func dumpClusterDiagnostics(t *testing.T, ctx context.Context, dc *DockerClient,
 // cluster_members sets. Polls 10s — callers should already be past
 // any settle wait (waitForFollowerConvergence etc.); this catches
 // persistent divergence, not apply-path race.
+func subscriberIMSIsOn(ctx context.Context, c *client.Client) (map[string]struct{}, error) {
+	const perPage = 100
+
+	out := make(map[string]struct{})
+
+	for page := 1; ; page++ {
+		resp, err := c.ListSubscribers(ctx, &client.ListSubscribersParams{
+			Page:    page,
+			PerPage: perPage,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list subscribers page %d: %w", page, err)
+		}
+
+		for _, sub := range resp.Items {
+			out[sub.Imsi] = struct{}{}
+		}
+
+		if len(resp.Items) < perPage || len(out) >= resp.TotalCount {
+			return out, nil
+		}
+	}
+}
+
+func assertAckedWritesDurable(t *testing.T, ctx context.Context, clients []*client.Client, report writerReport) {
+	t.Helper()
+
+	if len(report.acked) == 0 {
+		t.Fatal("writer acknowledged no writes; the durability check would be vacuous")
+	}
+
+	sets := make([]map[string]struct{}, len(clients))
+
+	for i, c := range clients {
+		imsis, err := subscriberIMSIsOn(ctx, c)
+		if err != nil {
+			t.Fatalf("collect subscribers from node %d: %v", i+1, err)
+		}
+
+		sets[i] = imsis
+	}
+
+	for i, set := range sets {
+		missing := make([]string, 0)
+
+		for _, imsi := range report.acked {
+			if _, ok := set[imsi]; !ok {
+				missing = append(missing, imsi)
+			}
+		}
+
+		if len(missing) > 0 {
+			t.Errorf("node %d lost %d of %d acknowledged writes; first missing: %v",
+				i+1, len(missing), len(report.acked), missing[:min(len(missing), 5)])
+		}
+	}
+
+	diverged := make([]string, 0)
+
+	for _, imsi := range report.unknown {
+		present := 0
+
+		for _, set := range sets {
+			if _, ok := set[imsi]; ok {
+				present++
+			}
+		}
+
+		if present != 0 && present != len(sets) {
+			diverged = append(diverged, fmt.Sprintf("%s on %d/%d", imsi, present, len(sets)))
+		}
+	}
+
+	if len(diverged) > 0 {
+		t.Errorf("%d unknown-outcome writes are present on some replicas but not others: %v",
+			len(diverged), diverged[:min(len(diverged), 5)])
+	}
+
+	HALogf(t, "durability: %d acknowledged writes present on all %d nodes; %d unknown-outcome writes agreed across replicas",
+		len(report.acked), len(clients), len(report.unknown))
+}
+
 func assertMembershipConsistent(t *testing.T, ctx context.Context, clients []*client.Client) {
 	t.Helper()
 

--- a/integration/ha_join_token_test.go
+++ b/integration/ha_join_token_test.go
@@ -5,6 +5,7 @@ package integration_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -100,7 +101,7 @@ func TestIntegrationHAJoinTokenRejection(t *testing.T) {
 	}{
 		{
 			name:         "tampered_hmac",
-			token:        tamperJoinToken(valid.Token),
+			token:        tamperJoinToken(t, valid.Token),
 			wantFragment: "join token",
 		},
 		{
@@ -188,19 +189,26 @@ func assertJoinRejected(t *testing.T, ctx context.Context, dc *DockerClient, lea
 	}
 }
 
-func tamperJoinToken(token string) string {
-	if token == "" {
-		return token
+func tamperJoinToken(t *testing.T, token string) string {
+	t.Helper()
+
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		t.Fatalf("decode join token: %v", err)
 	}
 
-	last := token[len(token)-1]
-
-	replacement := byte('A')
-	if last == 'A' {
-		replacement = 'B'
+	if len(raw) == 0 {
+		t.Fatal("join token decoded to zero bytes")
 	}
 
-	return token[:len(token)-1] + string(replacement)
+	raw[len(raw)-1] ^= 0x01
+
+	tampered := base64.RawURLEncoding.EncodeToString(raw)
+	if tampered == token {
+		t.Fatal("tampering did not change the join token")
+	}
+
+	return tampered
 }
 
 func composeRemoveService(ctx context.Context, composeDir, composeFile, service string) error {

--- a/integration/ha_join_token_test.go
+++ b/integration/ha_join_token_test.go
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+)
+
+const joinTokenComposeDir = "compose/ha-scaleup/"
+
+const joinTokenProject = "ha-scaleup"
+
+func TestIntegrationHAJoinTokenRejection(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	beginHATest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	dc, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dc.Close(); err != nil {
+			HALogf(t, "failed to close docker client: %v", err)
+		}
+	}()
+
+	composeFile := ComposeFile()
+
+	dc.ComposeCleanup(ctx)
+
+	t.Cleanup(func() {
+		dc.ComposeDownWithFile(context.Background(), joinTokenComposeDir, composeFile)
+	})
+
+	fullPeers := []string{
+		ClusterAddressWithPort(1, 7000),
+		ClusterAddressWithPort(2, 7000),
+		ClusterAddressWithPort(3, 7000),
+		ClusterAddressWithPort(4, 7000),
+	}
+
+	clients, err := bringUpHAClusterAt(t, ctx, dc, joinTokenComposeDir, haNodeServices,
+		[]string{ClusterAddressWithPort(4, 7000)})
+	if err != nil {
+		t.Fatalf("bring up 3-node cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		diagCtx, diagCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer diagCancel()
+
+		dumpClusterDiagnostics(t, diagCtx, dc, joinTokenComposeDir, haNodeServices, clients)
+	})
+
+	_, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("find leader: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("nodes not ready: %v", err)
+	}
+
+	valid, err := leader.MintClusterJoinToken(ctx, &client.MintJoinTokenOptions{
+		NodeID:     4,
+		TTLSeconds: 600,
+	})
+	if err != nil {
+		t.Fatalf("mint token for node 4: %v", err)
+	}
+
+	forOtherNode, err := leader.MintClusterJoinToken(ctx, &client.MintJoinTokenOptions{
+		NodeID:     5,
+		TTLSeconds: 600,
+	})
+	if err != nil {
+		t.Fatalf("mint token for node 5: %v", err)
+	}
+
+	cases := []struct {
+		name         string
+		token        string
+		wantFragment string
+	}{
+		{
+			name:         "tampered_hmac",
+			token:        tamperJoinToken(valid.Token),
+			wantFragment: "join token",
+		},
+		{
+			name:         "minted_for_another_node",
+			token:        forOtherNode.Token,
+			wantFragment: "but this node is",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertJoinRejected(t, ctx, dc, leader, composeFile, tc.token, tc.wantFragment)
+		})
+	}
+
+	HALog(t, "both bad tokens were rejected; confirming a valid token still admits node 4")
+
+	if err := stageAndStartJoiner(ctx, dc, leader, joinTokenComposeDir,
+		"ella-core-4", 4, fullPeers, "nonvoter"); err != nil {
+		t.Fatalf("stage + start node 4 with a freshly minted token: %v", err)
+	}
+
+	if err := waitForMemberSuffrage(ctx, leader, 4, "nonvoter"); err != nil {
+		t.Fatalf("node 4 did not join with a valid token, so the rejections above prove nothing: %v", err)
+	}
+
+	HALog(t, "valid token admitted node 4; join-token fence verified")
+}
+
+func assertJoinRejected(t *testing.T, ctx context.Context, dc *DockerClient, leader *client.Client, composeFile, token, wantFragment string) {
+	t.Helper()
+
+	if err := writeNodeConfig(joinTokenComposeDir, 4, []string{
+		ClusterAddressWithPort(1, 7000),
+		ClusterAddressWithPort(2, 7000),
+		ClusterAddressWithPort(3, 7000),
+		ClusterAddressWithPort(4, 7000),
+	}, token, "nonvoter"); err != nil {
+		t.Fatalf("write node 4 config: %v", err)
+	}
+
+	if err := dc.ComposeUpServicesWithFile(ctx, joinTokenComposeDir, composeFile, "ella-core-4"); err != nil {
+		t.Fatalf("start node 4: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := composeRemoveService(context.Background(), joinTokenComposeDir, composeFile, "ella-core-4"); err != nil {
+			HALogf(t, "cleanup node 4: %v", err)
+		}
+	})
+
+	if err := dc.DisableRestart(ctx, joinTokenProject, "ella-core-4"); err != nil {
+		HALogf(t, "disable restart on node 4: %v", err)
+	}
+
+	const window = 30 * time.Second
+
+	deadline := time.Now().Add(window)
+
+	for time.Now().Before(deadline) {
+		members, err := leader.ListClusterMembers(ctx)
+		if err == nil {
+			for _, m := range members {
+				if m.NodeID == 4 {
+					t.Fatalf("node 4 joined the cluster with a rejected token (suffrage=%s)", m.Suffrage)
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context ended while watching for a bad-token join: %v", ctx.Err())
+		case <-time.After(2 * time.Second):
+		}
+	}
+
+	logs, err := dc.ComposeLogs(ctx, joinTokenComposeDir, "ella-core-4")
+	if err != nil {
+		t.Fatalf("collect node 4 logs: %v", err)
+	}
+
+	if !strings.Contains(strings.ToLower(logs), strings.ToLower(wantFragment)) {
+		t.Errorf("node 4 stayed out of the cluster, but its logs never mention %q, so the rejection is unexplained; logs:\n%s",
+			wantFragment, tailLines(logs, 40))
+	}
+}
+
+func tamperJoinToken(token string) string {
+	if token == "" {
+		return token
+	}
+
+	last := token[len(token)-1]
+
+	replacement := byte('A')
+	if last == 'A' {
+		replacement = 'B'
+	}
+
+	return token[:len(token)-1] + string(replacement)
+}
+
+func composeRemoveService(ctx context.Context, composeDir, composeFile, service string) error {
+	rm := exec.CommandContext(ctx, "docker", "compose", "-f", composeFile, "rm", "-sf", service)
+	rm.Dir = composeDir
+
+	if out, err := rm.CombinedOutput(); err != nil {
+		return fmt.Errorf("compose rm %s: %w (%s)", service, err, out)
+	}
+
+	vol := exec.CommandContext(ctx, "docker", "volume", "rm", "-f", joinTokenProject+"_data4")
+	if out, err := vol.CombinedOutput(); err != nil {
+		return fmt.Errorf("volume rm for %s: %w (%s)", service, err, out)
+	}
+
+	return nil
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return s
+	}
+
+	return strings.Join(lines[len(lines)-n:], "\n")
+}

--- a/integration/ha_leader_crash_test.go
+++ b/integration/ha_leader_crash_test.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/client"
+)
+
+func TestIntegrationHALeaderCrash(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping integration tests, set environment variable INTEGRATION")
+	}
+
+	beginHATest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	dc, err := NewDockerClient()
+	if err != nil {
+		t.Fatalf("docker client: %v", err)
+	}
+
+	defer func() {
+		if err := dc.Close(); err != nil {
+			HALogf(t, "failed to close docker client: %v", err)
+		}
+	}()
+
+	composeFile := ComposeFile()
+
+	clients, err := bringUpHACluster(t, ctx, dc)
+	if err != nil {
+		t.Fatalf("bring up HA cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		diagCtx, diagCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer diagCancel()
+
+		dumpClusterDiagnostics(t, diagCtx, dc, haComposeDir, haNodeServices, clients)
+	})
+
+	leaderIdx, leader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("find leader: %v", err)
+	}
+
+	if err := waitForAllNodesReady(ctx, clients); err != nil {
+		t.Fatalf("nodes not ready: %v", err)
+	}
+
+	leaderStatus, err := leader.GetStatus(ctx)
+	if err != nil || leaderStatus.Cluster == nil {
+		t.Fatalf("read leader status pre-crash: %v", err)
+	}
+
+	crashedNodeID := leaderStatus.Cluster.NodeID
+	leaderService := haNodeServices[leaderIdx]
+
+	if err := dc.DisableRestart(ctx, haComposeProject, leaderService); err != nil {
+		t.Fatalf("disable restart on %s: %v", leaderService, err)
+	}
+
+	survivors := make([]*client.Client, 0, len(clients)-1)
+
+	for i, c := range clients {
+		if i != leaderIdx {
+			survivors = append(survivors, c)
+		}
+	}
+
+	writer := startSubscriberWriter(t, ctx, survivors, "001019756180000")
+
+	writerStopped := false
+
+	t.Cleanup(func() {
+		if !writerStopped {
+			writer.stop()
+		}
+	})
+
+	time.Sleep(2 * time.Second)
+
+	HALogf(t, "SIGKILLing leader %s (node %d)", leaderService, crashedNodeID)
+
+	if err := composeKill(ctx, haComposeDir, composeFile, leaderService); err != nil {
+		t.Fatalf("kill %s: %v", leaderService, err)
+	}
+
+	newLeader, err := waitForNewLeader(ctx, survivors)
+	if err != nil {
+		t.Fatalf("survivors did not elect a new leader after the crash: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	report, werr := writer.stopAndReport()
+	writerStopped = true
+
+	if werr != nil {
+		t.Fatalf("background writer reported a permanent failure: %v", werr)
+	}
+
+	HALogf(t, "writer: %d ok, %d transient, %d attempts, longest gap %s",
+		report.success, report.transient, report.attempts, report.maxGap)
+
+	if report.success < 2 {
+		t.Fatalf("writer landed %d successful writes; too few to prove anything about the crash",
+			report.success)
+	}
+
+	const crashWriteGapCeiling = 30 * time.Second
+
+	if report.maxGap > crashWriteGapCeiling {
+		t.Errorf("writes were unavailable for %s across the leader crash, ceiling is %s",
+			report.maxGap, crashWriteGapCeiling)
+	}
+
+	newLeaderIdx, err := leaderAppliedIndex(ctx, newLeader)
+	if err != nil {
+		t.Fatalf("new leader applied index: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, survivors, newLeaderIdx); err != nil {
+		t.Fatalf("survivors did not converge after the crash: %v", err)
+	}
+
+	HALog(t, "survivors converged; checking acknowledged writes survived on the majority side")
+
+	assertAckedWritesDurable(t, ctx, survivors, report)
+
+	HALogf(t, "restarting crashed node %s so it recovers from an uncleanly closed raft log", leaderService)
+
+	if err := dc.ComposeStartWithFile(ctx, haComposeDir, composeFile, leaderService); err != nil {
+		t.Fatalf("restart %s: %v", leaderService, err)
+	}
+
+	crashedClient := clients[leaderIdx]
+
+	if err := waitForNodeReady(ctx, crashedClient); err != nil {
+		t.Fatalf("crashed node did not become ready after restart: %v", err)
+	}
+
+	postRestartIdx, err := leaderAppliedIndex(ctx, newLeader)
+	if err != nil {
+		t.Fatalf("leader applied index after restart: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, []*client.Client{crashedClient}, postRestartIdx); err != nil {
+		t.Fatalf("crashed node did not converge after restart: %v", err)
+	}
+
+	HALog(t, "crashed node recovered and converged; checking it carries every acknowledged write")
+
+	assertAckedWritesDurable(t, ctx, clients, report)
+
+	assertMembershipConsistent(t, ctx, clients)
+}

--- a/integration/ha_remove_leader_test.go
+++ b/integration/ha_remove_leader_test.go
@@ -182,6 +182,8 @@ func TestIntegrationHARemoveLeader(t *testing.T) {
 	if err := waitForFollowerConvergence(ctx, survivors, idx); err != nil {
 		t.Fatalf("surviving follower did not converge: %v", err)
 	}
+
+	assertAckedWritesDurable(t, ctx, survivors, report)
 }
 
 func waitForMemberCount(ctx context.Context, c *client.Client, want int, timeout time.Duration) error {

--- a/integration/ha_rolling_test.go
+++ b/integration/ha_rolling_test.go
@@ -560,7 +560,7 @@ func startSubscriberWriter(t *testing.T, parent context.Context, clients []*clie
 				return
 			}
 
-			if isTransientWriteError(err) {
+			if isTransientWriteError(err) || isOutcomeUnknownWriteError(err) {
 				w.transient.Add(1)
 				w.unknown = append(w.unknown, imsi)
 
@@ -613,6 +613,10 @@ func (w *subscriberWriter) recordSuccess(now time.Time) {
 	if gap := now.UnixNano() - prev; gap > w.maxGapNanos.Load() {
 		w.maxGapNanos.Store(gap)
 	}
+}
+
+func isOutcomeUnknownWriteError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "write outcome unknown")
 }
 
 // isTransientWriteError matches errors expected during leadership

--- a/integration/ha_rolling_test.go
+++ b/integration/ha_rolling_test.go
@@ -271,6 +271,22 @@ func TestIntegrationHARollingUpgrade(t *testing.T) {
 		t.Fatal("background writer made zero successful writes; cluster was permanently unwriteable")
 	}
 
+	_, postRollLeader, err := findLeader(ctx, clients)
+	if err != nil {
+		t.Fatalf("find leader after roll: %v", err)
+	}
+
+	postRollIdx, err := leaderAppliedIndex(ctx, postRollLeader)
+	if err != nil {
+		t.Fatalf("leader applied index after roll: %v", err)
+	}
+
+	if err := waitForFollowerConvergence(ctx, clients, postRollIdx); err != nil {
+		t.Fatalf("nodes did not converge after roll: %v", err)
+	}
+
+	assertAckedWritesDurable(t, ctx, clients, writeReport)
+
 	assertMembershipConsistent(t, ctx, clients)
 }
 
@@ -461,6 +477,9 @@ type subscriberWriter struct {
 
 	lastSuccessNanos atomic.Int64
 	maxGapNanos      atomic.Int64
+
+	acked   []string
+	unknown []string
 }
 
 type writerReport struct {
@@ -469,6 +488,9 @@ type writerReport struct {
 	attempts  int64
 
 	maxGap time.Duration
+
+	acked   []string
+	unknown []string
 }
 
 // startSubscriberWriter creates subscribers round-robin at ~5/s.
@@ -520,25 +542,35 @@ func startSubscriberWriter(t *testing.T, parent context.Context, clients []*clie
 				SequenceNumber: "000000000022",
 				ProfileName:    "default",
 			})
-
-			// stop() cancels ctx; any in-flight request then fails with
-			// "context canceled". That is shutdown, not a real error.
-			if ctx.Err() != nil {
-				return
-			}
-
-			switch {
-			case err == nil:
+			if err == nil {
 				w.success.Add(1)
+				w.acked = append(w.acked, imsi)
 				w.recordSuccess(time.Now())
-			case isTransientWriteError(err):
-				w.transient.Add(1)
-			default:
-				e := fmt.Errorf("subscriber %s: %w", imsi, err)
-				w.fatalErr.Store(&e)
+
+				if ctx.Err() != nil {
+					return
+				}
+
+				continue
+			}
+
+			if ctx.Err() != nil {
+				w.unknown = append(w.unknown, imsi)
 
 				return
 			}
+
+			if isTransientWriteError(err) {
+				w.transient.Add(1)
+				w.unknown = append(w.unknown, imsi)
+
+				continue
+			}
+
+			e := fmt.Errorf("subscriber %s: %w", imsi, err)
+			w.fatalErr.Store(&e)
+
+			return
 		}
 	}()
 
@@ -561,6 +593,8 @@ func (w *subscriberWriter) stopAndReport() (writerReport, error) {
 		transient: w.transient.Load(),
 		attempts:  w.attempts.Load(),
 		maxGap:    time.Duration(w.maxGapNanos.Load()),
+		acked:     w.acked,
+		unknown:   w.unknown,
 	}
 
 	if e := w.fatalErr.Load(); e != nil {

--- a/integration/ha_snapshot_test.go
+++ b/integration/ha_snapshot_test.go
@@ -216,7 +216,11 @@ func TestIntegrationHASnapshotInstallOnNewJoiner(t *testing.T) {
 		t.Fatalf("node 4 returned IMSI %q, expected %q", sub.Imsi, lastIMSI)
 	}
 
-	assertMembershipConsistent(t, ctx, clients)
+	allNodes := make([]*client.Client, 0, len(clients)+1)
+	allNodes = append(allNodes, clients...)
+	allNodes = append(allNodes, node4Client)
+
+	assertMembershipConsistent(t, ctx, allNodes)
 }
 
 func snapshotIMSI(i int) string {

--- a/integration/ha_test.go
+++ b/integration/ha_test.go
@@ -498,6 +498,8 @@ func TestIntegrationHALeaderFailure(t *testing.T) {
 	HALogf(t, "autopilot recovered: failureTolerance=%d voters=%v",
 		apRecovered.FailureTolerance, apRecovered.Voters)
 
+	assertAckedWritesDurable(t, ctx, clients, writeReport)
+
 	assertMembershipConsistent(t, ctx, clients)
 }
 

--- a/internal/raft/forward.go
+++ b/internal/raft/forward.go
@@ -163,7 +163,7 @@ func (m *Manager) runForwardRetryLoop(ctx context.Context, timeout time.Duration
 
 	for range maxForwardAttempts {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, classifyForwardDeadline(lastErr, err)
 		}
 
 		remaining := time.Until(deadline)
@@ -194,7 +194,7 @@ func (m *Manager) runForwardRetryLoop(ctx context.Context, timeout time.Duration
 			lastErr = hraft.ErrNotLeader
 
 			if err := waitOrDone(ctx, noLeaderBackoff); err != nil {
-				return nil, err
+				return nil, classifyForwardDeadline(lastErr, err)
 			}
 
 			continue
@@ -296,6 +296,19 @@ func (m *Manager) waitForLocalApply(ctx context.Context, target uint64) {
 		case <-time.After(appliedIndexPollInterval):
 		}
 	}
+}
+
+// classifyForwardDeadline keeps a caller-context expiry from erasing what
+// the loop already knows. Both call sites are reached only after an attempt
+// reported a retryable status, so no entry was applied and lastErr carries
+// the right classification; the context error rides along for diagnostics.
+// Cancellation is propagated untouched — the caller went away.
+func classifyForwardDeadline(lastErr, ctxErr error) error {
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", lastErr, ctxErr)
+	}
+
+	return ctxErr
 }
 
 func waitOrDone(ctx context.Context, d time.Duration) error {

--- a/internal/raft/forward.go
+++ b/internal/raft/forward.go
@@ -219,11 +219,16 @@ func (m *Manager) doForwardRequest(ctx context.Context, leaderAddr string, leade
 		maxResponseBytes: maxForwardResponseBytes,
 	})
 	if err != nil {
-		if errors.Is(err, ErrLeaderUnreachable) {
+		switch {
+		case errors.Is(err, ErrLeaderUnreachable):
 			return nil, http.StatusServiceUnavailable, err
-		}
 
-		return nil, 0, err
+		case errors.Is(err, ErrLeaderRequestNotSent):
+			return nil, 0, err
+
+		default:
+			return nil, 0, fmt.Errorf("%w: %w", ErrOutcomeUnknown, err)
+		}
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/raft/forward_test.go
+++ b/internal/raft/forward_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -383,5 +385,65 @@ func TestDecodeForwardError_NoCodeStaysPlain(t *testing.T) {
 
 	if got := decodeForwardError(body, http.StatusMisdirectedRequest); errors.Is(got, ErrOutcomeUnknown) {
 		t.Fatalf("retryable error must not decode as outcome-unknown: %v", got)
+	}
+}
+
+func TestDoForwardRequest_PostSendFailureIsOutcomeUnknown(t *testing.T) {
+	addr := startClusterHTTPStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+
+		_ = conn.Close()
+	}))
+
+	m := newRetryLoopTestManager(t)
+	m.leaderClient = newLeaderHTTPClient(func(ctx context.Context, a string, _ int) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", a)
+	})
+
+	t.Cleanup(m.leaderClient.close)
+
+	_, status, err := m.doForwardRequest(context.Background(), addr, 1, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected an error when the leader hangs up mid-request")
+	}
+
+	if status != 0 {
+		t.Fatalf("post-send failure should carry no leader status, got %d", status)
+	}
+
+	if !errors.Is(err, ErrOutcomeUnknown) {
+		t.Fatalf("a request that reached the wire may have committed and must be outcome-unknown, got %v", err)
+	}
+}
+
+func TestDoForwardRequest_DialFailureIsRetryableNotOutcomeUnknown(t *testing.T) {
+	m := newRetryLoopTestManager(t)
+	m.leaderClient = newLeaderHTTPClient(func(context.Context, string, int) (net.Conn, error) {
+		return nil, errors.New("dial refused")
+	})
+
+	t.Cleanup(m.leaderClient.close)
+
+	_, status, err := m.doForwardRequest(context.Background(), "10.0.0.1:7000", 1, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected an error when the leader cannot be dialled")
+	}
+
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("dial failure should map to 503, got %d", status)
+	}
+
+	if errors.Is(err, ErrOutcomeUnknown) {
+		t.Fatal("nothing was sent on a dial failure, so the write must stay retryable rather than outcome-unknown")
 	}
 }

--- a/internal/raft/forward_test.go
+++ b/internal/raft/forward_test.go
@@ -426,6 +426,33 @@ func TestDoForwardRequest_PostSendFailureIsOutcomeUnknown(t *testing.T) {
 	}
 }
 
+func TestDoForwardRequest_DialTimeoutIsRetryableNotOutcomeUnknown(t *testing.T) {
+	m := newRetryLoopTestManager(t)
+	m.leaderClient = newLeaderHTTPClient(func(ctx context.Context, _ string, _ int) (net.Conn, error) {
+		<-ctx.Done()
+
+		return nil, errors.New("dial: i/o timeout")
+	})
+
+	t.Cleanup(m.leaderClient.close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, status, err := m.doForwardRequest(ctx, "10.0.0.1:7000", 1, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected an error when the dial outlives the request deadline")
+	}
+
+	if errors.Is(err, ErrOutcomeUnknown) {
+		t.Fatalf("no connection was ever established, so the write must stay retryable rather than outcome-unknown: %v", err)
+	}
+
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("a blackholed leader should map to 503, got %d", status)
+	}
+}
+
 func TestDoForwardRequest_DialFailureIsRetryableNotOutcomeUnknown(t *testing.T) {
 	m := newRetryLoopTestManager(t)
 	m.leaderClient = newLeaderHTTPClient(func(context.Context, string, int) (net.Conn, error) {

--- a/internal/raft/forward_test.go
+++ b/internal/raft/forward_test.go
@@ -474,3 +474,33 @@ func TestDoForwardRequest_DialFailureIsRetryableNotOutcomeUnknown(t *testing.T) 
 		t.Fatal("nothing was sent on a dial failure, so the write must stay retryable rather than outcome-unknown")
 	}
 }
+
+func TestRunForwardRetryLoop_CallerDeadlineStaysRetryable(t *testing.T) {
+	m := newRetryLoopTestManager(t)
+
+	s := &scriptedAttempter{
+		responses: []attemptResponse{
+			{status: http.StatusServiceUnavailable},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := m.runForwardRetryLoop(ctx, time.Minute, s.fn())
+	if err == nil {
+		t.Fatal("expected an error once the caller's context expired")
+	}
+
+	if !errors.Is(err, hraft.ErrNotLeader) {
+		t.Errorf("a caller deadline reached after retryable attempts must stay retryable, got %v", err)
+	}
+
+	if errors.Is(err, ErrOutcomeUnknown) {
+		t.Errorf("nothing was applied on a 503, so this must not read as outcome-unknown: %v", err)
+	}
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("the underlying deadline should survive for diagnostics, got %v", err)
+	}
+}

--- a/internal/raft/leader_http.go
+++ b/internal/raft/leader_http.go
@@ -11,8 +11,10 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -127,6 +129,12 @@ func (c *leaderHTTPClient) do(ctx context.Context, addr string, peerID int, spec
 		reqBody = bytes.NewReader(spec.body)
 	}
 
+	var connected atomic.Bool
+
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		GotConn: func(httptrace.GotConnInfo) { connected.Store(true) },
+	})
+
 	req, err := http.NewRequestWithContext(ctx, spec.method, "https://"+addr+spec.path, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("%w: new request: %w", ErrLeaderRequestNotSent, err)
@@ -142,6 +150,10 @@ func (c *leaderHTTPClient) do(ctx context.Context, addr string, peerID int, spec
 
 	resp, err := c.clientFor(addr, peerID).Do(req) // #nosec G107 -- addr comes from Raft, not user input
 	if err != nil {
+		if !connected.Load() {
+			return nil, fmt.Errorf("%w: request to leader: %w", ErrLeaderUnreachable, err)
+		}
+
 		return nil, fmt.Errorf("request to leader: %w", err)
 	}
 

--- a/internal/raft/leader_http.go
+++ b/internal/raft/leader_http.go
@@ -28,6 +28,11 @@ type peerDialFunc func(ctx context.Context, addr string, peerID int) (net.Conn, 
 
 var ErrLeaderUnreachable = errors.New("leader unreachable")
 
+// ErrLeaderRequestNotSent marks a failure that happened before any
+// bytes reached the wire, so the forwarded write definitively did not
+// reach the leader.
+var ErrLeaderRequestNotSent = errors.New("leader request not sent")
+
 type leaderHTTPClient struct {
 	dial peerDialFunc
 
@@ -124,7 +129,7 @@ func (c *leaderHTTPClient) do(ctx context.Context, addr string, peerID int, spec
 
 	req, err := http.NewRequestWithContext(ctx, spec.method, "https://"+addr+spec.path, reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("new request: %w", err)
+		return nil, fmt.Errorf("%w: new request: %w", ErrLeaderRequestNotSent, err)
 	}
 
 	if spec.contentType != "" {

--- a/internal/raft/leader_http_test.go
+++ b/internal/raft/leader_http_test.go
@@ -163,3 +163,25 @@ func TestLeaderHTTPClient_TimeoutBoundsTheRoundTrip(t *testing.T) {
 		t.Fatalf("request took %s; the timeout did not bound it", elapsed)
 	}
 }
+
+func TestLeaderHTTPClient_MalformedAddressIsNotSent(t *testing.T) {
+	c := newLeaderHTTPClient(func(context.Context, string, int) (net.Conn, error) {
+		t.Fatal("dial must not be attempted when the request cannot be built")
+		return nil, nil
+	})
+
+	defer c.close()
+
+	_, err := c.do(context.Background(), "bad\x7fhost:7000", 1, leaderHTTPRequest{
+		method:           http.MethodPost,
+		path:             ProposeForwardPath,
+		maxResponseBytes: 1024,
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unparseable leader address")
+	}
+
+	if !errors.Is(err, ErrLeaderRequestNotSent) {
+		t.Fatalf("a request that was never built cannot have been sent, got %v", err)
+	}
+}


### PR DESCRIPTION
# Description

Extend depth and coverage of HA-related integration tests:
- Verify acknowledged writes survive failover, removal, and rolling upgrade
- Include the new joiner in the snapshot test's membership check
- Cover force-removing an unreachable cluster member
- Cover join-token rejection for tampered and misaddressed tokens

We fix a bug in the Go client
- Send force as a query parameter when removing a cluster member

We addressed some minor correctness gaps in the HA-related documentation

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
