### PR TITLE
fix(ha): refuse to start when db is ahead of raft store

### DIFF
--- a/internal/db/raft_store_desync_test.go
+++ b/internal/db/raft_store_desync_test.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/db"
+	ellaraft "github.com/ellanetworks/core/internal/raft"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func seedSubscriber(t *testing.T, database *db.Database, imsi string) {
+	t.Helper()
+
+	profileID, err := createDataNetworkAndPolicy(database)
+	if err != nil {
+		t.Fatalf("create prerequisites: %s", err)
+	}
+
+	if err := database.CreateSubscriber(context.Background(), &db.Subscriber{
+		Imsi:           imsi,
+		SequenceNumber: "000000000001",
+		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
+		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
+		ProfileID:      profileID,
+	}); err != nil {
+		t.Fatalf("create subscriber: %s", err)
+	}
+}
+
+func resetLastApplied(t *testing.T, dbPath string) {
+	t.Helper()
+
+	conn, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open database: %s", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(context.Background(), "UPDATE fsm_state SET lastApplied = 0 WHERE id = 1"); err != nil {
+		t.Fatalf("reset lastApplied: %s", err)
+	}
+}
+
+func TestStartupRejectsDatabaseAheadOfRaftStore(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "ella.db")
+
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
+	if err != nil {
+		t.Fatalf("new database: %s", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %s", err)
+	}
+
+	seedSubscriber(t, database, "999010071245191")
+
+	if err := database.Close(); err != nil {
+		t.Fatalf("close database: %s", err)
+	}
+
+	if err := os.RemoveAll(filepath.Join(tempDir, "raft")); err != nil {
+		t.Fatalf("remove raft store: %s", err)
+	}
+
+	_, err = db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
+	if err == nil {
+		t.Fatal("expected startup to fail when the database is ahead of the raft store")
+	}
+
+	if !strings.Contains(err.Error(), "database is ahead of the raft store") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestStartupAcceptsResetLastAppliedAfterRaftStoreWipe(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "ella.db")
+
+	database, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
+	if err != nil {
+		t.Fatalf("new database: %s", err)
+	}
+
+	if err := database.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready: %s", err)
+	}
+
+	seedSubscriber(t, database, "999010071245191")
+
+	if err := database.Close(); err != nil {
+		t.Fatalf("close database: %s", err)
+	}
+
+	if err := os.RemoveAll(filepath.Join(tempDir, "raft")); err != nil {
+		t.Fatalf("remove raft store: %s", err)
+	}
+
+	resetLastApplied(t, dbPath)
+
+	recovered, err := db.NewDatabase(ctx, dbPath, ellaraft.FastTestConfig())
+	if err != nil {
+		t.Fatalf("reopen after reset: %s", err)
+	}
+
+	if err := recovered.WaitUntilReady(t.Context()); err != nil {
+		t.Fatalf("database never became ready after reset: %s", err)
+	}
+
+	defer func() {
+		if err := recovered.Close(); err != nil {
+			t.Fatalf("close database: %s", err)
+		}
+	}()
+
+	if err := recovered.CreateSubscriber(ctx, &db.Subscriber{
+		Imsi:           "999010071245192",
+		SequenceNumber: "000000000001",
+		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
+		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
+		ProfileID:      mustProfileID(t, recovered),
+	}); err != nil {
+		t.Fatalf("create subscriber after reset: %s", err)
+	}
+
+	_, total, err := recovered.ListSubscribersPage(ctx, nil, 1, 10)
+	if err != nil {
+		t.Fatalf("list subscribers: %s", err)
+	}
+
+	if total != 2 {
+		t.Fatalf("expected 2 subscribers after reset, got %d", total)
+	}
+}
+
+func mustProfileID(t *testing.T, database *db.Database) string {
+	t.Helper()
+
+	profile, err := database.GetProfile(context.Background(), "test-profile")
+	if err != nil {
+		t.Fatalf("get profile: %s", err)
+	}
+
+	return profile.ID
+}

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -336,6 +336,14 @@ func NewManager(_ context.Context, cfg ClusterConfig, applier Applier, dataDir s
 		return nil, fmt.Errorf("check existing raft state: %w", err)
 	}
 
+	if err := assertFSMNotAheadOfRaftStore(fsm, boltStore, snapshotStore, raftDir); err != nil {
+		closeTransport(transport)
+
+		_ = boltStore.Close()
+
+		return nil, err
+	}
+
 	recovered, err := maybeRecoverCluster(raftDir, raftConfig, fsm, logCache, boltStore, snapshotStore, transport)
 	if err != nil {
 		closeTransport(transport)
@@ -939,4 +947,46 @@ func (m *Manager) AddNonvoter(nodeID int, address string) error {
 	}
 
 	return nil
+}
+
+func assertFSMNotAheadOfRaftStore(fsm *FSM, logs raft.LogStore, snaps raft.SnapshotStore, raftDir string) error {
+	lastApplied, err := fsm.readLastApplied()
+	if err != nil {
+		return fmt.Errorf("read fsm_state.lastApplied: %w", err)
+	}
+
+	if lastApplied == 0 {
+		return nil
+	}
+
+	logLast, err := logs.LastIndex()
+	if err != nil {
+		return fmt.Errorf("read raft log last index: %w", err)
+	}
+
+	snapList, err := snaps.List()
+	if err != nil {
+		return fmt.Errorf("list raft snapshots: %w", err)
+	}
+
+	var snapLast uint64
+
+	for _, snap := range snapList {
+		if snap.Index > snapLast {
+			snapLast = snap.Index
+		}
+	}
+
+	durable := max(logLast, snapLast)
+	if lastApplied <= durable {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"database is ahead of the raft store: fsm_state.lastApplied=%d but the raft store in %s only reaches "+
+			"index %d (log=%d, snapshot=%d). The database and the raft store have diverged, most likely because "+
+			"one was deleted or replaced without the other. Starting would silently discard every write: the FSM "+
+			"skips log entries at or below lastApplied while the API still reports success. Restore the matching "+
+			"raft store, or delete the raft store and reset fsm_state.lastApplied to 0 to re-bootstrap this node",
+		lastApplied, raftDir, durable, logLast, snapLast)
 }

--- a/internal/raft/manager.go
+++ b/internal/raft/manager.go
@@ -983,10 +983,7 @@ func assertFSMNotAheadOfRaftStore(fsm *FSM, logs raft.LogStore, snaps raft.Snaps
 	}
 
 	return fmt.Errorf(
-		"database is ahead of the raft store: fsm_state.lastApplied=%d but the raft store in %s only reaches "+
-			"index %d (log=%d, snapshot=%d). The database and the raft store have diverged, most likely because "+
-			"one was deleted or replaced without the other. Starting would silently discard every write: the FSM "+
-			"skips log entries at or below lastApplied while the API still reports success. Restore the matching "+
-			"raft store, or delete the raft store and reset fsm_state.lastApplied to 0 to re-bootstrap this node",
+		"database is ahead of the raft store: fsm_state.lastApplied=%d but %s only reaches index %d "+
+			"(log=%d, snapshot=%d)",
 		lastApplied, raftDir, durable, logLast, snapLast)
 }

--- a/internal/raft/nodeid.go
+++ b/internal/raft/nodeid.go
@@ -70,8 +70,7 @@ func resolveNodeID(configNodeID int, dataDir string, fallback int) (int, error) 
 	// If the file already exists, validate consistency.
 	persisted, fileErr := readNodeIDFile(nodeIDPath)
 	if fileErr == nil && persisted != resolved {
-		return 0, fmt.Errorf("node ID mismatch: %s says %d but %s contains %d; "+
-			"changing a node's ID would invalidate every GUTI it ever issued",
+		return 0, fmt.Errorf("node ID mismatch: %s says %d but %s contains %d",
 			source, resolved, nodeIDPath, persisted)
 	}
 


### PR DESCRIPTION
# Description

Ella Core now refuses to start when its database and Raft log have drifted apart, instead of silently accepting configuration changes that were never actually saved.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
