### PR TITLE
fix(ui): announce the active sidebar route with aria-current

### DIFF
--- a/ui/src/components/DrawerLayout.test.tsx
+++ b/ui/src/components/DrawerLayout.test.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import DrawerLayout from "./DrawerLayout";
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ role: "Admin", setAuthData: vi.fn() }),
+}));
+
+vi.mock("@/queries/auth", () => ({ logout: vi.fn() }));
+
+vi.mock("./SupportModal", () => ({ default: () => null }));
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <DrawerLayout>
+        <div />
+      </DrawerLayout>
+    </MemoryRouter>,
+  );
+
+const nav = () => screen.getByRole("navigation", { name: "Main" });
+
+const current = () =>
+  within(nav())
+    .getAllByRole("link")
+    .filter((el) => el.getAttribute("aria-current") === "page")
+    .map((el) => el.textContent);
+
+describe("DrawerLayout marks the current route for assistive tech", () => {
+  it("sets aria-current on the exact-match route only", () => {
+    renderAt("/dashboard");
+
+    expect(current()).toEqual(["Dashboard"]);
+  });
+
+  it("keeps the section marked on a nested detail route", () => {
+    renderAt("/radios/abc-123");
+
+    expect(current()).toEqual(["Radios"]);
+  });
+
+  it("marks Traffic when its landing child is active", () => {
+    renderAt("/traffic/usage");
+
+    expect(current()).toEqual(["Traffic"]);
+  });
+
+  it("marks nothing when no nav route matches", () => {
+    renderAt("/profile");
+
+    expect(current()).toEqual([]);
+  });
+
+  it("does not mark an exact-only route from a deeper path", () => {
+    renderAt("/audit-logs/42");
+
+    expect(current()).toEqual([]);
+  });
+
+  it("leaves the external Support links unmarked", () => {
+    renderAt("/dashboard");
+
+    const doc = screen.getByRole("link", { name: /Documentation/ });
+    expect(doc).not.toHaveAttribute("aria-current");
+  });
+});

--- a/ui/src/components/DrawerLayout.tsx
+++ b/ui/src/components/DrawerLayout.tsx
@@ -72,6 +72,42 @@ const drawerSelectedSx = {
   },
 };
 
+function NavItem({
+  to,
+  label,
+  icon,
+  match,
+  exact = false,
+  pathname,
+  onNavigate,
+}: {
+  to: string;
+  label: string;
+  icon: React.ReactNode;
+  match?: string;
+  exact?: boolean;
+  pathname: string;
+  onNavigate: () => void;
+}) {
+  const base = match ?? to;
+  const current = exact ? pathname === base : pathname.startsWith(base);
+  return (
+    <ListItem disablePadding>
+      <ListItemButton
+        component={Link}
+        to={to}
+        selected={current}
+        aria-current={current ? "page" : undefined}
+        onClick={onNavigate}
+        sx={drawerSelectedSx}
+      >
+        <ListItemIcon>{icon}</ListItemIcon>
+        <ListItemText primary={label} />
+      </ListItemButton>
+    </ListItem>
+  );
+}
+
 export default function DrawerLayout({
   children,
 }: {
@@ -231,119 +267,64 @@ export default function DrawerLayout({
         }}
       >
         <Toolbar />
-        {/* A landmark, so the links are a region a screen reader can jump to
-            without tabbing through them (WCAG 1.3.1). */}
         <Box
           component="nav"
           aria-label="Main"
           sx={{ flexGrow: 1, overflow: "auto" }}
         >
           <List>
-            <ListItem disablePadding>
-              <ListItemButton
-                component={Link}
-                to="/dashboard"
-                selected={pathname === "/dashboard"}
-                onClick={handleNavClick}
-                sx={drawerSelectedSx}
-              >
-                <ListItemIcon>
-                  <DashboardIcon color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Dashboard" />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding>
-              <ListItemButton
-                component={Link}
-                to="/operator"
-                selected={pathname === "/operator"}
-                onClick={handleNavClick}
-                sx={drawerSelectedSx}
-              >
-                <ListItemIcon>
-                  <FeedIcon color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Operator" />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding>
-              <ListItemButton
-                component={Link}
-                to="/radios"
-                selected={pathname.startsWith("/radios")}
-                onClick={handleNavClick}
-                sx={drawerSelectedSx}
-              >
-                <ListItemIcon>
-                  <RouterIcon color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Radios" />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding>
-              <ListItemButton
-                component={Link}
-                to="/networking"
-                selected={pathname.startsWith("/networking")}
-                onClick={handleNavClick}
-                sx={drawerSelectedSx}
-              >
-                <ListItemIcon>
-                  <LanIcon color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Networking" />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding>
-              <ListItemButton
-                component={Link}
-                to="/profiles"
-                selected={pathname.startsWith("/profiles")}
-                onClick={handleNavClick}
-                sx={drawerSelectedSx}
-              >
-                <ListItemIcon>
-                  <TuneIcon color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Profiles" />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding>
-              <ListItemButton
-                component={Link}
-                to="/subscribers"
-                selected={pathname.startsWith("/subscribers")}
-                onClick={handleNavClick}
-                sx={drawerSelectedSx}
-              >
-                <ListItemIcon>
-                  <GroupsIcon color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Subscribers" />
-              </ListItemButton>
-            </ListItem>
-
-            <ListItem disablePadding>
-              <ListItemButton
-                component={Link}
-                to="/traffic/usage"
-                selected={pathname.startsWith("/traffic")}
-                onClick={handleNavClick}
-                sx={drawerSelectedSx}
-              >
-                <ListItemIcon>
-                  <BarChartIcon color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Traffic" />
-              </ListItemButton>
-            </ListItem>
-
+            <NavItem
+              to="/dashboard"
+              label="Dashboard"
+              icon={<DashboardIcon color="primary" />}
+              exact
+              pathname={pathname}
+              onNavigate={handleNavClick}
+            />
+            <NavItem
+              to="/operator"
+              label="Operator"
+              icon={<FeedIcon color="primary" />}
+              exact
+              pathname={pathname}
+              onNavigate={handleNavClick}
+            />
+            <NavItem
+              to="/radios"
+              label="Radios"
+              icon={<RouterIcon color="primary" />}
+              pathname={pathname}
+              onNavigate={handleNavClick}
+            />
+            <NavItem
+              to="/networking"
+              label="Networking"
+              icon={<LanIcon color="primary" />}
+              pathname={pathname}
+              onNavigate={handleNavClick}
+            />
+            <NavItem
+              to="/profiles"
+              label="Profiles"
+              icon={<TuneIcon color="primary" />}
+              pathname={pathname}
+              onNavigate={handleNavClick}
+            />
+            <NavItem
+              to="/subscribers"
+              label="Subscribers"
+              icon={<GroupsIcon color="primary" />}
+              pathname={pathname}
+              onNavigate={handleNavClick}
+            />
+            <NavItem
+              to="/traffic/usage"
+              label="Traffic"
+              icon={<BarChartIcon color="primary" />}
+              match="/traffic"
+              pathname={pathname}
+              onNavigate={handleNavClick}
+            />
             {role === "Admin" && (
               <>
                 <ListSubheader
@@ -356,66 +337,37 @@ export default function DrawerLayout({
                 >
                   System
                 </ListSubheader>
-
-                <ListItem disablePadding>
-                  <ListItemButton
-                    component={Link}
-                    to="/users"
-                    selected={pathname.startsWith("/users")}
-                    onClick={handleNavClick}
-                    sx={drawerSelectedSx}
-                  >
-                    <ListItemIcon>
-                      <AdminPanelSettingsIcon color="primary" />
-                    </ListItemIcon>
-                    <ListItemText primary="Users" />
-                  </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                  <ListItemButton
-                    component={Link}
-                    to="/audit-logs"
-                    selected={pathname === "/audit-logs"}
-                    onClick={handleNavClick}
-                    sx={drawerSelectedSx}
-                  >
-                    <ListItemIcon>
-                      <ReceiptLongIcon color="primary" />
-                    </ListItemIcon>
-                    <ListItemText primary="Audit Logs" />
-                  </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                  <ListItemButton
-                    component={Link}
-                    to="/backup-restore"
-                    selected={pathname === "/backup-restore"}
-                    onClick={handleNavClick}
-                    sx={drawerSelectedSx}
-                  >
-                    <ListItemIcon>
-                      <StorageIcon color="primary" />
-                    </ListItemIcon>
-                    <ListItemText primary="Backup and Restore" />
-                  </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                  <ListItemButton
-                    component={Link}
-                    to="/cluster"
-                    selected={pathname === "/cluster"}
-                    onClick={handleNavClick}
-                    sx={drawerSelectedSx}
-                  >
-                    <ListItemIcon>
-                      <HubIcon color="primary" />
-                    </ListItemIcon>
-                    <ListItemText primary="Cluster" />
-                  </ListItemButton>
-                </ListItem>
+                <NavItem
+                  to="/users"
+                  label="Users"
+                  icon={<AdminPanelSettingsIcon color="primary" />}
+                  pathname={pathname}
+                  onNavigate={handleNavClick}
+                />
+                <NavItem
+                  to="/audit-logs"
+                  label="Audit Logs"
+                  icon={<ReceiptLongIcon color="primary" />}
+                  exact
+                  pathname={pathname}
+                  onNavigate={handleNavClick}
+                />
+                <NavItem
+                  to="/backup-restore"
+                  label="Backup and Restore"
+                  icon={<StorageIcon color="primary" />}
+                  exact
+                  pathname={pathname}
+                  onNavigate={handleNavClick}
+                />
+                <NavItem
+                  to="/cluster"
+                  label="Cluster"
+                  icon={<HubIcon color="primary" />}
+                  exact
+                  pathname={pathname}
+                  onNavigate={handleNavClick}
+                />
               </>
             )}
           </List>


### PR DESCRIPTION
# Description

Replaced eleven hand-written sidebar entries with a single `NavItem` component that derives each route's active state once and exposes it both visually and to screen readers via aria-current="page".

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
