### PR TITLE
fix(db): stop one orphaned flow report from discarding its whole batch

### DIFF
--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -36,3 +36,12 @@ func isUniqueNameError(err error) bool {
 
 	return false
 }
+
+func isForeignKeyError(err error) bool {
+	var se sqlite3.Error
+	if errors.As(err, &se) {
+		return se.ExtendedCode == sqlite3.ErrConstraintForeignKey
+	}
+
+	return false
+}

--- a/internal/db/flow_reports.go
+++ b/internal/db/flow_reports.go
@@ -11,11 +11,13 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/dbwriter"
+	"github.com/ellanetworks/core/internal/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 )
 
 const FlowReportsTableName = "flow_reports"
@@ -189,8 +191,15 @@ func (db *Database) InsertFlowReports(ctx context.Context, flowReports []*dbwrit
 		return fmt.Errorf("begin transaction failed: %w", err)
 	}
 
+	orphaned := 0
+
 	for _, fr := range flowReports {
 		if err := tx.Query(ctx, db.insertFlowReportStmt, fr).Run(); err != nil {
+			if isForeignKeyError(err) {
+				orphaned++
+				continue
+			}
+
 			_ = tx.Rollback()
 
 			span.RecordError(err)
@@ -198,6 +207,14 @@ func (db *Database) InsertFlowReports(ctx context.Context, flowReports []*dbwrit
 
 			return fmt.Errorf("insert failed: %w", err)
 		}
+	}
+
+	if orphaned > 0 {
+		span.SetAttributes(attribute.Int("db.batch_orphaned", orphaned))
+		logger.DBLog.Warn("Dropped flow reports for deleted subscribers",
+			zap.Int("dropped", orphaned),
+			zap.Int("batch_size", len(flowReports)),
+		)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/db/flow_reports_test.go
+++ b/internal/db/flow_reports_test.go
@@ -183,6 +183,75 @@ func TestFlowReportsBatchInsert(t *testing.T) {
 	}
 }
 
+func TestFlowReportsBatchInsertSkipsDeletedSubscriber(t *testing.T) {
+	database := setupTestDB(t)
+
+	ctx := context.Background()
+
+	profileID, err := createDataNetworkPolicyAndSubscriber(database, "460123456789012")
+	if err != nil {
+		t.Fatalf("couldn't create prerequisite subscriber: %s", err)
+	}
+
+	err = database.CreateSubscriber(ctx, &db.Subscriber{
+		Imsi:           "460123456789013",
+		SequenceNumber: "000000000022",
+		PermanentKey:   "6f30087629feb0b089783c81d0ae09b5",
+		Opc:            "21a7e1897dfb481d62439142cdf1b6ee",
+		ProfileID:      profileID,
+	})
+	if err != nil {
+		t.Fatalf("couldn't create second subscriber: %s", err)
+	}
+
+	if err := database.DeleteSubscriber(ctx, "460123456789013"); err != nil {
+		t.Fatalf("couldn't delete second subscriber: %s", err)
+	}
+
+	now := time.Now().UTC()
+
+	report := func(imsi string, port uint16) *dbwriter.FlowReport {
+		return &dbwriter.FlowReport{
+			SubscriberID:    imsi,
+			SourceIP:        "192.168.1.100",
+			DestinationIP:   "8.8.8.8",
+			SourcePort:      port,
+			DestinationPort: 443,
+			Protocol:        6,
+			Packets:         3,
+			Bytes:           354,
+			StartTime:       now.Add(-time.Minute).Format(time.RFC3339),
+			EndTime:         now.Format(time.RFC3339),
+			Direction:       "downlink",
+		}
+	}
+
+	batch := []*dbwriter.FlowReport{
+		report("460123456789012", 10001),
+		report("460123456789013", 10002),
+		report("460123456789012", 10003),
+	}
+
+	if err := database.InsertFlowReports(ctx, batch); err != nil {
+		t.Fatalf("batch insert should not fail on an orphaned report: %s", err)
+	}
+
+	reports, total, err := database.ListFlowReports(ctx, 1, 20, nil)
+	if err != nil {
+		t.Fatalf("couldn't list flow reports: %s", err)
+	}
+
+	if total != 2 {
+		t.Fatalf("Expected the 2 live-subscriber reports to survive, but got %d", total)
+	}
+
+	for _, r := range reports {
+		if r.SubscriberID != "460123456789012" {
+			t.Fatalf("Expected only reports for the live subscriber, got %s", r.SubscriberID)
+		}
+	}
+}
+
 func TestFlowReportsBatchInsertEmpty(t *testing.T) {
 	database := setupTestDB(t)
 


### PR DESCRIPTION
# Description

Prevent one orphaned network flow report from discarding its whole batch. In practice this shouldn't be seen much in real deployment but it causes real flakes in our CI integration tests. The fix is also *correct* regardless.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
