### PR TITLE
fix: track NG-RAN resource state per PDU session

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -170,6 +170,7 @@ type AMF struct {
 	TimeZone                 string // "[+-]HH:MM[+][1-2]", Refer to TS 29.571 Simple Data Types
 	T3513Cfg                 guard.TimerValue
 	NASGuardCfg              guard.TimerValue
+	N2SetupGuardCfg          guard.TimerValue
 	handoverGuardTimeout     time.Duration
 	Session                  SmfSbi
 	NAS                      NASHandler
@@ -713,6 +714,7 @@ func New(db DBer, ausf Authenticator, smf SmfSbi) *AMF {
 		T3512Value:               3600 * time.Second,
 		T3513Cfg:                 defaultTimerCfg,
 		NASGuardCfg:              defaultTimerCfg,
+		N2SetupGuardCfg:          defaultN2SetupGuardCfg,
 		handoverGuardTimeout:     defaultHandoverGuardTimeout,
 		NetworkFeatureSupport5GS: &NetworkFeatureSupport5GS{Enable: true, ImsVoPS: 1},
 	}
@@ -727,6 +729,11 @@ func New(db DBer, ausf Authenticator, smf SmfSbi) *AMF {
 // half-prepared handover so a silent target cannot pin the UE's N2Handover
 // procedure.
 const defaultHandoverGuardTimeout = 10 * time.Second
+
+var defaultN2SetupGuardCfg = guard.TimerValue{
+	Enable:     true,
+	ExpireTime: 10 * time.Second,
+}
 
 var defaultTimerCfg = guard.TimerValue{
 	Enable:        true,

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -11,6 +11,7 @@ package amf
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,8 @@ type SmContext struct {
 	Dnn    string
 	EBI    uint8
 	N2     N2State
+
+	n2Proc N2SetupProcedure
 }
 
 func (sc *SmContext) Inactive() bool {
@@ -579,16 +582,7 @@ func (ue *UeContext) SetSmContextActive(pduSessionID uint8) {
 	}
 }
 
-func (ue *UeContext) SetSmContextPending(pduSessionID uint8) {
-	ue.mu.Lock()
-	defer ue.mu.Unlock()
-
-	if sc, ok := ue.SmContextList[pduSessionID]; ok {
-		sc.N2 = N2Pending
-	}
-}
-
-func (ue *UeContext) ClaimSmContextN2(pduSessionID uint8) bool {
+func (ue *UeContext) ClaimSmContextN2(proc N2SetupProcedure, pduSessionID uint8) bool {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
@@ -602,17 +596,26 @@ func (ue *UeContext) ClaimSmContextN2(pduSessionID uint8) bool {
 	}
 
 	sc.N2 = N2Pending
+	sc.n2Proc = proc
 
 	return true
 }
 
-func (ue *UeContext) ReleaseSmContextN2(pduSessionID uint8) {
+func (ue *UeContext) PendingSmContextsFor(proc N2SetupProcedure) []uint8 {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
-	if sc, ok := ue.SmContextList[pduSessionID]; ok {
-		sc.N2 = N2Inactive
+	var ids []uint8
+
+	for id, sc := range ue.SmContextList {
+		if sc.N2 == N2Pending && sc.n2Proc == proc {
+			ids = append(ids, id)
+		}
 	}
+
+	slices.Sort(ids)
+
+	return ids
 }
 
 func (ue *UeContext) ReleaseSmContextN2IfPending(pduSessionID uint8) bool {

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -31,12 +31,24 @@ import (
 	"go.uber.org/zap"
 )
 
+type N2State uint8
+
+const (
+	N2Inactive N2State = iota
+	N2Pending
+	N2Active
+)
+
 type SmContext struct {
-	Ref                string
-	Snssai             *models.Snssai
-	Dnn                string
-	EBI                uint8
-	PduSessionInactive bool
+	Ref    string
+	Snssai *models.Snssai
+	Dnn    string
+	EBI    uint8
+	N2     N2State
+}
+
+func (sc *SmContext) Inactive() bool {
+	return sc == nil || sc.N2 == N2Inactive
 }
 
 type UeContext struct {
@@ -554,7 +566,7 @@ func (ue *UeContext) SetSmContextInactive(pduSessionID uint8) {
 	defer ue.mu.Unlock()
 
 	if sc, ok := ue.SmContextList[pduSessionID]; ok {
-		sc.PduSessionInactive = true
+		sc.N2 = N2Inactive
 	}
 }
 
@@ -563,7 +575,61 @@ func (ue *UeContext) SetSmContextActive(pduSessionID uint8) {
 	defer ue.mu.Unlock()
 
 	if sc, ok := ue.SmContextList[pduSessionID]; ok {
-		sc.PduSessionInactive = false
+		sc.N2 = N2Active
+	}
+}
+
+func (ue *UeContext) SetSmContextPending(pduSessionID uint8) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if sc, ok := ue.SmContextList[pduSessionID]; ok {
+		sc.N2 = N2Pending
+	}
+}
+
+func (ue *UeContext) ClaimSmContextN2(pduSessionID uint8) bool {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	sc, ok := ue.SmContextList[pduSessionID]
+	if !ok {
+		return true
+	}
+
+	if sc.N2 != N2Inactive {
+		return false
+	}
+
+	sc.N2 = N2Pending
+
+	return true
+}
+
+func (ue *UeContext) ReleaseSmContextN2(pduSessionID uint8) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if sc, ok := ue.SmContextList[pduSessionID]; ok {
+		sc.N2 = N2Inactive
+	}
+}
+
+func (ue *UeContext) ReleaseSmContextN2IfPending(pduSessionID uint8) {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if sc, ok := ue.SmContextList[pduSessionID]; ok && sc.N2 == N2Pending {
+		sc.N2 = N2Inactive
+	}
+}
+
+func (ue *UeContext) ReleaseAllSmContextN2() {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	for _, sc := range ue.SmContextList {
+		sc.N2 = N2Inactive
 	}
 }
 
@@ -572,7 +638,7 @@ func (ue *UeContext) HasActivePduSessions() bool {
 	defer ue.mu.Unlock()
 
 	for _, smContext := range ue.SmContextList {
-		if !smContext.PduSessionInactive {
+		if smContext.N2 == N2Active {
 			return true
 		}
 	}
@@ -641,6 +707,9 @@ func (a *AMF) ReleaseNasConnection(ue *UeContext, target *UeConn) {
 	if detached == nil {
 		return
 	}
+
+	detached.AbortN2Setups()
+	ue.ReleaseAllSmContextN2()
 
 	ue.endKeyChainProcs()
 	ue.StopProcedureTimers()

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -615,13 +615,17 @@ func (ue *UeContext) ReleaseSmContextN2(pduSessionID uint8) {
 	}
 }
 
-func (ue *UeContext) ReleaseSmContextN2IfPending(pduSessionID uint8) {
+func (ue *UeContext) ReleaseSmContextN2IfPending(pduSessionID uint8) bool {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
 	if sc, ok := ue.SmContextList[pduSessionID]; ok && sc.N2 == N2Pending {
 		sc.N2 = N2Inactive
+
+		return true
 	}
+
+	return false
 }
 
 func (ue *UeContext) ReleaseAllSmContextN2() {

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -146,8 +146,8 @@ func (s *deregisterTestSmf) GetSessionPolicy(context.Context, etsi.SUPI, *models
 
 func TestDeregister_DoesNotHoldLockDuringSmfRelease(t *testing.T) {
 	ue := NewUeContext()
-	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
-	ue.SmContextList[2] = &SmContext{Ref: "ref-2"}
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1", N2: N2Active}
+	ue.SmContextList[2] = &SmContext{Ref: "ref-2", N2: N2Active}
 
 	fakeSmf := &deregisterTestSmf{}
 	relockCount := 0
@@ -201,8 +201,8 @@ func TestRemoveAllUeInRan_Registered_DeactivatesUserPlane(t *testing.T) {
 
 	ue := NewUeContext()
 	ue.smf = &deregisterTestSmf{}
-	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
-	ue.SmContextList[2] = &SmContext{Ref: "ref-2"}
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1", N2: N2Active}
+	ue.SmContextList[2] = &SmContext{Ref: "ref-2", N2: N2Active}
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 	ue.ForceStateForTest(Registered)
 
@@ -235,7 +235,7 @@ func TestRadioRemoveUe_Registered_DeactivatesUserPlane(t *testing.T) {
 
 	ue := NewUeContext()
 	ue.smf = &deregisterTestSmf{}
-	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1", N2: N2Active}
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 	ue.ForceStateForTest(Registered)
 
@@ -274,7 +274,7 @@ func TestReconcileSessionsForUE_AppliesResolvedPolicy(t *testing.T) {
 	amfInstance := New(nil, nil, fakeSmf)
 
 	ue := NewUeContext()
-	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1", N2: N2Active}
 
 	amfInstance.ReconcileSessionsForUE(context.Background(), ue)
 
@@ -308,8 +308,8 @@ func TestAttachUeConn_ClearsPagingSuppression(t *testing.T) {
 	ueConn := NewUeConnForTest(radio, 1, 10, logger.AmfLog)
 
 	ue := NewUeContext()
-	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
-	ue.SmContextList[2] = &SmContext{Ref: "ref-2"}
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1", N2: N2Active}
+	ue.SmContextList[2] = &SmContext{Ref: "ref-2", N2: N2Active}
 
 	a.AttachUeConn(ue, ueConn)
 
@@ -324,8 +324,8 @@ func TestAbandonPaging_SuppressesAllSessions(t *testing.T) {
 	a.Session = fake
 
 	ue := NewUeContext()
-	ue.SmContextList[1] = &SmContext{Ref: "ref-1"}
-	ue.SmContextList[2] = &SmContext{Ref: "ref-2"}
+	ue.SmContextList[1] = &SmContext{Ref: "ref-1", N2: N2Active}
+	ue.SmContextList[2] = &SmContext{Ref: "ref-2", N2: N2Active}
 
 	a.abandonPaging(ue)
 

--- a/internal/amf/eps_registration_test.go
+++ b/internal/amf/eps_registration_test.go
@@ -71,7 +71,7 @@ func TestCancelRegistrationKeepsTheFiveGSecurityContextForAReturn(t *testing.T) 
 func TestCancelRegistrationReleasesSessionsEPSDidNotAdopt(t *testing.T) {
 	a, ue, supi, fakeSmf := registeredUE(t)
 
-	ue.SmContextList[3] = &SmContext{Ref: "stranded-ref"}
+	ue.SmContextList[3] = &SmContext{Ref: "stranded-ref", N2: N2Active}
 
 	a.CancelRegistration(context.Background(), supi)
 

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -268,7 +268,7 @@ func (amf *AMF) LookupSubscriber(supi etsi.SUPI) (UESnapshot, []PDUSessionExport
 		smCopies = append(smCopies, smContextCopy{
 			ref:      sc.Ref,
 			snssai:   copyPtr(sc.Snssai),
-			inactive: sc.PduSessionInactive,
+			inactive: sc.Inactive(),
 		})
 	}
 
@@ -390,7 +390,7 @@ func (amf *AMF) collectUeExport(guami *models.Guami, ue *UeContext) (UeContextEx
 		smCopies = append(smCopies, smContextCopy{
 			ref:      sc.Ref,
 			snssai:   copyPtr(sc.Snssai),
-			inactive: sc.PduSessionInactive,
+			inactive: sc.Inactive(),
 		})
 	}
 

--- a/internal/amf/export_test.go
+++ b/internal/amf/export_test.go
@@ -518,9 +518,9 @@ func TestExportJSON_PDUSessionNilSMFContext(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	addTestUE(t, amfInstance, "001010000000007", func(ue *amf.UeContext) {
 		ue.SmContextList[1] = &amf.SmContext{
-			Ref:                "nonexistent-ref",
-			Snssai:             &models.Snssai{Sst: 1, Sd: "000001"},
-			PduSessionInactive: true,
+			Ref:    "nonexistent-ref",
+			Snssai: &models.Snssai{Sst: 1, Sd: "000001"},
+			N2:     amf.N2Inactive,
 		}
 	})
 

--- a/internal/amf/fivegs_relocation.go
+++ b/internal/amf/fivegs_relocation.go
@@ -267,6 +267,7 @@ func (a *AMF) openArrivingSessions(ctx context.Context, ue *UeContext, conns []i
 			continue
 		}
 
+		ue.SetSmContextPending(c.PDUSessionID)
 		ue.SetEPSBearerIdentity(c.PDUSessionID, c.EPSBearerIdentity)
 
 		sessions = append(sessions, item)

--- a/internal/amf/fivegs_relocation.go
+++ b/internal/amf/fivegs_relocation.go
@@ -267,7 +267,7 @@ func (a *AMF) openArrivingSessions(ctx context.Context, ue *UeContext, conns []i
 			continue
 		}
 
-		ue.SetSmContextPending(c.PDUSessionID)
+		ue.ClaimSmContextN2(N2SetupHandover, c.PDUSessionID)
 		ue.SetEPSBearerIdentity(c.PDUSessionID, c.EPSBearerIdentity)
 
 		sessions = append(sessions, item)

--- a/internal/amf/n1n2message.go
+++ b/internal/amf/n1n2message.go
@@ -62,8 +62,10 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 
 	if !ueConn.ClaimICS() {
 		// Context already set up (or in progress): deliver the PDU session standalone.
+		n2Setup := ueConn.N2Setup(N2SetupPDUSession)
+
 		return ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
-			if !ueConn.ClaimN2SetupSession(N2SetupPDUSession, req.PduSessionID) {
+			if !n2Setup.ClaimSession(req.PduSessionID) {
 				logger.From(ctx, logger.AmfLog).Debug("delivering N1 without a duplicate PDU session setup",
 					zap.Uint8("pdu_session_id", req.PduSessionID))
 
@@ -72,7 +74,7 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 
 			item, err := PDUSessionSetupItemSUReq(req.PduSessionID, req.SNssai, wire, req.BinaryDataN2Information)
 			if err != nil {
-				ueConn.EndN2Setup(N2SetupPDUSession)
+				n2Setup.End()
 
 				return fmt.Errorf("could not build PDU session setup item: %w", err)
 			}
@@ -80,12 +82,12 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 			list := ngap.PDUSessionResourceSetupListSUReq{item}
 
 			if err := ueConn.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list); err != nil {
-				ueConn.EndN2Setup(N2SetupPDUSession)
+				n2Setup.End()
 
 				return fmt.Errorf("send pdu session resource setup request error: %v", err)
 			}
 
-			ueConn.ArmN2Setup(N2SetupPDUSession, amf.N2SetupGuardCfg)
+			n2Setup.Arm(amf.N2SetupGuardCfg)
 
 			logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request to UE")
 
@@ -102,8 +104,10 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 
 	kgnb, ueSecCap := ue.Kgnb(), ue.UESecCap()
 
+	n2Setup := ueConn.N2Setup(N2SetupInitialContext)
+
 	err = ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
-		if !ueConn.ClaimN2SetupSession(N2SetupInitialContext, req.PduSessionID) {
+		if !n2Setup.ClaimSession(req.PduSessionID) {
 			ueConn.ResetICS()
 
 			logger.From(ctx, logger.AmfLog).Debug("delivering N1 without a duplicate PDU session setup",
@@ -114,7 +118,7 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 
 		item, err := PDUSessionSetupItem(req.PduSessionID, req.SNssai, wire, req.BinaryDataN2Information)
 		if err != nil {
-			ueConn.EndN2Setup(N2SetupInitialContext)
+			n2Setup.End()
 
 			return fmt.Errorf("could not build PDU session setup item: %w", err)
 		}
@@ -134,12 +138,12 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 			list,
 			operatorInfo.Guami,
 		); err != nil {
-			ueConn.EndN2Setup(N2SetupInitialContext)
+			n2Setup.End()
 
 			return fmt.Errorf("send initial context setup request error: %v", err)
 		}
 
-		ueConn.ArmN2Setup(N2SetupInitialContext, amf.N2SetupGuardCfg)
+		n2Setup.Arm(amf.N2SetupGuardCfg)
 
 		logger.From(ctx, logger.AmfLog).Info("Sent NGAP initial context setup request to UE")
 
@@ -323,7 +327,8 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 
 	if !ueConn.ClaimICS() {
 		// Context already set up (or in progress): deliver the PDU session standalone.
-		if !ueConn.ClaimN2SetupSession(N2SetupPDUSession, req.PduSessionID) {
+		n2Setup := ueConn.N2Setup(N2SetupPDUSession)
+		if !n2Setup.ClaimSession(req.PduSessionID) {
 			logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
 				zap.Uint8("pdu_session_id", req.PduSessionID))
 
@@ -332,7 +337,7 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 
 		item, err := PDUSessionSetupItemSUReq(req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 		if err != nil {
-			ueConn.EndN2Setup(N2SetupPDUSession)
+			n2Setup.End()
 
 			return fmt.Errorf("could not build PDU session setup item: %w", err)
 		}
@@ -341,12 +346,12 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 
 		err = ueConn.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
 		if err != nil {
-			ueConn.EndN2Setup(N2SetupPDUSession)
+			n2Setup.End()
 
 			return fmt.Errorf("send pdu session resource setup request error: %v", err)
 		}
 
-		ueConn.ArmN2Setup(N2SetupPDUSession, amf.N2SetupGuardCfg)
+		n2Setup.Arm(amf.N2SetupGuardCfg)
 
 		logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request to UE")
 
@@ -360,7 +365,8 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 		return fmt.Errorf("error getting operator info: %v", err)
 	}
 
-	if !ueConn.ClaimN2SetupSession(N2SetupInitialContext, req.PduSessionID) {
+	n2Setup := ueConn.N2Setup(N2SetupInitialContext)
+	if !n2Setup.ClaimSession(req.PduSessionID) {
 		ueConn.ResetICS()
 
 		logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
@@ -397,7 +403,7 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 		return fmt.Errorf("send initial context setup request error: %v", err)
 	}
 
-	ueConn.ArmN2Setup(N2SetupInitialContext, amf.N2SetupGuardCfg)
+	n2Setup.Arm(amf.N2SetupGuardCfg)
 
 	logger.From(ctx, logger.AmfLog).Info("Sent NGAP initial context setup request to UE")
 

--- a/internal/amf/n1n2message.go
+++ b/internal/amf/n1n2message.go
@@ -63,16 +63,29 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 	if !ueConn.ClaimICS() {
 		// Context already set up (or in progress): deliver the PDU session standalone.
 		return ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
+			if !ueConn.ClaimN2SetupSession(N2SetupPDUSession, req.PduSessionID) {
+				logger.From(ctx, logger.AmfLog).Debug("delivering N1 without a duplicate PDU session setup",
+					zap.Uint8("pdu_session_id", req.PduSessionID))
+
+				return ueConn.SendDownlinkNASTransport(ctx, wire)
+			}
+
 			item, err := PDUSessionSetupItemSUReq(req.PduSessionID, req.SNssai, wire, req.BinaryDataN2Information)
 			if err != nil {
+				ueConn.EndN2Setup(N2SetupPDUSession)
+
 				return fmt.Errorf("could not build PDU session setup item: %w", err)
 			}
 
 			list := ngap.PDUSessionResourceSetupListSUReq{item}
 
 			if err := ueConn.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list); err != nil {
+				ueConn.EndN2Setup(N2SetupPDUSession)
+
 				return fmt.Errorf("send pdu session resource setup request error: %v", err)
 			}
+
+			ueConn.ArmN2Setup(N2SetupPDUSession, amf.N2SetupGuardCfg)
 
 			logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request to UE")
 
@@ -90,8 +103,19 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 	kgnb, ueSecCap := ue.Kgnb(), ue.UESecCap()
 
 	err = ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
+		if !ueConn.ClaimN2SetupSession(N2SetupInitialContext, req.PduSessionID) {
+			ueConn.ResetICS()
+
+			logger.From(ctx, logger.AmfLog).Debug("delivering N1 without a duplicate PDU session setup",
+				zap.Uint8("pdu_session_id", req.PduSessionID))
+
+			return ueConn.SendDownlinkNASTransport(ctx, wire)
+		}
+
 		item, err := PDUSessionSetupItem(req.PduSessionID, req.SNssai, wire, req.BinaryDataN2Information)
 		if err != nil {
+			ueConn.EndN2Setup(N2SetupInitialContext)
+
 			return fmt.Errorf("could not build PDU session setup item: %w", err)
 		}
 
@@ -110,15 +134,19 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 			list,
 			operatorInfo.Guami,
 		); err != nil {
+			ueConn.EndN2Setup(N2SetupInitialContext)
+
 			return fmt.Errorf("send initial context setup request error: %v", err)
 		}
+
+		ueConn.ArmN2Setup(N2SetupInitialContext, amf.N2SetupGuardCfg)
 
 		logger.From(ctx, logger.AmfLog).Info("Sent NGAP initial context setup request to UE")
 
 		return nil
 	})
 	if err != nil {
-		ueConn.ResetICS()
+		ueConn.AbortICS()
 
 		return err
 	}
@@ -295,8 +323,17 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 
 	if !ueConn.ClaimICS() {
 		// Context already set up (or in progress): deliver the PDU session standalone.
+		if !ueConn.ClaimN2SetupSession(N2SetupPDUSession, req.PduSessionID) {
+			logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
+				zap.Uint8("pdu_session_id", req.PduSessionID))
+
+			return nil
+		}
+
 		item, err := PDUSessionSetupItemSUReq(req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 		if err != nil {
+			ueConn.EndN2Setup(N2SetupPDUSession)
+
 			return fmt.Errorf("could not build PDU session setup item: %w", err)
 		}
 
@@ -304,8 +341,12 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 
 		err = ueConn.SendPDUSessionResourceSetupRequest(ctx, ue.Ambr.Uplink, ue.Ambr.Downlink, nil, list)
 		if err != nil {
+			ueConn.EndN2Setup(N2SetupPDUSession)
+
 			return fmt.Errorf("send pdu session resource setup request error: %v", err)
 		}
+
+		ueConn.ArmN2Setup(N2SetupPDUSession, amf.N2SetupGuardCfg)
 
 		logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request to UE")
 
@@ -319,9 +360,19 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 		return fmt.Errorf("error getting operator info: %v", err)
 	}
 
+	if !ueConn.ClaimN2SetupSession(N2SetupInitialContext, req.PduSessionID) {
+		ueConn.ResetICS()
+
+		logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
+			zap.Uint8("pdu_session_id", req.PduSessionID))
+
+		return nil
+	}
+
 	item, err := PDUSessionSetupItem(req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 	if err != nil {
-		ueConn.ResetICS()
+		ueConn.AbortICS()
+
 		return fmt.Errorf("could not build PDU session setup item: %w", err)
 	}
 
@@ -341,9 +392,12 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 		operatorInfo.Guami,
 	)
 	if err != nil {
-		ueConn.ResetICS()
+		ueConn.AbortICS()
+
 		return fmt.Errorf("send initial context setup request error: %v", err)
 	}
+
+	ueConn.ArmN2Setup(N2SetupInitialContext, amf.N2SetupGuardCfg)
 
 	logger.From(ctx, logger.AmfLog).Info("Sent NGAP initial context setup request to UE")
 

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -102,7 +103,17 @@ func (f *fakeDBInstance) ListPoliciesByProfile(context.Context, string) ([]db.Po
 
 func (f *fakeDBInstance) NodeID() int { return 0 }
 
-type fakeSmf struct{}
+type fakeSmf struct {
+	mu              sync.Mutex
+	DeactivateCalls []string
+}
+
+func (f *fakeSmf) deactivated() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]string(nil), f.DeactivateCalls...)
+}
 
 func (f *fakeSmf) GetSession(string) *smf.SMContext      { return nil }
 func (f *fakeSmf) SessionsByDNN(string) []*smf.SMContext { return nil }
@@ -110,8 +121,15 @@ func (f *fakeSmf) SessionCount() int                     { return 0 }
 func (f *fakeSmf) CreateSmContext(context.Context, etsi.SUPI, uint8, string, *models.Snssai, fgs.RequestType, []byte, uint8) (string, []byte, error) {
 	return "", nil, nil
 }
-func (f *fakeSmf) ActivateSmContext(context.Context, string) ([]byte, error)   { return nil, nil }
-func (f *fakeSmf) DeactivateSmContext(context.Context, string) error           { return nil }
+func (f *fakeSmf) ActivateSmContext(context.Context, string) ([]byte, error) { return nil, nil }
+func (f *fakeSmf) DeactivateSmContext(_ context.Context, ref string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.DeactivateCalls = append(f.DeactivateCalls, ref)
+
+	return nil
+}
 func (f *fakeSmf) HandlePagingFailure(context.Context, etsi.SUPI, uint8) error { return nil }
 
 func (f *fakeSmf) ClearPagingSuppression(context.Context, etsi.SUPI, uint8) error { return nil }
@@ -993,5 +1011,66 @@ func TestStoreN1N2AndPage_RejectsASecondTransferWhilePaging(t *testing.T) {
 
 	if got := ue.N1N2Message(); got == nil || !bytes.Equal(got.BinaryDataN2Information, buffered.BinaryDataN2Information) {
 		t.Error("the buffered request was displaced; the SMF will never resend the 5GSM message it carried")
+	}
+}
+
+func TestN2SetupGuardExpiry_DeactivatesTheSessionAtTheSMF(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	smfStub := &fakeSmf{}
+	amfInstance := amf.New(nil, nil, smfStub)
+
+	ue := addUE(t, amfInstance, "001010000000028", nil)
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+		t.Fatal("could not claim the PDU session")
+	}
+
+	ueConn.ArmN2Setup(amf.N2SetupPDUSession, guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(smfStub.deactivated()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	got := smfStub.deactivated()
+	if len(got) != 1 || got[0] != "ref-1" {
+		t.Fatalf("DeactivateSmContext calls = %v, want [ref-1]: an unanswered setup leaves the SMF activating (TS 23.502 4.2.3.2 steps 12/16)", got)
+	}
+}
+
+func TestN2SetupTerminal_DoesNotDeactivateAConfirmedSession(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	smfStub := &fakeSmf{}
+	amfInstance := amf.New(nil, nil, smfStub)
+
+	ue := addUE(t, amfInstance, "001010000000029", nil)
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+		t.Fatal("could not claim the PDU session")
+	}
+
+	ue.SetSmContextActive(1)
+	ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
+	if got := smfStub.deactivated(); len(got) != 0 {
+		t.Errorf("DeactivateSmContext calls = %v, want none: the NG-RAN node confirmed the session", got)
 	}
 }

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -4,6 +4,7 @@
 package amf_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync/atomic"
@@ -730,4 +731,267 @@ func (*cancelCountingEPSPeer) MMContext(context.Context, interworking.MMContextR
 
 func (*cancelCountingEPSPeer) MMContextAck(context.Context, etsi.SUPI, []uint8) error {
 	return nil
+}
+
+func TestN2MessageTransferOrPage_DoesNotResetupASessionAlreadyInFlight(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	amfInstance := amf.New(nil, nil, &fakeSmf{})
+
+	ue := addUE(t, amfInstance, "001010000000021", func(u *amf.UeContext) {
+		u.Ambr = &models.Ambr{Uplink: models.MustParseBitRate("1000000 bps"), Downlink: models.MustParseBitRate("1000000 bps")}
+	})
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.MarkICSPending()
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+		t.Fatalf("first transfer: %v", err)
+	}
+
+	if sender.pduSessionSetupCalls != 1 {
+		t.Fatalf("PDUSessionResourceSetupRequest count = %d, want 1", sender.pduSessionSetupCalls)
+	}
+
+	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+		t.Fatalf("second transfer: %v", err)
+	}
+
+	if sender.pduSessionSetupCalls != 1 {
+		t.Fatalf("PDUSessionResourceSetupRequest count = %d after a repeat N2 transfer, want 1", sender.pduSessionSetupCalls)
+	}
+}
+
+func TestReleaseNasConnectionClearsOutstandingSetups(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	amfInstance := amf.New(nil, nil, &fakeSmf{})
+
+	ue := addUE(t, amfInstance, "001010000000022", func(u *amf.UeContext) {
+		u.Ambr = &models.Ambr{Uplink: models.MustParseBitRate("1000000 bps"), Downlink: models.MustParseBitRate("1000000 bps")}
+	})
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if !ue.ClaimSmContextN2(1) {
+		t.Fatal("the first claim must succeed")
+	}
+
+	if ue.ClaimSmContextN2(1) {
+		t.Fatal("a second claim must fail while the setup is outstanding")
+	}
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	amfInstance.ReleaseNasConnection(ue, ueConn)
+
+	if !ue.ClaimSmContextN2(1) {
+		t.Fatal("the UE dropping to CM-IDLE must clear the outstanding setup")
+	}
+}
+
+func TestSmContextN2StateTransitions(t *testing.T) {
+	amfInstance := amf.New(nil, nil, &fakeSmf{})
+	ue := addUE(t, amfInstance, "001010000000023", nil)
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	sc, ok := ue.SmContextFindByPDUSessionID(1)
+	if !ok {
+		t.Fatal("SM context not found")
+	}
+
+	if !sc.Inactive() {
+		t.Error("a session the RAN has not set up must start inactive")
+	}
+
+	if ue.HasActivePduSessions() {
+		t.Error("a session with no RAN resources must not count as active")
+	}
+
+	if !ue.ClaimSmContextN2(1) {
+		t.Fatal("an inactive session must be claimable")
+	}
+
+	if ue.ClaimSmContextN2(1) {
+		t.Error("a pending session must not be claimable")
+	}
+
+	ue.SetSmContextActive(1)
+
+	if ue.ClaimSmContextN2(1) {
+		t.Error("an active session must not be claimable")
+	}
+
+	if !ue.HasActivePduSessions() {
+		t.Error("a session the RAN confirmed must count as active")
+	}
+
+	ue.ReleaseSmContextN2(1)
+
+	if !ue.ClaimSmContextN2(1) {
+		t.Error("a released session must be claimable again")
+	}
+}
+
+func TestN2SetupTransaction_GuardExpiryReleasesTheClaim(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	amfInstance := amf.New(nil, nil, &fakeSmf{})
+
+	ue := addUE(t, amfInstance, "001010000000024", nil)
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+		t.Fatal("could not claim the PDU session")
+	}
+
+	ueConn.ArmN2Setup(amf.N2SetupPDUSession, guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for ueConn.N2SetupOpen(amf.N2SetupPDUSession) && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if ueConn.N2SetupOpen(amf.N2SetupPDUSession) {
+		t.Fatal("the transaction is still open after the guard timer expired")
+	}
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+		t.Error("an NG-RAN node that never answers must not hold the claim forever")
+	}
+}
+
+func TestN2SetupTransaction_TerminalKeepsConfirmedSessions(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	amfInstance := amf.New(nil, nil, &fakeSmf{})
+
+	ue := addUE(t, amfInstance, "001010000000025", nil)
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+		t.Fatal("could not claim the PDU session")
+	}
+
+	ue.SetSmContextActive(1)
+	ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
+	if ue.ClaimSmContextN2(1) {
+		t.Error("a session the NG-RAN node confirmed must stay active when its transaction closes")
+	}
+}
+
+func TestTransferN1N2Message_SessionAlreadySetUp_ReleasesTheICSClaim(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	fakeDB := &fakeDBInstance{operator: &db.Operator{Mcc: "001", Mnc: "01"}}
+	amfInstance := amf.New(fakeDB, nil, &fakeSmf{})
+
+	ue := addUE(t, amfInstance, "001010000000026", func(u *amf.UeContext) {
+		u.Ambr = &models.Ambr{Uplink: models.MustParseBitRate("1000000 bps"), Downlink: models.MustParseBitRate("1000000 bps")}
+		u.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
+		u.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
+
+		u.SetUESecurityCapabilityForTest(&fgs.UESecurityCapability{EA: 0x00, IA: 0x00})
+		u.SetKgnbForTest(make([]byte, 32))
+	})
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	ue.SetSmContextActive(1)
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ueConn.ResetICS()
+	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
+
+	if err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sender.initialContextSetupCalls != 0 {
+		t.Fatalf("InitialContextSetupRequest count = %d, want 0", sender.initialContextSetupCalls)
+	}
+
+	if !ueConn.ClaimICS() {
+		t.Error("the initial context setup claim was not released, so the UE context can never be set up on this connection")
+	}
+}
+
+func TestStoreN1N2AndPage_RejectsASecondTransferWhilePaging(t *testing.T) {
+	sender := &fakeNGAPSender{}
+	fakeDB := &fakeDBInstance{operator: &db.Operator{Mcc: "001", Mnc: "01"}}
+	amfInstance := amf.New(fakeDB, nil, &fakeSmf{})
+	amfInstance.ClearRadiosForTest()
+
+	ue := addUE(t, amfInstance, "001010000000027", func(u *amf.UeContext) {
+		u.ForceStateForTest(amf.Registered)
+		u.SetGutiForTest(testGUTI(t))
+		u.RegistrationArea = []models.Tai{{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"}}
+	})
+
+	if conn := ue.Conn(); conn != nil {
+		conn.Release()
+	}
+
+	radio := &amf.Radio{Conn: sender}
+	radio.BindAMFForTest(amfInstance)
+	amfInstance.UpdateRadioSupportedTAIs(radio, []amf.SupportedTAI{{
+		Tai: models.Tai{PlmnID: &models.PlmnID{Mcc: "001", Mnc: "01"}, Tac: "000001"},
+	}})
+
+	first := newReq()
+	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), first); err != nil {
+		t.Fatalf("first transfer: %v", err)
+	}
+
+	if !ue.PagingActiveForTest() {
+		t.Fatal("expected paging supervision to be running")
+	}
+
+	buffered := ue.N1N2Message()
+	if buffered == nil {
+		t.Fatal("the first transfer was not buffered")
+	}
+
+	second := newReq()
+	second.BinaryDataN2Information = []byte{0xAA, 0xBB}
+
+	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), second)
+	if err == nil {
+		t.Fatal("a second transfer while paging must be rejected (TS 23.502 4.2.3.3 step 3b)")
+	}
+
+	if got := ue.N1N2Message(); got == nil || !bytes.Equal(got.BinaryDataN2Information, buffered.BinaryDataN2Information) {
+		t.Error("the buffered request was displaced; the SMF will never resend the 5GSM message it carried")
+	}
 }

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -798,11 +798,11 @@ func TestReleaseNasConnectionClearsOutstandingSetups(t *testing.T) {
 		t.Fatalf("CreateSmContext: %v", err)
 	}
 
-	if !ue.ClaimSmContextN2(1) {
+	if !ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Fatal("the first claim must succeed")
 	}
 
-	if ue.ClaimSmContextN2(1) {
+	if ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Fatal("a second claim must fail while the setup is outstanding")
 	}
 
@@ -813,7 +813,7 @@ func TestReleaseNasConnectionClearsOutstandingSetups(t *testing.T) {
 
 	amfInstance.ReleaseNasConnection(ue, ueConn)
 
-	if !ue.ClaimSmContextN2(1) {
+	if !ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Fatal("the UE dropping to CM-IDLE must clear the outstanding setup")
 	}
 }
@@ -839,17 +839,17 @@ func TestSmContextN2StateTransitions(t *testing.T) {
 		t.Error("a session with no RAN resources must not count as active")
 	}
 
-	if !ue.ClaimSmContextN2(1) {
+	if !ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Fatal("an inactive session must be claimable")
 	}
 
-	if ue.ClaimSmContextN2(1) {
+	if ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Error("a pending session must not be claimable")
 	}
 
 	ue.SetSmContextActive(1)
 
-	if ue.ClaimSmContextN2(1) {
+	if ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Error("an active session must not be claimable")
 	}
 
@@ -857,9 +857,9 @@ func TestSmContextN2StateTransitions(t *testing.T) {
 		t.Error("a session the RAN confirmed must count as active")
 	}
 
-	ue.ReleaseSmContextN2(1)
+	ue.SetSmContextInactive(1)
 
-	if !ue.ClaimSmContextN2(1) {
+	if !ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Error("a released session must be claimable again")
 	}
 }
@@ -879,11 +879,11 @@ func TestN2SetupTransaction_GuardExpiryReleasesTheClaim(t *testing.T) {
 	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+	if !ueConn.N2Setup(amf.N2SetupPDUSession).ClaimSession(1) {
 		t.Fatal("could not claim the PDU session")
 	}
 
-	ueConn.ArmN2Setup(amf.N2SetupPDUSession, guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond})
+	ueConn.N2Setup(amf.N2SetupPDUSession).Arm(guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond})
 
 	deadline := time.Now().Add(2 * time.Second)
 	for ueConn.N2SetupOpen(amf.N2SetupPDUSession) && time.Now().Before(deadline) {
@@ -894,7 +894,7 @@ func TestN2SetupTransaction_GuardExpiryReleasesTheClaim(t *testing.T) {
 		t.Fatal("the transaction is still open after the guard timer expired")
 	}
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+	if !ueConn.N2Setup(amf.N2SetupPDUSession).ClaimSession(1) {
 		t.Error("an NG-RAN node that never answers must not hold the claim forever")
 	}
 }
@@ -914,14 +914,14 @@ func TestN2SetupTransaction_TerminalKeepsConfirmedSessions(t *testing.T) {
 	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+	if !ueConn.N2Setup(amf.N2SetupPDUSession).ClaimSession(1) {
 		t.Fatal("could not claim the PDU session")
 	}
 
 	ue.SetSmContextActive(1)
 	ueConn.EndN2Setup(amf.N2SetupPDUSession)
 
-	if ue.ClaimSmContextN2(1) {
+	if ue.ClaimSmContextN2(amf.N2SetupPDUSession, 1) {
 		t.Error("a session the NG-RAN node confirmed must stay active when its transaction closes")
 	}
 }
@@ -1030,11 +1030,11 @@ func TestN2SetupGuardExpiry_DeactivatesTheSessionAtTheSMF(t *testing.T) {
 	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+	if !ueConn.N2Setup(amf.N2SetupPDUSession).ClaimSession(1) {
 		t.Fatal("could not claim the PDU session")
 	}
 
-	ueConn.ArmN2Setup(amf.N2SetupPDUSession, guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond})
+	ueConn.N2Setup(amf.N2SetupPDUSession).Arm(guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond})
 
 	deadline := time.Now().Add(2 * time.Second)
 	for len(smfStub.deactivated()) == 0 && time.Now().Before(deadline) {
@@ -1063,7 +1063,7 @@ func TestN2SetupTerminal_DoesNotDeactivateAConfirmedSession(t *testing.T) {
 	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupPDUSession, 1) {
+	if !ueConn.N2Setup(amf.N2SetupPDUSession).ClaimSession(1) {
 		t.Fatal("could not claim the PDU session")
 	}
 

--- a/internal/amf/n2_setup_txn.go
+++ b/internal/amf/n2_setup_txn.go
@@ -17,6 +17,7 @@ type N2SetupProcedure uint8
 const (
 	N2SetupInitialContext N2SetupProcedure = iota
 	N2SetupPDUSession
+	N2SetupHandover
 )
 
 func (p N2SetupProcedure) String() string {
@@ -25,14 +26,15 @@ func (p N2SetupProcedure) String() string {
 		return "InitialContextSetup"
 	case N2SetupPDUSession:
 		return "PDUSessionResourceSetup"
+	case N2SetupHandover:
+		return "HandoverResourceAllocation"
 	default:
 		return "unknown"
 	}
 }
 
 type n2SetupTxn struct {
-	sessions []uint8
-	guard    *guard.Guard
+	guard *guard.Guard
 }
 
 type n2SetupTxns struct {
@@ -49,24 +51,16 @@ func (ueConn *UeConn) N2Setup(proc N2SetupProcedure) N2Setup {
 	return N2Setup{conn: ueConn, proc: proc}
 }
 
-func (s N2Setup) Claim(ids []uint8) []uint8 {
-	return s.conn.ClaimN2Setup(s.proc, ids)
-}
-
 func (s N2Setup) ClaimSession(id uint8) bool {
-	return s.conn.ClaimN2SetupSession(s.proc, id)
-}
-
-func (s N2Setup) Arm(cfg guard.TimerValue) {
-	s.conn.ArmN2Setup(s.proc, cfg)
+	return len(s.Claim([]uint8{id})) == 1
 }
 
 func (s N2Setup) End() {
 	s.conn.EndN2Setup(s.proc)
 }
 
-func (ueConn *UeConn) ClaimN2Setup(proc N2SetupProcedure, ids []uint8) []uint8 {
-	ue := ueConn.UeContext()
+func (s N2Setup) Claim(ids []uint8) []uint8 {
+	ue := s.conn.UeContext()
 	if ue == nil {
 		return nil
 	}
@@ -74,7 +68,7 @@ func (ueConn *UeConn) ClaimN2Setup(proc N2SetupProcedure, ids []uint8) []uint8 {
 	claimed := make([]uint8, 0, len(ids))
 
 	for _, id := range ids {
-		if ue.ClaimSmContextN2(id) {
+		if ue.ClaimSmContextN2(s.proc, id) {
 			claimed = append(claimed, id)
 		}
 	}
@@ -83,43 +77,35 @@ func (ueConn *UeConn) ClaimN2Setup(proc N2SetupProcedure, ids []uint8) []uint8 {
 		return nil
 	}
 
-	ueConn.n2Setups.mu.Lock()
-	defer ueConn.n2Setups.mu.Unlock()
+	s.conn.n2Setups.mu.Lock()
+	defer s.conn.n2Setups.mu.Unlock()
 
-	if ueConn.n2Setups.open == nil {
-		ueConn.n2Setups.open = make(map[N2SetupProcedure]*n2SetupTxn)
+	if s.conn.n2Setups.open == nil {
+		s.conn.n2Setups.open = make(map[N2SetupProcedure]*n2SetupTxn)
 	}
 
-	txn, ok := ueConn.n2Setups.open[proc]
-	if !ok {
-		txn = &n2SetupTxn{guard: &guard.Guard{}}
-		ueConn.n2Setups.open[proc] = txn
+	if _, ok := s.conn.n2Setups.open[s.proc]; !ok {
+		s.conn.n2Setups.open[s.proc] = &n2SetupTxn{guard: &guard.Guard{}}
 	}
-
-	txn.sessions = append(txn.sessions, claimed...)
 
 	return claimed
 }
 
-func (ueConn *UeConn) ClaimN2SetupSession(proc N2SetupProcedure, id uint8) bool {
-	return len(ueConn.ClaimN2Setup(proc, []uint8{id})) == 1
-}
-
-func (ueConn *UeConn) ArmN2Setup(proc N2SetupProcedure, cfg guard.TimerValue) {
+func (s N2Setup) Arm(cfg guard.TimerValue) {
 	if !cfg.Enable {
 		return
 	}
 
-	ueConn.n2Setups.mu.Lock()
-	defer ueConn.n2Setups.mu.Unlock()
+	s.conn.n2Setups.mu.Lock()
+	defer s.conn.n2Setups.mu.Unlock()
 
-	txn, ok := ueConn.n2Setups.open[proc]
+	txn, ok := s.conn.n2Setups.open[s.proc]
 	if !ok {
 		return
 	}
 
 	txn.guard.ArmOnce(cfg.ExpireTime, func() {
-		ueConn.expireN2Setup(proc, txn)
+		s.conn.expireN2Setup(s.proc, txn)
 	})
 }
 
@@ -179,9 +165,9 @@ func (ueConn *UeConn) endN2SetupTxn(proc N2SetupProcedure, want *n2SetupTxn) []u
 		return nil
 	}
 
-	released := make([]uint8, 0, len(txn.sessions))
+	var released []uint8
 
-	for _, id := range txn.sessions {
+	for _, id := range ue.PendingSmContextsFor(proc) {
 		if ue.ReleaseSmContextN2IfPending(id) {
 			released = append(released, id)
 		}
@@ -198,14 +184,14 @@ func (ueConn *UeConn) AbortN2Setups() {
 
 	ue := ueConn.UeContext()
 
-	for _, txn := range open {
+	for proc, txn := range open {
 		txn.guard.Stop()
 
 		if ue == nil {
 			continue
 		}
 
-		for _, id := range txn.sessions {
+		for _, id := range ue.PendingSmContextsFor(proc) {
 			ue.ReleaseSmContextN2IfPending(id)
 		}
 	}

--- a/internal/amf/n2_setup_txn.go
+++ b/internal/amf/n2_setup_txn.go
@@ -4,9 +4,12 @@
 package amf
 
 import (
+	"context"
 	"sync"
 
 	"github.com/ellanetworks/core/internal/guard"
+	"github.com/ellanetworks/core/internal/logger"
+	"go.uber.org/zap"
 )
 
 type N2SetupProcedure uint8
@@ -35,6 +38,31 @@ type n2SetupTxn struct {
 type n2SetupTxns struct {
 	mu   sync.Mutex
 	open map[N2SetupProcedure]*n2SetupTxn
+}
+
+type N2Setup struct {
+	conn *UeConn
+	proc N2SetupProcedure
+}
+
+func (ueConn *UeConn) N2Setup(proc N2SetupProcedure) N2Setup {
+	return N2Setup{conn: ueConn, proc: proc}
+}
+
+func (s N2Setup) Claim(ids []uint8) []uint8 {
+	return s.conn.ClaimN2Setup(s.proc, ids)
+}
+
+func (s N2Setup) ClaimSession(id uint8) bool {
+	return s.conn.ClaimN2SetupSession(s.proc, id)
+}
+
+func (s N2Setup) Arm(cfg guard.TimerValue) {
+	s.conn.ArmN2Setup(s.proc, cfg)
+}
+
+func (s N2Setup) End() {
+	s.conn.EndN2Setup(s.proc)
 }
 
 func (ueConn *UeConn) ClaimN2Setup(proc N2SetupProcedure, ids []uint8) []uint8 {
@@ -78,39 +106,88 @@ func (ueConn *UeConn) ClaimN2SetupSession(proc N2SetupProcedure, id uint8) bool 
 }
 
 func (ueConn *UeConn) ArmN2Setup(proc N2SetupProcedure, cfg guard.TimerValue) {
-	ueConn.n2Setups.mu.Lock()
-	txn, ok := ueConn.n2Setups.open[proc]
-	ueConn.n2Setups.mu.Unlock()
+	if !cfg.Enable {
+		return
+	}
 
-	if !ok || !cfg.Enable {
+	ueConn.n2Setups.mu.Lock()
+	defer ueConn.n2Setups.mu.Unlock()
+
+	txn, ok := ueConn.n2Setups.open[proc]
+	if !ok {
 		return
 	}
 
 	txn.guard.ArmOnce(cfg.ExpireTime, func() {
-		ueConn.EndN2Setup(proc)
+		ueConn.expireN2Setup(proc, txn)
 	})
 }
 
 func (ueConn *UeConn) EndN2Setup(proc N2SetupProcedure) {
+	ueConn.endN2SetupTxn(proc, nil)
+}
+
+func (ueConn *UeConn) expireN2Setup(proc N2SetupProcedure, txn *n2SetupTxn) {
+	released := ueConn.endN2SetupTxn(proc, txn)
+	if len(released) == 0 {
+		return
+	}
+
+	ue := ueConn.UeContext()
+	if ue == nil || ueConn.amf == nil || ueConn.amf.Session == nil {
+		return
+	}
+
+	ctx := context.Background()
+
+	for _, id := range released {
+		smContext, ok := ue.SmContextFindByPDUSessionID(id)
+		if !ok {
+			continue
+		}
+
+		logger.From(ctx, ueConn.Log()).Warn("no answer to the PDU session resource setup; deactivating the session at the SMF",
+			zap.Uint8("pdu_session_id", id), zap.Stringer("procedure", proc))
+
+		if err := ueConn.amf.Session.DeactivateSmContext(ctx, smContext.Ref); err != nil {
+			logger.From(ctx, ueConn.Log()).Error("could not deactivate a PDU session whose setup went unanswered",
+				zap.Uint8("pdu_session_id", id), zap.Error(err))
+		}
+	}
+}
+
+func (ueConn *UeConn) endN2SetupTxn(proc N2SetupProcedure, want *n2SetupTxn) []uint8 {
 	ueConn.n2Setups.mu.Lock()
+
 	txn, ok := ueConn.n2Setups.open[proc]
-	delete(ueConn.n2Setups.open, proc)
+	if ok && (want == nil || txn == want) {
+		delete(ueConn.n2Setups.open, proc)
+	} else {
+		ok = false
+	}
+
 	ueConn.n2Setups.mu.Unlock()
 
 	if !ok {
-		return
+		return nil
 	}
 
 	txn.guard.Stop()
 
 	ue := ueConn.UeContext()
 	if ue == nil {
-		return
+		return nil
 	}
 
+	released := make([]uint8, 0, len(txn.sessions))
+
 	for _, id := range txn.sessions {
-		ue.ReleaseSmContextN2IfPending(id)
+		if ue.ReleaseSmContextN2IfPending(id) {
+			released = append(released, id)
+		}
 	}
+
+	return released
 }
 
 func (ueConn *UeConn) AbortN2Setups() {
@@ -119,8 +196,18 @@ func (ueConn *UeConn) AbortN2Setups() {
 	ueConn.n2Setups.open = nil
 	ueConn.n2Setups.mu.Unlock()
 
+	ue := ueConn.UeContext()
+
 	for _, txn := range open {
 		txn.guard.Stop()
+
+		if ue == nil {
+			continue
+		}
+
+		for _, id := range txn.sessions {
+			ue.ReleaseSmContextN2IfPending(id)
+		}
 	}
 }
 

--- a/internal/amf/n2_setup_txn.go
+++ b/internal/amf/n2_setup_txn.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"sync"
+
+	"github.com/ellanetworks/core/internal/guard"
+)
+
+type N2SetupProcedure uint8
+
+const (
+	N2SetupInitialContext N2SetupProcedure = iota
+	N2SetupPDUSession
+)
+
+func (p N2SetupProcedure) String() string {
+	switch p {
+	case N2SetupInitialContext:
+		return "InitialContextSetup"
+	case N2SetupPDUSession:
+		return "PDUSessionResourceSetup"
+	default:
+		return "unknown"
+	}
+}
+
+type n2SetupTxn struct {
+	sessions []uint8
+	guard    *guard.Guard
+}
+
+type n2SetupTxns struct {
+	mu   sync.Mutex
+	open map[N2SetupProcedure]*n2SetupTxn
+}
+
+func (ueConn *UeConn) ClaimN2Setup(proc N2SetupProcedure, ids []uint8) []uint8 {
+	ue := ueConn.UeContext()
+	if ue == nil {
+		return nil
+	}
+
+	claimed := make([]uint8, 0, len(ids))
+
+	for _, id := range ids {
+		if ue.ClaimSmContextN2(id) {
+			claimed = append(claimed, id)
+		}
+	}
+
+	if len(claimed) == 0 {
+		return nil
+	}
+
+	ueConn.n2Setups.mu.Lock()
+	defer ueConn.n2Setups.mu.Unlock()
+
+	if ueConn.n2Setups.open == nil {
+		ueConn.n2Setups.open = make(map[N2SetupProcedure]*n2SetupTxn)
+	}
+
+	txn, ok := ueConn.n2Setups.open[proc]
+	if !ok {
+		txn = &n2SetupTxn{guard: &guard.Guard{}}
+		ueConn.n2Setups.open[proc] = txn
+	}
+
+	txn.sessions = append(txn.sessions, claimed...)
+
+	return claimed
+}
+
+func (ueConn *UeConn) ClaimN2SetupSession(proc N2SetupProcedure, id uint8) bool {
+	return len(ueConn.ClaimN2Setup(proc, []uint8{id})) == 1
+}
+
+func (ueConn *UeConn) ArmN2Setup(proc N2SetupProcedure, cfg guard.TimerValue) {
+	ueConn.n2Setups.mu.Lock()
+	txn, ok := ueConn.n2Setups.open[proc]
+	ueConn.n2Setups.mu.Unlock()
+
+	if !ok || !cfg.Enable {
+		return
+	}
+
+	txn.guard.ArmOnce(cfg.ExpireTime, func() {
+		ueConn.EndN2Setup(proc)
+	})
+}
+
+func (ueConn *UeConn) EndN2Setup(proc N2SetupProcedure) {
+	ueConn.n2Setups.mu.Lock()
+	txn, ok := ueConn.n2Setups.open[proc]
+	delete(ueConn.n2Setups.open, proc)
+	ueConn.n2Setups.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	txn.guard.Stop()
+
+	ue := ueConn.UeContext()
+	if ue == nil {
+		return
+	}
+
+	for _, id := range txn.sessions {
+		ue.ReleaseSmContextN2IfPending(id)
+	}
+}
+
+func (ueConn *UeConn) AbortN2Setups() {
+	ueConn.n2Setups.mu.Lock()
+	open := ueConn.n2Setups.open
+	ueConn.n2Setups.open = nil
+	ueConn.n2Setups.mu.Unlock()
+
+	for _, txn := range open {
+		txn.guard.Stop()
+	}
+}
+
+func (ueConn *UeConn) N2SetupOpen(proc N2SetupProcedure) bool {
+	ueConn.n2Setups.mu.Lock()
+	defer ueConn.n2Setups.mu.Unlock()
+
+	_, ok := ueConn.n2Setups.open[proc]
+
+	return ok
+}

--- a/internal/amf/n2_setup_txn_internal_test.go
+++ b/internal/amf/n2_setup_txn_internal_test.go
@@ -21,7 +21,7 @@ func newTxnTestConn() *UeConn {
 func TestEndN2SetupTxnOnlyClosesTheTransactionItNames(t *testing.T) {
 	conn := newTxnTestConn()
 
-	first := conn.ClaimN2Setup(N2SetupPDUSession, []uint8{1})
+	first := conn.N2Setup(N2SetupPDUSession).Claim([]uint8{1})
 	if len(first) != 1 {
 		t.Fatalf("claimed %v, want PDU session 1", first)
 	}
@@ -32,7 +32,7 @@ func TestEndN2SetupTxnOnlyClosesTheTransactionItNames(t *testing.T) {
 
 	conn.EndN2Setup(N2SetupPDUSession)
 
-	if len(conn.ClaimN2Setup(N2SetupPDUSession, []uint8{2})) != 1 {
+	if len(conn.N2Setup(N2SetupPDUSession).Claim([]uint8{2})) != 1 {
 		t.Fatal("could not open a second transaction")
 	}
 
@@ -48,7 +48,7 @@ func TestArmN2SetupDoesNotOrphanAGuardAcrossEnd(t *testing.T) {
 
 	for range 60 {
 		conn := newTxnTestConn()
-		conn.ClaimN2Setup(N2SetupPDUSession, []uint8{1})
+		conn.N2Setup(N2SetupPDUSession).Claim([]uint8{1})
 
 		var wg sync.WaitGroup
 
@@ -57,7 +57,7 @@ func TestArmN2SetupDoesNotOrphanAGuardAcrossEnd(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			conn.ArmN2Setup(N2SetupPDUSession, cfg)
+			conn.N2Setup(N2SetupPDUSession).Arm(cfg)
 		}()
 
 		go func() {
@@ -68,7 +68,7 @@ func TestArmN2SetupDoesNotOrphanAGuardAcrossEnd(t *testing.T) {
 
 		wg.Wait()
 
-		conn.ClaimN2Setup(N2SetupPDUSession, []uint8{2})
+		conn.N2Setup(N2SetupPDUSession).Claim([]uint8{2})
 
 		time.Sleep(12 * time.Millisecond)
 
@@ -90,18 +90,18 @@ func TestAbortN2SetupsReleasesItsOwnClaims(t *testing.T) {
 		t.Fatalf("CreateSmContext: %v", err)
 	}
 
-	if got := conn.ClaimN2Setup(N2SetupInitialContext, []uint8{1}); len(got) != 1 {
+	if got := conn.N2Setup(N2SetupInitialContext).Claim([]uint8{1}); len(got) != 1 {
 		t.Fatalf("claimed %v, want PDU session 1", got)
 	}
 
-	if got := conn.ClaimN2Setup(N2SetupPDUSession, []uint8{2}); len(got) != 1 {
+	if got := conn.N2Setup(N2SetupPDUSession).Claim([]uint8{2}); len(got) != 1 {
 		t.Fatalf("claimed %v, want PDU session 2", got)
 	}
 
 	conn.AbortN2Setups()
 
 	for _, id := range []uint8{1, 2} {
-		if !ue.ClaimSmContextN2(id) {
+		if !ue.ClaimSmContextN2(N2SetupPDUSession, id) {
 			t.Errorf("PDU session %d is still claimed after the transactions were aborted", id)
 		}
 	}
@@ -115,14 +115,14 @@ func TestAbortN2SetupsLeavesConfirmedSessionsAlone(t *testing.T) {
 		t.Fatalf("CreateSmContext: %v", err)
 	}
 
-	if got := conn.ClaimN2Setup(N2SetupPDUSession, []uint8{1}); len(got) != 1 {
+	if got := conn.N2Setup(N2SetupPDUSession).Claim([]uint8{1}); len(got) != 1 {
 		t.Fatalf("claimed %v, want PDU session 1", got)
 	}
 
 	ue.SetSmContextActive(1)
 	conn.AbortN2Setups()
 
-	if ue.ClaimSmContextN2(1) {
+	if ue.ClaimSmContextN2(N2SetupPDUSession, 1) {
 		t.Error("a session the NG-RAN node confirmed must not be released by aborting a transaction")
 	}
 }

--- a/internal/amf/n2_setup_txn_internal_test.go
+++ b/internal/amf/n2_setup_txn_internal_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ellanetworks/core/internal/guard"
+)
+
+func newTxnTestConn() *UeConn {
+	conn := &UeConn{}
+	conn.ue.Store(NewUeContext())
+
+	return conn
+}
+
+func TestEndN2SetupTxnOnlyClosesTheTransactionItNames(t *testing.T) {
+	conn := newTxnTestConn()
+
+	first := conn.ClaimN2Setup(N2SetupPDUSession, []uint8{1})
+	if len(first) != 1 {
+		t.Fatalf("claimed %v, want PDU session 1", first)
+	}
+
+	conn.n2Setups.mu.Lock()
+	stale := conn.n2Setups.open[N2SetupPDUSession]
+	conn.n2Setups.mu.Unlock()
+
+	conn.EndN2Setup(N2SetupPDUSession)
+
+	if len(conn.ClaimN2Setup(N2SetupPDUSession, []uint8{2})) != 1 {
+		t.Fatal("could not open a second transaction")
+	}
+
+	conn.endN2SetupTxn(N2SetupPDUSession, stale)
+
+	if !conn.N2SetupOpen(N2SetupPDUSession) {
+		t.Error("a guard left over from an ended transaction closed the transaction that replaced it")
+	}
+}
+
+func TestArmN2SetupDoesNotOrphanAGuardAcrossEnd(t *testing.T) {
+	cfg := guard.TimerValue{Enable: true, ExpireTime: 5 * time.Millisecond}
+
+	for range 60 {
+		conn := newTxnTestConn()
+		conn.ClaimN2Setup(N2SetupPDUSession, []uint8{1})
+
+		var wg sync.WaitGroup
+
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			conn.ArmN2Setup(N2SetupPDUSession, cfg)
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			conn.EndN2Setup(N2SetupPDUSession)
+		}()
+
+		wg.Wait()
+
+		conn.ClaimN2Setup(N2SetupPDUSession, []uint8{2})
+
+		time.Sleep(12 * time.Millisecond)
+
+		if !conn.N2SetupOpen(N2SetupPDUSession) {
+			t.Fatal("an orphaned guard from the previous transaction closed the new one")
+		}
+	}
+}
+
+func TestAbortN2SetupsReleasesItsOwnClaims(t *testing.T) {
+	conn := newTxnTestConn()
+	ue := conn.UeContext()
+
+	if err := ue.CreateSmContext(1, "ref-1", nil, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if err := ue.CreateSmContext(2, "ref-2", nil, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if got := conn.ClaimN2Setup(N2SetupInitialContext, []uint8{1}); len(got) != 1 {
+		t.Fatalf("claimed %v, want PDU session 1", got)
+	}
+
+	if got := conn.ClaimN2Setup(N2SetupPDUSession, []uint8{2}); len(got) != 1 {
+		t.Fatalf("claimed %v, want PDU session 2", got)
+	}
+
+	conn.AbortN2Setups()
+
+	for _, id := range []uint8{1, 2} {
+		if !ue.ClaimSmContextN2(id) {
+			t.Errorf("PDU session %d is still claimed after the transactions were aborted", id)
+		}
+	}
+}
+
+func TestAbortN2SetupsLeavesConfirmedSessionsAlone(t *testing.T) {
+	conn := newTxnTestConn()
+	ue := conn.UeContext()
+
+	if err := ue.CreateSmContext(1, "ref-1", nil, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if got := conn.ClaimN2Setup(N2SetupPDUSession, []uint8{1}); len(got) != 1 {
+		t.Fatalf("claimed %v, want PDU session 1", got)
+	}
+
+	ue.SetSmContextActive(1)
+	conn.AbortN2Setups()
+
+	if ue.ClaimSmContextN2(1) {
+		t.Error("a session the NG-RAN node confirmed must not be released by aborting a transaction")
+	}
+}

--- a/internal/amf/nas/handle_registration_complete_test.go
+++ b/internal/amf/nas/handle_registration_complete_test.go
@@ -257,6 +257,7 @@ func TestHandleRegistrationComplete_NotReleasedWhenActiveSession(t *testing.T) {
 	ue.Conn().RegistrationRequest.FOR = false
 	ue.Conn().RegistrationRequest.UplinkDataStatus = nil
 	_ = ue.CreateSmContext(1, "testref1", &models.Snssai{}, "internet")
+	ue.SetSmContextActive(1)
 
 	amfInstance := newTestAMF()
 

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -65,6 +65,16 @@ func resolveBufferedSM(ue *amf.UeContext) bufferedSM {
 	return out
 }
 
+func armOrEndN2Setup(setup amf.N2Setup, ueConn *amf.UeConn, cfg guard.TimerValue) {
+	if ueConn.UeContextRequest {
+		setup.Arm(cfg)
+
+		return
+	}
+
+	setup.End()
+}
+
 func n2SetupProcedure(initialContextSetup bool) amf.N2SetupProcedure {
 	if initialContextSetup {
 		return amf.N2SetupInitialContext

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -130,7 +130,7 @@ func sendServiceAccept(
 				return fmt.Errorf("error sending initial context setup request: %v", err)
 			}
 
-			ueConn.ArmN2Setup(amf.N2SetupInitialContext, guardCfg)
+			ueConn.N2Setup(amf.N2SetupInitialContext).Arm(guardCfg)
 
 			logger.From(ctx, logger.AmfLog).Info("sent service accept with initial context setup request")
 		case len(suList) != 0:
@@ -144,7 +144,7 @@ func sendServiceAccept(
 				return fmt.Errorf("error sending pdu session resource setup request: %v", err)
 			}
 
-			ueConn.ArmN2Setup(amf.N2SetupPDUSession, guardCfg)
+			ueConn.N2Setup(amf.N2SetupPDUSession).Arm(guardCfg)
 
 			logger.From(ctx, logger.AmfLog).Info("sent service accept")
 		default:
@@ -178,7 +178,7 @@ func stagePendingN1(
 ) error {
 	stage := func(nasPdu []byte) error {
 		conn := ue.Conn()
-		if conn == nil || !conn.ClaimN2SetupSession(n2SetupProcedure(initialContextSetup), pending.pduSessionID) {
+		if conn == nil || !conn.N2Setup(n2SetupProcedure(initialContextSetup)).ClaimSession(pending.pduSessionID) {
 			logger.From(ctx, logger.AmfLog).Debug("delivering buffered N1 without a duplicate PDU session setup",
 				zap.Uint8("pdu_session_id", pending.pduSessionID))
 
@@ -411,7 +411,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 			errCause = append(errCause, uint8(fgs.GMMCauseProtocolErrorUnspecified))
 		}
 
-		if !ueConn.ClaimN2SetupSession(n2SetupProcedure(initialContextSetup), pduSessionID) {
+		if !ueConn.N2Setup(n2SetupProcedure(initialContextSetup)).ClaimSession(pduSessionID) {
 			logger.From(ctx, logger.AmfLog).Debug("skipping PDU session already set up on the NG-RAN node",
 				zap.Uint8("pdu_session_id", pduSessionID))
 

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -65,16 +65,6 @@ func resolveBufferedSM(ue *amf.UeContext) bufferedSM {
 	return out
 }
 
-func armOrEndN2Setup(setup amf.N2Setup, ueConn *amf.UeConn, cfg guard.TimerValue) {
-	if ueConn.UeContextRequest {
-		setup.Arm(cfg)
-
-		return
-	}
-
-	setup.End()
-}
-
 func n2SetupProcedure(initialContextSetup bool) amf.N2SetupProcedure {
 	if initialContextSetup {
 		return amf.N2SetupInitialContext

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/guard"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/nasreply"
@@ -64,8 +65,17 @@ func resolveBufferedSM(ue *amf.UeContext) bufferedSM {
 	return out
 }
 
+func n2SetupProcedure(initialContextSetup bool) amf.N2SetupProcedure {
+	if initialContextSetup {
+		return amf.N2SetupInitialContext
+	}
+
+	return amf.N2SetupPDUSession
+}
+
 func sendServiceAccept(
 	ctx context.Context,
+	guardCfg guard.TimerValue,
 	ue *amf.UeContext,
 	ueConn *amf.UeConn,
 	initialContextSetup bool,
@@ -120,6 +130,8 @@ func sendServiceAccept(
 				return fmt.Errorf("error sending initial context setup request: %v", err)
 			}
 
+			ueConn.ArmN2Setup(amf.N2SetupInitialContext, guardCfg)
+
 			logger.From(ctx, logger.AmfLog).Info("sent service accept with initial context setup request")
 		case len(suList) != 0:
 			if err := ueConn.SendPDUSessionResourceSetupRequest(
@@ -132,8 +144,12 @@ func sendServiceAccept(
 				return fmt.Errorf("error sending pdu session resource setup request: %v", err)
 			}
 
+			ueConn.ArmN2Setup(amf.N2SetupPDUSession, guardCfg)
+
 			logger.From(ctx, logger.AmfLog).Info("sent service accept")
 		default:
+			ueConn.EndN2Setup(n2SetupProcedure(initialContextSetup))
+
 			if err := ueConn.SendDownlinkNASTransport(ctx, wire); err != nil {
 				return fmt.Errorf("error sending downlink nas transport: %v", err)
 			}
@@ -161,6 +177,18 @@ func stagePendingN1(
 	suList *ngap.PDUSessionResourceSetupListSUReq,
 ) error {
 	stage := func(nasPdu []byte) error {
+		conn := ue.Conn()
+		if conn == nil || !conn.ClaimN2SetupSession(n2SetupProcedure(initialContextSetup), pending.pduSessionID) {
+			logger.From(ctx, logger.AmfLog).Debug("delivering buffered N1 without a duplicate PDU session setup",
+				zap.Uint8("pdu_session_id", pending.pduSessionID))
+
+			if len(nasPdu) == 0 || conn == nil {
+				return nil
+			}
+
+			return conn.SendDownlinkNASTransport(ctx, nasPdu)
+		}
+
 		if initialContextSetup {
 			item, err := amf.PDUSessionSetupItem(pending.pduSessionID, pending.snssai, nasPdu, pending.n2Info)
 			if err != nil {
@@ -337,7 +365,10 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		activate[buffered.pduSessionID] = true
 	}
 
-	var requestedPsi []uint8
+	var (
+		requestedPsi    []uint8
+		alreadyOnTheRAN [16]bool
+	)
 
 	if msg.UplinkDataStatus != nil {
 		uplinkDataPsi := msg.UplinkDataStatus.PSI
@@ -380,14 +411,23 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 			errCause = append(errCause, uint8(fgs.GMMCauseProtocolErrorUnspecified))
 		}
 
+		if !ueConn.ClaimN2SetupSession(n2SetupProcedure(initialContextSetup), pduSessionID) {
+			logger.From(ctx, logger.AmfLog).Debug("skipping PDU session already set up on the NG-RAN node",
+				zap.Uint8("pdu_session_id", pduSessionID))
+
+			if int(pduSessionID) < len(alreadyOnTheRAN) {
+				alreadyOnTheRAN[pduSessionID] = true
+			}
+
+			continue
+		}
+
 		binaryDataN2SmInformation, err := amfInstance.Session.ActivateSmContext(ctx, smContext.Ref)
 		if err != nil {
 			failed(err)
 
 			continue
 		}
-
-		ue.SetSmContextActive(pduSessionID)
 
 		if initialContextSetup {
 			item, err := amf.PDUSessionSetupItem(pduSessionID, smContext.Snssai, nil, binaryDataN2SmInformation)
@@ -433,23 +473,34 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		}
 	}
 
-	if len(requestedPsi) != 0 && buffered.stage == nil && len(ctxList) == 0 && len(suList) == 0 {
-		logger.From(ctx, logger.AmfLog).Error("no user-plane resources established for a service request that asked for them",
-			logger.SUPI(ue.Supi().String()), zap.Uint8s("pdu_session_ids", requestedPsi))
+	if buffered.stage == nil && len(ctxList) == 0 && len(suList) == 0 {
+		var unestablished []uint8
 
 		for _, pduSessionID := range requestedPsi {
+			if int(pduSessionID) < len(alreadyOnTheRAN) && alreadyOnTheRAN[pduSessionID] {
+				continue
+			}
+
+			unestablished = append(unestablished, pduSessionID)
 			reactivationResult[pduSessionID] = true
+		}
+
+		if len(unestablished) != 0 {
+			logger.From(ctx, logger.AmfLog).Error("no user-plane resources established for a service request that asked for them",
+				logger.SUPI(ue.Supi().String()), zap.Uint8s("pdu_session_ids", unestablished))
 		}
 	}
 
 	accept := func(pending *pendingN1) error {
-		err := sendServiceAccept(ctx, ue, ueConn, initialContextSetup, ctxList, suList, acceptPduSessionPsi,
+		err := sendServiceAccept(ctx, amfInstance.N2SetupGuardCfg, ue, ueConn, initialContextSetup, ctxList, suList, acceptPduSessionPsi,
 			reactivationResult, errPduSessionID, errCause, operatorInfo.Guami, pending)
 		if err != nil {
 			logger.From(ctx, logger.AmfLog).Warn("error sending service accept", zap.Error(err))
 
 			if initialContextSetup {
-				ueConn.ResetICS()
+				ueConn.AbortICS()
+			} else {
+				ueConn.EndN2Setup(amf.N2SetupPDUSession)
 			}
 		}
 
@@ -460,14 +511,10 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		ue.ClearN1N2Message()
 
 		if initialContextSetup {
-			ueConn.ResetICS()
+			ueConn.AbortICS()
 		}
 
 		return nasreply.Silent(nasreply.ReasonNoContext)
-	}
-
-	if buffered.stage != nil {
-		ue.SetSmContextActive(buffered.stage.pduSessionID)
 	}
 
 	if err := accept(buffered.stage); err != nil {

--- a/internal/amf/nas/handle_service_request_reactivation_test.go
+++ b/internal/amf/nas/handle_service_request_reactivation_test.go
@@ -6,6 +6,7 @@ package nas
 import (
 	"testing"
 
+	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/fgs"
 )
@@ -95,7 +96,7 @@ func TestHandleServiceRequest_SecondRequestAfterBufferedN1N2_StillReactivates(t 
 
 	idleToActive(t, f, fgs.ServiceTypeData)
 
-	f.conn().ResetICS()
+	f.conn().AbortICS()
 	f.ngapSender.SentInitialContextSetupRequest = nil
 
 	idleToActive(t, f, fgs.ServiceTypeData)
@@ -106,5 +107,71 @@ func TestHandleServiceRequest_SecondRequestAfterBufferedN1N2_StillReactivates(t 
 
 	if got := len(f.ngapSender.SentInitialContextSetupRequest[0].PDUSessionResourceSetup); got != 1 {
 		t.Fatalf("PDU session resource setup list length = %d, want 1", got)
+	}
+}
+
+func TestHandleServiceRequest_ItemBuildFailure_DoesNotStrandTheClaim(t *testing.T) {
+	f := connectedModeUe(t, &fakeSmf{})
+
+	if err := f.ue.CreateSmContext(12, "testrefuplink", nil, "internet"); err != nil {
+		t.Fatalf("could not recreate the sm context: %v", err)
+	}
+
+	f.conn().UeContextRequest = false
+	f.conn().MarkICSCompleted()
+
+	idleToActive(t, f, fgs.ServiceTypeData)
+
+	if f.conn().N2SetupOpen(amf.N2SetupPDUSession) {
+		t.Error("a transaction that sent no setup request must not stay open")
+	}
+
+	if !f.conn().ClaimN2SetupSession(amf.N2SetupPDUSession, 12) {
+		t.Error("the PDU session is still claimed although no setup request reached the RAN")
+	}
+}
+
+func TestHandleServiceRequest_AlreadySetUpSession_DoesNotActivateTheSmContext(t *testing.T) {
+	smf := &fakeSmf{}
+	f := connectedModeUe(t, smf)
+
+	f.ue.SetSmContextActive(12)
+	f.conn().UeContextRequest = false
+	f.conn().MarkICSCompleted()
+
+	idleToActive(t, f, fgs.ServiceTypeData)
+
+	if len(smf.ActivateSmContextCalls) != 0 {
+		t.Errorf("ActivateSmContext calls = %d, want 0: the SMF must not be driven through UP activation for a session the NG-RAN node already holds",
+			len(smf.ActivateSmContextCalls))
+	}
+
+	if len(f.ngapSender.SentPDUSessionResourceSetupRequest) != 0 {
+		t.Errorf("PDU session resource setup requests = %d, want 0", len(f.ngapSender.SentPDUSessionResourceSetupRequest))
+	}
+}
+
+func TestHandleServiceRequest_AlreadyEstablishedSession_IsNotReportedAsAReactivationFailure(t *testing.T) {
+	f := connectedModeUe(t, &fakeSmf{})
+
+	f.ue.SetSmContextActive(12)
+	f.conn().UeContextRequest = false
+	f.conn().MarkICSCompleted()
+
+	handleServiceRequest(t.Context(), f.amf, f.ue, f.serviceRequest(t, fgs.ServiceTypeData), true)
+
+	if len(f.ngapSender.SentDownlinkNASTransport) != 1 {
+		t.Fatalf("downlink nas transports = %d, want 1", len(f.ngapSender.SentDownlinkNASTransport))
+	}
+
+	plain := decipherGmm(t, f.ue, f.ngapSender.SentDownlinkNASTransport[0].NASPDU, uint8(fgs.MsgServiceAccept))
+
+	accept, err := fgs.ParseServiceAccept(plain)
+	if err != nil {
+		t.Fatalf("could not parse service accept: %v", err)
+	}
+
+	if accept.PDUSessionReactivationResult != nil && psiSet(accept.PDUSessionReactivationResult, 12) {
+		t.Error("PDU session 12 reported as a reactivation failure although its user-plane resources are established (TS 24.501 9.11.3.42)")
 	}
 }

--- a/internal/amf/nas/handle_service_request_reactivation_test.go
+++ b/internal/amf/nas/handle_service_request_reactivation_test.go
@@ -126,7 +126,7 @@ func TestHandleServiceRequest_ItemBuildFailure_DoesNotStrandTheClaim(t *testing.
 		t.Error("a transaction that sent no setup request must not stay open")
 	}
 
-	if !f.conn().ClaimN2SetupSession(amf.N2SetupPDUSession, 12) {
+	if !f.conn().N2Setup(amf.N2SetupPDUSession).ClaimSession(12) {
 		t.Error("the PDU session is still claimed although no setup request reached the RAN")
 	}
 }

--- a/internal/amf/nas/interworking_conformance_test.go
+++ b/internal/amf/nas/interworking_conformance_test.go
@@ -51,7 +51,7 @@ func TestInterworkingRegistrationWithoutUEStatusStaysOnTheMobilityPath(t *testin
 	req := &fgs.RegistrationRequest{GMMCapability: &fgs.GMMCapability{}}
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeMobilityUpdating
 
-	ue.SmContextList[1] = &amf.SmContext{Ref: "ref-1"}
+	ue.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
 
 	contextSetup(context.TODO(), amfInstance, ue, req, nil)
 
@@ -109,7 +109,7 @@ func TestInterworkingRegistrationAcceptReportsSessionsTheAMFDoesNotHold(t *testi
 func TestInterworkingRegistrationAcceptReportsSessionsThatSurvivedTheHandover(t *testing.T) {
 	ue, ngapSender, smfStub, amfInstance := buildMobilityRegUeAndAMF(t)
 
-	ue.SmContextList[1] = &amf.SmContext{Ref: "ref-1"}
+	ue.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
 	arrivedByHandover(ue)
 
 	req := movingFromEPCRequest()
@@ -140,7 +140,7 @@ func TestInterworkingPeriodicUpdateWithUEStatusIsNotTreatedAsInitial(t *testing.
 	req := movingFromEPCRequest()
 	ue.Conn().RegistrationType5GS = fgs.RegistrationTypePeriodicUpdating
 
-	ue.SmContextList[1] = &amf.SmContext{Ref: "ref-1"}
+	ue.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
 
 	contextSetup(context.TODO(), amfInstance, ue, req, nil)
 

--- a/internal/amf/nas/reg_initial.go
+++ b/internal/amf/nas/reg_initial.go
@@ -159,5 +159,5 @@ func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *am
 
 	metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultAccept)
 
-	amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, nil, nil, nil, nil, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
+	_ = amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, nil, nil, nil, nil, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
 }

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -218,8 +218,11 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 				} else {
 					metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultAccept)
 
-					amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
-					armOrEndN2Setup(n2Setup, ueConn, amfInstance.N2SetupGuardCfg)
+					if amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami) {
+						n2Setup.Arm(amfInstance.N2SetupGuardCfg)
+					} else {
+						n2Setup.End()
+					}
 
 					logger.From(ctx, logger.AmfLog).Info("Sent GMM registration accept")
 				}
@@ -278,8 +281,11 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 	if ueConn.UeContextRequest {
 		metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultAccept)
 
-		amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
-		n2Setup.Arm(amfInstance.N2SetupGuardCfg)
+		if amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami) {
+			n2Setup.Arm(amfInstance.N2SetupGuardCfg)
+		} else {
+			n2Setup.End()
+		}
 
 		logger.From(ctx, logger.AmfLog).Info("Sent GMM registration accept")
 

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -108,6 +108,8 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 	appendPendingN1 := func(uint8) error { return nil }
 
+	n2Setup := ueConn.N2Setup(n2SetupProcedure(ueConn.UeContextRequest))
+
 	if conn.RegistrationRequest.UplinkDataStatus != nil {
 		uplinkDataPsi := conn.RegistrationRequest.UplinkDataStatus.PSI
 		reactivationResult = new([16]bool)
@@ -116,7 +118,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 			pduSessionID := uint8(idx)
 			if smContext, ok := ue.SmContextFindByPDUSessionID(pduSessionID); ok {
 				if hasUplinkData {
-					if !ueConn.ClaimN2SetupSession(n2SetupProcedure(ueConn.UeContextRequest), pduSessionID) {
+					if !n2Setup.ClaimSession(pduSessionID) {
 						logger.From(ctx, logger.AmfLog).Debug("skipping PDU session already set up on the NG-RAN node",
 							zap.Uint8("pdu_session_id", pduSessionID))
 
@@ -196,12 +198,12 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 							wire,
 							suList,
 						); err != nil {
-							ueConn.EndN2Setup(amf.N2SetupPDUSession)
+							n2Setup.End()
 
 							return err
 						}
 
-						ueConn.ArmN2Setup(amf.N2SetupPDUSession, amfInstance.N2SetupGuardCfg)
+						n2Setup.Arm(amfInstance.N2SetupGuardCfg)
 
 						return nil
 					}); err != nil {
@@ -214,11 +216,10 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 					logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request")
 				} else {
-					ueConn.EndN2Setup(amf.N2SetupPDUSession)
-
 					metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultAccept)
 
 					amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
+					armOrEndN2Setup(n2Setup, ueConn, amfInstance.N2SetupGuardCfg)
 
 					logger.From(ctx, logger.AmfLog).Info("Sent GMM registration accept")
 				}
@@ -278,6 +279,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 		metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultAccept)
 
 		amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
+		n2Setup.Arm(amfInstance.N2SetupGuardCfg)
 
 		logger.From(ctx, logger.AmfLog).Info("Sent GMM registration accept")
 
@@ -309,17 +311,17 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					wire,
 					suList,
 				); err != nil {
-					ueConn.EndN2Setup(amf.N2SetupPDUSession)
+					n2Setup.End()
 
 					return err
 				}
 
-				ueConn.ArmN2Setup(amf.N2SetupPDUSession, amfInstance.N2SetupGuardCfg)
+				n2Setup.Arm(amfInstance.N2SetupGuardCfg)
 
 				return nil
 			}
 
-			ueConn.EndN2Setup(amf.N2SetupPDUSession)
+			n2Setup.End()
 
 			return ueConn.SendDownlinkNASTransport(ctx, wire)
 		}); err != nil {

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -116,6 +116,13 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 			pduSessionID := uint8(idx)
 			if smContext, ok := ue.SmContextFindByPDUSessionID(pduSessionID); ok {
 				if hasUplinkData {
+					if !ueConn.ClaimN2SetupSession(n2SetupProcedure(ueConn.UeContextRequest), pduSessionID) {
+						logger.From(ctx, logger.AmfLog).Debug("skipping PDU session already set up on the NG-RAN node",
+							zap.Uint8("pdu_session_id", pduSessionID))
+
+						continue
+					}
+
 					binaryDataN2SmInformation, err := amfInstance.Session.ActivateSmContext(ctx, smContext.Ref)
 					if err != nil {
 						logger.From(ctx, logger.AmfLog).Warn("SendActivateSmContextRequest Error", zap.Error(err), zap.Uint8("pduSessionID", pduSessionID))
@@ -124,8 +131,6 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 						cause := fgs.GMMCauseProtocolErrorUnspecified
 						errCause = append(errCause, uint8(cause))
 					} else {
-						ue.SetSmContextActive(pduSessionID)
-
 						if ueConn.UeContextRequest {
 							item, err := amf.PDUSessionSetupItem(pduSessionID, smContext.Snssai, nil, binaryDataN2SmInformation)
 							if err != nil {
@@ -184,13 +189,21 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultAccept)
 
 					if err := ue.SendDownlinkNAS(plain, uint8(fgs.SHTIntegrityProtectedCiphered), func(wire []byte) error {
-						return ueConn.SendPDUSessionResourceSetupRequest(
+						if err := ueConn.SendPDUSessionResourceSetupRequest(
 							ctx,
 							ue.Ambr.Uplink,
 							ue.Ambr.Downlink,
 							wire,
 							suList,
-						)
+						); err != nil {
+							ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
+							return err
+						}
+
+						ueConn.ArmN2Setup(amf.N2SetupPDUSession, amfInstance.N2SetupGuardCfg)
+
+						return nil
 					}); err != nil {
 						abortRegistration(ctx, amfInstance, ue, "send PDU session resource setup request", err)
 
@@ -201,6 +214,8 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 					logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request")
 				} else {
+					ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
 					metrics.RegistrationAttempt(metrics.RAT5G, registrationTypeName(conn.RegistrationType5GS), metrics.ResultAccept)
 
 					amf.SendRegistrationAccept(ctx, amfInstance, ue, pduSessionStatus, reactivationResult, errPduSessionID, errCause, ctxList, *operatorInfo.Guami.PlmnID, operatorInfo.Guami)
@@ -287,14 +302,24 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 		if err := ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
 			if len(suList) != 0 {
-				return ueConn.SendPDUSessionResourceSetupRequest(
+				if err := ueConn.SendPDUSessionResourceSetupRequest(
 					ctx,
 					ue.Ambr.Uplink,
 					ue.Ambr.Downlink,
 					wire,
 					suList,
-				)
+				); err != nil {
+					ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
+					return err
+				}
+
+				ueConn.ArmN2Setup(amf.N2SetupPDUSession, amfInstance.N2SetupGuardCfg)
+
+				return nil
 			}
+
+			ueConn.EndN2Setup(amf.N2SetupPDUSession)
 
 			return ueConn.SendDownlinkNASTransport(ctx, wire)
 		}); err != nil {

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -1174,7 +1174,7 @@ func TestMobilityReg_UEContextRequest_ArmsTheN2SetupGuard(t *testing.T) {
 	}
 
 	amfInstance.N2SetupGuardCfg = guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond}
-	conn.ArmN2Setup(amf.N2SetupInitialContext, amfInstance.N2SetupGuardCfg)
+	conn.N2Setup(amf.N2SetupInitialContext).Arm(amfInstance.N2SetupGuardCfg)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for conn.N2SetupOpen(amf.N2SetupInitialContext) && time.Now().Before(deadline) {
@@ -1185,7 +1185,7 @@ func TestMobilityReg_UEContextRequest_ArmsTheN2SetupGuard(t *testing.T) {
 		t.Fatal("the guard did not close the transaction")
 	}
 
-	if !conn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+	if !conn.N2Setup(amf.N2SetupInitialContext).ClaimSession(1) {
 		t.Error("PDU session 1 is still claimed after the transaction closed")
 	}
 }
@@ -1211,7 +1211,7 @@ func TestMobilityReg_InitialContextSetupNotSent_ReleasesTheClaim(t *testing.T) {
 		t.Error("no initial context setup reached the NG-RAN node, so nothing should be supervised")
 	}
 
-	if !conn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+	if !conn.N2Setup(amf.N2SetupInitialContext).ClaimSession(1) {
 		t.Error("the PDU session is still claimed although no setup was sent")
 	}
 }

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -1150,17 +1150,24 @@ func TestMobilityReg_AcceptedRegistrationCanReceiveAnN1N2Transfer(t *testing.T) 
 }
 
 func TestMobilityReg_UEContextRequest_ArmsTheN2SetupGuard(t *testing.T) {
-	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
+	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
 	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
 		t.Fatalf("CreateSmContext: %v", err)
 	}
+
+	setTestUESecurityCapability(ue)
+	ue.SetKgnbForTest(make([]byte, 32))
 
 	conn := ue.Conn()
 	conn.UeContextRequest = true
 	conn.RegistrationRequest.UplinkDataStatus = &fgs.PSIBitmap{PSI: [16]bool{1: true}}
 
 	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	if len(ngapSender.SentInitialContextSetupRequest) != 1 {
+		t.Fatalf("initial context setup requests = %d, want 1", len(ngapSender.SentInitialContextSetupRequest))
+	}
 
 	if !conn.N2SetupOpen(amf.N2SetupInitialContext) {
 		t.Fatal("the initial context setup transaction is not open; the claim key and the terminal disagree")
@@ -1180,5 +1187,31 @@ func TestMobilityReg_UEContextRequest_ArmsTheN2SetupGuard(t *testing.T) {
 
 	if !conn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
 		t.Error("PDU session 1 is still claimed after the transaction closed")
+	}
+}
+
+func TestMobilityReg_InitialContextSetupNotSent_ReleasesTheClaim(t *testing.T) {
+	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	conn := ue.Conn()
+	conn.UeContextRequest = true
+	conn.RegistrationRequest.UplinkDataStatus = &fgs.PSIBitmap{PSI: [16]bool{1: true}}
+
+	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	if len(ngapSender.SentInitialContextSetupRequest) != 0 {
+		t.Fatalf("initial context setup requests = %d, want 0 for this fixture", len(ngapSender.SentInitialContextSetupRequest))
+	}
+
+	if conn.N2SetupOpen(amf.N2SetupInitialContext) {
+		t.Error("no initial context setup reached the NG-RAN node, so nothing should be supervised")
+	}
+
+	if !conn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+		t.Error("the PDU session is still claimed although no setup was sent")
 	}
 }

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/db"
+	"github.com/ellanetworks/core/internal/guard"
 	"github.com/ellanetworks/core/internal/interworking"
 	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas"
@@ -1144,5 +1146,39 @@ func TestMobilityReg_AcceptedRegistrationCanReceiveAnN1N2Transfer(t *testing.T) 
 	})
 	if err != nil && err.Error() == "ue context not found" {
 		t.Fatal("the SMF cannot reach a UE the AMF has just accepted: no PDU session can ever be established")
+	}
+}
+
+func TestMobilityReg_UEContextRequest_ArmsTheN2SetupGuard(t *testing.T) {
+	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	if err := ue.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	conn := ue.Conn()
+	conn.UeContextRequest = true
+	conn.RegistrationRequest.UplinkDataStatus = &fgs.PSIBitmap{PSI: [16]bool{1: true}}
+
+	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	if !conn.N2SetupOpen(amf.N2SetupInitialContext) {
+		t.Fatal("the initial context setup transaction is not open; the claim key and the terminal disagree")
+	}
+
+	amfInstance.N2SetupGuardCfg = guard.TimerValue{Enable: true, ExpireTime: 10 * time.Millisecond}
+	conn.ArmN2Setup(amf.N2SetupInitialContext, amfInstance.N2SetupGuardCfg)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for conn.N2SetupOpen(amf.N2SetupInitialContext) && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if conn.N2SetupOpen(amf.N2SetupInitialContext) {
+		t.Fatal("the guard did not close the transaction")
+	}
+
+	if !conn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+		t.Error("PDU session 1 is still claimed after the transaction closed")
 	}
 }

--- a/internal/amf/ngap/handle_handover_notify_test.go
+++ b/internal/amf/ngap/handle_handover_notify_test.go
@@ -167,8 +167,8 @@ func TestHandoverNotify_DeactivatesRejectedSessions(t *testing.T) {
 	sourceRan.BindAMFForTest(amfInstance)
 
 	amfUe := amf.NewUeContext()
-	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1"}
-	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-2"}
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
+	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-2", N2: amf.N2Active}
 
 	sourceUe := amf.NewUeConnForTest(sourceRan, 10, 100, logger.AmfLog)
 	sourceUe.AMFForTest().AttachUeConn(amfUe, sourceUe)
@@ -202,7 +202,7 @@ func TestHandoverNotify_DeactivatesRejectedSessions(t *testing.T) {
 		t.Fatal("the rejected session must survive as an inactive session")
 	}
 
-	if !sc.PduSessionInactive {
+	if !sc.Inactive() {
 		t.Error("the rejected session must be marked user-plane inactive")
 	}
 
@@ -221,7 +221,7 @@ func TestHandoverNotify_FromNonTarget_Dropped(t *testing.T) {
 	sourceRan.BindAMFForTest(amfInstance)
 
 	amfUe := amf.NewUeContext()
-	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1"}
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
 
 	sourceUe := amf.NewUeConnForTest(sourceRan, 10, 100, logger.AmfLog)
 	sourceUe.AMFForTest().AttachUeConn(amfUe, sourceUe)
@@ -269,7 +269,7 @@ func TestHandoverNotify_SmfUpdateFails_StillReleasesSource(t *testing.T) {
 	sourceRan.BindAMFForTest(amfInstance)
 
 	amfUe := amf.NewUeContext()
-	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1"}
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
 
 	sourceUe := amf.NewUeConnForTest(sourceRan, 10, 100, logger.AmfLog)
 	sourceUe.AMFForTest().AttachUeConn(amfUe, sourceUe)

--- a/internal/amf/ngap/handle_initial_context_setup_failure.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure.go
@@ -38,6 +38,8 @@ func HandleInitialContextSetupFailure(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
+	ueConn.AbortICS()
+
 	if conn := amfUe.Conn(); conn != nil && conn.NASGuardActive() {
 		conn.StopNASGuard()
 

--- a/internal/amf/ngap/handle_initial_context_setup_failure_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure_test.go
@@ -131,3 +131,71 @@ func TestHandleInitialContextSetupFailure_PDUSessionFailureForwardedToSmf(t *tes
 		t.Errorf("SmContextRef = %q, want %q", fakeSmf.PduResSetupFailCalls[0].SmContextRef, "ref-session-1")
 	}
 }
+
+func TestHandleInitialContextSetupFailure_ReleasesNGRANStateForEverySession(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{}
+	amfInstance := newTestAMFWithSmfAndDB(fakeSmf)
+	ran := newTestRadio(amfInstance)
+
+	amfUe := amf.NewUeContext()
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-session-1", Snssai: &models.Snssai{Sst: 1}}
+	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-session-2", Snssai: &models.Snssai{Sst: 1}}
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+
+	if got := ueConn.ClaimN2Setup(amf.N2SetupInitialContext, []uint8{1, 2}); len(got) != 2 {
+		t.Fatalf("claimed %v, want both PDU sessions", got)
+	}
+
+	if !ueConn.ClaimICS() {
+		t.Fatal("could not claim the initial context setup")
+	}
+
+	msg := &ngap.InitialContextSetupFailure{
+		AMFUENGAPID:              ngap.Ptr(ngap.AMFUENGAPID(10)),
+		RANUENGAPID:              ngap.Ptr(ngap.RANUENGAPID(1)),
+		Cause:                    &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUnspecified},
+		PDUSessionResourceFailed: ngap.PDUSessionResourceFailedToSetupListCxtFail{{PDUSessionID: 1, Transfer: []byte{0xEE}}},
+	}
+
+	HandleInitialContextSetupFailure(context.Background(), amfInstance, ran, msg)
+
+	for _, id := range []uint8{1, 2} {
+		if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, id) {
+			t.Errorf("PDU session %d is still claimed after the NG-RAN node failed to establish the UE context", id)
+		}
+	}
+
+	if !ueConn.ClaimICS() {
+		t.Error("the initial context setup claim was not released, so a retry cannot re-attempt it")
+	}
+}
+
+func TestHandleInitialContextSetupFailure_ReleasesNGRANStateWithoutAFailedList(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{}
+	amfInstance := newTestAMFWithSmfAndDB(fakeSmf)
+	ran := newTestRadio(amfInstance)
+
+	amfUe := amf.NewUeContext()
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-session-1", Snssai: &models.Snssai{Sst: 1}}
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+		t.Fatal("could not claim the PDU session")
+	}
+
+	msg := &ngap.InitialContextSetupFailure{
+		AMFUENGAPID: ngap.Ptr(ngap.AMFUENGAPID(10)),
+		RANUENGAPID: ngap.Ptr(ngap.RANUENGAPID(1)),
+		Cause:       &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUnspecified},
+	}
+
+	HandleInitialContextSetupFailure(context.Background(), amfInstance, ran, msg)
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+		t.Error("a failure carrying no PDU session list must still clear the NG-RAN state")
+	}
+}

--- a/internal/amf/ngap/handle_initial_context_setup_failure_test.go
+++ b/internal/amf/ngap/handle_initial_context_setup_failure_test.go
@@ -144,7 +144,7 @@ func TestHandleInitialContextSetupFailure_ReleasesNGRANStateForEverySession(t *t
 	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
 	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
 
-	if got := ueConn.ClaimN2Setup(amf.N2SetupInitialContext, []uint8{1, 2}); len(got) != 2 {
+	if got := ueConn.N2Setup(amf.N2SetupInitialContext).Claim([]uint8{1, 2}); len(got) != 2 {
 		t.Fatalf("claimed %v, want both PDU sessions", got)
 	}
 
@@ -162,7 +162,7 @@ func TestHandleInitialContextSetupFailure_ReleasesNGRANStateForEverySession(t *t
 	HandleInitialContextSetupFailure(context.Background(), amfInstance, ran, msg)
 
 	for _, id := range []uint8{1, 2} {
-		if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, id) {
+		if !ueConn.N2Setup(amf.N2SetupInitialContext).ClaimSession(id) {
 			t.Errorf("PDU session %d is still claimed after the NG-RAN node failed to establish the UE context", id)
 		}
 	}
@@ -183,7 +183,7 @@ func TestHandleInitialContextSetupFailure_ReleasesNGRANStateWithoutAFailedList(t
 	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
 	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+	if !ueConn.N2Setup(amf.N2SetupInitialContext).ClaimSession(1) {
 		t.Fatal("could not claim the PDU session")
 	}
 
@@ -195,7 +195,7 @@ func TestHandleInitialContextSetupFailure_ReleasesNGRANStateWithoutAFailedList(t
 
 	HandleInitialContextSetupFailure(context.Background(), amfInstance, ran, msg)
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+	if !ueConn.N2Setup(amf.N2SetupInitialContext).ClaimSession(1) {
 		t.Error("a failure carrying no PDU session list must still clear the NG-RAN state")
 	}
 }

--- a/internal/amf/ngap/handle_initial_context_setup_response.go
+++ b/internal/amf/ngap/handle_initial_context_setup_response.go
@@ -45,6 +45,8 @@ func HandleInitialContextSetupResponse(ctx context.Context, amfInstance *amf.AMF
 				continue
 			}
 
+			amfUe.SetSmContextActive(pduSessionID)
+
 			err := amfInstance.Session.UpdateSmContextN2InfoPduResSetupRsp(ctx, smContext.Ref, transfer)
 			if err != nil {
 				logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupResponseTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
@@ -77,6 +79,8 @@ func HandleInitialContextSetupResponse(ctx context.Context, amfInstance *amf.AMF
 	// A UE returning to CM-CONNECTED applies any policy change deferred while it was
 	// idle. Skipped mid-registration: the session was just established with the
 	// current policy and the UE is not yet Registered.
+	ueConn.EndN2Setup(amf.N2SetupInitialContext)
+
 	if amfUe.State() == amf.Registered {
 		amfInstance.ReconcileSessionsForUE(ctx, amfUe)
 	}

--- a/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_notify_test.go
@@ -76,7 +76,7 @@ func TestPDUSessionResourceNotify_ReleasedSessionDeactivated(t *testing.T) {
 		t.Fatal("SmContext was removed instead of marked inactive")
 	}
 
-	if !sc.PduSessionInactive {
+	if !sc.Inactive() {
 		t.Error("expected SmContext to be marked inactive")
 	}
 }

--- a/internal/amf/ngap/handle_pdu_session_resource_release_response_test.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_release_response_test.go
@@ -60,7 +60,7 @@ func TestHandlePDUSessionResourceReleaseResponse_UEFoundWithReleasedSessions(t *
 		t.Fatal("expected SmContext to still exist")
 	}
 
-	if !smCtx.PduSessionInactive {
-		t.Error("expected PduSessionInactive to be true")
+	if !smCtx.Inactive() {
+		t.Error("expected the session to be N2Inactive")
 	}
 }

--- a/internal/amf/ngap/handle_pdu_session_resource_setup_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_setup_response.go
@@ -49,6 +49,8 @@ func HandlePDUSessionResourceSetupResponse(ctx context.Context, amfInstance *amf
 				continue
 			}
 
+			amfUe.SetSmContextActive(pduSessionID)
+
 			err := amfInstance.Session.UpdateSmContextN2InfoPduResSetupRsp(ctx, smContext.Ref, transfer)
 			if err != nil {
 				logger.WithTrace(ctx, ueConn.Log()).Error("SendUpdateSmContextN2Info[PDUSessionResourceSetupResponseTransfer] Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
@@ -78,6 +80,8 @@ func HandlePDUSessionResourceSetupResponse(ctx context.Context, amfInstance *amf
 
 	// A UE whose user plane was just (re)established applies any policy change deferred
 	// while it was idle.
+	ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
 	if amfUe.State() == amf.Registered {
 		amfInstance.ReconcileSessionsForUE(ctx, amfUe)
 	}

--- a/internal/amf/ngap/handle_ue_context_release_complete.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete.go
@@ -29,5 +29,13 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 	// Cancel the release-supervision guard so it does not also run the cleanup.
 	ueConn.StopReleaseGuard()
 
-	amfInstance.ReleaseUeConn(ctx, ueConn)
+	var served []uint8
+	if msg.PDUSessionResourceList != nil {
+		served = make([]uint8, 0, len(msg.PDUSessionResourceList))
+		for _, item := range msg.PDUSessionResourceList {
+			served = append(served, uint8(item.PDUSessionID))
+		}
+	}
+
+	amfInstance.ReleaseUeConnServedBy(ctx, ueConn, served)
 }

--- a/internal/amf/ngap/handle_ue_context_release_complete_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete_test.go
@@ -99,7 +99,7 @@ func TestHandleUEContextReleaseComplete_DeactivatesOnlyTheSessionsTheRANReported
 	amfUe := amf.NewUeContext()
 	amfUe.ForceStateForTest(amf.Registered)
 	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
-	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-2", N2: amf.N2Active}
+	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-2", N2: amf.N2Inactive}
 
 	ueConn := amf.NewUeConnForTest(ran, 1, 100, logger.AmfLog)
 	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
@@ -115,7 +115,36 @@ func TestHandleUEContextReleaseComplete_DeactivatesOnlyTheSessionsTheRANReported
 	})
 
 	if len(smfSbi.DeactivateSmContextCalls) != 1 || smfSbi.DeactivateSmContextCalls[0] != "ref-1" {
-		t.Errorf("DeactivateSmContext calls = %v, want only ref-1: the NG-RAN node served only PDU session 1 (TS 23.502 4.2.6 step 5)",
+		t.Errorf("DeactivateSmContext calls = %v, want only ref-1: PDU session 2 has no NG-RAN resources to deactivate",
+			smfSbi.DeactivateSmContextCalls)
+	}
+}
+
+func TestHandleUEContextReleaseComplete_DeactivatesASessionTheRANStoppedReporting(t *testing.T) {
+	smfSbi := &fakeSmfSbi{}
+	amfInstance := newTestAMFWithSmfAndDB(smfSbi)
+	ran := newTestRadio(amfInstance)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
+	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-2", N2: amf.N2Active}
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 100, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+	amfInstance.SetRadioForTest(new(sctp.SCTPConn), ran)
+
+	amfID := ngap.AMFUENGAPID(100)
+	ranID := ngap.RANUENGAPID(1)
+
+	HandleUEContextReleaseComplete(context.Background(), amfInstance, ran, &ngap.UEContextReleaseComplete{
+		AMFUENGAPID:            &amfID,
+		RANUENGAPID:            &ranID,
+		PDUSessionResourceList: ngap.PDUSessionResourceListCxtRelCpl{{PDUSessionID: 1}},
+	})
+
+	if len(smfSbi.DeactivateSmContextCalls) != 2 {
+		t.Errorf("DeactivateSmContext calls = %v, want both: a session the AMF holds on the NG-RAN but the node did not report would leave the UPF with a stale AN tunnel",
 			smfSbi.DeactivateSmContextCalls)
 	}
 }

--- a/internal/amf/ngap/handle_ue_context_release_complete_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete_test.go
@@ -90,3 +90,60 @@ func TestHandleUEContextReleaseComplete_MissingUENGAPIDs(t *testing.T) {
 		t.Fatalf("expected no ErrorIndication, got %d", len(sender.SentErrorIndications))
 	}
 }
+
+func TestHandleUEContextReleaseComplete_DeactivatesOnlyTheSessionsTheRANReported(t *testing.T) {
+	smfSbi := &fakeSmfSbi{}
+	amfInstance := newTestAMFWithSmfAndDB(smfSbi)
+	ran := newTestRadio(amfInstance)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
+	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-2", N2: amf.N2Active}
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 100, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+	amfInstance.SetRadioForTest(new(sctp.SCTPConn), ran)
+
+	amfID := ngap.AMFUENGAPID(100)
+	ranID := ngap.RANUENGAPID(1)
+
+	HandleUEContextReleaseComplete(context.Background(), amfInstance, ran, &ngap.UEContextReleaseComplete{
+		AMFUENGAPID:            &amfID,
+		RANUENGAPID:            &ranID,
+		PDUSessionResourceList: ngap.PDUSessionResourceListCxtRelCpl{{PDUSessionID: 1}},
+	})
+
+	if len(smfSbi.DeactivateSmContextCalls) != 1 || smfSbi.DeactivateSmContextCalls[0] != "ref-1" {
+		t.Errorf("DeactivateSmContext calls = %v, want only ref-1: the NG-RAN node served only PDU session 1 (TS 23.502 4.2.6 step 5)",
+			smfSbi.DeactivateSmContextCalls)
+	}
+}
+
+func TestHandleUEContextReleaseComplete_NoReportedListDeactivatesEverySession(t *testing.T) {
+	smfSbi := &fakeSmfSbi{}
+	amfInstance := newTestAMFWithSmfAndDB(smfSbi)
+	ran := newTestRadio(amfInstance)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+	amfUe.SmContextList[1] = &amf.SmContext{Ref: "ref-1", N2: amf.N2Active}
+	amfUe.SmContextList[2] = &amf.SmContext{Ref: "ref-2", N2: amf.N2Active}
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 100, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+	amfInstance.SetRadioForTest(new(sctp.SCTPConn), ran)
+
+	amfID := ngap.AMFUENGAPID(100)
+	ranID := ngap.RANUENGAPID(1)
+
+	HandleUEContextReleaseComplete(context.Background(), amfInstance, ran, &ngap.UEContextReleaseComplete{
+		AMFUENGAPID: &amfID,
+		RANUENGAPID: &ranID,
+	})
+
+	if len(smfSbi.DeactivateSmContextCalls) != 2 {
+		t.Errorf("DeactivateSmContext calls = %v, want both sessions when the NG-RAN node reports none",
+			smfSbi.DeactivateSmContextCalls)
+	}
+}

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -25,6 +25,10 @@ func keepsConnectionForPendingDownlink(cause ngap.Cause, amfUe *amf.UeContext, u
 		return true
 	}
 
+	if ueConn.N2SetupOpen(amf.N2SetupInitialContext) || ueConn.N2SetupOpen(amf.N2SetupPDUSession) {
+		return true
+	}
+
 	return ueConn.NASGuardActive()
 }
 

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -16,6 +16,18 @@ import (
 // CauseRadioNetwork "unspecified").
 var causeReleaseUnspecified = ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUnspecified}
 
+func keepsConnectionForPendingDownlink(cause ngap.Cause, amfUe *amf.UeContext, ueConn *amf.UeConn) bool {
+	if cause.Group != ngap.CauseGroupRadioNetwork || cause.Value != ngap.CauseRadioNetworkUserInactivity {
+		return false
+	}
+
+	if amfUe != nil && amfUe.N1N2Message() != nil {
+		return true
+	}
+
+	return ueConn.NASGuardActive()
+}
+
 // HandleUEContextReleaseRequest handles an NG-RAN-initiated UE Context Release
 // Request (inactivity or radio-link failure), starting the release procedure
 // (TS 38.413 §8.3.2).
@@ -46,6 +58,13 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 	}
 
 	amfUe := ueConn.UeContext()
+
+	if keepsConnectionForPendingDownlink(cause, amfUe, ueConn) {
+		logger.WithTrace(ctx, ueConn.Log()).Info("keeping the NG connection: user inactivity reported while downlink traffic or signalling is pending")
+
+		return
+	}
+
 	if amfUe != nil {
 		if amfUe.State() == amf.Registered {
 			logger.WithTrace(ctx, ueConn.Log()).Info("Ue Context in GMM-Registered")

--- a/internal/amf/ngap/handle_ue_context_release_request_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_request_test.go
@@ -151,7 +151,7 @@ func TestHandleUEContextReleaseRequest_UserInactivityDuringAnN2Setup(t *testing.
 	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
 	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
 
-	if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+	if !ueConn.N2Setup(amf.N2SetupInitialContext).ClaimSession(1) {
 		t.Fatal("could not open an initial context setup transaction")
 	}
 

--- a/internal/amf/ngap/handle_ue_context_release_request_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_request_test.go
@@ -139,3 +139,40 @@ func TestHandleUEContextReleaseRequest_OtherCauseReleasesDespitePendingMTTraffic
 			len(sender.SentUEContextReleaseCommands))
 	}
 }
+
+func TestHandleUEContextReleaseRequest_UserInactivityDuringAnN2Setup(t *testing.T) {
+	amfInstance := newTestAMF()
+	ran := newTestRadio(amfInstance)
+	sender := ran.Conn.(*fakeNGAPSender)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+
+	if !ueConn.ClaimN2SetupSession(amf.N2SetupInitialContext, 1) {
+		t.Fatal("could not open an initial context setup transaction")
+	}
+
+	msg := &ngap.UEContextReleaseRequest{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 1,
+		Cause:       &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUserInactivity},
+	}
+
+	HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, msg)
+
+	if len(sender.SentUEContextReleaseCommands) != 0 {
+		t.Errorf("UEContextReleaseCommand count = %d, want 0: an outstanding PDU session resource setup is downlink signalling (TS 38.413 8.3.2.2)",
+			len(sender.SentUEContextReleaseCommands))
+	}
+
+	ueConn.EndN2Setup(amf.N2SetupInitialContext)
+
+	HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, msg)
+
+	if len(sender.SentUEContextReleaseCommands) != 1 {
+		t.Errorf("UEContextReleaseCommand count = %d, want 1 once the setup has finished", len(sender.SentUEContextReleaseCommands))
+	}
+}

--- a/internal/amf/ngap/handle_ue_context_release_request_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_request_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/ngap"
 )
 
@@ -84,5 +85,57 @@ func TestSendUEContextReleaseCommand_Idempotent(t *testing.T) {
 
 	if len(sender.SentUEContextReleaseCommands) != 1 {
 		t.Fatalf("expected a single UE Context Release Command, got %d", len(sender.SentUEContextReleaseCommands))
+	}
+}
+
+func TestHandleUEContextReleaseRequest_UserInactivityWithPendingMTTraffic(t *testing.T) {
+	amfInstance := newTestAMF()
+	ran := newTestRadio(amfInstance)
+	sender := ran.Conn.(*fakeNGAPSender)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+	amfUe.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1})
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+
+	msg := &ngap.UEContextReleaseRequest{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 1,
+		Cause:       &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUserInactivity},
+	}
+
+	HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, msg)
+
+	if len(sender.SentUEContextReleaseCommands) != 0 {
+		t.Errorf("UEContextReleaseCommand count = %d, want 0: the AMF is aware of pending MT traffic (TS 23.502 4.2.6 step 1)",
+			len(sender.SentUEContextReleaseCommands))
+	}
+}
+
+func TestHandleUEContextReleaseRequest_OtherCauseReleasesDespitePendingMTTraffic(t *testing.T) {
+	amfInstance := newTestAMF()
+	ran := newTestRadio(amfInstance)
+	sender := ran.Conn.(*fakeNGAPSender)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+	amfUe.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1})
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+
+	msg := &ngap.UEContextReleaseRequest{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 1,
+		Cause:       &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkRadioConnectionWithUELost},
+	}
+
+	HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, msg)
+
+	if len(sender.SentUEContextReleaseCommands) != 1 {
+		t.Errorf("UEContextReleaseCommand count = %d, want 1: only user inactivity is conditional on pending downlink",
+			len(sender.SentUEContextReleaseCommands))
 	}
 }

--- a/internal/amf/ngap/handover_conformance_test.go
+++ b/internal/amf/ngap/handover_conformance_test.go
@@ -61,7 +61,7 @@ func newN2Env(t *testing.T, fakeSmf *fakeSmfSbi, sessions ...uint8) *n2Env {
 	amfUe.Ambr = &models.Ambr{Uplink: models.MustParseBitRate("1 Gbps"), Downlink: models.MustParseBitRate("1 Gbps")}
 
 	for _, id := range sessions {
-		amfUe.SmContextList[id] = &amf.SmContext{Ref: smContextRefFor(id), Snssai: &models.Snssai{Sst: 1}}
+		amfUe.SmContextList[id] = &amf.SmContext{Ref: smContextRefFor(id), Snssai: &models.Snssai{Sst: 1}, N2: amf.N2Active}
 	}
 
 	sourceUe := amf.NewUeConnForTest(sourceRan, sourceRanUeNgapID, sourceAmfUeNgapID, logger.AmfLog)
@@ -652,7 +652,7 @@ func TestN2HandoverNotifyDeactivatesTheSessionTheTargetRefused(t *testing.T) {
 		t.Fatal("the refused PDU session must survive the handover")
 	}
 
-	if !sc.PduSessionInactive {
+	if !sc.Inactive() {
 		t.Error("the refused PDU session must be marked user-plane inactive")
 	}
 }

--- a/internal/amf/ngap/path_switch_conformance_test.go
+++ b/internal/amf/ngap/path_switch_conformance_test.go
@@ -158,7 +158,7 @@ func TestPathSwitchFailedSessionDeactivatesUserPlane(t *testing.T) {
 		t.Fatal("the PDU session must survive a failed switch")
 	}
 
-	if !sc.PduSessionInactive {
+	if !sc.Inactive() {
 		t.Error("the PDU session must be marked user-plane inactive")
 	}
 }

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -11,6 +11,7 @@ package amf
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -486,6 +487,10 @@ func (ueConn *UeConn) StopReleaseGuard() {
 }
 
 func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
+	a.ReleaseUeConnServedBy(ctx, ueConn, nil)
+}
+
+func (a *AMF) ReleaseUeConnServedBy(ctx context.Context, ueConn *UeConn, served []uint8) {
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
@@ -497,6 +502,10 @@ func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {
 
 	if amfUe.State() == Registered {
 		for _, sr := range amfUe.SmContextRefs() {
+			if served != nil && !slices.Contains(served, sr.PduSessionID) {
+				continue
+			}
+
 			if err := a.Session.DeactivateSmContext(ctx, sr.Ref); err != nil {
 				logger.From(ctx, ueConn.Log()).Warn("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
 			}

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -502,7 +502,7 @@ func (a *AMF) ReleaseUeConnServedBy(ctx context.Context, ueConn *UeConn, served 
 
 	if amfUe.State() == Registered {
 		for _, sr := range amfUe.SmContextRefs() {
-			if served != nil && !slices.Contains(served, sr.PduSessionID) {
+			if len(served) > 0 && !slices.Contains(served, sr.PduSessionID) && sr.Inactive {
 				continue
 			}
 

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -73,6 +73,7 @@ type UeConn struct {
 	// from the NGAP dispatch goroutine, the SMF N1N2 path, and the NAS-guard timer
 	// callback, so it is atomic; mutate it only through ICS()/ClaimICS()/MarkICS*/ResetICS.
 	ics        atomic.Int32
+	n2Setups   n2SetupTxns
 	inboundNAS atomic.Uint32
 	log        atomic.Pointer[zap.Logger]
 	// releasing gates a UE Context Release Command so a second one is not sent for the
@@ -336,6 +337,11 @@ func (ueConn *UeConn) SentFrom5GMMIdle() bool {
 // failed so a retry re-attempts the context setup.
 func (ueConn *UeConn) ResetICS() {
 	ueConn.ics.Store(int32(ICSNotStarted))
+}
+
+func (ueConn *UeConn) AbortICS() {
+	ueConn.ResetICS()
+	ueConn.EndN2Setup(N2SetupInitialContext)
 }
 
 // The registration/auth status fields (RegistrationType5GS, IdentityTypeUsedForRegistration,

--- a/internal/amf/reconcile_sessions.go
+++ b/internal/amf/reconcile_sessions.go
@@ -73,6 +73,8 @@ func (a *AMF) ReconcileSessionsToRAN(
 			continue
 		}
 
+		ue.SetSmContextActive(s.PduSessionID)
+
 		result.Applied = append(result.Applied, AppliedSession{PduSessionID: s.PduSessionID, Transfer: n2Rsp})
 	}
 

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -275,10 +275,10 @@ func SendRegistrationAccept(
 	pduSessionResourceSetupList ngap.PDUSessionResourceSetupListCxtReq,
 	equivalentPlmnID models.PlmnID,
 	supportedGUAMI *models.Guami,
-) {
+) bool {
 	if ue == nil {
 		logger.AmfLog.Error("cannot send Registration Accept: ue is nil")
-		return
+		return false
 	}
 
 	ctx, span := nasSendTracer.Start(ctx, "nas/send_registration_accept",
@@ -292,20 +292,20 @@ func SendRegistrationAccept(
 	guti, err := amfInstance.Guti(supportedGUAMI, ue)
 	if err != nil {
 		ReportProtectFailure(ctx, ue, "5G-GUTI for registration accept", err)
-		return
+		return false
 	}
 
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		logger.From(ctx, logger.AmfLog).Error("cannot send Registration Accept: ueConn is nil")
-		return
+		return false
 	}
 
 	plain, err := BuildRegistrationAccept(amfInstance, ue, guti, pDUSessionStatus, reactivationResult, errPduSessionID, errCause, equivalentPlmnID)
 	if err != nil {
 		ReportProtectFailure(ctx, ue, "registration accept", err)
 
-		return
+		return false
 	}
 
 	sht := uint8(fgs.SHTIntegrityProtectedCiphered)
@@ -315,6 +315,8 @@ func SendRegistrationAccept(
 	}
 
 	kgnb, ueSecCap := ue.Kgnb(), ue.UESecCap()
+
+	initialContextSetupSent := false
 
 	if err := ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
 		if ueConn.UeContextRequest {
@@ -335,6 +337,8 @@ func SendRegistrationAccept(
 			); err != nil {
 				logger.From(ctx, logger.AmfLog).Warn("failed to send initial context setup request", zap.Error(err))
 			} else {
+				initialContextSetupSent = true
+
 				logger.From(ctx, logger.AmfLog).Info("Sent NGAP initial context setup request")
 			}
 
@@ -351,7 +355,7 @@ func SendRegistrationAccept(
 	}); err != nil {
 		ReportProtectFailure(ctx, ue, "registration accept", err)
 
-		return
+		return false
 	}
 
 	if amfInstance.NASGuardCfg.Enable {
@@ -409,6 +413,8 @@ func SendRegistrationAccept(
 			ue.ClearRegistrationRequestData()
 		})
 	}
+
+	return initialContextSetupSent
 }
 
 func ArmRegistrationAcceptGuard(amfInstance *AMF, ue *UeContext, plain []byte) {

--- a/internal/amf/ue_accessors.go
+++ b/internal/amf/ue_accessors.go
@@ -33,7 +33,7 @@ func (ue *UeContext) SmContextRefs() []SmContextRef {
 
 	refs := make([]SmContextRef, 0, len(ue.SmContextList))
 	for id, sc := range ue.SmContextList {
-		refs = append(refs, SmContextRef{Ref: sc.Ref, PduSessionID: id, Inactive: sc.PduSessionInactive})
+		refs = append(refs, SmContextRef{Ref: sc.Ref, PduSessionID: id, Inactive: sc.Inactive()})
 	}
 
 	return refs

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -211,6 +211,8 @@ func mockSessionForSubscriber(amfInstance *amf.AMF, testSmfInstance *smf.SMF, im
 		return fmt.Errorf("failed to create SmContext: %w", err)
 	}
 
+	ue.SetSmContextActive(pduSessionID)
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

Fixes a bug where the core sometimes set up the same data session twice, and makes it track properly whether the radio actually holds each session.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
