### PR TITLE
feat(api)!: report subscriber state per registration with RAN UE identities

### DIFF
--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -103,8 +103,7 @@ type SessionSlice struct {
 // Session is a UE data session — a 5GS PDU session or an EPS PDN connection.
 type Session struct {
 	System       string        `json:"system"` // "5GS" | "EPS"
-	AccessTypes  []string      `json:"access_types"`
-	ID           uint8         `json:"id"` // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
+	ID           uint8         `json:"id"`     // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
 	Status       string        `json:"status"`
 	IPType       string        `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
 	IPv4Address  string        `json:"ipv4_address,omitempty"`

--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -35,12 +35,12 @@ type DeleteSubscriberOptions struct {
 
 // SubscriberStatus is the lightweight status carried in list responses.
 type SubscriberStatus struct {
-	Registered       bool     `json:"registered"`
-	ConnectionState  string   `json:"connection_state,omitempty"`
-	RadioAccessTypes []string `json:"radio_access_types,omitempty"`
-	NumSessions      int      `json:"num_sessions"`
-	LastSeenAt       string   `json:"last_seen_at,omitempty"`
-	LastSeenRadio    string   `json:"last_seen_radio,omitempty"`
+	Registered      bool     `json:"registered"`
+	ConnectionState string   `json:"connection_state,omitempty"`
+	Systems         []string `json:"systems,omitempty"`
+	NumSessions     int      `json:"num_sessions"`
+	LastSeenAt      string   `json:"last_seen_at,omitempty"`
+	LastSeenRadio   string   `json:"last_seen_radio,omitempty"`
 }
 
 // Subscriber is the summary form returned by ListSubscribers.

--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -93,23 +93,23 @@ type SubscriberDetail struct {
 	Sessions      []Session      `json:"sessions"`
 }
 
-// SessionSlice is the 5GS network slice identifier (S-NSSAI) of a session;
-// absent for EPS.
+// SessionSlice is the 5G network slice identifier (S-NSSAI) of a session;
+// absent for 4G.
 type SessionSlice struct {
 	SST int32  `json:"sst"`
 	SD  string `json:"sd,omitempty"`
 }
 
-// Session is a UE data session — a 5GS PDU session or an EPS PDN connection.
+// Session is a UE data session — a 5G PDU session or a 4G PDN connection.
 type Session struct {
-	System       string        `json:"system"` // "5GS" | "EPS"
-	ID           uint8         `json:"id"`     // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
+	System       string        `json:"system"` // "5G" | "4G"
+	ID           uint8         `json:"id"`     // PDU Session ID (5G) / linked EPS Bearer ID (4G)
 	Status       string        `json:"status"`
 	IPType       string        `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
 	IPv4Address  string        `json:"ipv4_address,omitempty"`
 	IPv6Prefix   string        `json:"ipv6_prefix,omitempty"`
-	DataNetwork  string        `json:"data_network,omitempty"` // DNN (5GS) / APN (EPS)
-	Slice        *SessionSlice `json:"slice,omitempty"`        // 5GS only
+	DataNetwork  string        `json:"data_network,omitempty"` // DNN (5G) / APN (4G)
+	Slice        *SessionSlice `json:"slice,omitempty"`        // 5G only
 	AMBRUplink   string        `json:"ambr_uplink,omitempty"`
 	AMBRDownlink string        `json:"ambr_downlink,omitempty"`
 }

--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -74,12 +74,10 @@ type UEConnection struct {
 
 type Registration struct {
 	System             string        `json:"system"`
-	AccessType         string        `json:"access_type"`
 	Registered         bool          `json:"registered"`
 	ConnectionState    *string       `json:"connection_state"`
 	Radio              string        `json:"radio,omitempty"`
 	LastSeenAt         string        `json:"last_seen_at,omitempty"`
-	Pei                string        `json:"pei,omitempty"`
 	Imei               string        `json:"imei,omitempty"`
 	CipheringAlgorithm string        `json:"ciphering_algorithm,omitempty"`
 	IntegrityAlgorithm string        `json:"integrity_algorithm,omitempty"`

--- a/client/subscribers.go
+++ b/client/subscribers.go
@@ -65,47 +65,56 @@ type ListSubscribersResponse struct {
 	TotalCount int          `json:"total_count"`
 }
 
-// SubscriberDetailStatus is the rich status carried in GetSubscriber responses.
-type SubscriberDetailStatus struct {
-	Registered         bool     `json:"registered"`
-	ConnectionState    string   `json:"connection_state,omitempty"`
-	RadioAccessTypes   []string `json:"radio_access_types,omitempty"`
-	Imei               string   `json:"imei"`
-	CipheringAlgorithm string   `json:"ciphering_algorithm"`
-	IntegrityAlgorithm string   `json:"integrity_algorithm"`
-	LastSeenAt         string   `json:"last_seen_at,omitempty"`
-	LastSeenRadio      string   `json:"last_seen_radio,omitempty"`
+type UEConnection struct {
+	AmfUeNgapID *int64 `json:"amf_ue_ngap_id,omitempty"`
+	RanUeNgapID *int64 `json:"ran_ue_ngap_id,omitempty"`
+	MMEUeS1apID *int64 `json:"mme_ue_s1ap_id,omitempty"`
+	ENBUeS1apID *int64 `json:"enb_ue_s1ap_id,omitempty"`
+}
+
+type Registration struct {
+	System             string        `json:"system"`
+	AccessType         string        `json:"access_type"`
+	Registered         bool          `json:"registered"`
+	ConnectionState    *string       `json:"connection_state"`
+	Radio              string        `json:"radio,omitempty"`
+	LastSeenAt         string        `json:"last_seen_at,omitempty"`
+	Pei                string        `json:"pei,omitempty"`
+	Imei               string        `json:"imei,omitempty"`
+	CipheringAlgorithm string        `json:"ciphering_algorithm,omitempty"`
+	IntegrityAlgorithm string        `json:"integrity_algorithm,omitempty"`
+	Connection         *UEConnection `json:"connection"`
 }
 
 // SubscriberDetail is the full form returned by GetSubscriber.
 type SubscriberDetail struct {
-	Imsi        string                 `json:"imsi"`
-	ProfileName string                 `json:"profile_name"`
-	Description string                 `json:"description,omitempty"`
-	Status      SubscriberDetailStatus `json:"status"`
-	Sessions    []Session              `json:"sessions"`
+	Imsi          string         `json:"imsi"`
+	ProfileName   string         `json:"profile_name"`
+	Description   string         `json:"description,omitempty"`
+	Registrations []Registration `json:"registrations"`
+	Sessions      []Session      `json:"sessions"`
 }
 
-// SessionSlice is the 5G network slice identifier (S-NSSAI) of a session;
-// absent for 4G.
+// SessionSlice is the 5GS network slice identifier (S-NSSAI) of a session;
+// absent for EPS.
 type SessionSlice struct {
 	SST int32  `json:"sst"`
 	SD  string `json:"sd,omitempty"`
 }
 
-// Session is a UE data session — a 5G PDU session or a 4G PDN connection —
-// self-describing via RadioAccessType.
+// Session is a UE data session — a 5GS PDU session or an EPS PDN connection.
 type Session struct {
-	RadioAccessType string        `json:"radio_access_type"` // "4G" | "5G"
-	ID              uint8         `json:"id"`                // PDU Session ID (5G) / linked EPS Bearer ID (4G)
-	Status          string        `json:"status"`
-	IPType          string        `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
-	IPv4Address     string        `json:"ipv4_address,omitempty"`
-	IPv6Prefix      string        `json:"ipv6_prefix,omitempty"`
-	DataNetwork     string        `json:"data_network,omitempty"` // DNN (5G) / APN (4G)
-	Slice           *SessionSlice `json:"slice,omitempty"`        // 5G only
-	AMBRUplink      string        `json:"ambr_uplink,omitempty"`
-	AMBRDownlink    string        `json:"ambr_downlink,omitempty"`
+	System       string        `json:"system"` // "5GS" | "EPS"
+	AccessTypes  []string      `json:"access_types"`
+	ID           uint8         `json:"id"` // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
+	Status       string        `json:"status"`
+	IPType       string        `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
+	IPv4Address  string        `json:"ipv4_address,omitempty"`
+	IPv6Prefix   string        `json:"ipv6_prefix,omitempty"`
+	DataNetwork  string        `json:"data_network,omitempty"` // DNN (5GS) / APN (EPS)
+	Slice        *SessionSlice `json:"slice,omitempty"`        // 5GS only
+	AMBRUplink   string        `json:"ambr_uplink,omitempty"`
+	AMBRDownlink string        `json:"ambr_downlink,omitempty"`
 }
 
 type SubscriberCredentials struct {

--- a/client/subscribers_test.go
+++ b/client/subscribers_test.go
@@ -45,7 +45,7 @@ func TestGetSubscriber_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "registrations": [{"system": "5GS", "registered": true, "connection_state": "connected", "radio": "gnb-01", "imei": "359881234567890", "ciphering_algorithm": "128-NEA2", "integrity_algorithm": "128-NIA2", "connection": {"amf_ue_ngap_id": 12, "ran_ue_ngap_id": 39}}], "sessions": [{"system": "5GS", "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
+			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "registrations": [{"system": "5G", "registered": true, "connection_state": "connected", "radio": "gnb-01", "imei": "359881234567890", "ciphering_algorithm": "128-NEA2", "integrity_algorithm": "128-NIA2", "connection": {"amf_ue_ngap_id": 12, "ran_ue_ngap_id": 39}}], "sessions": [{"system": "5G", "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
 		},
 		err: nil,
 	}
@@ -75,8 +75,8 @@ func TestGetSubscriber_Success(t *testing.T) {
 
 	reg := subscriber.Registrations[0]
 
-	if reg.System != "5GS" {
-		t.Fatalf("expected a 5GS registration, got %s", reg.System)
+	if reg.System != "5G" {
+		t.Fatalf("expected a 5G registration, got %s", reg.System)
 	}
 
 	if !reg.Registered {
@@ -108,15 +108,15 @@ func TestGetSubscriber_Success(t *testing.T) {
 	}
 
 	if reg.Connection.MMEUeS1apID != nil || reg.Connection.ENBUeS1apID != nil {
-		t.Fatalf("expected no S1AP identities on a 5GS registration, got %+v", reg.Connection)
+		t.Fatalf("expected no S1AP identities on a 5G registration, got %+v", reg.Connection)
 	}
 
 	if len(subscriber.Sessions) != 1 {
 		t.Fatalf("expected 1 session, got %d", len(subscriber.Sessions))
 	}
 
-	if subscriber.Sessions[0].System != "5GS" {
-		t.Fatalf("expected session system '5GS', got %s", subscriber.Sessions[0].System)
+	if subscriber.Sessions[0].System != "5G" {
+		t.Fatalf("expected session system '5G', got %s", subscriber.Sessions[0].System)
 	}
 
 	if subscriber.Sessions[0].ID != 1 {

--- a/client/subscribers_test.go
+++ b/client/subscribers_test.go
@@ -45,7 +45,7 @@ func TestGetSubscriber_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "status": {"registered": false, "imei": "", "ciphering_algorithm": "", "integrity_algorithm": ""}, "sessions": [{"radio_access_type": "5G", "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
+			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "registrations": [{"system": "5GS", "access_type": "3GPP", "registered": true, "connection_state": "connected", "radio": "gnb-01", "pei": "imeisv-3535938300494715", "ciphering_algorithm": "128-NEA2", "integrity_algorithm": "128-NIA2", "connection": {"amf_ue_ngap_id": 12, "ran_ue_ngap_id": 39}}], "sessions": [{"system": "5GS", "access_types": ["3GPP"], "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
 		},
 		err: nil,
 	}
@@ -69,20 +69,58 @@ func TestGetSubscriber_Success(t *testing.T) {
 		t.Fatalf("expected IMSI %s, got %s", imsi, subscriber.Imsi)
 	}
 
-	if subscriber.Status.Registered != false {
-		t.Fatalf("expected Registered false, got %v", subscriber.Status.Registered)
+	if len(subscriber.Registrations) != 1 {
+		t.Fatalf("expected 1 registration, got %d", len(subscriber.Registrations))
 	}
 
-	if subscriber.Status.CipheringAlgorithm != "" {
-		t.Fatalf("expected empty CipheringAlgorithm, got %s", subscriber.Status.CipheringAlgorithm)
+	reg := subscriber.Registrations[0]
+
+	if reg.System != "5GS" || reg.AccessType != "3GPP" {
+		t.Fatalf("expected a 5GS/3GPP registration, got %s/%s", reg.System, reg.AccessType)
 	}
 
-	if subscriber.Status.IntegrityAlgorithm != "" {
-		t.Fatalf("expected empty IntegrityAlgorithm, got %s", subscriber.Status.IntegrityAlgorithm)
+	if !reg.Registered {
+		t.Fatalf("expected Registered true, got %v", reg.Registered)
+	}
+
+	if reg.ConnectionState == nil || *reg.ConnectionState != "connected" {
+		t.Fatalf("expected ConnectionState 'connected', got %v", reg.ConnectionState)
+	}
+
+	if reg.Radio != "gnb-01" {
+		t.Fatalf("expected Radio 'gnb-01', got %s", reg.Radio)
+	}
+
+	if reg.Pei != "imeisv-3535938300494715" {
+		t.Fatalf("expected Pei 'imeisv-3535938300494715', got %s", reg.Pei)
+	}
+
+	if reg.CipheringAlgorithm != "128-NEA2" || reg.IntegrityAlgorithm != "128-NIA2" {
+		t.Fatalf("expected 128-NEA2/128-NIA2, got %s/%s", reg.CipheringAlgorithm, reg.IntegrityAlgorithm)
+	}
+
+	if reg.Connection == nil || reg.Connection.AmfUeNgapID == nil || *reg.Connection.AmfUeNgapID != 12 {
+		t.Fatalf("expected amf_ue_ngap_id 12, got %+v", reg.Connection)
+	}
+
+	if reg.Connection.RanUeNgapID == nil || *reg.Connection.RanUeNgapID != 39 {
+		t.Fatalf("expected ran_ue_ngap_id 39, got %+v", reg.Connection.RanUeNgapID)
+	}
+
+	if reg.Connection.MMEUeS1apID != nil || reg.Connection.ENBUeS1apID != nil {
+		t.Fatalf("expected no S1AP identities on a 5GS registration, got %+v", reg.Connection)
 	}
 
 	if len(subscriber.Sessions) != 1 {
 		t.Fatalf("expected 1 session, got %d", len(subscriber.Sessions))
+	}
+
+	if subscriber.Sessions[0].System != "5GS" {
+		t.Fatalf("expected session system '5GS', got %s", subscriber.Sessions[0].System)
+	}
+
+	if got := subscriber.Sessions[0].AccessTypes; len(got) != 1 || got[0] != "3GPP" {
+		t.Fatalf("expected session access_types [3GPP], got %v", got)
 	}
 
 	if subscriber.Sessions[0].ID != 1 {

--- a/client/subscribers_test.go
+++ b/client/subscribers_test.go
@@ -45,7 +45,7 @@ func TestGetSubscriber_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "registrations": [{"system": "5GS", "access_type": "3GPP", "registered": true, "connection_state": "connected", "radio": "gnb-01", "pei": "imeisv-3535938300494715", "ciphering_algorithm": "128-NEA2", "integrity_algorithm": "128-NIA2", "connection": {"amf_ue_ngap_id": 12, "ran_ue_ngap_id": 39}}], "sessions": [{"system": "5GS", "access_types": ["3GPP"], "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
+			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "registrations": [{"system": "5GS", "registered": true, "connection_state": "connected", "radio": "gnb-01", "imei": "359881234567890", "ciphering_algorithm": "128-NEA2", "integrity_algorithm": "128-NIA2", "connection": {"amf_ue_ngap_id": 12, "ran_ue_ngap_id": 39}}], "sessions": [{"system": "5GS", "access_types": ["3GPP"], "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
 		},
 		err: nil,
 	}
@@ -75,8 +75,8 @@ func TestGetSubscriber_Success(t *testing.T) {
 
 	reg := subscriber.Registrations[0]
 
-	if reg.System != "5GS" || reg.AccessType != "3GPP" {
-		t.Fatalf("expected a 5GS/3GPP registration, got %s/%s", reg.System, reg.AccessType)
+	if reg.System != "5GS" {
+		t.Fatalf("expected a 5GS registration, got %s", reg.System)
 	}
 
 	if !reg.Registered {
@@ -91,8 +91,8 @@ func TestGetSubscriber_Success(t *testing.T) {
 		t.Fatalf("expected Radio 'gnb-01', got %s", reg.Radio)
 	}
 
-	if reg.Pei != "imeisv-3535938300494715" {
-		t.Fatalf("expected Pei 'imeisv-3535938300494715', got %s", reg.Pei)
+	if reg.Imei != "359881234567890" {
+		t.Fatalf("expected Imei '359881234567890', got %s", reg.Imei)
 	}
 
 	if reg.CipheringAlgorithm != "128-NEA2" || reg.IntegrityAlgorithm != "128-NIA2" {

--- a/client/subscribers_test.go
+++ b/client/subscribers_test.go
@@ -45,7 +45,7 @@ func TestGetSubscriber_Success(t *testing.T) {
 		response: &client.RequestResponse{
 			StatusCode: 200,
 			Headers:    http.Header{},
-			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "registrations": [{"system": "5GS", "registered": true, "connection_state": "connected", "radio": "gnb-01", "imei": "359881234567890", "ciphering_algorithm": "128-NEA2", "integrity_algorithm": "128-NIA2", "connection": {"amf_ue_ngap_id": 12, "ran_ue_ngap_id": 39}}], "sessions": [{"system": "5GS", "access_types": ["3GPP"], "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
+			Result:     []byte(`{"imsi": "001010100000022", "profile_name": "default", "registrations": [{"system": "5GS", "registered": true, "connection_state": "connected", "radio": "gnb-01", "imei": "359881234567890", "ciphering_algorithm": "128-NEA2", "integrity_algorithm": "128-NIA2", "connection": {"amf_ue_ngap_id": 12, "ran_ue_ngap_id": 39}}], "sessions": [{"system": "5GS", "id": 1, "status": "active", "ipv4_address": "10.45.0.2", "data_network": "internet", "slice": {"sst": 1, "sd": "000001"}, "ambr_uplink": "100 Mbps", "ambr_downlink": "200 Mbps"}]}`),
 		},
 		err: nil,
 	}
@@ -117,10 +117,6 @@ func TestGetSubscriber_Success(t *testing.T) {
 
 	if subscriber.Sessions[0].System != "5GS" {
 		t.Fatalf("expected session system '5GS', got %s", subscriber.Sessions[0].System)
-	}
-
-	if got := subscriber.Sessions[0].AccessTypes; len(got) != 1 || got[0] != "3GPP" {
-		t.Fatalf("expected session access_types [3GPP], got %v", got)
 	}
 
 	if subscriber.Sessions[0].ID != 1 {

--- a/docs/explanation/subscriber_security.md
+++ b/docs/explanation/subscriber_security.md
@@ -38,8 +38,8 @@ Administrators configure a single, RAT-neutral set of ciphering and integrity al
 | Algorithm | 5G | 4G |
 |-----------|-----|-----|
 | NULL | NEA0 / NIA0 | EEA0 / EIA0 |
-| SNOW 3G | NEA1 / NIA1 | EEA1 / EIA1 |
-| AES | NEA2 / NIA2 | EEA2 / EIA2 |
+| SNOW 3G | 128-NEA1 / 128-NIA1 | 128-EEA1 / 128-EIA1 |
+| AES | 128-NEA2 / 128-NIA2 | 128-EEA2 / 128-EIA2 |
 
 !!! warning
     Null algorithms (NEA0/NIA0 on 5G, EEA0/EIA0 on 4G) provide no security protection. Only enable them for testing or device compatibility.

--- a/docs/reference/api/operator.md
+++ b/docs/reference/api/operator.md
@@ -202,7 +202,7 @@ This path updates the NAS security algorithm preference order for ciphering and 
 - `ciphering` (array of strings): The preferred ciphering algorithm order. Each entry must be one of `NULL`, `SNOW3G`, or `AES`. At least one algorithm is required, maximum 3. No duplicates allowed.
 - `integrity` (array of strings): The preferred integrity algorithm order. Each entry must be one of `NULL`, `SNOW3G`, or `AES`. At least one algorithm is required, maximum 3. No duplicates allowed.
 
-These algorithm names are RAT-neutral: Ella Core signals them as NEA/NIA to 5G subscribers and as EEA/EIA to 4G subscribers (`NULL` → NEA0/EEA0, `SNOW3G` → NEA1/EEA1, `AES` → NEA2/EEA2).
+These algorithm names are RAT-neutral: Ella Core signals them as NEA/NIA to 5G subscribers and as EEA/EIA to 4G subscribers (`NULL` → NEA0/EEA0, `SNOW3G` → 128-NEA1/128-EEA1, `AES` → 128-NEA2/128-EEA2).
 
 ### Sample Request
 

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -182,8 +182,8 @@ None
 | `radio` | Radio serving this registration, or the last one that did when the device is idle or deregistered, in which case it may be stale. Held in memory by the serving node: not shared across cluster nodes, and reset on restart. |
 | `last_seen_at` | Timestamp of last activity in this system (RFC 3339). |
 | `imei` | 15-digit IMEI of the device. Absent once the core has released the context. |
-| `ciphering_algorithm` | `NEA0` / `128-NEA1..3` in 5G, `EEA0` / `128-EEA1..3` in 4G. Absent once the core has released the context. |
-| `integrity_algorithm` | `NIA0` / `128-NIA1..3` in 5G, `EIA0` / `128-EIA1..3` in 4G. Absent once the core has released the context. |
+| `ciphering_algorithm` | `NEA0` / `128-NEA1..3` in 5G, `EEA0` / `128-EEA1..3` in 4G. Absent when none is established. |
+| `integrity_algorithm` | `NIA0` / `128-NIA1..3` in 5G, `EIA0` / `128-EIA1..3` in 4G. Absent when none is established. |
 | `connection` | UE-associated logical connection, or `null` when the device holds none. |
 
 ### Connection identifiers

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -37,7 +37,7 @@ This path returns the list of network subscribers, ordered by IMSI.
                 "status": {
                     "registered": true,
                     "connection_state": "connected",
-                    "radio_access_types": ["5G"],
+                    "systems": ["5GS"],
                     "num_sessions": 1,
                     "last_seen_at": "2026-03-16T12:34:56Z",
                     "last_seen_radio": "gNB-1"

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -126,12 +126,10 @@ None
     "registrations": [
       {
         "system": "5GS",
-        "access_type": "3GPP",
         "registered": true,
         "connection_state": "connected",
         "radio": "gNB-1",
         "last_seen_at": "2026-03-16T12:34:56Z",
-        "pei": "imeisv-3535938300494715",
         "imei": "359881234567890",
         "ciphering_algorithm": "128-NEA2",
         "integrity_algorithm": "128-NIA2",
@@ -142,7 +140,6 @@ None
       },
       {
         "system": "EPS",
-        "access_type": "3GPP",
         "registered": false,
         "connection_state": null,
         "radio": "eNB-7",
@@ -176,20 +173,18 @@ None
 
 ### Registrations
 
-`registrations` holds one entry per mobility-management context, ordered 5GS first. It is empty for a subscriber the core has never served.
+`registrations` holds one entry per mobility-management context, ordered with 5G first. It is empty for a subscriber the core has never served.
 
 | Field | Description |
 | ----- | ----------- |
-| `system` | `5GS` or `EPS`. The core that registered the device, independent of the radio: an NSA device on NR radio is registered in `EPS`. |
-| `access_type` | `3GPP` or `non-3GPP`. Always `3GPP` in this release. |
-| `registered` | RM state in 5GS (TS 23.501 §5.3.2.2), EMM state in EPS (TS 23.401 §4.6.2). `false` on an entry the core remembers but holds no context for. |
-| `connection_state` | `connected` or `idle`. CM state in 5GS (TS 23.501 §5.3.3.2), ECM state in EPS (TS 23.401 §4.6.3). Independent of `registered`: a device still registering is `connected` with `registered` false. `null` when the core holds no context. |
+| `system` | `5GS` for 5G, `EPS` for 4G. The core that registered the device, independent of the radio: an NSA device on 5G radio reports `EPS`. |
+| `registered` | RM state in 5G, EMM state in 4G. `false` on an entry the core remembers but holds no context for. |
+| `connection_state` | `connected` or `idle`. CM state in 5G, ECM state in 4G. Independent of `registered`: a device still registering is `connected` with `registered` false. `null` when the core holds no context. |
 | `radio` | Radio serving this registration, or the last one that did when the device is idle or deregistered, in which case it may be stale. Held in memory by the serving node: not shared across cluster nodes, and reset on restart. |
 | `last_seen_at` | Timestamp of last activity in this system (RFC 3339). |
-| `pei` | Permanent Equipment Identifier in NAS-prefixed form (`imei-…` / `imeisv-…`). 5GS only (TS 23.003 §6.4). Absent once the core has released the context. |
-| `imei` | 15-digit IMEI. On a 5GS registration this is the IMEI carried by `pei`, present only when the PEI is an IMEI or IMEISV. Absent once the core has released the context. |
-| `ciphering_algorithm` | `NEA0` / `128-NEA1..3` in 5GS (TS 33.501 Annex D), `EEA0` / `128-EEA1..3` in EPS (TS 33.401 Annex B). Absent once the core has released the context. |
-| `integrity_algorithm` | `NIA0` / `128-NIA1..3` in 5GS, `EIA0` / `128-EIA1..3` in EPS. Absent once the core has released the context. |
+| `imei` | 15-digit IMEI of the device. Absent once the core has released the context. |
+| `ciphering_algorithm` | `NEA0` / `128-NEA1..3` in 5G, `EEA0` / `128-EEA1..3` in 4G. Absent once the core has released the context. |
+| `integrity_algorithm` | `NIA0` / `128-NIA1..3` in 5G, `EIA0` / `128-EIA1..3` in 4G. Absent once the core has released the context. |
 | `connection` | UE-associated logical connection, or `null` when the device holds none. |
 
 ### Connection identifiers
@@ -198,26 +193,26 @@ None
 
 | Field | System | Description |
 | ----- | ------ | ----------- |
-| `amf_ue_ngap_id` | 5GS | AMF UE NGAP ID, `INTEGER (0..2^40-1)` (TS 38.413 §9.3.3.1). Allocated by the core. |
-| `ran_ue_ngap_id` | 5GS | RAN UE NGAP ID, `INTEGER (0..2^32-1)` (TS 38.413 §9.3.3.2). Allocated by the serving NG-RAN node. Absent until it is allocated, for example on a handover target before HANDOVER REQUEST ACKNOWLEDGE (TS 38.413 §9.2.3.5). |
-| `mme_ue_s1ap_id` | EPS | MME UE S1AP ID, `INTEGER (0..2^32-1)` (TS 36.413 §9.2.3.3). Allocated by the core. |
-| `enb_ue_s1ap_id` | EPS | eNB UE S1AP ID, `INTEGER (0..2^24-1)` (TS 36.413 §9.2.3.4). Allocated by the serving eNB. Absent until it is allocated. |
+| `amf_ue_ngap_id` | 5G | AMF UE NGAP ID, `INTEGER (0..2^40-1)`. Allocated by the core. |
+| `ran_ue_ngap_id` | 5G | RAN UE NGAP ID, `INTEGER (0..2^32-1)`. Allocated by the serving radio. Absent until the radio allocates one, for example on a handover target before it accepts the handover. |
+| `mme_ue_s1ap_id` | 4G | MME UE S1AP ID, `INTEGER (0..2^32-1)`. Allocated by the core. |
+| `enb_ue_s1ap_id` | 4G | eNB UE S1AP ID, `INTEGER (0..2^24-1)`. Allocated by the serving radio. Absent until the radio allocates one. |
 
 These values appear under the same names on Ella Core's log lines for the device.
 
-A RAN-allocated identifier is unique only within one NG or S1 interface instance and is reused after the connection ends, so it is not a stable device identifier.
+A radio-allocated identifier is unique only within that radio's connection to the core and is reused after the device disconnects, so it is not a stable device identifier.
 
 ### Sessions
 
 | Field | Description |
 | ----- | ----------- |
 | `system` | `5GS` or `EPS`, matching a registration's `system`. |
-| `access_types` | Every access the session is carried over. A Multi-Access PDU Session names both `3GPP` and `non-3GPP` (TS 23.501 §5.6.1); any other session names exactly one. |
-| `id` | PDU Session ID (5GS) or linked EPS Bearer ID (EPS). |
+| `access_types` | Every access the session is carried over. Always `["3GPP"]` in this release. |
+| `id` | PDU Session ID (5G) or linked EPS Bearer ID (4G). |
 | `status` | Session status (for example `active`, `inactive`). |
 | `ip_type` | `IPv4`, `IPv6` or `IPv4v6`. |
-| `data_network` | DNN (5GS) or APN (EPS). |
-| `slice` | S-NSSAI. 5GS only. |
+| `data_network` | DNN (5G) or APN (4G). |
+| `slice` | S-NSSAI. 5G only. |
 
 ## Get Subscriber Credentials
 

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -176,64 +176,46 @@ None
 
 ### Registrations
 
-`registrations` lists every mobility-management context the core holds — or still
-remembers — for the subscriber, ordered 5GS first. It is empty for a subscriber the
-core has never served.
-
-A subscriber can hold more than one. 5GS keeps an independent registration state per
-access type (TS 23.501 §5.3.2.4), and a device in dual-registration mode may be
-registered to both 5GC and EPC at the same time (TS 23.501 §5.17.2.1).
+`registrations` holds one entry per mobility-management context, ordered 5GS first. It is empty for a subscriber the core has never served.
 
 | Field | Description |
 | ----- | ----------- |
-| `system` | `5GS` or `EPS` — the core that registered the device, independent of the radio. An NSA device on NR radio is registered in `EPS`. |
+| `system` | `5GS` or `EPS`. The core that registered the device, independent of the radio: an NSA device on NR radio is registered in `EPS`. |
 | `access_type` | `3GPP` or `non-3GPP`. Always `3GPP` in this release. |
-| `registered` | RM state in 5GS (TS 23.501 §5.3.2.2), EMM state in EPS (TS 23.401 §4.6.2). `false` on an entry the core remembers but no longer holds a context for. |
-| `connection_state` | `connected` or `idle` — CM state in 5GS (TS 23.501 §5.3.3.2), ECM state in EPS (TS 23.401 §4.6.3). Independent of `registered`: a device still registering is `connected` with `registered` false. `null` when the core holds no context. |
-| `radio` | The radio serving this registration, or the last one that did once the device is idle or deregistered — in which case it may be stale. Held in memory by the serving node: not shared across cluster nodes, and reset on restart. |
+| `registered` | RM state in 5GS (TS 23.501 §5.3.2.2), EMM state in EPS (TS 23.401 §4.6.2). `false` on an entry the core remembers but holds no context for. |
+| `connection_state` | `connected` or `idle`. CM state in 5GS (TS 23.501 §5.3.3.2), ECM state in EPS (TS 23.401 §4.6.3). Independent of `registered`: a device still registering is `connected` with `registered` false. `null` when the core holds no context. |
+| `radio` | Radio serving this registration, or the last one that did when the device is idle or deregistered, in which case it may be stale. Held in memory by the serving node: not shared across cluster nodes, and reset on restart. |
 | `last_seen_at` | Timestamp of last activity in this system (RFC 3339). |
-| `pei` | Permanent Equipment Identifier in NAS-prefixed form (`imei-…` / `imeisv-…`). 5GS only (TS 23.003 §6.4). |
-| `imei` | 15-digit IMEI. On a 5GS registration this is the IMEI carried by `pei`, present only when the PEI is an IMEI or IMEISV. |
-| `ciphering_algorithm` | `NEA0` / `128-NEA1..3` in 5GS (TS 33.501 Annex D), `EEA0` / `128-EEA1..3` in EPS (TS 33.401 Annex B). |
-| `integrity_algorithm` | `NIA0` / `128-NIA1..3` in 5GS, `EIA0` / `128-EIA1..3` in EPS. |
-| `connection` | The UE-associated logical connection, or `null` when the device holds none. |
-
-Once a device deregisters, the entry survives with `radio` and `last_seen_at` intact so
-the last serving radio stays visible, but the fields owned by the released context —
-`pei`/`imei`, both algorithms, and `connection` — are absent.
+| `pei` | Permanent Equipment Identifier in NAS-prefixed form (`imei-…` / `imeisv-…`). 5GS only (TS 23.003 §6.4). Absent once the core has released the context. |
+| `imei` | 15-digit IMEI. On a 5GS registration this is the IMEI carried by `pei`, present only when the PEI is an IMEI or IMEISV. Absent once the core has released the context. |
+| `ciphering_algorithm` | `NEA0` / `128-NEA1..3` in 5GS (TS 33.501 Annex D), `EEA0` / `128-EEA1..3` in EPS (TS 33.401 Annex B). Absent once the core has released the context. |
+| `integrity_algorithm` | `NIA0` / `128-NIA1..3` in 5GS, `EIA0` / `128-EIA1..3` in EPS. Absent once the core has released the context. |
+| `connection` | UE-associated logical connection, or `null` when the device holds none. |
 
 ### Connection identifiers
 
-`connection` carries the UE-associated logical connection identity pair of the
-registration. Only the pair belonging to the registration's system is present.
+`connection` carries only the identifier pair belonging to the registration's `system`.
 
 | Field | System | Description |
 | ----- | ------ | ----------- |
 | `amf_ue_ngap_id` | 5GS | AMF UE NGAP ID, `INTEGER (0..2^40-1)` (TS 38.413 §9.3.3.1). Allocated by the core. |
-| `ran_ue_ngap_id` | 5GS | RAN UE NGAP ID, `INTEGER (0..2^32-1)` (TS 38.413 §9.3.3.2). Allocated by the serving NG-RAN node. |
+| `ran_ue_ngap_id` | 5GS | RAN UE NGAP ID, `INTEGER (0..2^32-1)` (TS 38.413 §9.3.3.2). Allocated by the serving NG-RAN node. Absent until it is allocated, for example on a handover target before HANDOVER REQUEST ACKNOWLEDGE (TS 38.413 §9.2.3.5). |
 | `mme_ue_s1ap_id` | EPS | MME UE S1AP ID, `INTEGER (0..2^32-1)` (TS 36.413 §9.2.3.3). Allocated by the core. |
-| `enb_ue_s1ap_id` | EPS | eNB UE S1AP ID, `INTEGER (0..2^24-1)` (TS 36.413 §9.2.3.4). Allocated by the serving eNB. |
+| `enb_ue_s1ap_id` | EPS | eNB UE S1AP ID, `INTEGER (0..2^24-1)` (TS 36.413 §9.2.3.4). Allocated by the serving eNB. Absent until it is allocated. |
 
-Use these to correlate core events with events logged by the radio: the same values
-appear as `amf_ue_ngap_id`, `ran_ue_ngap_id`, `mme_ue_s1ap_id` and `enb_ue_s1ap_id`
-fields on Ella Core's own log lines for the device.
+These values appear under the same names on Ella Core's log lines for the device.
 
-The RAN-allocated identifier is absent until the serving RAN node assigns one — for
-example on a handover target before HANDOVER REQUEST ACKNOWLEDGE (TS 38.413 §9.2.3.5).
-
-!!! warning
-    These identifiers are ephemeral. A RAN node allocates one for the duration of a
-    single connected period and reuses it afterwards, and it is unique only within one
-    NG or S1 interface instance. A value identifies a subscriber only together with
-    `radio` and the time it was read — never store it as a stable device identifier.
+A RAN-allocated identifier is unique only within one NG or S1 interface instance and is reused after the connection ends, so it is not a stable device identifier.
 
 ### Sessions
 
 | Field | Description |
 | ----- | ----------- |
 | `system` | `5GS` or `EPS`, matching a registration's `system`. |
-| `access_types` | Every access the session is carried over. A Multi-Access PDU Session is associated with 3GPP and non-3GPP access simultaneously (TS 23.501 §5.6.1); any other session names exactly one. |
+| `access_types` | Every access the session is carried over. A Multi-Access PDU Session names both `3GPP` and `non-3GPP` (TS 23.501 §5.6.1); any other session names exactly one. |
 | `id` | PDU Session ID (5GS) or linked EPS Bearer ID (EPS). |
+| `status` | Session status (for example `active`, `inactive`). |
+| `ip_type` | `IPv4`, `IPv6` or `IPv4v6`. |
 | `data_network` | DNN (5GS) or APN (EPS). |
 | `slice` | S-NSSAI. 5GS only. |
 

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -37,7 +37,7 @@ This path returns the list of network subscribers, ordered by IMSI.
                 "status": {
                     "registered": true,
                     "connection_state": "connected",
-                    "systems": ["5GS"],
+                    "systems": ["5G"],
                     "num_sessions": 1,
                     "last_seen_at": "2026-03-16T12:34:56Z",
                     "last_seen_radio": "gNB-1"
@@ -125,7 +125,7 @@ None
     "description": "Warehouse gate reader",
     "registrations": [
       {
-        "system": "5GS",
+        "system": "5G",
         "registered": true,
         "connection_state": "connected",
         "radio": "gNB-1",
@@ -139,7 +139,7 @@ None
         }
       },
       {
-        "system": "EPS",
+        "system": "4G",
         "registered": false,
         "connection_state": null,
         "radio": "eNB-7",
@@ -149,7 +149,7 @@ None
     ],
     "sessions": [
       {
-        "system": "5GS",
+        "system": "5G",
         "id": 1,
         "status": "active",
         "ip_type": "IPv4v6",
@@ -176,7 +176,7 @@ None
 
 | Field | Description |
 | ----- | ----------- |
-| `system` | `5GS` for 5G, `EPS` for 4G. The core that registered the device, independent of the radio: an NSA device on 5G radio reports `EPS`. |
+| `system` | `5G` or `4G`. The core that registered the device, not the radio it uses: an NSA device on 5G radio reports `4G`. |
 | `registered` | RM state in 5G, EMM state in 4G. `false` on an entry the core remembers but holds no context for. |
 | `connection_state` | `connected` or `idle`. CM state in 5G, ECM state in 4G. Independent of `registered`: a device still registering is `connected` with `registered` false. `null` when the core holds no context. |
 | `radio` | Radio serving this registration, or the last one that did when the device is idle or deregistered, in which case it may be stale. Held in memory by the serving node: not shared across cluster nodes, and reset on restart. |
@@ -205,7 +205,7 @@ A radio-allocated identifier is unique only within that radio's connection to th
 
 | Field | Description |
 | ----- | ----------- |
-| `system` | `5GS` or `EPS`, matching a registration's `system`. |
+| `system` | `5G` or `4G`, matching a registration's `system`. |
 | `id` | PDU Session ID (5G) or linked EPS Bearer ID (4G). |
 | `status` | Session status (for example `active`, `inactive`). |
 | `ip_type` | `IPv4`, `IPv6` or `IPv4v6`. |

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -150,7 +150,6 @@ None
     "sessions": [
       {
         "system": "5GS",
-        "access_types": ["3GPP"],
         "id": 1,
         "status": "active",
         "ip_type": "IPv4v6",
@@ -207,7 +206,6 @@ A radio-allocated identifier is unique only within that radio's connection to th
 | Field | Description |
 | ----- | ----------- |
 | `system` | `5GS` or `EPS`, matching a registration's `system`. |
-| `access_types` | Every access the session is carried over. Always `["3GPP"]` in this release. |
 | `id` | PDU Session ID (5G) or linked EPS Bearer ID (4G). |
 | `status` | Session status (for example `active`, `inactive`). |
 | `ip_type` | `IPv4`, `IPv6` or `IPv4v6`. |

--- a/docs/reference/api/subscribers.md
+++ b/docs/reference/api/subscribers.md
@@ -123,19 +123,37 @@ None
     "imsi": "001010100007487",
     "profile_name": "default",
     "description": "Warehouse gate reader",
-    "status": {
-      "registered": true,
-      "connection_state": "connected",
-      "radio_access_types": ["5G"],
-      "imei": "359881234567890",
-      "ciphering_algorithm": "SNOW3G",
-      "integrity_algorithm": "SNOW3G",
-      "last_seen_at": "2026-03-16T12:34:56Z",
-      "last_seen_radio": "gNB-1"
-    },
-  "sessions": [
+    "registrations": [
       {
-        "radio_access_type": "5G",
+        "system": "5GS",
+        "access_type": "3GPP",
+        "registered": true,
+        "connection_state": "connected",
+        "radio": "gNB-1",
+        "last_seen_at": "2026-03-16T12:34:56Z",
+        "pei": "imeisv-3535938300494715",
+        "imei": "359881234567890",
+        "ciphering_algorithm": "128-NEA2",
+        "integrity_algorithm": "128-NIA2",
+        "connection": {
+          "amf_ue_ngap_id": 12,
+          "ran_ue_ngap_id": 39
+        }
+      },
+      {
+        "system": "EPS",
+        "access_type": "3GPP",
+        "registered": false,
+        "connection_state": null,
+        "radio": "eNB-7",
+        "last_seen_at": "2026-03-16T12:30:11Z",
+        "connection": null
+      }
+    ],
+    "sessions": [
+      {
+        "system": "5GS",
+        "access_types": ["3GPP"],
         "id": 1,
         "status": "active",
         "ip_type": "IPv4v6",
@@ -155,6 +173,69 @@ None
 ```
 
 `description` is omitted when the subscriber has no note.
+
+### Registrations
+
+`registrations` lists every mobility-management context the core holds — or still
+remembers — for the subscriber, ordered 5GS first. It is empty for a subscriber the
+core has never served.
+
+A subscriber can hold more than one. 5GS keeps an independent registration state per
+access type (TS 23.501 §5.3.2.4), and a device in dual-registration mode may be
+registered to both 5GC and EPC at the same time (TS 23.501 §5.17.2.1).
+
+| Field | Description |
+| ----- | ----------- |
+| `system` | `5GS` or `EPS` — the core that registered the device, independent of the radio. An NSA device on NR radio is registered in `EPS`. |
+| `access_type` | `3GPP` or `non-3GPP`. Always `3GPP` in this release. |
+| `registered` | RM state in 5GS (TS 23.501 §5.3.2.2), EMM state in EPS (TS 23.401 §4.6.2). `false` on an entry the core remembers but no longer holds a context for. |
+| `connection_state` | `connected` or `idle` — CM state in 5GS (TS 23.501 §5.3.3.2), ECM state in EPS (TS 23.401 §4.6.3). Independent of `registered`: a device still registering is `connected` with `registered` false. `null` when the core holds no context. |
+| `radio` | The radio serving this registration, or the last one that did once the device is idle or deregistered — in which case it may be stale. Held in memory by the serving node: not shared across cluster nodes, and reset on restart. |
+| `last_seen_at` | Timestamp of last activity in this system (RFC 3339). |
+| `pei` | Permanent Equipment Identifier in NAS-prefixed form (`imei-…` / `imeisv-…`). 5GS only (TS 23.003 §6.4). |
+| `imei` | 15-digit IMEI. On a 5GS registration this is the IMEI carried by `pei`, present only when the PEI is an IMEI or IMEISV. |
+| `ciphering_algorithm` | `NEA0` / `128-NEA1..3` in 5GS (TS 33.501 Annex D), `EEA0` / `128-EEA1..3` in EPS (TS 33.401 Annex B). |
+| `integrity_algorithm` | `NIA0` / `128-NIA1..3` in 5GS, `EIA0` / `128-EIA1..3` in EPS. |
+| `connection` | The UE-associated logical connection, or `null` when the device holds none. |
+
+Once a device deregisters, the entry survives with `radio` and `last_seen_at` intact so
+the last serving radio stays visible, but the fields owned by the released context —
+`pei`/`imei`, both algorithms, and `connection` — are absent.
+
+### Connection identifiers
+
+`connection` carries the UE-associated logical connection identity pair of the
+registration. Only the pair belonging to the registration's system is present.
+
+| Field | System | Description |
+| ----- | ------ | ----------- |
+| `amf_ue_ngap_id` | 5GS | AMF UE NGAP ID, `INTEGER (0..2^40-1)` (TS 38.413 §9.3.3.1). Allocated by the core. |
+| `ran_ue_ngap_id` | 5GS | RAN UE NGAP ID, `INTEGER (0..2^32-1)` (TS 38.413 §9.3.3.2). Allocated by the serving NG-RAN node. |
+| `mme_ue_s1ap_id` | EPS | MME UE S1AP ID, `INTEGER (0..2^32-1)` (TS 36.413 §9.2.3.3). Allocated by the core. |
+| `enb_ue_s1ap_id` | EPS | eNB UE S1AP ID, `INTEGER (0..2^24-1)` (TS 36.413 §9.2.3.4). Allocated by the serving eNB. |
+
+Use these to correlate core events with events logged by the radio: the same values
+appear as `amf_ue_ngap_id`, `ran_ue_ngap_id`, `mme_ue_s1ap_id` and `enb_ue_s1ap_id`
+fields on Ella Core's own log lines for the device.
+
+The RAN-allocated identifier is absent until the serving RAN node assigns one — for
+example on a handover target before HANDOVER REQUEST ACKNOWLEDGE (TS 38.413 §9.2.3.5).
+
+!!! warning
+    These identifiers are ephemeral. A RAN node allocates one for the duration of a
+    single connected period and reuses it afterwards, and it is unique only within one
+    NG or S1 interface instance. A value identifies a subscriber only together with
+    `radio` and the time it was read — never store it as a stable device identifier.
+
+### Sessions
+
+| Field | Description |
+| ----- | ----------- |
+| `system` | `5GS` or `EPS`, matching a registration's `system`. |
+| `access_types` | Every access the session is carried over. A Multi-Access PDU Session is associated with 3GPP and non-3GPP access simultaneously (TS 23.501 §5.6.1); any other session names exactly one. |
+| `id` | PDU Session ID (5GS) or linked EPS Bearer ID (EPS). |
+| `data_network` | DNN (5GS) or APN (EPS). |
+| `slice` | S-NSSAI. 5GS only. |
 
 ## Get Subscriber Credentials
 

--- a/integration/api_matrix_ha_subscribers_test.go
+++ b/integration/api_matrix_ha_subscribers_test.go
@@ -158,15 +158,8 @@ func runSubscribersHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 
 		// Never-attached defaults. Locks the contract against handler
 		// regressions and JSON-key drift across the cluster.
-		if got.Status.Registered {
-			t.Fatalf("node %d Status.Registered: got true, want false (subscriber never attached)", i+1)
-		}
-
-		if got.Status.ConnectionState != "" || got.Status.Imei != "" || got.Status.CipheringAlgorithm != "" ||
-			got.Status.IntegrityAlgorithm != "" || got.Status.LastSeenAt != "" ||
-			got.Status.LastSeenRadio != "" {
-			t.Fatalf("node %d Status: expected zero-valued strings on a never-attached subscriber, got %+v",
-				i+1, got.Status)
+		if len(got.Registrations) != 0 {
+			t.Fatalf("node %d Registrations: got %d, want 0 (subscriber never attached)", i+1, len(got.Registrations))
 		}
 
 		if len(got.Sessions) != 0 {
@@ -193,8 +186,8 @@ func runSubscribersHAMatrix(ctx context.Context, t *testing.T, h *haMatrixEnv) {
 
 		Assert(t, subscribersContains(list.Items, imsi), fmt.Sprintf("node %d list missing %q after create", i+1, imsi))
 
-		// List response carries a different Status struct than Get-one,
-		// so the defaults are asserted independently.
+		// List response carries a merged Status struct where Get-one carries
+		// registrations, so the defaults are asserted independently.
 		for _, item := range list.Items {
 			if item.Imsi != imsi {
 				continue

--- a/integration/api_matrix_subscribers_test.go
+++ b/integration/api_matrix_subscribers_test.go
@@ -153,14 +153,8 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	// Defaults for a never-attached subscriber. Locks the contract
 	// against handler regressions and JSON-key drift.
-	if got.Status.Registered {
-		t.Fatalf("Status.Registered: got true, want false (subscriber never attached)")
-	}
-
-	if got.Status.ConnectionState != "" || got.Status.Imei != "" || got.Status.CipheringAlgorithm != "" ||
-		got.Status.IntegrityAlgorithm != "" || got.Status.LastSeenAt != "" ||
-		got.Status.LastSeenRadio != "" {
-		t.Fatalf("Status: expected zero-valued strings on a never-attached subscriber, got %+v", got.Status)
+	if len(got.Registrations) != 0 {
+		t.Fatalf("Registrations: got %d, want 0 (subscriber never attached)", len(got.Registrations))
 	}
 
 	if len(got.Sessions) != 0 {
@@ -187,8 +181,8 @@ func runSubscribersMatrix(ctx context.Context, t *testing.T, c *client.Client) {
 
 	Assert(t, contains(afterCreate.Items, imsi), fmt.Sprintf("list after create missing %q", imsi))
 
-	// List response carries a different Status struct than Get-one, so
-	// the defaults are asserted independently.
+	// List response carries a merged Status struct where Get-one carries
+	// registrations, so the defaults are asserted independently.
 	for _, item := range afterCreate.Items {
 		if item.Imsi != imsi {
 			continue

--- a/integration/ha_multi_gnb_5g_test.go
+++ b/integration/ha_multi_gnb_5g_test.go
@@ -252,8 +252,19 @@ func TestIntegration5GMultiGNB(t *testing.T) {
 				t.Fatalf("GetSubscriber(%s) on %s: %v", imsi, gn.service, err)
 			}
 
-			if !sub.Status.Registered {
-				t.Errorf("%s: subscriber %s: expected Registered=true, got false", gn.service, imsi)
+			registered := false
+
+			for _, reg := range sub.Registrations {
+				if reg.System == "5G" && reg.Registered {
+					registered = true
+
+					break
+				}
+			}
+
+			if !registered {
+				t.Errorf("%s: subscriber %s: expected a registered 5G registration, got %+v",
+					gn.service, imsi, sub.Registrations)
 			}
 
 			if len(sub.Sessions) == 0 {

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -777,7 +777,7 @@ func (a *AMF) NewUeConn(radio *Radio, ranUeNgapID models.RanUeNgapID) (*UeConn, 
 		conn:        radio.Conn,
 		amf:         a,
 	}
-	ueConn.setLog(radio.Log.With(logger.AmfUeNgapID(amfUeNgapID)))
+	ueConn.bindLog(radio.Log)
 
 	a.mu.Lock()
 	ueConn.setRadio(radioIDOf(radio), radio.name)

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -773,10 +773,10 @@ func (a *AMF) NewUeConn(radio *Radio, ranUeNgapID models.RanUeNgapID) (*UeConn, 
 
 	ueConn := &UeConn{
 		AmfUeNgapID: amfUeNgapID,
-		RanUeNgapID: ranUeNgapID,
 		conn:        radio.Conn,
 		amf:         a,
 	}
+	ueConn.setRanUeNgapID(ranUeNgapID)
 	ueConn.bindLog(radio.Log)
 
 	a.mu.Lock()
@@ -871,7 +871,7 @@ func (amf *AMF) RefreshLocation(ctx context.Context, supi etsi.SUPI) error {
 	logger.AmfLog.Info("location refresh triggered via LocationReportingControl(Direct)",
 		logger.SUPI(supi.String()),
 		zap.Uint64("amf_ue_ngap_id", uint64(ueConn.AmfUeNgapID)),
-		zap.Uint32("ran_ue_ngap_id", uint32(ueConn.RanUeNgapID)),
+		zap.Uint32("ran_ue_ngap_id", uint32(ueConn.RanUeNgapID())),
 	)
 
 	return nil

--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -870,8 +870,8 @@ func (amf *AMF) RefreshLocation(ctx context.Context, supi etsi.SUPI) error {
 
 	logger.AmfLog.Info("location refresh triggered via LocationReportingControl(Direct)",
 		logger.SUPI(supi.String()),
-		zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)),
-		zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)),
+		zap.Uint64("amf_ue_ngap_id", uint64(ueConn.AmfUeNgapID)),
+		zap.Uint32("ran_ue_ngap_id", uint32(ueConn.RanUeNgapID)),
 	)
 
 	return nil

--- a/internal/amf/amf_radio.go
+++ b/internal/amf/amf_radio.go
@@ -258,6 +258,7 @@ func (a *AMF) UpdateUERanNgapID(ueConn *UeConn, newRanUeNgapID models.RanUeNgapI
 	defer a.mu.Unlock()
 
 	ueConn.RanUeNgapID = newRanUeNgapID
+	ueConn.refreshLog()
 }
 
 func (a *AMF) FindUEByAmfUeNgapID(radio *Radio, amfUeNgapID models.AmfUeNgapID) *UeConn {

--- a/internal/amf/amf_radio.go
+++ b/internal/amf/amf_radio.go
@@ -243,7 +243,7 @@ func (a *AMF) FindUEByRanUeNgapID(radio *Radio, ranUeNgapID models.RanUeNgapID) 
 	defer a.mu.RUnlock()
 
 	for _, ueConn := range a.conns {
-		if ueConn.conn == radio.Conn && ueConn.RanUeNgapID == ranUeNgapID {
+		if ueConn.conn == radio.Conn && ueConn.RanUeNgapID() == ranUeNgapID {
 			return ueConn
 		}
 	}
@@ -257,7 +257,7 @@ func (a *AMF) UpdateUERanNgapID(ueConn *UeConn, newRanUeNgapID models.RanUeNgapI
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	ueConn.RanUeNgapID = newRanUeNgapID
+	ueConn.setRanUeNgapID(newRanUeNgapID)
 	ueConn.refreshLog()
 }
 

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -322,7 +322,6 @@ func (ue *UeContext) SetLastSeenForTest(t time.Time) {
 
 type UESnapshot struct {
 	Imei               string
-	Pei                string
 	LastSeenAt         time.Time
 	CipheringAlgorithm string
 	IntegrityAlgorithm string
@@ -342,7 +341,6 @@ func (ue *UeContext) Snapshot() UESnapshot {
 
 	snap := UESnapshot{
 		Imei:               ue.Imei.IMEI(),
-		Pei:                ue.Imei.String(),
 		LastSeenAt:         ue.lastSeenTime(),
 		CipheringAlgorithm: cipheringAlgName(ue.cipheringAlg),
 		IntegrityAlgorithm: integrityAlgName(ue.integrityAlg),

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -339,20 +339,22 @@ func (ue *UeContext) Snapshot() UESnapshot {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 
+	conn := ue.active.Load()
+
 	snap := UESnapshot{
 		Imei:               ue.Imei.IMEI(),
 		LastSeenAt:         ue.lastSeenTime(),
 		CipheringAlgorithm: cipheringAlgName(ue.cipheringAlg),
 		IntegrityAlgorithm: integrityAlgName(ue.integrityAlg),
-		Connected:          ue.active.Load() != nil,
+		Connected:          conn != nil,
 		Registered:         ue.state == Registered || ue.state == DeregistrationInitiated,
 	}
 
-	if conn := ue.active.Load(); conn != nil {
+	if conn != nil {
 		snap.Connection = &UEConnection{AmfUeNgapID: int64(conn.AmfUeNgapID)}
-		if conn.RanUeNgapID != models.RanUeNgapIDUnspecified {
-			ranID := int64(conn.RanUeNgapID)
-			snap.Connection.RanUeNgapID = &ranID
+		if ranID := conn.RanUeNgapID(); ranID != models.RanUeNgapIDUnspecified {
+			id := int64(ranID)
+			snap.Connection.RanUeNgapID = &id
 		}
 	}
 

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -322,11 +322,18 @@ func (ue *UeContext) SetLastSeenForTest(t time.Time) {
 
 type UESnapshot struct {
 	Imei               string
+	Pei                string
 	LastSeenAt         time.Time
 	CipheringAlgorithm string
 	IntegrityAlgorithm string
 	Connected          bool
 	Registered         bool
+	Connection         *UEConnection
+}
+
+type UEConnection struct {
+	AmfUeNgapID int64
+	RanUeNgapID *int64
 }
 
 func (ue *UeContext) Snapshot() UESnapshot {
@@ -335,11 +342,20 @@ func (ue *UeContext) Snapshot() UESnapshot {
 
 	snap := UESnapshot{
 		Imei:               ue.Imei.IMEI(),
+		Pei:                ue.Imei.String(),
 		LastSeenAt:         ue.lastSeenTime(),
 		CipheringAlgorithm: cipheringAlgName(ue.cipheringAlg),
 		IntegrityAlgorithm: integrityAlgName(ue.integrityAlg),
 		Connected:          ue.active.Load() != nil,
 		Registered:         ue.state == Registered || ue.state == DeregistrationInitiated,
+	}
+
+	if conn := ue.active.Load(); conn != nil {
+		snap.Connection = &UEConnection{AmfUeNgapID: int64(conn.AmfUeNgapID)}
+		if conn.RanUeNgapID != models.RanUeNgapIDUnspecified {
+			ranID := int64(conn.RanUeNgapID)
+			snap.Connection.RanUeNgapID = &ranID
+		}
 	}
 
 	return snap

--- a/internal/amf/amf_ue_snapshot_race_test.go
+++ b/internal/amf/amf_ue_snapshot_race_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+)
+
+func TestSnapshotConnectedAgreesWithConnection(t *testing.T) {
+	a := New(nil, nil, nil)
+	radio := &Radio{amf: a, name: "gnb-1", Log: logger.AmfLog}
+	ue := NewUeContext()
+
+	ueConn, err := a.NewUeConn(radio, models.RanUeNgapID(1))
+	if err != nil {
+		t.Fatalf("NewUeConn: %v", err)
+	}
+
+	ueConn.ue.Store(ue)
+
+	var (
+		wg   sync.WaitGroup
+		stop = make(chan struct{})
+	)
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+
+		for range 20000 {
+			a.mu.Lock()
+			a.attachUeConnLocked(ue, ueConn)
+			a.mu.Unlock()
+
+			ueConn.Release()
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for id := models.RanUeNgapID(1); ; id++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			a.UpdateUERanNgapID(ueConn, id)
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			snap := ue.Snapshot()
+			if snap.Connected != (snap.Connection != nil) {
+				t.Errorf("Snapshot torn: Connected = %v, Connection = %v", snap.Connected, snap.Connection)
+
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/amf/amf_ue_test.go
+++ b/internal/amf/amf_ue_test.go
@@ -72,9 +72,9 @@ func TestSnapshotCipheringAlgorithm(t *testing.T) {
 		expected string
 	}{
 		{"NEA0", nas.CipheringNull, "NEA0"},
-		{"NEA1", nas.CipheringSNOW3G, "NEA1"},
-		{"NEA2", nas.CipheringAES, "NEA2"},
-		{"NEA3", nas.CipheringZUC, "NEA3"},
+		{"NEA1", nas.CipheringSNOW3G, "128-NEA1"},
+		{"NEA2", nas.CipheringAES, "128-NEA2"},
+		{"NEA3", nas.CipheringZUC, "128-NEA3"},
 		{"unknown", 0xFF, ""},
 	}
 
@@ -98,9 +98,9 @@ func TestSnapshotIntegrityAlgorithm(t *testing.T) {
 		expected string
 	}{
 		{"NIA0", nas.IntegrityNull, "NIA0"},
-		{"NIA1", nas.IntegritySNOW3G, "NIA1"},
-		{"NIA2", nas.IntegrityAES, "NIA2"},
-		{"NIA3", nas.IntegrityZUC, "NIA3"},
+		{"NIA1", nas.IntegritySNOW3G, "128-NIA1"},
+		{"NIA2", nas.IntegrityAES, "128-NIA2"},
+		{"NIA3", nas.IntegrityZUC, "128-NIA3"},
 		{"unknown", 0xFF, ""},
 	}
 

--- a/internal/amf/decode_nas_message_test.go
+++ b/internal/amf/decode_nas_message_test.go
@@ -28,9 +28,9 @@ func newDecoderTestUE(t *testing.T) *UeContext {
 	ueConn := &UeConn{
 		conn:        radio.Conn,
 		amf:         radio.amf,
-		RanUeNgapID: 1,
 		AmfUeNgapID: 1,
 	}
+	ueConn.setRanUeNgapID(1)
 	ueConn.setRadio("", radio.name)
 	ueConn.setLog(zap.NewNop())
 	ueConn.amf.AttachUeConn(ue, ueConn)

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -401,7 +401,7 @@ func (amf *AMF) collectUeExport(guami *models.Guami, ue *UeContext) (UeContextEx
 		export.LastActivity.RadioNode = r.radioName()
 
 		rc := &RANConnectionExport{
-			RanUeNgapID: int64(r.RanUeNgapID),
+			RanUeNgapID: int64(r.RanUeNgapID()),
 			AmfUeNgapID: int64(r.AmfUeNgapID),
 			RanTai:      r.Tai,
 			RadioName:   r.radioName(),

--- a/internal/amf/export_test.go
+++ b/internal/amf/export_test.go
@@ -276,12 +276,12 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 	}
 
 	security := jsonMap(t, ueExport, "security")
-	if cipherAlg, ok := security["ciphering_algorithm"].(string); !ok || cipherAlg != "NEA2" {
-		t.Fatalf("expected security.ciphering_algorithm to be 'NEA2', got %v", security["ciphering_algorithm"])
+	if cipherAlg, ok := security["ciphering_algorithm"].(string); !ok || cipherAlg != "128-NEA2" {
+		t.Fatalf("expected security.ciphering_algorithm to be '128-NEA2', got %v", security["ciphering_algorithm"])
 	}
 
-	if integrityAlg, ok := security["integrity_algorithm"].(string); !ok || integrityAlg != "NIA2" {
-		t.Fatalf("expected security.integrity_algorithm to be 'NIA2', got %v", security["integrity_algorithm"])
+	if integrityAlg, ok := security["integrity_algorithm"].(string); !ok || integrityAlg != "128-NIA2" {
+		t.Fatalf("expected security.integrity_algorithm to be '128-NIA2', got %v", security["integrity_algorithm"])
 	}
 
 	ngKsi := jsonMap(t, security, "ng_ksi")

--- a/internal/amf/fivegs_relocation.go
+++ b/internal/amf/fivegs_relocation.go
@@ -184,7 +184,7 @@ func (a *AMF) relocateFromEPS(
 
 	logger.From(ctx, logger.AmfLog).Info("Handover Request (EPS to 5GS)",
 		logger.SUPI(ue.Supi().String()),
-		zap.Uint64("target-amf-ue-id", uint64(targetUe.AmfUeNgapID)),
+		zap.Uint64("target_amf_ue_ngap_id", uint64(targetUe.AmfUeNgapID)),
 		zap.Int("pdu-sessions", len(sessions)))
 
 	err = targetUe.SendHandoverRequest(ctx, HandoverRequestOpts{

--- a/internal/amf/nas_count_order_test.go
+++ b/internal/amf/nas_count_order_test.go
@@ -105,9 +105,9 @@ func newDownlinkOrderUE(t *testing.T) (*UeContext, *downlinkOrderConn) {
 	ueConn := &UeConn{
 		conn:        sender,
 		amf:         radio.amf,
-		RanUeNgapID: 1,
 		AmfUeNgapID: 1,
 	}
+	ueConn.setRanUeNgapID(1)
 	ueConn.setRadio("", radio.name)
 	ueConn.setLog(zap.NewNop())
 	ueConn.amf.AttachUeConn(ue, ueConn)

--- a/internal/amf/nas_security.go
+++ b/internal/amf/nas_security.go
@@ -13,11 +13,11 @@ func cipheringAlgName(alg nas.CipheringAlgorithm) string {
 	case nas.CipheringNull:
 		return "NEA0"
 	case nas.CipheringSNOW3G:
-		return "NEA1"
+		return "128-NEA1"
 	case nas.CipheringAES:
-		return "NEA2"
+		return "128-NEA2"
 	case nas.CipheringZUC:
-		return "NEA3"
+		return "128-NEA3"
 	default:
 		return ""
 	}
@@ -28,11 +28,11 @@ func integrityAlgName(alg nas.IntegrityAlgorithm) string {
 	case nas.IntegrityNull:
 		return "NIA0"
 	case nas.IntegritySNOW3G:
-		return "NIA1"
+		return "128-NIA1"
 	case nas.IntegrityAES:
-		return "NIA2"
+		return "128-NIA2"
 	case nas.IntegrityZUC:
-		return "NIA3"
+		return "128-NIA3"
 	default:
 		return ""
 	}

--- a/internal/amf/ngap/handle_error_indication.go
+++ b/internal/amf/ngap/handle_error_indication.go
@@ -129,11 +129,11 @@ func HandleErrorIndication(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 
 	fields := make([]zap.Field, 0, 3)
 	if msg.AMFUENGAPID != nil {
-		fields = append(fields, zap.Uint64("amf-ue-id", uint64(*msg.AMFUENGAPID)))
+		fields = append(fields, zap.Uint64("amf_ue_ngap_id", uint64(*msg.AMFUENGAPID)))
 	}
 
 	if msg.RANUENGAPID != nil {
-		fields = append(fields, zap.Uint32("ran-ue-id", uint32(*msg.RANUENGAPID)))
+		fields = append(fields, zap.Uint32("ran_ue_ngap_id", uint32(*msg.RANUENGAPID)))
 	}
 
 	if msg.Cause != nil {

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -20,7 +20,7 @@ func HandleHandoverCancel(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	logger.WithTrace(ctx, sourceUe.Log()).Debug("Handle Handover Cancel", zap.Uint32("source_ran_ue_ngap_id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source_amf_ue_ngap_id", uint64(sourceUe.AmfUeNgapID)))
+	logger.WithTrace(ctx, sourceUe.Log()).Debug("Handle Handover Cancel", zap.Uint32("source_ran_ue_ngap_id", uint32(sourceUe.RanUeNgapID())), zap.Uint64("source_amf_ue_ngap_id", uint64(sourceUe.AmfUeNgapID)))
 	sourceUe.TouchLastSeen()
 
 	cause := ngap.Cause{

--- a/internal/amf/ngap/handle_handover_cancel.go
+++ b/internal/amf/ngap/handle_handover_cancel.go
@@ -20,7 +20,7 @@ func HandleHandoverCancel(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 		return
 	}
 
-	logger.WithTrace(ctx, sourceUe.Log()).Debug("Handle Handover Cancel", zap.Uint32("source-ran-ue-id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source-amf-ue-id", uint64(sourceUe.AmfUeNgapID)))
+	logger.WithTrace(ctx, sourceUe.Log()).Debug("Handle Handover Cancel", zap.Uint32("source_ran_ue_ngap_id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source_amf_ue_ngap_id", uint64(sourceUe.AmfUeNgapID)))
 	sourceUe.TouchLastSeen()
 
 	cause := ngap.Cause{

--- a/internal/amf/ngap/handle_handover_failure.go
+++ b/internal/amf/ngap/handle_handover_failure.go
@@ -26,7 +26,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 
 	targetUe := amfInstance.FindUEByAmfUeNgapID(ran, models.AmfUeNgapID(*msg.AMFUENGAPID))
 	if targetUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Uint64("amf-ue-id", uint64(*msg.AMFUENGAPID)))
+		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Uint64("amf_ue_ngap_id", uint64(*msg.AMFUENGAPID)))
 		sendErrorIndication(ctx, ran, msg.AMFUENGAPID, nil, causeUnknownLocalUEID)
 
 		return
@@ -38,7 +38,7 @@ func HandleHandoverFailure(ctx context.Context, amfInstance *amf.AMF, ran *amf.R
 
 	if amfUe == nil || amfInstance.HandoverTarget(amfUe) != targetUe {
 		logger.WithTrace(ctx, ran.Log).Warn("ignoring Handover Failure not from the prepared handover target",
-			zap.Uint64("amf-ue-id", uint64(*msg.AMFUENGAPID)))
+			zap.Uint64("amf_ue_ngap_id", uint64(*msg.AMFUENGAPID)))
 
 		return
 	}

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -213,7 +213,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	logger.WithTrace(ctx, targetUe.Log()).Debug("handle handover request acknowledge", zap.Uint32("source_ran_ue_ngap_id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source_amf_ue_ngap_id", uint64(sourceUe.AmfUeNgapID)))
+	logger.WithTrace(ctx, targetUe.Log()).Debug("handle handover request acknowledge", zap.Uint32("source_ran_ue_ngap_id", uint32(sourceUe.RanUeNgapID())), zap.Uint64("source_amf_ue_ngap_id", uint64(sourceUe.AmfUeNgapID)))
 
 	sourceUe.SendHandoverCommand(ctx, admitted, releaseItems(ctx, targetUe, unadmitted, targetCauses), msg.TargetToSourceTransparentContainer)
 }

--- a/internal/amf/ngap/handle_handover_request_acknowledge.go
+++ b/internal/amf/ngap/handle_handover_request_acknowledge.go
@@ -104,14 +104,14 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 
 	targetUe := amfInstance.FindUEByAmfUeNgapID(ran, models.AmfUeNgapID(*msg.AMFUENGAPID))
 	if targetUe == nil {
-		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Uint64("amf-ue-id", uint64(*msg.AMFUENGAPID)))
+		logger.WithTrace(ctx, ran.Log).Error("No UE Context on this radio", zap.Uint64("amf_ue_ngap_id", uint64(*msg.AMFUENGAPID)))
 		sendErrorIndication(ctx, ran, msg.AMFUENGAPID, msg.RANUENGAPID, causeUnknownLocalUEID)
 
 		return
 	}
 
 	targetUe.TouchLastSeen()
-	logger.WithTrace(ctx, targetUe.Log()).Debug("Handle Handover Request Acknowledge", zap.Uint32("ran-ue-id", uint32(targetUe.RanUeNgapID)), zap.Uint64("amf-ue-id", uint64(targetUe.AmfUeNgapID)))
+	logger.WithTrace(ctx, targetUe.Log()).Debug("Handle Handover Request Acknowledge")
 
 	amfUe := targetUe.UeContext()
 	if amfUe == nil {
@@ -213,8 +213,7 @@ func HandleHandoverRequestAcknowledge(ctx context.Context, amfInstance *amf.AMF,
 		return
 	}
 
-	logger.WithTrace(ctx, targetUe.Log()).Debug("handle handover request acknowledge", zap.Uint32("source-ran-ue-id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source-amf-ue-id", uint64(sourceUe.AmfUeNgapID)),
-		zap.Uint32("target-ran-ue-id", uint32(targetUe.RanUeNgapID)), zap.Uint64("target-amf-ue-id", uint64(targetUe.AmfUeNgapID)))
+	logger.WithTrace(ctx, targetUe.Log()).Debug("handle handover request acknowledge", zap.Uint32("source_ran_ue_ngap_id", uint32(sourceUe.RanUeNgapID)), zap.Uint64("source_amf_ue_ngap_id", uint64(sourceUe.AmfUeNgapID)))
 
 	sourceUe.SendHandoverCommand(ctx, admitted, releaseItems(ctx, targetUe, unadmitted, targetCauses), msg.TargetToSourceTransparentContainer)
 }

--- a/internal/amf/ngap/handle_initial_ue_message.go
+++ b/internal/amf/ngap/handle_initial_ue_message.go
@@ -31,7 +31,7 @@ func HandleInitialUEMessage(ctx context.Context, amfInstance *amf.AMF, ran *amf.
 		return
 	}
 
-	logger.WithTrace(ctx, ueConn.Log()).Debug("Added Ran UE to the pool", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Added Ran UE to the pool")
 
 	reportDiagnostics(ctx, ran, ngap.ProcInitialUEMessage, ngap.TriggeringInitiatingMessage,
 		ueAssociated(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), msg.RANUENGAPID), msg.Diagnostics())
@@ -115,9 +115,9 @@ func resumeExistingContext(ctx context.Context, amfInstance *amf.AMF, ueConn *am
 	}
 
 	if amfUe.Conn() != nil {
-		logger.WithTrace(ctx, ueConn.Log()).Debug("Implicit Deregistration", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+		logger.WithTrace(ctx, ueConn.Log()).Debug("Implicit Deregistration")
 	}
 
-	logger.WithTrace(ctx, ueConn.Log()).Debug("UeContext Attach UeConn", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("UeContext Attach UeConn")
 	amfInstance.AttachUeConn(amfUe, ueConn)
 }

--- a/internal/amf/ngap/handle_initial_ue_message_test.go
+++ b/internal/amf/ngap/handle_initial_ue_message_test.go
@@ -39,8 +39,8 @@ func TestHandleInitialUEMessage_CreatesNewUeConn(t *testing.T) {
 		t.Fatal("FindUEByRanUeNgapID(1) is nil")
 	}
 
-	if ueConn.RanUeNgapID != 1 {
-		t.Errorf("RanUeNgapID = %d, want 1", ueConn.RanUeNgapID)
+	if ueConn.RanUeNgapID() != 1 {
+		t.Errorf("RanUeNgapID = %d, want 1", ueConn.RanUeNgapID())
 	}
 
 	if len(fakeNAS.Calls) != 1 {

--- a/internal/amf/ngap/handle_location_report.go
+++ b/internal/amf/ngap/handle_location_report.go
@@ -38,8 +38,6 @@ func HandleLocationReport(ctx context.Context, amfInstance *amf.AMF, ran *amf.Ra
 	}
 
 	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle Location Report",
-		zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)),
-		zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)),
 		zap.Int("report-area", int(msg.LocationReportingRequestType.ReportArea)))
 
 	switch msg.LocationReportingRequestType.EventType {

--- a/internal/amf/ngap/handle_nas_non_delivery_indication.go
+++ b/internal/amf/ngap/handle_nas_non_delivery_indication.go
@@ -25,10 +25,7 @@ func HandleNASNonDeliveryIndication(ctx context.Context, amfInstance *amf.AMF, r
 
 	reportDiagnostics(ctx, ran, ngap.ProcNASNonDeliveryIndication, ngap.TriggeringInitiatingMessage, ueAssociated(msg.AMFUENGAPID, msg.RANUENGAPID), msg.Diagnostics())
 
-	fields := []zap.Field{
-		zap.Uint64("amf-ue-id", uint64(msg.AMFUENGAPID)),
-		zap.Uint32("ran-ue-id", uint32(msg.RANUENGAPID)),
-	}
+	var fields []zap.Field
 	if msg.Cause != nil {
 		fields = append(fields, logger.Cause(msg.Cause.String()))
 	}

--- a/internal/amf/ngap/handle_ng_reset.go
+++ b/internal/amf/ngap/handle_ng_reset.go
@@ -69,7 +69,7 @@ func releaseListedUEs(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio,
 			// ignored; one naming a UE this AMF has already lost is equally
 			// nothing to release. Both are still echoed by the caller.
 			logger.WithTrace(ctx, ran.Log).Warn("NG Reset names a UE this AMF does not hold",
-				zap.Any("amf-ue-id", item.AMFUENGAPID), zap.Any("ran-ue-id", item.RANUENGAPID))
+				zap.Any("amf_ue_ngap_id", item.AMFUENGAPID), zap.Any("ran_ue_ngap_id", item.RANUENGAPID))
 
 			continue
 		}

--- a/internal/amf/ngap/handle_path_switch_request.go
+++ b/internal/amf/ngap/handle_path_switch_request.go
@@ -50,14 +50,14 @@ func HandlePathSwitchRequest(ctx context.Context, amfInstance *amf.AMF, ran *amf
 
 	ueConn := amfInstance.LookupUeConn(models.AmfUeNgapID(msg.SourceAMFUENGAPID))
 	if ueConn == nil {
-		logger.WithTrace(ctx, ran.Log).Error("Cannot find UE from sourceAMfUeNgapID", zap.Uint64("source-amf-ue-id", uint64(msg.SourceAMFUENGAPID)))
+		logger.WithTrace(ctx, ran.Log).Error("Cannot find UE from sourceAMfUeNgapID", zap.Uint64("source_amf_ue_ngap_id", uint64(msg.SourceAMFUENGAPID)))
 		sendPathSwitchRequestFailure(ctx, ran, msg, ngap.CauseRadioNetworkUnknownLocalUENGAPID)
 
 		return
 	}
 
 	ueConn.TouchLastSeen()
-	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle Path Switch Request", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle Path Switch Request")
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {

--- a/internal/amf/ngap/handle_path_switch_request_test.go
+++ b/internal/amf/ngap/handle_path_switch_request_test.go
@@ -431,8 +431,8 @@ func TestPathSwitchRequest_HappyPath(t *testing.T) {
 		t.Error("expected UeConn to be switched to targetRan")
 	}
 
-	if sourceUe.RanUeNgapID != models.RanUeNgapID(targetRanUeNgapID) {
-		t.Errorf("expected RanUeNgapID=%d, got %d", targetRanUeNgapID, sourceUe.RanUeNgapID)
+	if sourceUe.RanUeNgapID() != models.RanUeNgapID(targetRanUeNgapID) {
+		t.Errorf("expected RanUeNgapID=%d, got %d", targetRanUeNgapID, sourceUe.RanUeNgapID())
 	}
 
 	if len(targetNGAPSender.SentPathSwitchRequestFailures) != 0 {

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
@@ -66,7 +66,7 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 
 	confirm := &ngap.PDUSessionResourceModifyConfirm{
 		AMFUENGAPID:              ngap.Ptr(ngap.AMFUENGAPID(ueConn.AmfUeNgapID)),
-		RANUENGAPID:              ngap.Ptr(ngap.RANUENGAPID(ueConn.RanUeNgapID)),
+		RANUENGAPID:              ngap.Ptr(ngap.RANUENGAPID(ueConn.RanUeNgapID())),
 		PDUSessionResourceModify: modifyList,
 		PDUSessionResourceFailed: failedList,
 	}

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_indication.go
@@ -25,7 +25,7 @@ func HandlePDUSessionResourceModifyIndication(ctx context.Context, amfInstance *
 		ueConn.UpdateLocation(ctx, *msg.UserLocationInformation)
 	}
 
-	logger.WithTrace(ctx, ueConn.Log()).Debug("UE Context", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("UE Context")
 	ueConn.TouchLastSeen()
 
 	amfUe := ueConn.UeContext()

--- a/internal/amf/ngap/handle_pdu_session_resource_modify_response.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_modify_response.go
@@ -34,7 +34,7 @@ func HandlePDUSessionResourceModifyResponse(ctx context.Context, amfInstance *am
 	}
 
 	ueConn.TouchLastSeen()
-	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle PDUSessionResourceModifyResponse", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle PDUSessionResourceModifyResponse")
 
 	// The transfer carries the NG-RAN node's cause but is opaque here, so the
 	// rejection is surfaced by session id: without it a modification the RAN

--- a/internal/amf/ngap/handle_pdu_session_resource_notify.go
+++ b/internal/amf/ngap/handle_pdu_session_resource_notify.go
@@ -28,7 +28,7 @@ func HandlePDUSessionResourceNotify(ctx context.Context, amfInstance *amf.AMF, r
 	reportDiagnostics(ctx, ran, ngap.ProcPDUSessionResourceNotify, ngap.TriggeringInitiatingMessage, ueAssociated(msg.AMFUENGAPID, msg.RANUENGAPID), msg.Diagnostics())
 
 	ueConn.TouchLastSeen()
-	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle PDUSessionResourceNotify", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle PDUSessionResourceNotify")
 
 	amfUe := ueConn.UeContext()
 	if amfUe == nil {

--- a/internal/amf/ngap/handle_ue_context_release_complete_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_complete_test.go
@@ -43,7 +43,7 @@ func TestHandleUEContextReleaseComplete_HandoverTargetNilTargetUe(t *testing.T) 
 
 	HandleUEContextReleaseComplete(context.Background(), amfInstance, ran, msg)
 
-	if amfInstance.FindUEByRanUeNgapID(ran, targetUeConn.RanUeNgapID) != nil {
+	if amfInstance.FindUEByRanUeNgapID(ran, targetUeConn.RanUeNgapID()) != nil {
 		t.Fatal("expected target UeConn to be removed after release complete")
 	}
 }
@@ -70,7 +70,7 @@ func TestHandleUEContextReleaseComplete_SmContextNotFound(t *testing.T) {
 
 	HandleUEContextReleaseComplete(context.Background(), amfInstance, ran, msg)
 
-	if amfInstance.FindUEByRanUeNgapID(ran, ueConn.RanUeNgapID) != nil {
+	if amfInstance.FindUEByRanUeNgapID(ran, ueConn.RanUeNgapID()) != nil {
 		t.Fatal("expected UeConn to be removed after release complete")
 	}
 }

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -43,7 +43,7 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 	reportDiagnostics(ctx, ran, ngap.ProcUEContextReleaseRequest, ngap.TriggeringInitiatingMessage, ueAssociated(msg.AMFUENGAPID, msg.RANUENGAPID), msg.Diagnostics())
 
-	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle UE Context Release Request", zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)), zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	logger.WithTrace(ctx, ueConn.Log()).Debug("Handle UE Context Release Request")
 
 	// An omitted Cause is an ignore-criticality absence: the NG-RAN node has
 	// dropped the radio connection either way, so the release proceeds under a

--- a/internal/amf/ngap/handle_uplink_nas_transport.go
+++ b/internal/amf/ngap/handle_uplink_nas_transport.go
@@ -30,9 +30,7 @@ func HandleUplinkNASTransport(ctx context.Context, amfInstance *amf.AMF, ran *am
 			logger.WithTrace(ctx, ueConn.Log()).Error("error removing ran ue context", zap.Error(err))
 		}
 
-		logger.WithTrace(ctx, ueConn.Log()).Error("No UE Context of UeConn",
-			zap.Uint64("amf-ue-id", uint64(msg.AMFUENGAPID)),
-			zap.Uint32("ran-ue-id", uint32(msg.RANUENGAPID)))
+		logger.WithTrace(ctx, ueConn.Log()).Error("No UE Context of UeConn")
 
 		return
 	}

--- a/internal/amf/ngap/handle_uplink_nrppa_transport.go
+++ b/internal/amf/ngap/handle_uplink_nrppa_transport.go
@@ -26,7 +26,7 @@ func HandleUplinkUEAssociatedNRPPaTransport(ctx context.Context, amfInstance *am
 	ue := ueConn.UeContext()
 	if ue == nil {
 		logger.From(ctx, ran.Log).Warn("no AMF UE context for NRPPa transport",
-			zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
+			zap.Uint64("amf_ue_ngap_id", uint64(ueConn.AmfUeNgapID)))
 
 		return
 	}
@@ -37,7 +37,7 @@ func HandleUplinkUEAssociatedNRPPaTransport(ctx context.Context, amfInstance *am
 	// correlates a pending measurement against.
 	if !ue.KnownNRPPaRoutingID(msg.RoutingID) {
 		logger.From(ctx, ran.Log).Warn("ignoring uplink NRPPa transport with an unknown Routing ID",
-			zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)),
+			zap.Uint64("amf_ue_ngap_id", uint64(ueConn.AmfUeNgapID)),
 			zap.Binary("routing-id", msg.RoutingID))
 
 		return
@@ -46,7 +46,7 @@ func HandleUplinkUEAssociatedNRPPaTransport(ctx context.Context, amfInstance *am
 	ue.SetNRPPaMessage(msg.NRPPaPDU)
 
 	logger.From(ctx, ran.Log).Debug("stored uplink NRPPa PDU",
-		zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)),
+		zap.Uint64("amf_ue_ngap_id", uint64(ueConn.AmfUeNgapID)),
 		zap.Int("payload-len", len(msg.NRPPaPDU)),
 	)
 }

--- a/internal/amf/ngap/handover_conformance_test.go
+++ b/internal/amf/ngap/handover_conformance_test.go
@@ -231,8 +231,8 @@ func TestN2HandoverCommandCarriesMandatoryIEs(t *testing.T) {
 		t.Errorf("HANDOVER COMMAND AMF UE NGAP ID = %d, want the source's %d", cmd.AMFUENGAPID, env.sourceUe.AmfUeNgapID)
 	}
 
-	if cmd.RANUENGAPID != ngap.RANUENGAPID(env.sourceUe.RanUeNgapID) {
-		t.Errorf("HANDOVER COMMAND RAN UE NGAP ID = %d, want the source's %d", cmd.RANUENGAPID, env.sourceUe.RanUeNgapID)
+	if cmd.RANUENGAPID != ngap.RANUENGAPID(env.sourceUe.RanUeNgapID()) {
+		t.Errorf("HANDOVER COMMAND RAN UE NGAP ID = %d, want the source's %d", cmd.RANUENGAPID, env.sourceUe.RanUeNgapID())
 	}
 
 	if cmd.HandoverType != ngap.HandoverTypeIntra5GS {
@@ -688,7 +688,7 @@ func TestN2HandoverCancelReleasesTargetAndAcknowledges(t *testing.T) {
 
 	HandleHandoverCancel(context.Background(), env.amf, env.sourceRan, &ngap.HandoverCancel{
 		AMFUENGAPID: ngap.AMFUENGAPID(env.sourceUe.AmfUeNgapID),
-		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID),
+		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID()),
 		Cause:       &cause,
 	})
 
@@ -711,8 +711,8 @@ func TestN2HandoverCancelReleasesTargetAndAcknowledges(t *testing.T) {
 		t.Errorf("acknowledge AMF UE NGAP ID = %v, want the source's %d", ack.AMFUENGAPID, env.sourceUe.AmfUeNgapID)
 	}
 
-	if ack.RANUENGAPID == nil || *ack.RANUENGAPID != ngap.RANUENGAPID(env.sourceUe.RanUeNgapID) {
-		t.Errorf("acknowledge RAN UE NGAP ID = %v, want the source's %d", ack.RANUENGAPID, env.sourceUe.RanUeNgapID)
+	if ack.RANUENGAPID == nil || *ack.RANUENGAPID != ngap.RANUENGAPID(env.sourceUe.RanUeNgapID()) {
+		t.Errorf("acknowledge RAN UE NGAP ID = %v, want the source's %d", ack.RANUENGAPID, env.sourceUe.RanUeNgapID())
 	}
 
 	if env.amf.HandoverInProgress(env.ue) {
@@ -728,7 +728,7 @@ func TestN2HandoverCancelWithoutCauseStillCancels(t *testing.T) {
 
 	HandleHandoverCancel(context.Background(), env.amf, env.sourceRan, &ngap.HandoverCancel{
 		AMFUENGAPID: ngap.AMFUENGAPID(env.sourceUe.AmfUeNgapID),
-		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID),
+		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID()),
 	})
 
 	if len(env.target.SentUEContextReleaseCommands) != 1 {
@@ -752,7 +752,7 @@ func TestN2DownlinkRanStatusTransferAddressesTheTargetWithTheSameContainer(t *te
 
 	HandleUplinkRanStatusTransfer(context.Background(), env.amf, env.sourceRan, &ngap.UplinkRANStatusTransfer{
 		AMFUENGAPID: ngap.AMFUENGAPID(env.sourceUe.AmfUeNgapID),
-		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID),
+		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID()),
 		Container:   container,
 	})
 
@@ -802,7 +802,7 @@ func TestN2StatusTransferWithNoHandoverIsNotRelayed(t *testing.T) {
 
 	HandleUplinkRanStatusTransfer(context.Background(), env.amf, env.sourceRan, &ngap.UplinkRANStatusTransfer{
 		AMFUENGAPID: ngap.AMFUENGAPID(env.sourceUe.AmfUeNgapID),
-		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID),
+		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID()),
 		Container:   ngap.StatusTransferContainer{0x01},
 	})
 
@@ -826,7 +826,7 @@ func TestN2HandoverCancelDuringCommitDoesNotTearDown(t *testing.T) {
 
 	HandleHandoverCancel(context.Background(), env.amf, env.sourceRan, &ngap.HandoverCancel{
 		AMFUENGAPID: ngap.AMFUENGAPID(env.sourceUe.AmfUeNgapID),
-		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID),
+		RANUENGAPID: ngap.RANUENGAPID(env.sourceUe.RanUeNgapID()),
 	})
 
 	if !env.amf.HandoverInProgress(env.ue) {

--- a/internal/amf/ngap/resolve_ue.go
+++ b/internal/amf/ngap/resolve_ue.go
@@ -55,7 +55,7 @@ func resolveDecodedUE(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio,
 		ueConn := amfInstance.FindUEByAmfUeNgapID(ran, models.AmfUeNgapID(*amfID))
 		if ueConn == nil {
 			logger.WithTrace(ctx, ran.Log).Warn("Unknown local AMF-UE-NGAP-ID on this radio",
-				zap.Uint64("amf-ue-id", uint64(*amfID)))
+				zap.Uint64("amf_ue_ngap_id", uint64(*amfID)))
 			sendUnknownLocalUEError(ctx, ran, amfID, ranID)
 
 			return nil, false
@@ -63,9 +63,9 @@ func resolveDecodedUE(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio,
 
 		if ranID != nil && ueConn.RanUeNgapID != models.RanUeNgapID(*ranID) {
 			logger.WithTrace(ctx, ran.Log).Warn("Inconsistent remote RAN-UE-NGAP-ID",
-				zap.Uint64("amf-ue-id", uint64(*amfID)),
-				zap.Uint32("stored-ran-ue-id", uint32(ueConn.RanUeNgapID)),
-				zap.Uint32("received-ran-ue-id", uint32(*ranID)))
+				zap.Uint64("amf_ue_ngap_id", uint64(*amfID)),
+				zap.Uint32("stored_ran_ue_ngap_id", uint32(ueConn.RanUeNgapID)),
+				zap.Uint32("received_ran_ue_ngap_id", uint32(*ranID)))
 			sendInconsistentRemoteUEError(ctx, ran, amfID, ranID)
 
 			return nil, false
@@ -78,7 +78,7 @@ func resolveDecodedUE(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio,
 		ueConn := amfInstance.FindUEByRanUeNgapID(ran, models.RanUeNgapID(*ranID))
 		if ueConn == nil {
 			logger.WithTrace(ctx, ran.Log).Warn("Unknown remote RAN-UE-NGAP-ID on this radio",
-				zap.Uint32("ran-ue-id", uint32(*ranID)))
+				zap.Uint32("ran_ue_ngap_id", uint32(*ranID)))
 			sendInconsistentRemoteUEError(ctx, ran, amfID, ranID)
 
 			return nil, false

--- a/internal/amf/ngap/resolve_ue.go
+++ b/internal/amf/ngap/resolve_ue.go
@@ -61,10 +61,10 @@ func resolveDecodedUE(ctx context.Context, amfInstance *amf.AMF, ran *amf.Radio,
 			return nil, false
 		}
 
-		if ranID != nil && ueConn.RanUeNgapID != models.RanUeNgapID(*ranID) {
+		if ranID != nil && ueConn.RanUeNgapID() != models.RanUeNgapID(*ranID) {
 			logger.WithTrace(ctx, ran.Log).Warn("Inconsistent remote RAN-UE-NGAP-ID",
 				zap.Uint64("amf_ue_ngap_id", uint64(*amfID)),
-				zap.Uint32("stored_ran_ue_ngap_id", uint32(ueConn.RanUeNgapID)),
+				zap.Uint32("stored_ran_ue_ngap_id", uint32(ueConn.RanUeNgapID())),
 				zap.Uint32("received_ran_ue_ngap_id", uint32(*ranID)))
 			sendInconsistentRemoteUEError(ctx, ran, amfID, ranID)
 

--- a/internal/amf/ngap/superseded_release_test.go
+++ b/internal/amf/ngap/superseded_release_test.go
@@ -29,7 +29,7 @@ func supersedeOntoNewConnection(t *testing.T) (amfInstance *amf.AMF, ran *amf.Ra
 
 	amfInstance.AttachUeConn(amfUe, oldConn)
 	oldAmfID = int64(oldConn.AmfUeNgapID)
-	oldRanID = int64(oldConn.RanUeNgapID)
+	oldRanID = int64(oldConn.RanUeNgapID())
 
 	newConn, err := amfInstance.NewUeConn(ran, 2)
 	if err != nil {

--- a/internal/amf/path_switch_nh_test.go
+++ b/internal/amf/path_switch_nh_test.go
@@ -68,8 +68,8 @@ func TestPathSwitchNH_CommitOnlyOnConfirmedSwitch(t *testing.T) {
 			t.Fatal("CommitPathSwitch must commit the staged NH chain")
 		}
 
-		if ueConn.RanUeNgapID != 99 {
-			t.Errorf("RanUeNgapID = %d, want 99", ueConn.RanUeNgapID)
+		if ueConn.RanUeNgapID() != 99 {
+			t.Errorf("RanUeNgapID = %d, want 99", ueConn.RanUeNgapID())
 		}
 
 		if ueConn.Radio() != target {

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -640,9 +640,7 @@ func (a *AMF) DropStaleUe(ctx context.Context, radio *Radio, ranUeNgapID models.
 	a.mu.Unlock()
 
 	for _, ueConn := range stale {
-		logger.WithTrace(ctx, ueConn.Log()).Debug("RAN UE NGAP ID reused in InitialUEMessage, removing stale UeConn",
-			zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)),
-			zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)))
+		logger.WithTrace(ctx, ueConn.Log()).Debug("RAN UE NGAP ID reused in InitialUEMessage, removing stale UeConn")
 
 		if err := a.RemoveUeConn(ctx, ueConn); err != nil {
 			logger.WithTrace(ctx, ueConn.Log()).Error(err.Error())
@@ -668,8 +666,8 @@ func (a *AMF) RemoveUeConn(ctx context.Context, ueConn *UeConn) error {
 	a.connIDs.FreeID(int64(ueConn.AmfUeNgapID))
 
 	logger.AmfLog.Info("ran ue removed",
-		zap.Uint64("amf-ue-id", uint64(ueConn.AmfUeNgapID)),
-		zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)),
+		zap.Uint64("amf_ue_ngap_id", uint64(ueConn.AmfUeNgapID)),
+		zap.Uint32("ran_ue_ngap_id", uint32(ueConn.RanUeNgapID)),
 	)
 
 	return nil

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -51,7 +51,7 @@ const releaseGuardTimeout = 5 * time.Second
 // capture the returned pointer in a local and reuse it — the pointer may change between
 // calls.
 type UeConn struct {
-	RanUeNgapID  models.RanUeNgapID
+	ranUeNgapID  atomic.Int64
 	AmfUeNgapID  models.AmfUeNgapID
 	HandOverType ngap.HandoverType
 	Tai          models.Tai
@@ -193,8 +193,8 @@ func (ueConn *UeConn) refreshLog() {
 	}
 
 	fields := []zap.Field{logger.AmfUeNgapID(ueConn.AmfUeNgapID)}
-	if ueConn.RanUeNgapID != models.RanUeNgapIDUnspecified {
-		fields = append(fields, logger.RanUeNgapID(ueConn.RanUeNgapID))
+	if ranUeNgapID := ueConn.RanUeNgapID(); ranUeNgapID != models.RanUeNgapIDUnspecified {
+		fields = append(fields, logger.RanUeNgapID(ranUeNgapID))
 	}
 
 	ueConn.setLog(base.With(fields...))
@@ -203,6 +203,14 @@ func (ueConn *UeConn) refreshLog() {
 // Parent returns the UeContext this connection is bound to, or nil when bare.
 func (ueConn *UeConn) Parent() *UeContext {
 	return ueConn.ue.Load()
+}
+
+func (ueConn *UeConn) RanUeNgapID() models.RanUeNgapID {
+	return models.RanUeNgapID(ueConn.ranUeNgapID.Load())
+}
+
+func (ueConn *UeConn) setRanUeNgapID(ranUeNgapID models.RanUeNgapID) {
+	ueConn.ranUeNgapID.Store(int64(ranUeNgapID))
 }
 
 // Release stops the NAS guard and clears this connection from its UeContext. Clearing
@@ -632,7 +640,7 @@ func (a *AMF) DropStaleUe(ctx context.Context, radio *Radio, ranUeNgapID models.
 	var stale []*UeConn
 
 	for _, ueConn := range a.conns {
-		if ueConn.conn == radio.Conn && ueConn.RanUeNgapID == ranUeNgapID {
+		if ueConn.conn == radio.Conn && ueConn.RanUeNgapID() == ranUeNgapID {
 			stale = append(stale, ueConn)
 		}
 	}
@@ -667,7 +675,7 @@ func (a *AMF) RemoveUeConn(ctx context.Context, ueConn *UeConn) error {
 
 	logger.AmfLog.Info("ran ue removed",
 		zap.Uint64("amf_ue_ngap_id", uint64(ueConn.AmfUeNgapID)),
-		zap.Uint32("ran_ue_ngap_id", uint32(ueConn.RanUeNgapID)),
+		zap.Uint32("ran_ue_ngap_id", uint32(ueConn.RanUeNgapID())),
 	)
 
 	return nil
@@ -690,7 +698,7 @@ func (a *AMF) CommitPathSwitch(ue *UeContext, ueConn *UeConn, ran *Radio, ranUeN
 
 	ueConn.conn = ran.Conn
 	ueConn.setRadio(radioIDOf(ran), ran.name)
-	ueConn.RanUeNgapID = ranUeNgapID
+	ueConn.setRanUeNgapID(ranUeNgapID)
 
 	if supi := ue.Supi(); supi.IsIMSI() {
 		a.lastSeen.refresh(supi.IMSI(), radioIDOf(ran), ran.name, ue.lastSeenTime())
@@ -720,11 +728,11 @@ func NewUeConnForTest(radio *Radio, ranUeNgapID models.RanUeNgapID, amfUeNgapID 
 	}
 
 	ueConn := &UeConn{
-		RanUeNgapID: ranUeNgapID,
 		AmfUeNgapID: amfUeNgapID,
 		conn:        radio.Conn,
 		amf:         radio.amf,
 	}
+	ueConn.setRanUeNgapID(ranUeNgapID)
 	ueConn.setLog(log)
 
 	radio.amf.mu.Lock()

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -78,6 +78,7 @@ type UeConn struct {
 	n2Sessions n2Sessions
 	inboundNAS atomic.Uint32
 	log        atomic.Pointer[zap.Logger]
+	baseLog    atomic.Pointer[zap.Logger]
 	// releasing gates a UE Context Release Command so a second one is not sent for the
 	// same RAN UE. Guarded by AMF.mu, like the conns registry it lives in.
 	releasing bool
@@ -178,6 +179,25 @@ func (ueConn *UeConn) Log() *zap.Logger {
 
 func (ueConn *UeConn) setLog(l *zap.Logger) {
 	ueConn.log.Store(l)
+}
+
+func (ueConn *UeConn) bindLog(base *zap.Logger) {
+	ueConn.baseLog.Store(base)
+	ueConn.refreshLog()
+}
+
+func (ueConn *UeConn) refreshLog() {
+	base := ueConn.baseLog.Load()
+	if base == nil {
+		return
+	}
+
+	fields := []zap.Field{logger.AmfUeNgapID(ueConn.AmfUeNgapID)}
+	if ueConn.RanUeNgapID != models.RanUeNgapIDUnspecified {
+		fields = append(fields, logger.RanUeNgapID(ueConn.RanUeNgapID))
+	}
+
+	ueConn.setLog(base.With(fields...))
 }
 
 // Parent returns the UeContext this connection is bound to, or nil when bare.
@@ -683,10 +703,11 @@ func (a *AMF) CommitPathSwitch(ue *UeContext, ueConn *UeConn, ran *Radio, ranUeN
 	ue.ncc = ncc
 	ue.mu.Unlock()
 
+	ueConn.bindLog(ran.Log)
+
 	a.mu.Unlock()
 
-	ueConn.setLog(ran.Log.With(logger.AmfUeNgapID(ueConn.AmfUeNgapID)))
-	ueConn.Log().Info("ran ue switched to new Ran", zap.Uint32("ran-ue-id", uint32(ueConn.RanUeNgapID)))
+	ueConn.Log().Info("ran ue switched to new Ran")
 
 	return true
 }

--- a/internal/amf/ran_ue_log_fields_test.go
+++ b/internal/amf/ran_ue_log_fields_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestUeConnLogCarriesUeAssociationIDs(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	ueConn := &UeConn{AmfUeNgapID: 7, RanUeNgapID: models.RanUeNgapIDUnspecified}
+	ueConn.bindLog(zap.New(core))
+	ueConn.Log().Info("handover target prepared")
+
+	ueConn.RanUeNgapID = 42
+	ueConn.refreshLog()
+	ueConn.Log().Info("handover target assigned")
+
+	entries := logs.All()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(entries))
+	}
+
+	prepared := entries[0].ContextMap()
+	if prepared["amf_ue_ngap_id"] != int64(7) {
+		t.Errorf("expected amf_ue_ngap_id 7, got %v", prepared["amf_ue_ngap_id"])
+	}
+
+	if _, ok := prepared["ran_ue_ngap_id"]; ok {
+		t.Errorf("expected ran_ue_ngap_id to be omitted while unspecified, got %v", prepared["ran_ue_ngap_id"])
+	}
+
+	assigned := entries[1].ContextMap()
+	if assigned["amf_ue_ngap_id"] != int64(7) {
+		t.Errorf("expected amf_ue_ngap_id 7, got %v", assigned["amf_ue_ngap_id"])
+	}
+
+	if assigned["ran_ue_ngap_id"] != int64(42) {
+		t.Errorf("expected ran_ue_ngap_id 42, got %v", assigned["ran_ue_ngap_id"])
+	}
+}
+
+func TestUeConnLogWithoutBaseKeepsExplicitLogger(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	ueConn := &UeConn{AmfUeNgapID: 1, RanUeNgapID: 2}
+	ueConn.setLog(zap.New(core))
+	ueConn.refreshLog()
+	ueConn.Log().Info("still mine")
+
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", logs.Len())
+	}
+
+	if got := logs.All()[0].ContextMap(); len(got) != 0 {
+		t.Errorf("expected no injected fields, got %v", got)
+	}
+}

--- a/internal/amf/ran_ue_log_fields_test.go
+++ b/internal/amf/ran_ue_log_fields_test.go
@@ -15,11 +15,12 @@ import (
 func TestUeConnLogCarriesUeAssociationIDs(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
 
-	ueConn := &UeConn{AmfUeNgapID: 7, RanUeNgapID: models.RanUeNgapIDUnspecified}
+	ueConn := &UeConn{AmfUeNgapID: 7}
+	ueConn.setRanUeNgapID(models.RanUeNgapIDUnspecified)
 	ueConn.bindLog(zap.New(core))
 	ueConn.Log().Info("handover target prepared")
 
-	ueConn.RanUeNgapID = 42
+	ueConn.setRanUeNgapID(42)
 	ueConn.refreshLog()
 	ueConn.Log().Info("handover target assigned")
 
@@ -50,7 +51,8 @@ func TestUeConnLogCarriesUeAssociationIDs(t *testing.T) {
 func TestUeConnLogWithoutBaseKeepsExplicitLogger(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
 
-	ueConn := &UeConn{AmfUeNgapID: 1, RanUeNgapID: 2}
+	ueConn := &UeConn{AmfUeNgapID: 1}
+	ueConn.setRanUeNgapID(2)
 	ueConn.setLog(zap.New(core))
 	ueConn.refreshLog()
 	ueConn.Log().Info("still mine")

--- a/internal/amf/registration_accept_guard_conn_test.go
+++ b/internal/amf/registration_accept_guard_conn_test.go
@@ -42,9 +42,9 @@ func TestRegistrationAcceptGuardDoesNotRetransmitOnAReplacedConnection(t *testin
 	replacement := &UeConn{
 		conn:        replacementSender,
 		amf:         amfInstance,
-		RanUeNgapID: 2,
 		AmfUeNgapID: 2,
 	}
+	replacement.setRanUeNgapID(2)
 	replacement.setRadio("", "test-gNB")
 	replacement.setLog(zap.NewNop())
 

--- a/internal/amf/send.go
+++ b/internal/amf/send.go
@@ -625,7 +625,7 @@ func (ueConn *UeConn) SendDownlinkNASTransport(ctx context.Context, nasPdu []byt
 		return err
 	}
 
-	pkt, err := downlinkNASTransportBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), nasPdu)
+	pkt, err := downlinkNASTransportBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), nasPdu)
 	if err != nil {
 		return err
 	}
@@ -652,7 +652,7 @@ func (ueConn *UeConn) SendDownlinkNRPPaTransport(ctx context.Context, routingID 
 		return err
 	}
 
-	pkt, err := downlinkUEAssociatedNRPPaTransportBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), routingID, nrppaPdu)
+	pkt, err := downlinkUEAssociatedNRPPaTransportBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), routingID, nrppaPdu)
 	if err != nil {
 		return fmt.Errorf("build downlink NRPPa transport: %w", err)
 	}
@@ -692,7 +692,7 @@ func (ueConn *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause nga
 		return
 	}
 
-	pkt, err := ueContextReleaseCommandBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), cause)
+	pkt, err := ueContextReleaseCommandBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), cause)
 	if err != nil {
 		// The command cannot be sent, so no Release Complete will arrive; release
 		// locally now to avoid leaking the UeConn and its claim.
@@ -767,7 +767,7 @@ func (ueConn *UeConn) SendPDUSessionResourceSetupRequest(ctx context.Context, am
 		return err
 	}
 
-	pkt, err := pduSessionResourceSetupBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), ambrUp, ambrDown, nasPdu, list)
+	pkt, err := pduSessionResourceSetupBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), ambrUp, ambrDown, nasPdu, list)
 	if err != nil {
 		return err
 	}
@@ -799,7 +799,7 @@ func (ueConn *UeConn) SendPDUSessionResourceReleaseCommand(ctx context.Context, 
 		return err
 	}
 
-	pkt, err := pduSessionResourceReleaseBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), nasPdu, list)
+	pkt, err := pduSessionResourceReleaseBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), nasPdu, list)
 	if err != nil {
 		return err
 	}
@@ -917,7 +917,7 @@ func (ueConn *UeConn) SendInitialContextSetup(
 
 	pkt, err := initialContextSetupBytes(
 		ngap.AMFUENGAPID(ueConn.AmfUeNgapID),
-		ngap.RANUENGAPID(ueConn.RanUeNgapID),
+		ngap.RANUENGAPID(ueConn.RanUeNgapID()),
 		ambrUp,
 		ambrDown,
 		allowedNssai,
@@ -963,7 +963,7 @@ func (ueConn *UeConn) SendPDUSessionResourceModifyRequest(
 
 	pkt, err := pduSessionResourceModifyBytes(
 		ngap.AMFUENGAPID(ueConn.AmfUeNgapID),
-		ngap.RANUENGAPID(ueConn.RanUeNgapID),
+		ngap.RANUENGAPID(ueConn.RanUeNgapID()),
 		pduSessionResourceModifyList,
 	)
 	if err != nil {
@@ -991,7 +991,7 @@ func handoverPreparationFailureBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGA
 // FAILURE, which §8.4.1.3 has the AMF pass on to the source NG-RAN node; it is
 // nil where preparation failed before any target answered.
 func (ueConn *UeConn) SendHandoverPreparationFailure(ctx context.Context, cause ngap.Cause, criticalityDiagnostics *ngap.CriticalityDiagnostics, targetFailure ngap.TargettoSourceFailureTransparentContainer) {
-	pkt, err := handoverPreparationFailureBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), cause, criticalityDiagnostics, targetFailure)
+	pkt, err := handoverPreparationFailureBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), cause, criticalityDiagnostics, targetFailure)
 	if err != nil {
 		logger.From(ctx, ueConn.Log()).Error("failed to build Handover Preparation Failure", zap.Error(err))
 		return
@@ -1012,7 +1012,7 @@ func handoverCancelAcknowledgeBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAP
 }
 
 func (ueConn *UeConn) SendHandoverCancelAcknowledge(ctx context.Context) {
-	pkt, err := handoverCancelAcknowledgeBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID))
+	pkt, err := handoverCancelAcknowledgeBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()))
 	if err != nil {
 		logger.From(ctx, ueConn.Log()).Error("failed to build Handover Cancel Acknowledge", zap.Error(err))
 		return
@@ -1160,7 +1160,7 @@ func (ueConn *UeConn) SendHandoverCommand(
 	targetToSource ngap.TargetToSourceTransparentContainer,
 ) {
 	pkt, err := handoverCommandBytes(
-		ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID),
+		ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()),
 		ueConn.HandOverType, admitted, toRelease, targetToSource, nil,
 	)
 	if err != nil {
@@ -1178,7 +1178,7 @@ func (ueConn *UeConn) SendHandoverCommandToEPS(
 	nasSecurityParameters ngap.NASSecurityParametersFromNGRAN,
 ) {
 	pkt, err := handoverCommandBytes(
-		ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID),
+		ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()),
 		ngap.HandoverTypeFiveGSToEPS, nil, toRelease, targetToSource, nasSecurityParameters,
 	)
 	if err != nil {
@@ -1220,7 +1220,7 @@ func downlinkRANStatusTransferBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAP
 // SendDownlinkRANStatusTransfer relays the source node's PDCP SN/HFN status to
 // the handover target. The container is opaque to the AMF (TS 38.413 §9.3.1.108).
 func (ueConn *UeConn) SendDownlinkRANStatusTransfer(ctx context.Context, container ngap.StatusTransferContainer) {
-	pkt, err := downlinkRANStatusTransferBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), container)
+	pkt, err := downlinkRANStatusTransferBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), container)
 	if err != nil {
 		logger.From(ctx, ueConn.Log()).Error("failed to build Downlink RAN Status Transfer", zap.Error(err))
 		return
@@ -1282,7 +1282,7 @@ func (ueConn *UeConn) SendPathSwitchRequestAcknowledge(
 	}
 
 	pkt, err := pathSwitchRequestAcknowledgeBytes(
-		ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID),
+		ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()),
 		ueSecurityCapability, ncc, nh, switched, released, allowed,
 	)
 	if err != nil {
@@ -1311,7 +1311,7 @@ func locationReportingControlBytes(amfID ngap.AMFUENGAPID, ranID ngap.RANUENGAPI
 // SendLocationReportingControl asks the NG-RAN node to start, change or stop
 // reporting this UE's location (TS 38.413 §8.12.1).
 func (ueConn *UeConn) SendLocationReportingControl(ctx context.Context, eventType ngap.EventType) error {
-	pkt, err := locationReportingControlBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID), eventType)
+	pkt, err := locationReportingControlBytes(ngap.AMFUENGAPID(ueConn.AmfUeNgapID), ngap.RANUENGAPID(ueConn.RanUeNgapID()), eventType)
 	if err != nil {
 		return fmt.Errorf("build LocationReportingControl: %w", err)
 	}

--- a/internal/api/server/api_bitrate.go
+++ b/internal/api/server/api_bitrate.go
@@ -68,7 +68,7 @@ func checkSessionAmbrEncodable(allow4G, allow5G bool, label, bitrate string) err
 
 	if allow4G {
 		if bps > MaxSessionAmbrBpsFor4G {
-			return fmt.Errorf("%s of %s exceeds the 10 Gbps ceiling of a profile that allows 4G (TS 24.008 §10.5.6.5B)", label, bitrate)
+			return fmt.Errorf("%s of %s exceeds the 10 Gbps ceiling of a profile that allows 4G", label, bitrate)
 		}
 	}
 
@@ -93,11 +93,11 @@ func checkUeAmbrEncodable(allow4G, allow5G bool, label, bitrate string) error {
 	}
 
 	if allow4G && bps > MaxUeAmbrBpsFor4G {
-		return fmt.Errorf("%s of %s exceeds the 10 Gbps ceiling of a profile that allows 4G (TS 36.413 BitRate)", label, bitrate)
+		return fmt.Errorf("%s of %s exceeds the 10 Gbps ceiling of a profile that allows 4G", label, bitrate)
 	}
 
 	if allow5G && bps > MaxUeAmbrBpsFor5G {
-		return fmt.Errorf("%s of %s exceeds the 4 Tbps ceiling of 5G (TS 38.413 BitRate)", label, bitrate)
+		return fmt.Errorf("%s of %s exceeds the 4 Tbps ceiling of 5G", label, bitrate)
 	}
 
 	return nil

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -60,23 +60,33 @@ type ListSubscribersResponse struct {
 	TotalCount int          `json:"total_count"`
 }
 
-type SubscriberDetailStatus struct {
-	Registered         bool     `json:"registered"`
-	ConnectionState    string   `json:"connection_state,omitempty"`
-	RadioAccessTypes   []string `json:"radio_access_types,omitempty"`
-	Imei               string   `json:"imei"`
-	CipheringAlgorithm string   `json:"ciphering_algorithm"`
-	IntegrityAlgorithm string   `json:"integrity_algorithm"`
-	LastSeenAt         string   `json:"last_seen_at,omitempty"`
-	LastSeenRadio      string   `json:"last_seen_radio,omitempty"`
+type UEConnection struct {
+	AmfUeNgapID *int64 `json:"amf_ue_ngap_id,omitempty"`
+	RanUeNgapID *int64 `json:"ran_ue_ngap_id,omitempty"`
+	MMEUeS1apID *int64 `json:"mme_ue_s1ap_id,omitempty"`
+	ENBUeS1apID *int64 `json:"enb_ue_s1ap_id,omitempty"`
+}
+
+type Registration struct {
+	System             string        `json:"system"`
+	AccessType         string        `json:"access_type"`
+	Registered         bool          `json:"registered"`
+	ConnectionState    *string       `json:"connection_state"`
+	Radio              string        `json:"radio,omitempty"`
+	LastSeenAt         string        `json:"last_seen_at,omitempty"`
+	Pei                string        `json:"pei,omitempty"`
+	Imei               string        `json:"imei,omitempty"`
+	CipheringAlgorithm string        `json:"ciphering_algorithm,omitempty"`
+	IntegrityAlgorithm string        `json:"integrity_algorithm,omitempty"`
+	Connection         *UEConnection `json:"connection"`
 }
 
 type SubscriberDetail struct {
-	Imsi        string                 `json:"imsi"`
-	ProfileName string                 `json:"profile_name"`
-	Description string                 `json:"description,omitempty"`
-	Status      SubscriberDetailStatus `json:"status"`
-	Sessions    []Session              `json:"sessions"`
+	Imsi          string         `json:"imsi"`
+	ProfileName   string         `json:"profile_name"`
+	Description   string         `json:"description,omitempty"`
+	Registrations []Registration `json:"registrations"`
+	Sessions      []Session      `json:"sessions"`
 }
 
 type SubscriberCredentials struct {
@@ -91,17 +101,24 @@ type SNSSAI struct {
 }
 
 type Session struct {
-	RadioAccessType string  `json:"radio_access_type"` // "4G" | "5G"
-	ID              uint8   `json:"id"`                // PDU Session ID (5G) / linked EPS Bearer ID (4G)
-	Status          string  `json:"status"`
-	IPType          string  `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
-	IPv4Address     string  `json:"ipv4_address,omitempty"`
-	IPv6Prefix      string  `json:"ipv6_prefix,omitempty"`
-	DataNetwork     string  `json:"data_network,omitempty"` // DNN (5G) / APN (4G)
-	Slice           *SNSSAI `json:"slice,omitempty"`        // 5G only
-	AMBRUplink      string  `json:"ambr_uplink,omitempty"`
-	AMBRDownlink    string  `json:"ambr_downlink,omitempty"`
+	System       string   `json:"system"` // "5GS" | "EPS"
+	AccessTypes  []string `json:"access_types"`
+	ID           uint8    `json:"id"` // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
+	Status       string   `json:"status"`
+	IPType       string   `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
+	IPv4Address  string   `json:"ipv4_address,omitempty"`
+	IPv6Prefix   string   `json:"ipv6_prefix,omitempty"`
+	DataNetwork  string   `json:"data_network,omitempty"` // DNN (5GS) / APN (EPS)
+	Slice        *SNSSAI  `json:"slice,omitempty"`        // 5GS only
+	AMBRUplink   string   `json:"ambr_uplink,omitempty"`
+	AMBRDownlink string   `json:"ambr_downlink,omitempty"`
 }
+
+const (
+	System5GS      = "5GS"
+	SystemEPS      = "EPS"
+	AccessType3GPP = "3GPP"
+)
 
 const (
 	CreateSubscriberAction = "create_subscriber"
@@ -178,9 +195,6 @@ type accessView struct {
 	present       bool
 	registered    bool
 	connected     bool
-	imei          string
-	ciphering     string
-	integrity     string
 	lastSeenAt    time.Time
 	lastSeenRadio string
 }
@@ -193,9 +207,6 @@ type mergedAccess struct {
 	RATs          []string
 	Registered    bool
 	Connected     bool
-	Imei          string
-	Ciphering     string
-	Integrity     string
 	LastSeenAt    time.Time
 	LastSeenRadio string
 }
@@ -220,10 +231,6 @@ func mergeAccesses(views ...accessView) mergedAccess {
 		merged.Registered = merged.Registered || v.registered
 		merged.Connected = merged.Connected || v.connected
 
-		if merged.Imei == "" {
-			merged.Imei = v.imei
-		}
-
 		if v.newerThan(serving) {
 			serving = v
 		}
@@ -234,7 +241,6 @@ func mergeAccesses(views ...accessView) mergedAccess {
 		answering = retained
 	}
 
-	merged.Ciphering, merged.Integrity = serving.ciphering, serving.integrity
 	merged.LastSeenAt, merged.LastSeenRadio = answering.lastSeenAt, answering.lastSeenRadio
 
 	return merged
@@ -488,54 +494,29 @@ func GetSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance *m
 			on4G bool
 		)
 
-		if mmeInstance != nil {
-			cs, on4G = mmeInstance.LookupSubscriber(imsi)
-		}
-
-		var mmeLastSeen mme.LastSeen
-
-		if mmeInstance != nil {
-			mmeLastSeen, _ = mmeInstance.LastSeen(imsi)
-		}
-
-		amfLastSeen, _ := amfInstance.LastSeen(imsi)
-
-		merged := mergeAccesses(
-			accessView{
-				rat: "4G", present: on4G, registered: cs.Registered, connected: cs.Connected, imei: cs.Imei,
-				ciphering: cs.CipheringAlgorithm, integrity: cs.IntegrityAlgorithm,
-				lastSeenAt: lastSeenAt(on4G, cs.LastSeenAt, mmeLastSeen.At), lastSeenRadio: mmeLastSeen.RadioName,
-			},
-			accessView{
-				rat: "5G", present: found, registered: snap.Registered, connected: snap.Connected, imei: snap.Imei,
-				ciphering: snap.CipheringAlgorithm, integrity: snap.IntegrityAlgorithm,
-				lastSeenAt: lastSeenAt(found, snap.LastSeenAt, amfLastSeen.At), lastSeenRadio: amfLastSeen.RadioName,
-			},
+		var (
+			mmeLastSeen      mme.LastSeen
+			mmeLastSeenKnown bool
 		)
 
-		subscriberStatus := SubscriberDetailStatus{
-			Registered:         merged.Registered,
-			ConnectionState:    connectionState(on4G || found, merged.Connected),
-			RadioAccessTypes:   merged.RATs,
-			LastSeenRadio:      merged.LastSeenRadio,
-			Imei:               merged.Imei,
-			CipheringAlgorithm: merged.Ciphering,
-			IntegrityAlgorithm: merged.Integrity,
+		if mmeInstance != nil {
+			cs, on4G = mmeInstance.LookupSubscriber(imsi)
+			mmeLastSeen, mmeLastSeenKnown = mmeInstance.LastSeen(imsi)
 		}
 
-		if !merged.LastSeenAt.IsZero() {
-			subscriberStatus.LastSeenAt = merged.LastSeenAt.UTC().Format(time.RFC3339)
+		amfLastSeen, amfLastSeenKnown := amfInstance.LastSeen(imsi)
+
+		registrations := make([]Registration, 0, 2)
+
+		if reg, ok := registrationFrom5G(snap, found, amfLastSeen, amfLastSeenKnown); ok {
+			registrations = append(registrations, reg)
+		}
+
+		if reg, ok := registrationFrom4G(cs, on4G, mmeLastSeen, mmeLastSeenKnown); ok {
+			registrations = append(registrations, reg)
 		}
 
 		sessions := make([]Session, 0, len(pduSessions)+len(cs.Sessions))
-
-		for i := range cs.Sessions {
-			if len(sessions) >= MaxSessions {
-				break
-			}
-
-			sessions = append(sessions, sessionFrom4G(&cs.Sessions[i]))
-		}
 
 		if found {
 			for _, pdu := range pduSessions {
@@ -547,12 +528,20 @@ func GetSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance *m
 			}
 		}
 
+		for i := range cs.Sessions {
+			if len(sessions) >= MaxSessions {
+				break
+			}
+
+			sessions = append(sessions, sessionFrom4G(&cs.Sessions[i]))
+		}
+
 		subscriber := SubscriberDetail{
-			Imsi:        dbSubscriber.Imsi,
-			ProfileName: profile.Name,
-			Description: dbSubscriber.Description,
-			Status:      subscriberStatus,
-			Sessions:    sessions,
+			Imsi:          dbSubscriber.Imsi,
+			ProfileName:   profile.Name,
+			Description:   dbSubscriber.Description,
+			Registrations: registrations,
+			Sessions:      sessions,
 		}
 
 		writeResponse(r.Context(), w, subscriber, http.StatusOK, logger.APILog)
@@ -866,17 +855,107 @@ func DeleteSubscriber(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance
 	})
 }
 
+func connectionStatePtr(connected bool) *string {
+	state := "idle"
+	if connected {
+		state = "connected"
+	}
+
+	return &state
+}
+
+func registrationFrom5G(snap amf.UESnapshot, present bool, retained amf.LastSeen, known bool) (Registration, bool) {
+	if !present && !known {
+		return Registration{}, false
+	}
+
+	reg := Registration{
+		System:     System5GS,
+		AccessType: AccessType3GPP,
+		Radio:      retained.RadioName,
+	}
+
+	at := retained.At
+
+	if present {
+		reg.Registered = snap.Registered
+		reg.ConnectionState = connectionStatePtr(snap.Connected)
+		reg.Pei = snap.Pei
+		reg.Imei = snap.Imei
+		reg.CipheringAlgorithm = snap.CipheringAlgorithm
+		reg.IntegrityAlgorithm = snap.IntegrityAlgorithm
+
+		if !snap.LastSeenAt.IsZero() {
+			at = snap.LastSeenAt
+		}
+
+		if snap.Connection != nil {
+			amfID := snap.Connection.AmfUeNgapID
+			reg.Connection = &UEConnection{AmfUeNgapID: &amfID, RanUeNgapID: snap.Connection.RanUeNgapID}
+		}
+	}
+
+	if !at.IsZero() {
+		reg.LastSeenAt = at.UTC().Format(time.RFC3339)
+	}
+
+	return reg, true
+}
+
+func registrationFrom4G(cs mme.ConnectedSubscriber, present bool, retained mme.LastSeen, known bool) (Registration, bool) {
+	if !present && !known {
+		return Registration{}, false
+	}
+
+	reg := Registration{
+		System:     SystemEPS,
+		AccessType: AccessType3GPP,
+		Radio:      retained.RadioName,
+	}
+
+	at := retained.At
+
+	if present {
+		reg.Registered = cs.Registered
+		reg.ConnectionState = connectionStatePtr(cs.Connected)
+		reg.Imei = cs.Imei
+		reg.CipheringAlgorithm = cs.CipheringAlgorithm
+		reg.IntegrityAlgorithm = cs.IntegrityAlgorithm
+
+		if !cs.LastSeenAt.IsZero() {
+			at = cs.LastSeenAt
+		}
+
+		if cs.Connection != nil {
+			mmeID := int64(cs.Connection.MMEUES1APID)
+			reg.Connection = &UEConnection{MMEUeS1apID: &mmeID}
+
+			if cs.Connection.ENBUES1APID != nil {
+				enbID := int64(*cs.Connection.ENBUES1APID)
+				reg.Connection.ENBUeS1apID = &enbID
+			}
+		}
+	}
+
+	if !at.IsZero() {
+		reg.LastSeenAt = at.UTC().Format(time.RFC3339)
+	}
+
+	return reg, true
+}
+
 func sessionFrom4G(s *mme.SubscriberSession) Session {
 	return Session{
-		RadioAccessType: "4G",
-		ID:              s.BearerID,
-		Status:          "active",
-		IPType:          ipTypeName(uint8(s.PDNType)),
-		IPv4Address:     s.IPv4Address,
-		IPv6Prefix:      s.IPv6Prefix,
-		DataNetwork:     s.APN,
-		AMBRUplink:      s.AMBRUplink,
-		AMBRDownlink:    s.AMBRDownlink,
+		System:       SystemEPS,
+		AccessTypes:  []string{AccessType3GPP},
+		ID:           s.BearerID,
+		Status:       "active",
+		IPType:       ipTypeName(uint8(s.PDNType)),
+		IPv4Address:  s.IPv4Address,
+		IPv6Prefix:   s.IPv6Prefix,
+		DataNetwork:  s.APN,
+		AMBRUplink:   s.AMBRUplink,
+		AMBRDownlink: s.AMBRDownlink,
 	}
 }
 
@@ -887,13 +966,14 @@ func sessionFrom5G(pdu amf.PDUSessionExport) Session {
 	}
 
 	s := Session{
-		RadioAccessType: "5G",
-		ID:              pdu.PDUSessionID,
-		Status:          status,
-		IPType:          ipTypeName(pdu.PDUSessionType),
-		IPv4Address:     pdu.PDUIPV4Address,
-		IPv6Prefix:      pdu.PDUIPV6Prefix,
-		DataNetwork:     pdu.DNN,
+		System:      System5GS,
+		AccessTypes: []string{AccessType3GPP},
+		ID:          pdu.PDUSessionID,
+		Status:      status,
+		IPType:      ipTypeName(pdu.PDUSessionType),
+		IPv4Address: pdu.PDUIPV4Address,
+		IPv6Prefix:  pdu.PDUIPV6Prefix,
+		DataNetwork: pdu.DNN,
 	}
 	if pdu.Snssai != nil {
 		s.Slice = &SNSSAI{SST: pdu.Snssai.Sst, SD: pdu.Snssai.Sd}

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -38,12 +38,12 @@ type UpdateSubscriberParams struct {
 }
 
 type SubscriberStatus struct {
-	Registered       bool     `json:"registered"`
-	ConnectionState  string   `json:"connection_state,omitempty"`
-	RadioAccessTypes []string `json:"radio_access_types,omitempty"`
-	NumSessions      int      `json:"num_sessions"`
-	LastSeenAt       string   `json:"last_seen_at,omitempty"`
-	LastSeenRadio    string   `json:"last_seen_radio,omitempty"`
+	Registered      bool     `json:"registered"`
+	ConnectionState string   `json:"connection_state,omitempty"`
+	Systems         []string `json:"systems,omitempty"`
+	NumSessions     int      `json:"num_sessions"`
+	LastSeenAt      string   `json:"last_seen_at,omitempty"`
+	LastSeenRadio   string   `json:"last_seen_radio,omitempty"`
 }
 
 type Subscriber struct {
@@ -185,9 +185,9 @@ func radioIsKnown(amfInstance *amf.AMF, mmeInstance *mme.MME, name string) bool 
 	return amfInstance.HasRadio(name) || (mmeInstance != nil && mmeInstance.HasRadio(name))
 }
 
-// accessView is what one access — 4G or 5G — knows about a subscriber.
+// accessView is what one system — 4G or 5G — knows about a subscriber.
 type accessView struct {
-	rat           string
+	system        string
 	present       bool
 	registered    bool
 	connected     bool
@@ -200,7 +200,7 @@ func (v accessView) newerThan(other accessView) bool {
 }
 
 type mergedAccess struct {
-	RATs          []string
+	Systems       []string
 	Registered    bool
 	Connected     bool
 	LastSeenAt    time.Time
@@ -223,7 +223,7 @@ func mergeAccesses(views ...accessView) mergedAccess {
 			continue
 		}
 
-		merged.RATs = append(merged.RATs, v.rat)
+		merged.Systems = append(merged.Systems, v.system)
 		merged.Registered = merged.Registered || v.registered
 		merged.Connected = merged.Connected || v.connected
 
@@ -393,23 +393,23 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 
 			merged := mergeAccesses(
 				accessView{
-					rat: "4G", present: on4G, registered: mme4G.Registered, connected: mme4G.Connected,
-					lastSeenAt:    lastSeenAt(on4G, mme4G.LastSeenAt, mmeLastSeen[dbSubscriber.Imsi].At),
-					lastSeenRadio: mmeLastSeen[dbSubscriber.Imsi].RadioName,
-				},
-				accessView{
-					rat: "5G", present: on5G, registered: amf5G.Registered, connected: amf5G.Connected,
+					system: System5GS, present: on5G, registered: amf5G.Registered, connected: amf5G.Connected,
 					lastSeenAt:    lastSeenAt(on5G, amf5G.LastSeenAt, amf5GLastSeen[dbSubscriber.Imsi].At),
 					lastSeenRadio: amf5GLastSeen[dbSubscriber.Imsi].RadioName,
+				},
+				accessView{
+					system: SystemEPS, present: on4G, registered: mme4G.Registered, connected: mme4G.Connected,
+					lastSeenAt:    lastSeenAt(on4G, mme4G.LastSeenAt, mmeLastSeen[dbSubscriber.Imsi].At),
+					lastSeenRadio: mmeLastSeen[dbSubscriber.Imsi].RadioName,
 				},
 			)
 
 			subscriberStatus := SubscriberStatus{
-				Registered:       merged.Registered,
-				ConnectionState:  connectionState(on5G || on4G, merged.Connected),
-				RadioAccessTypes: merged.RATs,
-				NumSessions:      mme4G.NumSessions + amf5G.NumSessions,
-				LastSeenRadio:    merged.LastSeenRadio,
+				Registered:      merged.Registered,
+				ConnectionState: connectionState(on5G || on4G, merged.Connected),
+				Systems:         merged.Systems,
+				NumSessions:     mme4G.NumSessions + amf5G.NumSessions,
+				LastSeenRadio:   merged.LastSeenRadio,
 			}
 
 			if !merged.LastSeenAt.IsZero() {

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -99,23 +99,21 @@ type SNSSAI struct {
 }
 
 type Session struct {
-	System       string   `json:"system"` // "5GS" | "EPS"
-	AccessTypes  []string `json:"access_types"`
-	ID           uint8    `json:"id"` // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
-	Status       string   `json:"status"`
-	IPType       string   `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
-	IPv4Address  string   `json:"ipv4_address,omitempty"`
-	IPv6Prefix   string   `json:"ipv6_prefix,omitempty"`
-	DataNetwork  string   `json:"data_network,omitempty"` // DNN (5GS) / APN (EPS)
-	Slice        *SNSSAI  `json:"slice,omitempty"`        // 5GS only
-	AMBRUplink   string   `json:"ambr_uplink,omitempty"`
-	AMBRDownlink string   `json:"ambr_downlink,omitempty"`
+	System       string  `json:"system"` // "5GS" | "EPS"
+	ID           uint8   `json:"id"`     // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
+	Status       string  `json:"status"`
+	IPType       string  `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
+	IPv4Address  string  `json:"ipv4_address,omitempty"`
+	IPv6Prefix   string  `json:"ipv6_prefix,omitempty"`
+	DataNetwork  string  `json:"data_network,omitempty"` // DNN (5GS) / APN (EPS)
+	Slice        *SNSSAI `json:"slice,omitempty"`        // 5GS only
+	AMBRUplink   string  `json:"ambr_uplink,omitempty"`
+	AMBRDownlink string  `json:"ambr_downlink,omitempty"`
 }
 
 const (
-	System5GS      = "5GS"
-	SystemEPS      = "EPS"
-	AccessType3GPP = "3GPP"
+	System5GS = "5GS"
+	SystemEPS = "EPS"
 )
 
 const (
@@ -942,7 +940,6 @@ func registrationFrom4G(cs mme.ConnectedSubscriber, present bool, retained mme.L
 func sessionFrom4G(s *mme.SubscriberSession) Session {
 	return Session{
 		System:       SystemEPS,
-		AccessTypes:  []string{AccessType3GPP},
 		ID:           s.BearerID,
 		Status:       "active",
 		IPType:       ipTypeName(uint8(s.PDNType)),
@@ -962,7 +959,6 @@ func sessionFrom5G(pdu amf.PDUSessionExport) Session {
 
 	s := Session{
 		System:      System5GS,
-		AccessTypes: []string{AccessType3GPP},
 		ID:          pdu.PDUSessionID,
 		Status:      status,
 		IPType:      ipTypeName(pdu.PDUSessionType),

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -185,8 +185,8 @@ func radioIsKnown(amfInstance *amf.AMF, mmeInstance *mme.MME, name string) bool 
 	return amfInstance.HasRadio(name) || (mmeInstance != nil && mmeInstance.HasRadio(name))
 }
 
-// accessView is what one system — 4G or 5G — knows about a subscriber.
-type accessView struct {
+// systemView is what one system — 4G or 5G — knows about a subscriber.
+type systemView struct {
 	system        string
 	present       bool
 	registered    bool
@@ -195,11 +195,11 @@ type accessView struct {
 	lastSeenRadio string
 }
 
-func (v accessView) newerThan(other accessView) bool {
+func (v systemView) newerThan(other systemView) bool {
 	return !other.present || v.lastSeenAt.After(other.lastSeenAt)
 }
 
-type mergedAccess struct {
+type mergedStatus struct {
 	Systems       []string
 	Registered    bool
 	Connected     bool
@@ -207,11 +207,11 @@ type mergedAccess struct {
 	LastSeenRadio string
 }
 
-func mergeAccesses(views ...accessView) mergedAccess {
+func mergeSystems(views ...systemView) mergedStatus {
 	var (
-		merged   mergedAccess
-		serving  accessView
-		retained accessView
+		merged   mergedStatus
+		serving  systemView
+		retained systemView
 	)
 
 	for _, v := range views {
@@ -391,13 +391,13 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 			amf5G, on5G := amf5GStatus[dbSubscriber.Imsi]
 			mme4G, on4G := mmeStatus[dbSubscriber.Imsi]
 
-			merged := mergeAccesses(
-				accessView{
+			merged := mergeSystems(
+				systemView{
 					system: System5GS, present: on5G, registered: amf5G.Registered, connected: amf5G.Connected,
 					lastSeenAt:    lastSeenAt(on5G, amf5G.LastSeenAt, amf5GLastSeen[dbSubscriber.Imsi].At),
 					lastSeenRadio: amf5GLastSeen[dbSubscriber.Imsi].RadioName,
 				},
-				accessView{
+				systemView{
 					system: SystemEPS, present: on4G, registered: mme4G.Registered, connected: mme4G.Connected,
 					lastSeenAt:    lastSeenAt(on4G, mme4G.LastSeenAt, mmeLastSeen[dbSubscriber.Imsi].At),
 					lastSeenRadio: mmeLastSeen[dbSubscriber.Imsi].RadioName,

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -69,12 +69,10 @@ type UEConnection struct {
 
 type Registration struct {
 	System             string        `json:"system"`
-	AccessType         string        `json:"access_type"`
 	Registered         bool          `json:"registered"`
 	ConnectionState    *string       `json:"connection_state"`
 	Radio              string        `json:"radio,omitempty"`
 	LastSeenAt         string        `json:"last_seen_at,omitempty"`
-	Pei                string        `json:"pei,omitempty"`
 	Imei               string        `json:"imei,omitempty"`
 	CipheringAlgorithm string        `json:"ciphering_algorithm,omitempty"`
 	IntegrityAlgorithm string        `json:"integrity_algorithm,omitempty"`
@@ -870,9 +868,8 @@ func registrationFrom5G(snap amf.UESnapshot, present bool, retained amf.LastSeen
 	}
 
 	reg := Registration{
-		System:     System5GS,
-		AccessType: AccessType3GPP,
-		Radio:      retained.RadioName,
+		System: System5GS,
+		Radio:  retained.RadioName,
 	}
 
 	at := retained.At
@@ -880,7 +877,6 @@ func registrationFrom5G(snap amf.UESnapshot, present bool, retained amf.LastSeen
 	if present {
 		reg.Registered = snap.Registered
 		reg.ConnectionState = connectionStatePtr(snap.Connected)
-		reg.Pei = snap.Pei
 		reg.Imei = snap.Imei
 		reg.CipheringAlgorithm = snap.CipheringAlgorithm
 		reg.IntegrityAlgorithm = snap.IntegrityAlgorithm
@@ -908,9 +904,8 @@ func registrationFrom4G(cs mme.ConnectedSubscriber, present bool, retained mme.L
 	}
 
 	reg := Registration{
-		System:     SystemEPS,
-		AccessType: AccessType3GPP,
-		Radio:      retained.RadioName,
+		System: SystemEPS,
+		Radio:  retained.RadioName,
 	}
 
 	at := retained.At

--- a/internal/api/server/api_subscribers.go
+++ b/internal/api/server/api_subscribers.go
@@ -99,21 +99,21 @@ type SNSSAI struct {
 }
 
 type Session struct {
-	System       string  `json:"system"` // "5GS" | "EPS"
-	ID           uint8   `json:"id"`     // PDU Session ID (5GS) / linked EPS Bearer ID (EPS)
+	System       string  `json:"system"` // "5G" | "4G"
+	ID           uint8   `json:"id"`     // PDU Session ID (5G) / linked EPS Bearer ID (4G)
 	Status       string  `json:"status"`
 	IPType       string  `json:"ip_type,omitempty"` // IPv4 | IPv6 | IPv4v6
 	IPv4Address  string  `json:"ipv4_address,omitempty"`
 	IPv6Prefix   string  `json:"ipv6_prefix,omitempty"`
-	DataNetwork  string  `json:"data_network,omitempty"` // DNN (5GS) / APN (EPS)
-	Slice        *SNSSAI `json:"slice,omitempty"`        // 5GS only
+	DataNetwork  string  `json:"data_network,omitempty"` // DNN (5G) / APN (4G)
+	Slice        *SNSSAI `json:"slice,omitempty"`        // 5G only
 	AMBRUplink   string  `json:"ambr_uplink,omitempty"`
 	AMBRDownlink string  `json:"ambr_downlink,omitempty"`
 }
 
 const (
-	System5GS = "5GS"
-	SystemEPS = "EPS"
+	System5G = "5G"
+	System4G = "4G"
 )
 
 const (
@@ -393,12 +393,12 @@ func ListSubscribers(dbInstance *db.Database, amfInstance *amf.AMF, mmeInstance 
 
 			merged := mergeSystems(
 				systemView{
-					system: System5GS, present: on5G, registered: amf5G.Registered, connected: amf5G.Connected,
+					system: System5G, present: on5G, registered: amf5G.Registered, connected: amf5G.Connected,
 					lastSeenAt:    lastSeenAt(on5G, amf5G.LastSeenAt, amf5GLastSeen[dbSubscriber.Imsi].At),
 					lastSeenRadio: amf5GLastSeen[dbSubscriber.Imsi].RadioName,
 				},
 				systemView{
-					system: SystemEPS, present: on4G, registered: mme4G.Registered, connected: mme4G.Connected,
+					system: System4G, present: on4G, registered: mme4G.Registered, connected: mme4G.Connected,
 					lastSeenAt:    lastSeenAt(on4G, mme4G.LastSeenAt, mmeLastSeen[dbSubscriber.Imsi].At),
 					lastSeenRadio: mmeLastSeen[dbSubscriber.Imsi].RadioName,
 				},
@@ -866,7 +866,7 @@ func registrationFrom5G(snap amf.UESnapshot, present bool, retained amf.LastSeen
 	}
 
 	reg := Registration{
-		System: System5GS,
+		System: System5G,
 		Radio:  retained.RadioName,
 	}
 
@@ -902,7 +902,7 @@ func registrationFrom4G(cs mme.ConnectedSubscriber, present bool, retained mme.L
 	}
 
 	reg := Registration{
-		System: SystemEPS,
+		System: System4G,
 		Radio:  retained.RadioName,
 	}
 
@@ -939,7 +939,7 @@ func registrationFrom4G(cs mme.ConnectedSubscriber, present bool, retained mme.L
 
 func sessionFrom4G(s *mme.SubscriberSession) Session {
 	return Session{
-		System:       SystemEPS,
+		System:       System4G,
 		ID:           s.BearerID,
 		Status:       "active",
 		IPType:       ipTypeName(uint8(s.PDNType)),
@@ -958,7 +958,7 @@ func sessionFrom5G(pdu amf.PDUSessionExport) Session {
 	}
 
 	s := Session{
-		System:      System5GS,
+		System:      System5G,
 		ID:          pdu.PDUSessionID,
 		Status:      status,
 		IPType:      ipTypeName(pdu.PDUSessionType),

--- a/internal/api/server/api_subscribers_access_test.go
+++ b/internal/api/server/api_subscribers_access_test.go
@@ -15,12 +15,12 @@ func TestMergeAccesses(t *testing.T) {
 		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
 
 		on4G = accessView{
-			rat: "4G", present: true, registered: true, connected: true, imei: "490154203237518",
-			ciphering: "EEA2", integrity: "EIA2", lastSeenRadio: "enb-1",
+			rat: "4G", present: true, registered: true, connected: true,
+			lastSeenRadio: "enb-1",
 		}
 		on5G = accessView{
-			rat: "5G", present: true, registered: true, connected: true, imei: "490154203237518",
-			ciphering: "NEA2", integrity: "NIA2", lastSeenRadio: "gnb-1",
+			rat: "5G", present: true, registered: true, connected: true,
+			lastSeenRadio: "gnb-1",
 		}
 	)
 
@@ -38,7 +38,6 @@ func TestMergeAccesses(t *testing.T) {
 
 	deregistered := func(v accessView) accessView {
 		v.present, v.registered, v.connected = false, false, false
-		v.imei, v.ciphering, v.integrity = "", "", ""
 
 		return v
 	}
@@ -58,8 +57,7 @@ func TestMergeAccesses(t *testing.T) {
 			view4G:   at(on4G, older),
 			wantRATs: []string{"4G"},
 			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
-				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: older,
+				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: older,
 			},
 		},
 		{
@@ -67,8 +65,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, older),
 			wantRATs: []string{"5G"},
 			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
-				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: older,
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
 		},
 		{
@@ -77,8 +74,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, older),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
-				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: newer,
+				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
 		},
 		{
@@ -87,8 +83,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
-				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
@@ -97,8 +92,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(idle(on5G), older),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "enb-1", Imei: "490154203237518",
-				Ciphering: "EEA2", Integrity: "EIA2", LastSeenAt: newer,
+				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
 		},
 		{
@@ -107,8 +101,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(idle(on5G), newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
-				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
@@ -117,8 +110,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(on5G, older),
 			wantRATs: []string{"5G"},
 			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
-				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: older,
+				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
 		},
 		{
@@ -127,8 +119,7 @@ func TestMergeAccesses(t *testing.T) {
 			view5G:   at(idle(on5G), newer),
 			wantRATs: []string{"4G", "5G"},
 			want: mergedAccess{
-				Registered: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
-				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
+				Registered: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
@@ -137,21 +128,6 @@ func TestMergeAccesses(t *testing.T) {
 			view5G: at(deregistered(on5G), newer),
 			want: mergedAccess{
 				LastSeenRadio: "gnb-1", LastSeenAt: newer,
-			},
-		},
-		{
-			// The IMEI describes the device, not the access, so the access that knows it
-			// answers even when it is not the serving one.
-			name:   "only the older access reported an IMEI",
-			view4G: at(on4G, older),
-			view5G: at(accessView{
-				rat: "5G", present: true, registered: true, connected: true, lastSeenRadio: "gnb-1",
-				ciphering: "NEA2", integrity: "NIA2",
-			}, newer),
-			wantRATs: []string{"4G", "5G"},
-			want: mergedAccess{
-				Registered: true, Connected: true, LastSeenRadio: "gnb-1", Imei: "490154203237518",
-				Ciphering: "NEA2", Integrity: "NIA2", LastSeenAt: newer,
 			},
 		},
 	} {
@@ -174,53 +150,10 @@ func TestMergeAccesses(t *testing.T) {
 				t.Errorf("LastSeenRadio = %q, want %q", got.LastSeenRadio, tc.want.LastSeenRadio)
 			}
 
-			if got.Imei != tc.want.Imei {
-				t.Errorf("Imei = %q, want %q", got.Imei, tc.want.Imei)
-			}
-
-			if got.Ciphering != tc.want.Ciphering || got.Integrity != tc.want.Integrity {
-				t.Errorf("algorithms = %q/%q, want %q/%q",
-					got.Ciphering, got.Integrity, tc.want.Ciphering, tc.want.Integrity)
-			}
-
 			if !got.LastSeenAt.Equal(tc.want.LastSeenAt) {
 				t.Errorf("LastSeenAt = %v, want %v", got.LastSeenAt, tc.want.LastSeenAt)
 			}
 		})
-	}
-}
-
-// The last-seen radio and the algorithms are read together, so they have to come from the
-// same access however the two accesses are staggered.
-func TestMergeAccessesNeverPairsARadioWithAnotherAccessesAlgorithms(t *testing.T) {
-	base := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
-
-	for i := range 4 {
-		for j := range 4 {
-			view4G := accessView{
-				rat: "4G", present: true, lastSeenRadio: "enb-1",
-				ciphering: "EEA2", integrity: "EIA2", lastSeenAt: base.Add(time.Duration(i) * time.Minute),
-			}
-			view5G := accessView{
-				rat: "5G", present: true, lastSeenRadio: "gnb-1",
-				ciphering: "NEA2", integrity: "NIA2", lastSeenAt: base.Add(time.Duration(j) * time.Minute),
-			}
-
-			got := mergeAccesses(view4G, view5G)
-
-			switch got.LastSeenRadio {
-			case "enb-1":
-				if got.Ciphering != "EEA2" || got.Integrity != "EIA2" {
-					t.Errorf("4G=%d 5G=%d: radio enb-1 reported with %q/%q", i, j, got.Ciphering, got.Integrity)
-				}
-			case "gnb-1":
-				if got.Ciphering != "NEA2" || got.Integrity != "NIA2" {
-					t.Errorf("4G=%d 5G=%d: radio gnb-1 reported with %q/%q", i, j, got.Ciphering, got.Integrity)
-				}
-			default:
-				t.Errorf("4G=%d 5G=%d: no radio reported for two registered accesses", i, j)
-			}
-		}
 	}
 }
 

--- a/internal/api/server/api_subscribers_access_test.go
+++ b/internal/api/server/api_subscribers_access_test.go
@@ -15,11 +15,11 @@ func TestMergeAccesses(t *testing.T) {
 		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
 
 		on4G = accessView{
-			rat: "4G", present: true, registered: true, connected: true,
+			system: SystemEPS, present: true, registered: true, connected: true,
 			lastSeenRadio: "enb-1",
 		}
 		on5G = accessView{
-			rat: "5G", present: true, registered: true, connected: true,
+			system: System5GS, present: true, registered: true, connected: true,
 			lastSeenRadio: "gnb-1",
 		}
 	)
@@ -43,81 +43,81 @@ func TestMergeAccesses(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name     string
-		view4G   accessView
-		view5G   accessView
-		wantRATs []string
-		want     mergedAccess
+		name        string
+		view4G      accessView
+		view5G      accessView
+		wantSystems []string
+		want        mergedAccess
 	}{
 		{
 			name: "neither access holds a registration",
 		},
 		{
-			name:     "4G only",
-			view4G:   at(on4G, older),
-			wantRATs: []string{"4G"},
+			name:        "4G only",
+			view4G:      at(on4G, older),
+			wantSystems: []string{SystemEPS},
 			want: mergedAccess{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: older,
 			},
 		},
 		{
-			name:     "5G only",
-			view5G:   at(on5G, older),
-			wantRATs: []string{"5G"},
+			name:        "5G only",
+			view5G:      at(on5G, older),
+			wantSystems: []string{System5GS},
 			want: mergedAccess{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
 		},
 		{
-			name:     "both connected, 4G heard from last",
-			view4G:   at(on4G, newer),
-			view5G:   at(on5G, older),
-			wantRATs: []string{"4G", "5G"},
+			name:        "both connected, 4G heard from last",
+			view4G:      at(on4G, newer),
+			view5G:      at(on5G, older),
+			wantSystems: []string{System5GS, SystemEPS},
 			want: mergedAccess{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
 		},
 		{
-			name:     "both connected, 5G heard from last",
-			view4G:   at(on4G, older),
-			view5G:   at(on5G, newer),
-			wantRATs: []string{"4G", "5G"},
+			name:        "both connected, 5G heard from last",
+			view4G:      at(on4G, older),
+			view5G:      at(on5G, newer),
+			wantSystems: []string{System5GS, SystemEPS},
 			want: mergedAccess{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
-			name:     "4G connected, 5G registered but idle",
-			view4G:   at(on4G, newer),
-			view5G:   at(idle(on5G), older),
-			wantRATs: []string{"4G", "5G"},
+			name:        "4G connected, 5G registered but idle",
+			view4G:      at(on4G, newer),
+			view5G:      at(idle(on5G), older),
+			wantSystems: []string{System5GS, SystemEPS},
 			want: mergedAccess{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
 		},
 		{
-			name:     "the more recent access is idle, and still names the radio that served it",
-			view4G:   at(on4G, older),
-			view5G:   at(idle(on5G), newer),
-			wantRATs: []string{"4G", "5G"},
+			name:        "the more recent access is idle, and still names the radio that served it",
+			view4G:      at(on4G, older),
+			view5G:      at(idle(on5G), newer),
+			wantSystems: []string{System5GS, SystemEPS},
 			want: mergedAccess{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
-			name:     "the deregistered access is more recent than the registered one",
-			view4G:   at(deregistered(on4G), newer),
-			view5G:   at(on5G, older),
-			wantRATs: []string{"5G"},
+			name:        "the deregistered access is more recent than the registered one",
+			view4G:      at(deregistered(on4G), newer),
+			view5G:      at(on5G, older),
+			wantSystems: []string{System5GS},
 			want: mergedAccess{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
 		},
 		{
-			name:     "both idle",
-			view4G:   at(idle(on4G), older),
-			view5G:   at(idle(on5G), newer),
-			wantRATs: []string{"4G", "5G"},
+			name:        "both idle",
+			view4G:      at(idle(on4G), older),
+			view5G:      at(idle(on5G), newer),
+			wantSystems: []string{System5GS, SystemEPS},
 			want: mergedAccess{
 				Registered: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
@@ -132,10 +132,10 @@ func TestMergeAccesses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := mergeAccesses(tc.view4G, tc.view5G)
+			got := mergeAccesses(tc.view5G, tc.view4G)
 
-			if !slices.Equal(got.RATs, tc.wantRATs) {
-				t.Errorf("RATs = %v, want %v", got.RATs, tc.wantRATs)
+			if !slices.Equal(got.Systems, tc.wantSystems) {
+				t.Errorf("Systems = %v, want %v", got.Systems, tc.wantSystems)
 			}
 
 			if got.Registered != tc.want.Registered {

--- a/internal/api/server/api_subscribers_status_test.go
+++ b/internal/api/server/api_subscribers_status_test.go
@@ -15,11 +15,11 @@ func TestMergeSystems(t *testing.T) {
 		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
 
 		on4G = systemView{
-			system: SystemEPS, present: true, registered: true, connected: true,
+			system: System4G, present: true, registered: true, connected: true,
 			lastSeenRadio: "enb-1",
 		}
 		on5G = systemView{
-			system: System5GS, present: true, registered: true, connected: true,
+			system: System5G, present: true, registered: true, connected: true,
 			lastSeenRadio: "gnb-1",
 		}
 	)
@@ -55,7 +55,7 @@ func TestMergeSystems(t *testing.T) {
 		{
 			name:        "4G only",
 			view4G:      at(on4G, older),
-			wantSystems: []string{SystemEPS},
+			wantSystems: []string{System4G},
 			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: older,
 			},
@@ -63,7 +63,7 @@ func TestMergeSystems(t *testing.T) {
 		{
 			name:        "5G only",
 			view5G:      at(on5G, older),
-			wantSystems: []string{System5GS},
+			wantSystems: []string{System5G},
 			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
@@ -72,7 +72,7 @@ func TestMergeSystems(t *testing.T) {
 			name:        "both connected, 4G heard from last",
 			view4G:      at(on4G, newer),
 			view5G:      at(on5G, older),
-			wantSystems: []string{System5GS, SystemEPS},
+			wantSystems: []string{System5G, System4G},
 			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
@@ -81,7 +81,7 @@ func TestMergeSystems(t *testing.T) {
 			name:        "both connected, 5G heard from last",
 			view4G:      at(on4G, older),
 			view5G:      at(on5G, newer),
-			wantSystems: []string{System5GS, SystemEPS},
+			wantSystems: []string{System5G, System4G},
 			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
@@ -90,7 +90,7 @@ func TestMergeSystems(t *testing.T) {
 			name:        "4G connected, 5G registered but idle",
 			view4G:      at(on4G, newer),
 			view5G:      at(idle(on5G), older),
-			wantSystems: []string{System5GS, SystemEPS},
+			wantSystems: []string{System5G, System4G},
 			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
@@ -99,7 +99,7 @@ func TestMergeSystems(t *testing.T) {
 			name:        "the more recent system is idle, and still names the radio that served it",
 			view4G:      at(on4G, older),
 			view5G:      at(idle(on5G), newer),
-			wantSystems: []string{System5GS, SystemEPS},
+			wantSystems: []string{System5G, System4G},
 			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
@@ -108,7 +108,7 @@ func TestMergeSystems(t *testing.T) {
 			name:        "the deregistered system is more recent than the registered one",
 			view4G:      at(deregistered(on4G), newer),
 			view5G:      at(on5G, older),
-			wantSystems: []string{System5GS},
+			wantSystems: []string{System5G},
 			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
@@ -117,7 +117,7 @@ func TestMergeSystems(t *testing.T) {
 			name:        "both idle",
 			view4G:      at(idle(on4G), older),
 			view5G:      at(idle(on5G), newer),
-			wantSystems: []string{System5GS, SystemEPS},
+			wantSystems: []string{System5G, System4G},
 			want: mergedStatus{
 				Registered: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},

--- a/internal/api/server/api_subscribers_status_test.go
+++ b/internal/api/server/api_subscribers_status_test.go
@@ -9,34 +9,34 @@ import (
 	"time"
 )
 
-func TestMergeAccesses(t *testing.T) {
+func TestMergeSystems(t *testing.T) {
 	var (
 		older = time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
 		newer = time.Date(2026, 8, 17, 10, 5, 0, 0, time.UTC)
 
-		on4G = accessView{
+		on4G = systemView{
 			system: SystemEPS, present: true, registered: true, connected: true,
 			lastSeenRadio: "enb-1",
 		}
-		on5G = accessView{
+		on5G = systemView{
 			system: System5GS, present: true, registered: true, connected: true,
 			lastSeenRadio: "gnb-1",
 		}
 	)
 
-	at := func(v accessView, seen time.Time) accessView {
+	at := func(v systemView, seen time.Time) systemView {
 		v.lastSeenAt = seen
 
 		return v
 	}
 
-	idle := func(v accessView) accessView {
+	idle := func(v systemView) systemView {
 		v.connected = false
 
 		return v
 	}
 
-	deregistered := func(v accessView) accessView {
+	deregistered := func(v systemView) systemView {
 		v.present, v.registered, v.connected = false, false, false
 
 		return v
@@ -44,19 +44,19 @@ func TestMergeAccesses(t *testing.T) {
 
 	for _, tc := range []struct {
 		name        string
-		view4G      accessView
-		view5G      accessView
+		view4G      systemView
+		view5G      systemView
 		wantSystems []string
-		want        mergedAccess
+		want        mergedStatus
 	}{
 		{
-			name: "neither access holds a registration",
+			name: "neither system holds a registration",
 		},
 		{
 			name:        "4G only",
 			view4G:      at(on4G, older),
 			wantSystems: []string{SystemEPS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: older,
 			},
 		},
@@ -64,7 +64,7 @@ func TestMergeAccesses(t *testing.T) {
 			name:        "5G only",
 			view5G:      at(on5G, older),
 			wantSystems: []string{System5GS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
 		},
@@ -73,7 +73,7 @@ func TestMergeAccesses(t *testing.T) {
 			view4G:      at(on4G, newer),
 			view5G:      at(on5G, older),
 			wantSystems: []string{System5GS, SystemEPS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
 		},
@@ -82,7 +82,7 @@ func TestMergeAccesses(t *testing.T) {
 			view4G:      at(on4G, older),
 			view5G:      at(on5G, newer),
 			wantSystems: []string{System5GS, SystemEPS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
@@ -91,25 +91,25 @@ func TestMergeAccesses(t *testing.T) {
 			view4G:      at(on4G, newer),
 			view5G:      at(idle(on5G), older),
 			wantSystems: []string{System5GS, SystemEPS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "enb-1", LastSeenAt: newer,
 			},
 		},
 		{
-			name:        "the more recent access is idle, and still names the radio that served it",
+			name:        "the more recent system is idle, and still names the radio that served it",
 			view4G:      at(on4G, older),
 			view5G:      at(idle(on5G), newer),
 			wantSystems: []string{System5GS, SystemEPS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
-			name:        "the deregistered access is more recent than the registered one",
+			name:        "the deregistered system is more recent than the registered one",
 			view4G:      at(deregistered(on4G), newer),
 			view5G:      at(on5G, older),
 			wantSystems: []string{System5GS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, Connected: true, LastSeenRadio: "gnb-1", LastSeenAt: older,
 			},
 		},
@@ -118,21 +118,21 @@ func TestMergeAccesses(t *testing.T) {
 			view4G:      at(idle(on4G), older),
 			view5G:      at(idle(on5G), newer),
 			wantSystems: []string{System5GS, SystemEPS},
-			want: mergedAccess{
+			want: mergedStatus{
 				Registered: true, LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 		{
-			name:   "deregistered on both accesses",
+			name:   "deregistered on both systems",
 			view4G: at(deregistered(on4G), older),
 			view5G: at(deregistered(on5G), newer),
-			want: mergedAccess{
+			want: mergedStatus{
 				LastSeenRadio: "gnb-1", LastSeenAt: newer,
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := mergeAccesses(tc.view5G, tc.view4G)
+			got := mergeSystems(tc.view5G, tc.view4G)
 
 			if !slices.Equal(got.Systems, tc.wantSystems) {
 				t.Errorf("Systems = %v, want %v", got.Systems, tc.wantSystems)
@@ -166,7 +166,7 @@ func TestConnectionState(t *testing.T) {
 	}{
 		{name: "a context holding a signalling connection", present: true, connected: true, want: "connected"},
 		{name: "a context with no signalling connection", present: true, want: "idle"},
-		{name: "no context on either access", want: ""},
+		{name: "no context on either system", want: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := connectionState(tc.present, tc.connected); got != tc.want {
@@ -183,14 +183,14 @@ func TestLastSeenAtPrefersTheLiveContext(t *testing.T) {
 	)
 
 	if got := lastSeenAt(true, live, retained); !got.Equal(live) {
-		t.Errorf("registered access = %v, want the live timestamp %v", got, live)
+		t.Errorf("registered system = %v, want the live timestamp %v", got, live)
 	}
 
 	if got := lastSeenAt(false, live, retained); !got.Equal(retained) {
-		t.Errorf("deregistered access = %v, want the retained timestamp %v", got, retained)
+		t.Errorf("deregistered system = %v, want the retained timestamp %v", got, retained)
 	}
 
 	if got := lastSeenAt(true, time.Time{}, retained); !got.Equal(retained) {
-		t.Errorf("registered access with no live timestamp = %v, want %v", got, retained)
+		t.Errorf("registered system with no live timestamp = %v, want %v", got, retained)
 	}
 }

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -44,12 +44,12 @@ type CreateSubscriberSuccessResponse struct {
 
 // ListSubscriberStatus matches the lightweight status in list responses.
 type ListSubscriberStatus struct {
-	Registered       bool     `json:"registered"`
-	ConnectionState  string   `json:"connection_state,omitempty"`
-	RadioAccessTypes []string `json:"radio_access_types,omitempty"`
-	NumSessions      int      `json:"num_sessions"`
-	LastSeenAt       string   `json:"last_seen_at,omitempty"`
-	LastSeenRadio    string   `json:"last_seen_radio,omitempty"`
+	Registered      bool     `json:"registered"`
+	ConnectionState string   `json:"connection_state,omitempty"`
+	Systems         []string `json:"systems,omitempty"`
+	NumSessions     int      `json:"num_sessions"`
+	LastSeenAt      string   `json:"last_seen_at,omitempty"`
+	LastSeenRadio   string   `json:"last_seen_radio,omitempty"`
 }
 
 // ListSubscriber matches the summary representation in list responses.

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -60,16 +60,25 @@ type ListSubscriber struct {
 	Status      ListSubscriberStatus `json:"status"`
 }
 
-// SubscriberDetailStatus matches the rich status in get-single responses.
-type SubscriberDetailStatus struct {
-	Registered         bool     `json:"registered"`
-	ConnectionState    string   `json:"connection_state,omitempty"`
-	RadioAccessTypes   []string `json:"radio_access_types,omitempty"`
-	Imei               string   `json:"imei"`
-	CipheringAlgorithm string   `json:"ciphering_algorithm"`
-	IntegrityAlgorithm string   `json:"integrity_algorithm"`
-	LastSeenAt         string   `json:"last_seen_at,omitempty"`
-	LastSeenRadio      string   `json:"last_seen_radio,omitempty"`
+type UEConnection struct {
+	AmfUeNgapID *int64 `json:"amf_ue_ngap_id,omitempty"`
+	RanUeNgapID *int64 `json:"ran_ue_ngap_id,omitempty"`
+	MMEUeS1apID *int64 `json:"mme_ue_s1ap_id,omitempty"`
+	ENBUeS1apID *int64 `json:"enb_ue_s1ap_id,omitempty"`
+}
+
+type Registration struct {
+	System             string        `json:"system"`
+	AccessType         string        `json:"access_type"`
+	Registered         bool          `json:"registered"`
+	ConnectionState    *string       `json:"connection_state"`
+	Radio              string        `json:"radio,omitempty"`
+	LastSeenAt         string        `json:"last_seen_at,omitempty"`
+	Pei                string        `json:"pei,omitempty"`
+	Imei               string        `json:"imei,omitempty"`
+	CipheringAlgorithm string        `json:"ciphering_algorithm,omitempty"`
+	IntegrityAlgorithm string        `json:"integrity_algorithm,omitempty"`
+	Connection         *UEConnection `json:"connection"`
 }
 
 type Slice struct {
@@ -78,25 +87,36 @@ type Slice struct {
 }
 
 type Session struct {
-	RadioAccessType string `json:"radio_access_type"`
-	ID              uint8  `json:"id"`
-	Status          string `json:"status"`
-	IPType          string `json:"ip_type,omitempty"`
-	IPv4Address     string `json:"ipv4_address,omitempty"`
-	IPv6Prefix      string `json:"ipv6_prefix,omitempty"`
-	DataNetwork     string `json:"data_network,omitempty"`
-	Slice           *Slice `json:"slice,omitempty"`
-	AMBRUplink      string `json:"ambr_uplink,omitempty"`
-	AMBRDownlink    string `json:"ambr_downlink,omitempty"`
+	System       string   `json:"system"`
+	AccessTypes  []string `json:"access_types"`
+	ID           uint8    `json:"id"`
+	Status       string   `json:"status"`
+	IPType       string   `json:"ip_type,omitempty"`
+	IPv4Address  string   `json:"ipv4_address,omitempty"`
+	IPv6Prefix   string   `json:"ipv6_prefix,omitempty"`
+	DataNetwork  string   `json:"data_network,omitempty"`
+	Slice        *Slice   `json:"slice,omitempty"`
+	AMBRUplink   string   `json:"ambr_uplink,omitempty"`
+	AMBRDownlink string   `json:"ambr_downlink,omitempty"`
 }
 
 // SubscriberDetail matches the full representation in get-single responses.
 type SubscriberDetail struct {
-	Imsi        string                 `json:"imsi"`
-	ProfileName string                 `json:"profile_name"`
-	Description string                 `json:"description,omitempty"`
-	Status      SubscriberDetailStatus `json:"status"`
-	Sessions    []Session              `json:"sessions"`
+	Imsi          string         `json:"imsi"`
+	ProfileName   string         `json:"profile_name"`
+	Description   string         `json:"description,omitempty"`
+	Registrations []Registration `json:"registrations"`
+	Sessions      []Session      `json:"sessions"`
+}
+
+func (d SubscriberDetail) registrationFor(system string) (Registration, bool) {
+	for _, reg := range d.Registrations {
+		if reg.System == system {
+			return reg, true
+		}
+	}
+
+	return Registration{}, false
 }
 
 type GetSubscriberResponse struct {
@@ -332,20 +352,12 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 			t.Fatalf("expected profileName %s, got %s", TestProfileName, response.Result.ProfileName)
 		}
 
-		if response.Result.Status.Registered != false {
-			t.Fatalf("expected registered false, got %v", response.Result.Status.Registered)
+		if response.Result.Registrations == nil {
+			t.Fatalf("expected registrations field to be present, got nil")
 		}
 
-		if response.Result.Status.Imei != "" {
-			t.Fatalf("expected empty imei, got %s", response.Result.Status.Imei)
-		}
-
-		if response.Result.Status.CipheringAlgorithm != "" {
-			t.Fatalf("expected empty cipheringAlgorithm, got %s", response.Result.Status.CipheringAlgorithm)
-		}
-
-		if response.Result.Status.IntegrityAlgorithm != "" {
-			t.Fatalf("expected empty integrityAlgorithm, got %s", response.Result.Status.IntegrityAlgorithm)
+		if len(response.Result.Registrations) != 0 {
+			t.Fatalf("expected 0 registrations for a subscriber the core has never seen, got %d", len(response.Result.Registrations))
 		}
 
 		if response.Result.Sessions == nil {
@@ -733,16 +745,8 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 			t.Fatalf("expected profileName %s, got %s", TestProfileName, response.Result.ProfileName)
 		}
 
-		if response.Result.Status.Registered != false {
-			t.Fatalf("expected registered false, got %v", response.Result.Status.Registered)
-		}
-
-		if response.Result.Status.CipheringAlgorithm != "" {
-			t.Fatalf("expected empty cipheringAlgorithm, got %s", response.Result.Status.CipheringAlgorithm)
-		}
-
-		if response.Result.Status.IntegrityAlgorithm != "" {
-			t.Fatalf("expected empty integrityAlgorithm, got %s", response.Result.Status.IntegrityAlgorithm)
+		if len(response.Result.Registrations) != 0 {
+			t.Fatalf("expected 0 registrations for a subscriber the core has never seen, got %d", len(response.Result.Registrations))
 		}
 
 		if response.Result.Sessions == nil {
@@ -786,16 +790,29 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 			t.Fatalf("expected session ID 1, got %d", session.ID)
 		}
 
-		if session.RadioAccessType != "5G" {
-			t.Fatalf("expected radio_access_type '5G', got %q", session.RadioAccessType)
+		if session.System != "5GS" {
+			t.Fatalf("expected session system '5GS', got %q", session.System)
 		}
 
-		if got := response.Result.Status.RadioAccessTypes; len(got) != 1 || got[0] != "5G" {
-			t.Fatalf("expected radio_access_types [5G], got %v", got)
+		if got := session.AccessTypes; len(got) != 1 || got[0] != "3GPP" {
+			t.Fatalf("expected session access_types [3GPP], got %v", got)
 		}
 
-		if got := response.Result.Status.ConnectionState; got != "idle" {
-			t.Fatalf("expected connection_state 'idle' for a registered UE with no NGAP association, got %q", got)
+		reg, ok := response.Result.registrationFor("5GS")
+		if !ok {
+			t.Fatalf("expected a 5GS registration, got %+v", response.Result.Registrations)
+		}
+
+		if reg.AccessType != "3GPP" {
+			t.Fatalf("expected access_type '3GPP', got %q", reg.AccessType)
+		}
+
+		if reg.ConnectionState == nil || *reg.ConnectionState != "idle" {
+			t.Fatalf("expected connection_state 'idle' for a registered UE with no NGAP association, got %v", reg.ConnectionState)
+		}
+
+		if reg.Connection != nil {
+			t.Fatalf("expected no connection for a UE with no NGAP association, got %+v", reg.Connection)
 		}
 
 		// The UE holds no NG connection, so the PDU session survives with its user

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -85,17 +85,16 @@ type Slice struct {
 }
 
 type Session struct {
-	System       string   `json:"system"`
-	AccessTypes  []string `json:"access_types"`
-	ID           uint8    `json:"id"`
-	Status       string   `json:"status"`
-	IPType       string   `json:"ip_type,omitempty"`
-	IPv4Address  string   `json:"ipv4_address,omitempty"`
-	IPv6Prefix   string   `json:"ipv6_prefix,omitempty"`
-	DataNetwork  string   `json:"data_network,omitempty"`
-	Slice        *Slice   `json:"slice,omitempty"`
-	AMBRUplink   string   `json:"ambr_uplink,omitempty"`
-	AMBRDownlink string   `json:"ambr_downlink,omitempty"`
+	System       string `json:"system"`
+	ID           uint8  `json:"id"`
+	Status       string `json:"status"`
+	IPType       string `json:"ip_type,omitempty"`
+	IPv4Address  string `json:"ipv4_address,omitempty"`
+	IPv6Prefix   string `json:"ipv6_prefix,omitempty"`
+	DataNetwork  string `json:"data_network,omitempty"`
+	Slice        *Slice `json:"slice,omitempty"`
+	AMBRUplink   string `json:"ambr_uplink,omitempty"`
+	AMBRDownlink string `json:"ambr_downlink,omitempty"`
 }
 
 // SubscriberDetail matches the full representation in get-single responses.
@@ -790,10 +789,6 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 
 		if session.System != "5GS" {
 			t.Fatalf("expected session system '5GS', got %q", session.System)
-		}
-
-		if got := session.AccessTypes; len(got) != 1 || got[0] != "3GPP" {
-			t.Fatalf("expected session access_types [3GPP], got %v", got)
 		}
 
 		reg, ok := response.Result.registrationFor("5GS")

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -69,12 +69,10 @@ type UEConnection struct {
 
 type Registration struct {
 	System             string        `json:"system"`
-	AccessType         string        `json:"access_type"`
 	Registered         bool          `json:"registered"`
 	ConnectionState    *string       `json:"connection_state"`
 	Radio              string        `json:"radio,omitempty"`
 	LastSeenAt         string        `json:"last_seen_at,omitempty"`
-	Pei                string        `json:"pei,omitempty"`
 	Imei               string        `json:"imei,omitempty"`
 	CipheringAlgorithm string        `json:"ciphering_algorithm,omitempty"`
 	IntegrityAlgorithm string        `json:"integrity_algorithm,omitempty"`
@@ -801,10 +799,6 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 		reg, ok := response.Result.registrationFor("5GS")
 		if !ok {
 			t.Fatalf("expected a 5GS registration, got %+v", response.Result.Registrations)
-		}
-
-		if reg.AccessType != "3GPP" {
-			t.Fatalf("expected access_type '3GPP', got %q", reg.AccessType)
 		}
 
 		if reg.ConnectionState == nil || *reg.ConnectionState != "idle" {

--- a/internal/api/server/api_subscribers_test.go
+++ b/internal/api/server/api_subscribers_test.go
@@ -787,13 +787,13 @@ func TestSubscribersApiEndToEnd(t *testing.T) {
 			t.Fatalf("expected session ID 1, got %d", session.ID)
 		}
 
-		if session.System != "5GS" {
-			t.Fatalf("expected session system '5GS', got %q", session.System)
+		if session.System != "5G" {
+			t.Fatalf("expected session system '5G', got %q", session.System)
 		}
 
-		reg, ok := response.Result.registrationFor("5GS")
+		reg, ok := response.Result.registrationFor("5G")
 		if !ok {
-			t.Fatalf("expected a 5GS registration, got %+v", response.Result.Registrations)
+			t.Fatalf("expected a 5G registration, got %+v", response.Result.Registrations)
 		}
 
 		if reg.ConnectionState == nil || *reg.ConnectionState != "idle" {

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3911,15 +3911,16 @@ components:
             `registered` (TS 23.501 §5.3.3.2.2, TS 23.401 §4.6.1) — a device still
             registering is "connected" with `registered` false. Omitted when the core
             holds no context for the device.
-        radio_access_types:
+        systems:
           type: array
           items:
             type: string
-            enum: ["4G", "5G"]
+            enum: ["5GS", "EPS"]
           description: >-
-            Every access the subscriber is currently registered on. Usually one,
-            but a device moving between 4G and 5G holds both while it transfers
-            its sessions one at a time. Omitted if not connected.
+            Every system the subscriber is currently registered on, ordered 5G
+            first, matching a registration's `system` on the get-single response.
+            Usually one, but a device moving between 4G and 5G holds both while it
+            transfers its sessions one at a time. Omitted if not connected.
         num_sessions:
           type: integer
           description: >-

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3977,57 +3977,117 @@ components:
         result:
           $ref: "#/components/schemas/ListSubscribersResponse"
 
-    SubscriberDetailStatus:
+    UEConnection:
       type: object
+      description: >-
+        The UE-associated logical connection identity pair of a registration: the
+        AMF and RAN UE NGAP IDs in 5GS (TS 38.413 §9.3.3.1, §9.3.3.2), or the MME and
+        eNB UE S1AP IDs in EPS (TS 36.413 §9.2.3.3, §9.2.3.4). Only the pair belonging
+        to the registration's system is present. These identifiers are ephemeral: the
+        RAN allocates its own for the duration of one connected period and reuses it
+        afterwards, so a value identifies a subscriber only together with `radio` and
+        the time it was read.
       properties:
+        amf_ue_ngap_id:
+          type: integer
+          format: int64
+          description: "AMF UE NGAP ID (5GS). INTEGER (0..2^40-1)."
+        ran_ue_ngap_id:
+          type: integer
+          format: int64
+          description: >-
+            RAN UE NGAP ID (5GS). INTEGER (0..2^32-1), allocated by the serving NG-RAN
+            node. Absent until it is allocated, e.g. on a handover target before
+            HANDOVER REQUEST ACKNOWLEDGE (TS 38.413 §9.2.3.5).
+        mme_ue_s1ap_id:
+          type: integer
+          format: int64
+          description: "MME UE S1AP ID (EPS). INTEGER (0..2^32-1)."
+        enb_ue_s1ap_id:
+          type: integer
+          format: int64
+          description: >-
+            eNB UE S1AP ID (EPS). INTEGER (0..2^24-1), allocated by the serving eNB.
+            Absent until it is allocated.
+
+    Registration:
+      type: object
+      description: >-
+        One mobility-management context of a subscriber. A subscriber may hold
+        several: 5GS keeps an independent registration state per access type
+        (TS 23.501 §5.3.2.4), and a UE in dual-registration mode may be registered
+        to both 5GC and EPC at the same time (TS 23.501 §5.17.2.1). An entry is
+        present whenever the core holds a context for that system or still remembers
+        having served the subscriber there.
+      properties:
+        system:
+          type: string
+          enum: ["5GS", "EPS"]
+          description: >-
+            The system holding this registration — the 5G System (5GC) or the Evolved
+            Packet System (EPC). This is the core that registered the UE, independent
+            of the radio: an NSA device on NR radio is registered in EPS.
+        access_type:
+          type: string
+          enum: ["3GPP", "non-3GPP"]
+          description: >-
+            The access this registration was established over (TS 23.501 §5.3.2.4).
+            Always "3GPP" in this release.
         registered:
           type: boolean
+          description: >-
+            Whether the UE is registered in this system: RM state in 5GS
+            (TS 23.501 §5.3.2.2) and EMM state in EPS (TS 23.401 §4.6.2). False on an
+            entry the core remembers but no longer holds a context for.
         connection_state:
           type: string
+          nullable: true
           enum: ["idle", "connected"]
           description: >-
-            Whether the device holds a NAS signalling connection: CM state in 5G
-            (TS 23.501 §5.3.3.2) and ECM state in 4G (TS 23.401 §4.6.3). Independent of
-            `registered` (TS 23.501 §5.3.3.2.2, TS 23.401 §4.6.1) — a device still
-            registering is "connected" with `registered` false. Omitted when the core
-            holds no context for the device.
-        radio_access_types:
-          type: array
-          items:
-            type: string
-            enum: ["4G", "5G"]
+            Whether the UE holds a NAS signalling connection in this system: CM state
+            in 5GS (TS 23.501 §5.3.3.2) and ECM state in EPS (TS 23.401 §4.6.3).
+            Independent of `registered` — a UE still registering is "connected" with
+            `registered` false. Null when the core holds no context.
+        radio:
+          type: string
           description: >-
-            Every access the subscriber is currently registered on. When there is
-            more than one, last_seen_radio and the security algorithms below all
-            describe the serving access — the one that last heard from the UE —
-            so they can be read together.
+            Name of the radio serving this registration, or the last one that did once
+            the UE is idle or deregistered, in which case it may be stale. Held in
+            memory by the serving node: not shared across cluster nodes, and reset on
+            restart. Empty if never seen.
+        last_seen_at:
+          type: string
+          description: Timestamp of last activity in this system (RFC 3339).
+        pei:
+          type: string
+          description: >-
+            Permanent Equipment Identifier of the device, in its NAS-prefixed form
+            ("imei-…" / "imeisv-…"). 5GS only (TS 23.003 §6.4). Empty when unknown.
         imei:
           type: string
           description: >-
-            IMEI of the connected device. It identifies the device rather than an
-            access, so it is reported by whichever access knows it.
+            15-digit IMEI of the device (TS 23.003). On a 5GS registration this is
+            the IMEI carried by `pei`, present only when the PEI is an IMEI or IMEISV.
+            Empty when unknown.
         ciphering_algorithm:
           type: string
           description: >-
-            Ciphering algorithm negotiated on the serving access. Empty when that
-            access reports none.
+            NAS ciphering algorithm negotiated in this system: NEA0 / 128-NEA1..3 in
+            5GS (TS 33.501 Annex D), EEA0 / 128-EEA1..3 in EPS (TS 33.401 Annex B).
+            Empty when none is established.
         integrity_algorithm:
           type: string
           description: >-
-            Integrity algorithm negotiated on the serving access. Empty when that
-            access reports none.
-        last_seen_at:
-          type: string
-          description: Timestamp of last activity (RFC 3339).
-        last_seen_radio:
-          type: string
+            NAS integrity algorithm negotiated in this system: NIA0 / 128-NIA1..3 in
+            5GS, EIA0 / 128-EIA1..3 in EPS. Empty when none is established.
+        connection:
+          allOf:
+            - $ref: "#/components/schemas/UEConnection"
+          nullable: true
           description: >-
-            Name of the radio that last served the device. The core knows the serving node
-            only while the device is connected (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2), so
-            on an idle or deregistered device this is last known and may be stale. Held in
-            memory by the serving node: not shared across cluster nodes, and reset on
-            restart. Empty if never seen.
-      required: [registered, imei, ciphering_algorithm, integrity_algorithm]
+            The UE-associated logical connection, or null when the UE holds none
+            (CM-IDLE / ECM-IDLE, or deregistered).
+      required: [system, access_type, registered, connection_state, connection]
 
     SubscriberDetail:
       type: object
@@ -4040,14 +4100,20 @@ components:
           type: string
           maxLength: 64
           description: Free-text operator note. Absent when unset.
-        status:
-          $ref: "#/components/schemas/SubscriberDetailStatus"
+        registrations:
+          type: array
+          description: >-
+            Every mobility-management context the core holds or remembers for this
+            subscriber, ordered 5GS first. Empty for a subscriber the core has never
+            served.
+          items:
+            $ref: "#/components/schemas/Registration"
         sessions:
           type: array
-          description: "Active sessions for this subscriber (5G PDU sessions / 4G PDN connections)."
+          description: "Active sessions for this subscriber (5GS PDU sessions / EPS PDN connections)."
           items:
             $ref: "#/components/schemas/Session"
-      required: [imsi, profile_name, status]
+      required: [imsi, profile_name, registrations, sessions]
 
     SubscriberCredentials:
       type: object
@@ -4077,7 +4143,7 @@ components:
 
     SNSSAI:
       type: object
-      description: "5G network slice identifier (S-NSSAI). Absent for 4G sessions."
+      description: "5GS network slice identifier (S-NSSAI). Absent for EPS sessions."
       properties:
         sst:
           type: integer
@@ -4089,22 +4155,31 @@ components:
 
     Session:
       type: object
-      description: "A UE data session — a 5G PDU session or a 4G PDN connection."
+      description: "A UE data session — a 5GS PDU session or an EPS PDN connection."
       properties:
-        radio_access_type:
+        system:
           type: string
-          enum: ["4G", "5G"]
-          description: "The radio access technology serving this session."
+          enum: ["5GS", "EPS"]
+          description: "The system holding this session, matching a registration's `system`."
+        access_types:
+          type: array
+          items:
+            type: string
+            enum: ["3GPP", "non-3GPP"]
+          description: >-
+            Every access this session is carried over. A Multi-Access PDU Session is
+            associated with 3GPP and non-3GPP access simultaneously (TS 23.501
+            §5.6.1); any other session names exactly one.
         id:
           type: integer
-          description: "Session identifier: the PDU Session ID (5G) or the linked EPS Bearer ID (4G)."
+          description: "Session identifier: the PDU Session ID (5GS) or the linked EPS Bearer ID (EPS)."
         status:
           type: string
           description: "Session status (e.g. active, inactive)."
         ip_type:
           type: string
           enum: ["IPv4", "IPv6", "IPv4v6"]
-          description: "Negotiated IP type (5G PDU Session Type / 4G PDN Type)."
+          description: "Negotiated IP type (5GS PDU Session Type / EPS PDN Type)."
         ipv4_address:
           type: string
           description: "Assigned IPv4 address. Omitted if unknown."
@@ -4113,7 +4188,7 @@ components:
           description: "Assigned IPv6 prefix (/64). Omitted if unknown."
         data_network:
           type: string
-          description: "Data network name (DNN in 5G / APN in 4G)."
+          description: "Data network name (DNN in 5GS / APN in EPS)."
         slice:
           $ref: "#/components/schemas/SNSSAI"
         ambr_uplink:
@@ -4122,7 +4197,7 @@ components:
         ambr_downlink:
           type: string
           description: "Effective downlink session AMBR (e.g. \"200 Mbps\")."
-      required: [radio_access_type, id, status]
+      required: [system, access_types, id, status]
 
     CreateSubscriberParams:
       type: object

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3905,13 +3905,13 @@ components:
         connection_state:
           type: string
           enum: ["idle", "connected"]
-          description: "CM state in 5GS, ECM state in EPS. Absent when the core holds no context."
+          description: "CM state in 5G, ECM state in 4G. Absent when the core holds no context."
         systems:
           type: array
           items:
             type: string
-            enum: ["5GS", "EPS"]
-          description: "Systems the core holds a context for, 5GS first. Absent when it holds none."
+            enum: ["5G", "4G"]
+          description: "Systems the core holds a context for, 5G first. Absent when it holds none."
         num_sessions:
           type: integer
           description: "Number of active sessions across every system."
@@ -3969,19 +3969,19 @@ components:
         amf_ue_ngap_id:
           type: integer
           format: int64
-          description: "AMF UE NGAP ID (5GS). INTEGER (0..2^40-1)."
+          description: "AMF UE NGAP ID (5G). INTEGER (0..2^40-1)."
         ran_ue_ngap_id:
           type: integer
           format: int64
-          description: "RAN UE NGAP ID (5GS). INTEGER (0..2^32-1). Absent until the radio allocates one."
+          description: "RAN UE NGAP ID (5G). INTEGER (0..2^32-1). Absent until the radio allocates one."
         mme_ue_s1ap_id:
           type: integer
           format: int64
-          description: "MME UE S1AP ID (EPS). INTEGER (0..2^32-1)."
+          description: "MME UE S1AP ID (4G). INTEGER (0..2^32-1)."
         enb_ue_s1ap_id:
           type: integer
           format: int64
-          description: "eNB UE S1AP ID (EPS). INTEGER (0..2^24-1). Absent until the radio allocates one."
+          description: "eNB UE S1AP ID (4G). INTEGER (0..2^24-1). Absent until the radio allocates one."
 
     Registration:
       type: object
@@ -3989,15 +3989,15 @@ components:
       properties:
         system:
           type: string
-          enum: ["5GS", "EPS"]
+          enum: ["5G", "4G"]
           description: "The core holding this registration."
         registered:
           type: boolean
-          description: "RM state in 5GS, EMM state in EPS. False on an entry the core only remembers."
+          description: "RM state in 5G, EMM state in 4G. False on an entry the core only remembers."
         connection_state:
           type: ["string", "null"]
           enum: ["idle", "connected", null]
-          description: "CM state in 5GS, ECM state in EPS. Null on an entry the core only remembers."
+          description: "CM state in 5G, ECM state in 4G. Null on an entry the core only remembers."
         radio:
           type: string
           description: "Radio serving this registration, or the last one that did. Absent when never seen."
@@ -4009,10 +4009,10 @@ components:
           description: "IMEI of the device (15 digits). Absent when the core does not hold it."
         ciphering_algorithm:
           type: string
-          description: "NAS ciphering algorithm: NEA0 / 128-NEA1..3 in 5GS, EEA0 / 128-EEA1..3 in EPS. Absent when none is established."
+          description: "NAS ciphering algorithm: NEA0 / 128-NEA1..3 in 5G, EEA0 / 128-EEA1..3 in 4G. Absent when none is established."
         integrity_algorithm:
           type: string
-          description: "NAS integrity algorithm: NIA0 / 128-NIA1..3 in 5GS, EIA0 / 128-EIA1..3 in EPS. Absent when none is established."
+          description: "NAS integrity algorithm: NIA0 / 128-NIA1..3 in 5G, EIA0 / 128-EIA1..3 in 4G. Absent when none is established."
         connection:
           oneOf:
             - $ref: "#/components/schemas/UEConnection"
@@ -4033,7 +4033,7 @@ components:
           description: Free-text operator note. Absent when unset.
         registrations:
           type: array
-          description: "Mobility-management contexts the core holds or remembers, 5GS first."
+          description: "Mobility-management contexts the core holds or remembers, 5G first."
           items:
             $ref: "#/components/schemas/Registration"
         sessions:
@@ -4087,7 +4087,7 @@ components:
       properties:
         system:
           type: string
-          enum: ["5GS", "EPS"]
+          enum: ["5G", "4G"]
           description: "The system holding this session."
         id:
           type: integer

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3905,39 +3905,23 @@ components:
         connection_state:
           type: string
           enum: ["idle", "connected"]
-          description: >-
-            Whether the device holds a NAS signalling connection: CM state in 5G
-            (TS 23.501 §5.3.3.2) and ECM state in 4G (TS 23.401 §4.6.3). Independent of
-            `registered` (TS 23.501 §5.3.3.2.2, TS 23.401 §4.6.1) — a device still
-            registering is "connected" with `registered` false. Omitted when the core
-            holds no context for the device.
+          description: "CM state in 5GS, ECM state in EPS. Absent when the core holds no context."
         systems:
           type: array
           items:
             type: string
             enum: ["5GS", "EPS"]
-          description: >-
-            Every system the subscriber is currently registered on, ordered 5G
-            first, matching a registration's `system` on the get-single response.
-            Usually one, but a device moving between 4G and 5G holds both while it
-            transfers its sessions one at a time. Omitted if not connected.
+          description: "Systems the core holds a context for, 5GS first. Absent when it holds none."
         num_sessions:
           type: integer
-          description: >-
-            Number of active sessions (5G PDU sessions / 4G PDN connections) for
-            this subscriber, across every access it is registered on.
+          description: "Number of active sessions across every system."
         last_seen_at:
           type: string
           format: date-time
-          description: Timestamp when the subscriber was last seen (RFC 3339). Omitted if never seen.
+          description: "Timestamp when the subscriber was last seen (RFC 3339). Absent when never seen."
         last_seen_radio:
           type: string
-          description: >-
-            Name of the radio that last served the device. The core knows the serving node
-            only while the device is connected (TS 23.501 §5.4.2, TS 23.401 §4.6.3.2), so
-            on an idle or deregistered device this is last known and may be stale. Held in
-            memory by the serving node: not shared across cluster nodes, and reset on
-            restart. Omitted if never seen.
+          description: "Radio that last served the device. Absent when never seen."
       required: [registered, num_sessions]
 
     Subscriber:
@@ -3980,97 +3964,60 @@ components:
 
     UEConnection:
       type: object
-      description: >-
-        The UE-associated logical connection identity pair of a registration: the
-        AMF and RAN UE NGAP IDs in 5G, or the MME and eNB UE S1AP IDs in 4G. Only the
-        pair belonging to the registration's system is present. These identifiers are
-        ephemeral: the radio allocates its own for the duration of one connected
-        period and reuses it afterwards, so a value identifies a subscriber only
-        together with `radio` and the time it was read.
+      description: "Identity pair of a registration's UE-associated logical connection. Only the pair of the registration's system is present."
       properties:
         amf_ue_ngap_id:
           type: integer
           format: int64
-          description: "AMF UE NGAP ID (5G). INTEGER (0..2^40-1)."
+          description: "AMF UE NGAP ID (5GS). INTEGER (0..2^40-1)."
         ran_ue_ngap_id:
           type: integer
           format: int64
-          description: >-
-            RAN UE NGAP ID (5G). INTEGER (0..2^32-1), allocated by the serving radio.
-            Absent until the radio allocates one, e.g. on a handover target before it
-            accepts the handover.
+          description: "RAN UE NGAP ID (5GS). INTEGER (0..2^32-1). Absent until the radio allocates one."
         mme_ue_s1ap_id:
           type: integer
           format: int64
-          description: "MME UE S1AP ID (4G). INTEGER (0..2^32-1)."
+          description: "MME UE S1AP ID (EPS). INTEGER (0..2^32-1)."
         enb_ue_s1ap_id:
           type: integer
           format: int64
-          description: >-
-            eNB UE S1AP ID (4G). INTEGER (0..2^24-1), allocated by the serving radio.
-            Absent until it is allocated.
+          description: "eNB UE S1AP ID (EPS). INTEGER (0..2^24-1). Absent until the radio allocates one."
 
     Registration:
       type: object
-      description: >-
-        One mobility-management context of a subscriber. A device in dual-registration
-        mode may be registered on 4G and 5G at the same time, so a subscriber may hold
-        several. An entry is present whenever the core holds a context for that system
-        or still remembers having served the subscriber there.
+      description: "One mobility-management context the core holds or remembers for a subscriber."
       properties:
         system:
           type: string
           enum: ["5GS", "EPS"]
-          description: >-
-            The core that registered the device: "5GS" for 5G, "EPS" for 4G. This is
-            independent of the radio: an NSA device on 5G radio reports "EPS".
+          description: "The core holding this registration."
         registered:
           type: boolean
-          description: >-
-            Whether the device is registered in this system: RM state in 5G and EMM
-            state in 4G. False on an entry the core remembers but no longer holds a
-            context for.
+          description: "RM state in 5GS, EMM state in EPS. False on an entry the core only remembers."
         connection_state:
-          type: string
-          nullable: true
-          enum: ["idle", "connected"]
-          description: >-
-            Whether the device holds a NAS signalling connection in this system: CM
-            state in 5G and ECM state in 4G. Independent of `registered` — a device
-            still registering is "connected" with `registered` false. Null when the
-            core holds no context.
+          type: ["string", "null"]
+          enum: ["idle", "connected", null]
+          description: "CM state in 5GS, ECM state in EPS. Null on an entry the core only remembers."
         radio:
           type: string
-          description: >-
-            Name of the radio serving this registration, or the last one that did once
-            the device is idle or deregistered, in which case it may be stale. Held in
-            memory by the serving node: not shared across cluster nodes, and reset on
-            restart. Empty if never seen.
+          description: "Radio serving this registration, or the last one that did. Absent when never seen."
         last_seen_at:
           type: string
-          description: Timestamp of last activity in this system (RFC 3339).
+          description: "Timestamp of last activity in this system (RFC 3339). Absent when never seen."
         imei:
           type: string
-          description: >-
-            15-digit IMEI of the device. Empty when unknown or once the core has
-            released the context.
+          description: "IMEI of the device (15 digits). Absent when the core does not hold it."
         ciphering_algorithm:
           type: string
-          description: >-
-            NAS ciphering algorithm negotiated in this system: NEA0 / 128-NEA1..3 in
-            5G, EEA0 / 128-EEA1..3 in 4G. Empty when none is established.
+          description: "NAS ciphering algorithm: NEA0 / 128-NEA1..3 in 5GS, EEA0 / 128-EEA1..3 in EPS. Absent when none is established."
         integrity_algorithm:
           type: string
-          description: >-
-            NAS integrity algorithm negotiated in this system: NIA0 / 128-NIA1..3 in
-            5G, EIA0 / 128-EIA1..3 in 4G. Empty when none is established.
+          description: "NAS integrity algorithm: NIA0 / 128-NIA1..3 in 5GS, EIA0 / 128-EIA1..3 in EPS. Absent when none is established."
         connection:
-          allOf:
+          oneOf:
             - $ref: "#/components/schemas/UEConnection"
-          nullable: true
-          description: >-
-            The UE-associated logical connection, or null when the device holds none
-            (CM-IDLE / ECM-IDLE, or deregistered).
+            - type: "null"
+          description: "UE-associated logical connection. Null when the device holds none."
       required: [system, registered, connection_state, connection]
 
     SubscriberDetail:
@@ -4086,10 +4033,7 @@ components:
           description: Free-text operator note. Absent when unset.
         registrations:
           type: array
-          description: >-
-            Every mobility-management context the core holds or remembers for this
-            subscriber, ordered 5G first. Empty for a subscriber the core has never
-            served.
+          description: "Mobility-management contexts the core holds or remembers, 5GS first."
           items:
             $ref: "#/components/schemas/Registration"
         sessions:
@@ -4144,7 +4088,7 @@ components:
         system:
           type: string
           enum: ["5GS", "EPS"]
-          description: "The system holding this session, matching a registration's `system`."
+          description: "The system holding this session."
         id:
           type: integer
           description: "Session identifier: the PDU Session ID (5G) or the linked EPS Bearer ID (4G)."
@@ -4246,8 +4190,7 @@ components:
         description:
           type: string
         remote_prefix:
-          type: string
-          nullable: true
+          type: ["string", "null"]
           description: "CIDR notation (e.g. \"10.0.0.0/24\") or null."
         protocol:
           type: integer
@@ -4308,7 +4251,6 @@ components:
           description: Name of the data network this policy applies to.
         rules:
           $ref: "#/components/schemas/PolicyRules"
-          nullable: true
           description: "Optional network rules organized by direction (uplink/downlink)."
         default:
           type: boolean
@@ -4899,8 +4841,7 @@ components:
           type: string
           description: "Lease type (e.g. \"dynamic\")."
         session_id:
-          type: integer
-          nullable: true
+          type: ["integer", "null"]
           description: PDU session ID, or null if the lease is not tied to an active session.
       required: [address, imsi, type, session_id]
 
@@ -4945,8 +4886,7 @@ components:
           enum: [reserved, active]
           description: "\"active\" when bound to a session, otherwise \"reserved\"."
         session_id:
-          type: integer
-          nullable: true
+          type: ["integer", "null"]
           description: PDU session ID when active, or null when reserved.
       required: [imsi, data_network, ip_version, address, status, session_id]
 

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -4144,14 +4144,6 @@ components:
           type: string
           enum: ["5GS", "EPS"]
           description: "The system holding this session, matching a registration's `system`."
-        access_types:
-          type: array
-          items:
-            type: string
-            enum: ["3GPP", "non-3GPP"]
-          description: >-
-            Every access this session is carried over. Always ["3GPP"] in this
-            release.
         id:
           type: integer
           description: "Session identifier: the PDU Session ID (5G) or the linked EPS Bearer ID (4G)."
@@ -4179,7 +4171,7 @@ components:
         ambr_downlink:
           type: string
           description: "Effective downlink session AMBR (e.g. \"200 Mbps\")."
-      required: [system, access_types, id, status]
+      required: [system, id, status]
 
     CreateSubscriberParams:
       type: object

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -3981,113 +3981,96 @@ components:
       type: object
       description: >-
         The UE-associated logical connection identity pair of a registration: the
-        AMF and RAN UE NGAP IDs in 5GS (TS 38.413 §9.3.3.1, §9.3.3.2), or the MME and
-        eNB UE S1AP IDs in EPS (TS 36.413 §9.2.3.3, §9.2.3.4). Only the pair belonging
-        to the registration's system is present. These identifiers are ephemeral: the
-        RAN allocates its own for the duration of one connected period and reuses it
-        afterwards, so a value identifies a subscriber only together with `radio` and
-        the time it was read.
+        AMF and RAN UE NGAP IDs in 5G, or the MME and eNB UE S1AP IDs in 4G. Only the
+        pair belonging to the registration's system is present. These identifiers are
+        ephemeral: the radio allocates its own for the duration of one connected
+        period and reuses it afterwards, so a value identifies a subscriber only
+        together with `radio` and the time it was read.
       properties:
         amf_ue_ngap_id:
           type: integer
           format: int64
-          description: "AMF UE NGAP ID (5GS). INTEGER (0..2^40-1)."
+          description: "AMF UE NGAP ID (5G). INTEGER (0..2^40-1)."
         ran_ue_ngap_id:
           type: integer
           format: int64
           description: >-
-            RAN UE NGAP ID (5GS). INTEGER (0..2^32-1), allocated by the serving NG-RAN
-            node. Absent until it is allocated, e.g. on a handover target before
-            HANDOVER REQUEST ACKNOWLEDGE (TS 38.413 §9.2.3.5).
+            RAN UE NGAP ID (5G). INTEGER (0..2^32-1), allocated by the serving radio.
+            Absent until the radio allocates one, e.g. on a handover target before it
+            accepts the handover.
         mme_ue_s1ap_id:
           type: integer
           format: int64
-          description: "MME UE S1AP ID (EPS). INTEGER (0..2^32-1)."
+          description: "MME UE S1AP ID (4G). INTEGER (0..2^32-1)."
         enb_ue_s1ap_id:
           type: integer
           format: int64
           description: >-
-            eNB UE S1AP ID (EPS). INTEGER (0..2^24-1), allocated by the serving eNB.
+            eNB UE S1AP ID (4G). INTEGER (0..2^24-1), allocated by the serving radio.
             Absent until it is allocated.
 
     Registration:
       type: object
       description: >-
-        One mobility-management context of a subscriber. A subscriber may hold
-        several: 5GS keeps an independent registration state per access type
-        (TS 23.501 §5.3.2.4), and a UE in dual-registration mode may be registered
-        to both 5GC and EPC at the same time (TS 23.501 §5.17.2.1). An entry is
-        present whenever the core holds a context for that system or still remembers
-        having served the subscriber there.
+        One mobility-management context of a subscriber. A device in dual-registration
+        mode may be registered on 4G and 5G at the same time, so a subscriber may hold
+        several. An entry is present whenever the core holds a context for that system
+        or still remembers having served the subscriber there.
       properties:
         system:
           type: string
           enum: ["5GS", "EPS"]
           description: >-
-            The system holding this registration — the 5G System (5GC) or the Evolved
-            Packet System (EPC). This is the core that registered the UE, independent
-            of the radio: an NSA device on NR radio is registered in EPS.
-        access_type:
-          type: string
-          enum: ["3GPP", "non-3GPP"]
-          description: >-
-            The access this registration was established over (TS 23.501 §5.3.2.4).
-            Always "3GPP" in this release.
+            The core that registered the device: "5GS" for 5G, "EPS" for 4G. This is
+            independent of the radio: an NSA device on 5G radio reports "EPS".
         registered:
           type: boolean
           description: >-
-            Whether the UE is registered in this system: RM state in 5GS
-            (TS 23.501 §5.3.2.2) and EMM state in EPS (TS 23.401 §4.6.2). False on an
-            entry the core remembers but no longer holds a context for.
+            Whether the device is registered in this system: RM state in 5G and EMM
+            state in 4G. False on an entry the core remembers but no longer holds a
+            context for.
         connection_state:
           type: string
           nullable: true
           enum: ["idle", "connected"]
           description: >-
-            Whether the UE holds a NAS signalling connection in this system: CM state
-            in 5GS (TS 23.501 §5.3.3.2) and ECM state in EPS (TS 23.401 §4.6.3).
-            Independent of `registered` — a UE still registering is "connected" with
-            `registered` false. Null when the core holds no context.
+            Whether the device holds a NAS signalling connection in this system: CM
+            state in 5G and ECM state in 4G. Independent of `registered` — a device
+            still registering is "connected" with `registered` false. Null when the
+            core holds no context.
         radio:
           type: string
           description: >-
             Name of the radio serving this registration, or the last one that did once
-            the UE is idle or deregistered, in which case it may be stale. Held in
+            the device is idle or deregistered, in which case it may be stale. Held in
             memory by the serving node: not shared across cluster nodes, and reset on
             restart. Empty if never seen.
         last_seen_at:
           type: string
           description: Timestamp of last activity in this system (RFC 3339).
-        pei:
-          type: string
-          description: >-
-            Permanent Equipment Identifier of the device, in its NAS-prefixed form
-            ("imei-…" / "imeisv-…"). 5GS only (TS 23.003 §6.4). Empty when unknown.
         imei:
           type: string
           description: >-
-            15-digit IMEI of the device (TS 23.003). On a 5GS registration this is
-            the IMEI carried by `pei`, present only when the PEI is an IMEI or IMEISV.
-            Empty when unknown.
+            15-digit IMEI of the device. Empty when unknown or once the core has
+            released the context.
         ciphering_algorithm:
           type: string
           description: >-
             NAS ciphering algorithm negotiated in this system: NEA0 / 128-NEA1..3 in
-            5GS (TS 33.501 Annex D), EEA0 / 128-EEA1..3 in EPS (TS 33.401 Annex B).
-            Empty when none is established.
+            5G, EEA0 / 128-EEA1..3 in 4G. Empty when none is established.
         integrity_algorithm:
           type: string
           description: >-
             NAS integrity algorithm negotiated in this system: NIA0 / 128-NIA1..3 in
-            5GS, EIA0 / 128-EIA1..3 in EPS. Empty when none is established.
+            5G, EIA0 / 128-EIA1..3 in 4G. Empty when none is established.
         connection:
           allOf:
             - $ref: "#/components/schemas/UEConnection"
           nullable: true
           description: >-
-            The UE-associated logical connection, or null when the UE holds none
+            The UE-associated logical connection, or null when the device holds none
             (CM-IDLE / ECM-IDLE, or deregistered).
-      required: [system, access_type, registered, connection_state, connection]
+      required: [system, registered, connection_state, connection]
 
     SubscriberDetail:
       type: object
@@ -4104,13 +4087,13 @@ components:
           type: array
           description: >-
             Every mobility-management context the core holds or remembers for this
-            subscriber, ordered 5GS first. Empty for a subscriber the core has never
+            subscriber, ordered 5G first. Empty for a subscriber the core has never
             served.
           items:
             $ref: "#/components/schemas/Registration"
         sessions:
           type: array
-          description: "Active sessions for this subscriber (5GS PDU sessions / EPS PDN connections)."
+          description: "Active sessions for this subscriber (5G PDU sessions / 4G PDN connections)."
           items:
             $ref: "#/components/schemas/Session"
       required: [imsi, profile_name, registrations, sessions]
@@ -4143,7 +4126,7 @@ components:
 
     SNSSAI:
       type: object
-      description: "5GS network slice identifier (S-NSSAI). Absent for EPS sessions."
+      description: "5G network slice identifier (S-NSSAI). Absent for 4G sessions."
       properties:
         sst:
           type: integer
@@ -4155,7 +4138,7 @@ components:
 
     Session:
       type: object
-      description: "A UE data session — a 5GS PDU session or an EPS PDN connection."
+      description: "A UE data session — a 5G PDU session or a 4G PDN connection."
       properties:
         system:
           type: string
@@ -4167,19 +4150,18 @@ components:
             type: string
             enum: ["3GPP", "non-3GPP"]
           description: >-
-            Every access this session is carried over. A Multi-Access PDU Session is
-            associated with 3GPP and non-3GPP access simultaneously (TS 23.501
-            §5.6.1); any other session names exactly one.
+            Every access this session is carried over. Always ["3GPP"] in this
+            release.
         id:
           type: integer
-          description: "Session identifier: the PDU Session ID (5GS) or the linked EPS Bearer ID (EPS)."
+          description: "Session identifier: the PDU Session ID (5G) or the linked EPS Bearer ID (4G)."
         status:
           type: string
           description: "Session status (e.g. active, inactive)."
         ip_type:
           type: string
           enum: ["IPv4", "IPv6", "IPv4v6"]
-          description: "Negotiated IP type (5GS PDU Session Type / EPS PDN Type)."
+          description: "Negotiated IP type (5G PDU Session Type / 4G PDN Type)."
         ipv4_address:
           type: string
           description: "Assigned IPv4 address. Omitted if unknown."
@@ -4188,7 +4170,7 @@ components:
           description: "Assigned IPv6 prefix (/64). Omitted if unknown."
         data_network:
           type: string
-          description: "Data network name (DNN in 5GS / APN in EPS)."
+          description: "Data network name (DNN in 5G / APN in 4G)."
         slice:
           $ref: "#/components/schemas/SNSSAI"
         ambr_uplink:

--- a/internal/api/server/openapi_contract_test.go
+++ b/internal/api/server/openapi_contract_test.go
@@ -9,41 +9,31 @@ import (
 	"go/token"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
 
-func TestSpecRequiredFieldsAreNeverOmitEmpty(t *testing.T) {
-	var spec struct {
-		Components struct {
-			Schemas map[string]struct {
-				Required []string `yaml:"required"`
-			} `yaml:"schemas"`
-		} `yaml:"components"`
-	}
+type goField struct {
+	structName string
+	jsonName   string
+	pointer    bool
+	omitEmpty  bool
+}
 
-	if err := yaml.Unmarshal(openapiSpec, &spec); err != nil {
-		t.Fatalf("could not parse the embedded OpenAPI spec: %v", err)
-	}
-
-	required := make(map[string]map[string]bool, len(spec.Components.Schemas))
-	for name, schema := range spec.Components.Schemas {
-		fields := make(map[string]bool, len(schema.Required))
-		for _, field := range schema.Required {
-			fields[field] = true
-		}
-
-		required[name] = fields
-	}
-
-	fset := token.NewFileSet()
+func packageStructFields(t *testing.T) []goField {
+	t.Helper()
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatalf("could not list the package directory: %v", err)
 	}
+
+	fset := token.NewFileSet()
+
+	var out []goField
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -67,11 +57,6 @@ func TestSpecRequiredFieldsAreNeverOmitEmpty(t *testing.T) {
 				return true
 			}
 
-			fields, ok := required[spec.Name.Name]
-			if !ok {
-				return true
-			}
-
 			for _, field := range structType.Fields.List {
 				if field.Tag == nil {
 					continue
@@ -80,21 +65,124 @@ func TestSpecRequiredFieldsAreNeverOmitEmpty(t *testing.T) {
 				tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`")).Get("json")
 
 				parts := strings.Split(tag, ",")
-				if len(parts) < 2 || !fields[parts[0]] {
+				if parts[0] == "" || parts[0] == "-" {
 					continue
 				}
 
-				for _, opt := range parts[1:] {
-					if opt == "omitempty" {
-						t.Errorf(
-							"%s.%s is required by the OpenAPI spec but tagged omitempty",
-							spec.Name.Name, parts[0],
-						)
-					}
-				}
+				_, pointer := field.Type.(*ast.StarExpr)
+
+				out = append(out, goField{
+					structName: spec.Name.Name,
+					jsonName:   parts[0],
+					pointer:    pointer,
+					omitEmpty:  slices.Contains(parts[1:], "omitempty"),
+				})
 			}
 
 			return true
 		})
+	}
+
+	return out
+}
+
+func TestSpecRequiredFieldsAreNeverOmitEmpty(t *testing.T) {
+	var spec struct {
+		Components struct {
+			Schemas map[string]struct {
+				Required []string `yaml:"required"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+
+	if err := yaml.Unmarshal(openapiSpec, &spec); err != nil {
+		t.Fatalf("could not parse the embedded OpenAPI spec: %v", err)
+	}
+
+	for _, field := range packageStructFields(t) {
+		schema, ok := spec.Components.Schemas[field.structName]
+		if !ok || !slices.Contains(schema.Required, field.jsonName) {
+			continue
+		}
+
+		if field.omitEmpty {
+			t.Errorf(
+				"%s.%s is required by the OpenAPI spec but tagged omitempty",
+				field.structName, field.jsonName,
+			)
+		}
+	}
+}
+
+func admitsNull(schema map[string]any) bool {
+	switch declared := schema["type"].(type) {
+	case string:
+		if declared == "null" {
+			return true
+		}
+	case []any:
+		for _, entry := range declared {
+			if name, ok := entry.(string); ok && name == "null" {
+				return true
+			}
+		}
+	}
+
+	for _, keyword := range []string{"oneOf", "anyOf"} {
+		branches, ok := schema[keyword].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, branch := range branches {
+			if nested, ok := branch.(map[string]any); ok && admitsNull(nested) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func TestSpecDeclaresNullForEveryNullableField(t *testing.T) {
+	var spec struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]map[string]any `yaml:"properties"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+
+	if err := yaml.Unmarshal(openapiSpec, &spec); err != nil {
+		t.Fatalf("could not parse the embedded OpenAPI spec: %v", err)
+	}
+
+	for _, field := range packageStructFields(t) {
+		schema, ok := spec.Components.Schemas[field.structName]
+		if !ok {
+			continue
+		}
+
+		property, ok := schema.Properties[field.jsonName]
+		if !ok {
+			continue
+		}
+
+		marshalsNull := field.pointer && !field.omitEmpty
+		if marshalsNull == admitsNull(property) {
+			continue
+		}
+
+		if marshalsNull {
+			t.Errorf(
+				"%s.%s marshals as null when the pointer is nil, but its schema does not admit null",
+				field.structName, field.jsonName,
+			)
+		} else {
+			t.Errorf(
+				"%s.%s can never marshal as null, but its schema admits null",
+				field.structName, field.jsonName,
+			)
+		}
 	}
 }

--- a/internal/api/server/session_test.go
+++ b/internal/api/server/session_test.go
@@ -22,8 +22,12 @@ func TestSessionFrom5G_AllFields(t *testing.T) {
 		PolicyData:     &amf.PolicyDataExport{Ambr: &models.Ambr{Uplink: models.MustParseBitRate("100 Mbps"), Downlink: models.MustParseBitRate("200 Mbps")}},
 	})
 
-	if s.RadioAccessType != "5G" || s.ID != 1 || s.Status != "active" {
+	if s.System != System5GS || s.ID != 1 || s.Status != "active" {
 		t.Fatalf("session = %+v", s)
+	}
+
+	if got := s.AccessTypes; len(got) != 1 || got[0] != AccessType3GPP {
+		t.Fatalf("AccessTypes = %v", got)
 	}
 
 	if s.IPType != "IPv4v6" || s.IPv4Address != "10.45.0.2" || s.IPv6Prefix != "2001:db8:ad50:8500::" {
@@ -63,7 +67,7 @@ func TestSessionFrom5G_NilSnssaiAndPolicy(t *testing.T) {
 	}
 }
 
-// A 4G PDN connection: radio_access_type 4G, the data network is the APN, and no
+// A 4G PDN connection: system EPS, the data network is the APN, and no
 // network slice.
 func TestSessionFrom4G(t *testing.T) {
 	s := sessionFrom4G(&mme.SubscriberSession{
@@ -75,8 +79,12 @@ func TestSessionFrom4G(t *testing.T) {
 		AMBRDownlink: "1 Gbps",
 	})
 
-	if s.RadioAccessType != "4G" || s.ID != 5 || s.Status != "active" {
+	if s.System != SystemEPS || s.ID != 5 || s.Status != "active" {
 		t.Fatalf("session = %+v", s)
+	}
+
+	if got := s.AccessTypes; len(got) != 1 || got[0] != AccessType3GPP {
+		t.Fatalf("AccessTypes = %v", got)
 	}
 
 	if s.IPType != "IPv6" || s.IPv6Prefix != "2001:db8::" || s.DataNetwork != "internet" {

--- a/internal/api/server/session_test.go
+++ b/internal/api/server/session_test.go
@@ -26,10 +26,6 @@ func TestSessionFrom5G_AllFields(t *testing.T) {
 		t.Fatalf("session = %+v", s)
 	}
 
-	if got := s.AccessTypes; len(got) != 1 || got[0] != AccessType3GPP {
-		t.Fatalf("AccessTypes = %v", got)
-	}
-
 	if s.IPType != "IPv4v6" || s.IPv4Address != "10.45.0.2" || s.IPv6Prefix != "2001:db8:ad50:8500::" {
 		t.Fatalf("addressing = %+v", s)
 	}
@@ -81,10 +77,6 @@ func TestSessionFrom4G(t *testing.T) {
 
 	if s.System != SystemEPS || s.ID != 5 || s.Status != "active" {
 		t.Fatalf("session = %+v", s)
-	}
-
-	if got := s.AccessTypes; len(got) != 1 || got[0] != AccessType3GPP {
-		t.Fatalf("AccessTypes = %v", got)
 	}
 
 	if s.IPType != "IPv6" || s.IPv6Prefix != "2001:db8::" || s.DataNetwork != "internet" {

--- a/internal/api/server/session_test.go
+++ b/internal/api/server/session_test.go
@@ -22,7 +22,7 @@ func TestSessionFrom5G_AllFields(t *testing.T) {
 		PolicyData:     &amf.PolicyDataExport{Ambr: &models.Ambr{Uplink: models.MustParseBitRate("100 Mbps"), Downlink: models.MustParseBitRate("200 Mbps")}},
 	})
 
-	if s.System != System5GS || s.ID != 1 || s.Status != "active" {
+	if s.System != System5G || s.ID != 1 || s.Status != "active" {
 		t.Fatalf("session = %+v", s)
 	}
 
@@ -63,7 +63,7 @@ func TestSessionFrom5G_NilSnssaiAndPolicy(t *testing.T) {
 	}
 }
 
-// A 4G PDN connection: system EPS, the data network is the APN, and no
+// A 4G PDN connection: system 4G, the data network is the APN, and no
 // network slice.
 func TestSessionFrom4G(t *testing.T) {
 	s := sessionFrom4G(&mme.SubscriberSession{
@@ -75,7 +75,7 @@ func TestSessionFrom4G(t *testing.T) {
 		AMBRDownlink: "1 Gbps",
 	})
 
-	if s.System != SystemEPS || s.ID != 5 || s.Status != "active" {
+	if s.System != System4G || s.ID != 5 || s.Status != "active" {
 		t.Fatalf("session = %+v", s)
 	}
 

--- a/internal/lmf/engine_refresh_test.go
+++ b/internal/lmf/engine_refresh_test.go
@@ -618,7 +618,7 @@ func TestRefreshLocation_Success(t *testing.T) {
 		t.Fatal("AMF.FindUEByAmfUeNgapID returned nil - UE connection not registered")
 	}
 
-	t.Logf("Found UE connection: amfUeNgapID=%d, ranUeNgapID=%d", foundUeConn.AmfUeNgapID, foundUeConn.RanUeNgapID)
+	t.Logf("Found UE connection: amfUeNgapID=%d, ranUeNgapID=%d", foundUeConn.AmfUeNgapID, foundUeConn.RanUeNgapID())
 
 	ngap.HandleLocationReport(context.Background(), amfInstance, radio, msg)
 

--- a/internal/logger/fields.go
+++ b/internal/logger/fields.go
@@ -19,7 +19,8 @@ func TMSI(val string) zap.Field { return zap.String("tmsi", val) }
 func AmfUeNgapID(val models.AmfUeNgapID) zap.Field { return zap.Int64("amf_ue_ngap_id", int64(val)) }
 
 func RanUeNgapID(val models.RanUeNgapID) zap.Field { return zap.Int64("ran_ue_ngap_id", int64(val)) }
-func MMEUeS1apID(val uint32) zap.Field             { return zap.Uint32("mme-ue-id", val) }
+func MMEUeS1apID(val uint32) zap.Field             { return zap.Uint32("mme_ue_s1ap_id", val) }
+func ENBUeS1apID(val uint32) zap.Field             { return zap.Uint32("enb_ue_s1ap_id", val) }
 func PDUSessionID(val uint8) zap.Field             { return zap.Uint8("pdu_session_id", val) }
 func DNN(val string) zap.Field                     { return zap.String("dnn", val) }
 func SST(val uint8) zap.Field                      { return zap.Uint8("sst", val) }

--- a/internal/mme/export.go
+++ b/internal/mme/export.go
@@ -188,7 +188,7 @@ func (m *MME) exportUeContext(plmn models.PlmnID, ue *UeContext) UeContextExport
 	export := UeContextExport{
 		Identity: UEIdentityExport{
 			Supi:   ue.supi.String(),
-			Pei:    ue.Imei.IMEI(),
+			Pei:    ue.Imei.String(),
 			PlmnID: plmn,
 			// Direct reads: already under ue.mu, which Tmsi()/OldTmsi() take again.
 			Tmsi:    tmsiExport(ue.tmsi),

--- a/internal/mme/export_pei_test.go
+++ b/internal/mme/export_pei_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/ellanetworks/core/etsi"
+)
+
+func exportedIdentity(t *testing.T, m *MME) map[string]any {
+	t.Helper()
+
+	exports, err := m.ExportUEs(context.Background())
+	if err != nil {
+		t.Fatalf("ExportUEs: %v", err)
+	}
+
+	if len(exports) != 1 {
+		t.Fatalf("expected 1 UE in the export, got %d", len(exports))
+	}
+
+	raw, err := json.Marshal(exports[0])
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+
+	var decoded struct {
+		Identity map[string]any `json:"identity"`
+	}
+
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal export: %v", err)
+	}
+
+	return decoded.Identity
+}
+
+func TestExportPeiIsNASPrefixed(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		reported string
+		want     string
+	}{
+		{name: "IMEI", reported: "imei-123456789012345", want: "imei-123456789012345"},
+		{name: "IMEISV", reported: "imeisv-3535938300494715", want: "imeisv-3535938300494715"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMME(t)
+
+			ue := m.NewUe(&captureConn{}, 7)
+			if ue == nil {
+				t.Fatal("NewUe returned nil")
+			}
+
+			imei, err := etsi.NewIMEIFromPEI(tc.reported)
+			if err != nil {
+				t.Fatalf("NewIMEIFromPEI(%q): %v", tc.reported, err)
+			}
+
+			ue.MarkSecured(imei)
+			m.RegisterUEForTest(ue, "001010000000002")
+
+			identity := exportedIdentity(t, m)
+			if got, ok := identity["pei"].(string); !ok || got != tc.want {
+				t.Fatalf("identity.pei = %v, want %q", identity["pei"], tc.want)
+			}
+		})
+	}
+}

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -90,9 +90,9 @@ func (m *MME) PrepareHandover(ue *UeContext, target S1APWriter, reqMMEID s1ap.MM
 		return 0, [32]byte{}, 0, false
 	}
 
-	targetConn := &UeConn{m: m, MMEUES1APID: s1ap.MMEUES1APID(tid), ue: ue}
+	targetConn := &UeConn{m: m, MMEUES1APID: s1ap.MMEUES1APID(tid), ENBUES1APID: enbUES1APIDUnspecified, ue: ue}
 	targetConn.setConn(target)
-	targetConn.setLog(m.nodeLogLocked(target).With(logger.MMEUeS1apID(uint32(targetConn.MMEUES1APID))))
+	targetConn.bindLog(m.nodeLogLocked(target))
 	m.conns[tid] = targetConn
 
 	ho := &handoverContext{
@@ -220,9 +220,9 @@ func (m *MME) prepareRelocation(ue *UeContext, target S1APWriter, candidates []H
 
 	held.prepared = true
 
-	targetConn := &UeConn{m: m, MMEUES1APID: s1ap.MMEUES1APID(tid), ue: ue}
+	targetConn := &UeConn{m: m, MMEUES1APID: s1ap.MMEUES1APID(tid), ENBUES1APID: enbUES1APIDUnspecified, ue: ue}
 	targetConn.setConn(target)
-	targetConn.setLog(m.nodeLogLocked(target).With(logger.MMEUeS1apID(uint32(targetConn.MMEUES1APID))))
+	targetConn.bindLog(m.nodeLogLocked(target))
 	m.conns[tid] = targetConn
 
 	delivery := make(chan relocationOutcome, 1)
@@ -284,6 +284,7 @@ func (m *MME) MatchAndSetTargetENB(ue *UeContext, ackMMEID s1ap.MMEUES1APID, ack
 	}
 
 	ho.target.ENBUES1APID = ackENBID
+	ho.target.refreshLog()
 
 	return true
 }
@@ -471,7 +472,7 @@ func (m *MME) CommitPathSwitch(ue *UeContext, conn S1APWriter, enbUEID s1ap.ENBU
 
 	ue.Conn().setConn(conn)
 	ue.Conn().ENBUES1APID = enbUEID
-	ue.Conn().setLog(m.nodeLogLocked(conn).With(logger.MMEUeS1apID(uint32(ue.Conn().MMEUES1APID))))
+	ue.Conn().bindLog(m.nodeLogLocked(conn))
 
 	m.refreshLastSeenLocked(ue, ue.Conn())
 

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -61,7 +61,7 @@ func (m *MME) PrepareHandover(ue *UeContext, target S1APWriter, reqMMEID s1ap.MM
 	if !ue.BeginKeyChainProc(procedure.S1Handover) {
 		m.mu.Unlock()
 		logger.MmeLog.Warn("Handover Required while a key-changing procedure is in progress",
-			zap.Uint32("mme-ue-id", uint32(reqMMEID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(reqMMEID)))
 
 		return 0, [32]byte{}, 0, false
 	}
@@ -579,7 +579,7 @@ func (m *MME) unwindHandover(ctx context.Context, ue *UeContext, cause s1ap.Caus
 	}
 
 	logger.From(ctx, logger.MmeLog).Warn("S1 handover abandoned",
-		zap.Uint32("target-mme-ue-id", uint32(releaseTarget.MMEUES1APID)))
+		zap.Uint32("target_mme_ue_s1ap_id", uint32(releaseTarget.MMEUES1APID)))
 
 	SendUEContextRelease(ctx, m, releaseTarget.Conn(), releaseTarget.MMEUES1APID, releaseTarget.ENBUES1APID, releasePair, cause)
 
@@ -627,7 +627,7 @@ func SendUEContextRelease(ctx context.Context, m *MME, conn S1APWriter, mmeUEID 
 		return
 	}
 
-	logger.From(ctx, logger.MmeLog).Info("UE Context Release Command", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
+	logger.From(ctx, logger.MmeLog).Info("UE Context Release Command", zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)))
 	m.SendToRadio(ctx, conn, S1APProcedureUEContextReleaseCommand, b)
 }
 

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -548,7 +548,7 @@ func (m *MME) NewUeConn(conn S1APWriter, enbUEID s1ap.ENBUES1APID) *UeConn {
 
 	c := &UeConn{m: m, ENBUES1APID: enbUEID, MMEUES1APID: s1ap.MMEUES1APID(id)}
 	c.setConn(conn)
-	c.setLog(m.nodeLogLocked(conn).With(logger.MMEUeS1apID(uint32(c.MMEUES1APID))))
+	c.bindLog(m.nodeLogLocked(conn))
 	m.conns[id] = c
 
 	return c

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -230,7 +230,7 @@ func buildInitialContextSetup(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	// Log the AS-key inputs so an eNB RRC-reconfiguration failure from a key or
 	// algorithm mismatch can be told apart from a radio-side release (TS 33.401).
 	logger.From(ctx, logger.MmeLog).Info("Initial Context Setup Request",
-		zap.Uint32("enb-ue-id", uint32(ueConn.ENBUES1APID)),
+		zap.Uint32("enb_ue_s1ap_id", uint32(ueConn.ENBUES1APID)),
 		zap.Uint8("nas-pdu-bearer", carrier),
 		zap.Int("bearers", len(erabs)),
 		zap.Uint32("kenb-ul-count", kenbCount),

--- a/internal/mme/nas/handle_attach_request.go
+++ b/internal/mme/nas/handle_attach_request.go
@@ -26,7 +26,7 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 	// subscriber deletion, so a re-attach would fail authentication regardless.
 	if ue.EMMState() == mme.EMMDeregistrationInitiated {
 		logger.From(ctx, logger.MmeLog).Info("ignoring Attach Request during network-initiated detach",
-			zap.Uint32("mme-ue-id", uint32(ueConn.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(ueConn.MMEUES1APID)))
 
 		return nasreply.Silent(nasreply.ReasonOutOfState)
 	}
@@ -38,7 +38,7 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 	// earlier attach with the new one.
 	if ue.RegStep() == mme.RegStepContextSetup && bytes.Equal(plain, ueConn.AttachRequestPlain) {
 		logger.From(ctx, logger.MmeLog).Info("duplicate Attach Request with identical IEs; resending Attach Accept",
-			zap.Uint32("mme-ue-id", uint32(ueConn.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(ueConn.MMEUES1APID)))
 		ueConn.ResendAttachAccept(ctx)
 
 		return nasreply.Handled()
@@ -48,7 +48,7 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 	if step := ue.RegStep(); step == mme.RegStepAuthenticating || step == mme.RegStepSecurityMode {
 		if len(plain) > 0 && bytes.Equal(plain, ueConn.AttachRequestPlain) {
 			logger.From(ctx, logger.MmeLog).Info("duplicate Attach Request with identical IEs before Attach Accept; ignoring (TS 24.301 §5.5.1.2.7 case e)",
-				zap.Uint32("mme-ue-id", uint32(ueConn.MMEUES1APID)))
+				zap.Uint32("mme_ue_s1ap_id", uint32(ueConn.MMEUES1APID)))
 
 			return nasreply.Handled()
 		}
@@ -67,7 +67,7 @@ func handleAttachRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueC
 		return nasreply.Handled()
 	} else if !served {
 		logger.From(ctx, logger.MmeLog).Info("Attach rejected [Tracking area not allowed]",
-			zap.Uint32("mme-ue-id", uint32(ueConn.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(ueConn.MMEUES1APID)))
 		rejectAttach(ctx, m, ue, ueConn, eps.EMMCauseTrackingAreaNotAllowed)
 
 		return nasreply.Handled()

--- a/internal/mme/nas/handle_service_request.go
+++ b/internal/mme/nas/handle_service_request.go
@@ -81,7 +81,7 @@ func HandleServiceRequest(ctx context.Context, m *mme.MME, conn mme.S1APWriter, 
 	ue.PinKeNBFreshness()
 
 	logger.From(ctx, logger.MmeLog).Info("Service Request accepted",
-		zap.Uint32("enb-ue-id", uint32(c.ENBUES1APID)),
+		zap.Uint32("enb_ue_s1ap_id", uint32(c.ENBUES1APID)),
 		zap.String("imsi", ue.IMSI()))
 
 	qos, err := mme.ResolveQoS(ctx, m, ue.IMSI())

--- a/internal/mme/relocation.go
+++ b/internal/mme/relocation.go
@@ -156,7 +156,7 @@ func (m *MME) relocate(ctx context.Context, ue *UeContext, target *Radio, target
 
 	logger.From(ctx, logger.MmeLog).Info("Handover Request (5GS to EPS)",
 		zap.String("imsi", ue.IMSI()),
-		zap.Uint32("target-mme-ue-id", uint32(targetMMEID)),
+		zap.Uint32("target_mme_ue_s1ap_id", uint32(targetMMEID)),
 		zap.String("target-enb", targetID),
 		zap.Int("e-rabs", len(bearers)))
 	m.SendToRadio(ctx, target.Conn, S1APProcedureHandoverRequest, b)

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -29,13 +29,13 @@ const (
 	ICSCompleted
 )
 
+const enbUES1APIDUnspecified s1ap.ENBUES1APID = 0xFFFFFFFF
+
 // UeConn is a UE's transient state for one UE-associated logical S1-connection
 // (TS 36.413): the S1AP identities, the eNB association, the connection-scoped
 // NAS-guard supervision, and any in-flight handover. A fresh one is bound
 // on each idle→active transition; the persistent UeContext it belongs to survives
 // across them. Fields are guarded by MME.mu unless noted.
-const enbUES1APIDUnspecified s1ap.ENBUES1APID = 0xFFFFFFFF
-
 type UeConn struct {
 	ENBUES1APID               s1ap.ENBUES1APID
 	MMEUES1APID               s1ap.MMEUES1APID

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -34,11 +34,14 @@ const (
 // NAS-guard supervision, and any in-flight handover. A fresh one is bound
 // on each idle→active transition; the persistent UeContext it belongs to survives
 // across them. Fields are guarded by MME.mu unless noted.
+const enbUES1APIDUnspecified s1ap.ENBUES1APID = 0xFFFFFFFF
+
 type UeConn struct {
 	ENBUES1APID               s1ap.ENBUES1APID
 	MMEUES1APID               s1ap.MMEUES1APID
 	conn                      atomic.Pointer[S1APWriter]
 	log                       atomic.Pointer[zap.Logger]
+	baseLog                   atomic.Pointer[zap.Logger]
 	ue                        *UeContext
 	ServingTAI                s1ap.TAI
 	Location                  models.UserLocation
@@ -82,6 +85,25 @@ func (c *UeConn) Log() *zap.Logger {
 
 func (c *UeConn) setLog(l *zap.Logger) {
 	c.log.Store(l)
+}
+
+func (c *UeConn) bindLog(base *zap.Logger) {
+	c.baseLog.Store(base)
+	c.refreshLog()
+}
+
+func (c *UeConn) refreshLog() {
+	base := c.baseLog.Load()
+	if base == nil {
+		return
+	}
+
+	fields := []zap.Field{logger.MMEUeS1apID(uint32(c.MMEUES1APID))}
+	if c.ENBUES1APID != enbUES1APIDUnspecified {
+		fields = append(fields, logger.ENBUeS1apID(uint32(c.ENBUES1APID)))
+	}
+
+	c.setLog(base.With(fields...))
 }
 
 func (c *UeConn) ArrivedFrom5GS() bool {

--- a/internal/mme/s1_conn_log_fields_test.go
+++ b/internal/mme/s1_conn_log_fields_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/per"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestUeConnLogCarriesUeAssociationIDs(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	ueConn := &UeConn{MMEUES1APID: 7, ENBUES1APID: enbUES1APIDUnspecified}
+	ueConn.bindLog(zap.New(core))
+	ueConn.Log().Info("handover target prepared")
+
+	ueConn.ENBUES1APID = 42
+	ueConn.refreshLog()
+	ueConn.Log().Info("handover target assigned")
+
+	entries := logs.All()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(entries))
+	}
+
+	prepared := entries[0].ContextMap()
+	if prepared["mme_ue_s1ap_id"] != uint32(7) {
+		t.Errorf("expected mme_ue_s1ap_id 7, got %v", prepared["mme_ue_s1ap_id"])
+	}
+
+	if _, ok := prepared["enb_ue_s1ap_id"]; ok {
+		t.Errorf("expected enb_ue_s1ap_id to be omitted while unspecified, got %v", prepared["enb_ue_s1ap_id"])
+	}
+
+	assigned := entries[1].ContextMap()
+	if assigned["mme_ue_s1ap_id"] != uint32(7) {
+		t.Errorf("expected mme_ue_s1ap_id 7, got %v", assigned["mme_ue_s1ap_id"])
+	}
+
+	if assigned["enb_ue_s1ap_id"] != uint32(42) {
+		t.Errorf("expected enb_ue_s1ap_id 42, got %v", assigned["enb_ue_s1ap_id"])
+	}
+}
+
+func TestUeConnLogWithoutBaseKeepsExplicitLogger(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	ueConn := &UeConn{MMEUES1APID: 1, ENBUES1APID: 2}
+	ueConn.setLog(zap.New(core))
+	ueConn.refreshLog()
+	ueConn.Log().Info("still mine")
+
+	if logs.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", logs.Len())
+	}
+
+	if got := logs.All()[0].ContextMap(); len(got) != 0 {
+		t.Errorf("expected no injected fields, got %v", got)
+	}
+}
+
+func TestEnbUES1APIDUnspecifiedIsOutOfSpecRange(t *testing.T) {
+	if err := enbUES1APIDUnspecified.MarshalPER(per.NewWriter(), per.Aligned); err == nil {
+		t.Fatal("expected the unspecified marker to be unencodable as an ENB-UE-S1AP-ID")
+	}
+}

--- a/internal/mme/s1ap/handle_enb_status_transfer.go
+++ b/internal/mme/s1ap/handle_enb_status_transfer.go
@@ -33,7 +33,7 @@ func handleENBStatusTransfer(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 
 	targetConn, targetMMEID, targetENBID, ok := m.HandoverStatusTarget(ue)
 	if !ok {
-		logger.From(ctx, logger.MmeLog).Warn("eNB Status Transfer with no handover in progress", zap.Uint32("mme-ue-id", uint32(st.MMEUES1APID)))
+		logger.From(ctx, logger.MmeLog).Warn("eNB Status Transfer with no handover in progress", zap.Uint32("mme_ue_s1ap_id", uint32(st.MMEUES1APID)))
 
 		return
 	}

--- a/internal/mme/s1ap/handle_erab_modification_indication.go
+++ b/internal/mme/s1ap/handle_erab_modification_indication.go
@@ -45,7 +45,7 @@ func handleERABModificationIndication(m *mme.MME, ctx context.Context, radio *mm
 
 	if id, dup := duplicateModifiedERABID(msg); dup {
 		logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication repeats an E-RAB ID; releasing UE context",
-			zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(id)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(msg.MMEUES1APID)), zap.Uint8("e-rab-id", uint8(id)))
 		m.ReleaseUEContext(ctx, ue, causeMultipleERABInstances)
 
 		return
@@ -53,7 +53,7 @@ func handleERABModificationIndication(m *mme.MME, ctx context.Context, radio *mm
 
 	if ebi, omitted := omittedEstablishedERAB(ue, msg); omitted {
 		logger.From(ctx, logger.MmeLog).Warn("E-RAB Modification Indication omits an established E-RAB; releasing UE context",
-			zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)), zap.Uint8("e-rab-id", ebi))
+			zap.Uint32("mme_ue_s1ap_id", uint32(msg.MMEUES1APID)), zap.Uint8("e-rab-id", ebi))
 		m.ReleaseUEContext(ctx, ue, causeERABModOmittedERAB)
 
 		return
@@ -74,7 +74,7 @@ func handleERABModificationIndication(m *mme.MME, ctx context.Context, radio *mm
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("E-RAB Modification Indication",
-		zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(msg.MMEUES1APID)),
 		zap.Int("e-rabs-modified", len(modified)))
 
 	m.SendToRadio(ctx, radio.Conn, mme.S1APProcedureERABModificationConfirm, b)

--- a/internal/mme/s1ap/handle_erab_modify_response.go
+++ b/internal/mme/s1ap/handle_erab_modify_response.go
@@ -37,6 +37,6 @@ func handleERABModifyResponse(m *mme.MME, ctx context.Context, radio *mme.Radio,
 
 	if len(resp.ERABFailedToModify) > 0 {
 		logger.MmeLog.Warn("eNB failed to modify E-RAB(s)",
-			zap.Uint32("mme-ue-id", uint32(*resp.MMEUES1APID)), zap.Int("failed", len(resp.ERABFailedToModify)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(*resp.MMEUES1APID)), zap.Int("failed", len(resp.ERABFailedToModify)))
 	}
 }

--- a/internal/mme/s1ap/handle_error_indication.go
+++ b/internal/mme/s1ap/handle_error_indication.go
@@ -36,7 +36,7 @@ func resolveUE(m *mme.MME, conn mme.S1APWriter, mmeID s1ap.MMEUES1APID, enbID s1
 	ue, ok := m.LookupUe(mmeID)
 	if !ok {
 		logger.MmeLog.Warn("UE-associated S1AP message with unknown MME-UE-S1AP-ID",
-			zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint32("enb-ue-id", uint32(enbID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)), zap.Uint32("enb_ue_s1ap_id", uint32(enbID)))
 		sendErrorIndication(m, conn, &mmeID, &enbID, causeUnknownMMEUES1APID)
 
 		return nil, nil, false
@@ -47,7 +47,7 @@ func resolveUE(m *mme.MME, conn mme.S1APWriter, mmeID s1ap.MMEUES1APID, enbID s1
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		logger.MmeLog.Warn("UE-associated S1AP message for an MME-UE-S1AP-ID with no active S1 connection",
-			zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint32("enb-ue-id", uint32(enbID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)), zap.Uint32("enb_ue_s1ap_id", uint32(enbID)))
 		sendErrorIndication(m, conn, &mmeID, &enbID, causeUnknownMMEUES1APID)
 
 		return nil, nil, false
@@ -55,7 +55,7 @@ func resolveUE(m *mme.MME, conn mme.S1APWriter, mmeID s1ap.MMEUES1APID, enbID s1
 
 	if ueConn.Conn() != conn {
 		logger.MmeLog.Warn("UE-associated S1AP message for an MME-UE-S1AP-ID on a different S1 association",
-			zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint32("enb-ue-id", uint32(enbID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)), zap.Uint32("enb_ue_s1ap_id", uint32(enbID)))
 		sendErrorIndication(m, conn, &mmeID, &enbID, causeUnknownMMEUES1APID)
 
 		return nil, nil, false
@@ -63,9 +63,9 @@ func resolveUE(m *mme.MME, conn mme.S1APWriter, mmeID s1ap.MMEUES1APID, enbID s1
 
 	if ueConn.ENBUES1APID != enbID {
 		logger.MmeLog.Warn("UE-associated S1AP message with an inconsistent eNB-UE-S1AP-ID",
-			zap.Uint32("mme-ue-id", uint32(mmeID)),
-			zap.Uint32("stored-enb-ue-id", uint32(ueConn.ENBUES1APID)),
-			zap.Uint32("received-enb-ue-id", uint32(enbID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)),
+			zap.Uint32("stored_enb_ue_s1ap_id", uint32(ueConn.ENBUES1APID)),
+			zap.Uint32("received_enb_ue_s1ap_id", uint32(enbID)))
 		sendErrorIndication(m, conn, &mmeID, &enbID, causeUnknownPairUES1APID)
 
 		return nil, nil, false
@@ -310,11 +310,11 @@ func handleErrorIndication(m *mme.MME, ctx context.Context, radio *mme.Radio, va
 
 	fields := make([]zap.Field, 0, 4)
 	if msg.MMEUES1APID != nil {
-		fields = append(fields, zap.Uint32("mme-ue-id", uint32(*msg.MMEUES1APID)))
+		fields = append(fields, zap.Uint32("mme_ue_s1ap_id", uint32(*msg.MMEUES1APID)))
 	}
 
 	if msg.ENBUES1APID != nil {
-		fields = append(fields, zap.Uint32("enb-ue-id", uint32(*msg.ENBUES1APID)))
+		fields = append(fields, zap.Uint32("enb_ue_s1ap_id", uint32(*msg.ENBUES1APID)))
 	}
 
 	if msg.Cause != nil {
@@ -334,7 +334,7 @@ func handleErrorIndication(m *mme.MME, ctx context.Context, radio *mme.Radio, va
 
 	if ueConn := ue.Conn(); ueConn == nil || ueConn.Conn() != radio.Conn {
 		logger.From(ctx, logger.MmeLog).Warn("Error Indication for an MME-UE-S1AP-ID on a different S1 association",
-			zap.Uint32("mme-ue-id", uint32(*msg.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(*msg.MMEUES1APID)))
 
 		return
 	}

--- a/internal/mme/s1ap/handle_handover_cancel.go
+++ b/internal/mme/s1ap/handle_handover_cancel.go
@@ -60,7 +60,7 @@ func handleHandoverCancel(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 		mme.SendUEContextRelease(ctx, m, releaseConn, releaseMMEID, releaseENBID, pair, releaseCause)
 	}
 
-	logger.From(ctx, logger.MmeLog).Info("Handover Cancel", zap.Uint32("mme-ue-id", uint32(cancel.MMEUES1APID)))
+	logger.From(ctx, logger.MmeLog).Info("Handover Cancel", zap.Uint32("mme_ue_s1ap_id", uint32(cancel.MMEUES1APID)))
 	sendHandoverCancelAcknowledge(m, ctx, radio, cancel)
 }
 

--- a/internal/mme/s1ap/handle_handover_failure.go
+++ b/internal/mme/s1ap/handle_handover_failure.go
@@ -52,7 +52,7 @@ func handleHandoverFailure(m *mme.MME, ctx context.Context, radio *mme.Radio, va
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Handover Failure",
-		zap.Uint32("target-mme-ue-id", uint32(*fail.MMEUES1APID)),
+		zap.Uint32("target_mme_ue_s1ap_id", uint32(*fail.MMEUES1APID)),
 		zap.String("cause", mme.S1apCauseName(&cause)))
 
 	m.FailHandoverToSource(ctx, ue, cause)

--- a/internal/mme/s1ap/handle_handover_notify.go
+++ b/internal/mme/s1ap/handle_handover_notify.go
@@ -33,7 +33,7 @@ func handleHandoverNotify(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 	admitted, ok := m.MarkHandoverCommitting(ue, radio.Conn, notify.ENBUES1APID)
 	if !ok {
 		if _, _, valid := resolveUE(m, radio.Conn, notify.MMEUES1APID, notify.ENBUES1APID); valid {
-			logger.From(ctx, logger.MmeLog).Warn("Handover Notify with no matching prepared handover", zap.Uint32("target-mme-ue-id", uint32(notify.MMEUES1APID)))
+			logger.From(ctx, logger.MmeLog).Warn("Handover Notify with no matching prepared handover", zap.Uint32("target_mme_ue_s1ap_id", uint32(notify.MMEUES1APID)))
 		}
 
 		return
@@ -52,7 +52,7 @@ func handleHandoverNotify(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 	sourceConn, sourceMMEID, sourceENBID, targetMMEID, ok := m.FinishHandoverCommit(ue, radio.Conn, notify.ENBUES1APID)
 	if !ok {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Notify: UE released during the user-plane switch",
-			zap.Uint32("target-mme-ue-id", uint32(notify.MMEUES1APID)))
+			zap.Uint32("target_mme_ue_s1ap_id", uint32(notify.MMEUES1APID)))
 
 		return
 	}
@@ -64,8 +64,8 @@ func handleHandoverNotify(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Handover Notify",
-		zap.Uint32("target-mme-ue-id", uint32(targetMMEID)),
-		zap.Uint32("target-enb-ue-id", uint32(notify.ENBUES1APID)))
+		zap.Uint32("target_mme_ue_s1ap_id", uint32(targetMMEID)),
+		zap.Uint32("target_enb_ue_s1ap_id", uint32(notify.ENBUES1APID)))
 
 	if sourceConn == nil {
 		m.CompleteRelocation(ctx, ue)

--- a/internal/mme/s1ap/handle_handover_request_acknowledge.go
+++ b/internal/mme/s1ap/handle_handover_request_acknowledge.go
@@ -44,7 +44,7 @@ func handleHandoverRequestAcknowledge(m *mme.MME, ctx context.Context, radio *mm
 
 	if !m.MatchAndSetTargetENB(ue, mmeUEID, enbUEID, radio.Conn) {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Request Acknowledge with no matching preparation; dropping",
-			zap.Uint32("target-mme-ue-id", uint32(mmeUEID)))
+			zap.Uint32("target_mme_ue_s1ap_id", uint32(mmeUEID)))
 
 		return
 	}
@@ -55,7 +55,7 @@ func handleHandoverRequestAcknowledge(m *mme.MME, ctx context.Context, radio *mm
 		addr, ok := enbTransportAddress(it.TransportLayerAddress)
 		if !ok {
 			logger.From(ctx, logger.MmeLog).Warn("Handover Request Acknowledge E-RAB has an invalid target address; treating as failed",
-				zap.Uint32("target-mme-ue-id", uint32(mmeUEID)), zap.Uint8("e-rab-id", uint8(it.ERABID)))
+				zap.Uint32("target_mme_ue_s1ap_id", uint32(mmeUEID)), zap.Uint8("e-rab-id", uint8(it.ERABID)))
 
 			continue
 		}
@@ -67,7 +67,7 @@ func handleHandoverRequestAcknowledge(m *mme.MME, ctx context.Context, radio *mm
 
 	if len(admitted) == 0 {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Request Acknowledge admitted no E-RAB; rejecting handover",
-			zap.Uint32("target-mme-ue-id", uint32(mmeUEID)))
+			zap.Uint32("target_mme_ue_s1ap_id", uint32(mmeUEID)))
 		mme.SendUEContextRelease(ctx, m, radio.Conn, mmeUEID, enbUEID, true, causeHOFailureInTarget)
 		m.FailHandoverToSource(ctx, ue, causeHOFailureInTarget)
 
@@ -81,7 +81,7 @@ func handleHandoverRequestAcknowledge(m *mme.MME, ctx context.Context, radio *mm
 
 	if sourceConn == nil {
 		logger.From(ctx, logger.MmeLog).Info("Forward Relocation Response",
-			zap.Uint32("target-mme-ue-id", uint32(mmeUEID)),
+			zap.Uint32("target_mme_ue_s1ap_id", uint32(mmeUEID)),
 			zap.Int("admitted", len(admitted)),
 			zap.Int("not-admitted", len(unadmitted)))
 		m.FinishRelocationPreparation(ue, ack.TargetToSource, unadmitted)
@@ -104,7 +104,7 @@ func handleHandoverRequestAcknowledge(m *mme.MME, ctx context.Context, radio *mm
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Handover Command",
-		zap.Uint32("mme-ue-id", uint32(sourceMMEID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(sourceMMEID)),
 		zap.Int("admitted", len(admitted)),
 		zap.Int("released", len(unadmitted)))
 	m.SendToRadio(ctx, sourceConn, mme.S1APProcedureHandoverCommand, b)

--- a/internal/mme/s1ap/handle_handover_required.go
+++ b/internal/mme/s1ap/handle_handover_required.go
@@ -40,7 +40,7 @@ func handleHandoverRequired(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 
 	if !ue.Secured() || !ue.HasKASME() {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Required for a UE without a security context",
-			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(req.MMEUES1APID)))
 		mme.SendHandoverPreparationFailure(ctx, m, radio.Conn, req.MMEUES1APID, req.ENBUES1APID, causeHandoverNoSecurity)
 
 		return
@@ -54,7 +54,7 @@ func handleHandoverRequired(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 
 	if req.HandoverType != s1ap.HandoverTypeIntraLTE {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Required for an unsupported handover type",
-			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)), zap.Uint8("handover-type", uint8(req.HandoverType)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(req.MMEUES1APID)), zap.Uint8("handover-type", uint8(req.HandoverType)))
 		mme.SendHandoverPreparationFailure(ctx, m, radio.Conn, req.MMEUES1APID, req.ENBUES1APID, causeHOTargetNotAllowed)
 
 		return
@@ -63,7 +63,7 @@ func handleHandoverRequired(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 	target, ok := m.FindConnectedRadioByGlobalENBID(req.TargetID.TargeteNBID.GlobalENBID)
 	if !ok {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Required for an unknown target eNB",
-			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)), zap.String("target-enb", mme.ENBID(req.TargetID.TargeteNBID.GlobalENBID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(req.MMEUES1APID)), zap.String("target-enb", mme.ENBID(req.TargetID.TargeteNBID.GlobalENBID)))
 		mme.SendHandoverPreparationFailure(ctx, m, radio.Conn, req.MMEUES1APID, req.ENBUES1APID, causeUnknownTargetID)
 
 		return
@@ -71,7 +71,7 @@ func handleHandoverRequired(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 
 	if target.Conn == radio.Conn {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Required targets the source eNB",
-			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(req.MMEUES1APID)))
 		mme.SendHandoverPreparationFailure(ctx, m, radio.Conn, req.MMEUES1APID, req.ENBUES1APID, causeHOTargetNotAllowed)
 
 		return
@@ -117,7 +117,7 @@ func handleHandoverRequired(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Handover Request",
-		zap.Uint32("target-mme-ue-id", uint32(targetMMEID)),
+		zap.Uint32("target_mme_ue_s1ap_id", uint32(targetMMEID)),
 		zap.String("target-enb", mme.ENBID(req.TargetID.TargeteNBID.GlobalENBID)),
 		zap.Int("e-rabs", len(bearers)))
 	m.SendToRadio(ctx, target.Conn, mme.S1APProcedureHandoverRequest, b)

--- a/internal/mme/s1ap/handle_initial_context_setup_failure.go
+++ b/internal/mme/s1ap/handle_initial_context_setup_failure.go
@@ -31,7 +31,7 @@ func handleInitialContextSetupFailure(m *mme.MME, ctx context.Context, radio *mm
 
 	ue.TouchLastSeen()
 
-	fields := []zap.Field{zap.Uint32("mme-ue-id", uint32(*msg.MMEUES1APID))}
+	fields := []zap.Field{zap.Uint32("mme_ue_s1ap_id", uint32(*msg.MMEUES1APID))}
 	if msg.Cause != nil {
 		fields = append(fields, zap.String("cause", mme.S1apCauseName(msg.Cause)))
 	}

--- a/internal/mme/s1ap/handle_initial_context_setup_response.go
+++ b/internal/mme/s1ap/handle_initial_context_setup_response.go
@@ -61,7 +61,7 @@ func handleInitialContextSetupResponse(m *mme.MME, ctx context.Context, radio *m
 	setup := len(result.Applied)
 
 	logger.From(ctx, logger.MmeLog).Info("Initial Context Setup Response",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)),
 		zap.Int("e-rabs-setup", setup),
 		zap.Int("e-rabs-released", len(result.Released)))
 
@@ -107,7 +107,7 @@ func setupBearers(ctx context.Context, mmeUEID s1ap.MMEUES1APID, items []setupBe
 		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
 		if !ok {
 			logger.From(ctx, logger.MmeLog).Warn("E-RAB setup item with an invalid eNB transport address",
-				zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			continue
 		}

--- a/internal/mme/s1ap/handle_initial_ue_message.go
+++ b/internal/mme/s1ap/handle_initial_ue_message.go
@@ -53,9 +53,7 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 		c.UpdateLocation(*msg.EUTRANCGI, msg.TAI)
 	}
 
-	logger.From(ctx, c.Log()).Info("Initial UE Message",
-		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),
-	)
+	logger.From(ctx, c.Log()).Info("Initial UE Message")
 
 	// Optimistic S-TMSI resume: a security-protected message whose S-TMSI resolves a
 	// held, secured context is bound to that context only after the message verifies
@@ -91,7 +89,7 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 
 		metrics.RegistrationAttempt(metrics.RAT4G, "Tracking Area Update", metrics.ResultReject)
 		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update rejected; UE will re-attach",
-			zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)), zap.Stringer("cause", cause))
+			zap.Uint32("enb_ue_s1ap_id", uint32(msg.ENBUES1APID)), zap.Stringer("cause", cause))
 		c.SendDownlinkMessage(ctx, &eps.TrackingAreaUpdateReject{Cause: cause})
 
 		m.ReleaseAnsweredBareConn(ctx, c, mme.CauseNASUnspecified)
@@ -100,7 +98,7 @@ func HandleInitialUEMessage(m *mme.MME, ctx context.Context, radio *mme.Radio, v
 	}
 
 	logger.From(ctx, logger.MmeLog).Debug("dropping non-Attach Initial UE Message",
-		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)))
+		zap.Uint32("enb_ue_s1ap_id", uint32(msg.ENBUES1APID)))
 
 	m.ReleaseBareConn(c)
 }

--- a/internal/mme/s1ap/handle_location_report.go
+++ b/internal/mme/s1ap/handle_location_report.go
@@ -43,7 +43,7 @@ func handleLocationReport(m *mme.MME, ctx context.Context, radio *mme.Radio, val
 		ueConn.UpdateLocation(*msg.EUTRANCGI, *msg.TAI)
 	}
 
-	fields := []zap.Field{zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID))}
+	fields := []zap.Field{zap.Uint32("mme_ue_s1ap_id", uint32(msg.MMEUES1APID))}
 	if msg.RequestType != nil {
 		fields = append(fields, zap.Int("event-type", int(msg.RequestType.EventType)))
 	}

--- a/internal/mme/s1ap/handle_lppa_transport.go
+++ b/internal/mme/s1ap/handle_lppa_transport.go
@@ -32,7 +32,7 @@ func handleUplinkLPPaTransport(m *mme.MME, ctx context.Context, radio *mme.Radio
 	ue.SetLPPaMessage([]byte(msg.LPPaPDU))
 
 	logger.From(ctx, radio.Log).Debug("stored uplink LPPa PDU",
-		zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(msg.MMEUES1APID)),
 		zap.Int("payload-len", len(msg.LPPaPDU)),
 	)
 }

--- a/internal/mme/s1ap/handle_nas_non_delivery_indication.go
+++ b/internal/mme/s1ap/handle_nas_non_delivery_indication.go
@@ -37,8 +37,8 @@ func handleNASNonDeliveryIndication(m *mme.MME, ctx context.Context, radio *mme.
 	reportDiagnostics(m, ctx, radio.Conn, s1ap.ProcNASNonDeliveryIndication, s1ap.TriggeringInitiatingMessage, ueAssociated(ueConn.MMEUES1APID, ueConn.ENBUES1APID), msg.Diagnostics())
 
 	fields := []zap.Field{
-		zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)),
-		zap.Uint32("enb-ue-id", uint32(msg.ENBUES1APID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(msg.MMEUES1APID)),
+		zap.Uint32("enb_ue_s1ap_id", uint32(msg.ENBUES1APID)),
 	}
 	if msg.Cause != nil {
 		fields = append(fields, zap.String("cause", mme.S1apCauseName(msg.Cause)))

--- a/internal/mme/s1ap/handle_path_switch_request.go
+++ b/internal/mme/s1ap/handle_path_switch_request.go
@@ -45,7 +45,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	// abnormal condition the MME rejects.
 	if id, dup := duplicateERABID(req.ERABToBeSwitchedDL); dup {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request with a duplicate E-RAB ID",
-			zap.Uint32("source-mme-ue-id", uint32(req.SourceMMEUES1APID)), zap.Uint8("e-rab-id", uint8(id)))
+			zap.Uint32("source_mme_ue_s1ap_id", uint32(req.SourceMMEUES1APID)), zap.Uint8("e-rab-id", uint8(id)))
 		sendPathSwitchFailure(m, radio.Conn, req, causeMultipleERABInstances)
 
 		return
@@ -54,7 +54,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	ue, ok := m.LookupUe(req.SourceMMEUES1APID)
 	if !ok {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request for unknown UE",
-			zap.Uint32("source-mme-ue-id", uint32(req.SourceMMEUES1APID)))
+			zap.Uint32("source_mme_ue_s1ap_id", uint32(req.SourceMMEUES1APID)))
 		sendPathSwitchFailure(m, radio.Conn, req, causeUnknownMMEUES1APID)
 
 		return
@@ -81,7 +81,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	curNH, curNCC, mmeID, ok := m.BeginPathSwitch(ue)
 	if !ok {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request while the key chain is being advanced",
-			zap.Uint32("mme-ue-id", uint32(mmeID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)))
 		sendPathSwitchFailure(m, radio.Conn, req, causePathSwitchUPFailure)
 
 		return
@@ -112,7 +112,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 
 	if len(result.Applied) == 0 {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request switched no E-RAB",
-			zap.Uint32("mme-ue-id", uint32(mmeID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)))
 
 		m.DetachUEAfterPathSwitchFailure(ctx, ue)
 
@@ -126,7 +126,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	ncc, ok := m.CommitPathSwitch(ue, radio.Conn, req.ENBUES1APID, newNH, curNCC)
 	if !ok {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request: UE released during the user-plane switch",
-			zap.Uint32("mme-ue-id", uint32(mmeID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)))
 		sendPathSwitchFailure(m, radio.Conn, req, causePathSwitchUPFailure)
 
 		return
@@ -135,7 +135,7 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	ueConn := ue.Conn()
 	if ueConn == nil {
 		logger.From(ctx, logger.MmeLog).Warn("Path Switch Request: UE released immediately after the path switch",
-			zap.Uint32("mme-ue-id", uint32(mmeID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)))
 
 		return
 	}
@@ -158,8 +158,8 @@ func handlePathSwitchRequest(m *mme.MME, ctx context.Context, radio *mme.Radio, 
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Path Switch Request",
-		zap.Uint32("mme-ue-id", uint32(mmeID)),
-		zap.Uint32("enb-ue-id", uint32(req.ENBUES1APID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)),
+		zap.Uint32("enb_ue_s1ap_id", uint32(req.ENBUES1APID)),
 		zap.Int("e-rabs-switched", len(result.Applied)),
 		zap.Int("e-rabs-released", len(result.Released)),
 		zap.Uint8("ncc", ncc))
@@ -176,7 +176,7 @@ func pathSwitchBearers(ctx context.Context, mmeID s1ap.MMEUES1APID, items []s1ap
 		addr, ok := enbTransportAddress(erab.TransportLayerAddress)
 		if !ok {
 			logger.From(ctx, logger.MmeLog).Warn("Path Switch Request E-RAB has an invalid eNB transport address; not switched",
-				zap.Uint32("mme-ue-id", uint32(mmeID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
+				zap.Uint32("mme_ue_s1ap_id", uint32(mmeID)), zap.Uint8("e-rab-id", uint8(erab.ERABID)))
 
 			undecodable = append(undecodable, uint8(erab.ERABID))
 

--- a/internal/mme/s1ap/handle_ue_context_release_complete.go
+++ b/internal/mme/s1ap/handle_ue_context_release_complete.go
@@ -33,14 +33,14 @@ func HandleUEContextReleaseComplete(m *mme.MME, ctx context.Context, radio *mme.
 	// A Release Complete for a detached association removes only that connection; the UE
 	// stays active on its current association (TS 36.413 §8.3, §8.4).
 	if m.ReleaseDetachedConn(radio.Conn, mmeUEID, enbUEID) {
-		logger.MmeLog.Info("UE Context Release Complete (detached association)", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
+		logger.MmeLog.Info("UE Context Release Complete (detached association)", zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)))
 		return
 	}
 
 	ue, ueConn, ok := resolveUEQuiet(m, radio.Conn, mmeUEID, enbUEID)
 	if !ok {
 		logger.MmeLog.Info("UE Context Release Complete for a connection the MME no longer holds",
-			zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.Uint32("enb-ue-id", uint32(enbUEID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)), zap.Uint32("enb_ue_s1ap_id", uint32(enbUEID)))
 
 		return
 	}
@@ -57,7 +57,7 @@ func HandleUEContextReleaseComplete(m *mme.MME, ctx context.Context, radio *mme.
 	if ue.EMMState() != mme.EMMRegistered {
 		m.ReleaseAllSessions(ctx, ue)
 		m.RemoveUe(ue)
-		logger.MmeLog.Info("UE context released", zap.Uint32("mme-ue-id", uint32(mmeUEID)))
+		logger.MmeLog.Info("UE context released", zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)))
 
 		return
 	}
@@ -69,5 +69,5 @@ func HandleUEContextReleaseComplete(m *mme.MME, ctx context.Context, radio *mme.
 	m.StartMobileReachable(ue)
 
 	logger.MmeLog.Info("UE moved to ECM-IDLE",
-		zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("imsi", ue.IMSI()))
+		zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)), zap.String("imsi", ue.IMSI()))
 }

--- a/internal/mme/s1ap/handover_to_5gs.go
+++ b/internal/mme/s1ap/handover_to_5gs.go
@@ -17,7 +17,7 @@ import (
 func handoverRequiredToFiveGS(m *mme.MME, ctx context.Context, radio *mme.Radio, req *s1ap.HandoverRequired, ue *mme.UeContext, source *mme.UeConn) {
 	if req.TargetID.TargetNgRanNodeID == nil {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Required to 5GS whose target is not an NG-RAN node",
-			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(req.MMEUES1APID)))
 		mme.SendHandoverPreparationFailure(ctx, m, radio.Conn, req.MMEUES1APID, req.ENBUES1APID, causeUnknownTargetID)
 
 		return
@@ -26,7 +26,7 @@ func handoverRequiredToFiveGS(m *mme.MME, ctx context.Context, radio *mme.Radio,
 	target, err := mme.NGRANIdentityFromS1AP(*req.TargetID.TargetNgRanNodeID)
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Warn("Handover Required to 5GS with an unusable NG-RAN node identity",
-			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)), zap.Error(err))
+			zap.Uint32("mme_ue_s1ap_id", uint32(req.MMEUES1APID)), zap.Error(err))
 		mme.SendHandoverPreparationFailure(ctx, m, radio.Conn, req.MMEUES1APID, req.ENBUES1APID, causeUnknownTargetID)
 
 		return
@@ -35,7 +35,7 @@ func handoverRequiredToFiveGS(m *mme.MME, ctx context.Context, radio *mme.Radio,
 	prep, err := m.PrepareHandoverToFiveGS(ue, source, target, req.SourceToTarget, req.Cause)
 	if err != nil {
 		logger.From(ctx, logger.MmeLog).Info("handover to 5GS could not be prepared",
-			zap.Uint32("mme-ue-id", uint32(req.MMEUES1APID)), zap.Error(err))
+			zap.Uint32("mme_ue_s1ap_id", uint32(req.MMEUES1APID)), zap.Error(err))
 		mme.SendHandoverPreparationFailure(ctx, m, radio.Conn, req.MMEUES1APID, req.ENBUES1APID, preparationFailureCause(err))
 
 		return
@@ -59,7 +59,7 @@ func completeHandoverToFiveGS(ctx context.Context, m *mme.MME, ue *mme.UeContext
 
 	if len(resp.AcceptedEPSBearers) == 0 {
 		logger.From(ctx, logger.MmeLog).Warn("the 5GS peer accepted no EPS bearer; failing the preparation",
-			zap.Uint32("mme-ue-id", uint32(source.MMEUES1APID)))
+			zap.Uint32("mme_ue_s1ap_id", uint32(source.MMEUES1APID)))
 
 		if m.AbandonHandoverToFiveGS(ctx, ue, req.ID) {
 			mme.SendHandoverPreparationFailure(ctx, m, source.Conn(), source.MMEUES1APID, source.ENBUES1APID,
@@ -105,7 +105,7 @@ func completeHandoverToFiveGS(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	}
 
 	logger.From(ctx, logger.MmeLog).Info("Handover Command (EPS to 5GS)",
-		zap.Uint32("mme-ue-id", uint32(source.MMEUES1APID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(source.MMEUES1APID)),
 		zap.Int("accepted", len(accepted)),
 		zap.Int("released", len(unadmitted)))
 	m.SendToRadio(ctx, source.Conn(), mme.S1APProcedureHandoverCommand, b)

--- a/internal/mme/status.go
+++ b/internal/mme/status.go
@@ -21,11 +21,17 @@ type ConnectedSubscriber struct {
 	LastSeenAt         time.Time // most recent evidence the UE was present, zero if none
 	Connected          bool
 	Registered         bool
-	CipheringAlgorithm string // EPS NAS ciphering, e.g. "EEA2" (TS 33.401)
-	IntegrityAlgorithm string // EPS NAS integrity, e.g. "EIA2"
+	CipheringAlgorithm string // EPS NAS ciphering, e.g. "128-EEA2" (TS 33.401)
+	IntegrityAlgorithm string // EPS NAS integrity, e.g. "128-EIA2"
+	Connection         *UEConnection
 	// Sessions are the UE's PDN connections, one per active APN, ordered by EPS
 	// bearer identity (TS 23.401).
 	Sessions []SubscriberSession
+}
+
+type UEConnection struct {
+	MMEUES1APID uint32
+	ENBUES1APID *uint32
 }
 
 // SubscriberSession is one PDN connection of an attached UE — a default EPS
@@ -53,6 +59,14 @@ func (m *MME) connectedSubscriber(ue *UeContext) ConnectedSubscriber {
 		LastSeenAt:         snap.LastSeenAt,
 		CipheringAlgorithm: snap.CipheringAlgorithm,
 		IntegrityAlgorithm: snap.IntegrityAlgorithm,
+	}
+
+	if conn := ue.Conn(); conn != nil {
+		cs.Connection = &UEConnection{MMEUES1APID: uint32(conn.MMEUES1APID)}
+		if conn.ENBUES1APID != enbUES1APIDUnspecified {
+			enbID := uint32(conn.ENBUES1APID)
+			cs.Connection.ENBUES1APID = &enbID
+		}
 	}
 
 	cs.Sessions = append(cs.Sessions, m.pdnSessionViews(ue)...)
@@ -153,11 +167,11 @@ func cipheringAlgName(eea nas.CipheringAlgorithm) string {
 	case 0:
 		return "EEA0"
 	case 1:
-		return "EEA1"
+		return "128-EEA1"
 	case 2:
-		return "EEA2"
+		return "128-EEA2"
 	case 3:
-		return "EEA3"
+		return "128-EEA3"
 	default:
 		return ""
 	}
@@ -168,11 +182,11 @@ func integrityAlgName(eia nas.IntegrityAlgorithm) string {
 	case 0:
 		return "EIA0"
 	case 1:
-		return "EIA1"
+		return "128-EIA1"
 	case 2:
-		return "EIA2"
+		return "128-EIA2"
 	case 3:
-		return "EIA3"
+		return "128-EIA3"
 	default:
 		return ""
 	}

--- a/internal/mme/status_test.go
+++ b/internal/mme/status_test.go
@@ -53,8 +53,8 @@ func TestConnectedSubscribers(t *testing.T) {
 		t.Fatalf("NumSessions = %d, want 1", st.NumSessions)
 	}
 
-	if st.CipheringAlgorithm != "EEA2" || st.IntegrityAlgorithm != "EIA2" {
-		t.Fatalf("algorithms = %q/%q, want EEA2/EIA2", st.CipheringAlgorithm, st.IntegrityAlgorithm)
+	if st.CipheringAlgorithm != "128-EEA2" || st.IntegrityAlgorithm != "128-EIA2" {
+		t.Fatalf("algorithms = %q/%q, want 128-EEA2/128-EIA2", st.CipheringAlgorithm, st.IntegrityAlgorithm)
 	}
 
 	if len(st.Sessions) != 1 {

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -146,7 +146,7 @@ func (m *MME) ReleaseUEContextLocally(ue *UeContext, trigger string) {
 	if !registered {
 		m.ReleaseAllSessions(context.Background(), ue)
 		logger.MmeLog.Info("aborted incomplete UE registration",
-			zap.String("trigger", trigger), zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("imsi", imsi))
+			zap.String("trigger", trigger), zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)), zap.String("imsi", imsi))
 
 		return
 	}
@@ -154,5 +154,5 @@ func (m *MME) ReleaseUEContextLocally(ue *UeContext, trigger string) {
 	m.DeactivateAllSessions(context.Background(), ue)
 	m.StartMobileReachable(ue)
 	logger.MmeLog.Info("UE moved to ECM-IDLE",
-		zap.String("trigger", trigger), zap.Uint32("mme-ue-id", uint32(mmeUEID)), zap.String("imsi", imsi))
+		zap.String("trigger", trigger), zap.Uint32("mme_ue_s1ap_id", uint32(mmeUEID)), zap.String("imsi", imsi))
 }

--- a/internal/tester/s1enb/attach.go
+++ b/internal/tester/s1enb/attach.go
@@ -184,7 +184,7 @@ func (e *ENB) Attach(ue *UE, timeout time.Duration) (*AttachResult, error) {
 	}
 
 	logger.GnbLogger.Debug("Attach complete",
-		zap.String("imsi", ue.IMSI), zap.Int64("mme-ue-id", mmeUEID), zap.Int64("enb-ue-id", enbUEID))
+		zap.String("imsi", ue.IMSI), zap.Int64("mme_ue_s1ap_id", mmeUEID), zap.Int64("enb_ue_s1ap_id", enbUEID))
 
 	guti := accept.GUTI
 

--- a/internal/tester/s1enb/handle_lppa.go
+++ b/internal/tester/s1enb/handle_lppa.go
@@ -43,6 +43,6 @@ func (e *ENB) handleDownlinkLPPaTransport(value []byte) {
 	}
 
 	logger.GnbLogger.Debug("s1enb: sent LPPa E-CID response",
-		zap.Uint32("mme-ue-id", uint32(msg.MMEUES1APID)),
+		zap.Uint32("mme_ue_s1ap_id", uint32(msg.MMEUES1APID)),
 		zap.Int64("esmlc-meas-id", parsed.Request.ESMLCUEMeasurementID))
 }

--- a/internal/tester/s1enb/idle_mobility.go
+++ b/internal/tester/s1enb/idle_mobility.go
@@ -179,7 +179,7 @@ func (e *ENB) TrackingAreaUpdateFrom5GS(ue *UE, opts IdleTrackingAreaUpdateOpts,
 	}
 
 	logger.GnbLogger.Debug("Tracking area update from 5GS complete",
-		zap.String("imsi", ue.IMSI), zap.Int64("mme-ue-id", mmeUEID), zap.Int64("enb-ue-id", enbUEID))
+		zap.String("imsi", ue.IMSI), zap.Int64("mme_ue_s1ap_id", mmeUEID), zap.Int64("enb_ue_s1ap_id", enbUEID))
 
 	return &AttachResult{
 		MMEUES1APID:  mmeUEID,
@@ -218,7 +218,7 @@ func (e *ENB) idleTrackingAreaUpdateReturningToIdle(ue *UE, enbUEID int64, timeo
 	}
 
 	logger.GnbLogger.Debug("Tracking area update from 5GS complete, UE returned to idle",
-		zap.String("imsi", ue.IMSI), zap.Int64("mme-ue-id", mmeUEID), zap.Int64("enb-ue-id", enbUEID))
+		zap.String("imsi", ue.IMSI), zap.Int64("mme_ue_s1ap_id", mmeUEID), zap.Int64("enb_ue_s1ap_id", enbUEID))
 
 	return &AttachResult{
 		MMEUES1APID:  mmeUEID,

--- a/internal/tester/scenarios/gnb/pdu_session_release.go
+++ b/internal/tester/scenarios/gnb/pdu_session_release.go
@@ -123,7 +123,13 @@ func awaitSessionCount(ctx context.Context, env scenarios.Env, imsi string, want
 		if err == nil {
 			got = len(sub.Sessions)
 			if got == want {
-				if !sub.Status.Registered {
+				registered := false
+
+				for _, reg := range sub.Registrations {
+					registered = registered || reg.Registered
+				}
+
+				if !registered {
 					return fmt.Errorf("the subscriber reports %d sessions but is no longer registered", got)
 				}
 

--- a/internal/tester/scenarios/interworking/handover.go
+++ b/internal/tester/scenarios/interworking/handover.go
@@ -100,7 +100,7 @@ func runHandover5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "EPS")
+	return assertRegisteredOn(ctx, env, "4G")
 }
 
 // TS 23.003 §2.10.2.1.2
@@ -330,7 +330,7 @@ func runHandover5GSToEPSTargetRefuses(ctx context.Context, env scenarios.Env, _ 
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "5GS")
+	return assertRegisteredOn(ctx, env, "5G")
 }
 
 func refuseHandoverToEPS(gNodeB *gnb.GnodeB, e *s1enb.ENB, ranUENGAPID int64) error {

--- a/internal/tester/scenarios/interworking/handover.go
+++ b/internal/tester/scenarios/interworking/handover.go
@@ -100,7 +100,7 @@ func runHandover5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "4G")
+	return assertRegisteredOn(ctx, env, "EPS")
 }
 
 // TS 23.003 §2.10.2.1.2
@@ -330,7 +330,7 @@ func runHandover5GSToEPSTargetRefuses(ctx context.Context, env scenarios.Env, _ 
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "5G")
+	return assertRegisteredOn(ctx, env, "5GS")
 }
 
 func refuseHandoverToEPS(gNodeB *gnb.GnodeB, e *s1enb.ENB, ranUENGAPID int64) error {

--- a/internal/tester/scenarios/interworking/handover_to_5gs.go
+++ b/internal/tester/scenarios/interworking/handover_to_5gs.go
@@ -97,7 +97,7 @@ func runHandoverEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "5G")
+	return assertRegisteredOn(ctx, env, "5GS")
 }
 
 func runHandoverEPSTo5GSTargetRefuses(ctx context.Context, env scenarios.Env, _ any) error {
@@ -133,7 +133,7 @@ func runHandoverEPSTo5GSTargetRefuses(ctx context.Context, env scenarios.Env, _ 
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "4G")
+	return assertRegisteredOn(ctx, env, "EPS")
 }
 
 func attachAndProbeOverEPS(ctx context.Context, env scenarios.Env, e *s1enb.ENB) (*s1enb.UE, *s1enb.AttachResult, sessionFacts, error) {

--- a/internal/tester/scenarios/interworking/handover_to_5gs.go
+++ b/internal/tester/scenarios/interworking/handover_to_5gs.go
@@ -97,7 +97,7 @@ func runHandoverEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "5GS")
+	return assertRegisteredOn(ctx, env, "5G")
 }
 
 func runHandoverEPSTo5GSTargetRefuses(ctx context.Context, env scenarios.Env, _ any) error {
@@ -133,7 +133,7 @@ func runHandoverEPSTo5GSTargetRefuses(ctx context.Context, env scenarios.Env, _ 
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "EPS")
+	return assertRegisteredOn(ctx, env, "4G")
 }
 
 func attachAndProbeOverEPS(ctx context.Context, env scenarios.Env, e *s1enb.ENB) (*s1enb.UE, *s1enb.AttachResult, sessionFacts, error) {

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -147,7 +147,7 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, activeFlag bool) er
 	}
 
 	if !activeFlag {
-		return assertSessionOn(ctx, env, "4G", before.addrs)
+		return assertSessionOn(ctx, env, "EPS", before.addrs)
 	}
 
 	after, err := probeAfterHandover(ctx, env, e, handoverBearer{
@@ -247,7 +247,7 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, resume resumeUserPl
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "EPS", before.addrs); err != nil {
 		return err
 	}
 
@@ -271,7 +271,7 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, resume resumeUserPl
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "5G", before.addrs)
+	return assertSessionOn(ctx, env, "5GS", before.addrs)
 }
 
 type resumeUserPlane bool
@@ -388,7 +388,7 @@ func runIdleRoundTripThroughEPS(ctx context.Context, env scenarios.Env, _ any) e
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "5GS", before.addrs); err != nil {
 		return err
 	}
 
@@ -442,7 +442,7 @@ func roundTripOutboundLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.Gn
 		return nil, nil, nil, err
 	}
 
-	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "EPS", before.addrs); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -501,7 +501,7 @@ func roundTripReturnLeg(ctx context.Context, env scenarios.Env, e *s1enb.ENB, gN
 			"the UE arrived on a native 5G NAS security context the AMF still holds", got)
 	}
 
-	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "5GS", before.addrs); err != nil {
 		return err
 	}
 
@@ -538,7 +538,7 @@ func roundTripLeaveAgain(ctx context.Context, env scenarios.Env, e *s1enb.ENB, g
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "4G", before.addrs)
+	return assertSessionOn(ctx, env, "EPS", before.addrs)
 }
 
 func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) error {
@@ -568,7 +568,7 @@ func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) e
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "EPS", before.addrs); err != nil {
 		return err
 	}
 
@@ -594,7 +594,7 @@ func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) e
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "5GS", before.addrs); err != nil {
 		return err
 	}
 
@@ -631,7 +631,7 @@ func roundTripReturnToEPS(ctx context.Context, env scenarios.Env, e *s1enb.ENB, 
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "4G", before.addrs)
+	return assertSessionOn(ctx, env, "EPS", before.addrs)
 }
 
 func assertAdoptedSession(plain []byte) error {
@@ -667,9 +667,9 @@ func assertSessionOn(ctx context.Context, env scenarios.Env, want string, addrs 
 		sub, err := cl.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: interworkingIMSI})
 		if err == nil {
 			for _, s := range sub.Sessions {
-				last = s.RadioAccessType
+				last = s.System
 
-				if s.RadioAccessType != want {
+				if s.System != want {
 					continue
 				}
 

--- a/internal/tester/scenarios/interworking/idle.go
+++ b/internal/tester/scenarios/interworking/idle.go
@@ -147,7 +147,7 @@ func runIdle5GSToEPS(ctx context.Context, env scenarios.Env, activeFlag bool) er
 	}
 
 	if !activeFlag {
-		return assertSessionOn(ctx, env, "EPS", before.addrs)
+		return assertSessionOn(ctx, env, "4G", before.addrs)
 	}
 
 	after, err := probeAfterHandover(ctx, env, e, handoverBearer{
@@ -247,7 +247,7 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, resume resumeUserPl
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "EPS", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
 		return err
 	}
 
@@ -271,7 +271,7 @@ func runIdleEPSTo5GS(ctx context.Context, env scenarios.Env, resume resumeUserPl
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "5GS", before.addrs)
+	return assertSessionOn(ctx, env, "5G", before.addrs)
 }
 
 type resumeUserPlane bool
@@ -388,7 +388,7 @@ func runIdleRoundTripThroughEPS(ctx context.Context, env scenarios.Env, _ any) e
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "5GS", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
 		return err
 	}
 
@@ -442,7 +442,7 @@ func roundTripOutboundLeg(ctx context.Context, env scenarios.Env, gNodeB *gnb.Gn
 		return nil, nil, nil, err
 	}
 
-	if err := assertSessionOn(ctx, env, "EPS", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -501,7 +501,7 @@ func roundTripReturnLeg(ctx context.Context, env scenarios.Env, e *s1enb.ENB, gN
 			"the UE arrived on a native 5G NAS security context the AMF still holds", got)
 	}
 
-	if err := assertSessionOn(ctx, env, "5GS", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
 		return err
 	}
 
@@ -538,7 +538,7 @@ func roundTripLeaveAgain(ctx context.Context, env scenarios.Env, e *s1enb.ENB, g
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "EPS", before.addrs)
+	return assertSessionOn(ctx, env, "4G", before.addrs)
 }
 
 func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) error {
@@ -568,7 +568,7 @@ func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) e
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "EPS", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "4G", before.addrs); err != nil {
 		return err
 	}
 
@@ -594,7 +594,7 @@ func runIdleRoundTripThrough5GS(ctx context.Context, env scenarios.Env, _ any) e
 		return err
 	}
 
-	if err := assertSessionOn(ctx, env, "5GS", before.addrs); err != nil {
+	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
 		return err
 	}
 
@@ -631,7 +631,7 @@ func roundTripReturnToEPS(ctx context.Context, env scenarios.Env, e *s1enb.ENB, 
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "EPS", before.addrs)
+	return assertSessionOn(ctx, env, "4G", before.addrs)
 }
 
 func assertAdoptedSession(plain []byte) error {

--- a/internal/tester/scenarios/interworking/idle_bearer_status.go
+++ b/internal/tester/scenarios/interworking/idle_bearer_status.go
@@ -134,7 +134,7 @@ func runIdleEPSTo5GSBearerStatus(ctx context.Context, env scenarios.Env, _ any) 
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "5G", before.addrs)
+	return assertSessionOn(ctx, env, "5GS", before.addrs)
 }
 
 func arriveOn5GSReportingBearerStatus(gNodeB *gnb.GnodeB, epsUE *s1enb.UE, u *ue.UE, epsGUTI eps.GUTI) ([]byte, error) {

--- a/internal/tester/scenarios/interworking/idle_bearer_status.go
+++ b/internal/tester/scenarios/interworking/idle_bearer_status.go
@@ -134,7 +134,7 @@ func runIdleEPSTo5GSBearerStatus(ctx context.Context, env scenarios.Env, _ any) 
 		return err
 	}
 
-	return assertSessionOn(ctx, env, "5GS", before.addrs)
+	return assertSessionOn(ctx, env, "5G", before.addrs)
 }
 
 func arriveOn5GSReportingBearerStatus(gNodeB *gnb.GnodeB, epsUE *s1enb.UE, u *ue.UE, epsGUTI eps.GUTI) ([]byte, error) {

--- a/internal/tester/scenarios/interworking/status.go
+++ b/internal/tester/scenarios/interworking/status.go
@@ -34,20 +34,26 @@ func assertRegisteredOn(ctx context.Context, env scenarios.Env, want string) err
 
 	deadline := time.Now().Add(sessionSettle)
 
-	var last []string
+	last := make([]string, 0, 2)
 
 	for {
 		sub, err := cl.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: interworkingIMSI})
 		if err == nil {
-			last = sub.Status.RadioAccessTypes
+			last = last[:0]
 
-			if sub.Status.Registered && slices.Equal(last, []string{want}) {
+			for _, reg := range sub.Registrations {
+				if reg.Registered {
+					last = append(last, reg.System)
+				}
+			}
+
+			if slices.Equal(last, []string{want}) {
 				return nil
 			}
 		}
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("the subscriber is not registered on %s alone (radio access types %v)", want, last)
+			return fmt.Errorf("the subscriber is not registered on %s alone (registered systems %v)", want, last)
 		}
 
 		time.Sleep(statusPoll)

--- a/internal/tester/scenarios/interworking/status.go
+++ b/internal/tester/scenarios/interworking/status.go
@@ -37,23 +37,28 @@ func assertRegisteredOn(ctx context.Context, env scenarios.Env, want string) err
 	last := make([]string, 0, 2)
 
 	for {
+		registered := false
+
 		sub, err := cl.GetSubscriber(ctx, &client.GetSubscriberOptions{ID: interworkingIMSI})
 		if err == nil {
 			last = last[:0]
 
 			for _, reg := range sub.Registrations {
-				if reg.Registered {
-					last = append(last, reg.System)
+				if reg.ConnectionState == nil {
+					continue
 				}
+
+				last = append(last, reg.System)
+				registered = registered || reg.Registered
 			}
 
-			if slices.Equal(last, []string{want}) {
+			if registered && slices.Equal(last, []string{want}) {
 				return nil
 			}
 		}
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("the subscriber is not registered on %s alone (registered systems %v)", want, last)
+			return fmt.Errorf("the subscriber is not registered on %s alone (systems with a context %v)", want, last)
 		}
 
 		time.Sleep(statusPoll)

--- a/internal/tester/scenarios/interworking/transfer.go
+++ b/internal/tester/scenarios/interworking/transfer.go
@@ -99,7 +99,7 @@ func runTransfer5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "EPS")
+	return assertRegisteredOn(ctx, env, "4G")
 }
 
 func runTransferEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
@@ -165,7 +165,7 @@ func runTransferEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "5GS")
+	return assertRegisteredOn(ctx, env, "5G")
 }
 
 func establishOn5GS(ctx context.Context, env scenarios.Env) (sessionFacts, error) {

--- a/internal/tester/scenarios/interworking/transfer.go
+++ b/internal/tester/scenarios/interworking/transfer.go
@@ -99,7 +99,7 @@ func runTransfer5GSToEPS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "4G")
+	return assertRegisteredOn(ctx, env, "EPS")
 }
 
 func runTransferEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
@@ -165,7 +165,7 @@ func runTransferEPSTo5GS(ctx context.Context, env scenarios.Env, _ any) error {
 		return err
 	}
 
-	return assertRegisteredOn(ctx, env, "5G")
+	return assertRegisteredOn(ctx, env, "5GS")
 }
 
 func establishOn5GS(ctx context.Context, env scenarios.Env) (sessionFacts, error) {

--- a/ui/src/components/SubscriberConnectionCard.tsx
+++ b/ui/src/components/SubscriberConnectionCard.tsx
@@ -6,9 +6,10 @@ import { Box, Card, CardContent, Chip, Typography } from "@mui/material";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Link as RouterLink } from "react-router-dom";
 import AccessChip from "@/components/AccessChip";
-import type {
-  ConnectionState,
-  SubscriberDetailStatus,
+import {
+  SYSTEM_ACCESS_LABELS,
+  type ConnectionState,
+  type SubscriberDetailStatus,
 } from "@/queries/subscribers";
 import { formatRelativeTime } from "@/utils/formatters";
 
@@ -163,7 +164,9 @@ const SecurityAlgorithmsValue: React.FC<{
 const SubscriberConnectionCard: React.FC<SubscriberConnectionCardProps> = ({
   status,
 }) => {
-  const accessTypes = status.radio_access_types ?? [];
+  const accessTypes = (status.systems ?? []).map(
+    (system) => SYSTEM_ACCESS_LABELS[system] ?? system,
+  );
 
   return (
     <Card

--- a/ui/src/components/SubscriberConnectionCard.tsx
+++ b/ui/src/components/SubscriberConnectionCard.tsx
@@ -65,40 +65,15 @@ const InfoRow: React.FC<{
   );
 };
 
-// 5G uses NEA/NIA names; 4G uses EEA/EIA (TS 33.401 §5).
-const CIPHERING_LABELS: Record<string, string> = {
-  NEA0: "NEA0",
-  NEA1: "NEA1",
-  NEA2: "NEA2",
-  NEA3: "NEA3",
-  EEA0: "EEA0",
-  EEA1: "EEA1",
-  EEA2: "EEA2",
-  EEA3: "EEA3",
-};
-
-const INTEGRITY_LABELS: Record<string, string> = {
-  NIA0: "NIA0",
-  NIA1: "NIA1",
-  NIA2: "NIA2",
-  NIA3: "NIA3",
-  EIA0: "EIA0",
-  EIA1: "EIA1",
-  EIA2: "EIA2",
-  EIA3: "EIA3",
-};
-
 /** NEA0/NIA0 (5G) and EEA0/EIA0 (4G) are null ciphering/integrity. */
 const INSECURE_ALGS = new Set(["NEA0", "NIA0", "EEA0", "EIA0"]);
 
 const AlgorithmChip: React.FC<{
   kind: string;
   alg?: string;
-  labels: Record<string, string>;
-}> = ({ kind, alg, labels }) => {
+}> = ({ kind, alg }) => {
   if (!alg) return null;
 
-  const display = labels[alg] ?? alg;
   const isInsecure = INSECURE_ALGS.has(alg);
 
   return (
@@ -110,7 +85,7 @@ const AlgorithmChip: React.FC<{
           <Box component="span" sx={{ opacity: 0.85, fontWeight: 400 }}>
             {kind}:
           </Box>
-          <Box component="span">{display}</Box>
+          <Box component="span">{alg}</Box>
         </Box>
       }
       sx={{
@@ -179,20 +154,8 @@ const SecurityAlgorithmsValue: React.FC<{
     <Box
       sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}
     >
-      {ciphering && (
-        <AlgorithmChip
-          kind="Ciphering"
-          alg={ciphering}
-          labels={CIPHERING_LABELS}
-        />
-      )}
-      {integrity && (
-        <AlgorithmChip
-          kind="Integrity"
-          alg={integrity}
-          labels={INTEGRITY_LABELS}
-        />
-      )}
+      {ciphering && <AlgorithmChip kind="Ciphering" alg={ciphering} />}
+      {integrity && <AlgorithmChip kind="Integrity" alg={integrity} />}
     </Box>
   );
 };

--- a/ui/src/components/SubscriberConnectionCard.tsx
+++ b/ui/src/components/SubscriberConnectionCard.tsx
@@ -135,12 +135,10 @@ const ConnectionChip: React.FC<{ state?: ConnectionState }> = ({ state }) => {
   );
 };
 
-const AccessTypeChips: React.FC<{ accessTypes: string[] }> = ({
-  accessTypes,
-}) => (
+const SystemChips: React.FC<{ systems: string[] }> = ({ systems }) => (
   <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-    {accessTypes.map((accessType) => (
-      <AccessChip key={accessType} label={accessType} />
+    {systems.map((system) => (
+      <AccessChip key={system} label={system} />
     ))}
   </Box>
 );
@@ -164,7 +162,7 @@ const SecurityAlgorithmsValue: React.FC<{
 const SubscriberConnectionCard: React.FC<SubscriberConnectionCardProps> = ({
   status,
 }) => {
-  const accessTypes = (status.systems ?? []).map(
+  const systems = (status.systems ?? []).map(
     (system) => SYSTEM_ACCESS_LABELS[system] ?? system,
   );
 
@@ -185,10 +183,10 @@ const SubscriberConnectionCard: React.FC<SubscriberConnectionCardProps> = ({
           label="Connection"
           value={<ConnectionChip state={status.connection_state} />}
         />
-        {accessTypes.length > 0 && (
+        {systems.length > 0 && (
           <InfoRow
-            label={accessTypes.length > 1 ? "Access Types" : "Access Type"}
-            value={<AccessTypeChips accessTypes={accessTypes} />}
+            label={systems.length > 1 ? "Systems" : "System"}
+            value={<SystemChips systems={systems} />}
           />
         )}
         <InfoRow label="IMEI" value={status.imei} />

--- a/ui/src/components/SubscriberConnectionCard.tsx
+++ b/ui/src/components/SubscriberConnectionCard.tsx
@@ -6,10 +6,9 @@ import { Box, Card, CardContent, Chip, Typography } from "@mui/material";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Link as RouterLink } from "react-router-dom";
 import AccessChip from "@/components/AccessChip";
-import {
-  SYSTEM_ACCESS_LABELS,
-  type ConnectionState,
-  type SubscriberDetailStatus,
+import type {
+  ConnectionState,
+  SubscriberDetailStatus,
 } from "@/queries/subscribers";
 import { formatRelativeTime } from "@/utils/formatters";
 
@@ -162,9 +161,7 @@ const SecurityAlgorithmsValue: React.FC<{
 const SubscriberConnectionCard: React.FC<SubscriberConnectionCardProps> = ({
   status,
 }) => {
-  const systems = (status.systems ?? []).map(
-    (system) => SYSTEM_ACCESS_LABELS[system] ?? system,
-  );
+  const systems = status.systems ?? [];
 
   return (
     <Card

--- a/ui/src/components/SubscriberSessionsCard.tsx
+++ b/ui/src/components/SubscriberSessionsCard.tsx
@@ -32,7 +32,7 @@ const SubscriberSessionsCard: React.FC<SubscriberSessionsCardProps> = ({
       },
       {
         field: "system",
-        headerName: "Access",
+        headerName: "System",
         width: 90,
         valueGetter: (_value, row: SessionInfo) =>
           row.system ? (SYSTEM_ACCESS_LABELS[row.system] ?? row.system) : "",

--- a/ui/src/components/SubscriberSessionsCard.tsx
+++ b/ui/src/components/SubscriberSessionsCard.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "@mui/material/styles";
 import { Link as RouterLink } from "react-router-dom";
 import { type GridColDef, type GridRenderCellParams } from "@mui/x-data-grid";
 import EntityGrid from "@/components/grid/EntityGrid";
-import type { SessionInfo } from "@/queries/subscribers";
+import { SYSTEM_ACCESS_LABELS, type SessionInfo } from "@/queries/subscribers";
 import AccessChip from "@/components/AccessChip";
 
 interface SubscriberSessionsCardProps {
@@ -21,7 +21,7 @@ const SubscriberSessionsCard: React.FC<SubscriberSessionsCardProps> = ({
 }) => {
   const theme = useTheme();
 
-  const has5G = sessions.some((s) => s.radio_access_type === "5G");
+  const has5G = sessions.some((s) => s.system === "5GS");
 
   const columns: GridColDef<SessionInfo>[] = useMemo(
     () => [
@@ -31,9 +31,11 @@ const SubscriberSessionsCard: React.FC<SubscriberSessionsCardProps> = ({
         width: 60,
       },
       {
-        field: "radio_access_type",
+        field: "system",
         headerName: "Access",
         width: 90,
+        valueGetter: (_value, row: SessionInfo) =>
+          row.system ? (SYSTEM_ACCESS_LABELS[row.system] ?? row.system) : "",
         renderCell: (params: GridRenderCellParams<SessionInfo>) =>
           params.value ? (
             <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
@@ -186,7 +188,7 @@ const SubscriberSessionsCard: React.FC<SubscriberSessionsCardProps> = ({
         <EntityGrid<SessionInfo>
           rows={sessions}
           columns={columns}
-          getRowId={(row) => `${row.radio_access_type}-${row.id}`}
+          getRowId={(row) => `${row.system}-${row.id}`}
           hideFooter={sessions.length <= 25}
         />
       )}

--- a/ui/src/components/SubscriberSessionsCard.tsx
+++ b/ui/src/components/SubscriberSessionsCard.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "@mui/material/styles";
 import { Link as RouterLink } from "react-router-dom";
 import { type GridColDef, type GridRenderCellParams } from "@mui/x-data-grid";
 import EntityGrid from "@/components/grid/EntityGrid";
-import { SYSTEM_ACCESS_LABELS, type SessionInfo } from "@/queries/subscribers";
+import type { SessionInfo } from "@/queries/subscribers";
 import AccessChip from "@/components/AccessChip";
 
 interface SubscriberSessionsCardProps {
@@ -21,7 +21,7 @@ const SubscriberSessionsCard: React.FC<SubscriberSessionsCardProps> = ({
 }) => {
   const theme = useTheme();
 
-  const has5G = sessions.some((s) => s.system === "5GS");
+  const has5G = sessions.some((s) => s.system === "5G");
 
   const columns: GridColDef<SessionInfo>[] = useMemo(
     () => [
@@ -34,8 +34,7 @@ const SubscriberSessionsCard: React.FC<SubscriberSessionsCardProps> = ({
         field: "system",
         headerName: "System",
         width: 90,
-        valueGetter: (_value, row: SessionInfo) =>
-          row.system ? (SYSTEM_ACCESS_LABELS[row.system] ?? row.system) : "",
+        valueGetter: (_value, row: SessionInfo) => row.system ?? "",
         renderCell: (params: GridRenderCellParams<SessionInfo>) =>
           params.value ? (
             <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>

--- a/ui/src/pages/ProfileDetail.tsx
+++ b/ui/src/pages/ProfileDetail.tsx
@@ -324,11 +324,11 @@ const ProfileDetail: React.FC = () => {
                     <TableRow>
                       <TableCell sx={labelCellSx}>
                         <Tooltip
-                          title="Radio access technologies subscribers on this profile may use (TS 23.501 §5.3.4)."
+                          title="Systems subscribers on this profile may use."
                           arrow
                           placement="top"
                         >
-                          <span>Access</span>
+                          <span>Systems</span>
                         </Tooltip>
                       </TableCell>
                       <TableCell sx={valueCellSx}>

--- a/ui/src/pages/Profiles.tsx
+++ b/ui/src/pages/Profiles.tsx
@@ -106,9 +106,10 @@ const ProfilesPage: React.FC = () => {
         minWidth: 160,
       },
       {
-        field: "access",
-        headerName: "Access",
-        description: "Radio access technologies this profile permits (4G / 5G)",
+        field: "systems",
+        headerName: "Systems",
+        description:
+          "Systems this profile permits subscribers to use (4G / 5G)",
         flex: 0.6,
         minWidth: 110,
         renderCell: (params: GridRenderCellParams<APIProfile>) => (

--- a/ui/src/pages/SubscriberDetail.tsx
+++ b/ui/src/pages/SubscriberDetail.tsx
@@ -15,6 +15,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   getSubscriber,
   deleteSubscriber,
+  mergeRegistrations,
   type APISubscriber,
 } from "@/queries/subscribers";
 import { useAuth } from "@/contexts/AuthContext";
@@ -163,7 +164,9 @@ const SubscriberDetail: React.FC = () => {
                   gap: 3,
                 }}
               >
-                <SubscriberConnectionCard status={subscriber.status} />
+                <SubscriberConnectionCard
+                  status={mergeRegistrations(subscriber.registrations)}
+                />
               </Box>
             </Box>
 

--- a/ui/src/pages/Subscribers.tsx
+++ b/ui/src/pages/Subscribers.tsx
@@ -21,7 +21,6 @@ import EntityGrid from "@/components/grid/EntityGrid";
 import { Link } from "react-router-dom";
 import {
   listSubscribers,
-  SYSTEM_ACCESS_LABELS,
   type APISubscriberSummary,
   type ListSubscribersResponse,
 } from "@/queries/subscribers";
@@ -259,9 +258,7 @@ const SubscriberPage: React.FC = () => {
         flex: 0.4,
         minWidth: 90,
         valueGetter: (_v, row: APISubscriberSummary) =>
-          (row?.status?.systems ?? [])
-            .map((system) => SYSTEM_ACCESS_LABELS[system] ?? system)
-            .join(" "),
+          (row?.status?.systems ?? []).join(" "),
         renderCell: (params: GridRenderCellParams<APISubscriberSummary>) => {
           const systems = params.row?.status?.systems ?? [];
           if (systems.length === 0) return "—";
@@ -275,10 +272,7 @@ const SubscriberPage: React.FC = () => {
               }}
             >
               {systems.map((system) => (
-                <AccessChip
-                  key={system}
-                  label={SYSTEM_ACCESS_LABELS[system] ?? system}
-                />
+                <AccessChip key={system} label={system} />
               ))}
             </Box>
           );

--- a/ui/src/pages/Subscribers.tsx
+++ b/ui/src/pages/Subscribers.tsx
@@ -155,7 +155,7 @@ const SubscriberPage: React.FC = () => {
       },
       {
         field: "last_seen_radio",
-        headerName: "Last radio",
+        headerName: "Last Radio",
         flex: 0.8,
         minWidth: 110,
         valueGetter: (_v, row: APISubscriberSummary) =>
@@ -254,7 +254,7 @@ const SubscriberPage: React.FC = () => {
         },
       },
       {
-        field: "access",
+        field: "systems",
         headerName: "System",
         flex: 0.4,
         minWidth: 90,
@@ -296,7 +296,7 @@ const SubscriberPage: React.FC = () => {
       children: [
         { field: "registration" },
         { field: "connection" },
-        { field: "access" },
+        { field: "systems" },
       ],
     },
   ];

--- a/ui/src/pages/Subscribers.tsx
+++ b/ui/src/pages/Subscribers.tsx
@@ -255,7 +255,7 @@ const SubscriberPage: React.FC = () => {
       },
       {
         field: "access",
-        headerName: "Access",
+        headerName: "System",
         flex: 0.4,
         minWidth: 90,
         valueGetter: (_v, row: APISubscriberSummary) =>

--- a/ui/src/pages/Subscribers.tsx
+++ b/ui/src/pages/Subscribers.tsx
@@ -21,6 +21,7 @@ import EntityGrid from "@/components/grid/EntityGrid";
 import { Link } from "react-router-dom";
 import {
   listSubscribers,
+  SYSTEM_ACCESS_LABELS,
   type APISubscriberSummary,
   type ListSubscribersResponse,
 } from "@/queries/subscribers";
@@ -258,10 +259,12 @@ const SubscriberPage: React.FC = () => {
         flex: 0.4,
         minWidth: 90,
         valueGetter: (_v, row: APISubscriberSummary) =>
-          (row?.status?.radio_access_types ?? []).join(" "),
+          (row?.status?.systems ?? [])
+            .map((system) => SYSTEM_ACCESS_LABELS[system] ?? system)
+            .join(" "),
         renderCell: (params: GridRenderCellParams<APISubscriberSummary>) => {
-          const rats = params.row?.status?.radio_access_types ?? [];
-          if (rats.length === 0) return "—";
+          const systems = params.row?.status?.systems ?? [];
+          if (systems.length === 0) return "—";
           return (
             <Box
               sx={{
@@ -271,8 +274,11 @@ const SubscriberPage: React.FC = () => {
                 gap: 0.5,
               }}
             >
-              {rats.map((rat) => (
-                <AccessChip key={rat} label={rat} />
+              {systems.map((system) => (
+                <AccessChip
+                  key={system}
+                  label={SYSTEM_ACCESS_LABELS[system] ?? system}
+                />
               ))}
             </Box>
           );

--- a/ui/src/queries/mergeRegistrations.test.ts
+++ b/ui/src/queries/mergeRegistrations.test.ts
@@ -9,12 +9,10 @@ const newer = "2026-08-17T10:05:00Z";
 
 const on5GS: Registration = {
   system: "5GS",
-  access_type: "3GPP",
   registered: true,
   connection_state: "connected",
   radio: "gnb-1",
   last_seen_at: older,
-  pei: "imeisv-4901542032375181",
   imei: "490154203237518",
   ciphering_algorithm: "128-NEA2",
   integrity_algorithm: "128-NIA2",
@@ -23,7 +21,6 @@ const on5GS: Registration = {
 
 const onEPS: Registration = {
   system: "EPS",
-  access_type: "3GPP",
   registered: true,
   connection_state: "connected",
   radio: "enb-1",
@@ -47,7 +44,6 @@ const idle = (r: Registration): Registration => ({
 
 const deregistered = (r: Registration): Registration => ({
   system: r.system,
-  access_type: r.access_type,
   registered: false,
   connection_state: null,
   radio: r.radio,

--- a/ui/src/queries/mergeRegistrations.test.ts
+++ b/ui/src/queries/mergeRegistrations.test.ts
@@ -57,14 +57,14 @@ describe("mergeRegistrations", () => {
 
     expect(merged.registered).toBe(false);
     expect(merged.connection_state).toBeUndefined();
-    expect(merged.radio_access_types).toEqual([]);
+    expect(merged.systems).toEqual([]);
     expect(merged.imei).toBe("");
     expect(merged.last_seen_radio).toBeUndefined();
   });
 
-  it("labels a 5GS registration 5G and an EPS one 4G", () => {
-    expect(mergeRegistrations([on5GS]).radio_access_types).toEqual(["5G"]);
-    expect(mergeRegistrations([onEPS]).radio_access_types).toEqual(["4G"]);
+  it("reports the system each registration belongs to", () => {
+    expect(mergeRegistrations([on5GS]).systems).toEqual(["5GS"]);
+    expect(mergeRegistrations([onEPS]).systems).toEqual(["EPS"]);
   });
 
   it("pairs the serving radio with that registration's algorithms", () => {
@@ -105,7 +105,7 @@ describe("mergeRegistrations", () => {
 
     expect(merged.registered).toBe(false);
     expect(merged.connection_state).toBeUndefined();
-    expect(merged.radio_access_types).toEqual([]);
+    expect(merged.systems).toEqual([]);
     expect(merged.last_seen_radio).toBe("enb-1");
     expect(merged.last_seen_at).toBe(newer);
   });
@@ -117,7 +117,7 @@ describe("mergeRegistrations", () => {
     ]);
 
     expect(merged.registered).toBe(true);
-    expect(merged.radio_access_types).toEqual(["5G"]);
+    expect(merged.systems).toEqual(["5GS"]);
     expect(merged.last_seen_radio).toBe("gnb-1");
     expect(merged.last_seen_at).toBe(older);
   });

--- a/ui/src/queries/mergeRegistrations.test.ts
+++ b/ui/src/queries/mergeRegistrations.test.ts
@@ -7,8 +7,8 @@ import { mergeRegistrations, type Registration } from "@/queries/subscribers";
 const older = "2026-08-17T10:00:00Z";
 const newer = "2026-08-17T10:05:00Z";
 
-const on5GS: Registration = {
-  system: "5GS",
+const on5G: Registration = {
+  system: "5G",
   registered: true,
   connection_state: "connected",
   radio: "gnb-1",
@@ -19,8 +19,8 @@ const on5GS: Registration = {
   connection: { amf_ue_ngap_id: 12, ran_ue_ngap_id: 39 },
 };
 
-const onEPS: Registration = {
-  system: "EPS",
+const on4G: Registration = {
+  system: "4G",
   registered: true,
   connection_state: "connected",
   radio: "enb-1",
@@ -63,12 +63,12 @@ describe("mergeRegistrations", () => {
   });
 
   it("reports the system each registration belongs to", () => {
-    expect(mergeRegistrations([on5GS]).systems).toEqual(["5GS"]);
-    expect(mergeRegistrations([onEPS]).systems).toEqual(["EPS"]);
+    expect(mergeRegistrations([on5G]).systems).toEqual(["5G"]);
+    expect(mergeRegistrations([on4G]).systems).toEqual(["4G"]);
   });
 
   it("pairs the serving radio with that registration's algorithms", () => {
-    const merged = mergeRegistrations([at(on5GS, older), at(onEPS, newer)]);
+    const merged = mergeRegistrations([at(on5G, older), at(on4G, newer)]);
 
     expect(merged.last_seen_radio).toBe("enb-1");
     expect(merged.ciphering_algorithm).toBe("128-EEA2");
@@ -80,7 +80,7 @@ describe("mergeRegistrations", () => {
 
     for (const a of stamps) {
       for (const b of stamps) {
-        const merged = mergeRegistrations([at(on5GS, a), at(onEPS, b)]);
+        const merged = mergeRegistrations([at(on5G, a), at(on4G, b)]);
 
         if (merged.last_seen_radio === "gnb-1") {
           expect(merged.ciphering_algorithm).toBe("128-NEA2");
@@ -92,16 +92,16 @@ describe("mergeRegistrations", () => {
   });
 
   it("is connected when any registration is, and idle when none is", () => {
-    expect(mergeRegistrations([idle(on5GS), onEPS]).connection_state).toBe(
+    expect(mergeRegistrations([idle(on5G), on4G]).connection_state).toBe(
       "connected",
     );
-    expect(
-      mergeRegistrations([idle(on5GS), idle(onEPS)]).connection_state,
-    ).toBe("idle");
+    expect(mergeRegistrations([idle(on5G), idle(on4G)]).connection_state).toBe(
+      "idle",
+    );
   });
 
   it("keeps the last serving radio once the context is released", () => {
-    const merged = mergeRegistrations([deregistered(at(onEPS, newer))]);
+    const merged = mergeRegistrations([deregistered(at(on4G, newer))]);
 
     expect(merged.registered).toBe(false);
     expect(merged.connection_state).toBeUndefined();
@@ -112,17 +112,17 @@ describe("mergeRegistrations", () => {
 
   it("prefers a live registration over a more recent released one", () => {
     const merged = mergeRegistrations([
-      at(on5GS, older),
-      deregistered(at(onEPS, newer)),
+      at(on5G, older),
+      deregistered(at(on4G, newer)),
     ]);
 
     expect(merged.registered).toBe(true);
-    expect(merged.systems).toEqual(["5GS"]);
+    expect(merged.systems).toEqual(["5G"]);
     expect(merged.last_seen_radio).toBe("gnb-1");
     expect(merged.last_seen_at).toBe(older);
   });
 
   it("reports the IMEI rather than the prefixed PEI", () => {
-    expect(mergeRegistrations([on5GS]).imei).toBe("490154203237518");
+    expect(mergeRegistrations([on5G]).imei).toBe("490154203237518");
   });
 });

--- a/ui/src/queries/mergeRegistrations.test.ts
+++ b/ui/src/queries/mergeRegistrations.test.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from "vitest";
+import { mergeRegistrations, type Registration } from "@/queries/subscribers";
+
+const older = "2026-08-17T10:00:00Z";
+const newer = "2026-08-17T10:05:00Z";
+
+const on5GS: Registration = {
+  system: "5GS",
+  access_type: "3GPP",
+  registered: true,
+  connection_state: "connected",
+  radio: "gnb-1",
+  last_seen_at: older,
+  pei: "imeisv-4901542032375181",
+  imei: "490154203237518",
+  ciphering_algorithm: "128-NEA2",
+  integrity_algorithm: "128-NIA2",
+  connection: { amf_ue_ngap_id: 12, ran_ue_ngap_id: 39 },
+};
+
+const onEPS: Registration = {
+  system: "EPS",
+  access_type: "3GPP",
+  registered: true,
+  connection_state: "connected",
+  radio: "enb-1",
+  last_seen_at: older,
+  imei: "490154203237518",
+  ciphering_algorithm: "128-EEA2",
+  integrity_algorithm: "128-EIA2",
+  connection: { mme_ue_s1ap_id: 3, enb_ue_s1ap_id: 42 },
+};
+
+const at = (r: Registration, seen: string): Registration => ({
+  ...r,
+  last_seen_at: seen,
+});
+
+const idle = (r: Registration): Registration => ({
+  ...r,
+  connection_state: "idle",
+  connection: null,
+});
+
+const deregistered = (r: Registration): Registration => ({
+  system: r.system,
+  access_type: r.access_type,
+  registered: false,
+  connection_state: null,
+  radio: r.radio,
+  last_seen_at: r.last_seen_at,
+  connection: null,
+});
+
+describe("mergeRegistrations", () => {
+  it("reports nothing for a subscriber the core has never served", () => {
+    const merged = mergeRegistrations([]);
+
+    expect(merged.registered).toBe(false);
+    expect(merged.connection_state).toBeUndefined();
+    expect(merged.radio_access_types).toEqual([]);
+    expect(merged.imei).toBe("");
+    expect(merged.last_seen_radio).toBeUndefined();
+  });
+
+  it("labels a 5GS registration 5G and an EPS one 4G", () => {
+    expect(mergeRegistrations([on5GS]).radio_access_types).toEqual(["5G"]);
+    expect(mergeRegistrations([onEPS]).radio_access_types).toEqual(["4G"]);
+  });
+
+  it("pairs the serving radio with that registration's algorithms", () => {
+    const merged = mergeRegistrations([at(on5GS, older), at(onEPS, newer)]);
+
+    expect(merged.last_seen_radio).toBe("enb-1");
+    expect(merged.ciphering_algorithm).toBe("128-EEA2");
+    expect(merged.integrity_algorithm).toBe("128-EIA2");
+  });
+
+  it("never pairs a radio with another registration's algorithms", () => {
+    const stamps = [older, newer, "2026-08-17T10:10:00Z"];
+
+    for (const a of stamps) {
+      for (const b of stamps) {
+        const merged = mergeRegistrations([at(on5GS, a), at(onEPS, b)]);
+
+        if (merged.last_seen_radio === "gnb-1") {
+          expect(merged.ciphering_algorithm).toBe("128-NEA2");
+        } else {
+          expect(merged.ciphering_algorithm).toBe("128-EEA2");
+        }
+      }
+    }
+  });
+
+  it("is connected when any registration is, and idle when none is", () => {
+    expect(mergeRegistrations([idle(on5GS), onEPS]).connection_state).toBe(
+      "connected",
+    );
+    expect(
+      mergeRegistrations([idle(on5GS), idle(onEPS)]).connection_state,
+    ).toBe("idle");
+  });
+
+  it("keeps the last serving radio once the context is released", () => {
+    const merged = mergeRegistrations([deregistered(at(onEPS, newer))]);
+
+    expect(merged.registered).toBe(false);
+    expect(merged.connection_state).toBeUndefined();
+    expect(merged.radio_access_types).toEqual([]);
+    expect(merged.last_seen_radio).toBe("enb-1");
+    expect(merged.last_seen_at).toBe(newer);
+  });
+
+  it("prefers a live registration over a more recent released one", () => {
+    const merged = mergeRegistrations([
+      at(on5GS, older),
+      deregistered(at(onEPS, newer)),
+    ]);
+
+    expect(merged.registered).toBe(true);
+    expect(merged.radio_access_types).toEqual(["5G"]);
+    expect(merged.last_seen_radio).toBe("gnb-1");
+    expect(merged.last_seen_at).toBe(older);
+  });
+
+  it("reports the IMEI rather than the prefixed PEI", () => {
+    expect(mergeRegistrations([on5GS]).imei).toBe("490154203237518");
+  });
+});

--- a/ui/src/queries/subscribers.tsx
+++ b/ui/src/queries/subscribers.tsx
@@ -11,7 +11,7 @@ export type ConnectionState = "idle" | "connected";
 export type SubscriberListStatus = {
   registered?: boolean;
   connection_state?: ConnectionState;
-  radio_access_types?: string[];
+  systems?: System[];
   num_sessions?: number;
   last_seen_at?: string;
   last_seen_radio?: string;
@@ -55,7 +55,7 @@ export type Registration = {
 export type SubscriberDetailStatus = {
   registered: boolean;
   connection_state?: ConnectionState;
-  radio_access_types: string[];
+  systems: System[];
   imei: string;
   ciphering_algorithm: string;
   integrity_algorithm: string;
@@ -102,9 +102,7 @@ export function mergeRegistrations(
         : present.some((r) => r.connection_state === "connected")
           ? "connected"
           : "idle",
-    radio_access_types: present.map(
-      (r) => SYSTEM_ACCESS_LABELS[r.system] ?? r.system,
-    ),
+    systems: present.map((r) => r.system),
     imei: present.map((r) => r.imei ?? "").find(Boolean) ?? "",
     ciphering_algorithm: serving?.ciphering_algorithm ?? "",
     integrity_algorithm: serving?.integrity_algorithm ?? "",

--- a/ui/src/queries/subscribers.tsx
+++ b/ui/src/queries/subscribers.tsx
@@ -31,22 +31,97 @@ export type ListSubscribersResponse = {
   total_count: number;
 };
 
-export type SubscriberDetailStatus = {
-  registered?: boolean;
-  connection_state?: ConnectionState;
-  radio_access_types?: string[];
+export type System = "5GS" | "EPS";
+
+export type AccessType = "3GPP" | "non-3GPP";
+
+export type UEConnection = {
+  amf_ue_ngap_id?: number;
+  ran_ue_ngap_id?: number;
+  mme_ue_s1ap_id?: number;
+  enb_ue_s1ap_id?: number;
+};
+
+export type Registration = {
+  system: System;
+  access_type: AccessType;
+  registered: boolean;
+  connection_state: ConnectionState | null;
+  radio?: string;
+  last_seen_at?: string;
+  pei?: string;
   imei?: string;
   ciphering_algorithm?: string;
   integrity_algorithm?: string;
+  connection: UEConnection | null;
+};
+
+export type SubscriberDetailStatus = {
+  registered: boolean;
+  connection_state?: ConnectionState;
+  radio_access_types: string[];
+  imei: string;
+  ciphering_algorithm: string;
+  integrity_algorithm: string;
   last_seen_at?: string;
   last_seen_radio?: string;
 };
+
+export const SYSTEM_ACCESS_LABELS: Record<System, string> = {
+  "5GS": "5G",
+  EPS: "4G",
+};
+
+const isPresent = (registration: Registration) =>
+  registration.connection_state !== null &&
+  registration.connection_state !== undefined;
+
+const seenAt = (registration?: Registration) =>
+  registration?.last_seen_at ? Date.parse(registration.last_seen_at) : 0;
+
+export function mergeRegistrations(
+  registrations: Registration[],
+): SubscriberDetailStatus {
+  const present = registrations.filter(isPresent);
+
+  const serving = present.reduce<Registration | undefined>(
+    (best, candidate) =>
+      !best || seenAt(candidate) > seenAt(best) ? candidate : best,
+    undefined,
+  );
+
+  const retained = registrations.reduce<Registration | undefined>(
+    (best, candidate) =>
+      !best || seenAt(candidate) > seenAt(best) ? candidate : best,
+    undefined,
+  );
+
+  const answering = serving ?? retained;
+
+  return {
+    registered: present.some((r) => r.registered),
+    connection_state:
+      present.length === 0
+        ? undefined
+        : present.some((r) => r.connection_state === "connected")
+          ? "connected"
+          : "idle",
+    radio_access_types: present.map(
+      (r) => SYSTEM_ACCESS_LABELS[r.system] ?? r.system,
+    ),
+    imei: present.map((r) => r.imei ?? r.pei ?? "").find(Boolean) ?? "",
+    ciphering_algorithm: serving?.ciphering_algorithm ?? "",
+    integrity_algorithm: serving?.integrity_algorithm ?? "",
+    last_seen_at: answering?.last_seen_at,
+    last_seen_radio: answering?.radio,
+  };
+}
 
 export type APISubscriber = {
   imsi: string;
   profile_name: string;
   description?: string;
-  status: SubscriberDetailStatus;
+  registrations: Registration[];
   sessions: SessionInfo[];
 };
 
@@ -195,7 +270,8 @@ export interface SliceInfo {
 }
 
 export interface SessionInfo {
-  radio_access_type: string; // "4G" | "5G"
+  system: System;
+  access_types: AccessType[];
   id: number;
   status: string;
   ip_type?: string; // IPv4 | IPv6 | IPv4v6

--- a/ui/src/queries/subscribers.tsx
+++ b/ui/src/queries/subscribers.tsx
@@ -31,7 +31,7 @@ export type ListSubscribersResponse = {
   total_count: number;
 };
 
-export type System = "5GS" | "EPS";
+export type System = "5G" | "4G";
 
 export type UEConnection = {
   amf_ue_ngap_id?: number;
@@ -61,11 +61,6 @@ export type SubscriberDetailStatus = {
   integrity_algorithm: string;
   last_seen_at?: string;
   last_seen_radio?: string;
-};
-
-export const SYSTEM_ACCESS_LABELS: Record<System, string> = {
-  "5GS": "5G",
-  EPS: "4G",
 };
 
 const isPresent = (registration: Registration) =>

--- a/ui/src/queries/subscribers.tsx
+++ b/ui/src/queries/subscribers.tsx
@@ -44,12 +44,10 @@ export type UEConnection = {
 
 export type Registration = {
   system: System;
-  access_type: AccessType;
   registered: boolean;
   connection_state: ConnectionState | null;
   radio?: string;
   last_seen_at?: string;
-  pei?: string;
   imei?: string;
   ciphering_algorithm?: string;
   integrity_algorithm?: string;
@@ -109,7 +107,7 @@ export function mergeRegistrations(
     radio_access_types: present.map(
       (r) => SYSTEM_ACCESS_LABELS[r.system] ?? r.system,
     ),
-    imei: present.map((r) => r.imei ?? r.pei ?? "").find(Boolean) ?? "",
+    imei: present.map((r) => r.imei ?? "").find(Boolean) ?? "",
     ciphering_algorithm: serving?.ciphering_algorithm ?? "",
     integrity_algorithm: serving?.integrity_algorithm ?? "",
     last_seen_at: answering?.last_seen_at,

--- a/ui/src/queries/subscribers.tsx
+++ b/ui/src/queries/subscribers.tsx
@@ -33,8 +33,6 @@ export type ListSubscribersResponse = {
 
 export type System = "5GS" | "EPS";
 
-export type AccessType = "3GPP" | "non-3GPP";
-
 export type UEConnection = {
   amf_ue_ngap_id?: number;
   ran_ue_ngap_id?: number;
@@ -269,7 +267,6 @@ export interface SliceInfo {
 
 export interface SessionInfo {
   system: System;
-  access_types: AccessType[];
   id: number;
   status: string;
   ip_type?: string; // IPv4 | IPv6 | IPv4v6

--- a/ui/src/queries/utils.test.ts
+++ b/ui/src/queries/utils.test.ts
@@ -98,7 +98,7 @@ describe("apiFetch error mapping", () => {
     stubFetch(async () =>
       jsonResponse(400, {
         error:
-          "session_ambr_uplink of 20 Gbps exceeds the 10 Gbps ceiling of a profile that allows 4G (TS 24.008 §10.5.6.5B)",
+          "session_ambr_uplink of 20 Gbps exceeds the 10 Gbps ceiling of a profile that allows 4G",
       }),
     );
 


### PR DESCRIPTION
# Description

Exposes the RAN and core UE identities (RAN/AMF UE NGAP ID, eNB/MME UE S1AP ID) for correlating core events against radio events, both as structured fields on the AMF and MME log lines of a UE-associated connection and as a per-registration breakdown replacing the merged status object on the subscriber detail API.

**Breaking**:
- `status.radio_access_types` becomes `status.systems`
- `sessions[].radio_access_type` becomes `sessions[].system`
- `ciphering_algorithm/integrity_algorithm` report the spec's 128- prefixed names.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
