### PR TITLE
test(integration): capture metrics and export logs in any failure

### DIFF
--- a/.github/workflows/integration-tests-4g-srsran.yaml
+++ b/.github/workflows/integration-tests-4g-srsran.yaml
@@ -52,5 +52,15 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ipv4
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run 'TestIntegration4G' -skip 'TestIntegration4GHAFailover|TestIntegration4GNetworkRules|TestIntegration4GUE2UE' -timeout 30m -v
+
+      - name: Upload cluster logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-4g-srsran-cluster-logs-${{ matrix.attach_mode }}
+          path: ${{ runner.temp }}/integration-logs
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/integration-tests-4g.yaml
+++ b/.github/workflows/integration-tests-4g.yaml
@@ -63,7 +63,7 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run 'TestIntegrationTester/s1enb|TestIntegration4GNetworkRules' -timeout 30m -v
 
@@ -72,6 +72,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: integration-4g-cluster-logs-${{ matrix.arch }}-${{ matrix.ip_version }}
-          path: ${{ runner.temp }}/ha-cluster-logs
+          path: ${{ runner.temp }}/integration-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-5g.yaml
+++ b/.github/workflows/integration-tests-5g.yaml
@@ -63,7 +63,7 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -skip 'TestIntegrationHA|TestIntegration5GHAFailover|TestAPIMatrix|TestIntegration5GBGP|TestIntegration5GFramedRouting|TestIntegration5GUE2UE|TestIntegration4G|TestIntegrationTester/s1enb' -timeout 30m -v
 
@@ -72,6 +72,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: integration-5g-cluster-logs-${{ matrix.arch }}-${{ matrix.ip_version }}
-          path: ${{ runner.temp }}/ha-cluster-logs
+          path: ${{ runner.temp }}/integration-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-api-matrix-ha.yaml
+++ b/.github/workflows/integration-tests-api-matrix-ha.yaml
@@ -35,7 +35,7 @@ jobs:
         env:
           INTEGRATION: "1"
           IP_VERSION: ipv4
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration -run TestAPIMatrixHA -v -timeout 15m
 
@@ -44,6 +44,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: api-matrix-ha-cluster-logs
-          path: ${{ runner.temp }}/ha-cluster-logs
+          path: ${{ runner.temp }}/integration-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-api-matrix.yaml
+++ b/.github/workflows/integration-tests-api-matrix.yaml
@@ -47,6 +47,6 @@ jobs:
         env:
           INTEGRATION: "1"
           IP_VERSION: ipv4
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration -run '^TestAPIMatrix$' -timeout 10m -v

--- a/.github/workflows/integration-tests-bgp-4g.yaml
+++ b/.github/workflows/integration-tests-bgp-4g.yaml
@@ -51,7 +51,7 @@ jobs:
         env:
           INTEGRATION: "1"
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run TestIntegration4GBGP -timeout 15m -v
 

--- a/.github/workflows/integration-tests-bgp-5g.yaml
+++ b/.github/workflows/integration-tests-bgp-5g.yaml
@@ -51,7 +51,7 @@ jobs:
         env:
           INTEGRATION: "1"
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run TestIntegration5GBGP -timeout 15m -v
 

--- a/.github/workflows/integration-tests-framed-4g.yaml
+++ b/.github/workflows/integration-tests-framed-4g.yaml
@@ -49,7 +49,7 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/framed-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/framed-logs
         run: |
           go test ./integration/... -run TestIntegration4GFramedRouting -timeout 20m -v
 

--- a/.github/workflows/integration-tests-framed-5g.yaml
+++ b/.github/workflows/integration-tests-framed-5g.yaml
@@ -49,7 +49,7 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/framed-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/framed-logs
         run: |
           go test ./integration/... -run TestIntegration5GFramedRouting -timeout 20m -v
 

--- a/.github/workflows/integration-tests-ha-4g.yaml
+++ b/.github/workflows/integration-tests-ha-4g.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Run HA+3GPP 4G integration tests
         env:
           INTEGRATION: "1"
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run TestIntegration4GHAFailover -v -timeout 15m
 
@@ -48,6 +48,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ha-4g-cluster-logs
-          path: ${{ runner.temp }}/ha-cluster-logs
+          path: ${{ runner.temp }}/integration-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-ha-5g.yaml
+++ b/.github/workflows/integration-tests-ha-5g.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Run HA+3GPP integration tests
         env:
           INTEGRATION: "1"
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run TestIntegration5GHAFailover -v -timeout 15m
 
@@ -48,6 +48,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ha-5g-cluster-logs
-          path: ${{ runner.temp }}/ha-cluster-logs
+          path: ${{ runner.temp }}/integration-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-ha.yaml
+++ b/.github/workflows/integration-tests-ha.yaml
@@ -35,7 +35,7 @@ jobs:
         env:
           INTEGRATION: "1"
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run TestIntegrationHA -skip TestIntegrationHARollingUpgrade -v -timeout 15m
 
@@ -44,6 +44,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ha-cluster-logs-${{ matrix.ip_version }}
-          path: ${{ runner.temp }}/ha-cluster-logs
+          path: ${{ runner.temp }}/integration-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-n2-handover.yaml
+++ b/.github/workflows/integration-tests-n2-handover.yaml
@@ -49,7 +49,7 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run TestIntegration5GN2Handover -v -timeout 10m
 

--- a/.github/workflows/integration-tests-rolling-upgrade.yaml
+++ b/.github/workflows/integration-tests-rolling-upgrade.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Run rolling-upgrade integration test
         env:
           INTEGRATION: "1"
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ha-cluster-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/integration-logs
         run: |
           go test ./integration/... -run TestIntegrationHARollingUpgrade -v -timeout 15m
 
@@ -44,6 +44,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: rolling-upgrade-cluster-logs
-          path: ${{ runner.temp }}/ha-cluster-logs
+          path: ${{ runner.temp }}/integration-logs
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/integration-tests-ue2ue-4g.yaml
+++ b/.github/workflows/integration-tests-ue2ue-4g.yaml
@@ -49,7 +49,7 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ue2ue-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/ue2ue-logs
         run: |
           go test ./integration/... -run TestIntegration4GUE2UE -timeout 20m -v
 

--- a/.github/workflows/integration-tests-ue2ue-5g.yaml
+++ b/.github/workflows/integration-tests-ue2ue-5g.yaml
@@ -49,7 +49,7 @@ jobs:
           INTEGRATION: "1"
           ELLA_CORE_ATTACH_MODE: ${{ matrix.attach_mode }}
           IP_VERSION: ${{ matrix.ip_version }}
-          HA_CLUSTER_LOG_DIR: ${{ runner.temp }}/ue2ue-logs
+          INTEGRATION_LOG_DIR: ${{ runner.temp }}/ue2ue-logs
         run: |
           go test ./integration/... -run TestIntegration5GUE2UE -timeout 20m -v
 

--- a/integration/diagnostics_test.go
+++ b/integration/diagnostics_test.go
@@ -14,17 +14,9 @@ import (
 	"time"
 )
 
-const datapathMetricsTimeout = 10 * time.Second
+const metricsScrapeTimeout = 10 * time.Second
 
-// captureDatapathMetrics writes the node's Prometheus metrics beside the
-// container logs, so a failed run records what the data plane did with every
-// frame. app_upf_datapath_forward_total and app_upf_datapath_drop_total count
-// each frame exactly once between them, so they distinguish a packet the data
-// plane dropped (and why) from one that never reached it at all.
-//
-// Best-effort: a scrape failure is logged and never fails the test. Must run
-// before the stack is torn down.
-func captureDatapathMetrics(t *testing.T, baseURL, name string) {
+func captureMetrics(t *testing.T, baseURL, name string) {
 	t.Helper()
 
 	root := os.Getenv("INTEGRATION_LOG_DIR")
@@ -34,24 +26,24 @@ func captureDatapathMetrics(t *testing.T, baseURL, name string) {
 
 	body, err := scrapeMetrics(baseURL)
 	if err != nil {
-		t.Logf("captureDatapathMetrics: scrape %s: %v", baseURL, err)
+		t.Logf("captureMetrics: scrape %s: %v", baseURL, err)
 		return
 	}
 
 	dir := filepath.Join(root, sanitizeTestName(t.Name()))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Logf("captureDatapathMetrics: mkdir %s: %v", dir, err)
+		t.Logf("captureMetrics: mkdir %s: %v", dir, err)
 		return
 	}
 
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, body, 0o644); err != nil {
-		t.Logf("captureDatapathMetrics: write %s: %v", path, err)
+		t.Logf("captureMetrics: write %s: %v", path, err)
 	}
 }
 
 func scrapeMetrics(baseURL string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), datapathMetricsTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), metricsScrapeTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/metrics", nil)

--- a/integration/diagnostics_test.go
+++ b/integration/diagnostics_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const datapathMetricsTimeout = 10 * time.Second
+
+// captureDatapathMetrics writes the node's Prometheus metrics beside the
+// container logs, so a failed run records what the data plane did with every
+// frame. app_upf_datapath_forward_total and app_upf_datapath_drop_total count
+// each frame exactly once between them, so they distinguish a packet the data
+// plane dropped (and why) from one that never reached it at all.
+//
+// Best-effort: a scrape failure is logged and never fails the test. Must run
+// before the stack is torn down.
+func captureDatapathMetrics(t *testing.T, baseURL, name string) {
+	t.Helper()
+
+	root := os.Getenv("INTEGRATION_LOG_DIR")
+	if root == "" || !t.Failed() {
+		return
+	}
+
+	body, err := scrapeMetrics(baseURL)
+	if err != nil {
+		t.Logf("captureDatapathMetrics: scrape %s: %v", baseURL, err)
+		return
+	}
+
+	dir := filepath.Join(root, sanitizeTestName(t.Name()))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Logf("captureDatapathMetrics: mkdir %s: %v", dir, err)
+		return
+	}
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Logf("captureDatapathMetrics: write %s: %v", path, err)
+	}
+}
+
+func scrapeMetrics(baseURL string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), datapathMetricsTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/metrics", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+}

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -43,7 +43,7 @@ func captureClusterLogs(t *testing.T, dc *DockerClient, composeDir string, servi
 	}
 
 	for i := range services {
-		captureDatapathMetrics(t, APIAddressForCluster(i+1), fmt.Sprintf("metrics-node%d.txt", i+1))
+		captureMetrics(t, APIAddressForCluster(i+1), fmt.Sprintf("metrics-node%d.txt", i+1))
 	}
 
 	captured := 0

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -22,7 +22,7 @@ const haComposeDir = "compose/ha/"
 var haNodeServices = []string{"ella-core-1", "ella-core-2", "ella-core-3"}
 
 // captureClusterLogs collects each service's container logs and writes
-// them to <HA_CLUSTER_LOG_DIR>/<test-name>/<service>.log for CI artifact
+// them to <INTEGRATION_LOG_DIR>/<test-name>/<service>.log for CI artifact
 // upload. If printLogs is true, logs are also emitted via t.Logf.
 // Safe to call with no clients (e.g. on bring-up failure).
 func captureClusterLogs(t *testing.T, dc *DockerClient, composeDir string, services []string, printLogs bool) {
@@ -33,7 +33,7 @@ func captureClusterLogs(t *testing.T, dc *DockerClient, composeDir string, servi
 
 	var diskDir string
 
-	if root := os.Getenv("HA_CLUSTER_LOG_DIR"); root != "" {
+	if root := os.Getenv("INTEGRATION_LOG_DIR"); root != "" {
 		diskDir = filepath.Join(root, sanitizeTestName(t.Name()))
 		if err := os.MkdirAll(diskDir, 0o755); err != nil {
 			t.Logf("captureClusterLogs: mkdir %s: %v", diskDir, err)
@@ -104,7 +104,7 @@ func bringUpHACluster(t *testing.T, ctx context.Context, dc *DockerClient) ([]*c
 // more addresses than the starting set of services.
 //
 // On any error return, captureClusterLogs is invoked so per-node container
-// logs are emitted (and persisted to HA_CLUSTER_LOG_DIR if set) BEFORE the
+// logs are emitted (and persisted to INTEGRATION_LOG_DIR if set) BEFORE the
 // next test's ComposeCleanup tears the containers down.
 func bringUpHAClusterAt(t *testing.T, ctx context.Context, dc *DockerClient, composeDir string, services []string, extraPeers []string) ([]*client.Client, error) {
 	t.Helper()

--- a/integration/ha_helpers_test.go
+++ b/integration/ha_helpers_test.go
@@ -42,6 +42,10 @@ func captureClusterLogs(t *testing.T, dc *DockerClient, composeDir string, servi
 		}
 	}
 
+	for i := range services {
+		captureDatapathMetrics(t, APIAddressForCluster(i+1), fmt.Sprintf("metrics-node%d.txt", i+1))
+	}
+
 	captured := 0
 
 	for _, svc := range services {

--- a/integration/ha_rolling_test.go
+++ b/integration/ha_rolling_test.go
@@ -427,7 +427,7 @@ func swapNodeImage(t *testing.T, ctx context.Context, dc *DockerClient, nodeNum 
 func capturePreSwapLogs(t *testing.T, ctx context.Context, dc *DockerClient, service string) {
 	t.Helper()
 
-	dir := os.Getenv("HA_CLUSTER_LOG_DIR")
+	dir := os.Getenv("INTEGRATION_LOG_DIR")
 	if dir == "" {
 		return
 	}

--- a/integration/reporter_test.go
+++ b/integration/reporter_test.go
@@ -332,7 +332,7 @@ func beginHATest(t *testing.T) {
 
 // writeFailureReports writes detailed failure reports to files.
 func writeFailureReports(t *testing.T, testPrefix string) {
-	logDir := os.Getenv("HA_CLUSTER_LOG_DIR")
+	logDir := os.Getenv("INTEGRATION_LOG_DIR")
 	if logDir == "" {
 		logDir = filepath.Join(os.TempDir(), "integration-failures")
 	}

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -75,7 +75,7 @@ func setupTesterEnv(ctx context.Context, t *testing.T) *testerEnv {
 	}
 
 	t.Cleanup(func() {
-		captureDatapathMetrics(t, APIAddress(), "metrics.txt")
+		captureMetrics(t, APIAddress(), "metrics.txt")
 
 		logs, err := dc.ComposeLogs(ctx, composeDir, "ella-core")
 		if err == nil {

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -77,7 +77,7 @@ func setupTesterEnv(ctx context.Context, t *testing.T) *testerEnv {
 	t.Cleanup(func() {
 		logs, err := dc.ComposeLogs(ctx, composeDir, "ella-core")
 		if err == nil {
-			logDir := os.Getenv("HA_CLUSTER_LOG_DIR")
+			logDir := os.Getenv("INTEGRATION_LOG_DIR")
 			if logDir != "" && t.Failed() {
 				safeName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
 

--- a/integration/tester_env_test.go
+++ b/integration/tester_env_test.go
@@ -75,6 +75,8 @@ func setupTesterEnv(ctx context.Context, t *testing.T) *testerEnv {
 	}
 
 	t.Cleanup(func() {
+		captureDatapathMetrics(t, APIAddress(), "metrics.txt")
+
 		logs, err := dc.ComposeLogs(ctx, composeDir, "ella-core")
 		if err == nil {
 			logDir := os.Getenv("INTEGRATION_LOG_DIR")


### PR DESCRIPTION
# Description

Capture metrics and export logs on any failures. This was already partly wired in. This feature is useful whenever there's a flaky integration test that is hard to reproduce. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
