### PR TITLE
feat: answer the LCP, PAP, CHAP and IPCP protocol identifiers

### DIFF
--- a/internal/decoder/nas/pco.go
+++ b/internal/decoder/nas/pco.go
@@ -57,6 +57,10 @@ func containerValue(id uint16, dir naslib.PCODirection, b []byte) string {
 		return naslib.PCONBIFOMModeName(b[0])
 	}
 
+	if s := naslib.PCOProtocolOptionSummary(id, b); s != "" {
+		return s
+	}
+
 	switch dir {
 	case naslib.PCONetworkToMS:
 		return downlinkContainerValue(id, b)

--- a/internal/decoder/nas/pco_protocol_test.go
+++ b/internal/decoder/nas/pco_protocol_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"encoding/hex"
+	"testing"
+
+	naslib "github.com/ellanetworks/core/nas"
+)
+
+func decoded(t *testing.T, dir naslib.PCODirection, id uint16, content string) PCOContainer {
+	t.Helper()
+
+	b, err := hex.DecodeString(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := ExtendedPCO(&naslib.ProtocolConfigurationOptions{
+		Direction:  dir,
+		Containers: []naslib.PCOContainer{{ID: id, Content: b}},
+	})
+
+	if out == nil || len(out.Containers) != 1 {
+		t.Fatalf("got %+v", out)
+	}
+
+	return out.Containers[0]
+}
+
+func TestExtendedPCORendersTheDownlinkIPCPAnswer(t *testing.T) {
+	c := decoded(t, naslib.PCONetworkToMS, naslib.PCOProtocolIPCP,
+		"03000010"+"810608080808"+"830608080808")
+
+	if c.Name != "IPCP" {
+		t.Fatalf("name = %q", c.Name)
+	}
+
+	want := "Configure-Nak: Primary DNS Server Address 8.8.8.8, Secondary DNS Server Address 8.8.8.8"
+	if c.Value != want {
+		t.Fatalf("value = %q, want %q", c.Value, want)
+	}
+
+	if c.Hex != "" {
+		t.Fatalf("a decoded unit carries no hex fallback, got %q", c.Hex)
+	}
+}
+
+func TestExtendedPCORendersTheUplinkIPCPRequest(t *testing.T) {
+	c := decoded(t, naslib.PCOMSToNetwork, naslib.PCOProtocolIPCP,
+		"01000010"+"810600000000"+"830600000000")
+
+	want := "Configure-Request: Primary DNS Server Address 0.0.0.0, Secondary DNS Server Address 0.0.0.0"
+	if c.Value != want {
+		t.Fatalf("value = %q, want %q", c.Value, want)
+	}
+}
+
+func TestExtendedPCODoesNotRenderPAPCredentials(t *testing.T) {
+	c := decoded(t, naslib.PCOMSToNetwork, naslib.PCOProtocolPAP,
+		"0101000c"+"02"+"6162"+"04"+"70617373")
+
+	if c.Value != "Authenticate-Request" {
+		t.Fatalf("value = %q", c.Value)
+	}
+
+	if c.Hex != "" {
+		t.Fatalf("the peer-ID and password must not reach the event log, got %q", c.Hex)
+	}
+}

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -147,6 +147,7 @@ type UeContext struct {
 	RequestedAPN          string       // UE-requested APN at attach ("" = use the default policy, TS 24.301 §6.5.1.3)
 	RequestedPDUSessionID uint8
 	RequestedType         eps.RequestType
+	RequestedProtocolOpts []nas.PCOContainer
 	tmsi                  etsi.TMSI
 	oldTmsi               etsi.TMSI
 	Location              models.UserLocation

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -278,7 +278,7 @@ func buildAttachAccept(ctx context.Context, m *mme.MME, ue *mme.UeContext, qos *
 
 	plmn := operator.PLMN()
 
-	esm, err := buildActivateDefaultESM(p, qos, uint8(ue.RequestedPTI), plmn, ue.UsesEPCO(p))
+	esm, err := buildActivateDefaultESM(p, qos, uint8(ue.RequestedPTI), plmn, ue.UsesEPCO(p), ue.RequestedProtocolOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func sendNITZ(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.Ue
 	ueConn.SendDownlinkProtected(ctx, info)
 }
 
-func buildActivateDefaultESM(p *mme.PdnConnection, qos *mme.EpsQoS, pti uint8, plmn models.PlmnID, useEPCO bool) ([]byte, error) {
+func buildActivateDefaultESM(p *mme.PdnConnection, qos *mme.EpsQoS, pti uint8, plmn models.PlmnID, useEPCO bool, protocolRequests []nas.PCOContainer) ([]byte, error) {
 	apn := eps.APN(qos.APN)
 
 	// PDN Address per the negotiated type (TS 24.301): IPv4 carries the
@@ -461,6 +461,15 @@ func buildActivateDefaultESM(p *mme.PdnConnection, qos *mme.EpsQoS, pti uint8, p
 		}
 
 		pco.Containers = append(pco.Containers, mapped...)
+	}
+
+	if answers := nas.AnswerProtocolOptions(protocolRequests, p.Dns, p.UeIP); len(answers) > 0 {
+		with := pco
+		with.PrependProtocolOptions(answers)
+
+		if useEPCO || with.FitsUnextended() {
+			pco = with
+		}
 	}
 
 	if useEPCO {

--- a/internal/mme/nas/esm_information.go
+++ b/internal/mme/nas/esm_information.go
@@ -100,6 +100,10 @@ func handleESMInformationResponse(ctx context.Context, m *mme.MME, ue *mme.UeCon
 		ue.RequestedPDUSessionID = id
 	}
 
+	if opts, ok := protocolOptionsFromPCOs(req.ProtocolConfigurationOptions, req.ExtendedProtocolConfigurationOptions); ok {
+		ue.RequestedProtocolOpts = opts
+	}
+
 	logger.From(ctx, logger.MmeLog).Info("received deferred ESM information",
 		zap.String("imsi", ue.IMSI()), zap.String("apn", ue.RequestedAPN),
 		zap.Uint8("pdu_session_id", ue.RequestedPDUSessionID))

--- a/internal/mme/nas/esm_information_test.go
+++ b/internal/mme/nas/esm_information_test.go
@@ -310,3 +310,38 @@ func TestESMInformationResponseKeepsTheAttachPDUSessionIdentity(t *testing.T) {
 		t.Errorf("PDU session identity = %d, want the 7 the attach carried: a response that names none does not withdraw it, and zeroing it costs the UE its IP preservation", ue.RequestedPDUSessionID)
 	}
 }
+
+func TestESMInformationResponseReplacesTheAttachProtocolOptions(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, _ := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue, ue.Conn())
+
+	ue.RequestedProtocolOpts = []nas.PCOContainer{{ID: nas.PCOProtocolIPCP, Content: []byte{1, 0, 0, 4}}}
+
+	replacement := nas.NewRequestedProtocolConfigurationOptions(nas.PCOContainerDNSServerIPv4Address)
+
+	handleESMInformationResponse(context.Background(), m, ue, ue.Conn(), &eps.ESMInformationResponse{
+		PTI:                          3,
+		ProtocolConfigurationOptions: &replacement,
+	})
+
+	if len(ue.RequestedProtocolOpts) != 0 {
+		t.Fatalf("the attach's IPCP request survived a replacing IE: %+v", ue.RequestedProtocolOpts)
+	}
+}
+
+func TestESMInformationResponseWithoutPCOKeepsTheAttachProtocolOptions(t *testing.T) {
+	m := esmInfoTestMME()
+	ue, _ := esmInfoAttachUe(t, m, 3)
+
+	activateDefaultBearer(context.Background(), m, ue, ue.Conn())
+
+	ue.RequestedProtocolOpts = []nas.PCOContainer{{ID: nas.PCOProtocolIPCP, Content: []byte{1, 0, 0, 4}}}
+
+	handleESMInformationResponse(context.Background(), m, ue, ue.Conn(), &eps.ESMInformationResponse{PTI: 3})
+
+	if len(ue.RequestedProtocolOpts) != 1 {
+		t.Fatal("a response carrying no PCO IE replaces nothing")
+	}
+}

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -152,6 +152,7 @@ func ingestAttachRequest(ctx context.Context, ue *mme.UeContext, ueConn *mme.UeC
 		}
 
 		ue.RequestedPDUSessionID = pduSessionIDFromPCOs(pc.ProtocolConfigurationOptions, pc.ExtendedProtocolConfigurationOptions)
+		ue.RequestedProtocolOpts, _ = protocolOptionsFromPCOs(pc.ProtocolConfigurationOptions, pc.ExtendedProtocolConfigurationOptions)
 
 		if pc.RequestType != 0 {
 			ue.RequestedType = pc.RequestType

--- a/internal/mme/nas/interworking_eps_conformance_test.go
+++ b/internal/mme/nas/interworking_eps_conformance_test.go
@@ -195,7 +195,7 @@ func TestEPSExtendedPCOIsAPropertyOfThePDNConnection(t *testing.T) {
 				SessAmbrDL: models.MustParseBitRate("1 Gbps"),
 			}
 
-			raw, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, ue.UsesEPCO(p))
+			raw, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, ue.UsesEPCO(p), nil)
 			if err != nil {
 				t.Fatalf("build ACTIVATE DEFAULT EPS BEARER CONTEXT REQUEST: %v", err)
 			}

--- a/internal/mme/nas/interworking_pco_test.go
+++ b/internal/mme/nas/interworking_pco_test.go
@@ -90,7 +90,7 @@ func buildActivate(t *testing.T, p *mme.PdnConnection, qos *mme.EpsQoS) *eps.Act
 func buildActivateWithEPCO(t *testing.T, p *mme.PdnConnection, qos *mme.EpsQoS, useEPCO bool) *eps.ActivateDefaultEPSBearerContextRequest {
 	t.Helper()
 
-	wire, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, useEPCO)
+	wire, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, useEPCO, nil)
 	if err != nil {
 		t.Fatalf("buildActivateDefaultESM: %v", err)
 	}

--- a/internal/mme/nas/pdn_connectivity.go
+++ b/internal/mme/nas/pdn_connectivity.go
@@ -70,6 +70,7 @@ func handlePDNConnectivityRequest(ctx context.Context, m *mme.MME, ue *mme.UeCon
 	}
 
 	ue.RequestedPDUSessionID = pduSessionIDFromPCOs(req.ProtocolConfigurationOptions, req.ExtendedProtocolConfigurationOptions)
+	ue.RequestedProtocolOpts, _ = protocolOptionsFromPCOs(req.ProtocolConfigurationOptions, req.ExtendedProtocolConfigurationOptions)
 	ue.RequestedType = req.RequestType
 
 	if req.ESMInformationTransferFlag != nil && *req.ESMInformationTransferFlag {
@@ -178,7 +179,7 @@ func openPDNConnection(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueCon
 		return nasreply.Handled()
 	}
 
-	esm, err := buildActivateDefaultESM(p, qos, uint8(pti), plmn, ue.UsesEPCO(p))
+	esm, err := buildActivateDefaultESM(p, qos, uint8(pti), plmn, ue.UsesEPCO(p), ue.RequestedProtocolOpts)
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Error("failed to build Activate Default EPS Bearer Context Request", zap.Error(err))
 		m.ReleasePDN(ctx, ue, p)

--- a/internal/mme/nas/pdu_session_identity.go
+++ b/internal/mme/nas/pdu_session_identity.go
@@ -27,6 +27,18 @@ func pduSessionIDFromPCOs(pco, epco *nas.ProtocolConfigurationOptions) uint8 {
 	return 0
 }
 
+func protocolOptionsFromPCOs(pco, epco *nas.ProtocolConfigurationOptions) ([]nas.PCOContainer, bool) {
+	for _, opts := range []*nas.ProtocolConfigurationOptions{epco, pco} {
+		if opts == nil {
+			continue
+		}
+
+		return opts.ProtocolOptions(), true
+	}
+
+	return nil, false
+}
+
 func fiveGSMCauseFromPCOs(pco, epco *nas.ProtocolConfigurationOptions) (uint8, bool) {
 	for _, opts := range []*nas.ProtocolConfigurationOptions{epco, pco} {
 		if opts == nil {

--- a/internal/mme/nas/protocol_options_test.go
+++ b/internal/mme/nas/protocol_options_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"encoding/hex"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+func ipcpConfigureRequest(t *testing.T) []nas.PCOContainer {
+	t.Helper()
+
+	content, err := hex.DecodeString("01000010" + "810600000000" + "830600000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return []nas.PCOContainer{{ID: nas.PCOProtocolIPCP, Content: content}}
+}
+
+func activateWithProtocolOptions(t *testing.T, p *mme.PdnConnection, qos *mme.EpsQoS, useEPCO bool) *eps.ActivateDefaultEPSBearerContextRequest {
+	t.Helper()
+
+	wire, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, useEPCO, ipcpConfigureRequest(t))
+	if err != nil {
+		t.Fatalf("buildActivateDefaultESM: %v", err)
+	}
+
+	act, err := eps.ParseActivateDefaultEPSBearerContextRequest(wire)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	return act
+}
+
+func epsPdn() (*mme.PdnConnection, *mme.EpsQoS) {
+	p := &mme.PdnConnection{
+		Ebi:     mme.DefaultERABID,
+		PdnType: eps.PDNTypeIPv4,
+		UeIP:    netip.MustParseAddr("10.45.0.1"),
+		Dns:     netip.MustParseAddr("8.8.8.8"),
+	}
+	qos := &mme.EpsQoS{
+		APN: "internet", QCI: 9, MTU: 1400,
+		SessAmbrDL: models.MustParseBitRate("100 Mbps"),
+		SessAmbrUL: models.MustParseBitRate("50 Mbps"),
+	}
+
+	return p, qos
+}
+
+func TestActivateDefaultAnswersIPCP(t *testing.T) {
+	p, qos := epsPdn()
+
+	act := activateWithProtocolOptions(t, p, qos, false)
+	if act.ProtocolConfigurationOptions == nil {
+		t.Fatal("no protocol configuration options")
+	}
+
+	got := act.ProtocolConfigurationOptions.Containers
+	if got[0].ID != nas.PCOProtocolIPCP {
+		t.Fatalf("IPCP must lead the element (TS 24.008 §10.5.6.3 NOTE 1), got % x", containerIDs(got))
+	}
+
+	want := "03000010" + "810608080808" + "830608080808"
+	if hex.EncodeToString(got[0].Content) != want {
+		t.Fatalf("IPCP answer = %x, want %s", got[0].Content, want)
+	}
+}
+
+func TestActivateDefaultAnswersIPCPOverEPCO(t *testing.T) {
+	p, qos := epsPdn()
+
+	act := activateWithProtocolOptions(t, p, qos, true)
+	if act.ExtendedProtocolConfigurationOptions == nil {
+		t.Fatal("no extended protocol configuration options")
+	}
+
+	if act.ExtendedProtocolConfigurationOptions.Containers[0].ID != nas.PCOProtocolIPCP {
+		t.Fatal("IPCP must lead the extended element too")
+	}
+}
+
+func TestActivateDefaultDropsProtocolAnswersThatDoNotFitTheClassicIE(t *testing.T) {
+	p, qos := epsPdn()
+	p.Snssai = &models.Snssai{Sst: 1, Sd: "000001"}
+	p.PDUSessionID = 5
+
+	oversized := []nas.PCOContainer{{
+		ID:      nas.PCOProtocolLCP,
+		Content: append([]byte{1, 0, 0x00, 0xfe, 0x01, 0xfa}, make([]byte, 248)...),
+	}}
+
+	if answers := nas.AnswerProtocolOptions(oversized, p.Dns, p.UeIP); len(answers) != 1 {
+		t.Fatalf("the fixture must produce an answer to be dropped, got %d", len(answers))
+	}
+
+	wire, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, false, oversized)
+	if err != nil {
+		t.Fatalf("an oversized answer must be dropped, not fail the activation: %v", err)
+	}
+
+	act, err := eps.ParseActivateDefaultEPSBearerContextRequest(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range act.ProtocolConfigurationOptions.Containers {
+		if c.ID == nas.PCOProtocolLCP {
+			t.Fatal("the oversized answer was sent anyway")
+		}
+	}
+}
+
+func containerIDs(cs []nas.PCOContainer) string {
+	var b strings.Builder
+
+	for _, c := range cs {
+		b.WriteString(hex.EncodeToString([]byte{byte(c.ID >> 8), byte(c.ID)}) + " ")
+	}
+
+	return b.String()
+}

--- a/internal/mme/nas/session_ambr_nas_test.go
+++ b/internal/mme/nas/session_ambr_nas_test.go
@@ -17,7 +17,7 @@ func TestBuildActivateDefaultESMSignalsAPNAMBR(t *testing.T) {
 	p := &mme.PdnConnection{Ebi: mme.DefaultERABID, PdnType: eps.PDNTypeIPv4, UeIP: netip.MustParseAddr("10.45.0.1")}
 	qos := &mme.EpsQoS{APN: "internet", QCI: 9, SessAmbrDL: models.MustParseBitRate("100 Mbps"), SessAmbrUL: models.MustParseBitRate("50 Mbps")}
 
-	wire, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, false)
+	wire, err := buildActivateDefaultESM(p, qos, 1, models.PlmnID{Mcc: "001", Mnc: "01"}, false, nil)
 	if err != nil {
 		t.Fatalf("buildActivateDefaultESM: %v", err)
 	}

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -287,6 +287,7 @@ func parsePDUSessionRequest(req *fgs.PDUSessionEstablishmentRequest) (*smfNas.Pr
 
 	if req.ExtendedPCO != nil {
 		pco.IPv4LinkMTURequest = true
+		pco.ProtocolRequests = req.ExtendedPCO.ProtocolOptions()
 
 		for _, id := range req.ExtendedPCO.ContainerIDs() {
 			switch id {

--- a/internal/smf/nas/build_pdu_session_establishment_accept.go
+++ b/internal/smf/nas/build_pdu_session_establishment_accept.go
@@ -29,6 +29,7 @@ type ProtocolConfigurationOptions struct {
 	DNSIPv4Request     bool
 	DNSIPv6Request     bool
 	IPv4LinkMTURequest bool
+	ProtocolRequests   []nas.PCOContainer
 }
 
 // PDUSessionAddresses holds the address information for a PDU session.
@@ -108,25 +109,33 @@ func BuildGSMPDUSessionEstablishmentAccept(
 		m.MappedEPSBearerContexts = mapped
 	}
 
-	if pco.DNSIPv4Request || pco.DNSIPv6Request || pco.IPv4LinkMTURequest {
-		var dnsServers [][]byte
+	var dnsServers [][]byte
 
-		if pco.DNSIPv4Request || pco.DNSIPv6Request {
-			addr, _ := netip.AddrFromSlice(dns)
-			dnsServers = nas.DNSServers(addr)
-		}
+	dnsAddr, _ := netip.AddrFromSlice(dns)
 
-		// No meaning on a session with no IPv4, matching the PDN-type guard both
-		// EPS builders apply. The IPv6 link MTU rides the RA instead (TS 24.501).
-		var linkMTU uint16
-		if pco.IPv4LinkMTURequest &&
-			(pduSessionType == fgs.PDUSessionTypeIPv4 || pduSessionType == fgs.PDUSessionTypeIPv4v6) {
-			linkMTU = mtu
-		}
+	if pco.DNSIPv4Request || pco.DNSIPv6Request {
+		dnsServers = nas.DNSServers(dnsAddr)
+	}
 
-		if opts := nas.NewProtocolConfigurationOptions(dnsServers, linkMTU); !opts.Empty() {
-			m.ExtendedPCO = &opts
-		}
+	// No meaning on a session with no IPv4, matching the PDN-type guard both
+	// EPS builders apply. The IPv6 link MTU rides the RA instead (TS 24.501).
+	var linkMTU uint16
+	if pco.IPv4LinkMTURequest &&
+		(pduSessionType == fgs.PDUSessionTypeIPv4 || pduSessionType == fgs.PDUSessionTypeIPv4v6) {
+		linkMTU = mtu
+	}
+
+	var ueIPv4 netip.Addr
+
+	if addrs != nil {
+		ueIPv4, _ = netip.AddrFromSlice(addrs.IPv4Address)
+	}
+
+	opts := nas.NewProtocolConfigurationOptions(dnsServers, linkMTU)
+	opts.PrependProtocolOptions(nas.AnswerProtocolOptions(pco.ProtocolRequests, dnsAddr, ueIPv4))
+
+	if !opts.Empty() {
+		m.ExtendedPCO = &opts
 	}
 
 	return m.MarshalBinary()

--- a/internal/smf/nas/protocol_options_test.go
+++ b/internal/smf/nas/protocol_options_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas_test
+
+import (
+	"encoding/hex"
+	"net"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+	smfNas "github.com/ellanetworks/core/internal/smf/nas"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func ipcpRequest(t *testing.T, body string) []nas.PCOContainer {
+	t.Helper()
+
+	content, err := hex.DecodeString(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return []nas.PCOContainer{{ID: nas.PCOProtocolIPCP, Content: content}}
+}
+
+func TestEstablishmentAcceptAnswersIPCP(t *testing.T) {
+	pco := &smfNas.ProtocolConfigurationOptions{
+		DNSIPv4Request:   true,
+		ProtocolRequests: ipcpRequest(t, "01000010"+"810600000000"+"830600000000"),
+	}
+	addrs := &smfNas.PDUSessionAddresses{
+		PDUSessionType: fgs.PDUSessionTypeIPv4,
+		IPv4Address:    net.IP{10, 45, 0, 1},
+	}
+
+	acc := buildAccept(t, &models.Snssai{Sst: 1}, pco, net.IP{8, 8, 8, 8}, nil, addrs, nil)
+
+	if acc.ExtendedPCO == nil {
+		t.Fatal("no extended protocol configuration options")
+	}
+
+	got := acc.ExtendedPCO.Containers
+
+	if got[0].ID != nas.PCOProtocolIPCP {
+		t.Fatalf("IPCP must lead the element (TS 24.008 §10.5.6.3 NOTE 1), got %+v", got)
+	}
+
+	want := "03000010" + "810608080808" + "830608080808"
+	if hex.EncodeToString(got[0].Content) != want {
+		t.Fatalf("IPCP answer = %x, want %s", got[0].Content, want)
+	}
+
+	var sawDNS bool
+
+	for _, c := range got {
+		if c.ID == nas.PCOContainerDNSServerIPv4Address {
+			sawDNS = true
+		}
+	}
+
+	if !sawDNS {
+		t.Fatal("the 000D answer must still be sent alongside the IPCP one")
+	}
+}
+
+func TestEstablishmentAcceptNaksIPCPAddressWithTheAllocatedOne(t *testing.T) {
+	pco := &smfNas.ProtocolConfigurationOptions{
+		ProtocolRequests: ipcpRequest(t, "0100000a"+"030600000000"),
+	}
+	addrs := &smfNas.PDUSessionAddresses{
+		PDUSessionType: fgs.PDUSessionTypeIPv4,
+		IPv4Address:    net.IP{10, 45, 0, 7},
+	}
+
+	acc := buildAccept(t, &models.Snssai{Sst: 1}, pco, net.IP{8, 8, 8, 8}, nil, addrs, nil)
+
+	if acc.ExtendedPCO == nil {
+		t.Fatal("an IPCP answer alone still warrants the element")
+	}
+
+	want := "03" + "00" + "000a" + "0306" + "0a2d0007"
+	if hex.EncodeToString(acc.ExtendedPCO.Containers[0].Content) != want {
+		t.Fatalf("got %x, want %s", acc.ExtendedPCO.Containers[0].Content, want)
+	}
+}
+
+func TestEstablishmentAcceptWithoutProtocolRequestsIsUnchanged(t *testing.T) {
+	pco := &smfNas.ProtocolConfigurationOptions{DNSIPv4Request: true}
+
+	acc := buildAccept(t, &models.Snssai{Sst: 1}, pco, net.IP{8, 8, 8, 8}, nil, nil, nil)
+
+	if acc.ExtendedPCO == nil {
+		t.Fatal("no extended protocol configuration options")
+	}
+
+	for _, c := range acc.ExtendedPCO.Containers {
+		switch c.ID {
+		case nas.PCOProtocolIPCP, nas.PCOProtocolLCP, nas.PCOProtocolPAP, nas.PCOProtocolCHAP:
+			t.Fatalf("unsolicited protocol option %04x", c.ID)
+		}
+	}
+}

--- a/nas/pco.go
+++ b/nas/pco.go
@@ -306,6 +306,51 @@ func (p ProtocolConfigurationOptions) ContainerIDs() []uint16 {
 	return ids
 }
 
+// ProtocolOptions returns the units of the configuration protocol options list
+// this package answers — LCP, PAP, CHAP and IPCP, the four TS 24.008 §10.5.6.3
+// requires be supported — in wire order. Only an MS-to-network element carries a
+// request to answer.
+func (p ProtocolConfigurationOptions) ProtocolOptions() []PCOContainer {
+	if p.Direction != PCOMSToNetwork {
+		return nil
+	}
+
+	var out []PCOContainer
+
+	for _, c := range p.Containers {
+		switch c.ID {
+		case PCOProtocolIPCP, PCOProtocolLCP, PCOProtocolPAP, PCOProtocolCHAP:
+			out = append(out, c)
+		}
+	}
+
+	return out
+}
+
+// PrependProtocolOptions places cs ahead of every container already held. The
+// additional parameters list begins at the first unit bearing a container
+// identifier (TS 24.008 §10.5.6.3 NOTE 1), so a protocol identifier appended
+// after one is read as part of that list instead.
+func (p *ProtocolConfigurationOptions) PrependProtocolOptions(cs []PCOContainer) {
+	if len(cs) == 0 {
+		return
+	}
+
+	merged := make([]PCOContainer, 0, len(cs)+len(p.Containers))
+	merged = append(merged, cs...)
+	merged = append(merged, p.Containers...)
+	p.Containers = merged
+}
+
+// FitsUnextended reports whether the value fits the classic protocol
+// configuration options, a type 4 element of at most 253 octets (TS 24.008
+// §10.5.6.3). The extended element imposes no comparable bound.
+func (p ProtocolConfigurationOptions) FitsUnextended() bool {
+	b, err := p.MarshalBinary()
+
+	return err == nil && len(b) <= maxPCOLen
+}
+
 // DNSServers returns the DNS-server addresses carried, IPv4 and IPv6 together,
 // in wire order. A container whose content is not a 4- or 16-octet address is
 // skipped.

--- a/nas/ppp.go
+++ b/nas/ppp.go
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+)
+
+// The configuration protocol identifiers TS 24.008 §10.5.6.3 requires be
+// supported, whichever access carries the element. Their contents are PPP
+// packets stripped of the Protocol and Padding octets: LCP and IPCP are
+// specified in RFC 1661 and RFC 1332, PAP in RFC 1334 and CHAP in RFC 1994.
+const (
+	PCOProtocolIPCP uint16 = 0x8021
+	PCOProtocolLCP  uint16 = 0xc021
+	PCOProtocolPAP  uint16 = 0xc023
+	PCOProtocolCHAP uint16 = 0xc223
+)
+
+const (
+	pppConfigureRequest uint8 = 1
+	pppConfigureAck     uint8 = 2
+	pppConfigureNak     uint8 = 3
+	pppConfigureReject  uint8 = 4
+)
+
+const (
+	papAuthenticateRequest uint8 = 1
+	papAuthenticateAck     uint8 = 2
+)
+
+const (
+	chapResponse uint8 = 2
+	chapSuccess  uint8 = 3
+)
+
+const (
+	ipcpOptionIPAddress    uint8 = 3
+	ipcpOptionPrimaryDNS   uint8 = 129
+	ipcpOptionSecondaryDNS uint8 = 131
+)
+
+const (
+	pppHeaderLen    = 4
+	pppOptionHdrLen = 2
+	ipv4Len         = 4
+)
+
+type pppPacket struct {
+	code       uint8
+	identifier uint8
+	data       []byte
+}
+
+func parsePPPPacket(b []byte) (pppPacket, error) {
+	if len(b) < pppHeaderLen {
+		return pppPacket{}, fmt.Errorf("nas: ppp packet is %d octets, want at least %d", len(b), pppHeaderLen)
+	}
+
+	length := int(binary.BigEndian.Uint16(b[2:]))
+	if length < pppHeaderLen || length > len(b) {
+		return pppPacket{}, fmt.Errorf(
+			"nas: ppp packet length field is %d, want between %d and %d", length, pppHeaderLen, len(b))
+	}
+
+	return pppPacket{code: b[0], identifier: b[1], data: b[pppHeaderLen:length]}, nil
+}
+
+func (p pppPacket) marshal() ([]byte, error) {
+	total := pppHeaderLen + len(p.data)
+	if total > maxOneOctetContainerLen {
+		return nil, fmt.Errorf("nas: ppp packet is %d octets, want at most %d", total, maxOneOctetContainerLen)
+	}
+
+	out := make([]byte, pppHeaderLen, total)
+	out[0] = p.code
+	out[1] = p.identifier
+	binary.BigEndian.PutUint16(out[2:], uint16(total))
+
+	return append(out, p.data...), nil
+}
+
+type pppOption struct {
+	typ  uint8
+	data []byte
+}
+
+func parsePPPOptions(b []byte) ([]pppOption, error) {
+	var out []pppOption
+
+	for len(b) > 0 {
+		if len(b) < pppOptionHdrLen {
+			return nil, fmt.Errorf("nas: ppp option header is %d octets, want %d", len(b), pppOptionHdrLen)
+		}
+
+		length := int(b[1])
+		if length < pppOptionHdrLen || length > len(b) {
+			return nil, fmt.Errorf(
+				"nas: ppp option length is %d, want between %d and %d", length, pppOptionHdrLen, len(b))
+		}
+
+		out = append(out, pppOption{typ: b[0], data: b[pppOptionHdrLen:length]})
+		b = b[length:]
+	}
+
+	return out, nil
+}
+
+func appendPPPOption(b []byte, o pppOption) []byte {
+	b = append(b, o.typ, uint8(len(o.data)+pppOptionHdrLen))
+
+	return append(b, o.data...)
+}
+
+// AnswerProtocolOptions answers the configuration protocol options list of an
+// MS-to-network element. dns is the resolver offered over IPCP and ueIPv4 the
+// address already allocated to the session; an invalid address withdraws the
+// matching IPCP option from negotiation. A unit that is malformed, or that
+// carries a code with no defined answer, is left unanswered rather than
+// failing the session.
+//
+// The result belongs at the head of the reply — see
+// [ProtocolConfigurationOptions.PrependProtocolOptions].
+func AnswerProtocolOptions(requests []PCOContainer, dns, ueIPv4 netip.Addr) []PCOContainer {
+	dns = dns.Unmap()
+	ueIPv4 = ueIPv4.Unmap()
+
+	var out []PCOContainer
+
+	for _, c := range requests {
+		content, err := answerProtocolOption(c, dns, ueIPv4)
+		if err != nil || content == nil {
+			continue
+		}
+
+		out = append(out, PCOContainer{ID: c.ID, Content: content})
+	}
+
+	return out
+}
+
+func answerProtocolOption(c PCOContainer, dns, ueIPv4 netip.Addr) ([]byte, error) {
+	p, err := parsePPPPacket(c.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	switch c.ID {
+	case PCOProtocolIPCP:
+		if p.code != pppConfigureRequest {
+			return nil, nil
+		}
+
+		return answerIPCP(p, dns, ueIPv4)
+	case PCOProtocolLCP:
+		if p.code != pppConfigureRequest {
+			return nil, nil
+		}
+
+		return answerLCP(p)
+	case PCOProtocolPAP:
+		if p.code != papAuthenticateRequest {
+			return nil, nil
+		}
+
+		return pppPacket{code: papAuthenticateAck, identifier: p.identifier, data: []byte{0}}.marshal()
+	case PCOProtocolCHAP:
+		if p.code != chapResponse {
+			return nil, nil
+		}
+
+		return pppPacket{code: chapSuccess, identifier: p.identifier}.marshal()
+	default:
+		return nil, nil
+	}
+}
+
+func answerIPCP(req pppPacket, dns, ueIPv4 netip.Addr) ([]byte, error) {
+	options, err := parsePPPOptions(req.data)
+	if err != nil {
+		return nil, err
+	}
+
+	var rejected, naked []byte
+
+	for _, o := range options {
+		want, ok := ipcpOptionAddress(o.typ, dns, ueIPv4)
+		if !ok || len(o.data) != ipv4Len {
+			rejected = appendPPPOption(rejected, o)
+
+			continue
+		}
+
+		if netip.AddrFrom4([ipv4Len]byte(o.data)) == want {
+			continue
+		}
+
+		v := want.As4()
+		naked = appendPPPOption(naked, pppOption{typ: o.typ, data: v[:]})
+	}
+
+	switch {
+	case len(rejected) > 0:
+		return pppPacket{code: pppConfigureReject, identifier: req.identifier, data: rejected}.marshal()
+	case len(naked) > 0:
+		return pppPacket{code: pppConfigureNak, identifier: req.identifier, data: naked}.marshal()
+	default:
+		return pppPacket{code: pppConfigureAck, identifier: req.identifier, data: req.data}.marshal()
+	}
+}
+
+func ipcpOptionAddress(typ uint8, dns, ueIPv4 netip.Addr) (netip.Addr, bool) {
+	switch typ {
+	case ipcpOptionPrimaryDNS, ipcpOptionSecondaryDNS:
+		return dns, dns.Is4()
+	case ipcpOptionIPAddress:
+		return ueIPv4, ueIPv4.Is4()
+	default:
+		return netip.Addr{}, false
+	}
+}
+
+func answerLCP(req pppPacket) ([]byte, error) {
+	options, err := parsePPPOptions(req.data)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(options) == 0 {
+		return pppPacket{code: pppConfigureAck, identifier: req.identifier}.marshal()
+	}
+
+	return pppPacket{code: pppConfigureReject, identifier: req.identifier, data: req.data}.marshal()
+}

--- a/nas/ppp.go
+++ b/nas/ppp.go
@@ -7,6 +7,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net/netip"
+	"strconv"
+	"strings"
 )
 
 // The configuration protocol identifiers TS 24.008 §10.5.6.3 requires be
@@ -38,9 +40,11 @@ const (
 )
 
 const (
-	ipcpOptionIPAddress    uint8 = 3
-	ipcpOptionPrimaryDNS   uint8 = 129
-	ipcpOptionSecondaryDNS uint8 = 131
+	ipcpOptionIPAddress     uint8 = 3
+	ipcpOptionPrimaryDNS    uint8 = 129
+	ipcpOptionPrimaryNBNS   uint8 = 130
+	ipcpOptionSecondaryDNS  uint8 = 131
+	ipcpOptionSecondaryNBNS uint8 = 132
 )
 
 const (
@@ -234,4 +238,110 @@ func answerLCP(req pppPacket) ([]byte, error) {
 	}
 
 	return pppPacket{code: pppConfigureReject, identifier: req.identifier, data: req.data}.marshal()
+}
+
+// PCOProtocolOptionSummary renders the contents of a configuration protocol
+// options unit for display: the PPP code, and for IPCP the options it carries.
+// It returns the empty string for a unit it cannot read, leaving the caller to
+// fall back to the raw octets.
+func PCOProtocolOptionSummary(id uint16, content []byte) string {
+	p, err := parsePPPPacket(content)
+	if err != nil {
+		return ""
+	}
+
+	code := pppCodeName(id, p.code)
+	if code == "" {
+		return ""
+	}
+
+	if id != PCOProtocolIPCP {
+		return code
+	}
+
+	options, err := parsePPPOptions(p.data)
+	if err != nil || len(options) == 0 {
+		return code
+	}
+
+	rendered := make([]string, 0, len(options))
+	for _, o := range options {
+		rendered = append(rendered, ipcpOptionSummary(o))
+	}
+
+	return code + ": " + strings.Join(rendered, ", ")
+}
+
+func pppCodeName(id uint16, code uint8) string {
+	switch id {
+	case PCOProtocolIPCP, PCOProtocolLCP:
+		switch code {
+		case 1:
+			return "Configure-Request"
+		case 2:
+			return "Configure-Ack"
+		case 3:
+			return "Configure-Nak"
+		case 4:
+			return "Configure-Reject"
+		case 5:
+			return "Terminate-Request"
+		case 6:
+			return "Terminate-Ack"
+		case 7:
+			return "Code-Reject"
+		}
+	case PCOProtocolPAP:
+		switch code {
+		case 1:
+			return "Authenticate-Request"
+		case 2:
+			return "Authenticate-Ack"
+		case 3:
+			return "Authenticate-Nak"
+		}
+	case PCOProtocolCHAP:
+		switch code {
+		case 1:
+			return "Challenge"
+		case 2:
+			return "Response"
+		case 3:
+			return "Success"
+		case 4:
+			return "Failure"
+		}
+	}
+
+	return ""
+}
+
+func ipcpOptionSummary(o pppOption) string {
+	name := ipcpOptionName(o.typ)
+	if name == "" {
+		name = "option " + strconv.Itoa(int(o.typ))
+	}
+
+	if len(o.data) != ipv4Len {
+		return name
+	}
+
+	return name + " " + netip.AddrFrom4([ipv4Len]byte(o.data)).String()
+}
+
+func ipcpOptionName(typ uint8) string {
+	switch typ {
+	case ipcpOptionIPAddress:
+		return "IP Address"
+	case ipcpOptionPrimaryDNS:
+		return "Primary DNS Server Address"
+	case ipcpOptionPrimaryNBNS:
+		return "Primary NBNS Server Address"
+	case ipcpOptionSecondaryDNS:
+		return "Secondary DNS Server Address"
+	case ipcpOptionSecondaryNBNS:
+		return "Secondary NBNS Server Address"
+	default:
+		return ""
+	}
 }

--- a/nas/ppp_test.go
+++ b/nas/ppp_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas_test
+
+import (
+	"encoding/hex"
+	"net/netip"
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode %q: %v", s, err)
+	}
+
+	return b
+}
+
+func answer(t *testing.T, id uint16, content []byte, dns, ue netip.Addr) []byte {
+	t.Helper()
+
+	got := nas.AnswerProtocolOptions([]nas.PCOContainer{{ID: id, Content: content}}, dns, ue)
+	if len(got) == 0 {
+		return nil
+	}
+
+	if len(got) != 1 || got[0].ID != id {
+		t.Fatalf("answer: got %+v", got)
+	}
+
+	return got[0].Content
+}
+
+func TestIPCPConfigureNakSuppliesDNS(t *testing.T) {
+	dns := netip.MustParseAddr("8.8.8.8")
+
+	req := mustHex(t, "01000010"+"810600000000"+"830600000000")
+
+	got := answer(t, nas.PCOProtocolIPCP, req, dns, netip.MustParseAddr("10.45.0.2"))
+
+	want := mustHex(t, "03000010"+"810608080808"+"830608080808")
+	if hex.EncodeToString(got) != hex.EncodeToString(want) {
+		t.Fatalf("got %x, want %x", got, want)
+	}
+}
+
+func TestIPCPEchoesIdentifier(t *testing.T) {
+	req := mustHex(t, "017b000a"+"810600000000")
+
+	got := answer(t, nas.PCOProtocolIPCP, req, netip.MustParseAddr("1.1.1.1"), netip.Addr{})
+	if len(got) < 2 || got[1] != 0x7b {
+		t.Fatalf("identifier not echoed: %x", got)
+	}
+}
+
+func TestIPCPAcksAcceptableValues(t *testing.T) {
+	dns := netip.MustParseAddr("8.8.8.8")
+	req := mustHex(t, "0100000a"+"810608080808")
+
+	got := answer(t, nas.PCOProtocolIPCP, req, dns, netip.Addr{})
+	if got[0] != 2 {
+		t.Fatalf("want Configure-Ack, got code %d (%x)", got[0], got)
+	}
+
+	if hex.EncodeToString(got[4:]) != "810608080808" {
+		t.Fatalf("Ack must echo the requested options, got %x", got)
+	}
+}
+
+func TestIPCPRejectDisplacesNak(t *testing.T) {
+	req := mustHex(t, "01000010"+"810600000000"+"820600000000")
+
+	got := answer(t, nas.PCOProtocolIPCP, req, netip.MustParseAddr("8.8.8.8"), netip.Addr{})
+	if got[0] != 4 {
+		t.Fatalf("want Configure-Reject, got code %d (%x)", got[0], got)
+	}
+
+	if hex.EncodeToString(got[4:]) != "820600000000" {
+		t.Fatalf("reject must carry only the rejected option, got %x", got)
+	}
+}
+
+func TestIPCPAddressOptionUsesAllocatedAddress(t *testing.T) {
+	req := mustHex(t, "0100000a"+"030600000000")
+
+	got := answer(t, nas.PCOProtocolIPCP, req, netip.Addr{}, netip.MustParseAddr("10.45.0.2"))
+	if got[0] != 3 || hex.EncodeToString(got[4:]) != "03060a2d0002" {
+		t.Fatalf("want Nak with the allocated address, got %x", got)
+	}
+}
+
+func TestIPCPWithoutDNSConfiguredRejects(t *testing.T) {
+	req := mustHex(t, "0100000a"+"810600000000")
+
+	got := answer(t, nas.PCOProtocolIPCP, req, netip.Addr{}, netip.Addr{})
+	if got[0] != 4 {
+		t.Fatalf("want Configure-Reject, got code %d (%x)", got[0], got)
+	}
+}
+
+func TestProtocolAnswersForLCPPAPCHAP(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		id      uint16
+		request string
+		want    string
+	}{
+		{"LCP rejects options", nas.PCOProtocolLCP, "0100000e" + "010405dc" + "020600000000", "0400000e" + "010405dc" + "020600000000"},
+		{"LCP acks an empty request", nas.PCOProtocolLCP, "01000004", "02000004"},
+		{"PAP acks", nas.PCOProtocolPAP, "01010008" + "02616200", "02010005" + "00"},
+		{"CHAP succeeds", nas.PCOProtocolCHAP, "02050006" + "0000", "03050004"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := answer(t, tc.id, mustHex(t, tc.request), netip.Addr{}, netip.Addr{})
+			if hex.EncodeToString(got) != tc.want {
+				t.Fatalf("got %x, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProtocolAnswersIgnoreUnanswerableUnits(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		id      uint16
+		content string
+	}{
+		{"truncated packet", nas.PCOProtocolIPCP, "0100"},
+		{"length field past the end", nas.PCOProtocolIPCP, "010000ff"},
+		{"length field below the header", nas.PCOProtocolIPCP, "01000002"},
+		{"option runs past the end", nas.PCOProtocolIPCP, "0100000a" + "81ff00000000"},
+		{"not a Configure-Request", nas.PCOProtocolIPCP, "02000004"},
+		{"CHAP challenge, not a response", nas.PCOProtocolCHAP, "01000004"},
+		{"unsupported protocol identifier", 0x8281, "01000004"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := answer(t, tc.id, mustHex(t, tc.content), netip.MustParseAddr("8.8.8.8"), netip.Addr{}); got != nil {
+				t.Fatalf("want no answer, got %x", got)
+			}
+		})
+	}
+}
+
+func TestAnswerProtocolOptionsPreservesRequestOrder(t *testing.T) {
+	got := nas.AnswerProtocolOptions([]nas.PCOContainer{
+		{ID: nas.PCOProtocolPAP, Content: mustHex(t, "01010008"+"02616200")},
+		{ID: nas.PCOProtocolIPCP, Content: mustHex(t, "0100000a"+"810600000000")},
+	}, netip.MustParseAddr("8.8.8.8"), netip.Addr{})
+
+	if len(got) != 2 || got[0].ID != nas.PCOProtocolPAP || got[1].ID != nas.PCOProtocolIPCP {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestProtocolOptionsSelectsUplinkProtocolUnits(t *testing.T) {
+	opts := nas.ProtocolConfigurationOptions{
+		Direction: nas.PCOMSToNetwork,
+		Containers: []nas.PCOContainer{
+			{ID: nas.PCOProtocolIPCP, Content: []byte{1, 0, 0, 4}},
+			{ID: nas.PCOContainerDNSServerIPv4Address},
+			{ID: nas.PCOProtocolCHAP, Content: []byte{2, 0, 0, 4}},
+		},
+	}
+
+	got := opts.ProtocolOptions()
+	if len(got) != 2 || got[0].ID != nas.PCOProtocolIPCP || got[1].ID != nas.PCOProtocolCHAP {
+		t.Fatalf("got %+v", got)
+	}
+
+	downlink := opts
+	downlink.Direction = nas.PCONetworkToMS
+
+	if downlink.ProtocolOptions() != nil {
+		t.Fatal("a downlink element carries no request to answer")
+	}
+}
+
+func TestPrependProtocolOptionsPutsProtocolUnitsFirst(t *testing.T) {
+	opts := nas.NewProtocolConfigurationOptions([][]byte{{8, 8, 8, 8}}, 1400)
+	opts.PrependProtocolOptions([]nas.PCOContainer{{ID: nas.PCOProtocolIPCP, Content: []byte{3, 0, 0, 4}}})
+
+	if opts.Containers[0].ID != nas.PCOProtocolIPCP {
+		t.Fatalf("got %+v", opts.Containers)
+	}
+
+	b, err := opts.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hex.EncodeToString(b[1:4]) != "802104" {
+		t.Fatalf("IPCP is not the first unit on the wire: %x", b)
+	}
+}

--- a/nas/ppp_test.go
+++ b/nas/ppp_test.go
@@ -198,3 +198,69 @@ func TestPrependProtocolOptionsPutsProtocolUnitsFirst(t *testing.T) {
 		t.Fatalf("IPCP is not the first unit on the wire: %x", b)
 	}
 }
+
+func TestPCOProtocolOptionSummary(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		id      uint16
+		content string
+		want    string
+	}{
+		{
+			"IPCP request with placeholder addresses",
+			nas.PCOProtocolIPCP,
+			"01000010" + "810600000000" + "830600000000",
+			"Configure-Request: Primary DNS Server Address 0.0.0.0, Secondary DNS Server Address 0.0.0.0",
+		},
+		{
+			"IPCP nak we answer with",
+			nas.PCOProtocolIPCP,
+			"03000010" + "810608080808" + "830608080808",
+			"Configure-Nak: Primary DNS Server Address 8.8.8.8, Secondary DNS Server Address 8.8.8.8",
+		},
+		{
+			"IPCP reject of the NBNS pair",
+			nas.PCOProtocolIPCP,
+			"04000010" + "820600000000" + "840600000000",
+			"Configure-Reject: Primary NBNS Server Address 0.0.0.0, Secondary NBNS Server Address 0.0.0.0",
+		},
+		{
+			"IPCP option this network does not name",
+			nas.PCOProtocolIPCP,
+			"0100000a" + "020600000000",
+			"Configure-Request: option 2 0.0.0.0",
+		},
+		{"IPCP with no options", nas.PCOProtocolIPCP, "02000004", "Configure-Ack"},
+		{"LCP", nas.PCOProtocolLCP, "0400000e" + "010405dc" + "020600000000", "Configure-Reject"},
+		{"PAP request", nas.PCOProtocolPAP, "01010008" + "02616200", "Authenticate-Request"},
+		{"PAP ack", nas.PCOProtocolPAP, "02010005" + "00", "Authenticate-Ack"},
+		{"CHAP response", nas.PCOProtocolCHAP, "02050006" + "0000", "Response"},
+		{"CHAP success", nas.PCOProtocolCHAP, "03050004", "Success"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nas.PCOProtocolOptionSummary(tc.id, mustHex(t, tc.content)); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPCOProtocolOptionSummaryFallsBackToRawOctets(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		id      uint16
+		content string
+	}{
+		{"truncated", nas.PCOProtocolIPCP, "0100"},
+		{"length past the end", nas.PCOProtocolIPCP, "010000ff"},
+		{"unnamed code", nas.PCOProtocolIPCP, "0b000004"},
+		{"unnamed CHAP code", nas.PCOProtocolCHAP, "09000004"},
+		{"not a protocol identifier", nas.PCOContainerDNSServerIPv4Address, "01000004"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nas.PCOProtocolOptionSummary(tc.id, mustHex(t, tc.content)); got != "" {
+				t.Fatalf("want the empty string so the caller shows hex, got %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Phones and modems that ask for their DNS server the old PPP way now get an answer from Ella Core on both 4G and 5G.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
