### PR TITLE
fix(ha): track listener connections until close

### DIFF
--- a/internal/api/server/cluster_http.go
+++ b/internal/api/server/cluster_http.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"context"
-	"crypto/tls"
 	"net"
 	"net/http"
 	"sync"
@@ -124,16 +123,11 @@ func peerNodeIDConnContext(ctx context.Context, c net.Conn) context.Context {
 		return ctx
 	}
 
-	tc, ok := oc.Conn.(*tls.Conn)
-	if !ok {
-		return ctx
-	}
-
 	if clusterListenerForPeerLookup == nil {
 		return ctx
 	}
 
-	id, err := clusterListenerForPeerLookup.PeerNodeID(tc)
+	id, err := clusterListenerForPeerLookup.PeerNodeID(oc.Conn)
 	if err != nil {
 		return ctx
 	}

--- a/internal/cluster/listener/listener.go
+++ b/internal/cluster/listener/listener.go
@@ -340,18 +340,53 @@ func (l *Listener) dispatch(ctx context.Context, conn net.Conn) {
 	}
 
 	l.trackConn(tlsConn)
-	defer l.untrackConn(tlsConn)
 
 	if err := verifyConnection(l.cfg.Pin)(tlsConn.ConnectionState()); err != nil {
 		logger.RaftLog.Warn("Cluster connection rejected after handshake",
 			zap.String("remote", conn.RemoteAddr().String()),
 			zap.Error(err))
+		l.untrackConn(tlsConn)
+
 		_ = conn.Close()
 
 		return
 	}
 
-	handler(conn)
+	handler(&trackedConn{Conn: tlsConn, ln: l})
+}
+
+// trackedConn is the connection handed to an ALPN handler. Handlers own
+// the connection past the point where dispatch returns — they hand it to
+// a stream layer or an HTTP server — so the listener cannot untrack on
+// dispatch return without losing its handle on every live session.
+// Closing untracks instead, which keeps l.conns a map of the connections
+// CloseByPeerFingerprint must still be able to tear down.
+type trackedConn struct {
+	*tls.Conn
+
+	ln   *Listener
+	once sync.Once
+}
+
+func (c *trackedConn) Close() error {
+	c.once.Do(func() { c.ln.untrackConn(c.Conn) })
+
+	return c.Conn.Close()
+}
+
+// TLSConn returns the cluster TLS connection underlying c, unwrapping
+// the connection type the listener hands to ALPN handlers. The second
+// return is false for a connection that did not come from the cluster
+// listener.
+func TLSConn(c net.Conn) (*tls.Conn, bool) {
+	switch conn := c.(type) {
+	case *trackedConn:
+		return conn.Conn, true
+	case *tls.Conn:
+		return conn, true
+	default:
+		return nil, false
+	}
 }
 
 // trackConn registers a post-handshake connection so

--- a/internal/cluster/listener/listener.go
+++ b/internal/cluster/listener/listener.go
@@ -355,12 +355,6 @@ func (l *Listener) dispatch(ctx context.Context, conn net.Conn) {
 	handler(&trackedConn{Conn: tlsConn, ln: l})
 }
 
-// trackedConn is the connection handed to an ALPN handler. Handlers own
-// the connection past the point where dispatch returns — they hand it to
-// a stream layer or an HTTP server — so the listener cannot untrack on
-// dispatch return without losing its handle on every live session.
-// Closing untracks instead, which keeps l.conns a map of the connections
-// CloseByPeerFingerprint must still be able to tear down.
 type trackedConn struct {
 	*tls.Conn
 
@@ -374,10 +368,6 @@ func (c *trackedConn) Close() error {
 	return c.Conn.Close()
 }
 
-// TLSConn returns the cluster TLS connection underlying c, unwrapping
-// the connection type the listener hands to ALPN handlers. The second
-// return is false for a connection that did not come from the cluster
-// listener.
 func TLSConn(c net.Conn) (*tls.Conn, bool) {
 	switch conn := c.(type) {
 	case *trackedConn:

--- a/internal/cluster/listener/listener_pki_test.go
+++ b/internal/cluster/listener/listener_pki_test.go
@@ -44,7 +44,12 @@ func TestListener_BootstrapALPN_NoClientCert(t *testing.T) {
 		defer wg.Done()
 		defer func() { _ = conn.Close() }()
 
-		tc := conn.(*tls.Conn)
+		tc, ok := listener.TLSConn(conn)
+		if !ok {
+			t.Errorf("bootstrap handler got a non-cluster connection %T", conn)
+			return
+		}
+
 		if len(tc.ConnectionState().PeerCertificates) != 0 {
 			t.Errorf("bootstrap handler saw %d peer certs, want 0", len(tc.ConnectionState().PeerCertificates))
 		}

--- a/internal/cluster/listener/listener_test.go
+++ b/internal/cluster/listener/listener_test.go
@@ -5,7 +5,6 @@ package listener_test
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/ellanetworks/core/internal/cluster/listener"
 	"github.com/ellanetworks/core/internal/cluster/listener/testutil"
+	"github.com/ellanetworks/core/internal/pki"
 )
 
 // freePort returns an available TCP port on localhost.
@@ -237,7 +237,7 @@ func TestListener_PeerNodeID(t *testing.T) {
 		defer func() { _ = conn.Close() }()
 		defer wg.Done()
 
-		nodeID, err := ln1.PeerNodeID(conn.(*tls.Conn))
+		nodeID, err := ln1.PeerNodeID(conn)
 		if err != nil {
 			t.Errorf("PeerNodeID: %v", err)
 			return
@@ -415,4 +415,63 @@ func TestListener_UnknownALPN_Closed(t *testing.T) {
 	}
 
 	ln1.Stop()
+}
+
+func TestListener_CloseByPeerFingerprintClosesHandedOffConn(t *testing.T) {
+	p := testutil.GenTestPKI(t, []int{1, 2})
+
+	ln1, addr1 := newTestListener(t, p, 1)
+
+	handed := make(chan net.Conn, 1)
+
+	ln1.Register(listener.ALPNRaft, func(conn net.Conn) {
+		handed <- conn
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := ln1.Start(ctx); err != nil {
+		t.Fatalf("start listener: %v", err)
+	}
+
+	defer ln1.Stop()
+
+	ln2, _ := newTestListener(t, p, 2)
+	defer ln2.Stop()
+
+	client, err := ln2.Dial(ctx, addr1, 1, listener.ALPNRaft, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	defer func() { _ = client.Close() }()
+
+	var server net.Conn
+
+	select {
+	case server = <-handed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never received the connection")
+	}
+
+	defer func() { _ = server.Close() }()
+
+	fp := pki.Fingerprint(p.Nodes[2].Cert)
+
+	if n := ln1.CloseByPeerFingerprint(fp); n != 1 {
+		t.Fatalf("CloseByPeerFingerprint closed %d connections, want 1", n)
+	}
+
+	_ = server.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	if _, err := server.Read(make([]byte, 1)); err == nil {
+		t.Fatal("connection still readable after CloseByPeerFingerprint")
+	}
+
+	_ = server.Close()
+
+	if n := ln1.CloseByPeerFingerprint(fp); n != 0 {
+		t.Fatalf("CloseByPeerFingerprint closed %d connections after the handler closed it, want 0", n)
+	}
 }

--- a/internal/cluster/listener/verify.go
+++ b/internal/cluster/listener/verify.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 
 	"github.com/ellanetworks/core/internal/pki"
 )
@@ -71,8 +72,13 @@ func verifyConnection(pinFn PinFunc) func(tls.ConnectionState) error {
 // PeerNodeID returns the peer's nodeID by parsing the SPIFFE URI
 // SAN of its leaf. The leaf has already been pinned by
 // verifyConnection during the handshake, so no DB lookup is needed.
-func PeerNodeID(conn *tls.Conn) (int, error) {
-	state := conn.ConnectionState()
+func PeerNodeID(conn net.Conn) (int, error) {
+	tlsConn, ok := TLSConn(conn)
+	if !ok {
+		return 0, fmt.Errorf("cluster TLS: connection is not a cluster TLS connection")
+	}
+
+	state := tlsConn.ConnectionState()
 	if len(state.PeerCertificates) == 0 {
 		return 0, fmt.Errorf("cluster TLS: no peer certificates after handshake")
 	}
@@ -89,6 +95,6 @@ func peerNodeIDFromCert(cert *x509.Certificate) (int, error) {
 	return nodeID, nil
 }
 
-func (l *Listener) PeerNodeID(conn *tls.Conn) (int, error) {
+func (l *Listener) PeerNodeID(conn net.Conn) (int, error) {
 	return PeerNodeID(conn)
 }


### PR DESCRIPTION
# Description

The cluster listener now keeps its handle on an accepted connection until that connection is closed, so CloseByPeerFingerprint can actually tear down live Raft and cluster-HTTP sessions when a peer's pin is removed.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
