### PR TITLE
test(ha): wait for the leadership notification

### DIFF
--- a/internal/raft/leader_notify_test.go
+++ b/internal/raft/leader_notify_test.go
@@ -41,7 +41,7 @@ func TestWaitForLeaderDoesNotConsumeLeaderCh(t *testing.T) {
 		if !isLeader {
 			t.Fatal("expected the pending notification to report leadership")
 		}
-	default:
+	case <-time.After(10 * time.Second):
 		t.Fatal("waitForLeader took the transition off raft.LeaderCh(); raft delivers each value to exactly one receiver, so LeaderObserver must be its sole consumer or leadership callbacks are lost")
 	}
 }


### PR DESCRIPTION
# Description

Fix a flaky HA unit test.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
