### PR TITLE
feat(decoder): decode every message the S1AP, NGAP and NAS codecs parse

### DIFF
--- a/internal/decoder/nas/eps/emm.go
+++ b/internal/decoder/nas/eps/emm.go
@@ -22,23 +22,33 @@ type EMMMessage struct {
 	EMMHeader EMMHeader `json:"emm_header"`
 	Error     string    `json:"error,omitempty"`
 
-	AttachRequest             *AttachRequest             `json:"attach_request,omitempty"`
-	AttachAccept              *AttachAccept              `json:"attach_accept,omitempty"`
-	IdentityRequest           *IdentityRequest           `json:"identity_request,omitempty"`
-	IdentityResponse          *IdentityResponse          `json:"identity_response,omitempty"`
-	AuthenticationRequest     *AuthenticationRequest     `json:"authentication_request,omitempty"`
-	AuthenticationResponse    *AuthenticationResponse    `json:"authentication_response,omitempty"`
-	SecurityModeCommand       *SecurityModeCommand       `json:"security_mode_command,omitempty"`
-	TrackingAreaUpdateRequest *TrackingAreaUpdateRequest `json:"tracking_area_update_request,omitempty"`
-	TrackingAreaUpdateAccept  *TrackingAreaUpdateAccept  `json:"tracking_area_update_accept,omitempty"`
-	DetachRequest             *DetachRequest             `json:"detach_request,omitempty"`
-	ServiceRequest            *ServiceRequest            `json:"service_request,omitempty"`
-	AttachComplete            *AttachComplete            `json:"attach_complete,omitempty"`
-	TrackingAreaUpdateReject  *TrackingAreaUpdateReject  `json:"tracking_area_update_reject,omitempty"`
-	SecurityModeComplete      *SecurityModeComplete      `json:"security_mode_complete,omitempty"`
-	EMMInformation            *EMMInformation            `json:"emm_information,omitempty"`
-	GUTIReallocationCommand   *GUTIReallocationCommand   `json:"guti_reallocation_command,omitempty"`
-	GUTIReallocationComplete  *GUTIReallocationComplete  `json:"guti_reallocation_complete,omitempty"`
+	AttachRequest              *AttachRequest              `json:"attach_request,omitempty"`
+	AttachAccept               *AttachAccept               `json:"attach_accept,omitempty"`
+	IdentityRequest            *IdentityRequest            `json:"identity_request,omitempty"`
+	IdentityResponse           *IdentityResponse           `json:"identity_response,omitempty"`
+	AuthenticationRequest      *AuthenticationRequest      `json:"authentication_request,omitempty"`
+	AuthenticationResponse     *AuthenticationResponse     `json:"authentication_response,omitempty"`
+	SecurityModeCommand        *SecurityModeCommand        `json:"security_mode_command,omitempty"`
+	TrackingAreaUpdateRequest  *TrackingAreaUpdateRequest  `json:"tracking_area_update_request,omitempty"`
+	TrackingAreaUpdateAccept   *TrackingAreaUpdateAccept   `json:"tracking_area_update_accept,omitempty"`
+	DetachRequest              *DetachRequest              `json:"detach_request,omitempty"`
+	ServiceRequest             *ServiceRequest             `json:"service_request,omitempty"`
+	AttachComplete             *AttachComplete             `json:"attach_complete,omitempty"`
+	TrackingAreaUpdateReject   *TrackingAreaUpdateReject   `json:"tracking_area_update_reject,omitempty"`
+	SecurityModeComplete       *SecurityModeComplete       `json:"security_mode_complete,omitempty"`
+	EMMInformation             *EMMInformation             `json:"emm_information,omitempty"`
+	GUTIReallocationCommand    *GUTIReallocationCommand    `json:"guti_reallocation_command,omitempty"`
+	GUTIReallocationComplete   *GUTIReallocationComplete   `json:"guti_reallocation_complete,omitempty"`
+	AttachReject               *AttachReject               `json:"attach_reject,omitempty"`
+	AuthenticationFailure      *AuthenticationFailure      `json:"authentication_failure,omitempty"`
+	AuthenticationReject       *AuthenticationReject       `json:"authentication_reject,omitempty"`
+	DetachAccept               *DetachAccept               `json:"detach_accept,omitempty"`
+	DetachRequestNetwork       *DetachRequestNetwork       `json:"detach_request_network,omitempty"`
+	EMMStatus                  *EMMStatus                  `json:"emm_status,omitempty"`
+	SecurityModeReject         *SecurityModeReject         `json:"security_mode_reject,omitempty"`
+	ServiceAccept              *ServiceAccept              `json:"service_accept,omitempty"`
+	ServiceReject              *ServiceReject              `json:"service_reject,omitempty"`
+	TrackingAreaUpdateComplete *TrackingAreaUpdateComplete `json:"tracking_area_update_complete,omitempty"`
 }
 
 type GUTI struct {
@@ -68,8 +78,13 @@ func buildEMMMessage(b []byte) *EMMMessage {
 
 	// A capture carries no direction, and TS 24.301 table 9.8.1 gives DETACH
 	// REQUEST one message type for both: decode the uplink variant, the one a
-	// UE sends.
+	// UE sends, and fall back to the network variant when that fails, since the
+	// two have different layouts and only one of them can parse.
 	msg, err := eps.ParseMessage(b, nas.DirectionUplink)
+	if err != nil && !nas.SoftOnly(err) && mt == eps.MsgDetachRequest {
+		msg, err = eps.ParseMessage(b, nas.DirectionDownlink)
+	}
+
 	if err != nil && !nas.SoftOnly(err) {
 		m.Error = err.Error()
 
@@ -109,6 +124,26 @@ func buildEMMMessage(b []byte) *EMMMessage {
 		m.GUTIReallocationCommand = buildGUTIReallocationCommand(msg)
 	case *eps.GUTIReallocationComplete:
 		m.GUTIReallocationComplete = buildGUTIReallocationComplete(msg)
+	case *eps.AttachReject:
+		m.AttachReject = buildAttachReject(msg)
+	case *eps.AuthenticationFailure:
+		m.AuthenticationFailure = buildAuthenticationFailure(msg)
+	case *eps.AuthenticationReject:
+		m.AuthenticationReject = buildAuthenticationReject(msg)
+	case *eps.DetachAccept:
+		m.DetachAccept = buildDetachAccept(msg)
+	case *eps.DetachRequestNetwork:
+		m.DetachRequestNetwork = buildDetachRequestNetwork(msg)
+	case *eps.EMMStatus:
+		m.EMMStatus = buildEMMStatus(msg)
+	case *eps.SecurityModeReject:
+		m.SecurityModeReject = buildSecurityModeReject(msg)
+	case *eps.ServiceAccept:
+		m.ServiceAccept = buildServiceAccept(msg)
+	case *eps.ServiceReject:
+		m.ServiceReject = buildServiceReject(msg)
+	case *eps.TrackingAreaUpdateComplete:
+		m.TrackingAreaUpdateComplete = buildTrackingAreaUpdateComplete(msg)
 	}
 
 	return m

--- a/internal/decoder/nas/eps/emm_reject.go
+++ b/internal/decoder/nas/eps/emm_reject.go
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package eps
+
+import (
+	"encoding/hex"
+
+	nasie "github.com/ellanetworks/core/internal/decoder/nas"
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+type AttachReject struct {
+	EMMCause     utils.EnumField `json:"emm_cause"`
+	ESMContainer *ESMMessage     `json:"esm_container,omitempty"`
+	T3402        *uint8          `json:"t3402,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildAttachReject(msg *eps.AttachReject) *AttachReject {
+	out := &AttachReject{
+		EMMCause:     emmCauseToEnum(msg.Cause),
+		ESMContainer: decodeESMContainer(msg.ESMMessageContainer),
+		T3402:        optionalTimer(msg.T3402),
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type AuthenticationFailure struct {
+	EMMCause utils.EnumField `json:"emm_cause"`
+	AUTS     string          `json:"auts,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildAuthenticationFailure(msg *eps.AuthenticationFailure) *AuthenticationFailure {
+	out := &AuthenticationFailure{EMMCause: emmCauseToEnum(msg.Cause)}
+
+	if len(msg.AUTS) > 0 {
+		out.AUTS = hex.EncodeToString(msg.AUTS)
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type AuthenticationReject struct {
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildAuthenticationReject(msg *eps.AuthenticationReject) *AuthenticationReject {
+	return &AuthenticationReject{UnrecognizedIEs: utils.RawIEs(msg.Unrecognized)}
+}
+
+type DetachAccept struct {
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildDetachAccept(msg *eps.DetachAccept) *DetachAccept {
+	return &DetachAccept{UnrecognizedIEs: utils.RawIEs(msg.Unrecognized)}
+}
+
+type DetachRequestNetwork struct {
+	DetachType utils.EnumField  `json:"detach_type"`
+	EMMCause   *utils.EnumField `json:"emm_cause,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildDetachRequestNetwork(msg *eps.DetachRequestNetwork) *DetachRequestNetwork {
+	out := &DetachRequestNetwork{DetachType: detachTypeNetworkToEnum(msg.TypeOfDetach)}
+
+	if msg.Cause != nil {
+		c := emmCauseToEnum(*msg.Cause)
+		out.EMMCause = &c
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type EMMStatus struct {
+	EMMCause utils.EnumField `json:"emm_cause"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildEMMStatus(msg *eps.EMMStatus) *EMMStatus {
+	out := &EMMStatus{EMMCause: emmCauseToEnum(msg.Cause)}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type SecurityModeReject struct {
+	EMMCause utils.EnumField `json:"emm_cause"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildSecurityModeReject(msg *eps.SecurityModeReject) *SecurityModeReject {
+	out := &SecurityModeReject{EMMCause: emmCauseToEnum(msg.Cause)}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type ServiceAccept struct {
+	EPSBearerContextStatus []nasie.EPSBearerContextStatusItem `json:"eps_bearer_context_status,omitempty"`
+	T3448                  *uint8                             `json:"t3448,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildServiceAccept(msg *eps.ServiceAccept) *ServiceAccept {
+	out := &ServiceAccept{
+		EPSBearerContextStatus: nasie.EPSBearerContextStatus(msg.EPSBearerContextStatus),
+		T3448:                  optionalTimer(msg.T3448),
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type ServiceReject struct {
+	EMMCause utils.EnumField `json:"emm_cause"`
+	T3442    *uint8          `json:"t3442,omitempty"`
+	T3346    *uint8          `json:"t3346,omitempty"`
+	T3448    *uint8          `json:"t3448,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildServiceReject(msg *eps.ServiceReject) *ServiceReject {
+	out := &ServiceReject{
+		EMMCause: emmCauseToEnum(msg.Cause),
+		T3442:    optionalTimer(msg.T3442),
+		T3346:    optionalTimer(msg.T3346),
+		T3448:    optionalTimer(msg.T3448),
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type TrackingAreaUpdateComplete struct {
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildTrackingAreaUpdateComplete(msg *eps.TrackingAreaUpdateComplete) *TrackingAreaUpdateComplete {
+	return &TrackingAreaUpdateComplete{UnrecognizedIEs: utils.RawIEs(msg.Unrecognized)}
+}
+
+// optionalTimer renders a GPRS timer that the message may omit.
+func optionalTimer(t *nas.GPRSTimer2) *uint8 {
+	if t == nil {
+		return nil
+	}
+
+	v := timerOctet(*t)
+
+	return &v
+}

--- a/internal/decoder/nas/eps/enums.go
+++ b/internal/decoder/nas/eps/enums.go
@@ -44,3 +44,11 @@ func integrityAlgToEnum(v uint8) utils.EnumField {
 func emmCauseToEnum(c eps.EMMCause) utils.EnumField {
 	return utils.NamedEnum(uint8(c), c.Name())
 }
+
+func detachTypeNetworkToEnum(v eps.DetachTypeNetwork) utils.EnumField {
+	return utils.NamedEnum(uint8(v), v.String())
+}
+
+func esmCauseToEnum(c eps.ESMCause) utils.EnumField {
+	return utils.NamedEnum(uint8(c), c.Name())
+}

--- a/internal/decoder/nas/eps/eps_test.go
+++ b/internal/decoder/nas/eps/eps_test.go
@@ -293,3 +293,171 @@ func TestDecodeAttachCompleteCarriesESMContainer(t *testing.T) {
 		t.Errorf("EPS bearer identity = %d, want 5", complete.ESMContainer.ESMHeader.EPSBearerIdentity)
 	}
 }
+
+func TestDecodeEMMRejects(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		msg  interface{ MarshalBinary() ([]byte, error) }
+		want func(*testing.T, *EMMMessage)
+	}{
+		{
+			name: "AttachReject",
+			msg:  &eps.AttachReject{Cause: eps.EMMCauseIllegalUE},
+			want: func(t *testing.T, m *EMMMessage) {
+				if m.AttachReject == nil || m.AttachReject.EMMCause.Value != int64(eps.EMMCauseIllegalUE) {
+					t.Errorf("attach reject = %+v", m.AttachReject)
+				}
+			},
+		},
+		{
+			name: "AuthenticationFailure",
+			msg:  &eps.AuthenticationFailure{Cause: eps.EMMCauseMACFailure, AUTS: []byte{1, 2, 3}},
+			want: func(t *testing.T, m *EMMMessage) {
+				if m.AuthenticationFailure == nil || m.AuthenticationFailure.AUTS != "010203" {
+					t.Errorf("authentication failure = %+v", m.AuthenticationFailure)
+				}
+			},
+		},
+		{
+			name: "ServiceReject",
+			msg:  &eps.ServiceReject{Cause: eps.EMMCauseUEIdentityCannotBeDerived},
+			want: func(t *testing.T, m *EMMMessage) {
+				if m.ServiceReject == nil || m.ServiceReject.EMMCause.Label == "" {
+					t.Errorf("service reject = %+v", m.ServiceReject)
+				}
+			},
+		},
+		{
+			name: "EMMStatus",
+			msg:  &eps.EMMStatus{Cause: eps.EMMCauseIllegalUE},
+			want: func(t *testing.T, m *EMMMessage) {
+				if m.EMMStatus == nil {
+					t.Errorf("EMM status = %+v", m.EMMStatus)
+				}
+			},
+		},
+		{
+			// The network variant shares its message type with the UE one and only
+			// parses in the downlink direction (TS 24.301 table 9.8.1).
+			name: "DetachRequestNetwork",
+			msg:  &eps.DetachRequestNetwork{TypeOfDetach: eps.DetachTypeReattachRequired},
+			want: func(t *testing.T, m *EMMMessage) {
+				if m.DetachRequestNetwork == nil {
+					t.Fatalf("detach request (network) not decoded: %+v", m)
+				}
+
+				if m.DetachRequestNetwork.DetachType.Label == "" {
+					t.Errorf("detach type carries no label")
+				}
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := c.msg.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			msg := DecodeEPSNASMessage(b)
+			if msg.EMMMessage == nil {
+				t.Fatalf("no EMM message decoded")
+			}
+
+			c.want(t, msg.EMMMessage)
+		})
+	}
+}
+
+// Every ESM message here is network- or UE-originated with the same message
+// type space, so each is decoded end to end rather than trusted to the dispatch
+// table alone.
+func TestDecodeESMMessages(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		msg  interface{ MarshalBinary() ([]byte, error) }
+		want func(*testing.T, *ESMMessage)
+	}{
+		{
+			name: "PDNConnectivityReject",
+			msg:  &eps.PDNConnectivityReject{EPSBearerIdentity: 5, PTI: 1, Cause: eps.ESMCauseInsufficientResources},
+			want: func(t *testing.T, m *ESMMessage) {
+				if m.PDNConnectivityReject == nil || m.PDNConnectivityReject.ESMCause.Label == "" {
+					t.Errorf("pdn connectivity reject = %+v", m.PDNConnectivityReject)
+				}
+			},
+		},
+		{
+			name: "ESMStatus",
+			msg:  &eps.ESMStatus{EPSBearerIdentity: 5, PTI: 1, Cause: eps.ESMCauseInvalidEPSBearerIdentity},
+			want: func(t *testing.T, m *ESMMessage) {
+				if m.ESMStatus == nil {
+					t.Errorf("esm status = %+v", m.ESMStatus)
+				}
+			},
+		},
+		{
+			name: "DeactivateEPSBearerContextRequest",
+			msg:  &eps.DeactivateEPSBearerContextRequest{EPSBearerIdentity: 5, PTI: 1, Cause: eps.ESMCauseRegularDeactivation},
+			want: func(t *testing.T, m *ESMMessage) {
+				if m.DeactivateBearerRequest == nil {
+					t.Errorf("deactivate bearer request = %+v", m.DeactivateBearerRequest)
+				}
+			},
+		},
+		{
+			name: "ModifyEPSBearerContextRequest",
+			msg: &eps.ModifyEPSBearerContextRequest{
+				EPSBearerIdentity: 5, PTI: 1,
+				NewEPSQoS: &eps.EPSQoS{QCI: 9},
+			},
+			want: func(t *testing.T, m *ESMMessage) {
+				if m.ModifyEPSBearerContextRequest == nil || m.ModifyEPSBearerContextRequest.NewEPSQoS == nil {
+					t.Errorf("modify eps bearer context request = %+v", m.ModifyEPSBearerContextRequest)
+				}
+			},
+		},
+		{
+			name: "BearerResourceAllocationRequest",
+			msg: &eps.BearerResourceAllocationRequest{
+				EPSBearerIdentity: 0, PTI: 1, LinkedEPSBearerIdentity: 5,
+				TrafficFlowAggregate:   []byte{0x01, 0x02},
+				RequiredTrafficFlowQoS: eps.EPSQoS{QCI: 9},
+			},
+			want: func(t *testing.T, m *ESMMessage) {
+				if m.BearerResourceAllocationRequest == nil {
+					t.Fatalf("bearer resource allocation request not decoded")
+				}
+
+				if m.BearerResourceAllocationRequest.LinkedEPSBearerIdentity != 5 {
+					t.Errorf("linked EPS bearer identity = %d, want 5", m.BearerResourceAllocationRequest.LinkedEPSBearerIdentity)
+				}
+			},
+		},
+		{
+			name: "BearerResourceModificationRequest",
+			msg: &eps.BearerResourceModificationRequest{
+				EPSBearerIdentity: 0, PTI: 1, EPSBearerIdentityForPacketFilter: 5,
+				TrafficFlowAggregate: []byte{0x03},
+			},
+			want: func(t *testing.T, m *ESMMessage) {
+				if m.BearerResourceModificationRequest == nil {
+					t.Errorf("bearer resource modification request = %+v", m.BearerResourceModificationRequest)
+				}
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := c.msg.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			msg := DecodeEPSNASMessage(b)
+			if msg.ESMMessage == nil {
+				t.Fatalf("no ESM message decoded: %+v", msg)
+			}
+
+			c.want(t, msg.ESMMessage)
+		})
+	}
+}

--- a/internal/decoder/nas/eps/esm.go
+++ b/internal/decoder/nas/eps/esm.go
@@ -32,6 +32,19 @@ type ESMMessage struct {
 	ESMInformationResponse      *ESMInformationResponse      `json:"esm_information_response,omitempty"`
 	PDNDisconnectRequest        *PDNDisconnectRequest        `json:"pdn_disconnect_request,omitempty"`
 	DeactivateBearerAccept      *DeactivateBearerAccept      `json:"deactivate_bearer_accept,omitempty"`
+
+	ActivateDefaultBearerReject       *ESMCauseOnly                      `json:"activate_default_bearer_reject,omitempty"`
+	DeactivateBearerRequest           *ESMCauseOnly                      `json:"deactivate_bearer_request,omitempty"`
+	ESMStatus                         *ESMCauseOnly                      `json:"esm_status,omitempty"`
+	PDNConnectivityReject             *ESMCauseOnly                      `json:"pdn_connectivity_reject,omitempty"`
+	PDNDisconnectReject               *ESMCauseOnly                      `json:"pdn_disconnect_reject,omitempty"`
+	ModifyEPSBearerContextReject      *ESMCauseOnly                      `json:"modify_eps_bearer_context_reject,omitempty"`
+	BearerResourceAllocationReject    *ESMCauseOnly                      `json:"bearer_resource_allocation_reject,omitempty"`
+	BearerResourceModificationReject  *ESMCauseOnly                      `json:"bearer_resource_modification_reject,omitempty"`
+	ModifyEPSBearerContextRequest     *ModifyEPSBearerContextRequest     `json:"modify_eps_bearer_context_request,omitempty"`
+	ModifyEPSBearerContextAccept      *ModifyEPSBearerContextAccept      `json:"modify_eps_bearer_context_accept,omitempty"`
+	BearerResourceAllocationRequest   *BearerResourceAllocationRequest   `json:"bearer_resource_allocation_request,omitempty"`
+	BearerResourceModificationRequest *BearerResourceModificationRequest `json:"bearer_resource_modification_request,omitempty"`
 }
 
 // PDNAddress is the decoded PDN address IE (TS 24.301 §9.9.4.9): the assigned UE
@@ -77,6 +90,30 @@ func buildESMMessage(b []byte) *ESMMessage {
 		m.PDNDisconnectRequest = buildPDNDisconnectRequest(msg)
 	case *eps.DeactivateEPSBearerContextAccept:
 		m.DeactivateBearerAccept = buildDeactivateBearerAccept(msg)
+	case *eps.ActivateDefaultEPSBearerContextReject:
+		m.ActivateDefaultBearerReject = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.DeactivateEPSBearerContextRequest:
+		m.DeactivateBearerRequest = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.ESMStatus:
+		m.ESMStatus = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.PDNConnectivityReject:
+		m.PDNConnectivityReject = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.PDNDisconnectReject:
+		m.PDNDisconnectReject = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.ModifyEPSBearerContextReject:
+		m.ModifyEPSBearerContextReject = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.BearerResourceAllocationReject:
+		m.BearerResourceAllocationReject = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.BearerResourceModificationReject:
+		m.BearerResourceModificationReject = esmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *eps.ModifyEPSBearerContextRequest:
+		m.ModifyEPSBearerContextRequest = buildModifyEPSBearerContextRequest(msg)
+	case *eps.ModifyEPSBearerContextAccept:
+		m.ModifyEPSBearerContextAccept = buildModifyEPSBearerContextAccept(msg)
+	case *eps.BearerResourceAllocationRequest:
+		m.BearerResourceAllocationRequest = buildBearerResourceAllocationRequest(msg)
+	case *eps.BearerResourceModificationRequest:
+		m.BearerResourceModificationRequest = buildBearerResourceModificationRequest(msg)
 	}
 
 	return m

--- a/internal/decoder/nas/eps/esm_reject.go
+++ b/internal/decoder/nas/eps/esm_reject.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package eps
+
+import (
+	"encoding/hex"
+
+	nasie "github.com/ellanetworks/core/internal/decoder/nas"
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+// ESMCauseOnly is the shape of every ESM message whose only content beyond the
+// shared header is a cause: the bearer identity and transaction are rendered on
+// the ESM header, so the cause is all that is left.
+type ESMCauseOnly struct {
+	ESMCause utils.EnumField `json:"esm_cause"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func esmCauseOnly(c eps.ESMCause, unrecognized []nas.RawIE) *ESMCauseOnly {
+	return &ESMCauseOnly{ESMCause: esmCauseToEnum(c), UnrecognizedIEs: utils.RawIEs(unrecognized)}
+}
+
+type ModifyEPSBearerContextRequest struct {
+	NewEPSQoS                            *EPSQoS                             `json:"new_eps_qos,omitempty"`
+	APNAMBR                              *APNAMBR                            `json:"apn_ambr,omitempty"`
+	ProtocolConfigurationOptions         *nasie.ProtocolConfigurationOptions `json:"protocol_configuration_options,omitempty"`
+	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildModifyEPSBearerContextRequest(msg *eps.ModifyEPSBearerContextRequest) *ModifyEPSBearerContextRequest {
+	out := &ModifyEPSBearerContextRequest{
+		APNAMBR:                              apnAMBR(msg.APNAMBR),
+		ProtocolConfigurationOptions:         nasie.ExtendedPCO(msg.ProtocolConfigurationOptions),
+		ExtendedProtocolConfigurationOptions: nasie.ExtendedPCO(msg.ExtendedProtocolConfigurationOptions),
+	}
+
+	if msg.NewEPSQoS != nil {
+		out.NewEPSQoS = epsQoS(*msg.NewEPSQoS)
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type ModifyEPSBearerContextAccept struct {
+	ProtocolConfigurationOptions         *nasie.ProtocolConfigurationOptions `json:"protocol_configuration_options,omitempty"`
+	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildModifyEPSBearerContextAccept(msg *eps.ModifyEPSBearerContextAccept) *ModifyEPSBearerContextAccept {
+	out := &ModifyEPSBearerContextAccept{
+		ProtocolConfigurationOptions:         nasie.ExtendedPCO(msg.ProtocolConfigurationOptions),
+		ExtendedProtocolConfigurationOptions: nasie.ExtendedPCO(msg.ExtendedProtocolConfigurationOptions),
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+// BearerResourceAllocationRequest is the UE asking for resources for a traffic
+// flow it describes (TS 24.301 §8.3.8). The traffic flow aggregate is a TFT,
+// which the codec keeps as raw bytes.
+type BearerResourceAllocationRequest struct {
+	LinkedEPSBearerIdentity uint8   `json:"linked_eps_bearer_identity"`
+	TrafficFlowAggregate    string  `json:"traffic_flow_aggregate,omitempty"`
+	RequiredTrafficFlowQoS  *EPSQoS `json:"required_traffic_flow_qos,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildBearerResourceAllocationRequest(msg *eps.BearerResourceAllocationRequest) *BearerResourceAllocationRequest {
+	out := &BearerResourceAllocationRequest{
+		LinkedEPSBearerIdentity: uint8(msg.LinkedEPSBearerIdentity),
+		RequiredTrafficFlowQoS:  epsQoS(msg.RequiredTrafficFlowQoS),
+	}
+
+	if len(msg.TrafficFlowAggregate) > 0 {
+		out.TrafficFlowAggregate = hex.EncodeToString(msg.TrafficFlowAggregate)
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+// BearerResourceModificationRequest is the UE asking to change or drop the
+// resources bound to one packet filter (TS 24.301 §8.3.10).
+type BearerResourceModificationRequest struct {
+	EPSBearerIdentityForPacketFilter uint8            `json:"eps_bearer_identity_for_packet_filter"`
+	TrafficFlowAggregate             string           `json:"traffic_flow_aggregate,omitempty"`
+	RequiredTrafficFlowQoS           *EPSQoS          `json:"required_traffic_flow_qos,omitempty"`
+	ESMCause                         *utils.EnumField `json:"esm_cause,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildBearerResourceModificationRequest(msg *eps.BearerResourceModificationRequest) *BearerResourceModificationRequest {
+	out := &BearerResourceModificationRequest{
+		EPSBearerIdentityForPacketFilter: uint8(msg.EPSBearerIdentityForPacketFilter),
+	}
+
+	if len(msg.TrafficFlowAggregate) > 0 {
+		out.TrafficFlowAggregate = hex.EncodeToString(msg.TrafficFlowAggregate)
+	}
+
+	if msg.RequiredTrafficFlowQoS != nil {
+		out.RequiredTrafficFlowQoS = epsQoS(*msg.RequiredTrafficFlowQoS)
+	}
+
+	if msg.Cause != nil {
+		c := esmCauseToEnum(*msg.Cause)
+		out.ESMCause = &c
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}

--- a/internal/decoder/nas/fgs/gmm_misc.go
+++ b/internal/decoder/nas/fgs/gmm_misc.go
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fgs
+
+import (
+	"encoding/hex"
+
+	nasie "github.com/ellanetworks/core/internal/decoder/nas"
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	naslib "github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+// NetworkName is a network name the AMF pushes to the UE (TS 24.008 §10.5.3.5a).
+type NetworkName struct {
+	Name   string `json:"name"`
+	Coding string `json:"coding"`
+	AddCI  bool   `json:"add_country_initials,omitempty"`
+}
+
+// ConfigurationUpdateIndication says what the AMF wants back from the UE
+// (TS 24.501 §9.11.3.18).
+type ConfigurationUpdateIndication struct {
+	Acknowledgement      bool `json:"acknowledgement,omitempty"`
+	RegistrationRequired bool `json:"registration_requested,omitempty"`
+}
+
+type ConfigurationUpdateCommand struct {
+	ConfigurationUpdateIndication *ConfigurationUpdateIndication `json:"configuration_update_indication,omitempty"`
+	GUTI                          *MobileIdentity                `json:"guti,omitempty"`
+	FullNameForNetwork            *NetworkName                   `json:"full_name_for_network,omitempty"`
+	ShortNameForNetwork           *NetworkName                   `json:"short_name_for_network,omitempty"`
+	LocalTimeZone                 *string                        `json:"local_time_zone,omitempty"`
+	UniversalTime                 *string                        `json:"universal_time,omitempty"`
+	DaylightSavingTime            *uint8                         `json:"daylight_saving_time,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func networkName(n *naslib.NetworkName) *NetworkName {
+	if n == nil {
+		return nil
+	}
+
+	return &NetworkName{Name: n.Name, Coding: n.Coding.String(), AddCI: n.AddCI}
+}
+
+func timeZone(z *naslib.TimeZone) *string {
+	if z == nil {
+		return nil
+	}
+
+	s := z.String()
+
+	return &s
+}
+
+func buildConfigurationUpdateCommand(msg *fgs.ConfigurationUpdateCommand) *ConfigurationUpdateCommand {
+	out := &ConfigurationUpdateCommand{
+		FullNameForNetwork:  networkName(msg.FullNameForNetwork),
+		ShortNameForNetwork: networkName(msg.ShortNameForNetwork),
+		LocalTimeZone:       timeZone(msg.LocalTimeZone),
+	}
+
+	if ind := msg.ConfigurationUpdateIndication; ind != nil {
+		out.ConfigurationUpdateIndication = &ConfigurationUpdateIndication{
+			Acknowledgement:      ind.ACK,
+			RegistrationRequired: ind.RED,
+		}
+	}
+
+	if msg.GUTI != nil {
+		id := buildMobileIdentity(*msg.GUTI)
+		out.GUTI = &id
+	}
+
+	if msg.UniversalTime != nil {
+		if t, ok := msg.UniversalTime.Time(); ok {
+			s := t.Format("2006-01-02T15:04:05Z07:00")
+			out.UniversalTime = &s
+		}
+	}
+
+	if msg.DaylightSavingTime != nil {
+		v := uint8(*msg.DaylightSavingTime)
+		out.DaylightSavingTime = &v
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type ConfigurationUpdateComplete struct {
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildConfigurationUpdateComplete(msg *fgs.ConfigurationUpdateComplete) *ConfigurationUpdateComplete {
+	return &ConfigurationUpdateComplete{UnrecognizedIEs: utils.RawIEs(msg.Unrecognized)}
+}
+
+// DeregistrationRequestUEOriginating is the UE telling the network it is leaving
+// (TS 24.501 §8.2.12).
+type DeregistrationRequestUEOriginating struct {
+	AccessType             utils.EnumField `json:"access_type"`
+	ReRegistrationRequired bool            `json:"re_registration_required,omitempty"`
+	SwitchOff              bool            `json:"switch_off,omitempty"`
+	NgKSI                  uint8           `json:"ng_ksi"`
+	MobileIdentity         MobileIdentity  `json:"mobile_identity"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildDeregistrationRequestUEOriginating(msg *fgs.DeregistrationRequestUEOriginating) *DeregistrationRequestUEOriginating {
+	out := &DeregistrationRequestUEOriginating{
+		AccessType:             accessTypeToEnum(msg.AccessType),
+		ReRegistrationRequired: msg.ReRegistrationRequired,
+		SwitchOff:              msg.SwitchOff,
+		NgKSI:                  msg.NgKSI.HalfOctet(),
+		MobileIdentity:         buildMobileIdentity(msg.MobileIdentity),
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+// DeregistrationRequestUETerminated is the network detaching the UE
+// (TS 24.501 §8.2.14).
+type DeregistrationRequestUETerminated struct {
+	AccessType             utils.EnumField  `json:"access_type"`
+	ReRegistrationRequired bool             `json:"re_registration_required,omitempty"`
+	SwitchOff              bool             `json:"switch_off,omitempty"`
+	Cause                  *utils.EnumField `json:"cause_5gmm,omitempty"`
+	T3346                  *uint8           `json:"t3346,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildDeregistrationRequestUETerminated(msg *fgs.DeregistrationRequestUETerminated) *DeregistrationRequestUETerminated {
+	out := &DeregistrationRequestUETerminated{
+		AccessType:             accessTypeToEnum(msg.AccessType),
+		ReRegistrationRequired: msg.ReRegistrationRequired,
+		SwitchOff:              msg.SwitchOff,
+		T3346:                  timerOctetPtr(msg.T3346),
+	}
+
+	if msg.Cause != nil {
+		c := cause5GMMToEnum(*msg.Cause)
+		out.Cause = &c
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type DeregistrationAccept struct {
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildDeregistrationAcceptUEOriginating(msg *fgs.DeregistrationAcceptUEOriginating) *DeregistrationAccept {
+	return &DeregistrationAccept{UnrecognizedIEs: utils.RawIEs(msg.Unrecognized)}
+}
+
+func buildDeregistrationAcceptUETerminated(msg *fgs.DeregistrationAcceptUETerminated) *DeregistrationAccept {
+	return &DeregistrationAccept{UnrecognizedIEs: utils.RawIEs(msg.Unrecognized)}
+}
+
+// GMMCauseOnly is the shape of a 5GMM message whose only content is a cause.
+type GMMCauseOnly struct {
+	Cause utils.EnumField `json:"cause_5gmm"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func gmmCauseOnly(c fgs.GMMCause, unrecognized []naslib.RawIE) *GMMCauseOnly {
+	return &GMMCauseOnly{Cause: cause5GMMToEnum(c), UnrecognizedIEs: utils.RawIEs(unrecognized)}
+}
+
+type NotificationResponse struct {
+	PDUSessionStatus []PDUSessionStatusPDU `json:"pdu_session_status,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildNotificationResponse(msg *fgs.NotificationResponse) *NotificationResponse {
+	out := &NotificationResponse{PDUSessionStatus: decodePDUSessionStatus(msg.PDUSessionStatus)}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+// PDUSessionAuthenticationComplete carries the UE's final EAP message for a
+// session-level authentication (TS 24.501 §8.3.5).
+type PDUSessionAuthenticationComplete struct {
+	EAP         string                              `json:"eap,omitempty"`
+	ExtendedPCO *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildPDUSessionAuthenticationComplete(msg *fgs.PDUSessionAuthenticationComplete) *PDUSessionAuthenticationComplete {
+	out := &PDUSessionAuthenticationComplete{ExtendedPCO: nasie.ExtendedPCO(msg.ExtendedPCO)}
+
+	if len(msg.EAP) > 0 {
+		out.EAP = hex.EncodeToString(msg.EAP)
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+func accessTypeToEnum(a fgs.AccessType) utils.EnumField {
+	return utils.NamedEnum(uint8(a), a.String())
+}

--- a/internal/decoder/nas/fgs/gmm_misc_test.go
+++ b/internal/decoder/nas/fgs/gmm_misc_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fgs
+
+import (
+	"testing"
+
+	naslib "github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+// The deregistration request pair shares a message type between its UE- and
+// network-originated variants (TS 24.501 table 8.2.1), so each is decoded end to
+// end rather than trusted to the dispatch table.
+func TestDecodeGmmMisc(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		msg  interface{ MarshalBinary() ([]byte, error) }
+		want func(*testing.T, *GmmMessage)
+	}{
+		{
+			name: "ConfigurationUpdateCommand",
+			msg: &fgs.ConfigurationUpdateCommand{
+				ConfigurationUpdateIndication: &fgs.ConfigurationUpdateIndication{ACK: true},
+				FullNameForNetwork:            &naslib.NetworkName{Name: "Ella Networks"},
+			},
+			want: func(t *testing.T, m *GmmMessage) {
+				c := m.ConfigurationUpdateCommand
+				if c == nil || c.FullNameForNetwork == nil || c.FullNameForNetwork.Name != "Ella Networks" {
+					t.Fatalf("configuration update command = %+v", c)
+				}
+
+				if c.ConfigurationUpdateIndication == nil || !c.ConfigurationUpdateIndication.Acknowledgement {
+					t.Errorf("configuration update indication = %+v", c.ConfigurationUpdateIndication)
+				}
+			},
+		},
+		{
+			name: "DeregistrationRequestUETerminated",
+			msg: &fgs.DeregistrationRequestUETerminated{
+				AccessType: fgs.AccessType3GPP,
+				Cause:      func() *fgs.GMMCause { c := fgs.GMMCauseIllegalUE; return &c }(),
+			},
+			want: func(t *testing.T, m *GmmMessage) {
+				d := m.DeregistrationRequestUETerminated
+				if d == nil || d.Cause == nil || d.Cause.Label == "" {
+					t.Fatalf("deregistration request (network) = %+v", d)
+				}
+			},
+		},
+		{
+			name: "GMMStatus",
+			msg:  &fgs.GMMStatus{Cause: fgs.GMMCauseIllegalUE},
+			want: func(t *testing.T, m *GmmMessage) {
+				if m.GMMStatus == nil || m.GMMStatus.Cause.Label == "" {
+					t.Errorf("gmm status = %+v", m.GMMStatus)
+				}
+			},
+		},
+		{
+			name: "SecurityModeReject",
+			msg:  &fgs.SecurityModeReject{Cause: fgs.GMMCauseUESecurityCapabilitiesMismatch},
+			want: func(t *testing.T, m *GmmMessage) {
+				if m.SecurityModeReject == nil {
+					t.Errorf("security mode reject = %+v", m.SecurityModeReject)
+				}
+			},
+		},
+		{
+			name: "ConfigurationUpdateComplete",
+			msg:  &fgs.ConfigurationUpdateComplete{},
+			want: func(t *testing.T, m *GmmMessage) {
+				if m.ConfigurationUpdateComplete == nil {
+					t.Errorf("configuration update complete = %+v", m.ConfigurationUpdateComplete)
+				}
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := c.msg.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			msg := DecodeNASMessage(b)
+			if msg.GmmMessage == nil {
+				t.Fatalf("no 5GMM message decoded: %+v", msg)
+			}
+
+			c.want(t, msg.GmmMessage)
+		})
+	}
+}

--- a/internal/decoder/nas/fgs/gsm_session.go
+++ b/internal/decoder/nas/fgs/gsm_session.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fgs
+
+import (
+	nasie "github.com/ellanetworks/core/internal/decoder/nas"
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	naslib "github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+// GSMCauseOnly is the shape of a 5GSM message whose only content beyond the
+// shared header is a cause: the session id and transaction are rendered on the
+// GSM header, so the cause is all that is left.
+type GSMCauseOnly struct {
+	Cause5GSM utils.EnumField `json:"cause_5g_s_m"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func gsmCauseOnly(c fgs.GSMCause, unrecognized []naslib.RawIE) *GSMCauseOnly {
+	return &GSMCauseOnly{Cause5GSM: cause5GSMToString(c), UnrecognizedIEs: utils.RawIEs(unrecognized)}
+}
+
+// GSMOptionalCause is a 5GSM message whose cause the sender may omit.
+type GSMOptionalCause struct {
+	Cause5GSM *utils.EnumField `json:"cause_5g_s_m,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func gsmOptionalCause(c *fgs.GSMCause, unrecognized []naslib.RawIE) *GSMOptionalCause {
+	out := &GSMOptionalCause{UnrecognizedIEs: utils.RawIEs(unrecognized)}
+
+	if c != nil {
+		cause := cause5GSMToString(*c)
+		out.Cause5GSM = &cause
+	}
+
+	return out
+}
+
+// PDUSessionModificationRequest is the UE asking to change a live session: new
+// QoS rules or flows, and the mapped EPS bearers that follow it to 4G
+// (TS 24.501 §8.3.7).
+type PDUSessionModificationRequest struct {
+	Capability5GSM                       *Capability5GSM                     `json:"capability_5gsm,omitempty"`
+	Cause5GSM                            *utils.EnumField                    `json:"cause_5g_s_m,omitempty"`
+	AlwaysonPDUSessionRequested          *bool                               `json:"alwayson_pdu_session_requested,omitempty"`
+	RequestedQosRules                    []QosRule                           `json:"requested_qos_rules,omitempty"`
+	RequestedQosFlowDescriptions         []QoSFlowDescription                `json:"requested_qos_flow_descriptions,omitempty"`
+	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
+	MappedEPSBearerContexts              []MappedEPSBearerContext            `json:"mapped_eps_bearer_contexts,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildPDUSessionModificationRequest(msg *fgs.PDUSessionModificationRequest) *PDUSessionModificationRequest {
+	out := &PDUSessionModificationRequest{
+		AlwaysonPDUSessionRequested:          msg.AlwaysOnRequested,
+		RequestedQosRules:                    QosRulesFromNAS(msg.RequestedQoSRules),
+		RequestedQosFlowDescriptions:         QosFlowDescriptionsFromNAS(msg.RequestedQoSFlows),
+		ExtendedProtocolConfigurationOptions: nasie.ExtendedPCO(msg.ExtendedPCO),
+	}
+
+	if msg.GSMCapability != nil {
+		out.Capability5GSM = &Capability5GSM{
+			RqoS:   b2u(msg.GSMCapability.RqoS),
+			MH6PDU: b2u(msg.GSMCapability.MH6PDU),
+		}
+	}
+
+	if msg.Cause != nil {
+		cause := cause5GSMToString(*msg.Cause)
+		out.Cause5GSM = &cause
+	}
+
+	if msg.MappedEPSBearerContexts != nil {
+		out.MappedEPSBearerContexts = MappedEPSBearerContextsFromNAS(msg.MappedEPSBearerContexts)
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+// PDUSessionModificationCommand is the network's answer, carrying the QoS the
+// session actually gets (TS 24.501 §8.3.9).
+type PDUSessionModificationCommand struct {
+	SessionAMBR                          *SessionAMBR                        `json:"session_ambr,omitempty"`
+	MappedEPSBearerContexts              []MappedEPSBearerContext            `json:"mapped_eps_bearer_contexts,omitempty"`
+	AuthorizedQosFlowDescriptions        []QoSFlowDescription                `json:"authorized_qos_flow_descriptions,omitempty"`
+	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildPDUSessionModificationCommand(msg *fgs.PDUSessionModificationCommand) *PDUSessionModificationCommand {
+	out := &PDUSessionModificationCommand{
+		AuthorizedQosFlowDescriptions:        QosFlowDescriptionsFromNAS(msg.QoSFlowDescriptions),
+		ExtendedProtocolConfigurationOptions: nasie.ExtendedPCO(msg.ExtendedPCO),
+	}
+
+	if msg.SessionAMBR != nil {
+		ambr := buildSessionAMBR(*msg.SessionAMBR)
+		out.SessionAMBR = &ambr
+	}
+
+	if msg.MappedEPSBearerContexts != nil {
+		out.MappedEPSBearerContexts = MappedEPSBearerContextsFromNAS(msg.MappedEPSBearerContexts)
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+// PDUSessionModificationReject refuses the modification, with the back-off timer
+// that tells the UE how long to wait (TS 24.501 §8.3.8).
+type PDUSessionModificationReject struct {
+	Cause5GSM                            utils.EnumField                     `json:"cause_5g_s_m"`
+	BackoffTimer                         *GPRSTimer3Value                    `json:"backoff_timer,omitempty"`
+	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
+
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildPDUSessionModificationReject(msg *fgs.PDUSessionModificationReject) *PDUSessionModificationReject {
+	out := &PDUSessionModificationReject{
+		Cause5GSM:                            cause5GSMToString(msg.Cause),
+		BackoffTimer:                         gprsTimer3(msg.BackoffTimer),
+		ExtendedProtocolConfigurationOptions: nasie.ExtendedPCO(msg.ExtendedPCO),
+	}
+
+	out.UnrecognizedIEs = utils.RawIEs(msg.Unrecognized)
+
+	return out
+}
+
+type PDUSessionModificationComplete struct {
+	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
+}
+
+func buildPDUSessionModificationComplete(msg *fgs.PDUSessionModificationComplete) *PDUSessionModificationComplete {
+	return &PDUSessionModificationComplete{UnrecognizedIEs: utils.RawIEs(msg.Unrecognized)}
+}

--- a/internal/decoder/nas/fgs/gsm_session_test.go
+++ b/internal/decoder/nas/fgs/gsm_session_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fgs
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func TestDecodeGsmSession(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		msg  interface{ MarshalBinary() ([]byte, error) }
+		want func(*testing.T, *GsmMessage)
+	}{
+		{
+			name: "PDUSessionEstablishmentReject",
+			msg:  &fgs.PDUSessionEstablishmentReject{PDUSessionID: 1, PTI: 1, Cause: fgs.GSMCauseInsufficientResources},
+			want: func(t *testing.T, m *GsmMessage) {
+				if m.PDUSessionEstablishmentReject == nil || m.PDUSessionEstablishmentReject.Cause5GSM.Label == "" {
+					t.Errorf("establishment reject = %+v", m.PDUSessionEstablishmentReject)
+				}
+			},
+		},
+		{
+			name: "PDUSessionReleaseCommand",
+			msg:  &fgs.PDUSessionReleaseCommand{PDUSessionID: 1, PTI: 1, Cause: fgs.GSMCauseRegularDeactivation},
+			want: func(t *testing.T, m *GsmMessage) {
+				if m.PDUSessionReleaseCommand == nil {
+					t.Errorf("release command = %+v", m.PDUSessionReleaseCommand)
+				}
+			},
+		},
+		{
+			name: "PDUSessionReleaseComplete",
+			msg:  &fgs.PDUSessionReleaseComplete{PDUSessionID: 1, PTI: 1},
+			want: func(t *testing.T, m *GsmMessage) {
+				if m.PDUSessionReleaseComplete == nil {
+					t.Fatalf("release complete not decoded")
+				}
+
+				if m.PDUSessionReleaseComplete.Cause5GSM != nil {
+					t.Errorf("cause rendered for a message that carried none")
+				}
+			},
+		},
+		{
+			name: "GSMStatus",
+			msg:  &fgs.GSMStatus{PDUSessionID: 1, PTI: 1, Cause: fgs.GSMCauseInvalidPDUSessionIdentity},
+			want: func(t *testing.T, m *GsmMessage) {
+				if m.GSMStatus == nil {
+					t.Errorf("gsm status = %+v", m.GSMStatus)
+				}
+			},
+		},
+		{
+			name: "PDUSessionModificationRequest",
+			msg: &fgs.PDUSessionModificationRequest{
+				PDUSessionID: 1, PTI: 1,
+				GSMCapability: &fgs.GSMCapability{RqoS: true},
+			},
+			want: func(t *testing.T, m *GsmMessage) {
+				r := m.PDUSessionModificationRequest
+				if r == nil || r.Capability5GSM == nil || r.Capability5GSM.RqoS != 1 {
+					t.Errorf("modification request = %+v", r)
+				}
+			},
+		},
+		{
+			name: "PDUSessionModificationComplete",
+			msg:  &fgs.PDUSessionModificationComplete{PDUSessionID: 1, PTI: 1},
+			want: func(t *testing.T, m *GsmMessage) {
+				if m.PDUSessionModificationComplete == nil {
+					t.Errorf("modification complete = %+v", m.PDUSessionModificationComplete)
+				}
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := c.msg.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// A 5GSM message reaches the decoder inside a payload container, the
+			// way UL/DL NAS TRANSPORT carries it (TS 24.501 §8.2.10).
+			gsm := buildGsmMessage(b)
+			if gsm == nil {
+				t.Fatalf("no 5GSM message decoded")
+			}
+
+			if gsm.GsmHeader.PDUSessionID != 1 {
+				t.Errorf("PDU session id = %d, want 1", gsm.GsmHeader.PDUSessionID)
+			}
+
+			c.want(t, gsm)
+		})
+	}
+}

--- a/internal/decoder/nas/fgs/nas.go
+++ b/internal/decoder/nas/fgs/nas.go
@@ -36,6 +36,16 @@ type GmmMessage struct {
 	ServiceReject          *ServiceReject          `json:"service_reject,omitempty"`
 	IdentityRequest        *IdentityRequest        `json:"identity_request,omitempty"`
 	IdentityResponse       *IdentityResponse       `json:"identity_response,omitempty"`
+
+	ConfigurationUpdateCommand         *ConfigurationUpdateCommand         `json:"configuration_update_command,omitempty"`
+	ConfigurationUpdateComplete        *ConfigurationUpdateComplete        `json:"configuration_update_complete,omitempty"`
+	DeregistrationRequestUEOriginating *DeregistrationRequestUEOriginating `json:"deregistration_request_ue_originating,omitempty"`
+	DeregistrationAcceptUEOriginating  *DeregistrationAccept               `json:"deregistration_accept_ue_originating,omitempty"`
+	DeregistrationRequestUETerminated  *DeregistrationRequestUETerminated  `json:"deregistration_request_ue_terminated,omitempty"`
+	DeregistrationAcceptUETerminated   *DeregistrationAccept               `json:"deregistration_accept_ue_terminated,omitempty"`
+	GMMStatus                          *GMMCauseOnly                       `json:"gmm_status,omitempty"`
+	SecurityModeReject                 *GMMCauseOnly                       `json:"security_mode_reject,omitempty"`
+	NotificationResponse               *NotificationResponse               `json:"notification_response,omitempty"`
 }
 
 type GsmHeader struct {
@@ -50,6 +60,19 @@ type GsmMessage struct {
 
 	PDUSessionEstablishmentRequest *PDUSessionEstablishmentRequest `json:"pdu_session_establishment_request,omitempty"`
 	PDUSessionEstablishmentAccept  *PDUSessionEstablishmentAccept  `json:"pdu_session_establishment_accept,omitempty"`
+
+	PDUSessionAuthenticationComplete *PDUSessionAuthenticationComplete `json:"pdu_session_authentication_complete,omitempty"`
+
+	GSMStatus                           *GSMCauseOnly                   `json:"gsm_status,omitempty"`
+	PDUSessionEstablishmentReject       *GSMCauseOnly                   `json:"pdu_session_establishment_reject,omitempty"`
+	PDUSessionReleaseCommand            *GSMCauseOnly                   `json:"pdu_session_release_command,omitempty"`
+	PDUSessionModificationCommandReject *GSMCauseOnly                   `json:"pdu_session_modification_command_reject,omitempty"`
+	PDUSessionReleaseRequest            *GSMOptionalCause               `json:"pdu_session_release_request,omitempty"`
+	PDUSessionReleaseComplete           *GSMOptionalCause               `json:"pdu_session_release_complete,omitempty"`
+	PDUSessionModificationRequest       *PDUSessionModificationRequest  `json:"pdu_session_modification_request,omitempty"`
+	PDUSessionModificationCommand       *PDUSessionModificationCommand  `json:"pdu_session_modification_command,omitempty"`
+	PDUSessionModificationReject        *PDUSessionModificationReject   `json:"pdu_session_modification_reject,omitempty"`
+	PDUSessionModificationComplete      *PDUSessionModificationComplete `json:"pdu_session_modification_complete,omitempty"`
 }
 
 type SecurityHeader struct {
@@ -237,6 +260,24 @@ func buildGmmMessage(raw []byte) *GmmMessage {
 		gmmMessage.IdentityRequest = buildIdentityRequest(msg)
 	case *fgs.IdentityResponse:
 		gmmMessage.IdentityResponse = buildIdentityResponse(msg)
+	case *fgs.ConfigurationUpdateCommand:
+		gmmMessage.ConfigurationUpdateCommand = buildConfigurationUpdateCommand(msg)
+	case *fgs.ConfigurationUpdateComplete:
+		gmmMessage.ConfigurationUpdateComplete = buildConfigurationUpdateComplete(msg)
+	case *fgs.DeregistrationRequestUEOriginating:
+		gmmMessage.DeregistrationRequestUEOriginating = buildDeregistrationRequestUEOriginating(msg)
+	case *fgs.DeregistrationAcceptUEOriginating:
+		gmmMessage.DeregistrationAcceptUEOriginating = buildDeregistrationAcceptUEOriginating(msg)
+	case *fgs.DeregistrationRequestUETerminated:
+		gmmMessage.DeregistrationRequestUETerminated = buildDeregistrationRequestUETerminated(msg)
+	case *fgs.DeregistrationAcceptUETerminated:
+		gmmMessage.DeregistrationAcceptUETerminated = buildDeregistrationAcceptUETerminated(msg)
+	case *fgs.GMMStatus:
+		gmmMessage.GMMStatus = gmmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *fgs.SecurityModeReject:
+		gmmMessage.SecurityModeReject = gmmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *fgs.NotificationResponse:
+		gmmMessage.NotificationResponse = buildNotificationResponse(msg)
 	}
 
 	return gmmMessage
@@ -272,6 +313,50 @@ func buildGsmMessage(raw []byte) *GsmMessage {
 		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
 		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
 		gsmMessage.PDUSessionEstablishmentRequest = buildPDUSessionEstablishmentRequest(msg)
+	case *fgs.PDUSessionAuthenticationComplete:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionAuthenticationComplete = buildPDUSessionAuthenticationComplete(msg)
+	case *fgs.GSMStatus:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.GSMStatus = gsmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *fgs.PDUSessionEstablishmentReject:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionEstablishmentReject = gsmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *fgs.PDUSessionReleaseCommand:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionReleaseCommand = gsmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *fgs.PDUSessionModificationCommandReject:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionModificationCommandReject = gsmCauseOnly(msg.Cause, msg.Unrecognized)
+	case *fgs.PDUSessionReleaseRequest:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionReleaseRequest = gsmOptionalCause(msg.Cause, msg.Unrecognized)
+	case *fgs.PDUSessionReleaseComplete:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionReleaseComplete = gsmOptionalCause(msg.Cause, msg.Unrecognized)
+	case *fgs.PDUSessionModificationRequest:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionModificationRequest = buildPDUSessionModificationRequest(msg)
+	case *fgs.PDUSessionModificationCommand:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionModificationCommand = buildPDUSessionModificationCommand(msg)
+	case *fgs.PDUSessionModificationReject:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionModificationReject = buildPDUSessionModificationReject(msg)
+	case *fgs.PDUSessionModificationComplete:
+		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
+		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)
+		gsmMessage.PDUSessionModificationComplete = buildPDUSessionModificationComplete(msg)
 	case *fgs.PDUSessionEstablishmentAccept:
 		gsmMessage.GsmHeader.PDUSessionID = uint8(msg.PDUSessionID)
 		gsmMessage.GsmHeader.PTI = uint8(msg.PTI)

--- a/internal/decoder/ngap/golden_test.go
+++ b/internal/decoder/ngap/golden_test.go
@@ -89,6 +89,196 @@ func goldenCorpus(t *testing.T) map[string][]byte {
 		"invalid":                               {0xff, 0x00, 0x01},
 	}
 
+	psReqTransfer, err := (&lib.PathSwitchRequestTransfer{
+		DLNGUUPTNLInformation: lib.UPTransportLayerInformation{
+			GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 45, 0, 1}, GTPTEID: 0x21},
+		},
+		QosFlowAccepted: lib.QosFlowAcceptedList{{QosFlowIdentifier: 1}},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Path Switch Request Transfer: %v", err)
+	}
+
+	psAckTransfer, err := (&lib.PathSwitchRequestAcknowledgeTransfer{
+		ULNGUUPTNLInformation: &lib.UPTransportLayerInformation{
+			GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 46, 0, 1}, GTPTEID: 0x31},
+		},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Path Switch Request Acknowledge Transfer: %v", err)
+	}
+
+	psFailTransfer, err := (&lib.PathSwitchRequestUnsuccessfulTransfer{
+		Cause: lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Path Switch Request Unsuccessful Transfer: %v", err)
+	}
+
+	corpus["path_switch_request_full"] = mustMarshal(t, &lib.PathSwitchRequest{
+		RANUENGAPID:       3,
+		SourceAMFUENGAPID: 7,
+		UserLocationInformation: &lib.UserLocationInformation{
+			Kind:         lib.UserLocationNR,
+			PLMNIdentity: testPLMN,
+			CellIdentity: 0x000000010,
+			TAI:          testTAI,
+		},
+		UESecurityCapabilities: &lib.UESecurityCapabilities{
+			NREncryptionAlgorithms: 0xe000, NRIntegrityProtectionAlgorithms: 0xe000,
+			EUTRAEncryptionAlgorithms: 0xe000, EUTRAIntegrityProtectionAlgorithms: 0xe000,
+		},
+		PDUSessionResourceToBeSwitchedDLList: lib.PDUSessionResourceToBeSwitchedDLList{
+			{PDUSessionID: 1, Transfer: psReqTransfer},
+		},
+	})
+
+	corpus["path_switch_request_acknowledge_full"] = mustMarshal(t, &lib.PathSwitchRequestAcknowledge{
+		AMFUENGAPID:     lib.Ptr(lib.AMFUENGAPID(7)),
+		RANUENGAPID:     lib.Ptr(lib.RANUENGAPID(3)),
+		SecurityContext: lib.SecurityContext{NextHopChainingCount: 3, NextHopNH: lib.SecurityKey{0x01, 0x02}},
+		PDUSessionResourceSwitchedList: lib.PDUSessionResourceSwitchedList{
+			{PDUSessionID: 1, Transfer: psAckTransfer},
+		},
+		PDUSessionResourceReleased: lib.PDUSessionResourceReleasedListPSAck{
+			{PDUSessionID: 2, Transfer: psFailTransfer},
+		},
+		AllowedNSSAI: lib.AllowedNSSAI{{SNSSAI: lib.SNSSAI{SST: 1}}},
+	})
+
+	corpus["path_switch_request_failure_full"] = mustMarshal(t, &lib.PathSwitchRequestFailure{
+		AMFUENGAPID: lib.Ptr(lib.AMFUENGAPID(7)),
+		RANUENGAPID: lib.Ptr(lib.RANUENGAPID(3)),
+		PDUSessionResourceReleased: lib.PDUSessionResourceReleasedListPSFail{
+			{PDUSessionID: 1, Transfer: psFailTransfer},
+		},
+		CriticalityDiagnostics: &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcPathSwitchRequest)},
+	})
+
+	modReqTransfer, err := (&lib.PDUSessionResourceModifyRequestTransfer{
+		PDUSessionAggregateMaximumBitRate: &lib.PDUSessionAggregateMaximumBitRate{DL: 200000000, UL: 100000000},
+		QosFlowAddOrModifyRequest: lib.QosFlowAddOrModifyRequestList{{
+			QosFlowIdentifier: 1,
+			QosFlowLevelQosParameters: &lib.QosFlowLevelQosParameters{
+				QosCharacteristics: lib.QosCharacteristics{
+					Kind:          lib.QosCharacteristicsNonDynamic5QI,
+					NonDynamic5QI: lib.NonDynamic5QIDescriptor{FiveQI: 9},
+				},
+				AllocationAndRetentionPriority: lib.AllocationAndRetentionPriority{PriorityLevelARP: 8},
+			},
+		}},
+		QosFlowToRelease: lib.QosFlowListWithCause{
+			{QosFlowIdentifier: 2, Cause: lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0}},
+		},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Modify Request Transfer: %v", err)
+	}
+
+	modRespTransfer, err := (&lib.PDUSessionResourceModifyResponseTransfer{
+		DLNGUUPTNLInformation: &lib.UPTransportLayerInformation{
+			GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 45, 0, 1}, GTPTEID: 0x41},
+		},
+		QosFlowAddOrModifyResponse: lib.QosFlowAddOrModifyResponseList{{QosFlowIdentifier: 1}},
+		QosFlowFailedToAddOrModify: lib.QosFlowListWithCause{
+			{QosFlowIdentifier: 2, Cause: lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0}},
+		},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Modify Response Transfer: %v", err)
+	}
+
+	modIndTransfer, err := (&lib.PDUSessionResourceModifyIndicationTransfer{
+		DLQosFlowPerTNLInformation: lib.QosFlowPerTNLInformation{
+			UPTransportLayerInformation: lib.UPTransportLayerInformation{
+				GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 46, 0, 1}, GTPTEID: 0x51},
+			},
+			AssociatedQosFlowList: lib.AssociatedQosFlowList{{QosFlowIdentifier: 1}},
+		},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Modify Indication Transfer: %v", err)
+	}
+
+	modCfmTransfer, err := (&lib.PDUSessionResourceModifyConfirmTransfer{
+		QosFlowModifyConfirm: lib.QosFlowModifyConfirmList{{QosFlowIdentifier: 1}},
+		ULNGUUPTNLInformation: lib.UPTransportLayerInformation{
+			GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 47, 0, 1}, GTPTEID: 0x61},
+		},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Modify Confirm Transfer: %v", err)
+	}
+
+	modFailTransfer, err := (&lib.PDUSessionResourceModifyIndicationUnsuccessfulTransfer{
+		Cause: lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Modify Indication Unsuccessful Transfer: %v", err)
+	}
+
+	corpus["pdu_session_resource_modify_request_full"] = mustMarshal(t, &lib.PDUSessionResourceModifyRequest{
+		AMFUENGAPID: 7,
+		RANUENGAPID: 3,
+		PDUSessionResourceModify: lib.PDUSessionResourceModifyListModReq{
+			{PDUSessionID: 1, NASPDU: &lib.NASPDU{0x7e, 0x00, 0x68}, Transfer: modReqTransfer},
+		},
+	})
+
+	corpus["pdu_session_resource_modify_response_full"] = mustMarshal(t, &lib.PDUSessionResourceModifyResponse{
+		AMFUENGAPID:              lib.Ptr(lib.AMFUENGAPID(7)),
+		RANUENGAPID:              lib.Ptr(lib.RANUENGAPID(3)),
+		PDUSessionResourceModify: lib.PDUSessionResourceModifyListModRes{{PDUSessionID: 1, Transfer: modRespTransfer}},
+		PDUSessionResourceFailed: lib.PDUSessionResourceFailedToModifyListModRes{{PDUSessionID: 2, Transfer: modFailTransfer}},
+		CriticalityDiagnostics:   &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcPDUSessionResourceModify)},
+	})
+
+	corpus["pdu_session_resource_modify_indication_full"] = mustMarshal(t, &lib.PDUSessionResourceModifyIndication{
+		AMFUENGAPID:              7,
+		RANUENGAPID:              3,
+		PDUSessionResourceModify: lib.PDUSessionResourceModifyListModInd{{PDUSessionID: 1, Transfer: modIndTransfer}},
+	})
+
+	corpus["pdu_session_resource_modify_confirm_full"] = mustMarshal(t, &lib.PDUSessionResourceModifyConfirm{
+		AMFUENGAPID:              lib.Ptr(lib.AMFUENGAPID(7)),
+		RANUENGAPID:              lib.Ptr(lib.RANUENGAPID(3)),
+		PDUSessionResourceModify: lib.PDUSessionResourceModifyListModCfm{{PDUSessionID: 1, Transfer: modCfmTransfer}},
+		PDUSessionResourceFailed: lib.PDUSessionResourceFailedToModifyListModCfm{{PDUSessionID: 2, Transfer: modFailTransfer}},
+	})
+
+	corpus["pdu_session_resource_notify_full"] = mustMarshal(t, &lib.PDUSessionResourceNotify{
+		AMFUENGAPID:              7,
+		RANUENGAPID:              3,
+		PDUSessionResourceNotify: lib.PDUSessionResourceNotifyList{{PDUSessionID: 1, Transfer: lib.TransferContainer{0x01, 0x02}}},
+	})
+
+	corpus["ng_reset_all_full"] = mustMarshal(t, &lib.NGReset{
+		Cause:     &lib.Cause{Group: lib.CauseGroupMisc, Value: 3},
+		ResetType: lib.ResetType{All: true},
+	})
+
+	corpus["ng_reset_part_full"] = mustMarshal(t, &lib.NGReset{
+		Cause: &lib.Cause{Group: lib.CauseGroupTransport, Value: 0},
+		ResetType: lib.ResetType{Part: lib.UEAssociatedLogicalNGConnectionList{
+			{AMFUENGAPID: lib.Ptr(lib.AMFUENGAPID(7)), RANUENGAPID: lib.Ptr(lib.RANUENGAPID(3))},
+			{RANUENGAPID: lib.Ptr(lib.RANUENGAPID(4))},
+		}},
+	})
+
+	corpus["ng_reset_acknowledge_full"] = mustMarshal(t, &lib.NGResetAcknowledge{
+		ConnectionList: lib.UEAssociatedLogicalNGConnectionList{
+			{AMFUENGAPID: lib.Ptr(lib.AMFUENGAPID(7)), RANUENGAPID: lib.Ptr(lib.RANUENGAPID(3))},
+		},
+		CriticalityDiagnostics: &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcNGReset)},
+	})
+
+	corpus["nas_non_delivery_indication_full"] = mustMarshal(t, &lib.NASNonDeliveryIndication{
+		AMFUENGAPID: 7,
+		RANUENGAPID: 3,
+		NASPDU:      lib.NASPDU{0x7e, 0x00, 0x44},
+		Cause:       &lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 27},
+	})
+
 	corpus["paging_full"] = mustMarshal(t, &lib.Paging{
 		FiveGSTMSI:       &lib.FiveGSTMSI{AMFSetID: 1, AMFPointer: 2, FiveGTMSI: 0x01020304},
 		PagingDRX:        lib.Ptr(lib.PagingDRXv128),
@@ -246,12 +436,17 @@ func TestGoldenCoversEveryRenderedProcedure(t *testing.T) {
 			lib.ProcDownlinkNonUEAssociatedNRPPaTransport,
 			lib.ProcUplinkNonUEAssociatedNRPPaTransport, lib.ProcErrorIndication,
 			lib.ProcLocationReport, lib.ProcLocationReportingControl,
+			lib.ProcNGReset, lib.ProcPathSwitchRequest, lib.ProcNASNonDeliveryIndication,
+			lib.ProcPDUSessionResourceModify, lib.ProcPDUSessionResourceModifyIndication,
+			lib.ProcPDUSessionResourceNotify,
 		},
 		"SuccessfulOutcome": {
 			lib.ProcNGSetup, lib.ProcInitialContextSetup, lib.ProcPDUSessionResourceSetup,
 			lib.ProcUEContextRelease, lib.ProcPDUSessionResourceRelease,
+			lib.ProcNGReset, lib.ProcPathSwitchRequest,
+			lib.ProcPDUSessionResourceModify, lib.ProcPDUSessionResourceModifyIndication,
 		},
-		"UnsuccessfulOutcome": {lib.ProcNGSetup, lib.ProcInitialContextSetup},
+		"UnsuccessfulOutcome": {lib.ProcNGSetup, lib.ProcInitialContextSetup, lib.ProcPathSwitchRequest},
 	}
 
 	covered := map[string]map[int64]bool{}

--- a/internal/decoder/ngap/golden_test.go
+++ b/internal/decoder/ngap/golden_test.go
@@ -252,6 +252,197 @@ func goldenCorpus(t *testing.T) map[string][]byte {
 		PDUSessionResourceNotify: lib.PDUSessionResourceNotifyList{{PDUSessionID: 1, Transfer: lib.TransferContainer{0x01, 0x02}}},
 	})
 
+	hoRequiredTransfer, err := (&lib.HandoverRequiredTransfer{
+		DirectForwardingPathAvailability: lib.Ptr(lib.DirectForwardingPathAvailable),
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Handover Required Transfer: %v", err)
+	}
+
+	hoCommandTransfer, err := (&lib.HandoverCommandTransfer{
+		DLForwardingUPTNLInformation: &lib.UPTransportLayerInformation{
+			GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 45, 0, 9}, GTPTEID: 0x71},
+		},
+		QosFlowToBeForwarded: lib.QosFlowToBeForwardedList{{QosFlowIdentifier: 1}},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Handover Command Transfer: %v", err)
+	}
+
+	hoAckTransfer, err := (&lib.HandoverRequestAcknowledgeTransfer{
+		DLNGUUPTNLInformation: lib.UPTransportLayerInformation{
+			GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 46, 0, 9}, GTPTEID: 0x81},
+		},
+		SecurityResult:       &lib.SecurityResult{IntegrityProtectionResult: lib.IntegrityProtectionPerformed},
+		QosFlowSetupResponse: lib.QosFlowListWithDataForwarding{{QosFlowIdentifier: 1}},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Handover Request Acknowledge Transfer: %v", err)
+	}
+
+	hoAllocFailTransfer, err := (&lib.HandoverResourceAllocationUnsuccessfulTransfer{
+		Cause: lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Handover Resource Allocation Unsuccessful Transfer: %v", err)
+	}
+
+	hoPrepFailTransfer, err := (&lib.HandoverPreparationUnsuccessfulTransfer{
+		Cause: lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build Handover Preparation Unsuccessful Transfer: %v", err)
+	}
+
+	hoSetupTransfer, err := (&lib.PDUSessionResourceSetupRequestTransfer{
+		ULNGUUPTNLInformation: lib.UPTransportLayerInformation{
+			GTPTunnel: lib.GTPTunnel{TransportLayerAddress: lib.TransportLayerAddress{10, 47, 0, 9}, GTPTEID: 0x91},
+		},
+		PDUSessionType: lib.PDUSessionTypeIPv4,
+		QosFlowSetupRequest: lib.QosFlowSetupRequestList{{
+			QosFlowIdentifier: 1,
+			QosFlowLevelQosParameters: lib.QosFlowLevelQosParameters{
+				QosCharacteristics: lib.QosCharacteristics{
+					Kind:          lib.QosCharacteristicsNonDynamic5QI,
+					NonDynamic5QI: lib.NonDynamic5QIDescriptor{FiveQI: 9},
+				},
+				AllocationAndRetentionPriority: lib.AllocationAndRetentionPriority{PriorityLevelARP: 8},
+			},
+		}},
+	}).Marshal()
+	if err != nil {
+		t.Fatalf("build HO setup transfer: %v", err)
+	}
+
+	corpus["handover_required_full"] = mustMarshal(t, &lib.HandoverRequired{
+		AMFUENGAPID:  7,
+		RANUENGAPID:  3,
+		HandoverType: lib.HandoverTypeIntra5GS,
+		Cause:        &lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 16},
+		TargetID: lib.TargetID{TargetRANNodeID: &lib.TargetRANNodeID{
+			GlobalRANNodeID: lib.GlobalRANNodeID{Kind: lib.RANNodeIDGNB, PLMNIdentity: testPLMN, Value: 2, Bits: 22},
+			SelectedTAI:     testTAI,
+		}},
+		DirectForwardingPathAvailability: lib.Ptr(lib.DirectForwardingPathAvailable),
+		PDUSessionResourceListHORqd: lib.PDUSessionResourceListHORqd{
+			{PDUSessionID: 1, Transfer: hoRequiredTransfer},
+		},
+		SourceToTargetTransparentContainer: lib.SourceToTargetTransparentContainer{0x01, 0x02},
+	})
+
+	corpus["handover_command_full"] = mustMarshal(t, &lib.HandoverCommand{
+		AMFUENGAPID:                    7,
+		RANUENGAPID:                    3,
+		HandoverType:                   lib.HandoverTypeIntra5GS,
+		PDUSessionResourceHandoverList: lib.PDUSessionResourceHandoverList{{PDUSessionID: 1, Transfer: hoCommandTransfer}},
+		PDUSessionResourceToReleaseList: lib.PDUSessionResourceToReleaseListHOCmd{
+			{PDUSessionID: 2, Transfer: hoPrepFailTransfer},
+		},
+		TargetToSourceTransparentContainer: lib.TargetToSourceTransparentContainer{0x03, 0x04},
+	})
+
+	corpus["handover_preparation_failure_full"] = mustMarshal(t, &lib.HandoverPreparationFailure{
+		AMFUENGAPID:            lib.Ptr(lib.AMFUENGAPID(7)),
+		RANUENGAPID:            lib.Ptr(lib.RANUENGAPID(3)),
+		Cause:                  &lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0},
+		CriticalityDiagnostics: &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcHandoverPreparation)},
+	})
+
+	corpus["handover_request_full"] = mustMarshal(t, &lib.HandoverRequest{
+		AMFUENGAPID:               7,
+		HandoverType:              lib.HandoverTypeIntra5GS,
+		Cause:                     &lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 16},
+		UEAggregateMaximumBitRate: lib.UEAggregateMaximumBitRate{DL: 200000000, UL: 100000000},
+		UESecurityCapabilities: lib.UESecurityCapabilities{
+			NREncryptionAlgorithms: 0xe000, NRIntegrityProtectionAlgorithms: 0xe000,
+			EUTRAEncryptionAlgorithms: 0xe000, EUTRAIntegrityProtectionAlgorithms: 0xe000,
+		},
+		SecurityContext:                    lib.SecurityContext{NextHopChainingCount: 1, NextHopNH: lib.SecurityKey{0x0a}},
+		NewSecurityContextInd:              lib.Ptr(lib.NewSecurityContextIndTrue),
+		PDUSessionResourceSetupListHOReq:   lib.PDUSessionResourceSetupListHOReq{{PDUSessionID: 1, SNSSAI: lib.SNSSAI{SST: 1}, Transfer: hoSetupTransfer}},
+		AllowedNSSAI:                       lib.AllowedNSSAI{{SNSSAI: lib.SNSSAI{SST: 1}}},
+		SourceToTargetTransparentContainer: lib.SourceToTargetTransparentContainer{0x05, 0x06},
+		MobilityRestrictionList: &lib.MobilityRestrictionList{
+			ServingPLMN:     testPLMN,
+			EquivalentPLMNs: lib.EquivalentPLMNs{testPLMN},
+			RATRestrictions: lib.RATRestrictions{{PLMNIdentity: testPLMN, RATRestrictionInformation: lib.RATRestrictionEUTRA}},
+		},
+		GUAMI: lib.GUAMI{PLMNIdentity: testPLMN, AMFRegionID: 1, AMFSetID: 1, AMFPointer: 0},
+	})
+
+	corpus["handover_request_acknowledge_full"] = mustMarshal(t, &lib.HandoverRequestAcknowledge{
+		AMFUENGAPID:                    lib.Ptr(lib.AMFUENGAPID(7)),
+		RANUENGAPID:                    lib.Ptr(lib.RANUENGAPID(3)),
+		PDUSessionResourceAdmittedList: lib.PDUSessionResourceAdmittedList{{PDUSessionID: 1, Transfer: hoAckTransfer}},
+		PDUSessionResourceFailedToSetup: lib.PDUSessionResourceFailedToSetupListHOAck{
+			{PDUSessionID: 2, Transfer: hoAllocFailTransfer},
+		},
+		TargetToSourceTransparentContainer: lib.TargetToSourceTransparentContainer{0x07, 0x08},
+	})
+
+	corpus["handover_failure_full"] = mustMarshal(t, &lib.HandoverFailure{
+		AMFUENGAPID:            lib.Ptr(lib.AMFUENGAPID(7)),
+		Cause:                  &lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0},
+		CriticalityDiagnostics: &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcHandoverResourceAllocation)},
+	})
+
+	corpus["handover_notify_full"] = mustMarshal(t, &lib.HandoverNotify{
+		AMFUENGAPID: 7,
+		RANUENGAPID: 3,
+		UserLocationInformation: &lib.UserLocationInformation{
+			Kind: lib.UserLocationNR, PLMNIdentity: testPLMN, CellIdentity: 0x10, TAI: testTAI,
+		},
+		NotifySourceNGRANNode: lib.Ptr(lib.NotifySourceNGRANNodeNotifySource),
+	})
+
+	corpus["handover_cancel_full"] = mustMarshal(t, &lib.HandoverCancel{
+		AMFUENGAPID: 7, RANUENGAPID: 3,
+		Cause: &lib.Cause{Group: lib.CauseGroupRadioNetwork, Value: 0},
+	})
+
+	corpus["handover_cancel_acknowledge_full"] = mustMarshal(t, &lib.HandoverCancelAcknowledge{
+		AMFUENGAPID:            lib.Ptr(lib.AMFUENGAPID(7)),
+		RANUENGAPID:            lib.Ptr(lib.RANUENGAPID(3)),
+		CriticalityDiagnostics: &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcHandoverCancel)},
+	})
+
+	corpus["ran_configuration_update_full"] = mustMarshal(t, &lib.RANConfigurationUpdate{
+		RANNodeName:      lib.Ptr("gnb01"),
+		SupportedTAList:  lib.SupportedTAList{{TAC: 1, BroadcastPLMNList: lib.BroadcastPLMNList{{PLMNIdentity: testPLMN, TAISliceSupportList: lib.SliceSupportList{{SNSSAI: lib.SNSSAI{SST: 1}}}}}}},
+		DefaultPagingDRX: lib.Ptr(lib.PagingDRXv128),
+		GlobalRANNodeID:  &lib.GlobalRANNodeID{Kind: lib.RANNodeIDGNB, PLMNIdentity: testPLMN, Value: 1, Bits: 22},
+		NGRANTNLAssociationToRemoveList: lib.NGRANTNLAssociationToRemoveList{{
+			TNLAssociationTransportLayerAddress:    lib.CPTransportLayerInformation{EndpointIPAddress: lib.TransportLayerAddress{10, 0, 0, 1}},
+			TNLAssociationTransportLayerAddressAMF: &lib.CPTransportLayerInformation{EndpointIPAddress: lib.TransportLayerAddress{10, 0, 0, 2}},
+		}},
+	})
+
+	corpus["ran_configuration_update_acknowledge_full"] = mustMarshal(t, &lib.RANConfigurationUpdateAcknowledge{
+		CriticalityDiagnostics: &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcRANConfigurationUpdate)},
+	})
+
+	corpus["ran_configuration_update_failure_full"] = mustMarshal(t, &lib.RANConfigurationUpdateFailure{
+		Cause:                  &lib.Cause{Group: lib.CauseGroupMisc, Value: 3},
+		TimeToWait:             lib.Ptr(lib.TimeToWaitV10s),
+		CriticalityDiagnostics: &lib.CriticalityDiagnostics{ProcedureCode: lib.Ptr(lib.ProcRANConfigurationUpdate)},
+	})
+
+	corpus["uplink_ran_configuration_transfer_full"] = mustMarshal(t, &lib.UplinkRANConfigurationTransfer{
+		SONConfigurationTransfer: lib.SONConfigurationTransfer{0x01, 0x02, 0x03},
+	})
+
+	corpus["downlink_ran_configuration_transfer_full"] = mustMarshal(t, &lib.DownlinkRANConfigurationTransfer{
+		SONConfigurationTransfer: lib.SONConfigurationTransfer{0x04, 0x05, 0x06},
+	})
+
+	corpus["uplink_ran_status_transfer_full"] = mustMarshal(t, &lib.UplinkRANStatusTransfer{
+		AMFUENGAPID: 7, RANUENGAPID: 3, Container: lib.StatusTransferContainer{0x0a, 0x0b},
+	})
+
+	corpus["downlink_ran_status_transfer_full"] = mustMarshal(t, &lib.DownlinkRANStatusTransfer{
+		AMFUENGAPID: 7, RANUENGAPID: 3, Container: lib.StatusTransferContainer{0x0c, 0x0d},
+	})
+
 	corpus["ng_reset_all_full"] = mustMarshal(t, &lib.NGReset{
 		Cause:     &lib.Cause{Group: lib.CauseGroupMisc, Value: 3},
 		ResetType: lib.ResetType{All: true},
@@ -438,15 +629,24 @@ func TestGoldenCoversEveryRenderedProcedure(t *testing.T) {
 			lib.ProcLocationReport, lib.ProcLocationReportingControl,
 			lib.ProcNGReset, lib.ProcPathSwitchRequest, lib.ProcNASNonDeliveryIndication,
 			lib.ProcPDUSessionResourceModify, lib.ProcPDUSessionResourceModifyIndication,
-			lib.ProcPDUSessionResourceNotify,
+			lib.ProcPDUSessionResourceNotify, lib.ProcRANConfigurationUpdate,
+			lib.ProcUplinkRANConfigurationTransfer, lib.ProcDownlinkRANConfigurationTransfer,
+			lib.ProcUplinkRANStatusTransfer, lib.ProcDownlinkRANStatusTransfer,
+			lib.ProcHandoverPreparation, lib.ProcHandoverResourceAllocation,
+			lib.ProcHandoverNotification, lib.ProcHandoverCancel,
 		},
 		"SuccessfulOutcome": {
 			lib.ProcNGSetup, lib.ProcInitialContextSetup, lib.ProcPDUSessionResourceSetup,
 			lib.ProcUEContextRelease, lib.ProcPDUSessionResourceRelease,
 			lib.ProcNGReset, lib.ProcPathSwitchRequest,
 			lib.ProcPDUSessionResourceModify, lib.ProcPDUSessionResourceModifyIndication,
+			lib.ProcRANConfigurationUpdate, lib.ProcHandoverPreparation,
+			lib.ProcHandoverResourceAllocation, lib.ProcHandoverCancel,
 		},
-		"UnsuccessfulOutcome": {lib.ProcNGSetup, lib.ProcInitialContextSetup, lib.ProcPathSwitchRequest},
+		"UnsuccessfulOutcome": {
+			lib.ProcNGSetup, lib.ProcInitialContextSetup, lib.ProcPathSwitchRequest, lib.ProcRANConfigurationUpdate,
+			lib.ProcHandoverPreparation, lib.ProcHandoverResourceAllocation,
+		},
 	}
 
 	covered := map[string]map[int64]bool{}

--- a/internal/decoder/ngap/handover.go
+++ b/internal/decoder/ngap/handover.go
@@ -1,0 +1,671 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/ngap"
+)
+
+// TargetID names the node a handover is aimed at: an NG-RAN node for an intra-5GS
+// handover, an ng-eNB for one leaving 5GS (TS 38.413 §9.3.1.15).
+type TargetID struct {
+	TargetRANNodeID *TargetRANNodeID `json:"target_ran_node_id,omitempty"`
+	TargetENBID     *TargetENBID     `json:"target_enb_id,omitempty"`
+}
+
+type TargetRANNodeID struct {
+	GlobalRANNodeID GlobalRANNodeIDIE `json:"global_ran_node_id"`
+	SelectedTAI     TAI               `json:"selected_tai"`
+}
+
+type TargetENBID struct {
+	GlobalNgENBID  GlobalNgENBID `json:"global_ng_enb_id"`
+	SelectedEPSTAI EPSTAI        `json:"selected_eps_tai"`
+}
+
+type GlobalNgENBID struct {
+	PLMNIdentity PLMNID `json:"plmn_identity"`
+	NgENBID      string `json:"ng_enb_id"`
+}
+
+type EPSTAI struct {
+	PLMNIdentity PLMNID `json:"plmn_identity"`
+	TAC          string `json:"tac"`
+}
+
+// DataForwardingResponseDRB is one DRB's forwarding endpoints, as the target
+// node reports them (TS 38.413 §9.3.1.35).
+type DataForwardingResponseDRB struct {
+	DRBID                        uint8      `json:"drb_id"`
+	DLForwardingUPTNLInformation *GTPTunnel `json:"dl_forwarding_up_tnl_information,omitempty"`
+	ULForwardingUPTNLInformation *GTPTunnel `json:"ul_forwarding_up_tnl_information,omitempty"`
+}
+
+// QosFlowWithDataForwarding is a QoS flow the target admitted, and whether it
+// accepted data forwarding for it.
+type QosFlowWithDataForwarding struct {
+	QosFlowIdentifier      int64 `json:"qos_flow_identifier"`
+	DataForwardingAccepted *bool `json:"data_forwarding_accepted,omitempty"`
+}
+
+// HandoverRequiredTransferDecoded is the source node's per-session transfer
+// (TS 38.413 §9.3.4.15).
+type HandoverRequiredTransferDecoded struct {
+	DirectForwardingPathAvailability *bool `json:"direct_forwarding_path_availability,omitempty"`
+}
+
+// HandoverCommandTransferDecoded is the per-session forwarding plan the source
+// node is given (TS 38.413 §9.3.4.16).
+type HandoverCommandTransferDecoded struct {
+	DLForwardingUPTNLInformation *GTPTunnel                  `json:"dl_forwarding_up_tnl_information,omitempty"`
+	QosFlowToBeForwarded         []int64                     `json:"qos_flow_to_be_forwarded,omitempty"`
+	DataForwardingResponseDRB    []DataForwardingResponseDRB `json:"data_forwarding_response_drb,omitempty"`
+}
+
+// HandoverRequestAcknowledgeTransferDecoded is what the target node reports per
+// admitted session (TS 38.413 §9.3.4.13).
+type HandoverRequestAcknowledgeTransferDecoded struct {
+	DLNGUUPTNLInformation        GTPTunnel                   `json:"dl_ng_u_up_tnl_information"`
+	DLForwardingUPTNLInformation *GTPTunnel                  `json:"dl_forwarding_up_tnl_information,omitempty"`
+	SecurityResult               *SecurityResult             `json:"security_result,omitempty"`
+	QosFlowSetupResponse         []QosFlowWithDataForwarding `json:"qos_flow_setup_response,omitempty"`
+	QosFlowFailedToSetup         []QosFlowWithCause          `json:"qos_flow_failed_to_setup,omitempty"`
+	DataForwardingResponseDRB    []DataForwardingResponseDRB `json:"data_forwarding_response_drb,omitempty"`
+}
+
+// HandoverResourceAllocationUnsuccessfulTransferDecoded says why the target node
+// refused one session (TS 38.413 §9.3.4.14).
+type HandoverResourceAllocationUnsuccessfulTransferDecoded struct {
+	Cause                  Cause                   `json:"cause"`
+	CriticalityDiagnostics *CriticalityDiagnostics `json:"criticality_diagnostics,omitempty"`
+}
+
+// HandoverSession is one PDU session in a handover list, with whichever transfer
+// travelled with it.
+type HandoverSession struct {
+	PDUSessionID int64   `json:"pdu_session_id"`
+	SNSSAI       *SNSSAI `json:"snssai,omitempty"`
+
+	HandoverRequiredTransfer                       *HandoverRequiredTransferDecoded                       `json:"handover_required_transfer,omitempty"`
+	HandoverCommandTransfer                        *HandoverCommandTransferDecoded                        `json:"handover_command_transfer,omitempty"`
+	HandoverRequestAcknowledgeTransfer             *HandoverRequestAcknowledgeTransferDecoded             `json:"handover_request_acknowledge_transfer,omitempty"`
+	HandoverResourceAllocationUnsuccessfulTransfer *HandoverResourceAllocationUnsuccessfulTransferDecoded `json:"handover_resource_allocation_unsuccessful_transfer,omitempty"`
+	SetupRequestTransfer                           *PDUSessionResourceSetupRequestTransfer                `json:"pdu_session_resource_setup_request_transfer,omitempty"`
+	CauseTransfer                                  *CauseTransferDecoded                                  `json:"cause_transfer,omitempty"`
+
+	TransferHex string `json:"transfer_hex,omitempty"` // set when the transfer did not decode
+	Error       string `json:"error,omitempty"`
+}
+
+func dataForwardingResponseDRBs(list ngap.DataForwardingResponseDRBList) []DataForwardingResponseDRB {
+	out := make([]DataForwardingResponseDRB, 0, len(list))
+
+	for _, it := range list {
+		entry := DataForwardingResponseDRB{DRBID: uint8(it.DRBID)}
+
+		if it.DLForwardingUPTNLInformation != nil {
+			tunnel := libGTPTunnel(*it.DLForwardingUPTNLInformation)
+			entry.DLForwardingUPTNLInformation = &tunnel
+		}
+
+		if it.ULForwardingUPTNLInformation != nil {
+			tunnel := libGTPTunnel(*it.ULForwardingUPTNLInformation)
+			entry.ULForwardingUPTNLInformation = &tunnel
+		}
+
+		out = append(out, entry)
+	}
+
+	return out
+}
+
+func libHandoverRequiredTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParseHandoverRequiredTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &HandoverRequiredTransferDecoded{}
+
+	if t.DirectForwardingPathAvailability != nil {
+		available := *t.DirectForwardingPathAvailability == ngap.DirectForwardingPathAvailable
+		out.DirectForwardingPathAvailability = &available
+	}
+
+	return out, nil
+}
+
+func libHandoverCommandTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParseHandoverCommandTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &HandoverCommandTransferDecoded{DataForwardingResponseDRB: dataForwardingResponseDRBs(t.DataForwardingResponseDRB)}
+
+	if t.DLForwardingUPTNLInformation != nil {
+		tunnel := libGTPTunnel(*t.DLForwardingUPTNLInformation)
+		out.DLForwardingUPTNLInformation = &tunnel
+	}
+
+	for _, f := range t.QosFlowToBeForwarded {
+		out.QosFlowToBeForwarded = append(out.QosFlowToBeForwarded, int64(f.QosFlowIdentifier))
+	}
+
+	return out, nil
+}
+
+func libHandoverRequestAcknowledgeTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParseHandoverRequestAcknowledgeTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &HandoverRequestAcknowledgeTransferDecoded{
+		DLNGUUPTNLInformation:     libGTPTunnel(t.DLNGUUPTNLInformation),
+		QosFlowFailedToSetup:      qosFlowsWithCause(t.QosFlowFailedToSetup),
+		DataForwardingResponseDRB: dataForwardingResponseDRBs(t.DataForwardingResponseDRB),
+	}
+
+	if t.DLForwardingUPTNLInformation != nil {
+		tunnel := libGTPTunnel(*t.DLForwardingUPTNLInformation)
+		out.DLForwardingUPTNLInformation = &tunnel
+	}
+
+	if t.SecurityResult != nil {
+		result := securityResult(*t.SecurityResult)
+		out.SecurityResult = &result
+	}
+
+	for _, f := range t.QosFlowSetupResponse {
+		entry := QosFlowWithDataForwarding{QosFlowIdentifier: int64(f.QosFlowIdentifier)}
+		if f.DataForwardingAccepted != nil {
+			accepted := true
+			entry.DataForwardingAccepted = &accepted
+		}
+
+		out.QosFlowSetupResponse = append(out.QosFlowSetupResponse, entry)
+	}
+
+	return out, nil
+}
+
+func libHandoverResourceAllocationUnsuccessfulTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParseHandoverResourceAllocationUnsuccessfulTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &HandoverResourceAllocationUnsuccessfulTransferDecoded{Cause: cause(t.Cause)}
+	if t.CriticalityDiagnostics != nil {
+		cd := criticalityDiagnostics(*t.CriticalityDiagnostics)
+		out.CriticalityDiagnostics = &cd
+	}
+
+	return out, nil
+}
+
+func libHandoverPreparationUnsuccessfulTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParseHandoverPreparationUnsuccessfulTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CauseTransferDecoded{Cause: cause(t.Cause)}, nil
+}
+
+func libHandoverSetupRequestTransfer(raw ngap.TransferContainer) (any, error) {
+	return libPDUSessionResourceSetupRequestTransfer(raw)
+}
+
+func handoverSession(id ngap.PDUSessionID, raw ngap.TransferContainer, decode func(ngap.TransferContainer) (any, error)) HandoverSession {
+	s := HandoverSession{PDUSessionID: int64(id)}
+
+	decoded, err := decode(raw)
+	if err != nil {
+		s.Error = err.Error()
+		s.TransferHex = hex.EncodeToString(raw)
+
+		return s
+	}
+
+	switch v := decoded.(type) {
+	case *HandoverRequiredTransferDecoded:
+		s.HandoverRequiredTransfer = v
+	case *HandoverCommandTransferDecoded:
+		s.HandoverCommandTransfer = v
+	case *HandoverRequestAcknowledgeTransferDecoded:
+		s.HandoverRequestAcknowledgeTransfer = v
+	case *HandoverResourceAllocationUnsuccessfulTransferDecoded:
+		s.HandoverResourceAllocationUnsuccessfulTransfer = v
+	case *PDUSessionResourceSetupRequestTransfer:
+		s.SetupRequestTransfer = v
+	case *CauseTransferDecoded:
+		s.CauseTransfer = v
+	}
+
+	return s
+}
+
+func handoverTypeToEnum(h ngap.HandoverType) utils.EnumField {
+	return utils.NamedEnum(uint8(h), h.Name())
+}
+
+func tacsToStrings(list []ngap.TAC) []string {
+	out := make([]string, 0, len(list))
+	for _, t := range list {
+		out = append(out, fmt.Sprintf("%06x", uint32(t)))
+	}
+
+	return out
+}
+
+// ratRestrictionNames are the RATs a restriction bitmap can bar, in transmission
+// order (TS 38.413 §9.3.1.85).
+var ratRestrictionNames = []struct {
+	bit  ngap.RATRestrictionInformation
+	name string
+}{
+	{ngap.RATRestrictionEUTRA, "e-UTRA"},
+	{ngap.RATRestrictionNR, "nR"},
+	{ngap.RATRestrictionNRUnlicensed, "nR-unlicensed"},
+	{ngap.RATRestrictionNRLEO, "nR-LEO"},
+	{ngap.RATRestrictionNRMEO, "nR-MEO"},
+	{ngap.RATRestrictionNRGEO, "nR-GEO"},
+	{ngap.RATRestrictionNROtherSat, "nR-OTHERSAT"},
+}
+
+func ratRestrictionInformation(v ngap.RATRestrictionInformation) string {
+	var restricted []string
+
+	for _, r := range ratRestrictionNames {
+		if v&r.bit != 0 {
+			restricted = append(restricted, r.name)
+		}
+	}
+
+	if len(restricted) == 0 {
+		return "none"
+	}
+
+	out := restricted[0]
+	for _, r := range restricted[1:] {
+		out += "," + r
+	}
+
+	return out
+}
+
+func mobilityRestrictionList(l ngap.MobilityRestrictionList) MobilityRestrictionList {
+	out := MobilityRestrictionList{ServingPLMN: plmnIDToDecoder(l.ServingPLMN)}
+
+	for _, p := range l.EquivalentPLMNs {
+		out.EquivalentPLMNs = append(out.EquivalentPLMNs, plmnIDToDecoder(p))
+	}
+
+	for _, r := range l.RATRestrictions {
+		out.RATRestrictions = append(out.RATRestrictions, RATRestriction{
+			PLMNID:                    plmnIDToDecoder(r.PLMNIdentity),
+			RATRestrictionInformation: ratRestrictionInformation(r.RATRestrictionInformation),
+		})
+	}
+
+	for _, f := range l.ForbiddenAreaInformation {
+		out.ForbiddenAreaInformation = append(out.ForbiddenAreaInformation, ForbiddenAreaInformation{
+			PLMNID:        plmnIDToDecoder(f.PLMNIdentity),
+			ForbiddenTACs: tacsToStrings(f.ForbiddenTACs),
+		})
+	}
+
+	for _, a := range l.ServiceAreaInformation {
+		out.ServiceAreaInformation = append(out.ServiceAreaInformation, ServiceAreaInformation{
+			PLMNID:         plmnIDToDecoder(a.PLMNIdentity),
+			AllowedTACs:    tacsToStrings(a.AllowedTACs),
+			NotAllowedTACs: tacsToStrings(a.NotAllowedTACs),
+		})
+	}
+
+	return out
+}
+
+func targetID(t ngap.TargetID) TargetID {
+	var out TargetID
+
+	if t.TargetRANNodeID != nil {
+		selected := tai(t.TargetRANNodeID.SelectedTAI)
+		out.TargetRANNodeID = &TargetRANNodeID{
+			GlobalRANNodeID: buildGlobalRANNodeID(t.TargetRANNodeID.GlobalRANNodeID),
+			SelectedTAI:     selected,
+		}
+	}
+
+	if t.TargeteNBID != nil {
+		out.TargetENBID = &TargetENBID{
+			GlobalNgENBID: GlobalNgENBID{
+				PLMNIdentity: plmnIDToDecoder(t.TargeteNBID.GlobalENBID.PLMNIdentity),
+				NgENBID:      fmt.Sprintf("%x", t.TargeteNBID.GlobalENBID.NgENBID.Value),
+			},
+			SelectedEPSTAI: EPSTAI{
+				PLMNIdentity: plmnIDToDecoder(t.TargeteNBID.SelectedEPSTAI.PLMNIdentity),
+				TAC:          fmt.Sprintf("%04x", uint16(t.TargeteNBID.SelectedEPSTAI.TAC)),
+			},
+		}
+	}
+
+	return out
+}
+
+func buildHandoverRequired(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverRequired(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Required: %v", err)}
+	}
+
+	sessions := make([]HandoverSession, 0, len(m.PDUSessionResourceListHORqd))
+	for _, it := range m.PDUSessionResourceListHORqd {
+		sessions = append(sessions, handoverSession(it.PDUSessionID, it.Transfer, libHandoverRequiredTransfer))
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+		ie(ngap.IDHandoverType, ngap.CriticalityReject, handoverTypeToEnum(m.HandoverType)),
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	ies = append(ies, ie(ngap.IDTargetID, ngap.CriticalityReject, targetID(m.TargetID)))
+
+	if m.DirectForwardingPathAvailability != nil {
+		available := *m.DirectForwardingPathAvailability == ngap.DirectForwardingPathAvailable
+		ies = append(ies, ie(ngap.IDDirectForwardingPathAvailability, ngap.CriticalityIgnore, available))
+	}
+
+	ies = append(ies,
+		ie(ngap.IDPDUSessionResourceListHORqd, ngap.CriticalityReject, sessions),
+		ie(ngap.IDSourceToTargetTransparentContainer, ngap.CriticalityReject, hex.EncodeToString(m.SourceToTargetTransparentContainer)),
+	)
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverCommand(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverCommand(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Command: %v", err)}
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+		ie(ngap.IDHandoverType, ngap.CriticalityReject, handoverTypeToEnum(m.HandoverType)),
+	}
+
+	if len(m.NASSecurityParametersFromNGRAN) > 0 {
+		ies = append(ies, ie(ngap.IDNASSecurityParametersFromNGRAN, ngap.CriticalityReject, hex.EncodeToString(m.NASSecurityParametersFromNGRAN)))
+	}
+
+	if len(m.PDUSessionResourceHandoverList) > 0 {
+		sessions := make([]HandoverSession, 0, len(m.PDUSessionResourceHandoverList))
+		for _, it := range m.PDUSessionResourceHandoverList {
+			sessions = append(sessions, handoverSession(it.PDUSessionID, it.Transfer, libHandoverCommandTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceHandoverList, ngap.CriticalityIgnore, sessions))
+	}
+
+	if len(m.PDUSessionResourceToReleaseList) > 0 {
+		released := make([]HandoverSession, 0, len(m.PDUSessionResourceToReleaseList))
+		for _, it := range m.PDUSessionResourceToReleaseList {
+			released = append(released, handoverSession(it.PDUSessionID, it.Transfer, libHandoverPreparationUnsuccessfulTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceToReleaseListHOCmd, ngap.CriticalityIgnore, released))
+	}
+
+	ies = append(ies, ie(ngap.IDTargetToSourceTransparentContainer, ngap.CriticalityReject, hex.EncodeToString(m.TargetToSourceTransparentContainer)))
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverPreparationFailure(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverPreparationFailure(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Preparation Failure: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.RANUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDRANUENGAPID, ngap.CriticalityIgnore, int64(*m.RANUENGAPID)))
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	if len(m.TargettoSourceFailureTransparentContainer) > 0 {
+		ies = append(ies, ie(ngap.IDTargettoSourceFailureTransparentContainer, ngap.CriticalityIgnore, hex.EncodeToString(m.TargettoSourceFailureTransparentContainer)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverRequest(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverRequest(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Request: %v", err)}
+	}
+
+	sessions := make([]HandoverSession, 0, len(m.PDUSessionResourceSetupListHOReq))
+
+	for _, it := range m.PDUSessionResourceSetupListHOReq {
+		s := handoverSession(it.PDUSessionID, it.Transfer, libHandoverSetupRequestTransfer)
+		snssai := buildSNSSAIValue(it.SNSSAI)
+		s.SNSSAI = &snssai
+		sessions = append(sessions, s)
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDHandoverType, ngap.CriticalityReject, handoverTypeToEnum(m.HandoverType)),
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	ies = append(ies,
+		ie(ngap.IDUEAggregateMaximumBitRate, ngap.CriticalityReject, MaximumBitRate{
+			UplinkNAggregateMaximumBitRate:   uint64(m.UEAggregateMaximumBitRate.UL),
+			DownlinkNAggregateMaximumBitRate: uint64(m.UEAggregateMaximumBitRate.DL),
+			Unit:                             "bps",
+		}),
+		ie(ngap.IDUESecurityCapabilities, ngap.CriticalityReject, libUESecurityCapabilities(m.UESecurityCapabilities)),
+		ie(ngap.IDSecurityContext, ngap.CriticalityReject, SecurityContext{
+			NextHopChainingCount: int64(m.SecurityContext.NextHopChainingCount),
+			NextHopNH:            hex.EncodeToString(m.SecurityContext.NextHopNH[:]),
+		}),
+	)
+
+	if m.NewSecurityContextInd != nil {
+		ies = append(ies, ie(ngap.IDNewSecurityContextInd, ngap.CriticalityReject, true))
+	}
+
+	if len(m.NASC) > 0 {
+		ies = append(ies, ie(ngap.IDNASC, ngap.CriticalityReject, libNASPDU(m.NASC)))
+	}
+
+	ies = append(ies, ie(ngap.IDPDUSessionResourceSetupListHOReq, ngap.CriticalityReject, sessions))
+
+	if len(m.AllowedNSSAI) > 0 {
+		allowed := make([]SNSSAI, 0, len(m.AllowedNSSAI))
+		for _, it := range m.AllowedNSSAI {
+			allowed = append(allowed, buildSNSSAIValue(it.SNSSAI))
+		}
+
+		ies = append(ies, ie(ngap.IDAllowedNSSAI, ngap.CriticalityReject, allowed))
+	}
+
+	ies = append(ies, ie(ngap.IDSourceToTargetTransparentContainer, ngap.CriticalityReject, hex.EncodeToString(m.SourceToTargetTransparentContainer)))
+
+	if m.MobilityRestrictionList != nil {
+		ies = append(ies, ie(ngap.IDMobilityRestrictionList, ngap.CriticalityIgnore, mobilityRestrictionList(*m.MobilityRestrictionList)))
+	}
+
+	ies = append(ies, ie(ngap.IDGUAMI, ngap.CriticalityReject, guami(m.GUAMI)))
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverRequestAcknowledge(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverRequestAcknowledge(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Request Acknowledge: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.RANUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDRANUENGAPID, ngap.CriticalityIgnore, int64(*m.RANUENGAPID)))
+	}
+
+	if len(m.PDUSessionResourceAdmittedList) > 0 {
+		admitted := make([]HandoverSession, 0, len(m.PDUSessionResourceAdmittedList))
+		for _, it := range m.PDUSessionResourceAdmittedList {
+			admitted = append(admitted, handoverSession(it.PDUSessionID, it.Transfer, libHandoverRequestAcknowledgeTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceAdmittedList, ngap.CriticalityIgnore, admitted))
+	}
+
+	if len(m.PDUSessionResourceFailedToSetup) > 0 {
+		failed := make([]HandoverSession, 0, len(m.PDUSessionResourceFailedToSetup))
+		for _, it := range m.PDUSessionResourceFailedToSetup {
+			failed = append(failed, handoverSession(it.PDUSessionID, it.Transfer, libHandoverResourceAllocationUnsuccessfulTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceFailedToSetupListHOAck, ngap.CriticalityIgnore, failed))
+	}
+
+	ies = append(ies, ie(ngap.IDTargetToSourceTransparentContainer, ngap.CriticalityReject, hex.EncodeToString(m.TargetToSourceTransparentContainer)))
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverFailure(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverFailure(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Failure: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	if len(m.TargettoSourceFailureTransparentContainer) > 0 {
+		ies = append(ies, ie(ngap.IDTargettoSourceFailureTransparentContainer, ngap.CriticalityIgnore, hex.EncodeToString(m.TargettoSourceFailureTransparentContainer)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverNotify(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverNotify(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Notify: %v", err)}
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+	}
+
+	if m.UserLocationInformation != nil {
+		ies = append(ies, ie(ngap.IDUserLocationInformation, ngap.CriticalityIgnore, userLocationInformation(*m.UserLocationInformation)))
+	}
+
+	if m.NotifySourceNGRANNode != nil {
+		ies = append(ies, ie(ngap.IDNotifySourceNGRANNode, ngap.CriticalityIgnore, true))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverCancel(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverCancel(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Cancel: %v", err)}
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildHandoverCancelAcknowledge(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseHandoverCancelAcknowledge(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Handover Cancel Acknowledge: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.RANUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDRANUENGAPID, ngap.CriticalityIgnore, int64(*m.RANUENGAPID)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}

--- a/internal/decoder/ngap/handover.go
+++ b/internal/decoder/ngap/handover.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TargetID names the node a handover is aimed at: an NG-RAN node for an intra-5GS
-// handover, an ng-eNB for one leaving 5GS (TS 38.413 §9.3.1.15).
+// handover, an ng-eNB for one leaving 5GS (TS 38.413 §9.3.1.25).
 type TargetID struct {
 	TargetRANNodeID *TargetRANNodeID `json:"target_ran_node_id,omitempty"`
 	TargetENBID     *TargetENBID     `json:"target_enb_id,omitempty"`
@@ -39,7 +39,7 @@ type EPSTAI struct {
 }
 
 // DataForwardingResponseDRB is one DRB's forwarding endpoints, as the target
-// node reports them (TS 38.413 §9.3.1.35).
+// node reports them (TS 38.413 §9.3.1.77).
 type DataForwardingResponseDRB struct {
 	DRBID                        uint8      `json:"drb_id"`
 	DLForwardingUPTNLInformation *GTPTunnel `json:"dl_forwarding_up_tnl_information,omitempty"`
@@ -54,13 +54,13 @@ type QosFlowWithDataForwarding struct {
 }
 
 // HandoverRequiredTransferDecoded is the source node's per-session transfer
-// (TS 38.413 §9.3.4.15).
+// (TS 38.413 §9.3.4.14).
 type HandoverRequiredTransferDecoded struct {
 	DirectForwardingPathAvailability *bool `json:"direct_forwarding_path_availability,omitempty"`
 }
 
 // HandoverCommandTransferDecoded is the per-session forwarding plan the source
-// node is given (TS 38.413 §9.3.4.16).
+// node is given (TS 38.413 §9.3.4.10).
 type HandoverCommandTransferDecoded struct {
 	DLForwardingUPTNLInformation *GTPTunnel                  `json:"dl_forwarding_up_tnl_information,omitempty"`
 	QosFlowToBeForwarded         []int64                     `json:"qos_flow_to_be_forwarded,omitempty"`
@@ -68,7 +68,7 @@ type HandoverCommandTransferDecoded struct {
 }
 
 // HandoverRequestAcknowledgeTransferDecoded is what the target node reports per
-// admitted session (TS 38.413 §9.3.4.13).
+// admitted session (TS 38.413 §9.3.4.11).
 type HandoverRequestAcknowledgeTransferDecoded struct {
 	DLNGUUPTNLInformation        GTPTunnel                   `json:"dl_ng_u_up_tnl_information"`
 	DLForwardingUPTNLInformation *GTPTunnel                  `json:"dl_forwarding_up_tnl_information,omitempty"`
@@ -79,7 +79,7 @@ type HandoverRequestAcknowledgeTransferDecoded struct {
 }
 
 // HandoverResourceAllocationUnsuccessfulTransferDecoded says why the target node
-// refused one session (TS 38.413 §9.3.4.14).
+// refused one session (TS 38.413 §9.3.4.19).
 type HandoverResourceAllocationUnsuccessfulTransferDecoded struct {
 	Cause                  Cause                   `json:"cause"`
 	CriticalityDiagnostics *CriticalityDiagnostics `json:"criticality_diagnostics,omitempty"`

--- a/internal/decoder/ngap/initial_context_setup_request.go
+++ b/internal/decoder/ngap/initial_context_setup_request.go
@@ -90,7 +90,12 @@ type PDUSessionResourceSetupRequestTransfer struct {
 	PduSType                *utils.EnumField       `json:"pdu_s_type,omitempty"`
 	MaximumBitRate          *MaximumBitRate        `json:"maximum_bit_rate,omitempty"`
 	SecurityIndication      *SecurityIndication    `json:"security_indication,omitempty"`
-	UnrecognizedIEs         []IE                   `json:"unrecognized_ies,omitempty"`
+	// AdditionalULNGUUPTNLInformation carries the further uplink endpoints a
+	// multi-homed or redundant session uses (TS 38.413 §9.3.1.1).
+	AdditionalULNGUUPTNLInformation []GTPTunnel `json:"additional_ul_ng_u_up_tnl_information,omitempty"`
+	DataForwardingNotPossible       *bool       `json:"data_forwarding_not_possible,omitempty"`
+	NetworkInstance                 *uint16     `json:"network_instance,omitempty"`
+	UnrecognizedIEs                 []IE        `json:"unrecognized_ies,omitempty"`
 }
 
 type PDUSessionResourceSetupCxtReq struct {
@@ -144,7 +149,7 @@ func buildInitialContextSetupRequest(value []byte) NGAPMessageValue {
 				SNSSAI:       buildSNSSAIValue(item.SNSSAI),
 			}
 
-			transfer, err := libSetupRequestTransfer(item.Transfer)
+			transfer, err := libPDUSessionResourceSetupRequestTransfer(item.Transfer)
 			if err != nil {
 				entry.Error = fmt.Sprintf("failed to decode transfer: %v", err)
 			} else {

--- a/internal/decoder/ngap/ng_reset.go
+++ b/internal/decoder/ngap/ng_reset.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/ngap"
+)
+
+// UEAssociatedLogicalNGConnection names one UE-associated logical NG connection
+// (TS 38.413 §9.3.3.20). Either identity may be absent: the sender names the
+// connection with whichever ids it holds.
+type UEAssociatedLogicalNGConnection struct {
+	AMFUENGAPID *int64 `json:"amf_ue_ngap_id,omitempty"`
+	RANUENGAPID *int64 `json:"ran_ue_ngap_id,omitempty"`
+}
+
+// ResetType selects what the NG RESET covers (TS 38.413 §9.3.1.16): the whole NG
+// interface, or the listed UE-associated logical NG connections.
+type ResetType struct {
+	NGInterface bool                              `json:"ng_interface,omitempty"`
+	PartOfNG    []UEAssociatedLogicalNGConnection `json:"part_of_ng_interface,omitempty"`
+}
+
+func ueAssociatedConnections(items ngap.UEAssociatedLogicalNGConnectionList) []UEAssociatedLogicalNGConnection {
+	out := make([]UEAssociatedLogicalNGConnection, 0, len(items))
+
+	for _, it := range items {
+		var c UEAssociatedLogicalNGConnection
+
+		if it.AMFUENGAPID != nil {
+			v := int64(*it.AMFUENGAPID)
+			c.AMFUENGAPID = &v
+		}
+
+		if it.RANUENGAPID != nil {
+			v := int64(*it.RANUENGAPID)
+			c.RANUENGAPID = &v
+		}
+
+		out = append(out, c)
+	}
+
+	return out
+}
+
+func buildNGReset(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseNGReset(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse NG Reset: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	rt := ResetType{NGInterface: m.ResetType.All}
+	if !m.ResetType.All {
+		rt.PartOfNG = ueAssociatedConnections(m.ResetType.Part)
+	}
+
+	ies = append(ies, ie(ngap.IDResetType, ngap.CriticalityReject, rt))
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildNGResetAcknowledge(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseNGResetAcknowledge(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse NG Reset Acknowledge: %v", err)}
+	}
+
+	var ies []IE
+
+	if len(m.ConnectionList) > 0 {
+		ies = append(ies, ie(ngap.IDUEAssociatedLogicalNGConnectionList, ngap.CriticalityIgnore, ueAssociatedConnections(m.ConnectionList)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}

--- a/internal/decoder/ngap/ng_reset.go
+++ b/internal/decoder/ngap/ng_reset.go
@@ -10,14 +10,14 @@ import (
 )
 
 // UEAssociatedLogicalNGConnection names one UE-associated logical NG connection
-// (TS 38.413 §9.3.3.20). Either identity may be absent: the sender names the
+// (TS 38.413 §9.3.3.25). Either identity may be absent: the sender names the
 // connection with whichever ids it holds.
 type UEAssociatedLogicalNGConnection struct {
 	AMFUENGAPID *int64 `json:"amf_ue_ngap_id,omitempty"`
 	RANUENGAPID *int64 `json:"ran_ue_ngap_id,omitempty"`
 }
 
-// ResetType selects what the NG RESET covers (TS 38.413 §9.3.1.16): the whole NG
+// ResetType selects what the NG RESET covers (TS 38.413 §9.2.6.11): the whole NG
 // interface, or the listed UE-associated logical NG connections.
 type ResetType struct {
 	NGInterface bool                              `json:"ng_interface,omitempty"`

--- a/internal/decoder/ngap/ngap.go
+++ b/internal/decoder/ngap/ngap.go
@@ -160,6 +160,18 @@ func buildInitiatingMessage(m *ngap.InitiatingMessage) NGAPMessageValue {
 		return buildLocationReport(m.Value)
 	case ngap.ProcLocationReportingControl:
 		return buildLocationReportingControl(m.Value)
+	case ngap.ProcNGReset:
+		return buildNGReset(m.Value)
+	case ngap.ProcPathSwitchRequest:
+		return buildPathSwitchRequest(m.Value)
+	case ngap.ProcNASNonDeliveryIndication:
+		return buildNASNonDeliveryIndication(m.Value)
+	case ngap.ProcPDUSessionResourceModify:
+		return buildPDUSessionResourceModifyRequest(m.Value)
+	case ngap.ProcPDUSessionResourceModifyIndication:
+		return buildPDUSessionResourceModifyIndication(m.Value)
+	case ngap.ProcPDUSessionResourceNotify:
+		return buildPDUSessionResourceNotify(m.Value)
 	default:
 		return unsupportedProcedure(m.ProcedureCode)
 	}
@@ -177,6 +189,14 @@ func buildSuccessfulOutcome(m *ngap.SuccessfulOutcome) NGAPMessageValue {
 		return buildUEContextReleaseComplete(m.Value)
 	case ngap.ProcPDUSessionResourceRelease:
 		return buildPDUSessionResourceReleaseResponse(m.Value)
+	case ngap.ProcNGReset:
+		return buildNGResetAcknowledge(m.Value)
+	case ngap.ProcPathSwitchRequest:
+		return buildPathSwitchRequestAcknowledge(m.Value)
+	case ngap.ProcPDUSessionResourceModify:
+		return buildPDUSessionResourceModifyResponse(m.Value)
+	case ngap.ProcPDUSessionResourceModifyIndication:
+		return buildPDUSessionResourceModifyConfirm(m.Value)
 	default:
 		return unsupportedProcedure(m.ProcedureCode)
 	}
@@ -188,6 +208,8 @@ func buildUnsuccessfulOutcome(m *ngap.UnsuccessfulOutcome) NGAPMessageValue {
 		return buildNGSetupFailure(m.Value)
 	case ngap.ProcInitialContextSetup:
 		return buildInitialContextSetupFailure(m.Value)
+	case ngap.ProcPathSwitchRequest:
+		return buildPathSwitchRequestFailure(m.Value)
 	default:
 		return unsupportedProcedure(m.ProcedureCode)
 	}

--- a/internal/decoder/ngap/ngap.go
+++ b/internal/decoder/ngap/ngap.go
@@ -172,6 +172,24 @@ func buildInitiatingMessage(m *ngap.InitiatingMessage) NGAPMessageValue {
 		return buildPDUSessionResourceModifyIndication(m.Value)
 	case ngap.ProcPDUSessionResourceNotify:
 		return buildPDUSessionResourceNotify(m.Value)
+	case ngap.ProcRANConfigurationUpdate:
+		return buildRANConfigurationUpdate(m.Value)
+	case ngap.ProcUplinkRANConfigurationTransfer:
+		return buildUplinkRANConfigurationTransfer(m.Value)
+	case ngap.ProcDownlinkRANConfigurationTransfer:
+		return buildDownlinkRANConfigurationTransfer(m.Value)
+	case ngap.ProcUplinkRANStatusTransfer:
+		return buildUplinkRANStatusTransfer(m.Value)
+	case ngap.ProcDownlinkRANStatusTransfer:
+		return buildDownlinkRANStatusTransfer(m.Value)
+	case ngap.ProcHandoverPreparation:
+		return buildHandoverRequired(m.Value)
+	case ngap.ProcHandoverResourceAllocation:
+		return buildHandoverRequest(m.Value)
+	case ngap.ProcHandoverNotification:
+		return buildHandoverNotify(m.Value)
+	case ngap.ProcHandoverCancel:
+		return buildHandoverCancel(m.Value)
 	default:
 		return unsupportedProcedure(m.ProcedureCode)
 	}
@@ -197,6 +215,14 @@ func buildSuccessfulOutcome(m *ngap.SuccessfulOutcome) NGAPMessageValue {
 		return buildPDUSessionResourceModifyResponse(m.Value)
 	case ngap.ProcPDUSessionResourceModifyIndication:
 		return buildPDUSessionResourceModifyConfirm(m.Value)
+	case ngap.ProcRANConfigurationUpdate:
+		return buildRANConfigurationUpdateAcknowledge(m.Value)
+	case ngap.ProcHandoverPreparation:
+		return buildHandoverCommand(m.Value)
+	case ngap.ProcHandoverResourceAllocation:
+		return buildHandoverRequestAcknowledge(m.Value)
+	case ngap.ProcHandoverCancel:
+		return buildHandoverCancelAcknowledge(m.Value)
 	default:
 		return unsupportedProcedure(m.ProcedureCode)
 	}
@@ -210,6 +236,12 @@ func buildUnsuccessfulOutcome(m *ngap.UnsuccessfulOutcome) NGAPMessageValue {
 		return buildInitialContextSetupFailure(m.Value)
 	case ngap.ProcPathSwitchRequest:
 		return buildPathSwitchRequestFailure(m.Value)
+	case ngap.ProcRANConfigurationUpdate:
+		return buildRANConfigurationUpdateFailure(m.Value)
+	case ngap.ProcHandoverPreparation:
+		return buildHandoverPreparationFailure(m.Value)
+	case ngap.ProcHandoverResourceAllocation:
+		return buildHandoverFailure(m.Value)
 	default:
 		return unsupportedProcedure(m.ProcedureCode)
 	}

--- a/internal/decoder/ngap/path_switch.go
+++ b/internal/decoder/ngap/path_switch.go
@@ -12,7 +12,7 @@ import (
 )
 
 // SecurityContext is the {NCC, NH} pair the AMF hands the target node so it can
-// derive the next access-stratum key (TS 38.413 §9.3.1.27).
+// derive the next access-stratum key (TS 38.413 §9.3.1.88).
 type SecurityContext struct {
 	NextHopChainingCount int64  `json:"next_hop_chaining_count"`
 	NextHopNH            string `json:"next_hop_nh"`
@@ -32,7 +32,7 @@ type UserPlaneSecurityInformation struct {
 }
 
 // PathSwitchRequestTransferDecoded is the per-session transfer the target node
-// sends to move the downlink tunnel to itself (TS 38.413 §9.3.4.10).
+// sends to move the downlink tunnel to itself (TS 38.413 §9.3.4.8).
 type PathSwitchRequestTransferDecoded struct {
 	DLNGUUPTNLInformation        GTPTunnel                     `json:"dl_ng_u_up_tnl_information"`
 	DLNGUTNLInformationReused    *bool                         `json:"dl_ng_u_tnl_information_reused,omitempty"`
@@ -41,7 +41,7 @@ type PathSwitchRequestTransferDecoded struct {
 }
 
 // PathSwitchRequestAcknowledgeTransferDecoded is the transfer the AMF returns per
-// switched session (TS 38.413 §9.3.4.11).
+// switched session (TS 38.413 §9.3.4.9).
 type PathSwitchRequestAcknowledgeTransferDecoded struct {
 	ULNGUUPTNLInformation *GTPTunnel          `json:"ul_ng_u_up_tnl_information,omitempty"`
 	SecurityIndication    *SecurityIndication `json:"security_indication,omitempty"`

--- a/internal/decoder/ngap/path_switch.go
+++ b/internal/decoder/ngap/path_switch.go
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/ngap"
+)
+
+// SecurityContext is the {NCC, NH} pair the AMF hands the target node so it can
+// derive the next access-stratum key (TS 38.413 §9.3.1.27).
+type SecurityContext struct {
+	NextHopChainingCount int64  `json:"next_hop_chaining_count"`
+	NextHopNH            string `json:"next_hop_nh"`
+}
+
+// SecurityResult reports whether the target node actually applied the protection
+// the network asked for (TS 38.413 §9.3.1.59).
+type SecurityResult struct {
+	IntegrityProtectionResult       utils.EnumField `json:"integrity_protection_result"`
+	ConfidentialityProtectionResult utils.EnumField `json:"confidentiality_protection_result"`
+}
+
+// UserPlaneSecurityInformation pairs what was asked for with what was applied.
+type UserPlaneSecurityInformation struct {
+	SecurityResult     SecurityResult      `json:"security_result"`
+	SecurityIndication *SecurityIndication `json:"security_indication,omitempty"`
+}
+
+// PathSwitchRequestTransferDecoded is the per-session transfer the target node
+// sends to move the downlink tunnel to itself (TS 38.413 §9.3.4.10).
+type PathSwitchRequestTransferDecoded struct {
+	DLNGUUPTNLInformation        GTPTunnel                     `json:"dl_ng_u_up_tnl_information"`
+	DLNGUTNLInformationReused    *bool                         `json:"dl_ng_u_tnl_information_reused,omitempty"`
+	UserPlaneSecurityInformation *UserPlaneSecurityInformation `json:"user_plane_security_information,omitempty"`
+	QosFlowAccepted              []int64                       `json:"qos_flow_accepted,omitempty"`
+}
+
+// PathSwitchRequestAcknowledgeTransferDecoded is the transfer the AMF returns per
+// switched session (TS 38.413 §9.3.4.11).
+type PathSwitchRequestAcknowledgeTransferDecoded struct {
+	ULNGUUPTNLInformation *GTPTunnel          `json:"ul_ng_u_up_tnl_information,omitempty"`
+	SecurityIndication    *SecurityIndication `json:"security_indication,omitempty"`
+}
+
+// CauseTransferDecoded is a transfer carrying only a cause, as the failed and
+// released path-switch lists do.
+type CauseTransferDecoded struct {
+	Cause Cause `json:"cause"`
+}
+
+// PathSwitchSession is one PDU session in a path-switch list: its id, and the
+// transfer that travelled with it when the decoder could read it.
+type PathSwitchSession struct {
+	PDUSessionID int64 `json:"pdu_session_id"`
+
+	PathSwitchRequestTransfer            *PathSwitchRequestTransferDecoded            `json:"path_switch_request_transfer,omitempty"`
+	PathSwitchRequestAcknowledgeTransfer *PathSwitchRequestAcknowledgeTransferDecoded `json:"path_switch_request_acknowledge_transfer,omitempty"`
+	CauseTransfer                        *CauseTransferDecoded                        `json:"cause_transfer,omitempty"`
+
+	TransferHex string `json:"transfer_hex,omitempty"` // set when the transfer did not decode
+	Error       string `json:"error,omitempty"`
+}
+
+func securityResult(r ngap.SecurityResult) SecurityResult {
+	return SecurityResult{
+		IntegrityProtectionResult:       utils.NamedEnum(uint8(r.IntegrityProtectionResult), r.IntegrityProtectionResult.Name()),
+		ConfidentialityProtectionResult: utils.NamedEnum(uint8(r.ConfidentialityProtectionResult), r.ConfidentialityProtectionResult.Name()),
+	}
+}
+
+func libPathSwitchRequestTransfer(raw ngap.TransferContainer) (*PathSwitchRequestTransferDecoded, error) {
+	t, err := ngap.ParsePathSwitchRequestTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &PathSwitchRequestTransferDecoded{DLNGUUPTNLInformation: libGTPTunnel(t.DLNGUUPTNLInformation)}
+
+	if t.DLNGUTNLInformationReused != nil {
+		reused := *t.DLNGUTNLInformationReused == ngap.DLNGUTNLInformationReusedTrue
+		out.DLNGUTNLInformationReused = &reused
+	}
+
+	if u := t.UserPlaneSecurityInformation; u != nil {
+		indication := u.SecurityIndication
+		out.UserPlaneSecurityInformation = &UserPlaneSecurityInformation{
+			SecurityResult:     securityResult(u.SecurityResult),
+			SecurityIndication: securityIndication(&indication),
+		}
+	}
+
+	for _, flow := range t.QosFlowAccepted {
+		out.QosFlowAccepted = append(out.QosFlowAccepted, int64(flow.QosFlowIdentifier))
+	}
+
+	return out, nil
+}
+
+func libPathSwitchRequestAcknowledgeTransfer(raw ngap.TransferContainer) (*PathSwitchRequestAcknowledgeTransferDecoded, error) {
+	t, err := ngap.ParsePathSwitchRequestAcknowledgeTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &PathSwitchRequestAcknowledgeTransferDecoded{SecurityIndication: securityIndication(t.SecurityIndication)}
+
+	if t.ULNGUUPTNLInformation != nil {
+		tunnel := libGTPTunnel(*t.ULNGUUPTNLInformation)
+		out.ULNGUUPTNLInformation = &tunnel
+	}
+
+	return out, nil
+}
+
+func pathSwitchSession(id ngap.PDUSessionID, raw ngap.TransferContainer, decode func(ngap.TransferContainer) (any, error)) PathSwitchSession {
+	s := PathSwitchSession{PDUSessionID: int64(id)}
+
+	decoded, err := decode(raw)
+	if err != nil {
+		s.Error = err.Error()
+		s.TransferHex = hex.EncodeToString(raw)
+
+		return s
+	}
+
+	switch v := decoded.(type) {
+	case *PathSwitchRequestTransferDecoded:
+		s.PathSwitchRequestTransfer = v
+	case *PathSwitchRequestAcknowledgeTransferDecoded:
+		s.PathSwitchRequestAcknowledgeTransfer = v
+	case *CauseTransferDecoded:
+		s.CauseTransfer = v
+	}
+
+	return s
+}
+
+func decodeSetupFailedTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParsePathSwitchRequestSetupFailedTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CauseTransferDecoded{Cause: cause(t.Cause)}, nil
+}
+
+func decodeUnsuccessfulTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParsePathSwitchRequestUnsuccessfulTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CauseTransferDecoded{Cause: cause(t.Cause)}, nil
+}
+
+func buildPathSwitchRequest(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePathSwitchRequest(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Path Switch Request: %v", err)}
+	}
+
+	switched := make([]PathSwitchSession, 0, len(m.PDUSessionResourceToBeSwitchedDLList))
+	for _, it := range m.PDUSessionResourceToBeSwitchedDLList {
+		switched = append(switched, pathSwitchSession(it.PDUSessionID, it.Transfer, func(raw ngap.TransferContainer) (any, error) {
+			return libPathSwitchRequestTransfer(raw)
+		}))
+	}
+
+	ies := []IE{
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+		ie(ngap.IDSourceAMFUENGAPID, ngap.CriticalityReject, int64(m.SourceAMFUENGAPID)),
+	}
+
+	if m.UserLocationInformation != nil {
+		ies = append(ies, ie(ngap.IDUserLocationInformation, ngap.CriticalityIgnore, userLocationInformation(*m.UserLocationInformation)))
+	}
+
+	if m.UESecurityCapabilities != nil {
+		ies = append(ies, ie(ngap.IDUESecurityCapabilities, ngap.CriticalityIgnore, libUESecurityCapabilities(*m.UESecurityCapabilities)))
+	}
+
+	ies = append(ies, ie(ngap.IDPDUSessionResourceToBeSwitchedDLList, ngap.CriticalityReject, switched))
+
+	if len(m.PDUSessionResourceFailedToSetup) > 0 {
+		failed := make([]PathSwitchSession, 0, len(m.PDUSessionResourceFailedToSetup))
+		for _, it := range m.PDUSessionResourceFailedToSetup {
+			failed = append(failed, pathSwitchSession(it.PDUSessionID, it.Transfer, decodeSetupFailedTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceFailedToSetupListPSReq, ngap.CriticalityIgnore, failed))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildPathSwitchRequestAcknowledge(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePathSwitchRequestAcknowledge(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Path Switch Request Acknowledge: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.RANUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDRANUENGAPID, ngap.CriticalityIgnore, int64(*m.RANUENGAPID)))
+	}
+
+	if m.UESecurityCapabilities != nil {
+		ies = append(ies, ie(ngap.IDUESecurityCapabilities, ngap.CriticalityReject, libUESecurityCapabilities(*m.UESecurityCapabilities)))
+	}
+
+	ies = append(ies, ie(ngap.IDSecurityContext, ngap.CriticalityReject, SecurityContext{
+		NextHopChainingCount: int64(m.SecurityContext.NextHopChainingCount),
+		NextHopNH:            hex.EncodeToString(m.SecurityContext.NextHopNH[:]),
+	}))
+
+	if len(m.PDUSessionResourceSwitchedList) > 0 {
+		switched := make([]PathSwitchSession, 0, len(m.PDUSessionResourceSwitchedList))
+		for _, it := range m.PDUSessionResourceSwitchedList {
+			switched = append(switched, pathSwitchSession(it.PDUSessionID, it.Transfer, func(raw ngap.TransferContainer) (any, error) {
+				return libPathSwitchRequestAcknowledgeTransfer(raw)
+			}))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceSwitchedList, ngap.CriticalityIgnore, switched))
+	}
+
+	if len(m.PDUSessionResourceReleased) > 0 {
+		released := make([]PathSwitchSession, 0, len(m.PDUSessionResourceReleased))
+		for _, it := range m.PDUSessionResourceReleased {
+			released = append(released, pathSwitchSession(it.PDUSessionID, it.Transfer, decodeUnsuccessfulTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceReleasedListPSAck, ngap.CriticalityIgnore, released))
+	}
+
+	if len(m.AllowedNSSAI) > 0 {
+		allowed := make([]SNSSAI, 0, len(m.AllowedNSSAI))
+		for _, it := range m.AllowedNSSAI {
+			allowed = append(allowed, buildSNSSAIValue(it.SNSSAI))
+		}
+
+		ies = append(ies, ie(ngap.IDAllowedNSSAI, ngap.CriticalityReject, allowed))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildPathSwitchRequestFailure(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePathSwitchRequestFailure(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Path Switch Request Failure: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.RANUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDRANUENGAPID, ngap.CriticalityIgnore, int64(*m.RANUENGAPID)))
+	}
+
+	if len(m.PDUSessionResourceReleased) > 0 {
+		released := make([]PathSwitchSession, 0, len(m.PDUSessionResourceReleased))
+		for _, it := range m.PDUSessionResourceReleased {
+			released = append(released, pathSwitchSession(it.PDUSessionID, it.Transfer, decodeUnsuccessfulTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceReleasedListPSFail, ngap.CriticalityIgnore, released))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildNASNonDeliveryIndication(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseNASNonDeliveryIndication(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse NAS Non Delivery Indication: %v", err)}
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+		ie(ngap.IDNASPDU, ngap.CriticalityIgnore, libNASPDU(m.NASPDU)),
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}

--- a/internal/decoder/ngap/pdu_session_resource_modify.go
+++ b/internal/decoder/ngap/pdu_session_resource_modify.go
@@ -19,7 +19,7 @@ type QosFlowWithCause struct {
 
 // QosFlowAddOrModifyRequest is a QoS flow the AMF asks the RAN to add or change.
 // The QoS parameters are optional: a modify that only rebinds the E-RAB carries
-// none (TS 38.413 §9.3.1.14).
+// none (TS 38.413 §9.3.4.3).
 type QosFlowAddOrModifyRequest struct {
 	QosFlow *QosFlowSetupRequest `json:"qos_flow,omitempty"`
 
@@ -34,14 +34,14 @@ type ULNGUUPTNLModify struct {
 }
 
 // QosFlowPerTNLInformation is a tunnel endpoint and the QoS flows carried on it
-// (TS 38.413 §9.3.2.10).
+// (TS 38.413 §9.3.2.8).
 type QosFlowPerTNLInformation struct {
 	UPTransportLayerInformation GTPTunnel           `json:"up_transport_layer_information"`
 	AssociatedQosFlowList       []AssociatedQosFlow `json:"associated_qos_flow_list,omitempty"`
 }
 
 // PDUSessionResourceModifyRequestTransferDecoded is the per-session transfer the
-// AMF sends to change a session (TS 38.413 §9.3.4.4).
+// AMF sends to change a session (TS 38.413 §9.3.4.3).
 type PDUSessionResourceModifyRequestTransferDecoded struct {
 	MaximumBitRate                  *MaximumBitRate             `json:"maximum_bit_rate,omitempty"`
 	ULNGUUPTNLModify                []ULNGUUPTNLModify          `json:"ul_ng_u_up_tnl_modify,omitempty"`
@@ -52,7 +52,7 @@ type PDUSessionResourceModifyRequestTransferDecoded struct {
 }
 
 // PDUSessionResourceModifyResponseTransferDecoded is what the RAN reports back
-// per session (TS 38.413 §9.3.4.5).
+// per session (TS 38.413 §9.3.4.4).
 type PDUSessionResourceModifyResponseTransferDecoded struct {
 	DLNGUUPTNLInformation                *GTPTunnel                 `json:"dl_ng_u_up_tnl_information,omitempty"`
 	ULNGUUPTNLInformation                *GTPTunnel                 `json:"ul_ng_u_up_tnl_information,omitempty"`

--- a/internal/decoder/ngap/pdu_session_resource_modify.go
+++ b/internal/decoder/ngap/pdu_session_resource_modify.go
@@ -1,0 +1,458 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ellanetworks/core/ngap"
+)
+
+// QosFlowWithCause is a QoS flow the peer could not act on, and why
+// (TS 38.413 §9.3.1.13).
+type QosFlowWithCause struct {
+	QosFlowIdentifier int64 `json:"qos_flow_identifier"`
+	Cause             Cause `json:"cause"`
+}
+
+// QosFlowAddOrModifyRequest is a QoS flow the AMF asks the RAN to add or change.
+// The QoS parameters are optional: a modify that only rebinds the E-RAB carries
+// none (TS 38.413 §9.3.1.14).
+type QosFlowAddOrModifyRequest struct {
+	QosFlow *QosFlowSetupRequest `json:"qos_flow,omitempty"`
+
+	QosFlowIdentifier int64  `json:"qos_flow_identifier"`
+	ERABID            *uint8 `json:"erab_id,omitempty"`
+}
+
+// ULNGUUPTNLModify pairs the uplink and downlink endpoints a session moves to.
+type ULNGUUPTNLModify struct {
+	ULNGUUPTNLInformation GTPTunnel `json:"ul_ng_u_up_tnl_information"`
+	DLNGUUPTNLInformation GTPTunnel `json:"dl_ng_u_up_tnl_information"`
+}
+
+// QosFlowPerTNLInformation is a tunnel endpoint and the QoS flows carried on it
+// (TS 38.413 §9.3.2.10).
+type QosFlowPerTNLInformation struct {
+	UPTransportLayerInformation GTPTunnel           `json:"up_transport_layer_information"`
+	AssociatedQosFlowList       []AssociatedQosFlow `json:"associated_qos_flow_list,omitempty"`
+}
+
+// PDUSessionResourceModifyRequestTransferDecoded is the per-session transfer the
+// AMF sends to change a session (TS 38.413 §9.3.4.4).
+type PDUSessionResourceModifyRequestTransferDecoded struct {
+	MaximumBitRate                  *MaximumBitRate             `json:"maximum_bit_rate,omitempty"`
+	ULNGUUPTNLModify                []ULNGUUPTNLModify          `json:"ul_ng_u_up_tnl_modify,omitempty"`
+	NetworkInstance                 *uint16                     `json:"network_instance,omitempty"`
+	QosFlowAddOrModifyRequest       []QosFlowAddOrModifyRequest `json:"qos_flow_add_or_modify_request,omitempty"`
+	QosFlowToRelease                []QosFlowWithCause          `json:"qos_flow_to_release,omitempty"`
+	AdditionalULNGUUPTNLInformation []GTPTunnel                 `json:"additional_ul_ng_u_up_tnl_information,omitempty"`
+}
+
+// PDUSessionResourceModifyResponseTransferDecoded is what the RAN reports back
+// per session (TS 38.413 §9.3.4.5).
+type PDUSessionResourceModifyResponseTransferDecoded struct {
+	DLNGUUPTNLInformation                *GTPTunnel                 `json:"dl_ng_u_up_tnl_information,omitempty"`
+	ULNGUUPTNLInformation                *GTPTunnel                 `json:"ul_ng_u_up_tnl_information,omitempty"`
+	QosFlowAddOrModifyResponse           []int64                    `json:"qos_flow_add_or_modify_response,omitempty"`
+	AdditionalDLQosFlowPerTNLInformation []QosFlowPerTNLInformation `json:"additional_dl_qos_flow_per_tnl_information,omitempty"`
+	QosFlowFailedToAddOrModify           []QosFlowWithCause         `json:"qos_flow_failed_to_add_or_modify,omitempty"`
+}
+
+// PDUSessionResourceModifyIndicationTransferDecoded is the RAN-initiated
+// indication's per-session transfer (TS 38.413 §9.3.4.6).
+type PDUSessionResourceModifyIndicationTransferDecoded struct {
+	DLQosFlowPerTNLInformation           QosFlowPerTNLInformation   `json:"dl_qos_flow_per_tnl_information"`
+	AdditionalDLQosFlowPerTNLInformation []QosFlowPerTNLInformation `json:"additional_dl_qos_flow_per_tnl_information,omitempty"`
+}
+
+// PDUSessionResourceModifyConfirmTransferDecoded is the AMF's confirmation of a
+// RAN-initiated modification (TS 38.413 §9.3.4.7).
+type PDUSessionResourceModifyConfirmTransferDecoded struct {
+	QosFlowModifyConfirm          []int64            `json:"qos_flow_modify_confirm,omitempty"`
+	ULNGUUPTNLInformation         GTPTunnel          `json:"ul_ng_u_up_tnl_information"`
+	AdditionalNGUUPTNLInformation []ULNGUUPTNLModify `json:"additional_ng_u_up_tnl_information,omitempty"`
+	QosFlowFailedToModify         []QosFlowWithCause `json:"qos_flow_failed_to_modify,omitempty"`
+}
+
+// ModifySession is one PDU session in a modify list: its id, and whichever
+// transfer travelled with it.
+type ModifySession struct {
+	PDUSessionID int64   `json:"pdu_session_id"`
+	NASPDU       *NASPDU `json:"nas_pdu,omitempty"`
+
+	ModifyRequestTransfer    *PDUSessionResourceModifyRequestTransferDecoded    `json:"modify_request_transfer,omitempty"`
+	ModifyResponseTransfer   *PDUSessionResourceModifyResponseTransferDecoded   `json:"modify_response_transfer,omitempty"`
+	ModifyIndicationTransfer *PDUSessionResourceModifyIndicationTransferDecoded `json:"modify_indication_transfer,omitempty"`
+	ModifyConfirmTransfer    *PDUSessionResourceModifyConfirmTransferDecoded    `json:"modify_confirm_transfer,omitempty"`
+	CauseTransfer            *CauseTransferDecoded                              `json:"cause_transfer,omitempty"`
+
+	TransferHex string `json:"transfer_hex,omitempty"` // set when the transfer did not decode
+	Error       string `json:"error,omitempty"`
+}
+
+func qosFlowsWithCause(list ngap.QosFlowListWithCause) []QosFlowWithCause {
+	out := make([]QosFlowWithCause, 0, len(list))
+	for _, f := range list {
+		out = append(out, QosFlowWithCause{QosFlowIdentifier: int64(f.QosFlowIdentifier), Cause: cause(f.Cause)})
+	}
+
+	return out
+}
+
+func qosFlowPerTNLInformation(q ngap.QosFlowPerTNLInformation) QosFlowPerTNLInformation {
+	out := QosFlowPerTNLInformation{UPTransportLayerInformation: libGTPTunnel(q.UPTransportLayerInformation)}
+	for _, f := range q.AssociatedQosFlowList {
+		out.AssociatedQosFlowList = append(out.AssociatedQosFlowList, AssociatedQosFlow{QosFlowIdentifier: int64(f.QosFlowIdentifier)})
+	}
+
+	return out
+}
+
+func qosFlowPerTNLInformationList(list ngap.QosFlowPerTNLInformationList) []QosFlowPerTNLInformation {
+	out := make([]QosFlowPerTNLInformation, 0, len(list))
+	for _, q := range list {
+		out = append(out, qosFlowPerTNLInformation(q.QosFlowPerTNLInformation))
+	}
+
+	return out
+}
+
+func libPDUSessionResourceModifyRequestTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParsePDUSessionResourceModifyRequestTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &PDUSessionResourceModifyRequestTransferDecoded{}
+
+	if ambr := t.PDUSessionAggregateMaximumBitRate; ambr != nil {
+		out.MaximumBitRate = &MaximumBitRate{
+			UplinkNAggregateMaximumBitRate:   uint64(ambr.UL),
+			DownlinkNAggregateMaximumBitRate: uint64(ambr.DL),
+			Unit:                             "bps",
+		}
+	}
+
+	for _, m := range t.ULNGUUPTNLModify {
+		out.ULNGUUPTNLModify = append(out.ULNGUUPTNLModify, ULNGUUPTNLModify{
+			ULNGUUPTNLInformation: libGTPTunnel(m.ULNGUUPTNLInformation),
+			DLNGUUPTNLInformation: libGTPTunnel(m.DLNGUUPTNLInformation),
+		})
+	}
+
+	if t.NetworkInstance != nil {
+		v := uint16(*t.NetworkInstance)
+		out.NetworkInstance = &v
+	}
+
+	for _, f := range t.QosFlowAddOrModifyRequest {
+		entry := QosFlowAddOrModifyRequest{QosFlowIdentifier: int64(f.QosFlowIdentifier)}
+
+		if f.QosFlowLevelQosParameters != nil {
+			flow := libQosFlowSetupRequest(ngap.QosFlowSetupRequestItem{
+				QosFlowIdentifier:         f.QosFlowIdentifier,
+				QosFlowLevelQosParameters: *f.QosFlowLevelQosParameters,
+			})
+			entry.QosFlow = &flow
+		}
+
+		if f.ERABID != nil {
+			id := uint8(*f.ERABID)
+			entry.ERABID = &id
+		}
+
+		out.QosFlowAddOrModifyRequest = append(out.QosFlowAddOrModifyRequest, entry)
+	}
+
+	out.QosFlowToRelease = qosFlowsWithCause(t.QosFlowToRelease)
+
+	for _, item := range t.AdditionalULNGUUPTNLInformation {
+		out.AdditionalULNGUUPTNLInformation = append(out.AdditionalULNGUUPTNLInformation, libGTPTunnel(item.NGUUPTNLInformation))
+	}
+
+	return out, nil
+}
+
+func libPDUSessionResourceModifyResponseTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParsePDUSessionResourceModifyResponseTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &PDUSessionResourceModifyResponseTransferDecoded{
+		AdditionalDLQosFlowPerTNLInformation: qosFlowPerTNLInformationList(t.AdditionalDLQosFlowPerTNLInformation),
+		QosFlowFailedToAddOrModify:           qosFlowsWithCause(t.QosFlowFailedToAddOrModify),
+	}
+
+	if t.DLNGUUPTNLInformation != nil {
+		tunnel := libGTPTunnel(*t.DLNGUUPTNLInformation)
+		out.DLNGUUPTNLInformation = &tunnel
+	}
+
+	if t.ULNGUUPTNLInformation != nil {
+		tunnel := libGTPTunnel(*t.ULNGUUPTNLInformation)
+		out.ULNGUUPTNLInformation = &tunnel
+	}
+
+	for _, f := range t.QosFlowAddOrModifyResponse {
+		out.QosFlowAddOrModifyResponse = append(out.QosFlowAddOrModifyResponse, int64(f.QosFlowIdentifier))
+	}
+
+	return out, nil
+}
+
+func libPDUSessionResourceModifyIndicationTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParsePDUSessionResourceModifyIndicationTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PDUSessionResourceModifyIndicationTransferDecoded{
+		DLQosFlowPerTNLInformation:           qosFlowPerTNLInformation(t.DLQosFlowPerTNLInformation),
+		AdditionalDLQosFlowPerTNLInformation: qosFlowPerTNLInformationList(t.AdditionalDLQosFlowPerTNLInformation),
+	}, nil
+}
+
+func libPDUSessionResourceModifyConfirmTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParsePDUSessionResourceModifyConfirmTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &PDUSessionResourceModifyConfirmTransferDecoded{
+		ULNGUUPTNLInformation: libGTPTunnel(t.ULNGUUPTNLInformation),
+		QosFlowFailedToModify: qosFlowsWithCause(t.QosFlowFailedToModify),
+	}
+
+	for _, f := range t.QosFlowModifyConfirm {
+		out.QosFlowModifyConfirm = append(out.QosFlowModifyConfirm, int64(f.QosFlowIdentifier))
+	}
+
+	for _, p := range t.AdditionalNGUUPTNLInformation {
+		out.AdditionalNGUUPTNLInformation = append(out.AdditionalNGUUPTNLInformation, ULNGUUPTNLModify{
+			ULNGUUPTNLInformation: libGTPTunnel(p.ULNGUUPTNLInformation),
+			DLNGUUPTNLInformation: libGTPTunnel(p.DLNGUUPTNLInformation),
+		})
+	}
+
+	return out, nil
+}
+
+func libPDUSessionResourceModifyIndicationUnsuccessfulTransfer(raw ngap.TransferContainer) (any, error) {
+	t, err := ngap.ParsePDUSessionResourceModifyIndicationUnsuccessfulTransfer(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CauseTransferDecoded{Cause: cause(t.Cause)}, nil
+}
+
+// modifySession decodes one list item. A transfer the codec cannot model is kept
+// as hex rather than dropped.
+func modifySession(id ngap.PDUSessionID, raw ngap.TransferContainer, decode func(ngap.TransferContainer) (any, error)) ModifySession {
+	s := ModifySession{PDUSessionID: int64(id)}
+
+	if decode == nil {
+		s.TransferHex = hex.EncodeToString(raw)
+		return s
+	}
+
+	decoded, err := decode(raw)
+	if err != nil {
+		s.Error = err.Error()
+		s.TransferHex = hex.EncodeToString(raw)
+
+		return s
+	}
+
+	switch v := decoded.(type) {
+	case *PDUSessionResourceModifyRequestTransferDecoded:
+		s.ModifyRequestTransfer = v
+	case *PDUSessionResourceModifyResponseTransferDecoded:
+		s.ModifyResponseTransfer = v
+	case *PDUSessionResourceModifyIndicationTransferDecoded:
+		s.ModifyIndicationTransfer = v
+	case *PDUSessionResourceModifyConfirmTransferDecoded:
+		s.ModifyConfirmTransfer = v
+	case *CauseTransferDecoded:
+		s.CauseTransfer = v
+	}
+
+	return s
+}
+
+func buildPDUSessionResourceModifyRequest(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePDUSessionResourceModifyRequest(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse PDU Session Resource Modify Request: %v", err)}
+	}
+
+	sessions := make([]ModifySession, 0, len(m.PDUSessionResourceModify))
+
+	for _, it := range m.PDUSessionResourceModify {
+		s := modifySession(it.PDUSessionID, it.Transfer, libPDUSessionResourceModifyRequestTransfer)
+
+		if it.NASPDU != nil {
+			pdu := libNASPDU(*it.NASPDU)
+			s.NASPDU = &pdu
+		}
+
+		sessions = append(sessions, s)
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+		ie(ngap.IDPDUSessionResourceModifyListModReq, ngap.CriticalityReject, sessions),
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildPDUSessionResourceModifyResponse(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePDUSessionResourceModifyResponse(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse PDU Session Resource Modify Response: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.RANUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDRANUENGAPID, ngap.CriticalityIgnore, int64(*m.RANUENGAPID)))
+	}
+
+	if len(m.PDUSessionResourceModify) > 0 {
+		sessions := make([]ModifySession, 0, len(m.PDUSessionResourceModify))
+		for _, it := range m.PDUSessionResourceModify {
+			sessions = append(sessions, modifySession(it.PDUSessionID, it.Transfer, libPDUSessionResourceModifyResponseTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceModifyListModRes, ngap.CriticalityIgnore, sessions))
+	}
+
+	if len(m.PDUSessionResourceFailed) > 0 {
+		failed := make([]ModifySession, 0, len(m.PDUSessionResourceFailed))
+		for _, it := range m.PDUSessionResourceFailed {
+			failed = append(failed, modifySession(it.PDUSessionID, it.Transfer, libPDUSessionResourceModifyIndicationUnsuccessfulTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceFailedToModifyListModRes, ngap.CriticalityIgnore, failed))
+	}
+
+	if m.UserLocationInformation != nil {
+		ies = append(ies, ie(ngap.IDUserLocationInformation, ngap.CriticalityIgnore, userLocationInformation(*m.UserLocationInformation)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildPDUSessionResourceModifyIndication(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePDUSessionResourceModifyIndication(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse PDU Session Resource Modify Indication: %v", err)}
+	}
+
+	sessions := make([]ModifySession, 0, len(m.PDUSessionResourceModify))
+	for _, it := range m.PDUSessionResourceModify {
+		sessions = append(sessions, modifySession(it.PDUSessionID, it.Transfer, libPDUSessionResourceModifyIndicationTransfer))
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+		ie(ngap.IDPDUSessionResourceModifyListModInd, ngap.CriticalityReject, sessions),
+	}
+
+	if m.UserLocationInformation != nil {
+		ies = append(ies, ie(ngap.IDUserLocationInformation, ngap.CriticalityIgnore, userLocationInformation(*m.UserLocationInformation)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildPDUSessionResourceModifyConfirm(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePDUSessionResourceModifyConfirm(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse PDU Session Resource Modify Confirm: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.AMFUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDAMFUENGAPID, ngap.CriticalityIgnore, int64(*m.AMFUENGAPID)))
+	}
+
+	if m.RANUENGAPID != nil {
+		ies = append(ies, ie(ngap.IDRANUENGAPID, ngap.CriticalityIgnore, int64(*m.RANUENGAPID)))
+	}
+
+	if len(m.PDUSessionResourceModify) > 0 {
+		sessions := make([]ModifySession, 0, len(m.PDUSessionResourceModify))
+		for _, it := range m.PDUSessionResourceModify {
+			sessions = append(sessions, modifySession(it.PDUSessionID, it.Transfer, libPDUSessionResourceModifyConfirmTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceModifyListModCfm, ngap.CriticalityIgnore, sessions))
+	}
+
+	if len(m.PDUSessionResourceFailed) > 0 {
+		failed := make([]ModifySession, 0, len(m.PDUSessionResourceFailed))
+		for _, it := range m.PDUSessionResourceFailed {
+			failed = append(failed, modifySession(it.PDUSessionID, it.Transfer, libPDUSessionResourceModifyIndicationUnsuccessfulTransfer))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceFailedToModifyListModCfm, ngap.CriticalityIgnore, failed))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+// The codec models no PDU Session Resource Notify transfer, so the per-session
+// containers are reported as hex.
+func buildPDUSessionResourceNotify(value []byte) NGAPMessageValue {
+	m, err := ngap.ParsePDUSessionResourceNotify(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse PDU Session Resource Notify: %v", err)}
+	}
+
+	notified := make([]ModifySession, 0, len(m.PDUSessionResourceNotify))
+	for _, it := range m.PDUSessionResourceNotify {
+		notified = append(notified, modifySession(it.PDUSessionID, it.Transfer, nil))
+	}
+
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(m.AMFUENGAPID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(m.RANUENGAPID)),
+		ie(ngap.IDPDUSessionResourceNotifyList, ngap.CriticalityReject, notified),
+	}
+
+	if len(m.PDUSessionResourceReleased) > 0 {
+		released := make([]ModifySession, 0, len(m.PDUSessionResourceReleased))
+		for _, it := range m.PDUSessionResourceReleased {
+			released = append(released, modifySession(it.PDUSessionID, it.Transfer, nil))
+		}
+
+		ies = append(ies, ie(ngap.IDPDUSessionResourceReleasedListNot, ngap.CriticalityIgnore, released))
+	}
+
+	if m.UserLocationInformation != nil {
+		ies = append(ies, ie(ngap.IDUserLocationInformation, ngap.CriticalityIgnore, userLocationInformation(*m.UserLocationInformation)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}

--- a/internal/decoder/ngap/pdu_session_resource_setup_request.go
+++ b/internal/decoder/ngap/pdu_session_resource_setup_request.go
@@ -44,7 +44,7 @@ func buildPDUSessionResourceSetupRequest(value []byte) NGAPMessageValue {
 				SNSSAI:       buildSNSSAIValue(item.SNSSAI),
 			}
 
-			transfer, err := libSetupRequestTransfer(item.Transfer)
+			transfer, err := libPDUSessionResourceSetupRequestTransfer(item.Transfer)
 			if err != nil {
 				entry.Error = fmt.Sprintf("failed to decode transfer: %v", err)
 			} else {

--- a/internal/decoder/ngap/pdu_session_transfer.go
+++ b/internal/decoder/ngap/pdu_session_transfer.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ellanetworks/core/ngap"
 )
 
-// libSetupRequestTransfer renders the PDU Session Resource Setup Request
+// libPDUSessionResourceSetupRequestTransfer renders the PDU Session Resource Setup Request
 // Transfer both the setup request and the initial context setup carry per
 // session (TS 38.413 §9.3.4.1).
-func libSetupRequestTransfer(raw ngap.TransferContainer) (*PDUSessionResourceSetupRequestTransfer, error) {
+func libPDUSessionResourceSetupRequestTransfer(raw ngap.TransferContainer) (*PDUSessionResourceSetupRequestTransfer, error) {
 	t, err := ngap.ParsePDUSessionResourceSetupRequestTransfer(raw)
 	if err != nil {
 		return nil, err
@@ -34,6 +34,20 @@ func libSetupRequestTransfer(raw ngap.TransferContainer) (*PDUSessionResourceSet
 			DownlinkNAggregateMaximumBitRate: uint64(t.PDUSessionAggregateMaximumBitRate.DL),
 			Unit:                             "bps",
 		}
+	}
+
+	for _, item := range t.AdditionalULNGUUPTNLInformation {
+		out.AdditionalULNGUUPTNLInformation = append(out.AdditionalULNGUUPTNLInformation, libGTPTunnel(item.NGUUPTNLInformation))
+	}
+
+	if t.DataForwardingNotPossible != nil {
+		notPossible := *t.DataForwardingNotPossible == ngap.DataForwardingNotPossibleTrue
+		out.DataForwardingNotPossible = &notPossible
+	}
+
+	if t.NetworkInstance != nil {
+		v := uint16(*t.NetworkInstance)
+		out.NetworkInstance = &v
 	}
 
 	out.SecurityIndication = securityIndication(t.SecurityIndication)

--- a/internal/decoder/ngap/ran_configuration_update.go
+++ b/internal/decoder/ngap/ran_configuration_update.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ngap
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ellanetworks/core/ngap"
+)
+
+// NGRANTNLAssociationToRemove names a control-plane TNL association the RAN node
+// asks the AMF to drop (TS 38.413 §9.3.1.126).
+type NGRANTNLAssociationToRemove struct {
+	TNLAssociationTransportLayerAddress    string  `json:"tnl_association_transport_layer_address"`
+	TNLAssociationTransportLayerAddressAMF *string `json:"tnl_association_transport_layer_address_amf,omitempty"`
+}
+
+// SONConfigurationTransfer is the SON container two RAN nodes exchange through
+// the AMF. Its content is Xn, opaque to NGAP (TS 38.413 §9.3.3.10).
+type SONConfigurationTransfer struct {
+	Hex string `json:"hex"`
+}
+
+func buildRANConfigurationUpdate(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseRANConfigurationUpdate(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse RAN Configuration Update: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.RANNodeName != nil {
+		ies = append(ies, ie(ngap.IDRANNodeName, ngap.CriticalityIgnore, *m.RANNodeName))
+	}
+
+	if len(m.SupportedTAList) > 0 {
+		ies = append(ies, ie(ngap.IDSupportedTAList, ngap.CriticalityReject, buildSupportedTAList(m.SupportedTAList)))
+	}
+
+	if m.DefaultPagingDRX != nil {
+		ies = append(ies, ie(ngap.IDDefaultPagingDRX, ngap.CriticalityIgnore, buildPagingDRX(*m.DefaultPagingDRX)))
+	}
+
+	if m.GlobalRANNodeID != nil {
+		ies = append(ies, ie(ngap.IDGlobalRANNodeID, ngap.CriticalityIgnore, buildGlobalRANNodeID(*m.GlobalRANNodeID)))
+	}
+
+	if len(m.NGRANTNLAssociationToRemoveList) > 0 {
+		remove := make([]NGRANTNLAssociationToRemove, 0, len(m.NGRANTNLAssociationToRemoveList))
+
+		for _, it := range m.NGRANTNLAssociationToRemoveList {
+			entry := NGRANTNLAssociationToRemove{
+				TNLAssociationTransportLayerAddress: transportLayerAddressToString(it.TNLAssociationTransportLayerAddress.EndpointIPAddress),
+			}
+
+			if amf := it.TNLAssociationTransportLayerAddressAMF; amf != nil {
+				addr := transportLayerAddressToString(amf.EndpointIPAddress)
+				entry.TNLAssociationTransportLayerAddressAMF = &addr
+			}
+
+			remove = append(remove, entry)
+		}
+
+		ies = append(ies, ie(ngap.IDNGRANTNLAssociationToRemoveList, ngap.CriticalityReject, remove))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildRANConfigurationUpdateAcknowledge(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseRANConfigurationUpdateAcknowledge(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse RAN Configuration Update Acknowledge: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildRANConfigurationUpdateFailure(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseRANConfigurationUpdateFailure(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse RAN Configuration Update Failure: %v", err)}
+	}
+
+	var ies []IE
+
+	if m.Cause != nil {
+		ies = append(ies, ie(ngap.IDCause, ngap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	if m.TimeToWait != nil {
+		ies = append(ies, ie(ngap.IDTimeToWait, ngap.CriticalityIgnore, buildTimeToWait(*m.TimeToWait)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(ngap.IDCriticalityDiagnostics, ngap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildUplinkRANConfigurationTransfer(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseUplinkRANConfigurationTransfer(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Uplink RAN Configuration Transfer: %v", err)}
+	}
+
+	var ies []IE
+
+	if len(m.SONConfigurationTransfer) > 0 {
+		ies = append(ies, ie(ngap.IDSONConfigurationTransferUL, ngap.CriticalityIgnore,
+			SONConfigurationTransfer{Hex: hex.EncodeToString(m.SONConfigurationTransfer)}))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+func buildDownlinkRANConfigurationTransfer(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseDownlinkRANConfigurationTransfer(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Downlink RAN Configuration Transfer: %v", err)}
+	}
+
+	var ies []IE
+
+	if len(m.SONConfigurationTransfer) > 0 {
+		ies = append(ies, ie(ngap.IDSONConfigurationTransferDL, ngap.CriticalityIgnore,
+			SONConfigurationTransfer{Hex: hex.EncodeToString(m.SONConfigurationTransfer)}))
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(m.UnknownIEs())...)}
+}
+
+// The RAN status transfer container is a transparent PDCP status container the
+// two RAN nodes exchange through the AMF (TS 38.413 §9.3.1.31); NGAP does not
+// model its content.
+func ranStatusTransferValue(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAPID, container ngap.StatusTransferContainer, unknown []ngap.RawIE) NGAPMessageValue {
+	ies := []IE{
+		ie(ngap.IDAMFUENGAPID, ngap.CriticalityReject, int64(amfID)),
+		ie(ngap.IDRANUENGAPID, ngap.CriticalityReject, int64(ranID)),
+		ie(ngap.IDRANStatusTransferTransparentContainer, ngap.CriticalityReject, hex.EncodeToString(container)),
+	}
+
+	return NGAPMessageValue{IEs: append(ies, unmodeledIEs(unknown)...)}
+}
+
+func buildUplinkRANStatusTransfer(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseUplinkRANStatusTransfer(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Uplink RAN Status Transfer: %v", err)}
+	}
+
+	return ranStatusTransferValue(m.AMFUENGAPID, m.RANUENGAPID, m.Container, m.UnknownIEs())
+}
+
+func buildDownlinkRANStatusTransfer(value []byte) NGAPMessageValue {
+	m, err := ngap.ParseDownlinkRANStatusTransfer(value)
+	if err != nil {
+		return NGAPMessageValue{Error: fmt.Sprintf("parse Downlink RAN Status Transfer: %v", err)}
+	}
+
+	return ranStatusTransferValue(m.AMFUENGAPID, m.RANUENGAPID, m.Container, m.UnknownIEs())
+}

--- a/internal/decoder/ngap/ran_configuration_update.go
+++ b/internal/decoder/ngap/ran_configuration_update.go
@@ -11,14 +11,14 @@ import (
 )
 
 // NGRANTNLAssociationToRemove names a control-plane TNL association the RAN node
-// asks the AMF to drop (TS 38.413 §9.3.1.126).
+// asks the AMF to drop (TS 38.413 §9.2.6.4).
 type NGRANTNLAssociationToRemove struct {
 	TNLAssociationTransportLayerAddress    string  `json:"tnl_association_transport_layer_address"`
 	TNLAssociationTransportLayerAddressAMF *string `json:"tnl_association_transport_layer_address_amf,omitempty"`
 }
 
 // SONConfigurationTransfer is the SON container two RAN nodes exchange through
-// the AMF. Its content is Xn, opaque to NGAP (TS 38.413 §9.3.3.10).
+// the AMF. Its content is Xn, opaque to NGAP (TS 38.413 §9.3.3.6).
 type SONConfigurationTransfer struct {
 	Hex string `json:"hex"`
 }
@@ -140,7 +140,7 @@ func buildDownlinkRANConfigurationTransfer(value []byte) NGAPMessageValue {
 }
 
 // The RAN status transfer container is a transparent PDCP status container the
-// two RAN nodes exchange through the AMF (TS 38.413 §9.3.1.31); NGAP does not
+// two RAN nodes exchange through the AMF (TS 38.413 §9.3.1.108); NGAP does not
 // model its content.
 func ranStatusTransferValue(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAPID, container ngap.StatusTransferContainer, unknown []ngap.RawIE) NGAPMessageValue {
 	ies := []IE{

--- a/internal/decoder/ngap/testdata/golden/downlink_ran_configuration_transfer_full.json
+++ b/internal/decoder/ngap/testdata/golden/downlink_ran_configuration_transfer_full.json
@@ -1,0 +1,37 @@
+{
+  "summary": "DownlinkRANConfigurationTransfer",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 6,
+    "label": "DownlinkRANConfigurationTransfer",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 98,
+          "label": "SONConfigurationTransferDL",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "hex": "040506"
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/downlink_ran_status_transfer_full.json
+++ b/internal/decoder/ngap/testdata/golden/downlink_ran_status_transfer_full.json
@@ -1,0 +1,65 @@
+{
+  "summary": "DownlinkRANStatusTransfer, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 7,
+    "label": "DownlinkRANStatusTransfer",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 84,
+          "label": "RANStatusTransfer-TransparentContainer",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": "0c0d"
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_cancel_acknowledge_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_cancel_acknowledge_full.json
@@ -1,0 +1,72 @@
+{
+  "summary": "HandoverCancel, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 10,
+    "label": "HandoverCancel",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 10,
+            "label": "HandoverCancel",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_cancel_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_cancel_full.json
@@ -1,0 +1,78 @@
+{
+  "summary": "HandoverCancel, AMF-UE=7, RAN-UE=3, Cause=unspecified",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 10,
+    "label": "HandoverCancel",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 0,
+            "label": "unspecified",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_command_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_command_full.json
@@ -1,0 +1,148 @@
+{
+  "summary": "HandoverPreparation, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 12,
+    "label": "HandoverPreparation",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 29,
+          "label": "HandoverType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "type": "enum",
+          "value": 0,
+          "label": "intra5gs",
+          "unknown": false
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 59,
+          "label": "PDUSessionResourceHandoverList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "handover_command_transfer": {
+              "dl_forwarding_up_tnl_information": {
+                "gtp_teid": 113,
+                "transport_layer_address": "10.45.0.9"
+              },
+              "qos_flow_to_be_forwarded": [
+                1
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 78,
+          "label": "PDUSessionResourceToReleaseListHOCmd",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 2,
+            "cause_transfer": {
+              "cause": {
+                "group": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "radioNetwork",
+                  "unknown": false
+                },
+                "value": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "unspecified",
+                  "unknown": false
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 106,
+          "label": "TargetToSource-TransparentContainer",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": "0304"
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_failure_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_failure_full.json
@@ -1,0 +1,85 @@
+{
+  "summary": "HandoverResourceAllocation, AMF-UE=7, Cause=unspecified",
+  "pdu_type": "UnsuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 13,
+    "label": "HandoverResourceAllocation",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 0,
+            "label": "unspecified",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 13,
+            "label": "HandoverResourceAllocation",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_notify_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_notify_full.json
@@ -1,0 +1,97 @@
+{
+  "summary": "HandoverNotification, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 11,
+    "label": "HandoverNotification",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 121,
+          "label": "UserLocationInformation",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "nr": {
+            "nr_cgi": {
+              "plmn_id": {
+                "mcc": "001",
+                "mnc": "01"
+              },
+              "nr_cell_identity": "000000010"
+            },
+            "tai": {
+              "plmn_id": {
+                "mcc": "001",
+                "mnc": "01"
+              },
+              "tac": "000001"
+            }
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 269,
+          "label": "NotifySourceNGRANNode",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": true
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_preparation_failure_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_preparation_failure_full.json
@@ -1,0 +1,100 @@
+{
+  "summary": "HandoverPreparation, AMF-UE=7, RAN-UE=3, Cause=unspecified",
+  "pdu_type": "UnsuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 12,
+    "label": "HandoverPreparation",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 0,
+            "label": "unspecified",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 12,
+            "label": "HandoverPreparation",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_request_acknowledge_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_request_acknowledge_full.json
@@ -1,0 +1,144 @@
+{
+  "summary": "HandoverResourceAllocation, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 13,
+    "label": "HandoverResourceAllocation",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 53,
+          "label": "PDUSessionResourceAdmittedList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "handover_request_acknowledge_transfer": {
+              "dl_ng_u_up_tnl_information": {
+                "gtp_teid": 129,
+                "transport_layer_address": "10.46.0.9"
+              },
+              "security_result": {
+                "integrity_protection_result": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "performed",
+                  "unknown": false
+                },
+                "confidentiality_protection_result": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "performed",
+                  "unknown": false
+                }
+              },
+              "qos_flow_setup_response": [
+                {
+                  "qos_flow_identifier": 1
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 56,
+          "label": "PDUSessionResourceFailedToSetupListHOAck",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 2,
+            "handover_resource_allocation_unsuccessful_transfer": {
+              "cause": {
+                "group": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "radioNetwork",
+                  "unknown": false
+                },
+                "value": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "unspecified",
+                  "unknown": false
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 106,
+          "label": "TargetToSource-TransparentContainer",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": "0708"
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_request_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_request_full.json
@@ -1,0 +1,298 @@
+{
+  "summary": "HandoverResourceAllocation, AMF-UE=7, Cause=handover-desirable-for-radio-reason",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 13,
+    "label": "HandoverResourceAllocation",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 29,
+          "label": "HandoverType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "type": "enum",
+          "value": 0,
+          "label": "intra5gs",
+          "unknown": false
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 16,
+            "label": "handover-desirable-for-radio-reason",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 110,
+          "label": "UEAggregateMaximumBitRate",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "downlink_n_aggregate_maximum_bit_rate": 200000000,
+          "uplink_n_aggregate_maximum_bit_rate": 100000000,
+          "unit": "bps"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 119,
+          "label": "UESecurityCapabilities",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "nr_encryption_algorithms": [
+            "NEA1",
+            "NEA2",
+            "NEA3"
+          ],
+          "nr_integrity_protection_algorithms": [
+            "NIA1",
+            "NIA2",
+            "NIA3"
+          ],
+          "eutra_encryption_algorithms": "e000",
+          "eutra_integrity_protection_algorithms": "e000"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 93,
+          "label": "SecurityContext",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "next_hop_chaining_count": 1,
+          "next_hop_nh": "0a00000000000000000000000000000000000000000000000000000000000000"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 41,
+          "label": "NewSecurityContextInd",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": true
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 73,
+          "label": "PDUSessionResourceSetupListHOReq",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "snssai": {
+              "sst": 1
+            },
+            "pdu_session_resource_setup_request_transfer": {
+              "ul_ng_u_up_tnl_information": {
+                "gtp_tunnel": {
+                  "gtp_teid": 145,
+                  "transport_layer_address": "10.47.0.9"
+                }
+              },
+              "qos_flow_setup_request_list": [
+                {
+                  "qos_id": 1,
+                  "five_qi": 9,
+                  "pri_arp": 8
+                }
+              ],
+              "pdu_s_type": {
+                "type": "enum",
+                "value": 0,
+                "label": "ipv4",
+                "unknown": false
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "AllowedNSSAI",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "sst": 1
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 101,
+          "label": "SourceToTarget-TransparentContainer",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": "0506"
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 36,
+          "label": "MobilityRestrictionList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "serving_plmn": {
+            "mcc": "001",
+            "mnc": "01"
+          },
+          "equivalent_plmns": [
+            {
+              "mcc": "001",
+              "mnc": "01"
+            }
+          ],
+          "rat_restrictions": [
+            {
+              "plmn_id": {
+                "mcc": "001",
+                "mnc": "01"
+              },
+              "rat_restriction_information": "e-UTRA"
+            }
+          ]
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 28,
+          "label": "GUAMI",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "plmn_id": {
+            "mcc": "001",
+            "mnc": "01"
+          },
+          "amf_region_id": "01",
+          "amf_set_id": "004",
+          "amf_pointer": "00"
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/handover_required_full.json
+++ b/internal/decoder/ngap/testdata/golden/handover_required_full.json
@@ -1,0 +1,182 @@
+{
+  "summary": "HandoverPreparation, AMF-UE=7, RAN-UE=3, Cause=handover-desirable-for-radio-reason",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 12,
+    "label": "HandoverPreparation",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 29,
+          "label": "HandoverType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "type": "enum",
+          "value": 0,
+          "label": "intra5gs",
+          "unknown": false
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 16,
+            "label": "handover-desirable-for-radio-reason",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 105,
+          "label": "TargetID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "target_ran_node_id": {
+            "global_ran_node_id": {
+              "plmn_identity": {
+                "mcc": "001",
+                "mnc": "01"
+              },
+              "global_gnb_id": "000008"
+            },
+            "selected_tai": {
+              "plmn_id": {
+                "mcc": "001",
+                "mnc": "01"
+              },
+              "tac": "000001"
+            }
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 22,
+          "label": "DirectForwardingPathAvailability",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": true
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 61,
+          "label": "PDUSessionResourceListHORqd",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "handover_required_transfer": {
+              "direct_forwarding_path_availability": true
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 101,
+          "label": "SourceToTarget-TransparentContainer",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": "0102"
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/nas_non_delivery_indication_full.json
+++ b/internal/decoder/ngap/testdata/golden/nas_non_delivery_indication_full.json
@@ -1,0 +1,124 @@
+{
+  "summary": "NASNonDeliveryIndication, AMF-UE=7, RAN-UE=3, NAS=REGISTRATION REJECT, Cause=unkown-qos-flow-ID",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 19,
+    "label": "NASNonDeliveryIndication",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 38,
+          "label": "NAS-PDU",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "protocol": "NAS",
+          "raw_hex": "7e0044",
+          "decoded": {
+            "security_header": {
+              "protocol_discriminator": {
+                "type": "enum",
+                "value": 126,
+                "label": "5GMM",
+                "unknown": false
+              },
+              "security_header_type": {
+                "type": "enum",
+                "value": 0,
+                "label": "plain",
+                "unknown": false
+              },
+              "sequence_number": 0
+            },
+            "gmm_message": {
+              "gmm_header": {
+                "message_type": {
+                  "type": "enum",
+                  "value": 68,
+                  "label": "REGISTRATION REJECT",
+                  "unknown": false
+                }
+              }
+            },
+            "encrypted": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 27,
+            "label": "unkown-qos-flow-ID",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/ng_reset_acknowledge_full.json
+++ b/internal/decoder/ngap/testdata/golden/ng_reset_acknowledge_full.json
@@ -1,0 +1,62 @@
+{
+  "summary": "NGReset",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 20,
+    "label": "NGReset",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 111,
+          "label": "UE-associatedLogicalNG-connectionList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "amf_ue_ngap_id": 7,
+            "ran_ue_ngap_id": 3
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 20,
+            "label": "NGReset",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/ng_reset_all_full.json
+++ b/internal/decoder/ngap/testdata/golden/ng_reset_all_full.json
@@ -1,0 +1,65 @@
+{
+  "summary": "NGReset, Cause=om-intervention",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 20,
+    "label": "NGReset",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 4,
+            "label": "misc",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 3,
+            "label": "om-intervention",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 88,
+          "label": "ResetType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "ng_interface": true
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/ng_reset_part_full.json
+++ b/internal/decoder/ngap/testdata/golden/ng_reset_part_full.json
@@ -1,0 +1,73 @@
+{
+  "summary": "NGReset, Cause=transport-resource-unavailable",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 20,
+    "label": "NGReset",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 1,
+            "label": "transport",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 0,
+            "label": "transport-resource-unavailable",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 88,
+          "label": "ResetType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "part_of_ng_interface": [
+            {
+              "amf_ue_ngap_id": 7,
+              "ran_ue_ngap_id": 3
+            },
+            {
+              "ran_ue_ngap_id": 4
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/path_switch_request_acknowledge_full.json
+++ b/internal/decoder/ngap/testdata/golden/path_switch_request_acknowledge_full.json
@@ -1,0 +1,147 @@
+{
+  "summary": "PathSwitchRequest, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 25,
+    "label": "PathSwitchRequest",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 93,
+          "label": "SecurityContext",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "next_hop_chaining_count": 3,
+          "next_hop_nh": "0102000000000000000000000000000000000000000000000000000000000000"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 77,
+          "label": "PDUSessionResourceSwitchedList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "path_switch_request_acknowledge_transfer": {
+              "ul_ng_u_up_tnl_information": {
+                "gtp_teid": 49,
+                "transport_layer_address": "10.46.0.1"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 68,
+          "label": "PDUSessionResourceReleasedListPSAck",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 2,
+            "cause_transfer": {
+              "cause": {
+                "group": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "radioNetwork",
+                  "unknown": false
+                },
+                "value": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "unspecified",
+                  "unknown": false
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "AllowedNSSAI",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "sst": 1
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/path_switch_request_failure_full.json
+++ b/internal/decoder/ngap/testdata/golden/path_switch_request_failure_full.json
@@ -1,0 +1,107 @@
+{
+  "summary": "PathSwitchRequest, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "UnsuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 25,
+    "label": "PathSwitchRequest",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 69,
+          "label": "PDUSessionResourceReleasedListPSFail",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "cause_transfer": {
+              "cause": {
+                "group": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "radioNetwork",
+                  "unknown": false
+                },
+                "value": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "unspecified",
+                  "unknown": false
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 25,
+            "label": "PathSwitchRequest",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/path_switch_request_full.json
+++ b/internal/decoder/ngap/testdata/golden/path_switch_request_full.json
@@ -1,0 +1,138 @@
+{
+  "summary": "PathSwitchRequest, RAN-UE=3",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 25,
+    "label": "PathSwitchRequest",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 100,
+          "label": "SourceAMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 121,
+          "label": "UserLocationInformation",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "nr": {
+            "nr_cgi": {
+              "plmn_id": {
+                "mcc": "001",
+                "mnc": "01"
+              },
+              "nr_cell_identity": "000000010"
+            },
+            "tai": {
+              "plmn_id": {
+                "mcc": "001",
+                "mnc": "01"
+              },
+              "tac": "000001"
+            }
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 119,
+          "label": "UESecurityCapabilities",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "nr_encryption_algorithms": [
+            "NEA1",
+            "NEA2",
+            "NEA3"
+          ],
+          "nr_integrity_protection_algorithms": [
+            "NIA1",
+            "NIA2",
+            "NIA3"
+          ],
+          "eutra_encryption_algorithms": "e000",
+          "eutra_integrity_protection_algorithms": "e000"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 76,
+          "label": "PDUSessionResourceToBeSwitchedDLList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "path_switch_request_transfer": {
+              "dl_ng_u_up_tnl_information": {
+                "gtp_teid": 33,
+                "transport_layer_address": "10.45.0.1"
+              },
+              "qos_flow_accepted": [
+                1
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_confirm_full.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_confirm_full.json
@@ -1,0 +1,113 @@
+{
+  "summary": "PDUSessionResourceModifyIndication, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 27,
+    "label": "PDUSessionResourceModifyIndication",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 62,
+          "label": "PDUSessionResourceModifyListModCfm",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "modify_confirm_transfer": {
+              "qos_flow_modify_confirm": [
+                1
+              ],
+              "ul_ng_u_up_tnl_information": {
+                "gtp_teid": 97,
+                "transport_layer_address": "10.47.0.1"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 131,
+          "label": "PDUSessionResourceFailedToModifyListModCfm",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 2,
+            "cause_transfer": {
+              "cause": {
+                "group": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "radioNetwork",
+                  "unknown": false
+                },
+                "value": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "unspecified",
+                  "unknown": false
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_indication_full.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_indication_full.json
@@ -1,0 +1,82 @@
+{
+  "summary": "PDUSessionResourceModifyIndication, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 27,
+    "label": "PDUSessionResourceModifyIndication",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 63,
+          "label": "PDUSessionResourceModifyListModInd",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "modify_indication_transfer": {
+              "dl_qos_flow_per_tnl_information": {
+                "up_transport_layer_information": {
+                  "gtp_teid": 81,
+                  "transport_layer_address": "10.46.0.1"
+                },
+                "associated_qos_flow_list": [
+                  {
+                    "qos_flow_identifier": 1
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_request_full.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_request_full.json
@@ -1,0 +1,137 @@
+{
+  "summary": "PDUSessionResourceModify, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 26,
+    "label": "PDUSessionResourceModify",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 64,
+          "label": "PDUSessionResourceModifyListModReq",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "nas_pdu": {
+              "protocol": "NAS",
+              "raw_hex": "7e0068",
+              "decoded": {
+                "security_header": {
+                  "protocol_discriminator": {
+                    "type": "enum",
+                    "value": 126,
+                    "label": "5GMM",
+                    "unknown": false
+                  },
+                  "security_header_type": {
+                    "type": "enum",
+                    "value": 0,
+                    "label": "plain",
+                    "unknown": false
+                  },
+                  "sequence_number": 0
+                },
+                "gmm_message": {
+                  "gmm_header": {
+                    "message_type": {
+                      "type": "enum",
+                      "value": 104,
+                      "label": "DL NAS TRANSPORT",
+                      "unknown": false
+                    }
+                  }
+                },
+                "encrypted": false
+              }
+            },
+            "modify_request_transfer": {
+              "maximum_bit_rate": {
+                "downlink_n_aggregate_maximum_bit_rate": 200000000,
+                "uplink_n_aggregate_maximum_bit_rate": 100000000,
+                "unit": "bps"
+              },
+              "qos_flow_add_or_modify_request": [
+                {
+                  "qos_flow": {
+                    "qos_id": 1,
+                    "five_qi": 9,
+                    "pri_arp": 8
+                  },
+                  "qos_flow_identifier": 1
+                }
+              ],
+              "qos_flow_to_release": [
+                {
+                  "qos_flow_identifier": 2,
+                  "cause": {
+                    "group": {
+                      "type": "enum",
+                      "value": 0,
+                      "label": "radioNetwork",
+                      "unknown": false
+                    },
+                    "value": {
+                      "type": "enum",
+                      "value": 0,
+                      "label": "unspecified",
+                      "unknown": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_response_full.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_modify_response_full.json
@@ -1,0 +1,154 @@
+{
+  "summary": "PDUSessionResourceModify, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 26,
+    "label": "PDUSessionResourceModify",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 65,
+          "label": "PDUSessionResourceModifyListModRes",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "modify_response_transfer": {
+              "dl_ng_u_up_tnl_information": {
+                "gtp_teid": 65,
+                "transport_layer_address": "10.45.0.1"
+              },
+              "qos_flow_add_or_modify_response": [
+                1
+              ],
+              "qos_flow_failed_to_add_or_modify": [
+                {
+                  "qos_flow_identifier": 2,
+                  "cause": {
+                    "group": {
+                      "type": "enum",
+                      "value": 0,
+                      "label": "radioNetwork",
+                      "unknown": false
+                    },
+                    "value": {
+                      "type": "enum",
+                      "value": 0,
+                      "label": "unspecified",
+                      "unknown": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 54,
+          "label": "PDUSessionResourceFailedToModifyListModRes",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 2,
+            "cause_transfer": {
+              "cause": {
+                "group": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "radioNetwork",
+                  "unknown": false
+                },
+                "value": {
+                  "type": "enum",
+                  "value": 0,
+                  "label": "unspecified",
+                  "unknown": false
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 26,
+            "label": "PDUSessionResourceModify",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_notify_full.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_notify_full.json
@@ -1,0 +1,70 @@
+{
+  "summary": "PDUSessionResourceNotify, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 30,
+    "label": "PDUSessionResourceNotify",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 66,
+          "label": "PDUSessionResourceNotifyList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "pdu_session_id": 1,
+            "transfer_hex": "0102"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/pdu_session_resource_release_command.json
+++ b/internal/decoder/ngap/testdata/golden/pdu_session_resource_release_command.json
@@ -101,6 +101,14 @@
                       },
                       "pdu_session_id": 1,
                       "pti": 4
+                    },
+                    "pdu_session_release_command": {
+                      "cause_5g_s_m": {
+                        "type": "enum",
+                        "value": 0,
+                        "label": "",
+                        "unknown": true
+                      }
                     }
                   }
                 },

--- a/internal/decoder/ngap/testdata/golden/ran_configuration_update_acknowledge_full.json
+++ b/internal/decoder/ngap/testdata/golden/ran_configuration_update_acknowledge_full.json
@@ -1,0 +1,42 @@
+{
+  "summary": "RANConfigurationUpdate",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 35,
+    "label": "RANConfigurationUpdate",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 35,
+            "label": "RANConfigurationUpdate",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/ran_configuration_update_failure_full.json
+++ b/internal/decoder/ngap/testdata/golden/ran_configuration_update_failure_full.json
@@ -1,0 +1,90 @@
+{
+  "summary": "RANConfigurationUpdate, Cause=om-intervention",
+  "pdu_type": "UnsuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 35,
+    "label": "RANConfigurationUpdate",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 15,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 4,
+            "label": "misc",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 3,
+            "label": "om-intervention",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 107,
+          "label": "TimeToWait",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "type": "enum",
+          "value": 3,
+          "label": "v10s",
+          "unknown": false
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 19,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 35,
+            "label": "RANConfigurationUpdate",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/ran_configuration_update_full.json
+++ b/internal/decoder/ngap/testdata/golden/ran_configuration_update_full.json
@@ -1,0 +1,128 @@
+{
+  "summary": "RANConfigurationUpdate",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 35,
+    "label": "RANConfigurationUpdate",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 82,
+          "label": "RANNodeName",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": "gnb01"
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 102,
+          "label": "SupportedTAList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "tac": "000001",
+            "broadcast_plmn_list": [
+              {
+                "plmn_id": {
+                  "mcc": "001",
+                  "mnc": "01"
+                },
+                "slice_support_list": [
+                  {
+                    "sst": 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 21,
+          "label": "DefaultPagingDRX",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "type": "enum",
+          "value": 2,
+          "label": "v128",
+          "unknown": false
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 27,
+          "label": "GlobalRANNodeID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "plmn_identity": {
+            "mcc": "001",
+            "mnc": "01"
+          },
+          "global_gnb_id": "000004"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 167,
+          "label": "NGRAN-TNLAssociationToRemoveList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "tnl_association_transport_layer_address": "10.0.0.1",
+            "tnl_association_transport_layer_address_amf": "10.0.0.2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/uplink_nas_transport.json
+++ b/internal/decoder/ngap/testdata/golden/uplink_nas_transport.json
@@ -101,6 +101,14 @@
                       },
                       "pdu_session_id": 1,
                       "pti": 0
+                    },
+                    "gsm_status": {
+                      "cause_5g_s_m": {
+                        "type": "enum",
+                        "value": 81,
+                        "label": "Invalid PTI value",
+                        "unknown": false
+                      }
                     }
                   }
                 },

--- a/internal/decoder/ngap/testdata/golden/uplink_ran_configuration_transfer_full.json
+++ b/internal/decoder/ngap/testdata/golden/uplink_ran_configuration_transfer_full.json
@@ -1,0 +1,37 @@
+{
+  "summary": "UplinkRANConfigurationTransfer",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 48,
+    "label": "UplinkRANConfigurationTransfer",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 99,
+          "label": "SONConfigurationTransferUL",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "hex": "010203"
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/ngap/testdata/golden/uplink_ran_status_transfer_full.json
+++ b/internal/decoder/ngap/testdata/golden/uplink_ran_status_transfer_full.json
@@ -1,0 +1,65 @@
+{
+  "summary": "UplinkRANStatusTransfer, AMF-UE=7, RAN-UE=3",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 49,
+    "label": "UplinkRANStatusTransfer",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 10,
+          "label": "AMF-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 7
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 85,
+          "label": "RAN-UE-NGAP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 84,
+          "label": "RANStatusTransfer-TransparentContainer",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": "0a0b"
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/config_transfer.go
+++ b/internal/decoder/s1ap/config_transfer.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// SONConfigurationTransfer is the SON container the two eNBs exchange through
+// the MME. Its content is X2AP, opaque to S1AP (TS 36.413 §9.2.3.26).
+type SONConfigurationTransfer struct {
+	Hex string `json:"hex"`
+}
+
+func buildENBConfigurationTransfer(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseENBConfigurationTransfer(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse eNB Configuration Transfer: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if len(m.SONConfigurationTransfer) > 0 {
+		ies = append(ies, ie(s1ap.IDSONConfigurationTransferECT, s1ap.CriticalityIgnore,
+			SONConfigurationTransfer{Hex: hex.EncodeToString(m.SONConfigurationTransfer)}))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, "eNB Configuration Transfer"
+}
+
+func buildMMEConfigurationTransfer(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseMMEConfigurationTransfer(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse MME Configuration Transfer: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if len(m.SONConfigurationTransfer) > 0 {
+		ies = append(ies, ie(s1ap.IDSONConfigurationTransferMCT, s1ap.CriticalityIgnore,
+			SONConfigurationTransfer{Hex: hex.EncodeToString(m.SONConfigurationTransfer)}))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, "MME Configuration Transfer"
+}

--- a/internal/decoder/s1ap/enb_configuration_update.go
+++ b/internal/decoder/s1ap/enb_configuration_update.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/s1ap"
+)
+
+func buildENBConfigurationUpdate(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseENBConfigurationUpdate(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse eNB Configuration Update: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	name := ""
+	if m.ENBName != nil {
+		name = *m.ENBName
+		ies = append(ies, ie(s1ap.IDENBname, s1ap.CriticalityIgnore, name))
+	}
+
+	if len(m.SupportedTAs) > 0 {
+		ies = append(ies, ie(s1ap.IDSupportedTAs, s1ap.CriticalityReject, supportedTAs(m.SupportedTAs)))
+	}
+
+	if m.DefaultPagingDRX != nil {
+		ies = append(ies, ie(s1ap.IDDefaultPagingDRX, s1ap.CriticalityIgnore, pagingDRXToEnum(*m.DefaultPagingDRX)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	if name == "" {
+		return S1APMessageValue{IEs: ies}, "eNB Configuration Update"
+	}
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("eNB Configuration Update (%s)", name)
+}
+
+func buildENBConfigurationUpdateAcknowledge(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseENBConfigurationUpdateAcknowledge(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse eNB Configuration Update Acknowledge: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(s1ap.IDCriticalityDiagnostics, s1ap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, "eNB Configuration Update Acknowledge"
+}
+
+func buildENBConfigurationUpdateFailure(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseENBConfigurationUpdateFailure(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse eNB Configuration Update Failure: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if m.Cause != nil {
+		ies = append(ies, ie(s1ap.IDCause, s1ap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	if m.TimeToWait != nil {
+		ies = append(ies, ie(s1ap.IDTimeToWait, s1ap.CriticalityIgnore, timeToWaitToEnum(*m.TimeToWait)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(s1ap.IDCriticalityDiagnostics, s1ap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, "eNB Configuration Update Failure"
+}

--- a/internal/decoder/s1ap/erab_modify.go
+++ b/internal/decoder/s1ap/erab_modify.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ERABToBeModified is an E-RAB whose QoS the MME asks the eNB to change, with
-// the NAS message that tells the UE about it (TS 36.413 §9.2.1.30).
+// the NAS message that tells the UE about it (TS 36.413 §9.1.3.3).
 type ERABToBeModified struct {
 	ERABID uint8  `json:"erab_id"`
 	QCI    uint8  `json:"qci"`
@@ -18,13 +18,13 @@ type ERABToBeModified struct {
 	NASPDU NASPDU `json:"nas_pdu"`
 }
 
-// ERABModifiedItem is an E-RAB the eNB confirms modified (TS 36.413 §9.2.1.31).
+// ERABModifiedItem is an E-RAB the eNB confirms modified (TS 36.413 §9.1.3.4).
 type ERABModifiedItem struct {
 	ERABID uint8 `json:"erab_id"`
 }
 
 // ERABModifiedTunnel is an E-RAB whose downlink S1-U endpoint the eNB reports,
-// so the MME can move the tunnel (TS 36.413 §9.2.1.32).
+// so the MME can move the tunnel (TS 36.413 §9.1.3.8).
 type ERABModifiedTunnel struct {
 	ERABID                uint8  `json:"erab_id"`
 	TransportLayerAddress string `json:"transport_layer_address"`

--- a/internal/decoder/s1ap/erab_modify.go
+++ b/internal/decoder/s1ap/erab_modify.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// ERABToBeModified is an E-RAB whose QoS the MME asks the eNB to change, with
+// the NAS message that tells the UE about it (TS 36.413 §9.2.1.30).
+type ERABToBeModified struct {
+	ERABID uint8  `json:"erab_id"`
+	QCI    uint8  `json:"qci"`
+	ARP    ARP    `json:"arp"`
+	NASPDU NASPDU `json:"nas_pdu"`
+}
+
+// ERABModifiedItem is an E-RAB the eNB confirms modified (TS 36.413 §9.2.1.31).
+type ERABModifiedItem struct {
+	ERABID uint8 `json:"erab_id"`
+}
+
+// ERABModifiedTunnel is an E-RAB whose downlink S1-U endpoint the eNB reports,
+// so the MME can move the tunnel (TS 36.413 §9.2.1.32).
+type ERABModifiedTunnel struct {
+	ERABID                uint8  `json:"erab_id"`
+	TransportLayerAddress string `json:"transport_layer_address"`
+	DLGTPTEID             uint32 `json:"dl_gtp_teid"`
+}
+
+func erabModifiedTunnels(items []s1ap.ERABToBeModifiedItemBearerModInd) []ERABModifiedTunnel {
+	out := make([]ERABModifiedTunnel, 0, len(items))
+	for _, it := range items {
+		out = append(out, ERABModifiedTunnel{
+			ERABID:                uint8(it.ERABID),
+			TransportLayerAddress: transportLayerAddress(it.TransportLayerAddress),
+			DLGTPTEID:             uint32(it.DLGTPTEID),
+		})
+	}
+
+	return out
+}
+
+func buildERABModifyRequest(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseERABModifyRequest(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse E-RAB Modify Request: %v", err)}, ""
+	}
+
+	erabs := make([]ERABToBeModified, 0, len(m.ERABToBeModified))
+	for _, it := range m.ERABToBeModified {
+		erabs = append(erabs, ERABToBeModified{
+			ERABID: uint8(it.ERABID),
+			QCI:    uint8(it.QoS.QCI),
+			ARP: ARP{
+				PriorityLevel:           it.QoS.ARP.PriorityLevel,
+				PreemptionCapability:    uint8(it.QoS.ARP.PreemptionCapability),
+				PreemptionVulnerability: uint8(it.QoS.ARP.PreemptionVulnerability),
+			},
+			NASPDU: nasPDU(it.NASPDU),
+		})
+	}
+
+	ies := []IE{
+		ie(s1ap.IDMMEUES1APID, s1ap.CriticalityReject, uint32(m.MMEUES1APID)),
+		ie(s1ap.IDENBUES1APID, s1ap.CriticalityReject, uint32(m.ENBUES1APID)),
+	}
+
+	if ambr := m.UEAggregateMaximumBitRate; ambr != nil {
+		ies = append(ies, ie(s1ap.IDUEAggregateMaximumBitrate, s1ap.CriticalityReject, AMBR{DL: uint64(ambr.DL), UL: uint64(ambr.UL)}))
+	}
+
+	ies = append(ies, ie(s1ap.IDERABToBeModifiedListBearerModReq, s1ap.CriticalityReject, erabs))
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("E-RAB Modify Request (MME-UE %d, eNB-UE %d, %d E-RAB)", m.MMEUES1APID, m.ENBUES1APID, len(m.ERABToBeModified))
+}
+
+func buildERABModifyResponse(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseERABModifyResponse(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse E-RAB Modify Response: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if m.MMEUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDMMEUES1APID, s1ap.CriticalityIgnore, uint32(*m.MMEUES1APID)))
+	}
+
+	if m.ENBUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDENBUES1APID, s1ap.CriticalityIgnore, uint32(*m.ENBUES1APID)))
+	}
+
+	if len(m.ERABModify) > 0 {
+		modified := make([]ERABModifiedItem, 0, len(m.ERABModify))
+		for _, it := range m.ERABModify {
+			modified = append(modified, ERABModifiedItem{ERABID: uint8(it.ERABID)})
+		}
+
+		ies = append(ies, ie(s1ap.IDERABModifyListBearerModRes, s1ap.CriticalityIgnore, modified))
+	}
+
+	if len(m.ERABFailedToModify) > 0 {
+		ies = append(ies, ie(s1ap.IDERABFailedToModifyList, s1ap.CriticalityIgnore, erabFailedItems(m.ERABFailedToModify)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(s1ap.IDCriticalityDiagnostics, s1ap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	if m.UserLocationInformation != nil {
+		ies = append(ies, ie(s1ap.IDUserLocationInformation, s1ap.CriticalityIgnore, userLocationInformation(*m.UserLocationInformation)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("E-RAB Modify Response (MME-UE %s, eNB-UE %s, %d E-RAB)", ueIDText(m.MMEUES1APID), ueIDText(m.ENBUES1APID), len(m.ERABModify))
+}
+
+func buildERABModificationIndication(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseERABModificationIndication(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse E-RAB Modification Indication: %v", err)}, ""
+	}
+
+	ies := []IE{
+		ie(s1ap.IDMMEUES1APID, s1ap.CriticalityReject, uint32(m.MMEUES1APID)),
+		ie(s1ap.IDENBUES1APID, s1ap.CriticalityReject, uint32(m.ENBUES1APID)),
+		ie(s1ap.IDERABToBeModifiedListBearerModInd, s1ap.CriticalityReject, erabModifiedTunnels(m.ToBeModified)),
+	}
+
+	if len(m.NotToBeModified) > 0 {
+		ies = append(ies, ie(s1ap.IDERABNotToBeModifiedListBearerModInd, s1ap.CriticalityReject, erabModifiedTunnels(m.NotToBeModified)))
+	}
+
+	if m.UserLocationInformation != nil {
+		ies = append(ies, ie(s1ap.IDUserLocationInformation, s1ap.CriticalityIgnore, userLocationInformation(*m.UserLocationInformation)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("E-RAB Modification Indication (MME-UE %d, eNB-UE %d, %d E-RAB)", m.MMEUES1APID, m.ENBUES1APID, len(m.ToBeModified))
+}
+
+func buildERABModificationConfirm(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseERABModificationConfirm(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse E-RAB Modification Confirm: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if m.MMEUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDMMEUES1APID, s1ap.CriticalityIgnore, uint32(*m.MMEUES1APID)))
+	}
+
+	if m.ENBUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDENBUES1APID, s1ap.CriticalityIgnore, uint32(*m.ENBUES1APID)))
+	}
+
+	if len(m.ModifiedERABs) > 0 {
+		modified := make([]ERABModifiedItem, 0, len(m.ModifiedERABs))
+		for _, id := range m.ModifiedERABs {
+			modified = append(modified, ERABModifiedItem{ERABID: uint8(id)})
+		}
+
+		ies = append(ies, ie(s1ap.IDERABModifyListBearerModConf, s1ap.CriticalityIgnore, modified))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(s1ap.IDCriticalityDiagnostics, s1ap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("E-RAB Modification Confirm (MME-UE %s, eNB-UE %s, %d E-RAB)", ueIDText(m.MMEUES1APID), ueIDText(m.ENBUES1APID), len(m.ModifiedERABs))
+}

--- a/internal/decoder/s1ap/erab_release.go
+++ b/internal/decoder/s1ap/erab_release.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ERABToBeReleasedItem is a decoded E-RAB the MME asks the eNB to release, with
-// the cause it releases it for (TS 36.413 §9.2.1.35).
+// the cause it releases it for (TS 36.413 §9.2.1.36).
 type ERABToBeReleasedItem struct {
 	ERABID uint8 `json:"erab_id"`
 	Cause  Cause `json:"cause"`

--- a/internal/decoder/s1ap/erab_setup.go
+++ b/internal/decoder/s1ap/erab_setup.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ERABToBeSetupBearer is a decoded E-RAB the MME asks the eNB to add for an
-// additional PDN connection (TS 36.413 §9.2.1.2). Unlike the context-setup
+// additional PDN connection (TS 36.413 §9.1.3.1). Unlike the context-setup
 // variant its NAS-PDU is mandatory: it carries the ACTIVATE DEFAULT EPS BEARER
 // CONTEXT REQUEST.
 type ERABToBeSetupBearer struct {

--- a/internal/decoder/s1ap/golden_test.go
+++ b/internal/decoder/s1ap/golden_test.go
@@ -88,6 +88,103 @@ func goldenCorpus(t *testing.T) map[string][]byte {
 		"invalid":                       {0xff, 0x00, 0x01},
 	}
 
+	corpus["erab_modify_request_full"] = mustMarshal(t, &s1ap.ERABModifyRequest{
+		MMEUES1APID:               1,
+		ENBUES1APID:               2,
+		UEAggregateMaximumBitRate: &s1ap.UEAggregateMaximumBitRate{DL: 200000000, UL: 100000000},
+		ERABToBeModified: []s1ap.ERABToBeModifiedItemBearerModReq{{
+			ERABID: 5,
+			QoS:    s1ap.ERABLevelQoSParameters{QCI: 9, ARP: s1ap.AllocationAndRetentionPriority{PriorityLevel: 15}},
+			NASPDU: s1ap.NASPDU{0x07, 0x4b, 0x09},
+		}},
+	})
+
+	corpus["erab_modify_response_full"] = mustMarshal(t, &s1ap.ERABModifyResponse{
+		MMEUES1APID: s1ap.Ptr(s1ap.MMEUES1APID(1)),
+		ENBUES1APID: s1ap.Ptr(s1ap.ENBUES1APID(2)),
+		ERABModify:  []s1ap.ERABModifyItemBearerModRes{{ERABID: 5}},
+		ERABFailedToModify: []s1ap.ERABItem{
+			{ERABID: 6, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 0}},
+		},
+		CriticalityDiagnostics:  &s1ap.CriticalityDiagnostics{ProcedureCode: s1ap.Ptr(s1ap.ProcERABModify)},
+		UserLocationInformation: &s1ap.UserLocationInformation{EUTRANCGI: testCGI, TAI: testTAI},
+	})
+
+	corpus["erab_modification_indication_full"] = mustMarshal(t, &s1ap.ERABModificationIndication{
+		MMEUES1APID: 1,
+		ENBUES1APID: 2,
+		ToBeModified: []s1ap.ERABToBeModifiedItemBearerModInd{
+			{ERABID: 5, TransportLayerAddress: s1ap.TransportLayerAddress{10, 45, 0, 1}, DLGTPTEID: 0x21},
+		},
+		NotToBeModified: []s1ap.ERABToBeModifiedItemBearerModInd{
+			{ERABID: 6, TransportLayerAddress: s1ap.TransportLayerAddress{10, 45, 0, 2}, DLGTPTEID: 0x22},
+		},
+		UserLocationInformation: &s1ap.UserLocationInformation{EUTRANCGI: testCGI, TAI: testTAI},
+	})
+
+	corpus["erab_modification_confirm_full"] = mustMarshal(t, &s1ap.ERABModificationConfirm{
+		MMEUES1APID:            s1ap.Ptr(s1ap.MMEUES1APID(1)),
+		ENBUES1APID:            s1ap.Ptr(s1ap.ENBUES1APID(2)),
+		ModifiedERABs:          []s1ap.ERABID{5, 6},
+		CriticalityDiagnostics: &s1ap.CriticalityDiagnostics{ProcedureCode: s1ap.Ptr(s1ap.ProcERABModificationIndication)},
+	})
+
+	corpus["reset_all_full"] = mustMarshal(t, &s1ap.Reset{
+		Cause:     &s1ap.Cause{Group: s1ap.CauseGroupMisc, Value: s1ap.CauseMiscUnspecified},
+		ResetType: s1ap.ResetType{All: true},
+	})
+
+	corpus["reset_part_full"] = mustMarshal(t, &s1ap.Reset{
+		Cause: &s1ap.Cause{Group: s1ap.CauseGroupTransport, Value: 0},
+		ResetType: s1ap.ResetType{Part: []s1ap.UEAssociatedLogicalS1ConnectionItem{
+			{MMEUES1APID: s1ap.Ptr(s1ap.MMEUES1APID(7)), ENBUES1APID: s1ap.Ptr(s1ap.ENBUES1APID(3))},
+			{ENBUES1APID: s1ap.Ptr(s1ap.ENBUES1APID(4))},
+		}},
+	})
+
+	corpus["reset_acknowledge_full"] = mustMarshal(t, &s1ap.ResetAcknowledge{
+		ConnectionList: []s1ap.UEAssociatedLogicalS1ConnectionItem{
+			{MMEUES1APID: s1ap.Ptr(s1ap.MMEUES1APID(7)), ENBUES1APID: s1ap.Ptr(s1ap.ENBUES1APID(3))},
+		},
+		CriticalityDiagnostics: &s1ap.CriticalityDiagnostics{ProcedureCode: s1ap.Ptr(s1ap.ProcReset)},
+	})
+
+	corpus["path_switch_request_full"] = mustMarshal(t, &s1ap.PathSwitchRequest{
+		ENBUES1APID: 9,
+		ERABToBeSwitchedDL: []s1ap.ERABToBeSwitchedDLItem{
+			{ERABID: 5, TransportLayerAddress: s1ap.TransportLayerAddress{10, 45, 0, 1}, GTPTEID: 0x11},
+		},
+		SourceMMEUES1APID:      4,
+		EUTRANCGI:              s1ap.Ptr(testCGI),
+		TAI:                    s1ap.Ptr(testTAI),
+		UESecurityCapabilities: s1ap.Ptr(s1ap.UESecurityCapabilities{EncryptionAlgorithms: 0xe000, IntegrityProtectionAlgorithms: 0xe000}),
+	})
+
+	corpus["path_switch_request_acknowledge_full"] = mustMarshal(t, &s1ap.PathSwitchRequestAcknowledge{
+		MMEUES1APID:               s1ap.Ptr(s1ap.MMEUES1APID(4)),
+		ENBUES1APID:               s1ap.Ptr(s1ap.ENBUES1APID(9)),
+		UEAggregateMaximumBitRate: &s1ap.UEAggregateMaximumBitRate{DL: 200000000, UL: 100000000},
+		ERABToBeReleased: []s1ap.ERABItem{
+			{ERABID: 6, Cause: s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 0}},
+		},
+		SecurityContext:        s1ap.SecurityContext{NextHopChainingCount: 3, NextHopParameter: s1ap.SecurityKey{0x01, 0x02, 0x03}},
+		UESecurityCapabilities: s1ap.Ptr(s1ap.UESecurityCapabilities{EncryptionAlgorithms: 0xe000, IntegrityProtectionAlgorithms: 0xe000}),
+	})
+
+	corpus["path_switch_request_failure_full"] = mustMarshal(t, &s1ap.PathSwitchRequestFailure{
+		MMEUES1APID:            s1ap.Ptr(s1ap.MMEUES1APID(4)),
+		ENBUES1APID:            s1ap.Ptr(s1ap.ENBUES1APID(9)),
+		Cause:                  &s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 6},
+		CriticalityDiagnostics: &s1ap.CriticalityDiagnostics{ProcedureCode: s1ap.Ptr(s1ap.ProcPathSwitchRequest)},
+	})
+
+	corpus["nas_non_delivery_indication_full"] = mustMarshal(t, &s1ap.NASNonDeliveryIndication{
+		MMEUES1APID: 4,
+		ENBUES1APID: 9,
+		NASPDU:      s1ap.NASPDU{0x07, 0x4b, 0x09},
+		Cause:       &s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: 27},
+	})
+
 	corpus["s1_setup_request_full"] = mustMarshal(t, &s1ap.S1SetupRequest{
 		GlobalENBID: s1ap.GlobalENBID{
 			PLMNIdentity: testPLMN,
@@ -352,15 +449,20 @@ func TestGoldenCoversEveryRenderedProcedure(t *testing.T) {
 			s1ap.ProcENBStatusTransfer, s1ap.ProcMMEStatusTransfer,
 			s1ap.ProcDownlinkUEAssociatedLPPaTransport, s1ap.ProcUplinkUEAssociatedLPPaTransport,
 			s1ap.ProcERABSetup, s1ap.ProcERABRelease,
+			s1ap.ProcReset, s1ap.ProcPathSwitchRequest, s1ap.ProcNASNonDeliveryIndication,
+			s1ap.ProcERABModify, s1ap.ProcERABModificationIndication,
 		},
 		"SuccessfulOutcome": {
 			s1ap.ProcS1Setup, s1ap.ProcInitialContextSetup, s1ap.ProcUEContextRelease,
 			s1ap.ProcHandoverPreparation, s1ap.ProcHandoverResourceAllocation, s1ap.ProcHandoverCancel,
 			s1ap.ProcERABSetup, s1ap.ProcERABRelease,
+			s1ap.ProcReset, s1ap.ProcPathSwitchRequest,
+			s1ap.ProcERABModify, s1ap.ProcERABModificationIndication,
 		},
 		"UnsuccessfulOutcome": {
 			s1ap.ProcS1Setup, s1ap.ProcInitialContextSetup,
 			s1ap.ProcHandoverPreparation, s1ap.ProcHandoverResourceAllocation,
+			s1ap.ProcPathSwitchRequest,
 		},
 	}
 

--- a/internal/decoder/s1ap/golden_test.go
+++ b/internal/decoder/s1ap/golden_test.go
@@ -88,6 +88,38 @@ func goldenCorpus(t *testing.T) map[string][]byte {
 		"invalid":                       {0xff, 0x00, 0x01},
 	}
 
+	corpus["enb_configuration_update_full"] = mustMarshal(t, &s1ap.ENBConfigurationUpdate{
+		ENBName:          s1ap.Ptr("srsenb01"),
+		SupportedTAs:     s1ap.SupportedTAs{{TAC: 1, BroadcastPLMNs: s1ap.BPLMNs{testPLMN}}},
+		DefaultPagingDRX: s1ap.Ptr(s1ap.PagingDRXv128),
+	})
+
+	corpus["enb_configuration_update_acknowledge_full"] = mustMarshal(t, &s1ap.ENBConfigurationUpdateAcknowledge{
+		CriticalityDiagnostics: &s1ap.CriticalityDiagnostics{ProcedureCode: s1ap.Ptr(s1ap.ProcENBConfigurationUpdate)},
+	})
+
+	corpus["enb_configuration_update_failure_full"] = mustMarshal(t, &s1ap.ENBConfigurationUpdateFailure{
+		Cause:                  &s1ap.Cause{Group: s1ap.CauseGroupMisc, Value: s1ap.CauseMiscUnspecified},
+		TimeToWait:             s1ap.Ptr(s1ap.TimeToWaitV10s),
+		CriticalityDiagnostics: &s1ap.CriticalityDiagnostics{ProcedureCode: s1ap.Ptr(s1ap.ProcENBConfigurationUpdate)},
+	})
+
+	corpus["enb_configuration_transfer_full"] = mustMarshal(t, &s1ap.ENBConfigurationTransfer{
+		SONConfigurationTransfer: s1ap.SONConfigurationTransfer{0x01, 0x02, 0x03, 0x04},
+	})
+
+	corpus["mme_configuration_transfer_full"] = mustMarshal(t, &s1ap.MMEConfigurationTransfer{
+		SONConfigurationTransfer: s1ap.SONConfigurationTransfer{0x05, 0x06, 0x07, 0x08},
+	})
+
+	corpus["location_report_full"] = mustMarshal(t, &s1ap.LocationReport{
+		MMEUES1APID: 1,
+		ENBUES1APID: 2,
+		EUTRANCGI:   s1ap.Ptr(testCGI),
+		TAI:         s1ap.Ptr(testTAI),
+		RequestType: &s1ap.RequestType{EventType: s1ap.EventTypeChangeOfServeCell, ReportArea: s1ap.ReportAreaECGI},
+	})
+
 	corpus["erab_modify_request_full"] = mustMarshal(t, &s1ap.ERABModifyRequest{
 		MMEUES1APID:               1,
 		ENBUES1APID:               2,
@@ -370,6 +402,16 @@ func goldenCorpus(t *testing.T) map[string][]byte {
 		t.Fatalf("build LPPa PDU: %v", err)
 	}
 
+	corpus["downlink_non_ue_associated_lppa_transport_full"] = mustMarshal(t, &s1ap.DownlinkNonUEAssociatedLPPaTransport{
+		RoutingID: 3,
+		LPPaPDU:   lppaPDU,
+	})
+
+	corpus["uplink_non_ue_associated_lppa_transport_full"] = mustMarshal(t, &s1ap.UplinkNonUEAssociatedLPPaTransport{
+		RoutingID: 3,
+		LPPaPDU:   lppaPDU,
+	})
+
 	corpus["downlink_ue_associated_lppa_transport"] = mustMarshal(t, &s1ap.DownlinkUEAssociatedLPPaTransport{
 		MMEUES1APID: 5,
 		ENBUES1APID: 7,
@@ -451,6 +493,9 @@ func TestGoldenCoversEveryRenderedProcedure(t *testing.T) {
 			s1ap.ProcERABSetup, s1ap.ProcERABRelease,
 			s1ap.ProcReset, s1ap.ProcPathSwitchRequest, s1ap.ProcNASNonDeliveryIndication,
 			s1ap.ProcERABModify, s1ap.ProcERABModificationIndication,
+			s1ap.ProcENBConfigurationUpdate, s1ap.ProcENBConfigurationTransfer,
+			s1ap.ProcMMEConfigurationTransfer, s1ap.ProcLocationReport,
+			s1ap.ProcDownlinkNonUEAssociatedLPPaTransport, s1ap.ProcUplinkNonUEAssociatedLPPaTransport,
 		},
 		"SuccessfulOutcome": {
 			s1ap.ProcS1Setup, s1ap.ProcInitialContextSetup, s1ap.ProcUEContextRelease,
@@ -458,11 +503,12 @@ func TestGoldenCoversEveryRenderedProcedure(t *testing.T) {
 			s1ap.ProcERABSetup, s1ap.ProcERABRelease,
 			s1ap.ProcReset, s1ap.ProcPathSwitchRequest,
 			s1ap.ProcERABModify, s1ap.ProcERABModificationIndication,
+			s1ap.ProcENBConfigurationUpdate,
 		},
 		"UnsuccessfulOutcome": {
 			s1ap.ProcS1Setup, s1ap.ProcInitialContextSetup,
 			s1ap.ProcHandoverPreparation, s1ap.ProcHandoverResourceAllocation,
-			s1ap.ProcPathSwitchRequest,
+			s1ap.ProcPathSwitchRequest, s1ap.ProcENBConfigurationUpdate,
 		},
 	}
 

--- a/internal/decoder/s1ap/location_report.go
+++ b/internal/decoder/s1ap/location_report.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/decoder/utils"
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// RequestType is what the MME asked the eNB to report and over what area
+// (TS 36.413 §9.2.1.35).
+type RequestType struct {
+	EventType  utils.EnumField `json:"event_type"`
+	ReportArea utils.EnumField `json:"report_area"`
+}
+
+func requestType(r s1ap.RequestType) RequestType {
+	return RequestType{
+		EventType:  utils.NamedEnum(uint8(r.EventType), r.EventType.Name()),
+		ReportArea: utils.NamedEnum(uint8(r.ReportArea), r.ReportArea.Name()),
+	}
+}
+
+func buildLocationReport(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseLocationReport(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Location Report: %v", err)}, ""
+	}
+
+	ies := []IE{
+		ie(s1ap.IDMMEUES1APID, s1ap.CriticalityReject, uint32(m.MMEUES1APID)),
+		ie(s1ap.IDENBUES1APID, s1ap.CriticalityReject, uint32(m.ENBUES1APID)),
+	}
+
+	if m.EUTRANCGI != nil {
+		ies = append(ies, ie(s1ap.IDEUTRANCGI, s1ap.CriticalityIgnore, eutranCGI(*m.EUTRANCGI)))
+	}
+
+	if m.TAI != nil {
+		ies = append(ies, ie(s1ap.IDTAI, s1ap.CriticalityIgnore, tai(*m.TAI)))
+	}
+
+	if m.RequestType != nil {
+		ies = append(ies, ie(s1ap.IDRequestType, s1ap.CriticalityIgnore, requestType(*m.RequestType)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("Location Report (MME-UE %d, eNB-UE %d)", m.MMEUES1APID, m.ENBUES1APID)
+}

--- a/internal/decoder/s1ap/lppa_transport.go
+++ b/internal/decoder/s1ap/lppa_transport.go
@@ -124,6 +124,37 @@ func buildUplinkUEAssociatedLPPaTransport(value []byte) (S1APMessageValue, strin
 		fmt.Sprintf("Uplink UE Associated LPPa Transport (MME-UE %d, eNB-UE %d)", m.MMEUES1APID, m.ENBUES1APID)
 }
 
+func buildDownlinkNonUEAssociatedLPPaTransport(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseDownlinkNonUEAssociatedLPPaTransport(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Downlink Non UE Associated LPPa Transport: %v", err)}, ""
+	}
+
+	return nonUEAssociatedLPPaTransportValue(m.RoutingID, m.LPPaPDU, m.UnknownIEs()),
+		fmt.Sprintf("Downlink Non UE Associated LPPa Transport (routing %d)", m.RoutingID)
+}
+
+func buildUplinkNonUEAssociatedLPPaTransport(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseUplinkNonUEAssociatedLPPaTransport(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Uplink Non UE Associated LPPa Transport: %v", err)}, ""
+	}
+
+	return nonUEAssociatedLPPaTransportValue(m.RoutingID, m.LPPaPDU, m.UnknownIEs()),
+		fmt.Sprintf("Uplink Non UE Associated LPPa Transport (routing %d)", m.RoutingID)
+}
+
+// The non-UE-associated transports carry no S1AP UE ids: the routing id alone
+// names the E-SMLC the LPPa PDU belongs to (TS 36.413 §9.1.19.3).
+func nonUEAssociatedLPPaTransportValue(routing s1ap.RoutingID, pdu s1ap.LPPaPDU, unknown []s1ap.RawIE) S1APMessageValue {
+	ies := []IE{
+		ie(s1ap.IDRoutingID, s1ap.CriticalityReject, uint8(routing)),
+		ie(s1ap.IDLPPaPDU, s1ap.CriticalityReject, decodeLPPaPDU(pdu)),
+	}
+
+	return S1APMessageValue{IEs: appendUnknownIEs(ies, unknown)}
+}
+
 func lppaTransportValue(mmeID s1ap.MMEUES1APID, enbID s1ap.ENBUES1APID, routing s1ap.RoutingID, pdu s1ap.LPPaPDU, unknown []s1ap.RawIE) S1APMessageValue {
 	ies := []IE{
 		ie(s1ap.IDMMEUES1APID, s1ap.CriticalityReject, uint32(mmeID)),

--- a/internal/decoder/s1ap/path_switch.go
+++ b/internal/decoder/s1ap/path_switch.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// ERABToBeSwitchedDL is an E-RAB whose downlink GTP endpoint the target eNB asks
+// the MME to switch to it (TS 36.413 §9.2.1.53).
+type ERABToBeSwitchedDL struct {
+	ERABID                uint8  `json:"erab_id"`
+	TransportLayerAddress string `json:"transport_layer_address"`
+	GTPTEID               uint32 `json:"gtp_teid"`
+}
+
+func buildPathSwitchRequest(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParsePathSwitchRequest(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Path Switch Request: %v", err)}, ""
+	}
+
+	switched := make([]ERABToBeSwitchedDL, 0, len(m.ERABToBeSwitchedDL))
+	for _, it := range m.ERABToBeSwitchedDL {
+		switched = append(switched, ERABToBeSwitchedDL{
+			ERABID:                uint8(it.ERABID),
+			TransportLayerAddress: transportLayerAddress(it.TransportLayerAddress),
+			GTPTEID:               uint32(it.GTPTEID),
+		})
+	}
+
+	ies := []IE{
+		ie(s1ap.IDENBUES1APID, s1ap.CriticalityReject, uint32(m.ENBUES1APID)),
+		ie(s1ap.IDERABToBeSwitchedDLList, s1ap.CriticalityReject, switched),
+		ie(s1ap.IDSourceMMEUES1APID, s1ap.CriticalityReject, uint32(m.SourceMMEUES1APID)),
+	}
+
+	if m.EUTRANCGI != nil {
+		ies = append(ies, ie(s1ap.IDEUTRANCGI, s1ap.CriticalityIgnore, eutranCGI(*m.EUTRANCGI)))
+	}
+
+	if m.TAI != nil {
+		ies = append(ies, ie(s1ap.IDTAI, s1ap.CriticalityIgnore, tai(*m.TAI)))
+	}
+
+	if m.UESecurityCapabilities != nil {
+		ies = append(ies, ie(s1ap.IDUESecurityCapabilities, s1ap.CriticalityIgnore, UESecurityCapabilities{
+			EncryptionAlgorithms:          securityAlgorithms(m.UESecurityCapabilities.EncryptionAlgorithms, "EEA"),
+			IntegrityProtectionAlgorithms: securityAlgorithms(m.UESecurityCapabilities.IntegrityProtectionAlgorithms, "EIA"),
+		}))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("Path Switch Request (eNB-UE %d, source MME-UE %d, %d E-RAB)", m.ENBUES1APID, m.SourceMMEUES1APID, len(m.ERABToBeSwitchedDL))
+}
+
+func buildPathSwitchRequestAcknowledge(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParsePathSwitchRequestAcknowledge(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Path Switch Request Acknowledge: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if m.MMEUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDMMEUES1APID, s1ap.CriticalityIgnore, uint32(*m.MMEUES1APID)))
+	}
+
+	if m.ENBUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDENBUES1APID, s1ap.CriticalityIgnore, uint32(*m.ENBUES1APID)))
+	}
+
+	if ambr := m.UEAggregateMaximumBitRate; ambr != nil {
+		ies = append(ies, ie(s1ap.IDUEAggregateMaximumBitrate, s1ap.CriticalityIgnore, AMBR{DL: uint64(ambr.DL), UL: uint64(ambr.UL)}))
+	}
+
+	if len(m.ERABToBeReleased) > 0 {
+		ies = append(ies, ie(s1ap.IDERABToBeReleasedList, s1ap.CriticalityIgnore, erabFailedItems(m.ERABToBeReleased)))
+	}
+
+	ies = append(ies, ie(s1ap.IDSecurityContext, s1ap.CriticalityReject, securityContext(m.SecurityContext)))
+
+	if m.UESecurityCapabilities != nil {
+		ies = append(ies, ie(s1ap.IDUESecurityCapabilities, s1ap.CriticalityIgnore, UESecurityCapabilities{
+			EncryptionAlgorithms:          securityAlgorithms(m.UESecurityCapabilities.EncryptionAlgorithms, "EEA"),
+			IntegrityProtectionAlgorithms: securityAlgorithms(m.UESecurityCapabilities.IntegrityProtectionAlgorithms, "EIA"),
+		}))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("Path Switch Request Acknowledge (MME-UE %s, eNB-UE %s)", ueIDText(m.MMEUES1APID), ueIDText(m.ENBUES1APID))
+}
+
+func buildPathSwitchRequestFailure(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParsePathSwitchRequestFailure(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Path Switch Request Failure: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if m.MMEUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDMMEUES1APID, s1ap.CriticalityIgnore, uint32(*m.MMEUES1APID)))
+	}
+
+	if m.ENBUES1APID != nil {
+		ies = append(ies, ie(s1ap.IDENBUES1APID, s1ap.CriticalityIgnore, uint32(*m.ENBUES1APID)))
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(s1ap.IDCause, s1ap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(s1ap.IDCriticalityDiagnostics, s1ap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("Path Switch Request Failure (MME-UE %s, eNB-UE %s)", ueIDText(m.MMEUES1APID), ueIDText(m.ENBUES1APID))
+}
+
+func buildNASNonDeliveryIndication(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseNASNonDeliveryIndication(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse NAS Non Delivery Indication: %v", err)}, ""
+	}
+
+	ies := []IE{
+		ie(s1ap.IDMMEUES1APID, s1ap.CriticalityReject, uint32(m.MMEUES1APID)),
+		ie(s1ap.IDENBUES1APID, s1ap.CriticalityReject, uint32(m.ENBUES1APID)),
+		ie(s1ap.IDNASPDU, s1ap.CriticalityIgnore, nasPDU(m.NASPDU)),
+	}
+
+	if m.Cause != nil {
+		ies = append(ies, ie(s1ap.IDCause, s1ap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("NAS Non Delivery Indication (MME-UE %d, eNB-UE %d)", m.MMEUES1APID, m.ENBUES1APID)
+}

--- a/internal/decoder/s1ap/path_switch.go
+++ b/internal/decoder/s1ap/path_switch.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ERABToBeSwitchedDL is an E-RAB whose downlink GTP endpoint the target eNB asks
-// the MME to switch to it (TS 36.413 §9.2.1.53).
+// the MME to switch to it (TS 36.413 §9.1.5.8).
 type ERABToBeSwitchedDL struct {
 	ERABID                uint8  `json:"erab_id"`
 	TransportLayerAddress string `json:"transport_layer_address"`

--- a/internal/decoder/s1ap/reset.go
+++ b/internal/decoder/s1ap/reset.go
@@ -10,14 +10,14 @@ import (
 )
 
 // UEAssociatedLogicalS1Connection names one UE-associated logical S1 connection
-// (TS 36.413 §9.2.3.19). Either identity may be absent: the sender names the
+// (TS 36.413 §9.1.8.1). Either identity may be absent: the sender names the
 // connection with whichever ids it holds.
 type UEAssociatedLogicalS1Connection struct {
 	MMEUES1APID *uint32 `json:"mme_ue_s1ap_id,omitempty"`
 	ENBUES1APID *uint32 `json:"enb_ue_s1ap_id,omitempty"`
 }
 
-// ResetType selects what the RESET covers (TS 36.413 §9.2.1.51): the whole S1
+// ResetType selects what the RESET covers (TS 36.413 §9.1.8.1): the whole S1
 // interface, or the listed UE-associated logical S1 connections.
 type ResetType struct {
 	S1Interface bool                              `json:"s1_interface,omitempty"`

--- a/internal/decoder/s1ap/reset.go
+++ b/internal/decoder/s1ap/reset.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/s1ap"
+)
+
+// UEAssociatedLogicalS1Connection names one UE-associated logical S1 connection
+// (TS 36.413 §9.2.3.19). Either identity may be absent: the sender names the
+// connection with whichever ids it holds.
+type UEAssociatedLogicalS1Connection struct {
+	MMEUES1APID *uint32 `json:"mme_ue_s1ap_id,omitempty"`
+	ENBUES1APID *uint32 `json:"enb_ue_s1ap_id,omitempty"`
+}
+
+// ResetType selects what the RESET covers (TS 36.413 §9.2.1.51): the whole S1
+// interface, or the listed UE-associated logical S1 connections.
+type ResetType struct {
+	S1Interface bool                              `json:"s1_interface,omitempty"`
+	PartOfS1    []UEAssociatedLogicalS1Connection `json:"part_of_s1_interface,omitempty"`
+}
+
+func ueAssociatedConnections(items []s1ap.UEAssociatedLogicalS1ConnectionItem) []UEAssociatedLogicalS1Connection {
+	out := make([]UEAssociatedLogicalS1Connection, 0, len(items))
+
+	for _, it := range items {
+		var c UEAssociatedLogicalS1Connection
+
+		if it.MMEUES1APID != nil {
+			v := uint32(*it.MMEUES1APID)
+			c.MMEUES1APID = &v
+		}
+
+		if it.ENBUES1APID != nil {
+			v := uint32(*it.ENBUES1APID)
+			c.ENBUES1APID = &v
+		}
+
+		out = append(out, c)
+	}
+
+	return out
+}
+
+func buildReset(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseReset(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Reset: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if m.Cause != nil {
+		ies = append(ies, ie(s1ap.IDCause, s1ap.CriticalityIgnore, cause(*m.Cause)))
+	}
+
+	rt := ResetType{S1Interface: m.ResetType.All}
+	if !m.ResetType.All {
+		rt.PartOfS1 = ueAssociatedConnections(m.ResetType.Part)
+	}
+
+	ies = append(ies, ie(s1ap.IDResetType, s1ap.CriticalityReject, rt))
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	scope := fmt.Sprintf("%d connection(s)", len(m.ResetType.Part))
+	if m.ResetType.All {
+		scope = "whole S1 interface"
+	}
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("Reset (%s)", scope)
+}
+
+func buildResetAcknowledge(value []byte) (S1APMessageValue, string) {
+	m, err := s1ap.ParseResetAcknowledge(value)
+	if err != nil {
+		return S1APMessageValue{Error: fmt.Sprintf("parse Reset Acknowledge: %v", err)}, ""
+	}
+
+	var ies []IE
+
+	if len(m.ConnectionList) > 0 {
+		ies = append(ies, ie(s1ap.IDUEAssociatedLogicalS1ConnectionListResAck, s1ap.CriticalityIgnore, ueAssociatedConnections(m.ConnectionList)))
+	}
+
+	if m.CriticalityDiagnostics != nil {
+		ies = append(ies, ie(s1ap.IDCriticalityDiagnostics, s1ap.CriticalityIgnore, criticalityDiagnostics(*m.CriticalityDiagnostics)))
+	}
+
+	ies = appendUnknownIEs(ies, m.UnknownIEs())
+
+	return S1APMessageValue{IEs: ies}, fmt.Sprintf("Reset Acknowledge (%d connection(s))", len(m.ConnectionList))
+}

--- a/internal/decoder/s1ap/s1ap.go
+++ b/internal/decoder/s1ap/s1ap.go
@@ -100,6 +100,18 @@ func decodeInitiatingMessage(m *s1ap.InitiatingMessage) S1APMessage {
 		msg.Value, msg.Summary = buildERABModifyRequest(m.Value)
 	case s1ap.ProcERABModificationIndication:
 		msg.Value, msg.Summary = buildERABModificationIndication(m.Value)
+	case s1ap.ProcENBConfigurationUpdate:
+		msg.Value, msg.Summary = buildENBConfigurationUpdate(m.Value)
+	case s1ap.ProcENBConfigurationTransfer:
+		msg.Value, msg.Summary = buildENBConfigurationTransfer(m.Value)
+	case s1ap.ProcMMEConfigurationTransfer:
+		msg.Value, msg.Summary = buildMMEConfigurationTransfer(m.Value)
+	case s1ap.ProcLocationReport:
+		msg.Value, msg.Summary = buildLocationReport(m.Value)
+	case s1ap.ProcDownlinkNonUEAssociatedLPPaTransport:
+		msg.Value, msg.Summary = buildDownlinkNonUEAssociatedLPPaTransport(m.Value)
+	case s1ap.ProcUplinkNonUEAssociatedLPPaTransport:
+		msg.Value, msg.Summary = buildUplinkNonUEAssociatedLPPaTransport(m.Value)
 	case s1ap.ProcPaging:
 		msg.Value, msg.Summary = buildPaging(m.Value)
 	case s1ap.ProcErrorIndication:
@@ -153,6 +165,8 @@ func decodeSuccessfulOutcome(m *s1ap.SuccessfulOutcome) S1APMessage {
 		msg.Value, msg.Summary = buildERABModifyResponse(m.Value)
 	case s1ap.ProcERABModificationIndication:
 		msg.Value, msg.Summary = buildERABModificationConfirm(m.Value)
+	case s1ap.ProcENBConfigurationUpdate:
+		msg.Value, msg.Summary = buildENBConfigurationUpdateAcknowledge(m.Value)
 	case s1ap.ProcHandoverPreparation:
 		msg.Value, msg.Summary = buildHandoverCommand(m.Value)
 	case s1ap.ProcHandoverResourceAllocation:
@@ -184,6 +198,8 @@ func decodeUnsuccessfulOutcome(m *s1ap.UnsuccessfulOutcome) S1APMessage {
 		msg.Value, msg.Summary = buildHandoverFailure(m.Value)
 	case s1ap.ProcPathSwitchRequest:
 		msg.Value, msg.Summary = buildPathSwitchRequestFailure(m.Value)
+	case s1ap.ProcENBConfigurationUpdate:
+		msg.Value, msg.Summary = buildENBConfigurationUpdateFailure(m.Value)
 	default:
 		msg.Value = unsupportedProcedure(m.ProcedureCode)
 	}

--- a/internal/decoder/s1ap/s1ap.go
+++ b/internal/decoder/s1ap/s1ap.go
@@ -90,6 +90,16 @@ func decodeInitiatingMessage(m *s1ap.InitiatingMessage) S1APMessage {
 		msg.Value, msg.Summary = buildERABSetupRequest(m.Value)
 	case s1ap.ProcERABRelease:
 		msg.Value, msg.Summary = buildERABReleaseCommand(m.Value)
+	case s1ap.ProcReset:
+		msg.Value, msg.Summary = buildReset(m.Value)
+	case s1ap.ProcPathSwitchRequest:
+		msg.Value, msg.Summary = buildPathSwitchRequest(m.Value)
+	case s1ap.ProcNASNonDeliveryIndication:
+		msg.Value, msg.Summary = buildNASNonDeliveryIndication(m.Value)
+	case s1ap.ProcERABModify:
+		msg.Value, msg.Summary = buildERABModifyRequest(m.Value)
+	case s1ap.ProcERABModificationIndication:
+		msg.Value, msg.Summary = buildERABModificationIndication(m.Value)
 	case s1ap.ProcPaging:
 		msg.Value, msg.Summary = buildPaging(m.Value)
 	case s1ap.ProcErrorIndication:
@@ -135,6 +145,14 @@ func decodeSuccessfulOutcome(m *s1ap.SuccessfulOutcome) S1APMessage {
 		msg.Value, msg.Summary = buildERABSetupResponse(m.Value)
 	case s1ap.ProcERABRelease:
 		msg.Value, msg.Summary = buildERABReleaseResponse(m.Value)
+	case s1ap.ProcReset:
+		msg.Value, msg.Summary = buildResetAcknowledge(m.Value)
+	case s1ap.ProcPathSwitchRequest:
+		msg.Value, msg.Summary = buildPathSwitchRequestAcknowledge(m.Value)
+	case s1ap.ProcERABModify:
+		msg.Value, msg.Summary = buildERABModifyResponse(m.Value)
+	case s1ap.ProcERABModificationIndication:
+		msg.Value, msg.Summary = buildERABModificationConfirm(m.Value)
 	case s1ap.ProcHandoverPreparation:
 		msg.Value, msg.Summary = buildHandoverCommand(m.Value)
 	case s1ap.ProcHandoverResourceAllocation:
@@ -164,6 +182,8 @@ func decodeUnsuccessfulOutcome(m *s1ap.UnsuccessfulOutcome) S1APMessage {
 		msg.Value, msg.Summary = buildHandoverPreparationFailure(m.Value)
 	case s1ap.ProcHandoverResourceAllocation:
 		msg.Value, msg.Summary = buildHandoverFailure(m.Value)
+	case s1ap.ProcPathSwitchRequest:
+		msg.Value, msg.Summary = buildPathSwitchRequestFailure(m.Value)
 	default:
 		msg.Value = unsupportedProcedure(m.ProcedureCode)
 	}

--- a/internal/decoder/s1ap/testdata/golden/downlink_non_ue_associated_lppa_transport_full.json
+++ b/internal/decoder/s1ap/testdata/golden/downlink_non_ue_associated_lppa_transport_full.json
@@ -1,0 +1,57 @@
+{
+  "summary": "Downlink Non UE Associated LPPa Transport (routing 3)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 46,
+    "label": "DownlinkNonUEAssociatedLPPaTransport",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 148,
+          "label": "Routing-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 147,
+          "label": "LPPa-PDU",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "protocol": "LPPa",
+          "raw_hex": "00020000001c000003000200015000030001000005000b04000b000100000b000110",
+          "decoded": {
+            "kind": "E-CIDMeasurementInitiationRequest",
+            "esmlc_ue_measurement_id": 11
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/enb_configuration_transfer_full.json
+++ b/internal/decoder/s1ap/testdata/golden/enb_configuration_transfer_full.json
@@ -1,0 +1,37 @@
+{
+  "summary": "eNB Configuration Transfer",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 40,
+    "label": "ENBConfigurationTransfer",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 129,
+          "label": "SONConfigurationTransferECT",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "hex": "01020304"
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/enb_configuration_update_acknowledge_full.json
+++ b/internal/decoder/s1ap/testdata/golden/enb_configuration_update_acknowledge_full.json
@@ -1,0 +1,42 @@
+{
+  "summary": "eNB Configuration Update Acknowledge",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 29,
+    "label": "ENBConfigurationUpdate",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 58,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 29,
+            "label": "ENBConfigurationUpdate",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/enb_configuration_update_failure_full.json
+++ b/internal/decoder/s1ap/testdata/golden/enb_configuration_update_failure_full.json
@@ -1,0 +1,90 @@
+{
+  "summary": "eNB Configuration Update Failure",
+  "pdu_type": "UnsuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 29,
+    "label": "ENBConfigurationUpdate",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 2,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 4,
+            "label": "misc",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 4,
+            "label": "unspecified",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 65,
+          "label": "TimeToWait",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "type": "enum",
+          "value": 3,
+          "label": "v10s",
+          "unknown": false
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 58,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 29,
+            "label": "ENBConfigurationUpdate",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/enb_configuration_update_full.json
+++ b/internal/decoder/s1ap/testdata/golden/enb_configuration_update_full.json
@@ -1,0 +1,80 @@
+{
+  "summary": "eNB Configuration Update (srsenb01)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 29,
+    "label": "ENBConfigurationUpdate",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 60,
+          "label": "eNBname",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": "srsenb01"
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 64,
+          "label": "SupportedTAs",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "tac": 1,
+            "broadcast_plmns": [
+              {
+                "mcc": "001",
+                "mnc": "01"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 137,
+          "label": "DefaultPagingDRX",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "type": "enum",
+          "value": 2,
+          "label": "v128",
+          "unknown": false
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/erab_modification_confirm_full.json
+++ b/internal/decoder/s1ap/testdata/golden/erab_modification_confirm_full.json
@@ -1,0 +1,94 @@
+{
+  "summary": "E-RAB Modification Confirm (MME-UE 1, eNB-UE 2, 2 E-RAB)",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 50,
+    "label": "ERABModificationIndication",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 1
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 2
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 203,
+          "label": "E-RABModifyListBearerModConf",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 5
+          },
+          {
+            "erab_id": 6
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 58,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 50,
+            "label": "ERABModificationIndication",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/erab_modification_indication_full.json
+++ b/internal/decoder/s1ap/testdata/golden/erab_modification_indication_full.json
@@ -1,0 +1,122 @@
+{
+  "summary": "E-RAB Modification Indication (MME-UE 1, eNB-UE 2, 1 E-RAB)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 50,
+    "label": "ERABModificationIndication",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 1
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 2
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 199,
+          "label": "E-RABToBeModifiedListBearerModInd",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 5,
+            "transport_layer_address": "10.45.0.1",
+            "dl_gtp_teid": 33
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 201,
+          "label": "E-RABNotToBeModifiedListBearerModInd",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 6,
+            "transport_layer_address": "10.45.0.2",
+            "dl_gtp_teid": 34
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 189,
+          "label": "UserLocationInformation",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "eutran_cgi": {
+            "plmn_id": {
+              "mcc": "001",
+              "mnc": "01"
+            },
+            "cell_id": "0019b01"
+          },
+          "tai": {
+            "plmn_id": {
+              "mcc": "001",
+              "mnc": "01"
+            },
+            "tac": 1
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/erab_modify_request_full.json
+++ b/internal/decoder/s1ap/testdata/golden/erab_modify_request_full.json
@@ -1,0 +1,132 @@
+{
+  "summary": "E-RAB Modify Request (MME-UE 1, eNB-UE 2, 1 E-RAB)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 6,
+    "label": "ERABModify",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 1
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 2
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 66,
+          "label": "uEaggregateMaximumBitrate",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "dl": 200000000,
+          "ul": 100000000
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 30,
+          "label": "E-RABToBeModifiedListBearerModReq",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 5,
+            "qci": 9,
+            "arp": {
+              "priority_level": 15,
+              "preemption_capability": 0,
+              "preemption_vulnerability": 0
+            },
+            "nas_pdu": {
+              "protocol": "NAS",
+              "raw_hex": "074b09",
+              "decoded": {
+                "security_header": {
+                  "protocol_discriminator": {
+                    "type": "enum",
+                    "value": 7,
+                    "label": "EMM",
+                    "unknown": false
+                  },
+                  "security_header_type": {
+                    "type": "enum",
+                    "value": 0,
+                    "label": "plain",
+                    "unknown": false
+                  }
+                },
+                "emm_message": {
+                  "emm_header": {
+                    "message_type": {
+                      "type": "enum",
+                      "value": 75,
+                      "label": "TRACKING AREA UPDATE REJECT",
+                      "unknown": false
+                    }
+                  },
+                  "tracking_area_update_reject": {
+                    "emm_cause": {
+                      "type": "enum",
+                      "value": 9,
+                      "label": "UE identity cannot be derived by the network",
+                      "unknown": false
+                    }
+                  }
+                },
+                "encrypted": false
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/erab_modify_response_full.json
+++ b/internal/decoder/s1ap/testdata/golden/erab_modify_response_full.json
@@ -1,0 +1,154 @@
+{
+  "summary": "E-RAB Modify Response (MME-UE 1, eNB-UE 2, 1 E-RAB)",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 6,
+    "label": "ERABModify",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 1
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 2
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 31,
+          "label": "E-RABModifyListBearerModRes",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 5
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 32,
+          "label": "E-RABFailedToModifyList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 6,
+            "cause": {
+              "group": {
+                "type": "enum",
+                "value": 0,
+                "label": "radioNetwork",
+                "unknown": false
+              },
+              "value": {
+                "type": "enum",
+                "value": 0,
+                "label": "unspecified",
+                "unknown": false
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 58,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 6,
+            "label": "ERABModify",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 189,
+          "label": "UserLocationInformation",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "eutran_cgi": {
+            "plmn_id": {
+              "mcc": "001",
+              "mnc": "01"
+            },
+            "cell_id": "0019b01"
+          },
+          "tai": {
+            "plmn_id": {
+              "mcc": "001",
+              "mnc": "01"
+            },
+            "tac": 1
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/erab_release_command.json
+++ b/internal/decoder/s1ap/testdata/golden/erab_release_command.json
@@ -121,6 +121,14 @@
                 },
                 "eps_bearer_identity": 6,
                 "procedure_transaction_identity": 189
+              },
+              "deactivate_bearer_request": {
+                "esm_cause": {
+                  "type": "enum",
+                  "value": 36,
+                  "label": "Regular deactivation",
+                  "unknown": false
+                }
               }
             },
             "encrypted": false

--- a/internal/decoder/s1ap/testdata/golden/location_report_full.json
+++ b/internal/decoder/s1ap/testdata/golden/location_report_full.json
@@ -1,0 +1,120 @@
+{
+  "summary": "Location Report (MME-UE 1, eNB-UE 2)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 33,
+    "label": "LocationReport",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 1
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 2
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 100,
+          "label": "EUTRAN-CGI",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "plmn_id": {
+            "mcc": "001",
+            "mnc": "01"
+          },
+          "cell_id": "0019b01"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 67,
+          "label": "TAI",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "plmn_id": {
+            "mcc": "001",
+            "mnc": "01"
+          },
+          "tac": 1
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 98,
+          "label": "RequestType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "event_type": {
+            "type": "enum",
+            "value": 1,
+            "label": "change-of-serve-cell",
+            "unknown": false
+          },
+          "report_area": {
+            "type": "enum",
+            "value": 0,
+            "label": "ecgi",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/mme_configuration_transfer_full.json
+++ b/internal/decoder/s1ap/testdata/golden/mme_configuration_transfer_full.json
@@ -1,0 +1,37 @@
+{
+  "summary": "MME Configuration Transfer",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 41,
+    "label": "MMEConfigurationTransfer",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 130,
+          "label": "SONConfigurationTransferMCT",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "hex": "05060708"
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/nas_non_delivery_indication_full.json
+++ b/internal/decoder/s1ap/testdata/golden/nas_non_delivery_indication_full.json
@@ -1,0 +1,131 @@
+{
+  "summary": "NAS Non Delivery Indication (MME-UE 4, eNB-UE 9)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 16,
+    "label": "NASNonDeliveryIndication",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 4
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 9
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 26,
+          "label": "NAS-PDU",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "protocol": "NAS",
+          "raw_hex": "074b09",
+          "decoded": {
+            "security_header": {
+              "protocol_discriminator": {
+                "type": "enum",
+                "value": 7,
+                "label": "EMM",
+                "unknown": false
+              },
+              "security_header_type": {
+                "type": "enum",
+                "value": 0,
+                "label": "plain",
+                "unknown": false
+              }
+            },
+            "emm_message": {
+              "emm_header": {
+                "message_type": {
+                  "type": "enum",
+                  "value": 75,
+                  "label": "TRACKING AREA UPDATE REJECT",
+                  "unknown": false
+                }
+              },
+              "tracking_area_update_reject": {
+                "emm_cause": {
+                  "type": "enum",
+                  "value": 9,
+                  "label": "UE identity cannot be derived by the network",
+                  "unknown": false
+                }
+              }
+            },
+            "encrypted": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 2,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 27,
+            "label": "invalid-qos-combination",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/path_switch_request_acknowledge_full.json
+++ b/internal/decoder/s1ap/testdata/golden/path_switch_request_acknowledge_full.json
@@ -1,0 +1,145 @@
+{
+  "summary": "Path Switch Request Acknowledge (MME-UE 4, eNB-UE 9)",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 3,
+    "label": "PathSwitchRequest",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 4
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 9
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 66,
+          "label": "uEaggregateMaximumBitrate",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "dl": 200000000,
+          "ul": 100000000
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 33,
+          "label": "E-RABToBeReleasedList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 6,
+            "cause": {
+              "group": {
+                "type": "enum",
+                "value": 0,
+                "label": "radioNetwork",
+                "unknown": false
+              },
+              "value": {
+                "type": "enum",
+                "value": 0,
+                "label": "unspecified",
+                "unknown": false
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 40,
+          "label": "SecurityContext",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "next_hop_chaining_count": 3,
+          "next_hop_parameter": "0102030000000000000000000000000000000000000000000000000000000000"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 107,
+          "label": "UESecurityCapabilities",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "encryption_algorithms": [
+            "EEA1",
+            "EEA2",
+            "EEA3"
+          ],
+          "integrity_protection_algorithms": [
+            "EIA1",
+            "EIA2",
+            "EIA3"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/path_switch_request_failure_full.json
+++ b/internal/decoder/s1ap/testdata/golden/path_switch_request_failure_full.json
@@ -1,0 +1,100 @@
+{
+  "summary": "Path Switch Request Failure (MME-UE 4, eNB-UE 9)",
+  "pdu_type": "UnsuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 3,
+    "label": "PathSwitchRequest",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 0,
+          "label": "MME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 4
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": 9
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 2,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 0,
+            "label": "radioNetwork",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 6,
+            "label": "ho-failure-in-target-EPC-eNB-or-target-system",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 58,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 3,
+            "label": "PathSwitchRequest",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/path_switch_request_full.json
+++ b/internal/decoder/s1ap/testdata/golden/path_switch_request_full.json
@@ -1,0 +1,139 @@
+{
+  "summary": "Path Switch Request (eNB-UE 9, source MME-UE 4, 1 E-RAB)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 3,
+    "label": "PathSwitchRequest",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 8,
+          "label": "eNB-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 9
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 22,
+          "label": "E-RABToBeSwitchedDLList",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": [
+          {
+            "erab_id": 5,
+            "transport_layer_address": "10.45.0.1",
+            "gtp_teid": 17
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 88,
+          "label": "SourceMME-UE-S1AP-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 4
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 100,
+          "label": "EUTRAN-CGI",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "plmn_id": {
+            "mcc": "001",
+            "mnc": "01"
+          },
+          "cell_id": "0019b01"
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 67,
+          "label": "TAI",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "plmn_id": {
+            "mcc": "001",
+            "mnc": "01"
+          },
+          "tac": 1
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 107,
+          "label": "UESecurityCapabilities",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "encryption_algorithms": [
+            "EEA1",
+            "EEA2",
+            "EEA3"
+          ],
+          "integrity_protection_algorithms": [
+            "EIA1",
+            "EIA2",
+            "EIA3"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/reset_acknowledge_full.json
+++ b/internal/decoder/s1ap/testdata/golden/reset_acknowledge_full.json
@@ -1,0 +1,62 @@
+{
+  "summary": "Reset Acknowledge (1 connection(s))",
+  "pdu_type": "SuccessfulOutcome",
+  "procedure_code": {
+    "type": "enum",
+    "value": 14,
+    "label": "Reset",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 93,
+          "label": "UE-associatedLogicalS1-ConnectionListResAck",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": [
+          {
+            "mme_ue_s1ap_id": 7,
+            "enb_ue_s1ap_id": 3
+          }
+        ]
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 58,
+          "label": "CriticalityDiagnostics",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "procedure_code": {
+            "type": "enum",
+            "value": 14,
+            "label": "Reset",
+            "unknown": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/reset_all_full.json
+++ b/internal/decoder/s1ap/testdata/golden/reset_all_full.json
@@ -1,0 +1,65 @@
+{
+  "summary": "Reset (whole S1 interface)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 14,
+    "label": "Reset",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 2,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 4,
+            "label": "misc",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 4,
+            "label": "unspecified",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 92,
+          "label": "ResetType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "s1_interface": true
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/reset_part_full.json
+++ b/internal/decoder/s1ap/testdata/golden/reset_part_full.json
@@ -1,0 +1,73 @@
+{
+  "summary": "Reset (2 connection(s))",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 14,
+    "label": "Reset",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 0,
+    "label": "reject",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 2,
+          "label": "Cause",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 1,
+          "label": "ignore",
+          "unknown": false
+        },
+        "value": {
+          "group": {
+            "type": "enum",
+            "value": 1,
+            "label": "transport",
+            "unknown": false
+          },
+          "value": {
+            "type": "enum",
+            "value": 0,
+            "label": "transport-resource-unavailable",
+            "unknown": false
+          }
+        }
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 92,
+          "label": "ResetType",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "part_of_s1_interface": [
+            {
+              "mme_ue_s1ap_id": 7,
+              "enb_ue_s1ap_id": 3
+            },
+            {
+              "enb_ue_s1ap_id": 4
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/s1ap/testdata/golden/uplink_non_ue_associated_lppa_transport_full.json
+++ b/internal/decoder/s1ap/testdata/golden/uplink_non_ue_associated_lppa_transport_full.json
@@ -1,0 +1,57 @@
+{
+  "summary": "Uplink Non UE Associated LPPa Transport (routing 3)",
+  "pdu_type": "InitiatingMessage",
+  "procedure_code": {
+    "type": "enum",
+    "value": 47,
+    "label": "UplinkNonUEAssociatedLPPaTransport",
+    "unknown": false
+  },
+  "criticality": {
+    "type": "enum",
+    "value": 1,
+    "label": "ignore",
+    "unknown": false
+  },
+  "value": {
+    "ies": [
+      {
+        "id": {
+          "type": "enum",
+          "value": 148,
+          "label": "Routing-ID",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": 3
+      },
+      {
+        "id": {
+          "type": "enum",
+          "value": 147,
+          "label": "LPPa-PDU",
+          "unknown": false
+        },
+        "criticality": {
+          "type": "enum",
+          "value": 0,
+          "label": "reject",
+          "unknown": false
+        },
+        "value": {
+          "protocol": "LPPa",
+          "raw_hex": "00020000001c000003000200015000030001000005000b04000b000100000b000110",
+          "decoded": {
+            "kind": "E-CIDMeasurementInitiationRequest",
+            "esmlc_ue_measurement_id": 11
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/decoder/utils/coverage_test.go
+++ b/internal/decoder/utils/coverage_test.go
@@ -135,8 +135,12 @@ func readsPerMessage(files []*ast.File) map[string]map[string]bool {
 				continue
 			}
 
-			if strings.HasPrefix(fn.Name.Name, "build") {
-				add(strings.TrimPrefix(fn.Name.Name, "build"), selectorNames(fn.Body))
+			// A decoder names a message builder build<Message>, or lib<Message>
+			// where it renders a container carried inside another message.
+			for _, prefix := range []string{"build", "lib"} {
+				if strings.HasPrefix(fn.Name.Name, prefix) {
+					add(strings.TrimPrefix(fn.Name.Name, prefix), selectorNames(fn.Body))
+				}
 			}
 
 			for _, sw := range typeSwitches(fn.Body) {

--- a/internal/decoder/utils/coverage_test.go
+++ b/internal/decoder/utils/coverage_test.go
@@ -18,17 +18,23 @@ import (
 // check is reachability rather than name matching, because a decoder is free to
 // render a field under another name or at another level — the EPS bearer
 // identity, for one, is rendered on the ESM header rather than per message.
+var codecPairs = []struct {
+	decoder string
+	codec   string
+}{
+	{"../ngap", "../../../ngap"},
+	{"../s1ap", "../../../s1ap"},
+	{"../nas/fgs", "../../../nas/fgs"},
+	{"../nas/eps", "../../../nas/eps"},
+}
+
+func pairName(decoder string) string {
+	return strings.ReplaceAll(strings.TrimPrefix(decoder, "../"), "/", "-")
+}
+
 func TestDecodersReadEveryCodecField(t *testing.T) {
-	for _, d := range []struct {
-		decoder string
-		codec   string
-	}{
-		{"../ngap", "../../../ngap"},
-		{"../s1ap", "../../../s1ap"},
-		{"../nas/fgs", "../../../nas/fgs"},
-		{"../nas/eps", "../../../nas/eps"},
-	} {
-		t.Run(strings.ReplaceAll(strings.TrimPrefix(d.decoder, "../"), "/", "-"), func(t *testing.T) {
+	for _, d := range codecPairs {
+		t.Run(pairName(d.decoder), func(t *testing.T) {
 			decoder := parseGoFiles(t, d.decoder)
 			codec := parseGoFiles(t, d.codec)
 
@@ -312,4 +318,61 @@ func exportedFields(files []*ast.File, typeName string) []string {
 	}
 
 	return out
+}
+
+// messageNames are the codec's message types, the set a decoder is expected to
+// build a body for.
+func messageNames(files []*ast.File) []string {
+	var out []string
+
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+
+			if _, ok := ts.Type.(*ast.StructType); !ok {
+				return true
+			}
+
+			if isMessage(files, ts.Name.Name) {
+				out = append(out, ts.Name.Name)
+			}
+
+			return false
+		})
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// A message the codec parses and no decoder builds a body for reaches the API and
+// the UI as a bare header: every element it carried is dropped without trace. The
+// companion check, TestDecodersReadEveryCodecField, only inspects messages a
+// decoder already handles, so it cannot see this.
+func TestDecodersBuildEveryCodecMessage(t *testing.T) {
+	for _, d := range codecPairs {
+		t.Run(pairName(d.decoder), func(t *testing.T) {
+			decoder := parseGoFiles(t, d.decoder)
+			codec := parseGoFiles(t, d.codec)
+
+			read := readsPerMessage(decoder)
+
+			var undecoded []string
+
+			for _, msg := range messageNames(codec) {
+				if _, handled := read[msg]; !handled {
+					undecoded = append(undecoded, msg)
+				}
+			}
+
+			if len(undecoded) > 0 {
+				t.Errorf("the codec parses %d message(s) no decoder builds a body for, so their contents are dropped:\n  %s",
+					len(undecoded), strings.Join(undecoded, "\n  "))
+			}
+		})
+	}
 }

--- a/ngap/enum_names.go
+++ b/ngap/enum_names.go
@@ -107,3 +107,19 @@ var pduSessionTypeNames = map[PDUSessionType]string{
 }
 
 func (t PDUSessionType) Name() string { return pduSessionTypeNames[t] }
+
+var integrityProtectionResultNames = map[IntegrityProtectionResult]string{
+	IntegrityProtectionPerformed:    "performed",
+	IntegrityProtectionNotPerformed: "not-performed",
+}
+
+func (i IntegrityProtectionResult) Name() string { return integrityProtectionResultNames[i] }
+
+var confidentialityProtectionResultNames = map[ConfidentialityProtectionResult]string{
+	ConfidentialityProtectionPerformed:    "performed",
+	ConfidentialityProtectionNotPerformed: "not-performed",
+}
+
+func (c ConfidentialityProtectionResult) Name() string {
+	return confidentialityProtectionResultNames[c]
+}

--- a/ngap/enum_names.go
+++ b/ngap/enum_names.go
@@ -123,3 +123,11 @@ var confidentialityProtectionResultNames = map[ConfidentialityProtectionResult]s
 func (c ConfidentialityProtectionResult) Name() string {
 	return confidentialityProtectionResultNames[c]
 }
+
+var handoverTypeNames = map[HandoverType]string{
+	HandoverTypeIntra5GS:    "intra5gs",
+	HandoverTypeFiveGSToEPS: "fivegs-to-eps",
+	HandoverTypeEPSToFiveGS: "eps-to-5gs",
+}
+
+func (h HandoverType) Name() string { return handoverTypeNames[h] }

--- a/s1ap/enum_names.go
+++ b/s1ap/enum_names.go
@@ -127,3 +127,17 @@ var enbIDKindNames = map[ENBIDKind]string{
 
 // Name returns the name of the ENB-ID CHOICE alternative the kind selects.
 func (k ENBIDKind) Name() string { return enbIDKindNames[k] }
+
+var eventTypeNames = map[EventType]string{
+	EventTypeDirect:                "direct",
+	EventTypeChangeOfServeCell:     "change-of-serve-cell",
+	EventTypeStopChangeOfServeCell: "stop-change-of-serve-cell",
+}
+
+func (e EventType) Name() string { return eventTypeNames[e] }
+
+var reportAreaNames = map[ReportArea]string{
+	ReportAreaECGI: "ecgi",
+}
+
+func (r ReportArea) Name() string { return reportAreaNames[r] }

--- a/s1ap/erab_modification.go
+++ b/s1ap/erab_modification.go
@@ -257,3 +257,7 @@ func (m *ERABModificationConfirm) Marshal() ([]byte, error) {
 		Value:         w.Bytes(),
 	})
 }
+
+func ParseERABModificationConfirm(value []byte) (*ERABModificationConfirm, error) {
+	return parseMessageBody[ERABModificationConfirm](ProcERABModificationIndication, TriggeringSuccessfulOutcome, erabModificationConfirmIEs, value)
+}

--- a/s1ap/parsers.go
+++ b/s1ap/parsers.go
@@ -19,6 +19,7 @@ var messageParsers = []messageParser{
 	{"ParseENBConfigurationUpdateFailure", func(v []byte) error { _, err := ParseENBConfigurationUpdateFailure(v); return err }},
 	{"ParseENBStatusTransfer", func(v []byte) error { _, err := ParseENBStatusTransfer(v); return err }},
 	{"ParseERABModificationIndication", func(v []byte) error { _, err := ParseERABModificationIndication(v); return err }},
+	{"ParseERABModificationConfirm", func(v []byte) error { _, err := ParseERABModificationConfirm(v); return err }},
 	{"ParseERABModifyRequest", func(v []byte) error { _, err := ParseERABModifyRequest(v); return err }},
 	{"ParseERABModifyResponse", func(v []byte) error { _, err := ParseERABModifyResponse(v); return err }},
 	{"ParseERABReleaseCommand", func(v []byte) error { _, err := ParseERABReleaseCommand(v); return err }},


### PR DESCRIPTION
# Description

Every 4G and 5G signalling message Ella Core can already understand internally is now fully visible in the network events UI and API. This is a follow up to #1649. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
