### PR TITLE
feat(ui): give each page its own document title

### DIFF
--- a/ui/src/components/ListPageHeader.tsx
+++ b/ui/src/components/ListPageHeader.tsx
@@ -3,6 +3,7 @@
 
 import React from "react";
 import { Box, Typography } from "@mui/material";
+import PageTitle from "@/components/PageTitle";
 
 interface ListPageHeaderProps {
   title: string;
@@ -23,12 +24,13 @@ const ListPageHeader: React.FC<ListPageHeaderProps> = ({
 }) => (
   <Box sx={{ mb: 3, display: "flex", flexDirection: "column", gap: 2 }}>
     <Box>
-      <Typography
-        variant={variant === "page" ? "h4" : "h5"}
-        component={variant === "page" ? "h1" : "h2"}
-      >
-        {count === undefined ? title : `${title} (${count})`}
-      </Typography>
+      {variant === "page" ? (
+        <PageTitle title={title} count={count} />
+      ) : (
+        <Typography variant="h5" component="h2">
+          {count === undefined ? title : `${title} (${count})`}
+        </Typography>
+      )}
       <Typography
         variant={variant === "page" ? "body1" : "body2"}
         color="textSecondary"

--- a/ui/src/components/PageTitle.test.tsx
+++ b/ui/src/components/PageTitle.test.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import PageTitle from "./PageTitle";
+
+const renderTitle = (ui: React.ReactNode) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe("PageTitle", () => {
+  beforeEach(() => {
+    document.title = "";
+  });
+
+  it("names the document after the heading it renders", () => {
+    renderTitle(<PageTitle title="Audit Logs" />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Audit Logs" }),
+    ).toBeInTheDocument();
+    expect(document.title).toBe("Audit Logs · Ella Core");
+  });
+
+  it("qualifies a detail page with its parent", () => {
+    renderTitle(
+      <PageTitle parent={{ label: "Radios", to: "/radios" }} title="gnb-001" />,
+    );
+
+    expect(screen.getByRole("link", { name: "Radios" })).toHaveAttribute(
+      "href",
+      "/radios",
+    );
+    expect(document.title).toBe("Radios / gnb-001 · Ella Core");
+  });
+
+  it("keeps a live count out of the document title", () => {
+    renderTitle(<PageTitle title="Radios" count={12} />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Radios (12)" }),
+    ).toBeInTheDocument();
+    expect(document.title).toBe("Radios · Ella Core");
+  });
+
+  it("lets a page whose heading is not its name override the title", () => {
+    renderTitle(<PageTitle title="Ella Core" documentTitle="Dashboard" />);
+
+    expect(document.title).toBe("Dashboard · Ella Core");
+  });
+
+  it("does not repeat the app name when the page is the app name", () => {
+    renderTitle(<PageTitle title="Ella Core" />);
+
+    expect(document.title).toBe("Ella Core");
+  });
+
+  it("retitles when the name changes", () => {
+    const { rerender } = renderTitle(<PageTitle title="Profiles" />);
+    expect(document.title).toBe("Profiles · Ella Core");
+
+    rerender(
+      <MemoryRouter>
+        <PageTitle title="Users" />
+      </MemoryRouter>,
+    );
+    expect(document.title).toBe("Users · Ella Core");
+  });
+});

--- a/ui/src/components/PageTitle.tsx
+++ b/ui/src/components/PageTitle.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+import React, { useEffect } from "react";
+import { Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+import { Link as RouterLink } from "react-router-dom";
+
+const APP_NAME = "Ella Core";
+
+export interface PageTitleProps {
+  title: string;
+  count?: number;
+  parent?: { label: string; to: string };
+  size?: "h4" | "h5";
+  documentTitle?: string;
+  adornment?: React.ReactNode;
+  gutterBottom?: boolean;
+  sx?: SxProps<Theme>;
+}
+
+export default function PageTitle({
+  title,
+  count,
+  parent,
+  size = "h4",
+  documentTitle,
+  adornment,
+  gutterBottom,
+  sx,
+}: PageTitleProps) {
+  const name = documentTitle ?? (parent ? `${parent.label} / ${title}` : title);
+
+  useEffect(() => {
+    document.title = name === APP_NAME ? APP_NAME : `${name} · ${APP_NAME}`;
+  }, [name]);
+
+  if (parent) {
+    return (
+      <Typography
+        variant={size}
+        component="h1"
+        sx={[
+          { display: "flex", alignItems: "baseline", gap: 0 },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+      >
+        <Typography
+          component={RouterLink}
+          to={parent.to}
+          variant={size}
+          sx={{
+            color: "text.secondary",
+            textDecoration: "none",
+            "&:hover": { textDecoration: "underline" },
+          }}
+        >
+          {parent.label}
+        </Typography>
+        <Typography
+          component="span"
+          variant={size}
+          sx={{ color: "text.secondary", mx: 1 }}
+        >
+          /
+        </Typography>
+        <Typography component="span" variant={size}>
+          {title}
+        </Typography>
+        {adornment}
+      </Typography>
+    );
+  }
+
+  return (
+    <Typography
+      variant={size}
+      component="h1"
+      gutterBottom={gutterBottom}
+      sx={sx}
+    >
+      {count === undefined ? title : `${title} (${count})`}
+      {adornment}
+    </Typography>
+  );
+}

--- a/ui/src/pages/AuditLogs.tsx
+++ b/ui/src/pages/AuditLogs.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo, useState } from "react";
+import PageTitle from "@/components/PageTitle";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Alert,
@@ -218,9 +219,7 @@ const AuditLog: React.FC = () => {
           gap: 2,
         }}
       >
-        <Typography variant="h4" component="h1">
-          Audit Logs
-        </Typography>
+        <PageTitle title="Audit Logs" />
 
         <Typography variant="body1" color="textSecondary">
           {descriptionText}

--- a/ui/src/pages/BackupRestore.tsx
+++ b/ui/src/pages/BackupRestore.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useRef, useState } from "react";
+import PageTitle from "@/components/PageTitle";
 import {
   Alert,
   Box,
@@ -190,9 +191,7 @@ const BackupRestore = () => {
             gap: 2,
           }}
         >
-          <Typography variant="h4" component="h1">
-            Backup & Restore
-          </Typography>
+          <PageTitle title="Backup & Restore" />
           <Typography variant="body1" color="textSecondary">
             {pageDescription}
           </Typography>

--- a/ui/src/pages/Cluster.tsx
+++ b/ui/src/pages/Cluster.tsx
@@ -47,6 +47,7 @@ import ResumeNodeModal from "@/components/ResumeNodeModal";
 import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
 import { formatDateTime } from "@/utils/formatters";
+import PageTitle from "@/components/PageTitle";
 
 type JoinedRow = ClusterMember & {
   id: number;
@@ -528,9 +529,7 @@ const ClusterPage: React.FC = () => {
           px: PAGE_PADDING_X,
         }}
       >
-        <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
-          Cluster
-        </Typography>
+        <PageTitle title="Cluster" sx={{ mb: 2 }} />
         <Paper sx={{ p: 3 }}>
           <Typography variant="body1">
             This node is running in single-node mode. High availability is not
@@ -547,9 +546,7 @@ const ClusterPage: React.FC = () => {
     >
       <Grid container spacing={2} sx={{ mb: 2, alignItems: "center" }}>
         <Grid size={{ xs: 12, md: 8 }}>
-          <Typography variant="h4" component="h1">
-            Cluster
-          </Typography>
+          <PageTitle title="Cluster" />
           <Typography variant="body1" color="textSecondary">
             High-availability cluster members and health.
           </Typography>

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/utils/formatters";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
 import { defaultDateRange } from "@/utils/dates";
+import PageTitle from "@/components/PageTitle";
 
 const nf = new Intl.NumberFormat();
 const formatNumber = (n: number | null | undefined) =>
@@ -348,14 +349,20 @@ const Dashboard = () => {
           gap: 2,
         }}
       >
-        <Typography variant="h4" component="h1">
-          Ella Core{" "}
-          {statusLoading ? (
-            <CircularProgress size={22} sx={{ ml: 1 }} />
-          ) : (
-            (version ?? "—")
-          )}
-        </Typography>
+        <PageTitle
+          title="Ella Core"
+          documentTitle="Dashboard"
+          adornment={
+            <>
+              {" "}
+              {statusLoading ? (
+                <CircularProgress size={22} sx={{ ml: 1 }} />
+              ) : (
+                (version ?? "—")
+              )}
+            </>
+          }
+        />
       </Box>
 
       <Typography variant="h5" component="h2" sx={{ mb: 2 }}>

--- a/ui/src/pages/DataNetworkDetail.tsx
+++ b/ui/src/pages/DataNetworkDetail.tsx
@@ -56,6 +56,7 @@ import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
 import EmptyState from "@/components/EmptyState";
 import QueryState from "@/components/QueryState";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 const tableContainerSx = {
   border: 1,
@@ -547,34 +548,10 @@ const DataNetworkDetail: React.FC = () => {
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{ display: "flex", alignItems: "baseline", gap: 0 }}
-          >
-            <Typography
-              component={RouterLink}
-              to="/networking/data-networks"
-              variant="h4"
-              sx={{
-                color: "text.secondary",
-                textDecoration: "none",
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Data Networks
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography component="span" variant="h4">
-              {name}
-            </Typography>
-          </Typography>
+          <PageTitle
+            parent={{ label: "Data Networks", to: "/networking/data-networks" }}
+            title={name ?? ""}
+          />
         </Box>
         {canEdit && (
           <Box sx={{ display: "flex", gap: 1 }}>

--- a/ui/src/pages/Initialize.tsx
+++ b/ui/src/pages/Initialize.tsx
@@ -18,6 +18,7 @@ import { ValidationError } from "yup";
 import { initialize } from "@/queries/initialize";
 import { getStatus } from "@/queries/status";
 import { useSnackbar } from "@/contexts/SnackbarContext";
+import PageTitle from "@/components/PageTitle";
 
 const schema = yup.object().shape({
   email: yup
@@ -140,14 +141,12 @@ const InitializePage = () => {
         }}
       >
         <form onSubmit={handleSubmit} noValidate>
-          <Typography
-            variant="h5"
-            component="h1"
+          <PageTitle
+            title="Initialize Ella Core"
+            size="h5"
             gutterBottom
             sx={{ textAlign: "center" }}
-          >
-            Initialize Ella Core
-          </Typography>
+          />
           <Typography variant="body1" sx={{ marginBottom: 2 }}>
             Create the first user
           </Typography>

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -9,7 +9,6 @@ import {
   IconButton,
   InputAdornment,
   TextField,
-  Typography,
   CircularProgress,
 } from "@mui/material";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
@@ -18,6 +17,7 @@ import { ValidationError } from "yup";
 import { login, refresh } from "@/queries/auth";
 import { getStatus } from "@/queries/status";
 import { useSnackbar } from "@/contexts/SnackbarContext";
+import PageTitle from "@/components/PageTitle";
 
 const schema = yup.object().shape({
   email: yup
@@ -165,14 +165,12 @@ const LoginPage = () => {
         }}
       >
         <form onSubmit={handleSubmit} noValidate>
-          <Typography
-            variant="h5"
-            component="h1"
+          <PageTitle
+            title="Login"
+            size="h5"
             gutterBottom
             sx={{ textAlign: "center" }}
-          >
-            Login
-          </Typography>
+          />
 
           <TextField
             label="Email"

--- a/ui/src/pages/Networking.tsx
+++ b/ui/src/pages/Networking.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useSnackbar } from "@/contexts/SnackbarContext";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 const TAB_SEGMENTS = [
   "data-networks",
@@ -44,9 +45,7 @@ export default function NetworkingPage() {
     <Box
       sx={{ pt: 6, pb: 4, maxWidth: MAX_WIDTH, mx: "auto", px: PAGE_PADDING_X }}
     >
-      <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
-        Networking
-      </Typography>
+      <PageTitle title="Networking" sx={{ mb: 1 }} />
       <Typography variant="body1" color="textSecondary" sx={{ mb: 2 }}>
         Configure networks and packet forwarding for Subscriber traffic.
       </Typography>

--- a/ui/src/pages/Operator.tsx
+++ b/ui/src/pages/Operator.tsx
@@ -45,6 +45,7 @@ import TacValue from "@/components/TacValue";
 import { useAuth } from "@/contexts/AuthContext";
 import { useSnackbar } from "@/contexts/SnackbarContext";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 const profileDescriptions: Record<string, string> = {
   A: "ECIES with X25519 (Curve25519)",
@@ -250,9 +251,7 @@ const Operator = () => {
     <Box
       sx={{ pt: 6, pb: 4, maxWidth: MAX_WIDTH, mx: "auto", px: PAGE_PADDING_X }}
     >
-      <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
-        Operator
-      </Typography>
+      <PageTitle title="Operator" sx={{ mb: 1 }} />
 
       <Typography variant="body1" color="textSecondary" sx={{ mb: 3 }}>
         Review and configure your operator identifiers and core settings.

--- a/ui/src/pages/PolicyDetail.tsx
+++ b/ui/src/pages/PolicyDetail.tsx
@@ -41,6 +41,7 @@ import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
 import QueryState from "@/components/QueryState";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
 import IPProtocolChip from "@/components/IPProtocolChip";
+import PageTitle from "@/components/PageTitle";
 
 const labelCellSx = { fontWeight: 600, width: "35%" } as const;
 const valueCellSx = { width: "65%", textAlign: "right" } as const;
@@ -262,67 +263,10 @@ const PolicyDetail: React.FC = () => {
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{ display: "flex", alignItems: "baseline", gap: 0 }}
-          >
-            <Typography
-              component={RouterLink}
-              to="/profiles"
-              variant="h4"
-              sx={{
-                color: "text.secondary",
-                textDecoration: "none",
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Profiles
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography
-              component={RouterLink}
-              to={`/profiles/${profileName}`}
-              variant="h4"
-              sx={{
-                color: "text.secondary",
-                textDecoration: "none",
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              {profileName}
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary" }}
-            >
-              Policies
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography component="span" variant="h4">
-              {name}
-            </Typography>
-          </Typography>
+          <PageTitle
+            parent={{ label: "Profiles", to: "/profiles" }}
+            title={name ?? ""}
+          />
           <Typography variant="body2" color="textSecondary" sx={{ mt: 0.5 }}>
             A policy defines the QoS parameters and network rules applied to a
             subscriber's session on a specific data network.

--- a/ui/src/pages/Profile.tsx
+++ b/ui/src/pages/Profile.tsx
@@ -20,6 +20,7 @@ import UserPasswordCard from "@/components/UserPasswordCard";
 import UserAPITokensCard from "@/components/UserAPITokensCard";
 import QueryState from "@/components/QueryState";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 export default function Profile() {
   const navigate = useNavigate();
@@ -82,9 +83,7 @@ export default function Profile() {
     <Box
       sx={{ pt: 6, pb: 4, maxWidth: MAX_WIDTH, mx: "auto", px: PAGE_PADDING_X }}
     >
-      <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
-        My Profile
-      </Typography>
+      <PageTitle title="My Profile" sx={{ mb: 1 }} />
       <Typography variant="body1" color="textSecondary" sx={{ mb: 3 }}>
         Manage how you authenticate with Ella Core.
       </Typography>

--- a/ui/src/pages/ProfileDetail.tsx
+++ b/ui/src/pages/ProfileDetail.tsx
@@ -41,6 +41,7 @@ import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
 import EmptyState from "@/components/EmptyState";
 import QueryState from "@/components/QueryState";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 const labelCellSx = {
   fontWeight: 600,
@@ -198,34 +199,10 @@ const ProfileDetail: React.FC = () => {
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{ display: "flex", alignItems: "baseline", gap: 0 }}
-          >
-            <Typography
-              component={RouterLink}
-              to="/profiles"
-              variant="h4"
-              sx={{
-                color: "text.secondary",
-                textDecoration: "none",
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Profiles
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography component="span" variant="h4">
-              {name}
-            </Typography>
-          </Typography>
+          <PageTitle
+            parent={{ label: "Profiles", to: "/profiles" }}
+            title={name ?? ""}
+          />
           <Typography variant="body2" color="textSecondary" sx={{ mt: 0.5 }}>
             A profile defines the aggregate bitrate limits for a subscriber and
             groups the QoS policies applied to their sessions.

--- a/ui/src/pages/RadioDetail.tsx
+++ b/ui/src/pages/RadioDetail.tsx
@@ -47,6 +47,7 @@ import EastIcon from "@mui/icons-material/East";
 import WestIcon from "@mui/icons-material/West";
 import { Tooltip } from "@mui/material";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 const tableContainerSx = {
   border: 1,
@@ -318,34 +319,10 @@ const RadioDetail: React.FC = () => {
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{ display: "flex", alignItems: "baseline", gap: 0 }}
-          >
-            <Typography
-              component={RouterLink}
-              to="/radios"
-              variant="h4"
-              sx={{
-                color: "text.secondary",
-                textDecoration: "none",
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Radios
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography component="span" variant="h4">
-              {radioLabel}
-            </Typography>
-          </Typography>
+          <PageTitle
+            parent={{ label: "Radios", to: "/radios" }}
+            title={radioLabel}
+          />
         </Box>
         {role === "Admin" && (
           <Box sx={{ display: "flex", gap: 1 }}>

--- a/ui/src/pages/SubscriberDetail.tsx
+++ b/ui/src/pages/SubscriberDetail.tsx
@@ -29,6 +29,7 @@ import SubscriberUsageChart from "@/components/SubscriberUsageChart";
 import SubscriberProtocolChart from "@/components/SubscriberProtocolChart";
 import QueryState from "@/components/QueryState";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 const SubscriberDetail: React.FC = () => {
   const { imsi } = useParams<{ imsi: string }>();
@@ -101,34 +102,10 @@ const SubscriberDetail: React.FC = () => {
       >
         <Box sx={{ flex: 1 }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 0.5 }}>
-            <Typography
-              variant="h4"
-              component="h1"
-              sx={{ display: "flex", alignItems: "baseline", gap: 0 }}
-            >
-              <Typography
-                component={RouterLink}
-                to="/subscribers"
-                variant="h4"
-                sx={{
-                  color: "text.secondary",
-                  textDecoration: "none",
-                  "&:hover": { textDecoration: "underline" },
-                }}
-              >
-                Subscribers
-              </Typography>
-              <Typography
-                component="span"
-                variant="h4"
-                sx={{ color: "text.secondary", mx: 1 }}
-              >
-                /
-              </Typography>
-              <Typography component="span" variant="h4">
-                {imsi}
-              </Typography>
-            </Typography>
+            <PageTitle
+              parent={{ label: "Subscribers", to: "/subscribers" }}
+              title={imsi ?? ""}
+            />
           </Box>
         </Box>
         {canEdit && (

--- a/ui/src/pages/Traffic.tsx
+++ b/ui/src/pages/Traffic.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useMemo, useState, useCallback } from "react";
+import PageTitle from "@/components/PageTitle";
 import {
   Autocomplete,
   Box,
@@ -833,9 +834,7 @@ const Traffic: React.FC = () => {
             gap: 2,
           }}
         >
-          <Typography variant="h4" component="h1">
-            Traffic
-          </Typography>
+          <PageTitle title="Traffic" />
           <Typography variant="body1" color="textSecondary">
             Monitor network traffic — view aggregated data usage and individual
             flow records collected by the user plane.

--- a/ui/src/pages/UserDetail.tsx
+++ b/ui/src/pages/UserDetail.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import React, { useEffect, useState } from "react";
-import { Box, Button, Skeleton, Typography } from "@mui/material";
-import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
+import { Box, Button, Skeleton } from "@mui/material";
+import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getUser, type APIUser } from "@/queries/users";
 import {
@@ -28,6 +28,7 @@ import UserAPITokensCard from "@/components/UserAPITokensCard";
 import UserAuditLogsCard from "@/components/UserAuditLogsCard";
 import QueryState from "@/components/QueryState";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 const UserDetail: React.FC = () => {
   const { email } = useParams<{ email: string }>();
@@ -134,34 +135,10 @@ const UserDetail: React.FC = () => {
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{ display: "flex", alignItems: "baseline" }}
-          >
-            <Typography
-              component={RouterLink}
-              to="/users"
-              variant="h4"
-              sx={{
-                color: "text.secondary",
-                textDecoration: "none",
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Users
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography component="span" variant="h4">
-              {email}
-            </Typography>
-          </Typography>
+          <PageTitle
+            parent={{ label: "Users", to: "/users" }}
+            title={email ?? ""}
+          />
         </Box>
         {isAdmin && !isSelf && (
           <Button

--- a/ui/src/pages/radios/RadioEvents.tsx
+++ b/ui/src/pages/radios/RadioEvents.tsx
@@ -58,6 +58,7 @@ import type { LogRow } from "@/components/EventDetails";
 import ProtocolChip from "@/components/ProtocolChip";
 import { formatDateTime } from "@/utils/formatters";
 import { useFilteredPagination } from "@/hooks/useFilteredPagination";
+import PageTitle from "@/components/PageTitle";
 
 const NGAP_MESSAGE_TYPES = [
   "AMFConfigurationUpdate",
@@ -608,34 +609,10 @@ export default function RadioEvents() {
         }}
       >
         <Box>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{ display: "flex", alignItems: "baseline", gap: 0 }}
-          >
-            <Typography
-              component={Link}
-              to="/radios"
-              variant="h4"
-              sx={{
-                color: "text.secondary",
-                textDecoration: "none",
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Radios
-            </Typography>
-            <Typography
-              component="span"
-              variant="h4"
-              sx={{ color: "text.secondary", mx: 1 }}
-            >
-              /
-            </Typography>
-            <Typography component="span" variant="h4">
-              Network Events
-            </Typography>
-          </Typography>
+          <PageTitle
+            parent={{ label: "Radios", to: "/radios" }}
+            title="Network Events"
+          />
           <Typography variant="body1" color="textSecondary">
             {subDescription}
           </Typography>

--- a/ui/src/pages/radios/RadiosList.tsx
+++ b/ui/src/pages/radios/RadiosList.tsx
@@ -22,6 +22,7 @@ import RanNodeTypeChip from "@/components/RanNodeTypeChip";
 import { useAuth } from "@/contexts/AuthContext";
 import { useQuery } from "@tanstack/react-query";
 import { MAX_WIDTH, PAGE_PADDING_X } from "@/utils/layout";
+import PageTitle from "@/components/PageTitle";
 
 export default function RadiosList() {
   const { accessToken } = useAuth();
@@ -123,9 +124,7 @@ export default function RadiosList() {
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
-            {knownCount === undefined ? "Radios" : `Radios (${knownCount})`}
-          </Typography>
+          <PageTitle title="Radios" count={knownCount} sx={{ mb: 1 }} />
           <Typography variant="body1" color="textSecondary">
             {descriptionText}
           </Typography>


### PR DESCRIPTION
# Description

Every page in the UI now has its own browser tab title instead of all of them sharing one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
