### PR TITLE
feat(decoder): surface unrecognized NAS IEs for 4G and 5G

### DIFF
--- a/internal/decoder/eps/emm.go
+++ b/internal/decoder/eps/emm.go
@@ -56,6 +56,8 @@ type AttachRequest struct {
 	AttachType     utils.EnumField `json:"attach_type"`
 	MobileIdentity MobileIdentity  `json:"mobile_identity"`
 	ESMContainer   *ESMMessage     `json:"esm_container,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type AttachAccept struct {
@@ -64,46 +66,64 @@ type AttachAccept struct {
 	GUTI         *MobileIdentity `json:"guti,omitempty"`
 	EMMCause     *uint8          `json:"emm_cause,omitempty"`
 	ESMContainer *ESMMessage     `json:"esm_container,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type IdentityRequest struct {
 	IdentityType uint8 `json:"identity_type"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type IdentityResponse struct {
 	MobileIdentity string `json:"mobile_identity"` // raw value, hex
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type AuthenticationRequest struct {
 	NASKeySetIdentifier uint8  `json:"nas_key_set_identifier"`
 	RAND                string `json:"rand"`
 	AUTN                string `json:"autn"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type AuthenticationResponse struct {
 	RES string `json:"res"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type SecurityModeCommand struct {
 	CipheringAlgorithm utils.EnumField `json:"ciphering_algorithm"`
 	IntegrityAlgorithm utils.EnumField `json:"integrity_algorithm"`
 	IMEISVRequested    bool            `json:"imeisv_requested"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type TrackingAreaUpdateRequest struct {
 	UpdateType utils.EnumField `json:"update_type"`
 	ActiveFlag bool            `json:"active_flag"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type TrackingAreaUpdateAccept struct {
 	UpdateResult utils.EnumField `json:"update_result"`
 	GUTI         *MobileIdentity `json:"guti,omitempty"`
 	EMMCause     *uint8          `json:"emm_cause,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type DetachRequest struct {
 	SwitchOff  bool  `json:"switch_off"`
 	DetachType uint8 `json:"detach_type"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type ServiceRequest struct {
@@ -132,6 +152,8 @@ func buildEMMMessage(b []byte) *EMMMessage {
 			MobileIdentity: mobileIdentity(msg.EPSMobileIdentity),
 			ESMContainer:   decodeESMContainer(msg.ESMMessageContainer),
 		}
+
+		m.AttachRequest.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.AttachAccept:
 		a := &AttachAccept{
 			AttachResult: attachResultToEnum(msg.EPSAttachResult),
@@ -145,29 +167,43 @@ func buildEMMMessage(b []byte) *EMMMessage {
 		}
 
 		m.AttachAccept = a
+
+		m.AttachAccept.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.IdentityRequest:
 		m.IdentityRequest = &IdentityRequest{IdentityType: uint8(msg.IdentityType)}
+
+		m.IdentityRequest.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.IdentityResponse:
 		m.IdentityResponse = &IdentityResponse{MobileIdentity: msg.MobileIdentity.String()}
+
+		m.IdentityResponse.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.AuthenticationRequest:
 		m.AuthenticationRequest = &AuthenticationRequest{
 			NASKeySetIdentifier: msg.NASKeySetIdentifier.HalfOctet(),
 			RAND:                hex.EncodeToString(msg.RAND[:]),
 			AUTN:                hex.EncodeToString(msg.AUTN[:]),
 		}
+
+		m.AuthenticationRequest.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.AuthenticationResponse:
 		m.AuthenticationResponse = &AuthenticationResponse{RES: hex.EncodeToString(msg.RES)}
+
+		m.AuthenticationResponse.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.SecurityModeCommand:
 		m.SecurityModeCommand = &SecurityModeCommand{
 			CipheringAlgorithm: cipheringAlgToEnum(uint8(msg.CipheringAlgorithm)),
 			IntegrityAlgorithm: integrityAlgToEnum(uint8(msg.IntegrityAlgorithm)),
 			IMEISVRequested:    msg.IMEISVRequested != nil && msg.IMEISVRequested.Requested(),
 		}
+
+		m.SecurityModeCommand.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.TrackingAreaUpdateRequest:
 		m.TrackingAreaUpdateRequest = &TrackingAreaUpdateRequest{
 			UpdateType: updateTypeToEnum(msg.EPSUpdateType),
 			ActiveFlag: msg.ActiveFlag,
 		}
+
+		m.TrackingAreaUpdateRequest.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.TrackingAreaUpdateAccept:
 		a := &TrackingAreaUpdateAccept{
 			UpdateResult: updateResultToEnum(msg.EPSUpdateResult),
@@ -179,8 +215,12 @@ func buildEMMMessage(b []byte) *EMMMessage {
 		}
 
 		m.TrackingAreaUpdateAccept = a
+
+		m.TrackingAreaUpdateAccept.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.DetachRequestUE:
 		m.DetachRequest = &DetachRequest{SwitchOff: msg.SwitchOff, DetachType: uint8(msg.TypeOfDetach)}
+
+		m.DetachRequest.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	}
 
 	return m

--- a/internal/decoder/eps/esm.go
+++ b/internal/decoder/eps/esm.go
@@ -32,11 +32,15 @@ type ESMMessage struct {
 type PDNConnectivityRequest struct {
 	RequestType utils.EnumField `json:"request_type"`
 	PDNType     utils.EnumField `json:"pdn_type"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 type ActivateDefaultBearer struct {
 	AccessPointName string      `json:"access_point_name,omitempty"`
 	PDNAddress      *PDNAddress `json:"pdn_address,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 // PDNAddress is the decoded PDN address IE (TS 24.301 §9.9.4.9): the assigned UE
@@ -73,11 +77,15 @@ func buildESMMessage(b []byte) *ESMMessage {
 			RequestType: requestTypeToEnum(uint8(msg.RequestType)),
 			PDNType:     pdnTypeToEnum(msg.PDNType),
 		}
+
+		m.PDNConnectivityRequest.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	case *eps.ActivateDefaultEPSBearerContextRequest:
 		m.ActivateDefaultBearer = &ActivateDefaultBearer{
 			AccessPointName: string(msg.AccessPointName),
 			PDNAddress:      pdnAddress(msg.PDNAddress),
 		}
+
+		m.ActivateDefaultBearer.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 	}
 
 	return m

--- a/internal/decoder/nas/authentication_failure.go
+++ b/internal/decoder/nas/authentication_failure.go
@@ -14,6 +14,8 @@ type AuthenticationFailure struct {
 	Cause5GMM utils.EnumField `json:"cause"`
 
 	AuthenticationFailureParameter *string `json:"authentication_failure_parameter,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildAuthenticationFailure(msg *fgs.AuthenticationFailure) *AuthenticationFailure {
@@ -25,6 +27,8 @@ func buildAuthenticationFailure(msg *fgs.AuthenticationFailure) *AuthenticationF
 		s := hex.EncodeToString(msg.AUTS)
 		out.AuthenticationFailureParameter = &s
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/authentication_reject.go
+++ b/internal/decoder/nas/authentication_reject.go
@@ -3,14 +3,23 @@
 
 package nas
 
-import "github.com/ellanetworks/core/nas/fgs"
+import (
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas/fgs"
+)
 
 type AuthenticationReject struct {
 	EAPMessage []byte `json:"eap_message,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildAuthenticationReject(msg *fgs.AuthenticationReject) *AuthenticationReject {
-	return &AuthenticationReject{
+	out := &AuthenticationReject{
 		EAPMessage: msg.EAP,
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
 }

--- a/internal/decoder/nas/authentication_request.go
+++ b/internal/decoder/nas/authentication_request.go
@@ -3,7 +3,10 @@
 
 package nas
 
-import "github.com/ellanetworks/core/nas/fgs"
+import (
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas/fgs"
+)
 
 type AuthenticationRequest struct {
 	SpareHalfOctetAndNgksi      uint8     `json:"spare_half_octet_and_ngksi"`
@@ -11,6 +14,8 @@ type AuthenticationRequest struct {
 	AuthenticationParameterAUTN [16]uint8 `json:"authentication_parameter_autn,omitempty"`
 	AuthenticationParameterRAND [16]uint8 `json:"authentication_parameter_rand,omitempty"`
 	EAPMessage                  []byte    `json:"eap_message,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildAuthenticationRequest(msg *fgs.AuthenticationRequest) *AuthenticationRequest {
@@ -27,6 +32,8 @@ func buildAuthenticationRequest(msg *fgs.AuthenticationRequest) *AuthenticationR
 	if msg.AUTN != nil {
 		out.AuthenticationParameterAUTN = *msg.AUTN
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/authentication_response.go
+++ b/internal/decoder/nas/authentication_response.go
@@ -3,7 +3,10 @@
 
 package nas
 
-import "github.com/ellanetworks/core/nas/fgs"
+import (
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas/fgs"
+)
 
 type AuthenticationResponseParameter struct {
 	ResStar [16]uint8 `json:"res_star"`
@@ -12,6 +15,8 @@ type AuthenticationResponseParameter struct {
 type AuthenticationResponse struct {
 	AuthenticationResponseParameter *AuthenticationResponseParameter `json:"authentication_response_parameter,omitempty"`
 	EAPMessage                      []byte                           `json:"eap_message,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildAuthenticationResponse(msg *fgs.AuthenticationResponse) *AuthenticationResponse {
@@ -24,6 +29,8 @@ func buildAuthenticationResponse(msg *fgs.AuthenticationResponse) *Authenticatio
 		copy(p.ResStar[:], msg.RES)
 		out.AuthenticationResponseParameter = &p
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/dl_nas_transport.go
+++ b/internal/decoder/nas/dl_nas_transport.go
@@ -4,6 +4,7 @@
 package nas
 
 import (
+	"encoding/hex"
 	"time"
 
 	"github.com/ellanetworks/core/internal/decoder/lpp"
@@ -19,6 +20,8 @@ type DLNASTransport struct {
 	BackoffTimerSeconds                   *uint32          `json:"backoff_timer_seconds,omitempty"`
 
 	AdditionalInformation *UnsupportedIE `json:"additional_information,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildDLNASTransport(msg *fgs.DLNASTransport) *DLNASTransport {
@@ -47,12 +50,14 @@ func buildDLNASTransport(msg *fgs.DLNASTransport) *DLNASTransport {
 		out.Cause5GMM = &cause
 	}
 
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
 	return out
 }
 
 func buildDLPayloadContainer(containerType fgs.PayloadContainerType, contents []byte) PayloadContainer {
 	payloadContainer := PayloadContainer{
-		Raw: contents,
+		RawHex: hex.EncodeToString(contents),
 	}
 
 	switch containerType {

--- a/internal/decoder/nas/identity_request.go
+++ b/internal/decoder/nas/identity_request.go
@@ -10,10 +10,16 @@ import (
 
 type IdentityRequest struct {
 	TypeOfIdentity utils.EnumField `json:"type_of_identity"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildIdentityRequest(msg *fgs.IdentityRequest) *IdentityRequest {
-	return &IdentityRequest{
+	out := &IdentityRequest{
 		TypeOfIdentity: buildTypeOfIdentityEnum(uint8(msg.IdentityType)),
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
 }

--- a/internal/decoder/nas/identity_response.go
+++ b/internal/decoder/nas/identity_response.go
@@ -20,10 +20,16 @@ type MobileIdentity struct {
 
 type IdentityResponse struct {
 	MobileIdentity MobileIdentity `json:"mobile_identity"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildIdentityResponse(msg *fgs.IdentityResponse) *IdentityResponse {
-	return &IdentityResponse{
+	out := &IdentityResponse{
 		MobileIdentity: buildMobileIdentity(msg.MobileIdentity),
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
 }

--- a/internal/decoder/nas/pdu_session_establishment_accept.go
+++ b/internal/decoder/nas/pdu_session_establishment_accept.go
@@ -40,6 +40,8 @@ type PDUSessionEstablishmentAccept struct {
 	RQTimerValue                 *UnsupportedIE `json:"rq_timer_value,omitempty"`
 	AlwaysonPDUSessionIndication *UnsupportedIE `json:"alwayson_pdu_session_indication,omitempty"`
 	EAPMessage                   *UnsupportedIE `json:"eap_message,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildPDUSessionEstablishmentAccept(msg *fgs.PDUSessionEstablishmentAccept) *PDUSessionEstablishmentAccept {
@@ -98,6 +100,8 @@ func buildPDUSessionEstablishmentAccept(msg *fgs.PDUSessionEstablishmentAccept) 
 		name := string(*msg.DNN)
 		estAcc.DNN = &name
 	}
+
+	estAcc.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return estAcc
 }

--- a/internal/decoder/nas/pdu_session_establishment_request.go
+++ b/internal/decoder/nas/pdu_session_establishment_request.go
@@ -70,6 +70,8 @@ type PDUSessionEstablishmentRequest struct {
 	MaximumNumberOfSupportedPacketFilters *uint16        `json:"maximum_number_of_supported_packet_filters,omitempty"`
 	AlwaysonPDUSessionRequested           *bool          `json:"alwayson_pdu_session_requested,omitempty"`
 	SMPDUDNRequestContainer               *UnsupportedIE `json:"smpdu_dn_request_container,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildPDUSessionEstablishmentRequest(msg *fgs.PDUSessionEstablishmentRequest) *PDUSessionEstablishmentRequest {
@@ -116,6 +118,8 @@ func buildPDUSessionEstablishmentRequest(msg *fgs.PDUSessionEstablishmentRequest
 			}
 		}
 	}
+
+	out.UnrecognizedIEs = utils.RawIEsExcept(msg.Unrecognized, ieiMaxPacketFilters, ieiSMPDUDNRequest, ieiExtendedPCO)
 
 	return out
 }

--- a/internal/decoder/nas/registration_accept.go
+++ b/internal/decoder/nas/registration_accept.go
@@ -79,6 +79,8 @@ type RegistrationAccept struct {
 	NegotiatedDRXParameters                  *UnsupportedIE                  `json:"negotiated_drx_parameters,omitempty"`
 	Non3GppNwPolicies                        *UnsupportedIE                  `json:"non_3gpp_nw_policies,omitempty"`
 	EPSBearerContextStatus                   *UnsupportedIE                  `json:"eps_bearer_context_status,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func registrationResult5GSEnum(value fgs.RegistrationResult) utils.EnumField {
@@ -146,6 +148,8 @@ func buildRegistrationAccept(msg *fgs.RegistrationAccept) *RegistrationAccept {
 			*p.dest = makeUnsupportedIE()
 		}
 	}
+
+	out.UnrecognizedIEs = utils.RawIEsExcept(msg.Unrecognized, ieiEmergencyNumberList, ieiEquivalentPLMNs, ieiExtEmergencyNumberList, ieiLADNInformation, ieiNetworkSlicingIndication, ieiNon3GppNwPolicies, ieiNSSAIInclusionMode, ieiOperatorAccessCategory, ieiPDUReactErrCause, ieiRejectedNSSAI, ieiServiceAreaList)
 
 	return out
 }

--- a/internal/decoder/nas/registration_complete.go
+++ b/internal/decoder/nas/registration_complete.go
@@ -3,14 +3,23 @@
 
 package nas
 
-import "github.com/ellanetworks/core/nas/fgs"
+import (
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas/fgs"
+)
 
 type RegistrationComplete struct {
 	GetSORContent []uint8 `json:"sor_transparent_container,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildRegistrationComplete(msg *fgs.RegistrationComplete) *RegistrationComplete {
-	return &RegistrationComplete{
+	out := &RegistrationComplete{
 		GetSORContent: msg.SORTransparentContainer,
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
 }

--- a/internal/decoder/nas/registration_reject.go
+++ b/internal/decoder/nas/registration_reject.go
@@ -14,6 +14,8 @@ type RegistrationReject struct {
 	T3346Value *UnsupportedIE `json:"t3346_value,omitempty"`
 	T3502Value *UnsupportedIE `json:"t3502_value,omitempty"`
 	EAPMessage *UnsupportedIE `json:"eap_message,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildRegistrationReject(msg *fgs.RegistrationReject) *RegistrationReject {
@@ -32,6 +34,8 @@ func buildRegistrationReject(msg *fgs.RegistrationReject) *RegistrationReject {
 	if msg.EAP != nil {
 		out.EAPMessage = makeUnsupportedIE()
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/registration_request.go
+++ b/internal/decoder/nas/registration_request.go
@@ -34,6 +34,8 @@ type RegistrationRequest struct {
 	NetworkSlicingIndication            *UnsupportedIE `json:"network_slicing_indication,omitempty"`
 	UpdateType5GS                       *UnsupportedIE `json:"update_type_5gs,omitempty"`
 	EPSBearerContextStatus              *UnsupportedIE `json:"eps_bearer_context_status,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildRegistrationRequest(msg *fgs.RegistrationRequest) *RegistrationRequest {
@@ -108,6 +110,8 @@ func buildRegistrationRequest(msg *fgs.RegistrationRequest) *RegistrationRequest
 			out.NetworkSlicingIndication = makeUnsupportedIE()
 		}
 	}
+
+	out.UnrecognizedIEs = utils.RawIEsExcept(msg.Unrecognized, ieiNoncurrentNativeNASKSI, ieiS1UENetworkCapability, ieiUesUsageSetting, ieiLastVisitedTAI, ieiEPSBearerContextStatus, ieiEPSNASMessageContainer, ieiLADNIndication, ieiAdditionalGUTI, ieiPayloadContainer, ieiNetworkSlicingIndication)
 
 	return out
 }

--- a/internal/decoder/nas/security_mode_command.go
+++ b/internal/decoder/nas/security_mode_command.go
@@ -53,6 +53,8 @@ type SecurityModeCommand struct {
 	ABBA                             []uint8                           `json:"abba,omitempty"`
 
 	ReplayedS1UESecurityCapabilities *S1UESecurityCapability `json:"replayed_s1_ue_security_capabilities,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildSecurityModeCommand(msg *fgs.SecurityModeCommand) *SecurityModeCommand {
@@ -89,6 +91,8 @@ func buildSecurityModeCommand(msg *fgs.SecurityModeCommand) *SecurityModeCommand
 	if msg.ReplayedS1UESecurityCapability != nil {
 		out.ReplayedS1UESecurityCapabilities = s1UESecurityCapability(msg.ReplayedS1UESecurityCapability)
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/security_mode_complete.go
+++ b/internal/decoder/nas/security_mode_complete.go
@@ -3,11 +3,16 @@
 
 package nas
 
-import "github.com/ellanetworks/core/nas/fgs"
+import (
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas/fgs"
+)
 
 type SecurityModeComplete struct {
 	IMEISV              *string `json:"imeisv,omitempty"`
 	NASMessageContainer []byte  `json:"nas_message_container,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildSecurityModeComplete(msg *fgs.SecurityModeComplete) *SecurityModeComplete {
@@ -19,6 +24,8 @@ func buildSecurityModeComplete(msg *fgs.SecurityModeComplete) *SecurityModeCompl
 		pei := msg.IMEISV.String()
 		out.IMEISV = &pei
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/service_accept.go
+++ b/internal/decoder/nas/service_accept.go
@@ -24,6 +24,8 @@ type ServiceAccept struct {
 	PDUSessionReactivationResult           []PDUSessionReactivateResultPDU `json:"pdu_session_reactivation_result,omitempty"`
 	PDUSessionReactivationResultErrorCause []PDUSessionCause               `json:"pdu_session_reactivation_result_error_cause,omitempty"`
 	EAPMessage                             []byte                          `json:"eap_message,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildServiceAccept(msg *fgs.ServiceAccept) *ServiceAccept {
@@ -54,6 +56,8 @@ func buildServiceAccept(msg *fgs.ServiceAccept) *ServiceAccept {
 			out.PDUSessionReactivationResultErrorCause = pduSessionCauses
 		}
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/service_reject.go
+++ b/internal/decoder/nas/service_reject.go
@@ -14,6 +14,8 @@ type ServiceReject struct {
 	PDUSessionStatus []PDUSessionStatusPDU `json:"pdu_session_status,omitempty"`
 	T3346Value       *uint8                `json:"t3346_value,omitempty"`
 	EAPMessage       []byte                `json:"eap_message,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildServiceReject(msg *fgs.ServiceReject) *ServiceReject {
@@ -26,6 +28,8 @@ func buildServiceReject(msg *fgs.ServiceReject) *ServiceReject {
 	if msg.PDUSessionStatus != nil {
 		out.PDUSessionStatus = decodePDUSessionStatus(msg.PDUSessionStatus)
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/service_request.go
+++ b/internal/decoder/nas/service_request.go
@@ -58,6 +58,8 @@ type ServiceRequest struct {
 	PDUSessionStatus        []PDUSessionStatusPDU     `json:"pdu_session_status,omitempty"`
 	AllowedPDUSessionStatus []AllowedPDUSessionStatus `json:"allowed_pdu_session_status,omitempty"`
 	NASMessageContainer     []byte                    `json:"nas_message_container,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildServiceRequest(msg *fgs.ServiceRequest) *ServiceRequest {
@@ -96,6 +98,8 @@ func buildServiceRequest(msg *fgs.ServiceRequest) *ServiceRequest {
 
 		out.AllowedPDUSessionStatus = aps
 	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
 
 	return out
 }

--- a/internal/decoder/nas/testdata/golden/dl_nas_transport_full.json
+++ b/internal/decoder/nas/testdata/golden/dl_nas_transport_full.json
@@ -26,7 +26,7 @@
     "dl_nas_transport": {
       "spare_half_octet_and_payload_container_type": 1,
       "payload_container": {
-        "raw": "LgEAwRH/",
+        "raw_hex": "2e0100c111ff",
         "gsm_message": {
           "gsm_header": {
             "message_type": {

--- a/internal/decoder/nas/testdata/golden/pdu_session_establishment_accept_full.json
+++ b/internal/decoder/nas/testdata/golden/pdu_session_establishment_accept_full.json
@@ -26,7 +26,7 @@
     "dl_nas_transport": {
       "spare_half_octet_and_payload_container_type": 1,
       "payload_container": {
-        "raw": "LgEAwhEACQEABjExAQH/CQYGA+gGA+gpBQEKLQACIgQBqrvMJQkIaW50ZXJuZXQ=",
+        "raw_hex": "2e0100c211000901000631310101ff09060603e80603e82905010a2d0002220401aabbcc250908696e7465726e6574",
         "gsm_message": {
           "gsm_header": {
             "message_type": {

--- a/internal/decoder/nas/testdata/golden/pdu_session_establishment_request_full.json
+++ b/internal/decoder/nas/testdata/golden/pdu_session_establishment_request_full.json
@@ -26,7 +26,7 @@
     "ul_nas_transport": {
       "spare_half_octet_and_payload_container_type": 1,
       "payload_container": {
-        "raw": "LgEAwRH/kaEoAQNVABCxOQEAewAHgAABAAAOAA==",
+        "raw_hex": "2e0100c111ff91a1280103550010b13901007b000780000100000e00",
         "gsm_message": {
           "gsm_header": {
             "message_type": {

--- a/internal/decoder/nas/testdata/golden/ul_nas_transport_full.json
+++ b/internal/decoder/nas/testdata/golden/ul_nas_transport_full.json
@@ -26,7 +26,7 @@
     "ul_nas_transport": {
       "spare_half_octet_and_payload_container_type": 1,
       "payload_container": {
-        "raw": "LgEAwRH/",
+        "raw_hex": "2e0100c111ff",
         "gsm_message": {
           "gsm_header": {
             "message_type": {

--- a/internal/decoder/nas/ul_nas_transport.go
+++ b/internal/decoder/nas/ul_nas_transport.go
@@ -14,7 +14,7 @@ import (
 )
 
 type PayloadContainer struct {
-	Raw        []byte      `json:"raw"`
+	RawHex     string      `json:"raw_hex"`
 	GsmMessage *GsmMessage `json:"gsm_message,omitempty"`
 	LppMessage *lpp.PDU    `json:"lpp_message,omitempty"`
 
@@ -31,6 +31,8 @@ type ULNASTransport struct {
 	DNN                                   *string          `json:"dnn,omitempty"`
 
 	AdditionalInformation *UnsupportedIE `json:"additional_information,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
 
 func buildULNASTransport(msg *fgs.ULNASTransport) *ULNASTransport {
@@ -66,6 +68,8 @@ func buildULNASTransport(msg *fgs.ULNASTransport) *ULNASTransport {
 		out.AdditionalInformation = makeUnsupportedIE()
 	}
 
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
 	return out
 }
 
@@ -75,7 +79,7 @@ func requestTypeEnum(rt uint8) utils.EnumField {
 
 func buildULPayloadContainer(containerType fgs.PayloadContainerType, contents []byte) PayloadContainer {
 	payloadContainer := PayloadContainer{
-		Raw: contents,
+		RawHex: hex.EncodeToString(contents),
 	}
 
 	switch containerType {

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_release_command.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_release_command.json
@@ -90,7 +90,7 @@
               "dl_nas_transport": {
                 "spare_half_octet_and_payload_container_type": 1,
                 "payload_container": {
-                  "raw": "LgEE0wA=",
+                  "raw_hex": "2e0104d300",
                   "gsm_message": {
                     "gsm_header": {
                       "message_type": {

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_setup_request.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_setup_request.json
@@ -93,7 +93,7 @@
                   "dl_nas_transport": {
                     "spare_half_octet_and_payload_container_type": 1,
                     "payload_container": {
-                      "raw": "LgEBwhEACf8ABjH/AQH/CQYGAMgGAMgpBQEKLQACIgQBECAweQAQASBDAQEJBAMGAMgFAwYAyHsADYAADQQICAgIABACBXglCQhpbnRlcm5ldA==",
+                      "raw_hex": "2e0101c2110009ff000631ff0101ff09060600c80600c82905010a2d000222040110203079001001204301010904030600c805030600c87b000d80000d04080808080010020578250908696e7465726e6574",
                       "gsm_message": {
                         "gsm_header": {
                           "message_type": {

--- a/internal/decoder/ngap/testdata/golden/uplink_nas_transport.json
+++ b/internal/decoder/ngap/testdata/golden/uplink_nas_transport.json
@@ -90,7 +90,7 @@
               "ul_nas_transport": {
                 "spare_half_octet_and_payload_container_type": 1,
                 "payload_container": {
-                  "raw": "LgEA1lE=",
+                  "raw_hex": "2e0100d651",
                   "gsm_message": {
                     "gsm_header": {
                       "message_type": {

--- a/internal/decoder/s1ap/testdata/golden/initial_ue_message.json
+++ b/internal/decoder/s1ap/testdata/golden/initial_ue_message.json
@@ -79,7 +79,21 @@
                   "label": "TA updating",
                   "unknown": false
                 },
-                "active_flag": false
+                "active_flag": false,
+                "unrecognized_ies": [
+                  {
+                    "iei": 82,
+                    "hex": "99f9100001"
+                  },
+                  {
+                    "iei": 93,
+                    "hex": "06"
+                  },
+                  {
+                    "iei": 192,
+                    "hex": "01"
+                  }
+                ]
               }
             },
             "encrypted": false

--- a/internal/decoder/utils/raw_ie.go
+++ b/internal/decoder/utils/raw_ie.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package utils
+
+import (
+	"encoding/hex"
+	"slices"
+
+	"github.com/ellanetworks/core/nas"
+)
+
+// RawIE is a NAS information element the decoder does not model, carried through
+// so a capture shows the element arrived rather than dropping it silently. It
+// mirrors what the NGAP and S1AP decoders render for an unmodelled IE, with the
+// identifier NAS puts on the element itself rather than on a wrapper.
+type RawIE struct {
+	IEI uint8  `json:"iei"`
+	Hex string `json:"hex"`
+}
+
+// RawIEs renders the elements a NAS message preserved but the decoder does not
+// model. It returns nil for none, so the field stays out of the JSON.
+func RawIEs(raw []nas.RawIE) []RawIE {
+	return RawIEsExcept(raw)
+}
+
+// RawIEsExcept is RawIEs for a builder that already renders some preserved
+// elements itself: those identifiers are named here so an element is reported
+// once, either as its own field or as a raw one, never both.
+func RawIEsExcept(raw []nas.RawIE, handled ...uint8) []RawIE {
+	var out []RawIE
+
+	for _, r := range raw {
+		if slices.Contains(handled, r.IEI) {
+			continue
+		}
+
+		out = append(out, RawIE{IEI: r.IEI, Hex: hex.EncodeToString(r.Value)})
+	}
+
+	return out
+}

--- a/internal/decoder/utils/raw_ie_test.go
+++ b/internal/decoder/utils/raw_ie_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas"
+)
+
+func TestRawIEs(t *testing.T) {
+	raw := []nas.RawIE{
+		{IEI: 0x52, Value: []byte{0x99, 0xf9}},
+		{IEI: 0x5d, Value: []byte{0x06}},
+	}
+
+	got := utils.RawIEs(raw)
+	if len(got) != 2 {
+		t.Fatalf("got %d elements, want 2", len(got))
+	}
+
+	if got[0].IEI != 0x52 || got[0].Hex != "99f9" {
+		t.Errorf("got %+v, want IEI 0x52 hex 99f9", got[0])
+	}
+}
+
+// An element a builder already renders itself must not also appear as a raw one.
+func TestRawIEsExceptSkipsHandled(t *testing.T) {
+	raw := []nas.RawIE{
+		{IEI: 0x52, Value: []byte{0x01}},
+		{IEI: 0x5d, Value: []byte{0x02}},
+	}
+
+	got := utils.RawIEsExcept(raw, 0x52)
+	if len(got) != 1 || got[0].IEI != 0x5d {
+		t.Fatalf("got %+v, want only IEI 0x5d", got)
+	}
+}
+
+func TestRawIEsEmptyStaysNil(t *testing.T) {
+	if got := utils.RawIEs(nil); got != nil {
+		t.Fatalf("got %+v, want nil so the field stays out of the JSON", got)
+	}
+}


### PR DESCRIPTION
# Description

Network event captures now show every information element a device sends, including ones Ella Core does not yet interpret, so operators can see what arrived.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
