### PR TITLE
feat: expose UE connection state and retain last-seen radio across idle

### DIFF
--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -36,9 +36,11 @@ type DeleteSubscriberOptions struct {
 // SubscriberStatus is the lightweight status carried in list responses.
 type SubscriberStatus struct {
 	Registered       bool     `json:"registered"`
+	ConnectionState  string   `json:"connection_state,omitempty"`
 	RadioAccessTypes []string `json:"radio_access_types,omitempty"`
 	NumSessions      int      `json:"num_sessions"`
 	LastSeenAt       string   `json:"last_seen_at,omitempty"`
+	LastSeenRadio    string   `json:"last_seen_radio,omitempty"`
 }
 
 // Subscriber is the summary form returned by ListSubscribers.
@@ -46,7 +48,6 @@ type Subscriber struct {
 	Imsi        string           `json:"imsi"`
 	ProfileName string           `json:"profile_name"`
 	Description string           `json:"description,omitempty"`
-	Radio       string           `json:"radio,omitempty"`
 	Status      SubscriberStatus `json:"status"`
 }
 
@@ -67,6 +68,7 @@ type ListSubscribersResponse struct {
 // SubscriberDetailStatus is the rich status carried in GetSubscriber responses.
 type SubscriberDetailStatus struct {
 	Registered         bool     `json:"registered"`
+	ConnectionState    string   `json:"connection_state,omitempty"`
 	RadioAccessTypes   []string `json:"radio_access_types,omitempty"`
 	Imei               string   `json:"imei"`
 	CipheringAlgorithm string   `json:"ciphering_algorithm"`

--- a/client/subscribers_test.go
+++ b/client/subscribers_test.go
@@ -182,7 +182,7 @@ func TestListSubscribers_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"items": [{"imsi": "001010100000022", "profile_name": "default", "radio": "gnb-01", "status": {"registered": true, "num_sessions": 1, "last_seen_at": "2025-01-01T00:00:00Z"}}], "page": 1, "per_page": 10, "total_count": 1}`),
+			Result:     []byte(`{"items": [{"imsi": "001010100000022", "profile_name": "default", "status": {"registered": true, "connection_state": "idle", "num_sessions": 1, "last_seen_at": "2025-01-01T00:00:00Z", "last_seen_radio": "gnb-01"}}], "page": 1, "per_page": 10, "total_count": 1}`),
 		},
 		err: nil,
 	}
@@ -207,8 +207,12 @@ func TestListSubscribers_Success(t *testing.T) {
 	}
 
 	sub := resp.Items[0]
-	if sub.Radio != "gnb-01" {
-		t.Fatalf("expected radio %q, got %q", "gnb-01", sub.Radio)
+	if sub.Status.LastSeenRadio != "gnb-01" {
+		t.Fatalf("expected last_seen_radio %q, got %q", "gnb-01", sub.Status.LastSeenRadio)
+	}
+
+	if sub.Status.ConnectionState != "idle" {
+		t.Fatalf("expected connection_state %q, got %q", "idle", sub.Status.ConnectionState)
 	}
 
 	if sub.Status.LastSeenAt != "2025-01-01T00:00:00Z" {

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -20,7 +20,7 @@ This path returns the list of network subscribers, ordered by IMSI.
 | ---------- | ----- | ---- | ------- | ------- | ----------------------------- |
 | `page`     | query | int  | `1`     | `>= 1`  | 1-based page index.           |
 | `per_page` | query | int  | `25`    | `1…100` | Number of items per page.     |
-| `radio`    | query | str  |         |         | Filter by radio name. Returns only subscribers connected to the specified radio. |
+| `radio`    | query | str  |         |         | Filter by radio name. Returns registered subscribers whose last-seen radio is this one, so an idle subscriber still matches the radio that last served it. |
 | `data_network` | query | str |     |         | Filter by data network name. Returns only subscribers whose profile reaches it. |
 | `search`   | query | str  |         | ≤ 254 chars | Filter by IMSI or description substring. The value is matched literally, so `%` and `_` are not wildcards. Case is ignored for ASCII letters only. |
 
@@ -36,8 +36,11 @@ This path returns the list of network subscribers, ordered by IMSI.
                 "description": "Warehouse gate reader",
                 "status": {
                     "registered": true,
+                    "connection_state": "connected",
                     "radio_access_types": ["5G"],
-                    "num_sessions": 1
+                    "num_sessions": 1,
+                    "last_seen_at": "2026-03-16T12:34:56Z",
+                    "last_seen_radio": "gNB-1"
                 }
             }
         ],
@@ -49,6 +52,10 @@ This path returns the list of network subscribers, ordered by IMSI.
 ```
 
 `description` is omitted from an item when that subscriber has no note.
+
+`connection_state` is `connected` while the device holds a signalling connection to the core and `idle` otherwise. It is independent of `registered`: a device part-way through registration is `connected` while `registered` is still `false`. It is omitted when the core holds no context for the device.
+
+`last_seen_radio` is the radio that last served the device. The core knows the serving radio only while the device is connected, so on an idle or deregistered device this is last known and may be stale. It is held in memory by the serving node, not shared across cluster nodes, and reset on restart.
 
 ## Create a Subscriber
 
@@ -122,6 +129,7 @@ None
     "description": "Warehouse gate reader",
     "status": {
       "registered": true,
+      "connection_state": "connected",
       "radio_access_types": ["5G"],
       "imei": "359881234567890",
       "ciphering_algorithm": "SNOW3G",

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -53,10 +53,6 @@ This path returns the list of network subscribers, ordered by IMSI.
 
 `description` is omitted from an item when that subscriber has no note.
 
-`connection_state` is `connected` while the device holds a signalling connection to the core and `idle` otherwise. It is independent of `registered`: a device part-way through registration is `connected` while `registered` is still `false`. It is omitted when the core holds no context for the device.
-
-`last_seen_radio` is the radio that last served the device. The core knows the serving radio only while the device is connected, so on an idle or deregistered device this is last known and may be stale. It is held in memory by the serving node, not shared across cluster nodes, and reset on restart.
-
 ## Create a Subscriber
 
 This path creates a new network subscriber.

--- a/integration/api_matrix_ha_subscribers_test.go
+++ b/integration/api_matrix_ha_subscribers_test.go
@@ -162,7 +162,7 @@ func runSubscribersHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 			t.Fatalf("node %d Status.Registered: got true, want false (subscriber never attached)", i+1)
 		}
 
-		if got.Status.Imei != "" || got.Status.CipheringAlgorithm != "" ||
+		if got.Status.ConnectionState != "" || got.Status.Imei != "" || got.Status.CipheringAlgorithm != "" ||
 			got.Status.IntegrityAlgorithm != "" || got.Status.LastSeenAt != "" ||
 			got.Status.LastSeenRadio != "" {
 			t.Fatalf("node %d Status: expected zero-valued strings on a never-attached subscriber, got %+v",

--- a/integration/api_matrix_subscribers_test.go
+++ b/integration/api_matrix_subscribers_test.go
@@ -157,7 +157,7 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 		t.Fatalf("Status.Registered: got true, want false (subscriber never attached)")
 	}
 
-	if got.Status.Imei != "" || got.Status.CipheringAlgorithm != "" ||
+	if got.Status.ConnectionState != "" || got.Status.Imei != "" || got.Status.CipheringAlgorithm != "" ||
 		got.Status.IntegrityAlgorithm != "" || got.Status.LastSeenAt != "" ||
 		got.Status.LastSeenRadio != "" {
 		t.Fatalf("Status: expected zero-valued strings on a never-attached subscriber, got %+v", got.Status)

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -161,6 +161,7 @@ type AMF struct {
 	conns                    map[int64]*UeConn        // UE-associated NGAP connections keyed by AMF-UE-NGAP-ID
 	reg                      *radioreg.Registry[NGAPWriter, string, *Radio]
 	relocatingFromEPS        map[etsi.SUPI]*fromEPSRelocation
+	lastSeen                 lastSeenStore
 	RelativeCapacity         int64
 	Name                     string
 	NetworkFeatureSupport5GS *NetworkFeatureSupport5GS
@@ -308,6 +309,10 @@ func (amf *AMF) DeregisterAndRemoveUeContext(ctx context.Context, ue *UeContext)
 		}
 	}
 
+	if supi := ue.Supi(); supi.IsIMSI() {
+		amf.lastSeen.record(supi.IMSI(), "", "", ue.lastSeenTime())
+	}
+
 	amf.mu.Lock()
 	amf.releaseTmsisLocked(ue)
 	amf.endRelocationFromEPSLocked(ue.supi, ue)
@@ -412,6 +417,15 @@ func radioIDKey(id *models.GlobalRanNodeID) (string, bool) {
 	}
 
 	return "", false
+}
+
+func radioIDOf(radio *Radio) string {
+	key, ok := radio.IDKey()
+	if !ok {
+		return ""
+	}
+
+	return key
 }
 
 func (amf *AMF) FindConnectedRadioByRanID(ranNodeID models.GlobalRanNodeID) (*Radio, bool) {
@@ -722,6 +736,7 @@ func (a *AMF) NewUeConn(radio *Radio, ranUeNgapID models.RanUeNgapID) (*UeConn, 
 		RanUeNgapID: ranUeNgapID,
 		conn:        radio.Conn,
 		radioName:   radio.name,
+		radioID:     radioIDOf(radio),
 		amf:         a,
 	}
 	ueConn.setLog(radio.Log.With(logger.AmfUeNgapID(amfUeNgapID)))

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -735,10 +735,9 @@ func (a *AMF) NewUeConn(radio *Radio, ranUeNgapID models.RanUeNgapID) (*UeConn, 
 		AmfUeNgapID: amfUeNgapID,
 		RanUeNgapID: ranUeNgapID,
 		conn:        radio.Conn,
-		radioName:   radio.name,
-		radioID:     radioIDOf(radio),
 		amf:         a,
 	}
+	ueConn.setRadio(radioIDOf(radio), radio.name)
 	ueConn.setLog(radio.Log.With(logger.AmfUeNgapID(amfUeNgapID)))
 
 	a.mu.Lock()

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -217,6 +217,16 @@ func (amf *AMF) CommitUEIdentity(ctx context.Context, ue *UeContext, _ AuthProof
 	superseded = superseded && old != ue
 	amf.UEs[ue.supi] = ue
 	ue.smf = amf.Session
+
+	if ue.supi.IsIMSI() {
+		var radioID, radioName string
+		if conn := ue.active.Load(); conn != nil {
+			radioID, radioName = conn.radioIDName()
+		}
+
+		amf.lastSeen.record(ue.supi.IMSI(), radioID, radioName, ue.lastSeenTime())
+	}
+
 	amf.mu.Unlock()
 
 	if superseded {
@@ -310,7 +320,7 @@ func (amf *AMF) DeregisterAndRemoveUeContext(ctx context.Context, ue *UeContext)
 	}
 
 	if supi := ue.Supi(); supi.IsIMSI() {
-		amf.lastSeen.record(supi.IMSI(), "", "", ue.lastSeenTime())
+		amf.lastSeen.refresh(supi.IMSI(), "", "", ue.lastSeenTime())
 	}
 
 	amf.mu.Lock()
@@ -737,10 +747,10 @@ func (a *AMF) NewUeConn(radio *Radio, ranUeNgapID models.RanUeNgapID) (*UeConn, 
 		conn:        radio.Conn,
 		amf:         a,
 	}
-	ueConn.setRadio(radioIDOf(radio), radio.name)
 	ueConn.setLog(radio.Log.With(logger.AmfUeNgapID(amfUeNgapID)))
 
 	a.mu.Lock()
+	ueConn.setRadio(radioIDOf(radio), radio.name)
 	a.conns[int64(amfUeNgapID)] = ueConn
 	a.mu.Unlock()
 

--- a/internal/amf/amf_test.go
+++ b/internal/amf/amf_test.go
@@ -311,7 +311,7 @@ func TestGetUESnapshot(t *testing.T) {
 
 	supi := newSUPI(t, "001010000000011")
 
-	if _, _, _, ok := amfInstance.LookupSubscriber(supi); ok {
+	if _, _, ok := amfInstance.LookupSubscriber(supi); ok {
 		t.Fatal("expected no snapshot for missing UE")
 	}
 
@@ -322,7 +322,7 @@ func TestGetUESnapshot(t *testing.T) {
 		ue.SetLastSeenForTest(now)
 	})
 
-	snap, _, _, ok := amfInstance.LookupSubscriber(supi)
+	snap, _, ok := amfInstance.LookupSubscriber(supi)
 	if !ok {
 		t.Fatal("expected snapshot for existing Registered UE")
 	}

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -313,7 +313,7 @@ func (ue *UeContext) Snapshot() UESnapshot {
 		CipheringAlgorithm: cipheringAlgName(ue.cipheringAlg),
 		IntegrityAlgorithm: integrityAlgName(ue.integrityAlg),
 		Connected:          ue.active.Load() != nil,
-		Registered:         ue.state == Registered,
+		Registered:         ue.state == Registered || ue.state == DeregistrationInitiated,
 	}
 
 	return snap

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -212,7 +212,12 @@ func (a *AMF) attachUeConnLocked(ue *UeContext, ueConn *UeConn) *UeConn {
 		}
 	}
 
-	ue.lastSeen.Store(time.Now().UnixNano())
+	now := time.Now()
+	ue.lastSeen.Store(now.UnixNano())
+
+	if supi := ue.Supi(); supi.IsIMSI() {
+		a.lastSeen.record(supi.IMSI(), ueConn.radioID, ueConn.radioName, now)
+	}
 
 	ue.active.Store(ueConn)
 
@@ -293,6 +298,7 @@ type UESnapshot struct {
 	LastSeenAt         time.Time
 	CipheringAlgorithm string
 	IntegrityAlgorithm string
+	Connected          bool
 }
 
 func (ue *UeContext) Snapshot() UESnapshot {
@@ -304,6 +310,7 @@ func (ue *UeContext) Snapshot() UESnapshot {
 		LastSeenAt:         ue.lastSeenTime(),
 		CipheringAlgorithm: cipheringAlgName(ue.cipheringAlg),
 		IntegrityAlgorithm: integrityAlgName(ue.integrityAlg),
+		Connected:          ue.active.Load() != nil,
 	}
 
 	return snap

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -216,7 +216,8 @@ func (a *AMF) attachUeConnLocked(ue *UeContext, ueConn *UeConn) *UeConn {
 	ue.lastSeen.Store(now.UnixNano())
 
 	if supi := ue.Supi(); supi.IsIMSI() {
-		a.lastSeen.record(supi.IMSI(), ueConn.radioID, ueConn.radioName, now)
+		radioID, radioName := ueConn.radioIDName()
+		a.lastSeen.record(supi.IMSI(), radioID, radioName, now)
 	}
 
 	ue.active.Store(ueConn)
@@ -299,6 +300,7 @@ type UESnapshot struct {
 	CipheringAlgorithm string
 	IntegrityAlgorithm string
 	Connected          bool
+	Registered         bool
 }
 
 func (ue *UeContext) Snapshot() UESnapshot {
@@ -311,6 +313,7 @@ func (ue *UeContext) Snapshot() UESnapshot {
 		CipheringAlgorithm: cipheringAlgName(ue.cipheringAlg),
 		IntegrityAlgorithm: integrityAlgName(ue.integrityAlg),
 		Connected:          ue.active.Load() != nil,
+		Registered:         ue.state == Registered,
 	}
 
 	return snap

--- a/internal/amf/decode_nas_message_test.go
+++ b/internal/amf/decode_nas_message_test.go
@@ -27,11 +27,11 @@ func newDecoderTestUE(t *testing.T) *UeContext {
 
 	ueConn := &UeConn{
 		conn:        radio.Conn,
-		radioName:   radio.name,
 		amf:         radio.amf,
 		RanUeNgapID: 1,
 		AmfUeNgapID: 1,
 	}
+	ueConn.setRadio("", radio.name)
 	ueConn.setLog(zap.NewNop())
 	ueConn.amf.AttachUeConn(ue, ueConn)
 

--- a/internal/amf/eps_registration_test.go
+++ b/internal/amf/eps_registration_test.go
@@ -51,7 +51,7 @@ func TestCancelRegistrationDropsTheFiveGSRegistration(t *testing.T) {
 		t.Errorf("5GMM state = %s after the UE attached in EPS, want Deregistered: the subscriber holds two MM states on one 3GPP access", state)
 	}
 
-	if _, _, _, found := a.LookupSubscriber(supi); found {
+	if _, _, found := a.LookupSubscriber(supi); found {
 		t.Error("the subscriber still reports a 5GS registration, so the API reports it on both 4G and 5G")
 	}
 }

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -248,14 +248,14 @@ func (amf *AMF) ExportUEs(ctx context.Context) ([]UeContextExport, error) {
 	return exports, nil
 }
 
-// LookupSubscriber returns the snapshot, live radio name, and PDU sessions of a
-// Registered UE by SUPI (ok is false for an unknown or not-yet-Registered UE), so the
+// LookupSubscriber returns the snapshot, live radio name, and PDU sessions of a UE
+// with a 5GMM context by SUPI (ok is false for an unknown or Deregistered UE), so the
 // views cannot tear across separate registry lookups. Session detail is built after the
 // session refs are copied out from under the UE lock, because it reaches the SMF
 // (SMF-delegated sessions, TS 23.501) and must not run under the registry lock.
 func (amf *AMF) LookupSubscriber(supi etsi.SUPI) (UESnapshot, string, []PDUSessionExport, bool) {
 	ue, ok := amf.LookupUeBySupi(supi)
-	if !ok || ue.State() != Registered {
+	if !ok || ue.State() == Deregistered {
 		return UESnapshot{}, "", nil, false
 	}
 
@@ -264,7 +264,7 @@ func (amf *AMF) LookupSubscriber(supi etsi.SUPI) (UESnapshot, string, []PDUSessi
 	// The radio is the UE's live connection (an idle UE reports none).
 	radioName := ""
 	if conn := ue.Conn(); conn != nil {
-		radioName = conn.radioName
+		radioName = conn.radioName()
 	}
 
 	ue.mu.Lock()
@@ -402,13 +402,13 @@ func (amf *AMF) collectUeExport(guami *models.Guami, ue *UeContext) (UeContextEx
 
 	if r := ue.active.Load(); r != nil {
 		// The last-seen radio is the UE's live connection (an idle UE is on none).
-		export.LastActivity.RadioNode = r.radioName
+		export.LastActivity.RadioNode = r.radioName()
 
 		rc := &RANConnectionExport{
 			RanUeNgapID: int64(r.RanUeNgapID),
 			AmfUeNgapID: int64(r.AmfUeNgapID),
 			RanTai:      r.Tai,
-			RadioName:   r.radioName,
+			RadioName:   r.radioName(),
 		}
 
 		export.RANConnection = rc

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -248,24 +248,18 @@ func (amf *AMF) ExportUEs(ctx context.Context) ([]UeContextExport, error) {
 	return exports, nil
 }
 
-// LookupSubscriber returns the snapshot, live radio name, and PDU sessions of a UE
-// with a 5GMM context by SUPI (ok is false for an unknown or Deregistered UE), so the
+// LookupSubscriber returns the snapshot and PDU sessions of a UE with a 5GMM context
+// by SUPI (ok is false for an unknown or Deregistered UE), so the
 // views cannot tear across separate registry lookups. Session detail is built after the
 // session refs are copied out from under the UE lock, because it reaches the SMF
 // (SMF-delegated sessions, TS 23.501) and must not run under the registry lock.
-func (amf *AMF) LookupSubscriber(supi etsi.SUPI) (UESnapshot, string, []PDUSessionExport, bool) {
+func (amf *AMF) LookupSubscriber(supi etsi.SUPI) (UESnapshot, []PDUSessionExport, bool) {
 	ue, ok := amf.LookupUeBySupi(supi)
 	if !ok || ue.State() == Deregistered {
-		return UESnapshot{}, "", nil, false
+		return UESnapshot{}, nil, false
 	}
 
 	snap := ue.Snapshot()
-
-	// The radio is the UE's live connection (an idle UE reports none).
-	radioName := ""
-	if conn := ue.Conn(); conn != nil {
-		radioName = conn.radioName()
-	}
 
 	ue.mu.Lock()
 
@@ -287,7 +281,7 @@ func (amf *AMF) LookupSubscriber(supi etsi.SUPI) (UESnapshot, string, []PDUSessi
 		result = append(result, s)
 	}
 
-	return snap, radioName, result, true
+	return snap, result, true
 }
 
 // smContextCopy is a local copy of AMF SmContext fields used to avoid holding the UE lock while querying SMF.

--- a/internal/amf/last_seen.go
+++ b/internal/amf/last_seen.go
@@ -20,6 +20,14 @@ type lastSeenStore struct {
 }
 
 func (s *lastSeenStore) record(imsi string, radioID, radioName string, at time.Time) {
+	s.write(imsi, radioID, radioName, at, true)
+}
+
+func (s *lastSeenStore) refresh(imsi string, radioID, radioName string, at time.Time) {
+	s.write(imsi, radioID, radioName, at, false)
+}
+
+func (s *lastSeenStore) write(imsi string, radioID, radioName string, at time.Time, create bool) {
 	if imsi == "" {
 		return
 	}
@@ -27,11 +35,14 @@ func (s *lastSeenStore) record(imsi string, radioID, radioName string, at time.T
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	entry, known := s.entries[imsi]
+	if !known && !create {
+		return
+	}
+
 	if s.entries == nil {
 		s.entries = make(map[string]LastSeen)
 	}
-
-	entry := s.entries[imsi]
 
 	if radioID != "" || radioName != "" {
 		entry.RadioID, entry.RadioName = radioID, radioName

--- a/internal/amf/last_seen.go
+++ b/internal/amf/last_seen.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"sync"
+	"time"
+)
+
+type LastSeen struct {
+	RadioID   string
+	RadioName string
+	At        time.Time
+}
+
+type lastSeenStore struct {
+	mu      sync.RWMutex
+	entries map[string]LastSeen
+}
+
+func (s *lastSeenStore) record(imsi string, radioID, radioName string, at time.Time) {
+	if imsi == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.entries == nil {
+		s.entries = make(map[string]LastSeen)
+	}
+
+	entry := s.entries[imsi]
+
+	if radioID != "" || radioName != "" {
+		entry.RadioID, entry.RadioName = radioID, radioName
+	}
+
+	if at.After(entry.At) {
+		entry.At = at
+	}
+
+	s.entries[imsi] = entry
+}
+
+func (s *lastSeenStore) get(imsi string) (LastSeen, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, ok := s.entries[imsi]
+
+	return entry, ok
+}
+
+func (s *lastSeenStore) all() map[string]LastSeen {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[string]LastSeen, len(s.entries))
+	for imsi, entry := range s.entries {
+		out[imsi] = entry
+	}
+
+	return out
+}
+
+func (s *lastSeenStore) forget(imsi string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.entries, imsi)
+}
+
+func (a *AMF) LastSeen(imsi string) (LastSeen, bool) {
+	entry, ok := a.lastSeen.get(imsi)
+	if !ok {
+		return entry, false
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	entry.RadioName = a.resolveRadioNameLocked(entry)
+
+	return entry, true
+}
+
+func (a *AMF) LastSeenAll() map[string]LastSeen {
+	entries := a.lastSeen.all()
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	for imsi, entry := range entries {
+		entry.RadioName = a.resolveRadioNameLocked(entry)
+		entries[imsi] = entry
+	}
+
+	return entries
+}
+
+func (a *AMF) ForgetSubscriber(imsi string) {
+	a.lastSeen.forget(imsi)
+}
+
+func (a *AMF) resolveRadioNameLocked(entry LastSeen) string {
+	if entry.RadioID == "" {
+		return entry.RadioName
+	}
+
+	if radio, ok := a.reg.ClaimedBy(entry.RadioID); ok && radio.name != "" {
+		return radio.name
+	}
+
+	return entry.RadioName
+}

--- a/internal/amf/last_seen_lifecycle_test.go
+++ b/internal/amf/last_seen_lifecycle_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/sctp"
+	"go.uber.org/zap"
+)
+
+func TestLastSeenRadioSurvivesIdleAndDeregistration(t *testing.T) {
+	const imsi = "001010000000021"
+
+	amfInstance := amf.New(nil, nil, nil)
+	radio := newRadioForTest(amfInstance, &sctp.SCTPConn{}, "gnb-a")
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+
+	supi := newSUPI(t, imsi)
+
+	ue := addTestUE(t, amfInstance, imsi, func(ue *amf.UeContext) {
+		ue.ForceStateForTest(amf.Registered)
+		ue.SetSecuredForTest(false)
+	})
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	if snap, _, _, ok := amfInstance.LookupSubscriber(supi); !ok || !snap.Connected {
+		t.Fatalf("connected UE: found=%v Connected=%v, want true/true", ok, snap.Connected)
+	}
+
+	amfInstance.ReleaseUeConn(context.Background(), ueConn)
+
+	snap, _, _, ok := amfInstance.LookupSubscriber(supi)
+	if !ok {
+		t.Fatal("idle UE missing from LookupSubscriber")
+	}
+
+	if snap.Connected {
+		t.Error("Connected = true for a UE with no NGAP UE association")
+	}
+
+	if seen, ok := amfInstance.LastSeen(imsi); !ok || seen.RadioName != "gnb-a" {
+		t.Errorf("idle UE last-seen radio = %q (found %v), want gnb-a", seen.RadioName, ok)
+	}
+
+	amfInstance.DeregisterSubscriber(context.Background(), supi)
+
+	if _, _, _, ok := amfInstance.LookupSubscriber(supi); ok {
+		t.Fatal("deregistered UE still reported as registered")
+	}
+
+	if seen, ok := amfInstance.LastSeen(imsi); !ok || seen.RadioName != "gnb-a" {
+		t.Errorf("deregistered UE last-seen radio = %q (found %v), want it retained as gnb-a", seen.RadioName, ok)
+	}
+
+	amfInstance.ForgetSubscriber(imsi)
+
+	if _, ok := amfInstance.LastSeen(imsi); ok {
+		t.Error("ForgetSubscriber left the retained record in place")
+	}
+}
+
+func TestLastSeenRadioFollowsARename(t *testing.T) {
+	const imsi = "001010000000022"
+
+	amfInstance := amf.New(nil, nil, nil)
+	conn := &sctp.SCTPConn{}
+	radio := newRadioForTest(amfInstance, conn, "gnb-a")
+	amfInstance.SetRadioForTest(conn, radio)
+	amfInstance.ClaimRanID(radio, gnbGlobalRANNodeID(t, "ABCDE1"))
+
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ue := addTestUE(t, amfInstance, imsi, func(ue *amf.UeContext) {
+		ue.ForceStateForTest(amf.Registered)
+	})
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	amfInstance.UpdateRadioName(radio, "gnb-a-renamed")
+
+	seen, ok := amfInstance.LastSeen(imsi)
+	if !ok {
+		t.Fatal("retained record missing after rename")
+	}
+
+	if seen.RadioName != "gnb-a-renamed" {
+		t.Errorf("RadioName = %q, want the current name gnb-a-renamed", seen.RadioName)
+	}
+}
+
+func TestLastSeenRadioFallsBackToTheCapturedName(t *testing.T) {
+	const imsi = "001010000000023"
+
+	amfInstance := amf.New(nil, nil, nil)
+	conn := &sctp.SCTPConn{}
+	radio := newRadioForTest(amfInstance, conn, "gnb-unclaimed")
+	amfInstance.SetRadioForTest(conn, radio)
+
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+	ue := addTestUE(t, amfInstance, imsi, func(ue *amf.UeContext) {
+		ue.ForceStateForTest(amf.Registered)
+	})
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	seen, ok := amfInstance.LastSeen(imsi)
+	if !ok {
+		t.Fatal("retained record missing")
+	}
+
+	if seen.RadioID != "" {
+		t.Errorf("RadioID = %q, want empty for a radio with no Global RAN Node ID", seen.RadioID)
+	}
+
+	if seen.RadioName != "gnb-unclaimed" {
+		t.Errorf("RadioName = %q, want the captured name gnb-unclaimed", seen.RadioName)
+	}
+}

--- a/internal/amf/last_seen_lifecycle_test.go
+++ b/internal/amf/last_seen_lifecycle_test.go
@@ -5,6 +5,7 @@ package amf_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
@@ -115,5 +116,141 @@ func TestLastSeenRadioFallsBackToTheCapturedName(t *testing.T) {
 
 	if seen.RadioName != "gnb-unclaimed" {
 		t.Errorf("RadioName = %q, want the captured name gnb-unclaimed", seen.RadioName)
+	}
+}
+
+func TestLastSeenRadioFollowsAnXnPathSwitch(t *testing.T) {
+	const imsi = "001010000000024"
+
+	amfInstance := amf.New(nil, nil, nil)
+
+	sourceConn := &sctp.SCTPConn{}
+	source := newRadioForTest(amfInstance, sourceConn, "gnb-a")
+	amfInstance.SetRadioForTest(sourceConn, source)
+	amfInstance.ClaimRanID(source, gnbGlobalRANNodeID(t, "ABCDE1"))
+
+	targetConn := &sctp.SCTPConn{}
+	target := newRadioForTest(amfInstance, targetConn, "gnb-b")
+	amfInstance.SetRadioForTest(targetConn, target)
+	amfInstance.ClaimRanID(target, gnbGlobalRANNodeID(t, "ABCDE2"))
+
+	ueConn := amf.NewUeConnForTest(source, 1, 1, zap.NewNop())
+	ue := addTestUE(t, amfInstance, imsi, func(ue *amf.UeContext) {
+		ue.ForceStateForTest(amf.Registered)
+	})
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	if !amfInstance.CommitPathSwitch(ue, ueConn, target, 2, [32]uint8{}, 0) {
+		t.Fatal("CommitPathSwitch reported the UE released")
+	}
+
+	seen, ok := amfInstance.LastSeen(imsi)
+	if !ok {
+		t.Fatal("retained record missing after the path switch")
+	}
+
+	if seen.RadioName != "gnb-b" {
+		t.Errorf("RadioName = %q, want the target gnb-b", seen.RadioName)
+	}
+}
+
+func TestRegisteringUEIsReportedAsConnectedButNotRegistered(t *testing.T) {
+	const imsi = "001010000000025"
+
+	amfInstance := amf.New(nil, nil, nil)
+	radio := newRadioForTest(amfInstance, &sctp.SCTPConn{}, "gnb-a")
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+
+	ue := addTestUE(t, amfInstance, imsi, func(ue *amf.UeContext) {
+		ue.ForceStateForTest(amf.RegistrationInitiated)
+	})
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	cs, ok := amfInstance.ConnectedSubscribers()[imsi]
+	if !ok {
+		t.Fatal("a UE part-way through registration is missing from ConnectedSubscribers")
+	}
+
+	if cs.Registered {
+		t.Error("Registered = true for a UE that has not completed registration")
+	}
+
+	if !cs.Connected {
+		t.Error("Connected = false for a UE holding an NGAP UE association")
+	}
+
+	snap, _, _, ok := amfInstance.LookupSubscriber(newSUPI(t, imsi))
+	if !ok {
+		t.Fatal("a UE part-way through registration is missing from LookupSubscriber")
+	}
+
+	if snap.Registered || !snap.Connected {
+		t.Errorf("snapshot Registered=%v Connected=%v, want false/true", snap.Registered, snap.Connected)
+	}
+}
+
+func TestUeConnRadioConcurrentAccess(t *testing.T) {
+	const (
+		imsi  = "001010000000026"
+		iters = 1500
+	)
+
+	amfInstance := amf.New(nil, nil, nil)
+
+	sourceConn := &sctp.SCTPConn{}
+	source := newRadioForTest(amfInstance, sourceConn, "gnb-a")
+	amfInstance.SetRadioForTest(sourceConn, source)
+	amfInstance.ClaimRanID(source, gnbGlobalRANNodeID(t, "ABCDE1"))
+
+	targetConn := &sctp.SCTPConn{}
+	target := newRadioForTest(amfInstance, targetConn, "gnb-b")
+	amfInstance.SetRadioForTest(targetConn, target)
+	amfInstance.ClaimRanID(target, gnbGlobalRANNodeID(t, "ABCDE2"))
+
+	ueConn := amf.NewUeConnForTest(source, 1, 1, zap.NewNop())
+	ue := addTestUE(t, amfInstance, imsi, func(ue *amf.UeContext) {
+		ue.ForceStateForTest(amf.Registered)
+	})
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range iters {
+			ueConn.TouchLastSeen()
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range iters {
+			amfInstance.CommitPathSwitch(ue, ueConn, target, 2, [32]uint8{}, 0)
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range iters {
+			_ = amfInstance.ConnectedSubscribers()
+		}
+	}()
+
+	wg.Wait()
+
+	amfInstance.CommitPathSwitch(ue, ueConn, target, 2, [32]uint8{}, 0)
+	ueConn.TouchLastSeen()
+
+	if seen, ok := amfInstance.LastSeen(imsi); !ok || seen.RadioName != "gnb-b" {
+		t.Errorf("last-seen radio = %q (found %v), want gnb-b", seen.RadioName, ok)
 	}
 }

--- a/internal/amf/last_seen_lifecycle_test.go
+++ b/internal/amf/last_seen_lifecycle_test.go
@@ -28,13 +28,13 @@ func TestLastSeenRadioSurvivesIdleAndDeregistration(t *testing.T) {
 	})
 	amfInstance.AttachUeConn(ue, ueConn)
 
-	if snap, _, _, ok := amfInstance.LookupSubscriber(supi); !ok || !snap.Connected {
+	if snap, _, ok := amfInstance.LookupSubscriber(supi); !ok || !snap.Connected {
 		t.Fatalf("connected UE: found=%v Connected=%v, want true/true", ok, snap.Connected)
 	}
 
 	amfInstance.ReleaseUeConn(context.Background(), ueConn)
 
-	snap, _, _, ok := amfInstance.LookupSubscriber(supi)
+	snap, _, ok := amfInstance.LookupSubscriber(supi)
 	if !ok {
 		t.Fatal("idle UE missing from LookupSubscriber")
 	}
@@ -49,7 +49,7 @@ func TestLastSeenRadioSurvivesIdleAndDeregistration(t *testing.T) {
 
 	amfInstance.DeregisterSubscriber(context.Background(), supi)
 
-	if _, _, _, ok := amfInstance.LookupSubscriber(supi); ok {
+	if _, _, ok := amfInstance.LookupSubscriber(supi); ok {
 		t.Fatal("deregistered UE still reported as registered")
 	}
 
@@ -179,7 +179,7 @@ func TestRegisteringUEIsReportedAsConnectedButNotRegistered(t *testing.T) {
 		t.Error("Connected = false for a UE holding an NGAP UE association")
 	}
 
-	snap, _, _, ok := amfInstance.LookupSubscriber(newSUPI(t, imsi))
+	snap, _, ok := amfInstance.LookupSubscriber(newSUPI(t, imsi))
 	if !ok {
 		t.Fatal("a UE part-way through registration is missing from LookupSubscriber")
 	}
@@ -252,5 +252,65 @@ func TestUeConnRadioConcurrentAccess(t *testing.T) {
 
 	if seen, ok := amfInstance.LastSeen(imsi); !ok || seen.RadioName != "gnb-b" {
 		t.Errorf("last-seen radio = %q (found %v), want gnb-b", seen.RadioName, ok)
+	}
+}
+
+func TestLastSeenRadioIsRecordedWhenTheSupiArrivesAfterTheBind(t *testing.T) {
+	const imsi = "001010000000027"
+
+	amfInstance := amf.New(nil, nil, nil)
+	radio := newRadioForTest(amfInstance, &sctp.SCTPConn{}, "gnb-a")
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+
+	ue := amf.NewUeContext()
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	if _, ok := amfInstance.LastSeen(imsi); ok {
+		t.Fatal("a record exists before the SUPI is known")
+	}
+
+	ue.SetSupi(newSUPI(t, imsi))
+
+	if err := amfInstance.CommitUEIdentity(context.Background(), ue, amf.MintAuthProofForRegistrationCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	t.Cleanup(func() { amfInstance.DeregisterAndRemoveUeContext(context.Background(), ue) })
+
+	seen, ok := amfInstance.LastSeen(imsi)
+	if !ok {
+		t.Fatal("no record after CommitUEIdentity; a UE registering with a SUCI is never captured")
+	}
+
+	if seen.RadioName != "gnb-a" {
+		t.Errorf("RadioName = %q, want gnb-a", seen.RadioName)
+	}
+}
+
+func TestDeregistrationInitiatedStillReportsRegistered(t *testing.T) {
+	const imsi = "001010000000028"
+
+	amfInstance := amf.New(nil, nil, nil)
+	radio := newRadioForTest(amfInstance, &sctp.SCTPConn{}, "gnb-a")
+	ueConn := amf.NewUeConnForTest(radio, 1, 1, zap.NewNop())
+
+	ue := addTestUE(t, amfInstance, imsi, func(ue *amf.UeContext) {
+		ue.ForceStateForTest(amf.Registered)
+	})
+	amfInstance.AttachUeConn(ue, ueConn)
+
+	ue.ForceStateForTest(amf.DeregistrationInitiated)
+
+	cs, ok := amfInstance.ConnectedSubscribers()[imsi]
+	if !ok {
+		t.Fatal("a UE mid network-initiated deregistration is missing from ConnectedSubscribers")
+	}
+
+	if !cs.Registered {
+		t.Error("Registered = false while the deregistration procedure is still in flight")
+	}
+
+	if !cs.Connected {
+		t.Error("Connected = false for a UE still holding an NGAP UE association")
 	}
 }

--- a/internal/amf/last_seen_test.go
+++ b/internal/amf/last_seen_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLastSeenStore(t *testing.T) {
+	var (
+		older = time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
+		imsi  = "001010000000001"
+	)
+
+	t.Run("an unknown subscriber has no record", func(t *testing.T) {
+		var store lastSeenStore
+
+		if _, ok := store.get(imsi); ok {
+			t.Error("get on an empty store reported a record")
+		}
+	})
+
+	t.Run("an empty radio keeps the one already stored", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-gnb-01", "gnb-01", older)
+		store.record(imsi, "", "", newer)
+
+		got, ok := store.get(imsi)
+		if !ok {
+			t.Fatal("record did not store the subscriber")
+		}
+
+		if got.RadioID != "id-gnb-01" || got.RadioName != "gnb-01" {
+			t.Errorf("radio = %q/%q, want it retained as id-gnb-01/gnb-01", got.RadioID, got.RadioName)
+		}
+
+		if !got.At.Equal(newer) {
+			t.Errorf("At = %v, want %v", got.At, newer)
+		}
+	})
+
+	t.Run("an older timestamp does not rewind the record", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-gnb-01", "gnb-01", newer)
+		store.record(imsi, "id-gnb-02", "gnb-02", older)
+
+		got, _ := store.get(imsi)
+		if !got.At.Equal(newer) {
+			t.Errorf("At = %v, want %v", got.At, newer)
+		}
+
+		if got.RadioID != "id-gnb-02" || got.RadioName != "gnb-02" {
+			t.Errorf("radio = %q/%q, want id-gnb-02/gnb-02", got.RadioID, got.RadioName)
+		}
+	})
+
+	t.Run("forget drops the record", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-gnb-01", "gnb-01", older)
+		store.forget(imsi)
+
+		if _, ok := store.get(imsi); ok {
+			t.Error("forget left the record in place")
+		}
+	})
+
+	t.Run("an empty IMSI is not stored", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record("", "id-gnb-01", "gnb-01", older)
+
+		if len(store.all()) != 0 {
+			t.Errorf("all() = %v, want empty", store.all())
+		}
+	})
+
+	t.Run("all returns a copy", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-gnb-01", "gnb-01", older)
+
+		snapshot := store.all()
+		snapshot[imsi] = LastSeen{RadioName: "tampered"}
+
+		got, _ := store.get(imsi)
+		if got.RadioName != "gnb-01" {
+			t.Errorf("RadioName = %q, want the store unaffected at %q", got.RadioName, "gnb-01")
+		}
+	})
+}

--- a/internal/amf/last_seen_test.go
+++ b/internal/amf/last_seen_test.go
@@ -94,3 +94,41 @@ func TestLastSeenStore(t *testing.T) {
 		}
 	})
 }
+
+func TestLastSeenStoreRefreshDoesNotResurrectAForgottenSubscriber(t *testing.T) {
+	var (
+		attach   = time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+		teardown = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
+		imsi     = "001010000000002"
+	)
+
+	t.Run("a deregistration completing after forget leaves nothing behind", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-gnb-01", "gnb-01", attach)
+		store.forget(imsi)
+
+		store.refresh(imsi, "id-gnb-01", "gnb-01", teardown)
+		store.refresh(imsi, "", "", teardown)
+
+		if entry, ok := store.get(imsi); ok {
+			t.Errorf("refresh resurrected the record as %+v", entry)
+		}
+	})
+
+	t.Run("refresh still updates a live record", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-gnb-01", "gnb-01", attach)
+		store.refresh(imsi, "id-gnb-02", "gnb-02", teardown)
+
+		got, ok := store.get(imsi)
+		if !ok {
+			t.Fatal("refresh dropped a live record")
+		}
+
+		if got.RadioName != "gnb-02" || !got.At.Equal(teardown) {
+			t.Errorf("record = %q/%v, want gnb-02/%v", got.RadioName, got.At, teardown)
+		}
+	})
+}

--- a/internal/amf/nas_count_order_test.go
+++ b/internal/amf/nas_count_order_test.go
@@ -104,11 +104,11 @@ func newDownlinkOrderUE(t *testing.T) (*UeContext, *downlinkOrderConn) {
 
 	ueConn := &UeConn{
 		conn:        sender,
-		radioName:   radio.name,
 		amf:         radio.amf,
 		RanUeNgapID: 1,
 		AmfUeNgapID: 1,
 	}
+	ueConn.setRadio("", radio.name)
 	ueConn.setLog(zap.NewNop())
 	ueConn.amf.AttachUeConn(ue, ueConn)
 

--- a/internal/amf/ngap/handle_nas_non_delivery_indication.go
+++ b/internal/amf/ngap/handle_nas_non_delivery_indication.go
@@ -25,8 +25,6 @@ func HandleNASNonDeliveryIndication(ctx context.Context, amfInstance *amf.AMF, r
 
 	reportDiagnostics(ctx, ran, ngap.ProcNASNonDeliveryIndication, ngap.TriggeringInitiatingMessage, ueAssociated(msg.AMFUENGAPID, msg.RANUENGAPID), msg.Diagnostics())
 
-	ueConn.TouchLastSeen()
-
 	fields := []zap.Field{
 		zap.Uint64("amf-ue-id", uint64(msg.AMFUENGAPID)),
 		zap.Uint32("ran-ue-id", uint32(msg.RANUENGAPID)),

--- a/internal/amf/ngap/handle_ue_context_release_complete.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete.go
@@ -26,8 +26,6 @@ func HandleUEContextReleaseComplete(ctx context.Context, amfInstance *amf.AMF, r
 		ueConn.UpdateLocation(ctx, *msg.UserLocationInformation)
 	}
 
-	ueConn.TouchLastSeen()
-
 	// Cancel the release-supervision guard so it does not also run the cleanup.
 	ueConn.StopReleaseGuard()
 

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -27,7 +27,6 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 	reportDiagnostics(ctx, ran, ngap.ProcUEContextReleaseRequest, ngap.TriggeringInitiatingMessage, ueAssociated(msg.AMFUENGAPID, msg.RANUENGAPID), msg.Diagnostics())
 
-	ueConn.TouchLastSeen()
 	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle UE Context Release Request", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
 
 	// An omitted Cause is an ignore-criticality absence: the NG-RAN node has

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -454,13 +454,7 @@ func (ueConn *UeConn) TouchLastSeen() {
 		return
 	}
 
-	now := time.Now()
-	ue.lastSeen.Store(now.UnixNano())
-
-	if supi := ue.Supi(); supi.IsIMSI() && ueConn.amf != nil {
-		radioID, radioName := ueConn.radioIDName()
-		ueConn.amf.lastSeen.record(supi.IMSI(), radioID, radioName, now)
-	}
+	ue.TouchLastSeen()
 }
 
 // sendTarget resolves the AMF and radio this RAN UE sends through.
@@ -665,7 +659,7 @@ func (a *AMF) CommitPathSwitch(ue *UeContext, ueConn *UeConn, ran *Radio, ranUeN
 	ueConn.RanUeNgapID = ranUeNgapID
 
 	if supi := ue.Supi(); supi.IsIMSI() {
-		a.lastSeen.record(supi.IMSI(), radioIDOf(ran), ran.name, ue.lastSeenTime())
+		a.lastSeen.refresh(supi.IMSI(), radioIDOf(ran), ran.name, ue.lastSeenTime())
 	}
 
 	ue.mu.Lock()
@@ -696,10 +690,11 @@ func NewUeConnForTest(radio *Radio, ranUeNgapID models.RanUeNgapID, amfUeNgapID 
 		conn:        radio.Conn,
 		amf:         radio.amf,
 	}
-	ueConn.setRadio(radioIDOf(radio), radio.name)
 	ueConn.setLog(log)
 
 	radio.amf.mu.Lock()
+
+	ueConn.setRadio(radioIDOf(radio), radio.name)
 
 	radio.amf.conns[int64(amfUeNgapID)] = ueConn
 	if radio.Conn != nil {

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -64,6 +64,7 @@ type UeConn struct {
 	// radioName is the node name captured at bind, for hot-path last-seen tagging without
 	// a registry lookup. Immutable after bind.
 	radioName string
+	radioID   string
 	// amf is the owning registry; connection-lifecycle methods reach amf.mu through it.
 	// Always set at creation.
 	amf              *AMF
@@ -426,8 +427,16 @@ func (ueConn *UeConn) TouchLastSeen() {
 		return
 	}
 
-	if ue := ueConn.ue.Load(); ue != nil {
-		ue.TouchLastSeen()
+	ue := ueConn.ue.Load()
+	if ue == nil {
+		return
+	}
+
+	now := time.Now()
+	ue.lastSeen.Store(now.UnixNano())
+
+	if supi := ue.Supi(); supi.IsIMSI() && ueConn.amf != nil {
+		ueConn.amf.lastSeen.record(supi.IMSI(), ueConn.radioID, ueConn.radioName, now)
 	}
 }
 
@@ -659,6 +668,7 @@ func NewUeConnForTest(radio *Radio, ranUeNgapID models.RanUeNgapID, amfUeNgapID 
 		AmfUeNgapID: amfUeNgapID,
 		conn:        radio.Conn,
 		radioName:   radio.name,
+		radioID:     radioIDOf(radio),
 		amf:         radio.amf,
 	}
 	ueConn.setLog(log)

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -61,10 +61,9 @@ type UeConn struct {
 	// conn is the NGAP association this UE sends through and the key into the AMF's
 	// radios index for node metadata (looked up via amf.radioFor(conn)).
 	conn NGAPWriter
-	// radioName is the node name captured at bind, for hot-path last-seen tagging without
-	// a registry lookup. Immutable after bind.
-	radioName string
-	radioID   string
+	// radio is the serving node's ID and name, for hot-path last-seen tagging without a
+	// registry lookup. Atomic: written under amf.mu, read off it on the dispatch path.
+	radio atomic.Pointer[radioRef]
 	// amf is the owning registry; connection-lifecycle methods reach amf.mu through it.
 	// Always set at creation.
 	amf              *AMF
@@ -141,6 +140,29 @@ func (a *EPSArrival) ArrivingSessions() *interworking.ArrivingSessions {
 	}
 
 	return a.Sessions
+}
+
+type radioRef struct {
+	id   string
+	name string
+}
+
+func (ueConn *UeConn) setRadio(id, name string) {
+	ueConn.radio.Store(&radioRef{id: id, name: name})
+}
+
+func (ueConn *UeConn) radioIDName() (string, string) {
+	if r := ueConn.radio.Load(); r != nil {
+		return r.id, r.name
+	}
+
+	return "", ""
+}
+
+func (ueConn *UeConn) radioName() string {
+	_, name := ueConn.radioIDName()
+
+	return name
 }
 
 func (ueConn *UeConn) Log() *zap.Logger {
@@ -436,7 +458,8 @@ func (ueConn *UeConn) TouchLastSeen() {
 	ue.lastSeen.Store(now.UnixNano())
 
 	if supi := ue.Supi(); supi.IsIMSI() && ueConn.amf != nil {
-		ueConn.amf.lastSeen.record(supi.IMSI(), ueConn.radioID, ueConn.radioName, now)
+		radioID, radioName := ueConn.radioIDName()
+		ueConn.amf.lastSeen.record(supi.IMSI(), radioID, radioName, now)
 	}
 }
 
@@ -638,8 +661,12 @@ func (a *AMF) CommitPathSwitch(ue *UeContext, ueConn *UeConn, ran *Radio, ranUeN
 	}
 
 	ueConn.conn = ran.Conn
-	ueConn.radioName = ran.name
+	ueConn.setRadio(radioIDOf(ran), ran.name)
 	ueConn.RanUeNgapID = ranUeNgapID
+
+	if supi := ue.Supi(); supi.IsIMSI() {
+		a.lastSeen.record(supi.IMSI(), radioIDOf(ran), ran.name, ue.lastSeenTime())
+	}
 
 	ue.mu.Lock()
 	ue.nh = nh
@@ -667,10 +694,9 @@ func NewUeConnForTest(radio *Radio, ranUeNgapID models.RanUeNgapID, amfUeNgapID 
 		RanUeNgapID: ranUeNgapID,
 		AmfUeNgapID: amfUeNgapID,
 		conn:        radio.Conn,
-		radioName:   radio.name,
-		radioID:     radioIDOf(radio),
 		amf:         radio.amf,
 	}
+	ueConn.setRadio(radioIDOf(radio), radio.name)
 	ueConn.setLog(log)
 
 	radio.amf.mu.Lock()

--- a/internal/amf/status.go
+++ b/internal/amf/status.go
@@ -14,6 +14,7 @@ type ConnectedSubscriber struct {
 	RadioName   string
 	NumSessions int
 	LastSeenAt  time.Time
+	Connected   bool
 }
 
 // ConnectedSubscribers returns a snapshot of every Registered 5G subscriber keyed by
@@ -34,8 +35,10 @@ func (amf *AMF) ConnectedSubscribers() map[string]ConnectedSubscriber {
 		registered := ue.state == Registered
 
 		radioName := ""
-		if r := ue.active.Load(); r != nil {
-			radioName = r.radioName
+		conn := ue.active.Load()
+
+		if conn != nil {
+			radioName = conn.radioName
 		}
 
 		numSessions := len(ue.SmContextList)
@@ -49,6 +52,7 @@ func (amf *AMF) ConnectedSubscribers() map[string]ConnectedSubscriber {
 			RadioName:   radioName,
 			NumSessions: numSessions,
 			LastSeenAt:  ue.lastSeenTime(),
+			Connected:   conn != nil,
 		}
 	}
 

--- a/internal/amf/status.go
+++ b/internal/amf/status.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// ConnectedSubscriber is a consistent snapshot of a Registered 5G subscriber's live
+// ConnectedSubscriber is a consistent snapshot of a 5G subscriber's live
 // status for the status API, taken under a single registry lock so the fields cannot
 // tear across per-field reads.
 type ConnectedSubscriber struct {
@@ -15,9 +15,10 @@ type ConnectedSubscriber struct {
 	NumSessions int
 	LastSeenAt  time.Time
 	Connected   bool
+	Registered  bool
 }
 
-// ConnectedSubscribers returns a snapshot of every Registered 5G subscriber keyed by
+// ConnectedSubscribers returns a snapshot of every 5G subscriber with a 5GMM context keyed by
 // IMSI, built under one amf.mu.RLock so it is a single consistent read that cannot tear
 // against a concurrent register/idle transition.
 func (amf *AMF) ConnectedSubscribers() map[string]ConnectedSubscriber {
@@ -32,19 +33,19 @@ func (amf *AMF) ConnectedSubscribers() map[string]ConnectedSubscriber {
 		}
 
 		ue.mu.Lock()
-		registered := ue.state == Registered
+		state := ue.state
 
 		radioName := ""
 		conn := ue.active.Load()
 
 		if conn != nil {
-			radioName = conn.radioName
+			radioName = conn.radioName()
 		}
 
 		numSessions := len(ue.SmContextList)
 		ue.mu.Unlock()
 
-		if !registered {
+		if state == Deregistered {
 			continue
 		}
 
@@ -53,6 +54,7 @@ func (amf *AMF) ConnectedSubscribers() map[string]ConnectedSubscriber {
 			NumSessions: numSessions,
 			LastSeenAt:  ue.lastSeenTime(),
 			Connected:   conn != nil,
+			Registered:  state == Registered,
 		}
 	}
 

--- a/internal/amf/status.go
+++ b/internal/amf/status.go
@@ -11,7 +11,6 @@ import (
 // status for the status API, taken under a single registry lock so the fields cannot
 // tear across per-field reads.
 type ConnectedSubscriber struct {
-	RadioName   string
 	NumSessions int
 	LastSeenAt  time.Time
 	Connected   bool
@@ -34,14 +33,7 @@ func (amf *AMF) ConnectedSubscribers() map[string]ConnectedSubscriber {
 
 		ue.mu.Lock()
 		state := ue.state
-
-		radioName := ""
 		conn := ue.active.Load()
-
-		if conn != nil {
-			radioName = conn.radioName()
-		}
-
 		numSessions := len(ue.SmContextList)
 		ue.mu.Unlock()
 
@@ -50,11 +42,10 @@ func (amf *AMF) ConnectedSubscribers() map[string]ConnectedSubscriber {
 		}
 
 		out[ue.supi.IMSI()] = ConnectedSubscriber{
-			RadioName:   radioName,
 			NumSessions: numSessions,
 			LastSeenAt:  ue.lastSeenTime(),
 			Connected:   conn != nil,
-			Registered:  state == Registered,
+			Registered:  state == Registered || state == DeregistrationInitiated,
 		}
 	}
 

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -39,16 +39,17 @@ type UpdateSubscriberParams struct {
 
 type SubscriberStatus struct {
 	Registered       bool     `json:"registered"`
+	ConnectionState  string   `json:"connection_state,omitempty"`
 	RadioAccessTypes []string `json:"radio_access_types,omitempty"`
 	NumSessions      int      `json:"num_sessions"`
 	LastSeenAt       string   `json:"last_seen_at,omitempty"`
+	LastSeenRadio    string   `json:"last_seen_radio,omitempty"`
 }
 
 type Subscriber struct {
 	Imsi        string           `json:"imsi"`
 	ProfileName string           `json:"profile_name"`
 	Description string           `json:"description,omitempty"`
-	Radio       string           `json:"radio,omitempty"`
 	Status      SubscriberStatus `json:"status"`
 }
 
@@ -61,6 +62,7 @@ type ListSubscribersResponse struct {
 
 type SubscriberDetailStatus struct {
 	Registered         bool     `json:"registered"`
+	ConnectionState    string   `json:"connection_state,omitempty"`
 	RadioAccessTypes   []string `json:"radio_access_types,omitempty"`
 	Imei               string   `json:"imei"`
 	CipheringAlgorithm string   `json:"ciphering_algorithm"`
@@ -172,13 +174,14 @@ func radioIsKnown(amfInstance *amf.AMF, mmeInstance *mme.MME, name string) bool 
 
 // accessView is what one access — 4G or 5G — knows about a subscriber.
 type accessView struct {
-	rat        string
-	present    bool
-	radioName  string
-	imei       string
-	ciphering  string
-	integrity  string
-	lastSeenAt time.Time
+	rat           string
+	present       bool
+	connected     bool
+	imei          string
+	ciphering     string
+	integrity     string
+	lastSeenAt    time.Time
+	lastSeenRadio string
 }
 
 func (v accessView) newerThan(other accessView) bool {
@@ -186,26 +189,33 @@ func (v accessView) newerThan(other accessView) bool {
 }
 
 type mergedAccess struct {
-	RATs       []string
-	RadioName  string
-	Imei       string
-	Ciphering  string
-	Integrity  string
-	LastSeenAt time.Time
+	RATs          []string
+	Connected     bool
+	Imei          string
+	Ciphering     string
+	Integrity     string
+	LastSeenAt    time.Time
+	LastSeenRadio string
 }
 
 func mergeAccesses(views ...accessView) mergedAccess {
 	var (
-		merged  mergedAccess
-		serving accessView
+		merged   mergedAccess
+		serving  accessView
+		lastSeen accessView
 	)
 
 	for _, v := range views {
+		if v.lastSeenAt.After(lastSeen.lastSeenAt) {
+			lastSeen = v
+		}
+
 		if !v.present {
 			continue
 		}
 
 		merged.RATs = append(merged.RATs, v.rat)
+		merged.Connected = merged.Connected || v.connected
 
 		if merged.Imei == "" {
 			merged.Imei = v.imei
@@ -216,11 +226,29 @@ func mergeAccesses(views ...accessView) mergedAccess {
 		}
 	}
 
-	merged.RadioName = serving.radioName
 	merged.Ciphering, merged.Integrity = serving.ciphering, serving.integrity
-	merged.LastSeenAt = serving.lastSeenAt
+	merged.LastSeenAt, merged.LastSeenRadio = lastSeen.lastSeenAt, lastSeen.lastSeenRadio
 
 	return merged
+}
+
+func lastSeenAt(present bool, live, retained time.Time) time.Time {
+	if present && !live.IsZero() {
+		return live
+	}
+
+	return retained
+}
+
+func connectionState(registered, connected bool) string {
+	switch {
+	case !registered:
+		return ""
+	case connected:
+		return "connected"
+	default:
+		return "idle"
+	}
 }
 
 func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance *mme.MME) http.Handler {
@@ -257,6 +285,14 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 
 		amf5GStatus := amfInstance.ConnectedSubscribers()
 
+		amf5GLastSeen := amfInstance.LastSeenAll()
+
+		var mmeLastSeen map[string]mme.LastSeen
+
+		if mmeInstance != nil {
+			mmeLastSeen = mmeInstance.LastSeenAll()
+		}
+
 		var radioIMSIs map[string]struct{}
 
 		if radioFilter != "" {
@@ -268,14 +304,14 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 
 			radioIMSIs = make(map[string]struct{})
 
-			for imsi, cs := range amf5GStatus {
-				if cs.RadioName == radioFilter {
+			for imsi := range amf5GStatus {
+				if amf5GLastSeen[imsi].RadioName == radioFilter {
 					radioIMSIs[imsi] = struct{}{}
 				}
 			}
 
-			for imsi, st := range mmeStatus {
-				if st.RadioName == radioFilter {
+			for imsi := range mmeStatus {
+				if mmeLastSeen[imsi].RadioName == radioFilter {
 					radioIMSIs[imsi] = struct{}{}
 				}
 			}
@@ -346,14 +382,26 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 			mme4G, on4G := mmeStatus[dbSubscriber.Imsi]
 
 			merged := mergeAccesses(
-				accessView{rat: "4G", present: on4G, radioName: mme4G.RadioName, lastSeenAt: mme4G.LastSeenAt},
-				accessView{rat: "5G", present: on5G, radioName: amf5G.RadioName, lastSeenAt: amf5G.LastSeenAt},
+				accessView{
+					rat: "4G", present: on4G, connected: mme4G.Connected,
+					lastSeenAt:    lastSeenAt(on4G, mme4G.LastSeenAt, mmeLastSeen[dbSubscriber.Imsi].At),
+					lastSeenRadio: mmeLastSeen[dbSubscriber.Imsi].RadioName,
+				},
+				accessView{
+					rat: "5G", present: on5G, connected: amf5G.Connected,
+					lastSeenAt:    lastSeenAt(on5G, amf5G.LastSeenAt, amf5GLastSeen[dbSubscriber.Imsi].At),
+					lastSeenRadio: amf5GLastSeen[dbSubscriber.Imsi].RadioName,
+				},
 			)
 
+			registered := on5G || on4G
+
 			subscriberStatus := SubscriberStatus{
-				Registered:       on5G || on4G,
+				Registered:       registered,
+				ConnectionState:  connectionState(registered, merged.Connected),
 				RadioAccessTypes: merged.RATs,
 				NumSessions:      mme4G.NumSessions + amf5G.NumSessions,
+				LastSeenRadio:    merged.LastSeenRadio,
 			}
 
 			if !merged.LastSeenAt.IsZero() {
@@ -364,7 +412,6 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 				Imsi:        dbSubscriber.Imsi,
 				ProfileName: profile.Name,
 				Description: dbSubscriber.Description,
-				Radio:       merged.RadioName,
 				Status:      subscriberStatus,
 			})
 		}
@@ -428,7 +475,7 @@ func GetSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance *m
 			return
 		}
 
-		snap, radioName, pduSessions, found := amfInstance.LookupSubscriber(supi)
+		snap, _, pduSessions, found := amfInstance.LookupSubscriber(supi)
 
 		var (
 			cs   mme.ConnectedSubscriber
@@ -439,21 +486,34 @@ func GetSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance *m
 			cs, on4G = mmeInstance.LookupSubscriber(imsi)
 		}
 
+		var mmeLastSeen mme.LastSeen
+
+		if mmeInstance != nil {
+			mmeLastSeen, _ = mmeInstance.LastSeen(imsi)
+		}
+
+		amfLastSeen, _ := amfInstance.LastSeen(imsi)
+
 		merged := mergeAccesses(
 			accessView{
-				rat: "4G", present: on4G, radioName: cs.RadioName, imei: cs.Imei,
-				ciphering: cs.CipheringAlgorithm, integrity: cs.IntegrityAlgorithm, lastSeenAt: cs.LastSeenAt,
+				rat: "4G", present: on4G, connected: cs.Connected, imei: cs.Imei,
+				ciphering: cs.CipheringAlgorithm, integrity: cs.IntegrityAlgorithm,
+				lastSeenAt: lastSeenAt(on4G, cs.LastSeenAt, mmeLastSeen.At), lastSeenRadio: mmeLastSeen.RadioName,
 			},
 			accessView{
-				rat: "5G", present: found, radioName: radioName, imei: snap.Imei,
-				ciphering: snap.CipheringAlgorithm, integrity: snap.IntegrityAlgorithm, lastSeenAt: snap.LastSeenAt,
+				rat: "5G", present: found, connected: snap.Connected, imei: snap.Imei,
+				ciphering: snap.CipheringAlgorithm, integrity: snap.IntegrityAlgorithm,
+				lastSeenAt: lastSeenAt(found, snap.LastSeenAt, amfLastSeen.At), lastSeenRadio: amfLastSeen.RadioName,
 			},
 		)
 
+		registered := on4G || found
+
 		subscriberStatus := SubscriberDetailStatus{
-			Registered:         on4G || found,
+			Registered:         registered,
+			ConnectionState:    connectionState(registered, merged.Connected),
 			RadioAccessTypes:   merged.RATs,
-			LastSeenRadio:      merged.RadioName,
+			LastSeenRadio:      merged.LastSeenRadio,
 			Imei:               merged.Imei,
 			CipheringAlgorithm: merged.Ciphering,
 			IntegrityAlgorithm: merged.Integrity,
@@ -778,9 +838,11 @@ func DeleteSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance
 		}
 
 		amfInstance.DeregisterSubscriber(r.Context(), supi)
+		amfInstance.ForgetSubscriber(imsi)
 
 		if mmeInstance != nil {
 			mmeInstance.DetachSubscriber(r.Context(), imsi)
+			mmeInstance.ForgetSubscriber(imsi)
 		}
 
 		if err := dbInstance.DeleteSubscriber(r.Context(), imsi); err != nil {

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -176,6 +176,7 @@ func radioIsKnown(amfInstance *amf.AMF, mmeInstance *mme.MME, name string) bool 
 type accessView struct {
 	rat           string
 	present       bool
+	registered    bool
 	connected     bool
 	imei          string
 	ciphering     string
@@ -190,6 +191,7 @@ func (v accessView) newerThan(other accessView) bool {
 
 type mergedAccess struct {
 	RATs          []string
+	Registered    bool
 	Connected     bool
 	Imei          string
 	Ciphering     string
@@ -202,12 +204,12 @@ func mergeAccesses(views ...accessView) mergedAccess {
 	var (
 		merged   mergedAccess
 		serving  accessView
-		lastSeen accessView
+		retained accessView
 	)
 
 	for _, v := range views {
-		if v.lastSeenAt.After(lastSeen.lastSeenAt) {
-			lastSeen = v
+		if v.lastSeenAt.After(retained.lastSeenAt) {
+			retained = v
 		}
 
 		if !v.present {
@@ -215,6 +217,7 @@ func mergeAccesses(views ...accessView) mergedAccess {
 		}
 
 		merged.RATs = append(merged.RATs, v.rat)
+		merged.Registered = merged.Registered || v.registered
 		merged.Connected = merged.Connected || v.connected
 
 		if merged.Imei == "" {
@@ -226,8 +229,13 @@ func mergeAccesses(views ...accessView) mergedAccess {
 		}
 	}
 
+	answering := serving
+	if !answering.present {
+		answering = retained
+	}
+
 	merged.Ciphering, merged.Integrity = serving.ciphering, serving.integrity
-	merged.LastSeenAt, merged.LastSeenRadio = lastSeen.lastSeenAt, lastSeen.lastSeenRadio
+	merged.LastSeenAt, merged.LastSeenRadio = answering.lastSeenAt, answering.lastSeenRadio
 
 	return merged
 }
@@ -240,9 +248,9 @@ func lastSeenAt(present bool, live, retained time.Time) time.Time {
 	return retained
 }
 
-func connectionState(registered, connected bool) string {
+func connectionState(present, connected bool) string {
 	switch {
-	case !registered:
+	case !present:
 		return ""
 	case connected:
 		return "connected"
@@ -383,22 +391,20 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 
 			merged := mergeAccesses(
 				accessView{
-					rat: "4G", present: on4G, connected: mme4G.Connected,
+					rat: "4G", present: on4G, registered: mme4G.Registered, connected: mme4G.Connected,
 					lastSeenAt:    lastSeenAt(on4G, mme4G.LastSeenAt, mmeLastSeen[dbSubscriber.Imsi].At),
 					lastSeenRadio: mmeLastSeen[dbSubscriber.Imsi].RadioName,
 				},
 				accessView{
-					rat: "5G", present: on5G, connected: amf5G.Connected,
+					rat: "5G", present: on5G, registered: amf5G.Registered, connected: amf5G.Connected,
 					lastSeenAt:    lastSeenAt(on5G, amf5G.LastSeenAt, amf5GLastSeen[dbSubscriber.Imsi].At),
 					lastSeenRadio: amf5GLastSeen[dbSubscriber.Imsi].RadioName,
 				},
 			)
 
-			registered := on5G || on4G
-
 			subscriberStatus := SubscriberStatus{
-				Registered:       registered,
-				ConnectionState:  connectionState(registered, merged.Connected),
+				Registered:       merged.Registered,
+				ConnectionState:  connectionState(on5G || on4G, merged.Connected),
 				RadioAccessTypes: merged.RATs,
 				NumSessions:      mme4G.NumSessions + amf5G.NumSessions,
 				LastSeenRadio:    merged.LastSeenRadio,
@@ -496,22 +502,20 @@ func GetSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance *m
 
 		merged := mergeAccesses(
 			accessView{
-				rat: "4G", present: on4G, connected: cs.Connected, imei: cs.Imei,
+				rat: "4G", present: on4G, registered: cs.Registered, connected: cs.Connected, imei: cs.Imei,
 				ciphering: cs.CipheringAlgorithm, integrity: cs.IntegrityAlgorithm,
 				lastSeenAt: lastSeenAt(on4G, cs.LastSeenAt, mmeLastSeen.At), lastSeenRadio: mmeLastSeen.RadioName,
 			},
 			accessView{
-				rat: "5G", present: found, connected: snap.Connected, imei: snap.Imei,
+				rat: "5G", present: found, registered: snap.Registered, connected: snap.Connected, imei: snap.Imei,
 				ciphering: snap.CipheringAlgorithm, integrity: snap.IntegrityAlgorithm,
 				lastSeenAt: lastSeenAt(found, snap.LastSeenAt, amfLastSeen.At), lastSeenRadio: amfLastSeen.RadioName,
 			},
 		)
 
-		registered := on4G || found
-
 		subscriberStatus := SubscriberDetailStatus{
-			Registered:         registered,
-			ConnectionState:    connectionState(registered, merged.Connected),
+			Registered:         merged.Registered,
+			ConnectionState:    connectionState(on4G || found, merged.Connected),
 			RadioAccessTypes:   merged.RATs,
 			LastSeenRadio:      merged.LastSeenRadio,
 			Imei:               merged.Imei,

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -481,7 +481,7 @@ func GetSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance *m
 			return
 		}
 
-		snap, _, pduSessions, found := amfInstance.LookupSubscriber(supi)
+		snap, pduSessions, found := amfInstance.LookupSubscriber(supi)
 
 		var (
 			cs   mme.ConnectedSubscriber

--- a/internal/api/server/api_subscribers_access_test.go
+++ b/internal/api/server/api_subscribers_access_test.go
@@ -15,12 +15,12 @@ func TestMergeAccesses(t *testing.T) {
 		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
 
 		on4G = accessView{
-			rat: "4G", present: true, radioName: "enb-1", imei: "490154203237518",
-			ciphering: "EEA2", integrity: "EIA2",
+			rat: "4G", present: true, connected: true, imei: "490154203237518",
+			ciphering: "EEA2", integrity: "EIA2", lastSeenRadio: "enb-1",
 		}
 		on5G = accessView{
-			rat: "5G", present: true, radioName: "gnb-1", imei: "490154203237518",
-			ciphering: "NEA2", integrity: "NIA2",
+			rat: "5G", present: true, connected: true, imei: "490154203237518",
+			ciphering: "NEA2", integrity: "NIA2", lastSeenRadio: "gnb-1",
 		}
 	)
 
@@ -31,7 +31,14 @@ func TestMergeAccesses(t *testing.T) {
 	}
 
 	idle := func(v accessView) accessView {
-		v.radioName = ""
+		v.connected = false
+
+		return v
+	}
+
+	deregistered := func(v accessView) accessView {
+		v.present, v.connected = false, false
+		v.imei, v.ciphering, v.integrity = "", "", ""
 
 		return v
 	}
@@ -51,7 +58,7 @@ func TestMergeAccesses(t *testing.T) {
 			view4G:   at(on4G, older),
 			wantRATs: []string{"4G"},
 			want: mergedAccess{
-				RadioName: "enb-1", Imei: "490154203237518",
+				Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
 				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: older,
 			},
 		},
@@ -60,7 +67,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, older),
 			wantRATs: []string{"5G"},
 			want: mergedAccess{
-				RadioName: "gnb-1", Imei: "490154203237518",
+				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: older,
 			},
 		},
@@ -70,7 +77,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, older),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				RadioName: "enb-1", Imei: "490154203237518",
+				Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
 				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: newer,
 			},
 		},
@@ -80,50 +87,60 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				RadioName: "gnb-1", Imei: "490154203237518",
+				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
 			},
 		},
 		{
-			name:     "4G serving, 5G registered but idle",
+			name:     "4G connected, 5G registered but idle",
 			view4G:   at(on4G, newer),
 			view5G:   at(idle(on5G), older),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				RadioName: "enb-1", Imei: "490154203237518",
+				Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
 				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: newer,
 			},
 		},
 		{
-			// The serving access answers for the radio as well as the algorithms. Falling
-			// back to the 4G eNB here would pair it with 5G's algorithms and describe a
-			// state the subscriber was never in.
-			name:     "the more recent access is idle and names no radio",
+			name:     "the more recent access is idle, and still names the radio that served it",
 			view4G:   at(on4G, older),
 			view5G:   at(idle(on5G), newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Imei: "490154203237518", Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
+				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
 			},
 		},
 		{
 			name:     "both idle",
-			view4G:   idle(on4G),
-			view5G:   idle(on5G),
+			view4G:   at(idle(on4G), older),
+			view5G:   at(idle(on5G), newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Imei: "490154203237518", Ciphering: "EEA2", Integrity: "EIA2",
+				LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
+			},
+		},
+		{
+			name:   "deregistered on both accesses",
+			view4G: at(deregistered(on4G), older),
+			view5G: at(deregistered(on5G), newer),
+			want: mergedAccess{
+				LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
 			// The IMEI describes the device, not the access, so the access that knows it
 			// answers even when it is not the serving one.
-			name:     "only the older access reported an IMEI",
-			view4G:   at(on4G, older),
-			view5G:   at(accessView{rat: "5G", present: true, radioName: "gnb-1", ciphering: "NEA2", integrity: "NIA2"}, newer),
+			name:   "only the older access reported an IMEI",
+			view4G: at(on4G, older),
+			view5G: at(accessView{
+				rat: "5G", present: true, connected: true, lastSeenRadio: "gnb-1",
+				ciphering: "NEA2", integrity: "NIA2",
+			}, newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				RadioName: "gnb-1", Imei: "490154203237518",
+				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
 			},
 		},
@@ -135,8 +152,12 @@ func TestMergeAccesses(t *testing.T) {
 				t.Errorf("RATs = %v, want %v", got.RATs, tc.wantRATs)
 			}
 
-			if got.RadioName != tc.want.RadioName {
-				t.Errorf("RadioName = %q, want %q", got.RadioName, tc.want.RadioName)
+			if got.Connected != tc.want.Connected {
+				t.Errorf("Connected = %v, want %v", got.Connected, tc.want.Connected)
+			}
+
+			if got.LastSeenRadio != tc.want.LastSeenRadio {
+				t.Errorf("LastSeenRadio = %q, want %q", got.LastSeenRadio, tc.want.LastSeenRadio)
 			}
 
 			if got.Imei != tc.want.Imei {
@@ -155,7 +176,7 @@ func TestMergeAccesses(t *testing.T) {
 	}
 }
 
-// The serving radio and the algorithms are read together, so they have to come from the
+// The last-seen radio and the algorithms are read together, so they have to come from the
 // same access however the two accesses are staggered.
 func TestMergeAccessesNeverPairsARadioWithAnotherAccessesAlgorithms(t *testing.T) {
 	base := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
@@ -163,17 +184,17 @@ func TestMergeAccessesNeverPairsARadioWithAnotherAccessesAlgorithms(t *testing.T
 	for i := range 4 {
 		for j := range 4 {
 			view4G := accessView{
-				rat: "4G", present: true, radioName: "enb-1",
+				rat: "4G", present: true, lastSeenRadio: "enb-1",
 				ciphering: "EEA2", integrity: "EIA2", lastSeenAt: base.Add(time.Duration(i) * time.Minute),
 			}
 			view5G := accessView{
-				rat: "5G", present: true, radioName: "gnb-1",
+				rat: "5G", present: true, lastSeenRadio: "gnb-1",
 				ciphering: "NEA2", integrity: "NIA2", lastSeenAt: base.Add(time.Duration(j) * time.Minute),
 			}
 
 			got := mergeAccesses(view4G, view5G)
 
-			switch got.RadioName {
+			switch got.LastSeenRadio {
 			case "enb-1":
 				if got.Ciphering != "EEA2" || got.Integrity != "EIA2" {
 					t.Errorf("4G=%d 5G=%d: radio enb-1 reported with %q/%q", i, j, got.Ciphering, got.Integrity)
@@ -183,8 +204,46 @@ func TestMergeAccessesNeverPairsARadioWithAnotherAccessesAlgorithms(t *testing.T
 					t.Errorf("4G=%d 5G=%d: radio gnb-1 reported with %q/%q", i, j, got.Ciphering, got.Integrity)
 				}
 			default:
-				t.Errorf("4G=%d 5G=%d: no radio reported for two connected accesses", i, j)
+				t.Errorf("4G=%d 5G=%d: no radio reported for two registered accesses", i, j)
 			}
 		}
+	}
+}
+
+func TestConnectionState(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		registered bool
+		connected  bool
+		want       string
+	}{
+		{name: "registered and connected", registered: true, connected: true, want: "connected"},
+		{name: "registered and idle", registered: true, want: "idle"},
+		{name: "not registered occupies neither state", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := connectionState(tc.registered, tc.connected); got != tc.want {
+				t.Errorf("connectionState(%v, %v) = %q, want %q", tc.registered, tc.connected, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLastSeenAtPrefersTheLiveContext(t *testing.T) {
+	var (
+		retained = time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+		live     = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
+	)
+
+	if got := lastSeenAt(true, live, retained); !got.Equal(live) {
+		t.Errorf("registered access = %v, want the live timestamp %v", got, live)
+	}
+
+	if got := lastSeenAt(false, live, retained); !got.Equal(retained) {
+		t.Errorf("deregistered access = %v, want the retained timestamp %v", got, retained)
+	}
+
+	if got := lastSeenAt(true, time.Time{}, retained); !got.Equal(retained) {
+		t.Errorf("registered access with no live timestamp = %v, want %v", got, retained)
 	}
 }

--- a/internal/api/server/api_subscribers_access_test.go
+++ b/internal/api/server/api_subscribers_access_test.go
@@ -15,11 +15,11 @@ func TestMergeAccesses(t *testing.T) {
 		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
 
 		on4G = accessView{
-			rat: "4G", present: true, connected: true, imei: "490154203237518",
+			rat: "4G", present: true, registered: true, connected: true, imei: "490154203237518",
 			ciphering: "EEA2", integrity: "EIA2", lastSeenRadio: "enb-1",
 		}
 		on5G = accessView{
-			rat: "5G", present: true, connected: true, imei: "490154203237518",
+			rat: "5G", present: true, registered: true, connected: true, imei: "490154203237518",
 			ciphering: "NEA2", integrity: "NIA2", lastSeenRadio: "gnb-1",
 		}
 	)
@@ -37,7 +37,7 @@ func TestMergeAccesses(t *testing.T) {
 	}
 
 	deregistered := func(v accessView) accessView {
-		v.present, v.connected = false, false
+		v.present, v.registered, v.connected = false, false, false
 		v.imei, v.ciphering, v.integrity = "", "", ""
 
 		return v
@@ -58,7 +58,7 @@ func TestMergeAccesses(t *testing.T) {
 			view4G:   at(on4G, older),
 			wantRATs: []string{"4G"},
 			want: mergedAccess{
-				Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
+				Registered: true, Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
 				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: older,
 			},
 		},
@@ -67,7 +67,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, older),
 			wantRATs: []string{"5G"},
 			want: mergedAccess{
-				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: older,
 			},
 		},
@@ -77,7 +77,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, older),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
+				Registered: true, Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
 				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: newer,
 			},
 		},
@@ -87,7 +87,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
 			},
 		},
@@ -97,7 +97,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(idle(on5G), older),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
+				Registered: true, Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
 				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: newer,
 			},
 		},
@@ -107,8 +107,18 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(idle(on5G), newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
+			},
+		},
+		{
+			name:     "the deregistered access is more recent than the registered one",
+			view4G:   at(deregistered(on4G), newer),
+			view5G:   at(on5G, older),
+			wantRATs: []string{"5G"},
+			want: mergedAccess{
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: older,
 			},
 		},
 		{
@@ -117,7 +127,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(idle(on5G), newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Registered: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
 			},
 		},
@@ -135,12 +145,12 @@ func TestMergeAccesses(t *testing.T) {
 			name:   "only the older access reported an IMEI",
 			view4G: at(on4G, older),
 			view5G: at(accessView{
-				rat: "5G", present: true, connected: true, lastSeenRadio: "gnb-1",
+				rat: "5G", present: true, registered: true, connected: true, lastSeenRadio: "gnb-1",
 				ciphering: "NEA2", integrity: "NIA2",
 			}, newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
 				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
 			},
 		},
@@ -150,6 +160,10 @@ func TestMergeAccesses(t *testing.T) {
 
 			if !slices.Equal(got.RATs, tc.wantRATs) {
 				t.Errorf("RATs = %v, want %v", got.RATs, tc.wantRATs)
+			}
+
+			if got.Registered != tc.want.Registered {
+				t.Errorf("Registered = %v, want %v", got.Registered, tc.want.Registered)
 			}
 
 			if got.Connected != tc.want.Connected {
@@ -212,18 +226,18 @@ func TestMergeAccessesNeverPairsARadioWithAnotherAccessesAlgorithms(t *testing.T
 
 func TestConnectionState(t *testing.T) {
 	for _, tc := range []struct {
-		name       string
-		registered bool
-		connected  bool
-		want       string
+		name      string
+		present   bool
+		connected bool
+		want      string
 	}{
-		{name: "registered and connected", registered: true, connected: true, want: "connected"},
-		{name: "registered and idle", registered: true, want: "idle"},
-		{name: "not registered occupies neither state", want: ""},
+		{name: "a context holding a signalling connection", present: true, connected: true, want: "connected"},
+		{name: "a context with no signalling connection", present: true, want: "idle"},
+		{name: "no context on either access", want: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := connectionState(tc.registered, tc.connected); got != tc.want {
-				t.Errorf("connectionState(%v, %v) = %q, want %q", tc.registered, tc.connected, got, tc.want)
+			if got := connectionState(tc.present, tc.connected); got != tc.want {
+				t.Errorf("connectionState(%v, %v) = %q, want %q", tc.present, tc.connected, got, tc.want)
 			}
 		})
 	}

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -45,9 +45,11 @@ type CreateSubscriberSuccessResponse struct {
 // ListSubscriberStatus matches the lightweight status in list responses.
 type ListSubscriberStatus struct {
 	Registered       bool     `json:"registered"`
+	ConnectionState  string   `json:"connection_state,omitempty"`
 	RadioAccessTypes []string `json:"radio_access_types,omitempty"`
 	NumSessions      int      `json:"num_sessions"`
 	LastSeenAt       string   `json:"last_seen_at,omitempty"`
+	LastSeenRadio    string   `json:"last_seen_radio,omitempty"`
 }
 
 // ListSubscriber matches the summary representation in list responses.
@@ -55,13 +57,13 @@ type ListSubscriber struct {
 	Imsi        string               `json:"imsi"`
 	ProfileName string               `json:"profile_name"`
 	Description string               `json:"description,omitempty"`
-	Radio       string               `json:"radio,omitempty"`
 	Status      ListSubscriberStatus `json:"status"`
 }
 
 // SubscriberDetailStatus matches the rich status in get-single responses.
 type SubscriberDetailStatus struct {
 	Registered         bool     `json:"registered"`
+	ConnectionState    string   `json:"connection_state,omitempty"`
 	RadioAccessTypes   []string `json:"radio_access_types,omitempty"`
 	Imei               string   `json:"imei"`
 	CipheringAlgorithm string   `json:"ciphering_algorithm"`
@@ -790,6 +792,10 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 
 		if got := response.Result.Status.RadioAccessTypes; len(got) != 1 || got[0] != "5G" {
 			t.Fatalf("expected radio_access_types [5G], got %v", got)
+		}
+
+		if got := response.Result.Status.ConnectionState; got != "idle" {
+			t.Fatalf("expected connection_state 'idle' for a registered UE with no NGAP association, got %q", got)
 		}
 
 		if session.Status != "active" {

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3906,12 +3906,11 @@ components:
           type: string
           enum: ["idle", "connected"]
           description: >-
-            Whether the device holds a signalling connection to the core: the CM state in
-            5G (TS 23.501 §5.3.3.2, CM-IDLE / CM-CONNECTED) and the ECM state in 4G
-            (TS 23.401 §4.6.3, ECM-IDLE / ECM-CONNECTED). "connected" reports a signalling
-            connection, not radio activity — a connected UE may have its radio in
-            RRC_INACTIVE. Omitted when the subscriber is not registered, which is neither
-            state.
+            Whether the device holds a NAS signalling connection: CM state in 5G
+            (TS 23.501 §5.3.3.2) and ECM state in 4G (TS 23.401 §4.6.3). Independent of
+            `registered` (TS 23.501 §5.3.3.2.1, TS 23.401 §4.6.1) — a device still
+            registering is "connected" with `registered` false. Omitted when the core
+            holds no context for the device.
         radio_access_types:
           type: array
           items:
@@ -3933,10 +3932,10 @@ components:
         last_seen_radio:
           type: string
           description: >-
-            Name of the radio that last served the device. Retained while the device is
-            idle and after it deregisters, so it is last known rather than current — the
-            core knows the serving radio only while the device is connected
-            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Omitted if never seen.
+            Name of the radio that last served the device — last known, not current
+            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Held in memory by the serving node
+            while the device is idle and after it deregisters: not shared across cluster
+            nodes, and reset on restart. Omitted if never seen.
       required: [registered, num_sessions]
 
     Subscriber:
@@ -3986,12 +3985,8 @@ components:
           type: string
           enum: ["idle", "connected"]
           description: >-
-            Whether the device holds a signalling connection to the core: the CM state in
-            5G (TS 23.501 §5.3.3.2, CM-IDLE / CM-CONNECTED) and the ECM state in 4G
-            (TS 23.401 §4.6.3, ECM-IDLE / ECM-CONNECTED). "connected" reports a signalling
-            connection, not radio activity — a connected UE may have its radio in
-            RRC_INACTIVE. Omitted when the subscriber is not registered, which is neither
-            state.
+            Whether the device holds a NAS signalling connection: CM state in 5G
+            (TS 23.501 §5.3.3.2) and ECM state in 4G (TS 23.401 §4.6.3).
         radio_access_types:
           type: array
           items:
@@ -4023,10 +4018,10 @@ components:
         last_seen_radio:
           type: string
           description: >-
-            Name of the radio that last served the device. Retained while the device is
-            idle and after it deregisters, so it is last known rather than current — the
-            core knows the serving radio only while the device is connected
-            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Empty if never seen.
+            Name of the radio that last served the device — last known, not current
+            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Held in memory by the serving node
+            while the device is idle and after it deregisters: not shared across cluster
+            nodes, and reset on restart. Empty if never seen.
       required: [registered, imei, ciphering_algorithm, integrity_algorithm]
 
     SubscriberDetail:

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -897,7 +897,9 @@ paths:
           in: query
           schema:
             type: string
-          description: Filter subscribers connected to a specific radio by name.
+          description: >-
+            Filter to registered subscribers whose last-seen radio is this one, so an
+            idle subscriber still matches the radio that last served it.
         - name: data_network
           in: query
           schema:
@@ -3900,6 +3902,16 @@ components:
         registered:
           type: boolean
           description: Whether the device is currently registered on the network.
+        connection_state:
+          type: string
+          enum: ["idle", "connected"]
+          description: >-
+            Whether the device holds a signalling connection to the core: the CM state in
+            5G (TS 23.501 §5.3.3.2, CM-IDLE / CM-CONNECTED) and the ECM state in 4G
+            (TS 23.401 §4.6.3, ECM-IDLE / ECM-CONNECTED). "connected" reports a signalling
+            connection, not radio activity — a connected UE may have its radio in
+            RRC_INACTIVE. Omitted when the subscriber is not registered, which is neither
+            state.
         radio_access_types:
           type: array
           items:
@@ -3918,6 +3930,13 @@ components:
           type: string
           format: date-time
           description: Timestamp when the subscriber was last seen (RFC 3339). Omitted if never seen.
+        last_seen_radio:
+          type: string
+          description: >-
+            Name of the radio that last served the device. Retained while the device is
+            idle and after it deregisters, so it is last known rather than current — the
+            core knows the serving radio only while the device is connected
+            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Omitted if never seen.
       required: [registered, num_sessions]
 
     Subscriber:
@@ -3933,9 +3952,6 @@ components:
           type: string
           maxLength: 64
           description: Free-text operator note. Absent when unset.
-        radio:
-          type: string
-          description: Radio name the subscriber is connected through (empty if not connected).
         status:
           $ref: "#/components/schemas/SubscriberStatus"
       required: [imsi, profile_name, status]
@@ -3966,6 +3982,16 @@ components:
       properties:
         registered:
           type: boolean
+        connection_state:
+          type: string
+          enum: ["idle", "connected"]
+          description: >-
+            Whether the device holds a signalling connection to the core: the CM state in
+            5G (TS 23.501 §5.3.3.2, CM-IDLE / CM-CONNECTED) and the ECM state in 4G
+            (TS 23.401 §4.6.3, ECM-IDLE / ECM-CONNECTED). "connected" reports a signalling
+            connection, not radio activity — a connected UE may have its radio in
+            RRC_INACTIVE. Omitted when the subscriber is not registered, which is neither
+            state.
         radio_access_types:
           type: array
           items:
@@ -3997,8 +4023,10 @@ components:
         last_seen_radio:
           type: string
           description: >-
-            Name of the radio serving the device on that access. Empty when the
-            device is registered but idle, with no radio connection to name.
+            Name of the radio that last served the device. Retained while the device is
+            idle and after it deregisters, so it is last known rather than current — the
+            core knows the serving radio only while the device is connected
+            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Empty if never seen.
       required: [registered, imei, ciphering_algorithm, integrity_algorithm]
 
     SubscriberDetail:

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3908,7 +3908,7 @@ components:
           description: >-
             Whether the device holds a NAS signalling connection: CM state in 5G
             (TS 23.501 §5.3.3.2) and ECM state in 4G (TS 23.401 §4.6.3). Independent of
-            `registered` (TS 23.501 §5.3.3.2.1, TS 23.401 §4.6.1) — a device still
+            `registered` (TS 23.501 §5.3.3.2.2, TS 23.401 §4.6.1) — a device still
             registering is "connected" with `registered` false. Omitted when the core
             holds no context for the device.
         radio_access_types:
@@ -3932,10 +3932,11 @@ components:
         last_seen_radio:
           type: string
           description: >-
-            Name of the radio that last served the device — last known, not current
-            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Held in memory by the serving node
-            while the device is idle and after it deregisters: not shared across cluster
-            nodes, and reset on restart. Omitted if never seen.
+            Name of the radio that last served the device. The core knows the serving node
+            only while the device is connected (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2), so
+            on an idle or deregistered device this is last known and may be stale. Held in
+            memory by the serving node: not shared across cluster nodes, and reset on
+            restart. Omitted if never seen.
       required: [registered, num_sessions]
 
     Subscriber:
@@ -3986,7 +3987,10 @@ components:
           enum: ["idle", "connected"]
           description: >-
             Whether the device holds a NAS signalling connection: CM state in 5G
-            (TS 23.501 §5.3.3.2) and ECM state in 4G (TS 23.401 §4.6.3).
+            (TS 23.501 §5.3.3.2) and ECM state in 4G (TS 23.401 §4.6.3). Independent of
+            `registered` (TS 23.501 §5.3.3.2.2, TS 23.401 §4.6.1) — a device still
+            registering is "connected" with `registered` false. Omitted when the core
+            holds no context for the device.
         radio_access_types:
           type: array
           items:
@@ -4018,10 +4022,11 @@ components:
         last_seen_radio:
           type: string
           description: >-
-            Name of the radio that last served the device — last known, not current
-            (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2). Held in memory by the serving node
-            while the device is idle and after it deregisters: not shared across cluster
-            nodes, and reset on restart. Empty if never seen.
+            Name of the radio that last served the device. The core knows the serving node
+            only while the device is connected (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2), so
+            on an idle or deregistered device this is last known and may be stale. Held in
+            memory by the serving node: not shared across cluster nodes, and reset on
+            restart. Empty if never seen.
       required: [registered, imei, ciphering_algorithm, integrity_algorithm]
 
     SubscriberDetail:

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -385,7 +385,7 @@ func (m *MME) FinishHandoverCommit(ue *UeContext, conn S1APWriter, notifyENBID s
 	target.ICS = ICSCompleted
 
 	ue.active.Store(target)
-	m.recordLastSeenLocked(ue, target)
+	m.refreshLastSeenLocked(ue, target)
 
 	if source == nil {
 		m.clearHandoverLocked(ue)
@@ -473,7 +473,7 @@ func (m *MME) CommitPathSwitch(ue *UeContext, conn S1APWriter, enbUEID s1ap.ENBU
 	ue.Conn().ENBUES1APID = enbUEID
 	ue.Conn().setLog(m.nodeLogLocked(conn).With(logger.MMEUeS1apID(uint32(ue.Conn().MMEUES1APID))))
 
-	m.recordLastSeenLocked(ue, ue.Conn())
+	m.refreshLastSeenLocked(ue, ue.Conn())
 
 	ue.mu.Lock()
 	ue.nh = newNH

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -473,6 +473,8 @@ func (m *MME) CommitPathSwitch(ue *UeContext, conn S1APWriter, enbUEID s1ap.ENBU
 	ue.Conn().ENBUES1APID = enbUEID
 	ue.Conn().setLog(m.nodeLogLocked(conn).With(logger.MMEUeS1apID(uint32(ue.Conn().MMEUES1APID))))
 
+	m.recordLastSeenLocked(ue, ue.Conn())
+
 	ue.mu.Lock()
 	ue.nh = newNH
 	ue.ncc = (curNCC + 1) & 0x07

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -385,6 +385,7 @@ func (m *MME) FinishHandoverCommit(ue *UeContext, conn S1APWriter, notifyENBID s
 	target.ICS = ICSCompleted
 
 	ue.active.Store(target)
+	m.recordLastSeenLocked(ue, target)
 
 	if source == nil {
 		m.clearHandoverLocked(ue)

--- a/internal/mme/last_seen.go
+++ b/internal/mme/last_seen.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"sync"
+	"time"
+)
+
+type LastSeen struct {
+	RadioID   string
+	RadioName string
+	At        time.Time
+}
+
+type lastSeenStore struct {
+	mu      sync.RWMutex
+	entries map[string]LastSeen
+}
+
+func (s *lastSeenStore) record(imsi string, radioID, radioName string, at time.Time) {
+	if imsi == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.entries == nil {
+		s.entries = make(map[string]LastSeen)
+	}
+
+	entry := s.entries[imsi]
+
+	if radioID != "" || radioName != "" {
+		entry.RadioID, entry.RadioName = radioID, radioName
+	}
+
+	if at.After(entry.At) {
+		entry.At = at
+	}
+
+	s.entries[imsi] = entry
+}
+
+func (s *lastSeenStore) get(imsi string) (LastSeen, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, ok := s.entries[imsi]
+
+	return entry, ok
+}
+
+func (s *lastSeenStore) all() map[string]LastSeen {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[string]LastSeen, len(s.entries))
+	for imsi, entry := range s.entries {
+		out[imsi] = entry
+	}
+
+	return out
+}
+
+func (s *lastSeenStore) forget(imsi string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.entries, imsi)
+}
+
+func (m *MME) LastSeen(imsi string) (LastSeen, bool) {
+	entry, ok := m.lastSeen.get(imsi)
+	if !ok {
+		return entry, false
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entry.RadioName = m.resolveRadioNameLocked(entry)
+
+	return entry, true
+}
+
+func (m *MME) LastSeenAll() map[string]LastSeen {
+	entries := m.lastSeen.all()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for imsi, entry := range entries {
+		entry.RadioName = m.resolveRadioNameLocked(entry)
+		entries[imsi] = entry
+	}
+
+	return entries
+}
+
+func (m *MME) ForgetSubscriber(imsi string) {
+	m.lastSeen.forget(imsi)
+}
+
+func (m *MME) resolveRadioNameLocked(entry LastSeen) string {
+	if entry.RadioID == "" {
+		return entry.RadioName
+	}
+
+	if radio, ok := m.reg.ClaimedBy(entry.RadioID); ok && radio.name != "" {
+		return radio.name
+	}
+
+	return entry.RadioName
+}

--- a/internal/mme/last_seen.go
+++ b/internal/mme/last_seen.go
@@ -20,6 +20,14 @@ type lastSeenStore struct {
 }
 
 func (s *lastSeenStore) record(imsi string, radioID, radioName string, at time.Time) {
+	s.write(imsi, radioID, radioName, at, true)
+}
+
+func (s *lastSeenStore) refresh(imsi string, radioID, radioName string, at time.Time) {
+	s.write(imsi, radioID, radioName, at, false)
+}
+
+func (s *lastSeenStore) write(imsi string, radioID, radioName string, at time.Time, create bool) {
 	if imsi == "" {
 		return
 	}
@@ -27,11 +35,14 @@ func (s *lastSeenStore) record(imsi string, radioID, radioName string, at time.T
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	entry, known := s.entries[imsi]
+	if !known && !create {
+		return
+	}
+
 	if s.entries == nil {
 		s.entries = make(map[string]LastSeen)
 	}
-
-	entry := s.entries[imsi]
 
 	if radioID != "" || radioName != "" {
 		entry.RadioID, entry.RadioName = radioID, radioName

--- a/internal/mme/last_seen_test.go
+++ b/internal/mme/last_seen_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLastSeenStore(t *testing.T) {
+	var (
+		older = time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
+		imsi  = "001010000000001"
+	)
+
+	t.Run("an unknown subscriber has no record", func(t *testing.T) {
+		var store lastSeenStore
+
+		if _, ok := store.get(imsi); ok {
+			t.Error("get on an empty store reported a record")
+		}
+	})
+
+	t.Run("an empty radio keeps the one already stored", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-enb-01", "enb-01", older)
+		store.record(imsi, "", "", newer)
+
+		got, ok := store.get(imsi)
+		if !ok {
+			t.Fatal("record did not store the subscriber")
+		}
+
+		if got.RadioID != "id-enb-01" || got.RadioName != "enb-01" {
+			t.Errorf("radio = %q/%q, want it retained as id-enb-01/enb-01", got.RadioID, got.RadioName)
+		}
+
+		if !got.At.Equal(newer) {
+			t.Errorf("At = %v, want %v", got.At, newer)
+		}
+	})
+
+	t.Run("an older timestamp does not rewind the record", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-enb-01", "enb-01", newer)
+		store.record(imsi, "id-enb-02", "enb-02", older)
+
+		got, _ := store.get(imsi)
+		if !got.At.Equal(newer) {
+			t.Errorf("At = %v, want %v", got.At, newer)
+		}
+
+		if got.RadioID != "id-enb-02" || got.RadioName != "enb-02" {
+			t.Errorf("radio = %q/%q, want id-enb-02/enb-02", got.RadioID, got.RadioName)
+		}
+	})
+
+	t.Run("forget drops the record", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-enb-01", "enb-01", older)
+		store.forget(imsi)
+
+		if _, ok := store.get(imsi); ok {
+			t.Error("forget left the record in place")
+		}
+	})
+
+	t.Run("an empty IMSI is not stored", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record("", "id-enb-01", "enb-01", older)
+
+		if len(store.all()) != 0 {
+			t.Errorf("all() = %v, want empty", store.all())
+		}
+	})
+
+	t.Run("all returns a copy", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-enb-01", "enb-01", older)
+
+		snapshot := store.all()
+		snapshot[imsi] = LastSeen{RadioName: "tampered"}
+
+		got, _ := store.get(imsi)
+		if got.RadioName != "enb-01" {
+			t.Errorf("RadioName = %q, want the store unaffected at %q", got.RadioName, "enb-01")
+		}
+	})
+}

--- a/internal/mme/last_seen_test.go
+++ b/internal/mme/last_seen_test.go
@@ -94,3 +94,41 @@ func TestLastSeenStore(t *testing.T) {
 		}
 	})
 }
+
+func TestLastSeenStoreRefreshDoesNotResurrectAForgottenSubscriber(t *testing.T) {
+	var (
+		attach   = time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+		teardown = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
+		imsi     = "001010000000002"
+	)
+
+	t.Run("a deregistration completing after forget leaves nothing behind", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-enb-01", "enb-01", attach)
+		store.forget(imsi)
+
+		store.refresh(imsi, "id-enb-01", "enb-01", teardown)
+		store.refresh(imsi, "", "", teardown)
+
+		if entry, ok := store.get(imsi); ok {
+			t.Errorf("refresh resurrected the record as %+v", entry)
+		}
+	})
+
+	t.Run("refresh still updates a live record", func(t *testing.T) {
+		var store lastSeenStore
+
+		store.record(imsi, "id-enb-01", "enb-01", attach)
+		store.refresh(imsi, "id-enb-02", "enb-02", teardown)
+
+		got, ok := store.get(imsi)
+		if !ok {
+			t.Fatal("refresh dropped a live record")
+		}
+
+		if got.RadioName != "enb-02" || !got.At.Equal(teardown) {
+			t.Errorf("record = %q/%v, want enb-02/%v", got.RadioName, got.At, teardown)
+		}
+	})
+}

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -103,6 +103,8 @@ type MME struct {
 
 	relocating map[etsi.SUPI]*relocation
 
+	lastSeen lastSeenStore
+
 	relocationIDs atomic.Uint64
 
 	tmsi *etsi.TmsiAllocator

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -204,13 +204,13 @@ type UeContext struct {
 	lppaBuf   *LPPaBuffered
 }
 
-// TouchLastSeen records the current time as the UE's most recent uplink NAS
-// activity. Safe for concurrent use.
+// TouchLastSeen records the current time as the most recent evidence the UE was
+// present. Safe for concurrent use.
 func (ue *UeContext) TouchLastSeen() {
 	ue.lastSeen.Store(time.Now().UnixNano())
 }
 
-// lastSeenTime returns the UE's most recent uplink NAS activity, or the zero
+// lastSeenTime returns the most recent evidence the UE was present, or the zero
 // time if none has been recorded. Safe for concurrent use.
 func (ue *UeContext) lastSeenTime() time.Time {
 	ns := ue.lastSeen.Load()
@@ -259,6 +259,7 @@ func (m *MME) CommitUEIdentity(ctx context.Context, ue *UeContext, _ AuthProof) 
 	}
 
 	m.UEs[supi] = ue
+	m.recordLastSeenLocked(ue, ue.Conn())
 	m.mu.Unlock()
 
 	// TS 24.301 §5.5.1.2.7 f): a genuine re-attach supersedes the old context and
@@ -645,6 +646,7 @@ func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) (superseded *UeConn) 
 
 	// Becoming connected is activity; refresh liveness at the bind point.
 	ue.TouchLastSeen()
+	m.recordLastSeenLocked(ue, c)
 
 	return superseded
 }
@@ -749,8 +751,25 @@ func (m *MME) removeContextLocked(ue *UeContext) {
 	m.endRelocationLocked(ue.supi, ue)
 
 	if supi := ue.supi; supi.IsIMSI() && m.UEs[supi] == ue {
+		m.lastSeen.record(supi.IMSI(), "", "", ue.lastSeenTime())
 		delete(m.UEs, supi)
 	}
+}
+
+func (m *MME) recordLastSeenLocked(ue *UeContext, c *UeConn) {
+	supi := ue.supi
+	if !supi.IsIMSI() {
+		return
+	}
+
+	var radioID, radioName string
+
+	if s, ok := m.reg.Radio(c.Conn()); ok {
+		radioID, _ = s.IDKey()
+		radioName = s.name
+	}
+
+	m.lastSeen.record(supi.IMSI(), radioID, radioName, ue.lastSeenTime())
 }
 
 // UeConnected reports whether the UE currently holds a UE-associated S1

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -751,12 +751,20 @@ func (m *MME) removeContextLocked(ue *UeContext) {
 	m.endRelocationLocked(ue.supi, ue)
 
 	if supi := ue.supi; supi.IsIMSI() && m.UEs[supi] == ue {
-		m.lastSeen.record(supi.IMSI(), "", "", ue.lastSeenTime())
+		m.lastSeen.refresh(supi.IMSI(), "", "", ue.lastSeenTime())
 		delete(m.UEs, supi)
 	}
 }
 
 func (m *MME) recordLastSeenLocked(ue *UeContext, c *UeConn) {
+	m.writeLastSeenLocked(ue, c, true)
+}
+
+func (m *MME) refreshLastSeenLocked(ue *UeContext, c *UeConn) {
+	m.writeLastSeenLocked(ue, c, false)
+}
+
+func (m *MME) writeLastSeenLocked(ue *UeContext, c *UeConn, create bool) {
 	supi := ue.supi
 	if !supi.IsIMSI() {
 		return
@@ -769,7 +777,13 @@ func (m *MME) recordLastSeenLocked(ue *UeContext, c *UeConn) {
 		radioName = s.name
 	}
 
-	m.lastSeen.record(supi.IMSI(), radioID, radioName, ue.lastSeenTime())
+	if create {
+		m.lastSeen.record(supi.IMSI(), radioID, radioName, ue.lastSeenTime())
+
+		return
+	}
+
+	m.lastSeen.refresh(supi.IMSI(), radioID, radioName, ue.lastSeenTime())
 }
 
 // UeConnected reports whether the UE currently holds a UE-associated S1

--- a/internal/mme/s1ap/handle_nas_non_delivery_indication.go
+++ b/internal/mme/s1ap/handle_nas_non_delivery_indication.go
@@ -29,14 +29,12 @@ func handleNASNonDeliveryIndication(m *mme.MME, ctx context.Context, radio *mme.
 		return
 	}
 
-	ue, ueConn, ok := resolveUE(m, radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID)
+	_, ueConn, ok := resolveUE(m, radio.Conn, msg.MMEUES1APID, msg.ENBUES1APID)
 	if !ok {
 		return
 	}
 
 	reportDiagnostics(m, ctx, radio.Conn, s1ap.ProcNASNonDeliveryIndication, s1ap.TriggeringInitiatingMessage, ueAssociated(ueConn.MMEUES1APID, ueConn.ENBUES1APID), msg.Diagnostics())
-
-	ue.TouchLastSeen()
 
 	fields := []zap.Field{
 		zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)),

--- a/internal/mme/s1ap/handle_ue_context_release_complete.go
+++ b/internal/mme/s1ap/handle_ue_context_release_complete.go
@@ -49,8 +49,6 @@ func HandleUEContextReleaseComplete(m *mme.MME, ctx context.Context, radio *mme.
 
 	captureUserLocation(ueConn, msg.UserLocationInformation)
 
-	ue.TouchLastSeen()
-
 	// Cancel the release-supervision guard so it does not also run the cleanup.
 	ueConn.StopReleaseGuard()
 

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -47,8 +47,6 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 
 	reportDiagnostics(m, ctx, radio.Conn, s1ap.ProcUEContextReleaseRequest, s1ap.TriggeringInitiatingMessage, ueAssociated(ueConn.MMEUES1APID, ueConn.ENBUES1APID), msg.Diagnostics())
 
-	ue.TouchLastSeen()
-
 	fields := []zap.Field{
 		zap.String("imsi", ue.IMSI()),
 		zap.String("cause", mme.S1apCauseName(&cause)),

--- a/internal/mme/status.go
+++ b/internal/mme/status.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ellanetworks/core/nas/eps"
 )
 
-// ConnectedSubscriber is a runtime view of an EMM-registered UE for the API
+// ConnectedSubscriber is a runtime view of a UE with an EMM context for the API
 // layer.
 type ConnectedSubscriber struct {
 	RadioName          string
@@ -21,6 +21,7 @@ type ConnectedSubscriber struct {
 	Imei               string    // 15-digit IMEI from the UE's IMEISV, empty if unknown
 	LastSeenAt         time.Time // most recent evidence the UE was present, zero if none
 	Connected          bool
+	Registered         bool
 	CipheringAlgorithm string // EPS NAS ciphering, e.g. "EEA2" (TS 33.401)
 	IntegrityAlgorithm string // EPS NAS integrity, e.g. "EIA2"
 	// Sessions are the UE's PDN connections, one per active APN, ordered by EPS
@@ -57,6 +58,7 @@ func (m *MME) connectedSubscriber(ue *UeContext) ConnectedSubscriber {
 	cs := ConnectedSubscriber{
 		RadioName:          radioName,
 		Connected:          ue.Connected(),
+		Registered:         ue.EMMState() == EMMRegistered,
 		Imei:               snap.Imei,
 		LastSeenAt:         snap.LastSeenAt,
 		CipheringAlgorithm: snap.CipheringAlgorithm,
@@ -103,7 +105,7 @@ func (m *MME) pdnSessionViews(ue *UeContext) []SubscriberSession {
 	return out
 }
 
-// ConnectedSubscribers returns the status of every EMM-registered UE keyed by
+// ConnectedSubscribers returns the status of every UE with an EMM context keyed by
 // IMSI.
 func (m *MME) ConnectedSubscribers() map[string]ConnectedSubscriber {
 	m.mu.RLock()
@@ -112,7 +114,7 @@ func (m *MME) ConnectedSubscribers() map[string]ConnectedSubscriber {
 	out := make(map[string]ConnectedSubscriber)
 
 	for supi, ue := range m.UEs {
-		if ue.EMMState() != EMMRegistered || ue.imsiOrEmpty() == "" {
+		if ue.EMMState() == EMMDeregistered || ue.imsiOrEmpty() == "" {
 			continue
 		}
 
@@ -122,7 +124,7 @@ func (m *MME) ConnectedSubscribers() map[string]ConnectedSubscriber {
 	return out
 }
 
-// LookupSubscriber returns the runtime status of an EMM-registered UE by IMSI.
+// LookupSubscriber returns the runtime status of a UE with an EMM context by IMSI.
 func (m *MME) LookupSubscriber(imsi string) (ConnectedSubscriber, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -133,7 +135,7 @@ func (m *MME) LookupSubscriber(imsi string) (ConnectedSubscriber, bool) {
 	}
 
 	ue, ok := m.UEs[supi]
-	if !ok || ue.EMMState() != EMMRegistered {
+	if !ok || ue.EMMState() == EMMDeregistered {
 		return ConnectedSubscriber{}, false
 	}
 

--- a/internal/mme/status.go
+++ b/internal/mme/status.go
@@ -19,9 +19,10 @@ type ConnectedSubscriber struct {
 	RadioName          string
 	NumSessions        int
 	Imei               string    // 15-digit IMEI from the UE's IMEISV, empty if unknown
-	LastSeenAt         time.Time // most recent uplink NAS activity, zero if none
-	CipheringAlgorithm string    // EPS NAS ciphering, e.g. "EEA2" (TS 33.401)
-	IntegrityAlgorithm string    // EPS NAS integrity, e.g. "EIA2"
+	LastSeenAt         time.Time // most recent evidence the UE was present, zero if none
+	Connected          bool
+	CipheringAlgorithm string // EPS NAS ciphering, e.g. "EEA2" (TS 33.401)
+	IntegrityAlgorithm string // EPS NAS integrity, e.g. "EIA2"
 	// Sessions are the UE's PDN connections, one per active APN, ordered by EPS
 	// bearer identity (TS 23.401).
 	Sessions []SubscriberSession
@@ -55,6 +56,7 @@ func (m *MME) connectedSubscriber(ue *UeContext) ConnectedSubscriber {
 
 	cs := ConnectedSubscriber{
 		RadioName:          radioName,
+		Connected:          ue.Connected(),
 		Imei:               snap.Imei,
 		LastSeenAt:         snap.LastSeenAt,
 		CipheringAlgorithm: snap.CipheringAlgorithm,

--- a/internal/mme/status.go
+++ b/internal/mme/status.go
@@ -16,7 +16,6 @@ import (
 // ConnectedSubscriber is a runtime view of a UE with an EMM context for the API
 // layer.
 type ConnectedSubscriber struct {
-	RadioName          string
 	NumSessions        int
 	Imei               string    // 15-digit IMEI from the UE's IMEISV, empty if unknown
 	LastSeenAt         time.Time // most recent evidence the UE was present, zero if none
@@ -45,20 +44,11 @@ type SubscriberSession struct {
 
 // connectedSubscriber builds the runtime view of a UE. The caller must hold m.mu.
 func (m *MME) connectedSubscriber(ue *UeContext) ConnectedSubscriber {
-	radioName := ""
-
-	if ue.Conn() != nil {
-		if s, ok := m.reg.Radio(ue.Conn().Conn()); ok {
-			radioName = s.name
-		}
-	}
-
 	snap := ue.Snapshot()
 
 	cs := ConnectedSubscriber{
-		RadioName:          radioName,
 		Connected:          ue.Connected(),
-		Registered:         ue.EMMState() == EMMRegistered,
+		Registered:         ue.EMMState() == EMMRegistered || ue.EMMState() == EMMDeregistrationInitiated,
 		Imei:               snap.Imei,
 		LastSeenAt:         snap.LastSeenAt,
 		CipheringAlgorithm: snap.CipheringAlgorithm,

--- a/internal/mme/status_test.go
+++ b/internal/mme/status_test.go
@@ -292,3 +292,36 @@ func TestLastSeenRadioFallsBackToTheCapturedName(t *testing.T) {
 		t.Errorf("RadioName = %q, want the captured name enb-unclaimed", seen.RadioName)
 	}
 }
+
+func TestLastSeenRadioFollowsAnX2PathSwitch(t *testing.T) {
+	const imsi = "001010000000001"
+
+	m := newTestMME(t)
+	source := connectENB(t, m, "enb-a", 1)
+	target := connectENB(t, m, "enb-b", 2)
+
+	ue := m.NewUe(source, 7)
+	registerTestUE(m, ue, imsi)
+	ue.ForceStateForTest(EMMRegistered)
+
+	if err := m.CommitUEIdentity(t.Context(), ue, MintAuthProofForAttachCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	ue.TouchLastSeen()
+
+	if _, ok := m.CommitPathSwitch(ue, target, 9, [32]byte{}, 0); !ok {
+		t.Fatal("CommitPathSwitch reported the UE released")
+	}
+
+	m.FreeUeConn(ue)
+
+	seen, ok := m.LastSeen(imsi)
+	if !ok {
+		t.Fatal("retained record missing after the path switch")
+	}
+
+	if seen.RadioName != "enb-b" {
+		t.Errorf("RadioName = %q, want the target enb-b", seen.RadioName)
+	}
+}

--- a/internal/mme/status_test.go
+++ b/internal/mme/status_test.go
@@ -49,10 +49,6 @@ func TestConnectedSubscribers(t *testing.T) {
 		t.Fatalf("registered subscriber missing from %+v", got)
 	}
 
-	if st.RadioName != "enb-a" {
-		t.Fatalf("RadioName = %q, want %q", st.RadioName, "enb-a")
-	}
-
 	if st.NumSessions != 1 {
 		t.Fatalf("NumSessions = %d, want 1", st.NumSessions)
 	}
@@ -101,13 +97,8 @@ func TestStatusIncludesIdleSubscriber(t *testing.T) {
 		t.Fatalf("idle registered subscriber not counted: got %d", got)
 	}
 
-	cs, ok := m.LookupSubscriber("001010000000001")
-	if !ok {
+	if _, ok := m.LookupSubscriber("001010000000001"); !ok {
 		t.Fatal("idle registered subscriber not found by LookupSubscriber")
-	}
-
-	if cs.RadioName != "" {
-		t.Fatalf("idle subscriber RadioName = %q, want empty", cs.RadioName)
 	}
 
 	if _, ok := m.ConnectedSubscribers()["001010000000001"]; !ok {
@@ -140,13 +131,8 @@ func TestLookupSubscriber(t *testing.T) {
 		t.Fatal("LookupSubscriber found an unknown IMSI")
 	}
 
-	cs, ok := m.LookupSubscriber("001010000000001")
-	if !ok {
+	if _, ok := m.LookupSubscriber("001010000000001"); !ok {
 		t.Fatal("LookupSubscriber did not find the registered IMSI")
-	}
-
-	if cs.RadioName != "enb-a" {
-		t.Fatalf("RadioName = %q, want enb-a", cs.RadioName)
 	}
 }
 

--- a/internal/mme/status_test.go
+++ b/internal/mme/status_test.go
@@ -184,3 +184,111 @@ func TestHasENBAndCount(t *testing.T) {
 		t.Fatalf("CountRadios = %d, want 2", got)
 	}
 }
+
+func TestLastSeenRadioSurvivesIdleAndDeregistration(t *testing.T) {
+	m := newTestMME(t)
+
+	conn := new(sctp.SCTPConn)
+	m.trackRadio(conn, RadioInfo{Name: "enb-a", ID: "00f110-1"})
+
+	ue := m.NewUe(conn, 7)
+	registerTestUE(m, ue, "001010000000001")
+	ue.ForceStateForTest(EMMRegistered)
+
+	if err := m.CommitUEIdentity(t.Context(), ue, MintAuthProofForAttachCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	cs, ok := m.LookupSubscriber("001010000000001")
+	if !ok || !cs.Connected {
+		t.Fatalf("connected UE: found=%v Connected=%v, want true/true", ok, cs.Connected)
+	}
+
+	m.FreeUeConn(ue)
+
+	cs, ok = m.LookupSubscriber("001010000000001")
+	if !ok {
+		t.Fatal("idle UE missing from LookupSubscriber")
+	}
+
+	if cs.Connected {
+		t.Error("Connected = true for a UE with no S1-connection")
+	}
+
+	if seen, ok := m.LastSeen("001010000000001"); !ok || seen.RadioName != "enb-a" {
+		t.Errorf("idle UE last-seen radio = %q (found %v), want enb-a", seen.RadioName, ok)
+	}
+
+	m.RemoveUe(ue)
+
+	if _, ok := m.LookupSubscriber("001010000000001"); ok {
+		t.Fatal("deregistered UE still reported as registered")
+	}
+
+	if seen, ok := m.LastSeen("001010000000001"); !ok || seen.RadioName != "enb-a" {
+		t.Errorf("deregistered UE last-seen radio = %q (found %v), want it retained as enb-a", seen.RadioName, ok)
+	}
+
+	m.ForgetSubscriber("001010000000001")
+
+	if _, ok := m.LastSeen("001010000000001"); ok {
+		t.Error("ForgetSubscriber left the retained record in place")
+	}
+}
+
+func TestLastSeenRadioFollowsARename(t *testing.T) {
+	const imsi = "001010000000001"
+
+	m := newTestMME(t)
+	conn := connectENB(t, m, "enb-a", 1)
+
+	ue := m.NewUe(conn, 7)
+	registerTestUE(m, ue, imsi)
+	ue.ForceStateForTest(EMMRegistered)
+
+	if err := m.CommitUEIdentity(t.Context(), ue, MintAuthProofForAttachCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	m.FreeUeConn(ue)
+
+	m.UpdateRadioName(m.RadioForConn(conn), "enb-a-renamed")
+
+	seen, ok := m.LastSeen(imsi)
+	if !ok {
+		t.Fatal("retained record missing after rename")
+	}
+
+	if seen.RadioName != "enb-a-renamed" {
+		t.Errorf("RadioName = %q, want the current name enb-a-renamed", seen.RadioName)
+	}
+}
+
+func TestLastSeenRadioFallsBackToTheCapturedName(t *testing.T) {
+	const imsi = "001010000000001"
+
+	m := newTestMME(t)
+	conn := new(sctp.SCTPConn)
+	m.trackRadio(conn, RadioInfo{Name: "enb-unclaimed"})
+
+	ue := m.NewUe(conn, 7)
+	registerTestUE(m, ue, imsi)
+	ue.ForceStateForTest(EMMRegistered)
+
+	if err := m.CommitUEIdentity(t.Context(), ue, MintAuthProofForAttachCommit()); err != nil {
+		t.Fatalf("CommitUEIdentity: %v", err)
+	}
+
+	seen, ok := m.LastSeen(imsi)
+	if !ok {
+		t.Fatal("retained record missing")
+	}
+
+	if seen.RadioID != "" {
+		t.Errorf("RadioID = %q, want empty for a radio with no Global eNB ID", seen.RadioID)
+	}
+
+	if seen.RadioName != "enb-unclaimed" {
+		t.Errorf("RadioName = %q, want the captured name enb-unclaimed", seen.RadioName)
+	}
+}

--- a/ui/src/components/SubscriberConnectionCard.tsx
+++ b/ui/src/components/SubscriberConnectionCard.tsx
@@ -6,7 +6,10 @@ import { Box, Card, CardContent, Chip, Typography } from "@mui/material";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Link as RouterLink } from "react-router-dom";
 import AccessChip from "@/components/AccessChip";
-import type { SubscriberDetailStatus } from "@/queries/subscribers";
+import type {
+  ConnectionState,
+  SubscriberDetailStatus,
+} from "@/queries/subscribers";
 import { formatRelativeTime } from "@/utils/formatters";
 
 interface SubscriberConnectionCardProps {
@@ -146,6 +149,21 @@ const StateChip: React.FC<{ registered?: boolean }> = ({ registered }) => {
   );
 };
 
+const ConnectionChip: React.FC<{ state?: ConnectionState }> = ({ state }) => {
+  if (!state) return null;
+
+  const connected = state === "connected";
+
+  return (
+    <Chip
+      size="small"
+      label={connected ? "Connected" : "Idle"}
+      color={connected ? "success" : "info"}
+      variant={connected ? "filled" : "outlined"}
+    />
+  );
+};
+
 const AccessTypeChips: React.FC<{ accessTypes: string[] }> = ({
   accessTypes,
 }) => (
@@ -196,11 +214,15 @@ const SubscriberConnectionCard: React.FC<SubscriberConnectionCardProps> = ({
     >
       <CardContent sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
         <Typography variant="h6" sx={{ mb: 1.5 }}>
-          Connection
+          Status
         </Typography>
         <InfoRow
-          label="State"
+          label="Registration"
           value={<StateChip registered={status.registered} />}
+        />
+        <InfoRow
+          label="Connection"
+          value={<ConnectionChip state={status.connection_state} />}
         />
         {accessTypes.length > 0 && (
           <InfoRow

--- a/ui/src/components/SubscriberConnectionCard.tsx
+++ b/ui/src/components/SubscriberConnectionCard.tsx
@@ -158,8 +158,8 @@ const ConnectionChip: React.FC<{ state?: ConnectionState }> = ({ state }) => {
     <Chip
       size="small"
       label={connected ? "Connected" : "Idle"}
-      color={connected ? "success" : "info"}
-      variant={connected ? "filled" : "outlined"}
+      color={connected ? "success" : "default"}
+      variant="filled"
     />
   );
 };

--- a/ui/src/pages/Subscribers.test.tsx
+++ b/ui/src/pages/Subscribers.test.tsx
@@ -333,3 +333,67 @@ describe("Subscribers description column", () => {
     ).toHaveTextContent(DESCRIPTIONS[IMSIS[0]]);
   });
 });
+
+describe("Subscribers connection state", () => {
+  const seedStatuses = (statuses: Record<string, Record<string, unknown>>) => {
+    api.get(SUBSCRIBERS_PATH, () => ({
+      items: Object.entries(statuses).map(([imsi, status]) => ({
+        imsi,
+        profile_name: "default",
+        status,
+      })),
+      page: 1,
+      per_page: 25,
+      total_count: Object.keys(statuses).length,
+    }));
+  };
+
+  const cellOf = (imsi: string, field: string) =>
+    screen
+      .getByText(imsi)
+      .closest(".MuiDataGrid-row")
+      ?.querySelector(`[data-field="${field}"]`);
+
+  it("shows registration and connection as separate cells", async () => {
+    seedStatuses({
+      [IMSIS[0]]: {
+        registered: true,
+        connection_state: "connected",
+        last_seen_radio: "gnb-01",
+      },
+      [IMSIS[1]]: {
+        registered: true,
+        connection_state: "idle",
+        last_seen_radio: "gnb-01",
+      },
+      [IMSIS[2]]: { registered: false },
+    });
+    await renderSubscribers();
+    await screen.findByText(IMSIS[0]);
+
+    expect(cellOf(IMSIS[0], "registration")).toHaveTextContent("Registered");
+    expect(cellOf(IMSIS[0], "connection")).toHaveTextContent("Connected");
+
+    expect(cellOf(IMSIS[1], "registration")).toHaveTextContent("Registered");
+    expect(cellOf(IMSIS[1], "connection")).toHaveTextContent("Idle");
+
+    expect(cellOf(IMSIS[2], "registration")).toHaveTextContent("Deregistered");
+    expect(cellOf(IMSIS[2], "connection")).toHaveTextContent("—");
+  });
+
+  it("keeps the last radio on an idle subscriber", async () => {
+    seedStatuses({
+      [IMSIS[0]]: {
+        registered: true,
+        connection_state: "idle",
+        last_seen_radio: "gnb-01",
+      },
+      [IMSIS[1]]: { registered: false },
+    });
+    await renderSubscribers();
+    await screen.findByText(IMSIS[0]);
+
+    expect(cellOf(IMSIS[0], "last_seen_radio")).toHaveTextContent("gnb-01");
+    expect(cellOf(IMSIS[1], "last_seen_radio")).toHaveTextContent("—");
+  });
+});

--- a/ui/src/pages/Subscribers.tsx
+++ b/ui/src/pages/Subscribers.tsx
@@ -153,12 +153,14 @@ const SubscriberPage: React.FC = () => {
         minWidth: 100,
       },
       {
-        field: "radio",
-        headerName: "Radio",
+        field: "last_seen_radio",
+        headerName: "Last radio",
         flex: 0.8,
-        minWidth: 100,
+        minWidth: 110,
+        valueGetter: (_v, row: APISubscriberSummary) =>
+          row?.status?.last_seen_radio ?? "",
         renderCell: (params: GridRenderCellParams<APISubscriberSummary>) => {
-          const radioName = params.row.radio;
+          const radioName = params.row?.status?.last_seen_radio;
           if (!radioName) {
             return (
               <Box
@@ -224,6 +226,33 @@ const SubscriberPage: React.FC = () => {
         },
       },
       {
+        field: "connection",
+        headerName: "Connection",
+        flex: 0.6,
+        minWidth: 110,
+        valueGetter: (_v, row: APISubscriberSummary) =>
+          row?.status?.connection_state ?? "",
+        renderCell: (params: GridRenderCellParams<APISubscriberSummary>) => {
+          const state = params.row?.status?.connection_state;
+          if (!state) {
+            return (
+              <Typography variant="body2" color="textSecondary">
+                —
+              </Typography>
+            );
+          }
+          const connected = state === "connected";
+          return (
+            <Chip
+              size="small"
+              label={connected ? "Connected" : "Idle"}
+              color={connected ? "success" : "info"}
+              variant={connected ? "filled" : "outlined"}
+            />
+          );
+        },
+      },
+      {
         field: "access",
         headerName: "Access",
         flex: 0.4,
@@ -249,26 +278,6 @@ const SubscriberPage: React.FC = () => {
           );
         },
       },
-      {
-        field: "sessions",
-        headerName: "Sessions",
-        flex: 0.5,
-        minWidth: 100,
-        valueGetter: (_v, row: APISubscriberSummary) =>
-          row?.status?.num_sessions ?? 0,
-        renderCell: (params: GridRenderCellParams<APISubscriberSummary>) => {
-          const count = params.row?.status?.num_sessions ?? 0;
-          return (
-            <Chip
-              size="small"
-              label={count}
-              color={count > 0 ? "success" : "default"}
-              variant="filled"
-              sx={{ fontSize: "0.75rem" }}
-            />
-          );
-        },
-      },
     ];
 
     return base;
@@ -280,8 +289,8 @@ const SubscriberPage: React.FC = () => {
       headerName: "Status",
       children: [
         { field: "registration" },
+        { field: "connection" },
         { field: "access" },
-        { field: "sessions" },
       ],
     },
   ];

--- a/ui/src/pages/Subscribers.tsx
+++ b/ui/src/pages/Subscribers.tsx
@@ -246,8 +246,8 @@ const SubscriberPage: React.FC = () => {
             <Chip
               size="small"
               label={connected ? "Connected" : "Idle"}
-              color={connected ? "success" : "info"}
-              variant={connected ? "filled" : "outlined"}
+              color={connected ? "success" : "default"}
+              variant="filled"
             />
           );
         },

--- a/ui/src/queries/subscribers.tsx
+++ b/ui/src/queries/subscribers.tsx
@@ -6,18 +6,21 @@ import { apiFetch, apiFetchVoid } from "@/queries/utils";
 // Mirrors MaxDescriptionLength in internal/api/server/api_subscribers.go.
 export const MAX_DESCRIPTION_LENGTH = 64;
 
+export type ConnectionState = "idle" | "connected";
+
 export type SubscriberListStatus = {
   registered?: boolean;
+  connection_state?: ConnectionState;
   radio_access_types?: string[];
   num_sessions?: number;
   last_seen_at?: string;
+  last_seen_radio?: string;
 };
 
 export type APISubscriberSummary = {
   imsi: string;
   profile_name: string;
   description?: string;
-  radio?: string;
   status: SubscriberListStatus;
 };
 
@@ -30,6 +33,7 @@ export type ListSubscribersResponse = {
 
 export type SubscriberDetailStatus = {
   registered?: boolean;
+  connection_state?: ConnectionState;
   radio_access_types?: string[];
   imei?: string;
   ciphering_algorithm?: string;


### PR DESCRIPTION
# Description

Expose UE connection state in the API and UI, and retain last-seen radio across idle.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
