### PR TITLE
fix(upf): apply the datapath toggles in one reload instead of three

### DIFF
--- a/internal/upf/reconciler.go
+++ b/internal/upf/reconciler.go
@@ -218,9 +218,6 @@ func (r *SettingsReconciler) reconcileSettings(ctx context.Context) error {
 	return nil
 }
 
-// Each toggle is a load-time constant in the datapath, so changing any of
-// them costs a full verify-and-reattach. Reading all three and applying
-// them together keeps that cost to one reload per pass instead of three.
 func (r *SettingsReconciler) reconcileDatapathSettings(ctx context.Context) error {
 	desired, err := r.desiredDatapathSettings(ctx)
 	if err != nil {

--- a/internal/upf/reconciler.go
+++ b/internal/upf/reconciler.go
@@ -38,12 +38,17 @@ type SettingsStore interface {
 	ListRulesForPolicy(ctx context.Context, policyID string) ([]*db.NetworkRule, error)
 }
 
+// DatapathSettings is the set of load-time datapath toggles applied together.
+type DatapathSettings struct {
+	NAT            bool
+	FlowAccounting bool
+	LocalSwitch    bool
+}
+
 // Updater is the narrow view the reconciler needs over the UPF runtime.
 // *UPF satisfies it.
 type Updater interface {
-	ReloadNAT(enabled bool) error
-	ReloadFlowAccounting(enabled bool) error
-	ReloadLocalSwitch(enabled bool) error
+	ApplyDatapathSettings(settings DatapathSettings) error
 	UpdateAdvertisedN3Address(addr netip.Addr)
 	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error
 }
@@ -66,12 +71,10 @@ type SettingsReconciler struct {
 	cancel context.CancelFunc
 	done   chan struct{}
 
-	stateMu               sync.Mutex
-	appliedNAT            *bool
-	appliedFlowAccounting *bool
-	appliedLocalSwitch    *bool
-	appliedN3Address      netip.Addr
-	appliedFilters        map[string]filterSnapshot
+	stateMu          sync.Mutex
+	appliedSettings  *DatapathSettings
+	appliedN3Address netip.Addr
+	appliedFilters   map[string]filterSnapshot
 }
 
 type filterSnapshot struct {
@@ -204,16 +207,8 @@ func (r *SettingsReconciler) Reconcile(ctx context.Context) error {
 }
 
 func (r *SettingsReconciler) reconcileSettings(ctx context.Context) error {
-	if err := r.reconcileNAT(ctx); err != nil {
-		return fmt.Errorf("nat: %w", err)
-	}
-
-	if err := r.reconcileFlowAccounting(ctx); err != nil {
-		return fmt.Errorf("flow accounting: %w", err)
-	}
-
-	if err := r.reconcileLocalSwitch(ctx); err != nil {
-		return fmt.Errorf("local switch: %w", err)
+	if err := r.reconcileDatapathSettings(ctx); err != nil {
+		return err
 	}
 
 	if err := r.reconcileN3Address(ctx); err != nil {
@@ -223,88 +218,64 @@ func (r *SettingsReconciler) reconcileSettings(ctx context.Context) error {
 	return nil
 }
 
-func (r *SettingsReconciler) reconcileNAT(ctx context.Context) error {
-	desired, err := r.store.IsNATEnabled(ctx)
+// Each toggle is a load-time constant in the datapath, so changing any of
+// them costs a full verify-and-reattach. Reading all three and applying
+// them together keeps that cost to one reload per pass instead of three.
+func (r *SettingsReconciler) reconcileDatapathSettings(ctx context.Context) error {
+	desired, err := r.desiredDatapathSettings(ctx)
 	if err != nil {
 		return err
 	}
 
 	r.stateMu.Lock()
-	current := r.appliedNAT
+	current := r.appliedSettings
 	r.stateMu.Unlock()
 
 	if current != nil && *current == desired {
 		return nil
 	}
 
-	if err := r.updater.ReloadNAT(desired); err != nil {
-		return err
+	if err := r.updater.ApplyDatapathSettings(desired); err != nil {
+		return fmt.Errorf("apply datapath settings: %w", err)
 	}
 
 	r.stateMu.Lock()
-	v := desired
-	r.appliedNAT = &v
+	applied := desired
+	r.appliedSettings = &applied
 	r.stateMu.Unlock()
 
-	logger.UpfLog.Info("applied NAT setting", zap.Bool("enabled", desired))
+	logger.UpfLog.Info("applied datapath settings",
+		zap.Bool("nat", desired.NAT),
+		zap.Bool("flow_accounting", desired.FlowAccounting),
+		zap.Bool("local_switch", desired.LocalSwitch),
+	)
 
 	return nil
 }
 
-func (r *SettingsReconciler) reconcileFlowAccounting(ctx context.Context) error {
-	desired, err := r.store.IsFlowAccountingEnabled(ctx)
+func (r *SettingsReconciler) desiredDatapathSettings(ctx context.Context) (DatapathSettings, error) {
+	var desired DatapathSettings
+
+	nat, err := r.store.IsNATEnabled(ctx)
 	if err != nil {
-		return err
+		return desired, fmt.Errorf("nat: %w", err)
 	}
 
-	r.stateMu.Lock()
-	current := r.appliedFlowAccounting
-	r.stateMu.Unlock()
-
-	if current != nil && *current == desired {
-		return nil
-	}
-
-	if err := r.updater.ReloadFlowAccounting(desired); err != nil {
-		return err
-	}
-
-	r.stateMu.Lock()
-	v := desired
-	r.appliedFlowAccounting = &v
-	r.stateMu.Unlock()
-
-	logger.UpfLog.Info("applied flow accounting setting", zap.Bool("enabled", desired))
-
-	return nil
-}
-
-func (r *SettingsReconciler) reconcileLocalSwitch(ctx context.Context) error {
-	desired, err := r.store.IsLocalSwitchEnabled(ctx)
+	flowAccounting, err := r.store.IsFlowAccountingEnabled(ctx)
 	if err != nil {
-		return err
+		return desired, fmt.Errorf("flow accounting: %w", err)
 	}
 
-	r.stateMu.Lock()
-	current := r.appliedLocalSwitch
-	r.stateMu.Unlock()
-
-	if current != nil && *current == desired {
-		return nil
+	localSwitch, err := r.store.IsLocalSwitchEnabled(ctx)
+	if err != nil {
+		return desired, fmt.Errorf("local switch: %w", err)
 	}
 
-	if err := r.updater.ReloadLocalSwitch(desired); err != nil {
-		return err
-	}
+	desired.NAT = nat
+	desired.FlowAccounting = flowAccounting
+	desired.LocalSwitch = localSwitch
 
-	r.stateMu.Lock()
-	v := desired
-	r.appliedLocalSwitch = &v
-	r.stateMu.Unlock()
-
-	logger.UpfLog.Info("applied local switch setting", zap.Bool("enabled", desired))
-
-	return nil
+	return desired, nil
 }
 
 func (r *SettingsReconciler) reconcileN3Address(ctx context.Context) error {

--- a/internal/upf/reconciler_test.go
+++ b/internal/upf/reconciler_test.go
@@ -88,22 +88,18 @@ type filterCall struct {
 
 type fakeUpdater struct {
 	mu                sync.Mutex
-	natCalls          []bool
-	flowCalls         []bool
-	localSwitchCalls  []bool
+	settingsCalls     []DatapathSettings
 	n3Calls           []netip.Addr
 	filterCalls       []filterCall
-	natErr            error
-	flowErr           error
-	localSwitchErr    error
+	settingsErr       error
 	updateFiltersErr  error
 	updateFiltersFunc func(policyID string, direction models.Direction, rules []models.FilterRule) error
-	reloadNATFunc     func(enabled bool) error
+	applyFunc         func(settings DatapathSettings) error
 }
 
-func (f *fakeUpdater) ReloadNAT(enabled bool) error {
-	if f.reloadNATFunc != nil {
-		if err := f.reloadNATFunc(enabled); err != nil {
+func (f *fakeUpdater) ApplyDatapathSettings(settings DatapathSettings) error {
+	if f.applyFunc != nil {
+		if err := f.applyFunc(settings); err != nil {
 			return err
 		}
 	}
@@ -111,39 +107,37 @@ func (f *fakeUpdater) ReloadNAT(enabled bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if f.natErr != nil {
-		return f.natErr
+	if f.settingsErr != nil {
+		return f.settingsErr
 	}
 
-	f.natCalls = append(f.natCalls, enabled)
+	f.settingsCalls = append(f.settingsCalls, settings)
 
 	return nil
 }
 
-func (f *fakeUpdater) ReloadFlowAccounting(enabled bool) error {
+func (f *fakeUpdater) natCalls() []bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if f.flowErr != nil {
-		return f.flowErr
+	out := make([]bool, len(f.settingsCalls))
+	for i, c := range f.settingsCalls {
+		out[i] = c.NAT
 	}
 
-	f.flowCalls = append(f.flowCalls, enabled)
-
-	return nil
+	return out
 }
 
-func (f *fakeUpdater) ReloadLocalSwitch(enabled bool) error {
+func (f *fakeUpdater) flowCalls() []bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if f.localSwitchErr != nil {
-		return f.localSwitchErr
+	out := make([]bool, len(f.settingsCalls))
+	for i, c := range f.settingsCalls {
+		out[i] = c.FlowAccounting
 	}
 
-	f.localSwitchCalls = append(f.localSwitchCalls, enabled)
-
-	return nil
+	return out
 }
 
 func (f *fakeUpdater) UpdateAdvertisedN3Address(addr netip.Addr) {
@@ -187,16 +181,16 @@ func TestReconcile_NATAppliesOnFirstTickAndSkipsWhenUnchanged(t *testing.T) {
 		t.Fatalf("first reconcile: %v", err)
 	}
 
-	if got := len(updater.natCalls); got != 1 || updater.natCalls[0] != true {
-		t.Fatalf("expected one ReloadNAT(true), got %v", updater.natCalls)
+	if got := len(updater.natCalls()); got != 1 || updater.natCalls()[0] != true {
+		t.Fatalf("expected one datapath apply with NAT on, got %v", updater.natCalls())
 	}
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("second reconcile: %v", err)
 	}
 
-	if got := len(updater.natCalls); got != 1 {
-		t.Fatalf("expected ReloadNAT to NOT fire on unchanged second tick, got %d total calls", got)
+	if got := len(updater.natCalls()); got != 1 {
+		t.Fatalf("expected no datapath apply on an unchanged second tick, got %d total calls", got)
 	}
 }
 
@@ -218,8 +212,8 @@ func TestReconcile_NATFiresOnChange(t *testing.T) {
 		t.Fatalf("reconcile 2: %v", err)
 	}
 
-	if !reflect.DeepEqual(updater.natCalls, []bool{true, false}) {
-		t.Fatalf("expected NAT calls [true, false], got %v", updater.natCalls)
+	if !reflect.DeepEqual(updater.natCalls(), []bool{true, false}) {
+		t.Fatalf("expected NAT calls [true, false], got %v", updater.natCalls())
 	}
 }
 
@@ -237,8 +231,8 @@ func TestReconcile_FlowAccountingDiff(t *testing.T) {
 		t.Fatalf("second reconcile: %v", err)
 	}
 
-	if !reflect.DeepEqual(updater.flowCalls, []bool{true}) {
-		t.Fatalf("expected one ReloadFlowAccounting(true), got %v", updater.flowCalls)
+	if !reflect.DeepEqual(updater.flowCalls(), []bool{true}) {
+		t.Fatalf("expected one datapath apply with flow accounting on, got %v", updater.flowCalls())
 	}
 }
 
@@ -540,9 +534,7 @@ func TestReconcile_LoopWakesOnChangefeedEvent(t *testing.T) {
 	deadline := time.Now().Add(time.Second)
 
 	for time.Now().Before(deadline) {
-		updater.mu.Lock()
-		count := len(updater.natCalls)
-		updater.mu.Unlock()
+		count := len(updater.natCalls())
 
 		if count == 1 {
 			break
@@ -551,9 +543,7 @@ func TestReconcile_LoopWakesOnChangefeedEvent(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	updater.mu.Lock()
-	initialNATCalls := len(updater.natCalls)
-	updater.mu.Unlock()
+	initialNATCalls := len(updater.natCalls())
 
 	if initialNATCalls != 1 {
 		t.Fatalf("expected 1 NAT call after initial reconcile, got %d", initialNATCalls)
@@ -568,9 +558,7 @@ func TestReconcile_LoopWakesOnChangefeedEvent(t *testing.T) {
 	deadline = time.Now().Add(time.Second)
 
 	for time.Now().Before(deadline) {
-		updater.mu.Lock()
-		count := len(updater.natCalls)
-		updater.mu.Unlock()
+		count := len(updater.natCalls())
 
 		if count == 2 {
 			return
@@ -579,16 +567,14 @@ func TestReconcile_LoopWakesOnChangefeedEvent(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	updater.mu.Lock()
-	finalNATCalls := len(updater.natCalls)
-	updater.mu.Unlock()
+	finalNATCalls := len(updater.natCalls())
 
 	t.Fatalf("expected reconcile to fire from changefeed event; got %d total NAT calls", finalNATCalls)
 }
 
 func TestReconcile_PropagatesNATError(t *testing.T) {
 	store := &fakeStore{natEnabled: true}
-	updater := &fakeUpdater{natErr: errors.New("xdp attach failed")}
+	updater := &fakeUpdater{settingsErr: errors.New("xdp attach failed")}
 
 	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
 
@@ -626,7 +612,7 @@ func TestStart_FiltersDoNotWaitOnASettingsReload(t *testing.T) {
 	filtersApplied := make(chan struct{})
 
 	updater := &fakeUpdater{
-		reloadNATFunc: func(bool) error {
+		applyFunc: func(DatapathSettings) error {
 			<-release
 
 			return nil
@@ -654,5 +640,60 @@ func TestStart_FiltersDoNotWaitOnASettingsReload(t *testing.T) {
 	case <-filtersApplied:
 	case <-time.After(5 * time.Second):
 		t.Fatal("filters were not applied while a settings reload was in flight")
+	}
+}
+
+func TestReconcile_TogglesShareOneDatapathApply(t *testing.T) {
+	store := &fakeStore{natEnabled: true, flowAccounting: true, localSwitch: true}
+	updater := &fakeUpdater{}
+
+	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	updater.mu.Lock()
+	calls := updater.settingsCalls
+	updater.mu.Unlock()
+
+	if len(calls) != 1 {
+		t.Fatalf("three toggles produced %d datapath applies, want 1", len(calls))
+	}
+
+	want := DatapathSettings{NAT: true, FlowAccounting: true, LocalSwitch: true}
+	if calls[0] != want {
+		t.Fatalf("applied %+v, want %+v", calls[0], want)
+	}
+}
+
+func TestReconcile_OneChangedToggleReappliesAllOfThem(t *testing.T) {
+	store := &fakeStore{natEnabled: true}
+	updater := &fakeUpdater{}
+
+	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	store.mu.Lock()
+	store.localSwitch = true
+	store.mu.Unlock()
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	updater.mu.Lock()
+	calls := updater.settingsCalls
+	updater.mu.Unlock()
+
+	if len(calls) != 2 {
+		t.Fatalf("got %d datapath applies, want 2", len(calls))
+	}
+
+	if !calls[1].NAT || !calls[1].LocalSwitch {
+		t.Fatalf("second apply lost a setting: %+v", calls[1])
 	}
 }

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -357,11 +357,12 @@ func (u *UPF) updateAttachedPrograms() error {
 	return nil
 }
 
-func (u *UPF) ReloadNAT(masquerade bool) error {
-	u.se.BpfObjects.Masquerade = masquerade
+func (u *UPF) ApplyDatapathSettings(settings DatapathSettings) error {
+	u.se.BpfObjects.Masquerade = settings.NAT
+	u.se.BpfObjects.FlowAccounting = settings.FlowAccounting
+	u.se.BpfObjects.LocalSwitch = settings.LocalSwitch
 
-	err := u.se.BpfObjects.LoadWithMapReplacements()
-	if err != nil {
+	if err := u.se.BpfObjects.LoadWithMapReplacements(); err != nil {
 		return fmt.Errorf("couldn't load BPF objects: %w", err)
 	}
 
@@ -369,46 +370,16 @@ func (u *UPF) ReloadNAT(masquerade bool) error {
 		return err
 	}
 
-	if masquerade {
+	if settings.NAT {
 		u.startGC(u.ctx)
 	} else {
 		u.stopGC()
 	}
 
-	return nil
-}
-
-func (u *UPF) ReloadFlowAccounting(flowact bool) error {
-	u.se.BpfObjects.FlowAccounting = flowact
-
-	err := u.se.BpfObjects.LoadWithMapReplacements()
-	if err != nil {
-		return fmt.Errorf("couldn't load BPF objects: %w", err)
-	}
-
-	if err := u.updateAttachedPrograms(); err != nil {
-		return err
-	}
-
-	if flowact {
+	if settings.FlowAccounting {
 		u.startFlowCollection(u.ctx)
 	} else {
 		u.stopFlowCollection()
-	}
-
-	return nil
-}
-
-func (u *UPF) ReloadLocalSwitch(localSwitch bool) error {
-	u.se.BpfObjects.LocalSwitch = localSwitch
-
-	err := u.se.BpfObjects.LoadWithMapReplacements()
-	if err != nil {
-		return fmt.Errorf("couldn't load BPF objects: %w", err)
-	}
-
-	if err := u.updateAttachedPrograms(); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Speed up startup by applying the datapath toggles in one reload instead of three.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
