### PR TITLE
fix(nas): answer UE-requested session modification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,9 +112,8 @@ Ella Core's frontend is built with [Vite](https://vite.dev/) and static files ar
 
 ### Troubleshooting
 
-Restore LXD bridge connectivity when Docker is running on the same system:
+Running Docker on the same system as Ella Core can cause containers to lose connectivity to each other, because an `inet filter` nftables table takes precedence over the rules Docker installs. The symptom is that every integration scenario fails to reach the core (`no N2 peer reachable`, `no S1-MME peer reachable`) while `docker compose up` and the host-published API port still work. `iptables -L` does not show the offending table. Restore Docker networking with:
 
 ```shell
-sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
-sudo iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT
+sudo nft delete table inet filter
 ```

--- a/integration/core_tester_test.go
+++ b/integration/core_tester_test.go
@@ -72,19 +72,20 @@ var scenarioIPFamilyRestrictions = map[string]IPFamily{
 }
 
 var scenarioFollowsDeploymentIPFamily = map[string]bool{
-	"interworking/transfer_5gs_to_eps":                true,
-	"interworking/transfer_eps_to_5gs":                true,
-	"interworking/handover_5gs_to_eps":                true,
-	"interworking/handover_5gs_to_eps_target_refuses": true,
-	"interworking/handover_eps_to_5gs":                true,
-	"interworking/handover_eps_to_5gs_target_refuses": true,
-	"interworking/idle_5gs_to_eps":                    true,
-	"interworking/idle_5gs_to_eps_returning_to_idle":  true,
-	"interworking/idle_eps_to_5gs":                    true,
-	"interworking/idle_eps_to_5gs_returning_to_idle":  true,
-	"interworking/idle_round_trip_through_eps":        true,
-	"interworking/idle_round_trip_through_5gs":        true,
-	"interworking/idle_eps_to_5gs_bearer_status":      true,
+	"interworking/transfer_5gs_to_eps":                  true,
+	"interworking/transfer_eps_to_5gs":                  true,
+	"interworking/handover_5gs_to_eps":                  true,
+	"interworking/handover_5gs_to_eps_target_refuses":   true,
+	"interworking/handover_eps_to_5gs":                  true,
+	"interworking/handover_eps_to_5gs_target_refuses":   true,
+	"interworking/idle_5gs_to_eps":                      true,
+	"interworking/idle_5gs_to_eps_returning_to_idle":    true,
+	"interworking/idle_eps_to_5gs":                      true,
+	"interworking/idle_eps_to_5gs_returning_to_idle":    true,
+	"interworking/idle_round_trip_through_eps":          true,
+	"interworking/idle_round_trip_through_5gs":          true,
+	"interworking/idle_eps_to_5gs_bearer_status":        true,
+	"interworking/idle_eps_to_5gs_session_modification": true,
 }
 
 // scenarioIPFamilyExclusions returns a map of scenario name → set of IP

--- a/internal/decoder/nas/fgs/gsm_session.go
+++ b/internal/decoder/nas/fgs/gsm_session.go
@@ -45,13 +45,15 @@ func gsmOptionalCause(c *fgs.GSMCause, unrecognized []naslib.RawIE) *GSMOptional
 // QoS rules or flows, and the mapped EPS bearers that follow it to 4G
 // (TS 24.501 §8.3.7).
 type PDUSessionModificationRequest struct {
-	Capability5GSM                       *Capability5GSM                     `json:"capability_5gsm,omitempty"`
-	Cause5GSM                            *utils.EnumField                    `json:"cause_5g_s_m,omitempty"`
-	AlwaysonPDUSessionRequested          *bool                               `json:"alwayson_pdu_session_requested,omitempty"`
-	RequestedQosRules                    []QosRule                           `json:"requested_qos_rules,omitempty"`
-	RequestedQosFlowDescriptions         []QoSFlowDescription                `json:"requested_qos_flow_descriptions,omitempty"`
-	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
-	MappedEPSBearerContexts              []MappedEPSBearerContext            `json:"mapped_eps_bearer_contexts,omitempty"`
+	Capability5GSM                        *Capability5GSM                     `json:"capability_5gsm,omitempty"`
+	Cause5GSM                             *utils.EnumField                    `json:"cause_5g_s_m,omitempty"`
+	MaximumNumberOfSupportedPacketFilters *uint16                             `json:"maximum_number_of_supported_packet_filters,omitempty"`
+	IntegrityProtectionMaximumDataRate    *IntegrityProtectionMaximumDataRate `json:"integrity_protection_maximum_data_rate,omitempty"`
+	AlwaysonPDUSessionRequested           *bool                               `json:"alwayson_pdu_session_requested,omitempty"`
+	RequestedQosRules                     []QosRule                           `json:"requested_qos_rules,omitempty"`
+	RequestedQosFlowDescriptions          []QoSFlowDescription                `json:"requested_qos_flow_descriptions,omitempty"`
+	ExtendedProtocolConfigurationOptions  *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
+	MappedEPSBearerContexts               []MappedEPSBearerContext            `json:"mapped_eps_bearer_contexts,omitempty"`
 
 	UnrecognizedIEs []utils.RawIE `json:"unrecognized_ies,omitempty"`
 }
@@ -76,6 +78,15 @@ func buildPDUSessionModificationRequest(msg *fgs.PDUSessionModificationRequest) 
 		out.Cause5GSM = &cause
 	}
 
+	out.MaximumNumberOfSupportedPacketFilters = msg.MaxPacketFilters
+
+	if msg.IntegrityProtMaxDataRate != nil {
+		out.IntegrityProtectionMaximumDataRate = &IntegrityProtectionMaximumDataRate{
+			Uplink:   msg.IntegrityProtMaxDataRate[0],
+			Downlink: msg.IntegrityProtMaxDataRate[1],
+		}
+	}
+
 	if msg.MappedEPSBearerContexts != nil {
 		out.MappedEPSBearerContexts = MappedEPSBearerContextsFromNAS(msg.MappedEPSBearerContexts)
 	}
@@ -89,6 +100,8 @@ func buildPDUSessionModificationRequest(msg *fgs.PDUSessionModificationRequest) 
 // session actually gets (TS 24.501 §8.3.9).
 type PDUSessionModificationCommand struct {
 	SessionAMBR                          *SessionAMBR                        `json:"session_ambr,omitempty"`
+	AlwaysonPDUSessionIndication         *bool                               `json:"alwayson_pdu_session_indication,omitempty"`
+	AuthorizedQosRules                   []QosRule                           `json:"authorized_qos_rules,omitempty"`
 	MappedEPSBearerContexts              []MappedEPSBearerContext            `json:"mapped_eps_bearer_contexts,omitempty"`
 	AuthorizedQosFlowDescriptions        []QoSFlowDescription                `json:"authorized_qos_flow_descriptions,omitempty"`
 	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
@@ -98,6 +111,8 @@ type PDUSessionModificationCommand struct {
 
 func buildPDUSessionModificationCommand(msg *fgs.PDUSessionModificationCommand) *PDUSessionModificationCommand {
 	out := &PDUSessionModificationCommand{
+		AlwaysonPDUSessionIndication:         msg.AlwaysOn,
+		AuthorizedQosRules:                   QosRulesFromNAS(msg.AuthorizedQoSRules),
 		AuthorizedQosFlowDescriptions:        QosFlowDescriptionsFromNAS(msg.QoSFlowDescriptions),
 		ExtendedProtocolConfigurationOptions: nasie.ExtendedPCO(msg.ExtendedPCO),
 	}

--- a/internal/decoder/nas/fgs/gsm_session.go
+++ b/internal/decoder/nas/fgs/gsm_session.go
@@ -101,7 +101,6 @@ func buildPDUSessionModificationRequest(msg *fgs.PDUSessionModificationRequest) 
 type PDUSessionModificationCommand struct {
 	SessionAMBR                          *SessionAMBR                        `json:"session_ambr,omitempty"`
 	AlwaysonPDUSessionIndication         *bool                               `json:"alwayson_pdu_session_indication,omitempty"`
-	AuthorizedQosRules                   []QosRule                           `json:"authorized_qos_rules,omitempty"`
 	MappedEPSBearerContexts              []MappedEPSBearerContext            `json:"mapped_eps_bearer_contexts,omitempty"`
 	AuthorizedQosFlowDescriptions        []QoSFlowDescription                `json:"authorized_qos_flow_descriptions,omitempty"`
 	ExtendedProtocolConfigurationOptions *nasie.ProtocolConfigurationOptions `json:"extended_protocol_configuration_options,omitempty"`
@@ -112,7 +111,6 @@ type PDUSessionModificationCommand struct {
 func buildPDUSessionModificationCommand(msg *fgs.PDUSessionModificationCommand) *PDUSessionModificationCommand {
 	out := &PDUSessionModificationCommand{
 		AlwaysonPDUSessionIndication:         msg.AlwaysOn,
-		AuthorizedQosRules:                   QosRulesFromNAS(msg.AuthorizedQoSRules),
 		AuthorizedQosFlowDescriptions:        QosFlowDescriptionsFromNAS(msg.QoSFlowDescriptions),
 		ExtendedProtocolConfigurationOptions: nasie.ExtendedPCO(msg.ExtendedPCO),
 	}

--- a/internal/mme/bearer_support.go
+++ b/internal/mme/bearer_support.go
@@ -66,24 +66,6 @@ func (ue *UeContext) PDNCount() int {
 	return len(ue.Pdns)
 }
 
-func (ue *UeContext) BeginUnchangedBearerModification(p *PdnConnection) bool {
-	ue.mu.Lock()
-	defer ue.mu.Unlock()
-
-	if p.Deactivating || p.Modifying {
-		return false
-	}
-
-	p.Modifying = true
-	p.PendingDNConfig = p.DnConfig
-	p.PendingSessAmbrDLBps = p.SessAmbrDLBps
-	p.PendingSessAmbrULBps = p.SessAmbrULBps
-	p.PendingQCI = p.Qci
-	p.PendingARP = p.Arp
-
-	return true
-}
-
 // CommitBearerModification commits a PDN connection's pending in-place
 // modification, reporting false (a no-op) if no modification was in flight
 // (TS 24.301 §6.4.2.3).

--- a/internal/mme/bearer_support.go
+++ b/internal/mme/bearer_support.go
@@ -66,6 +66,24 @@ func (ue *UeContext) PDNCount() int {
 	return len(ue.Pdns)
 }
 
+func (ue *UeContext) BeginUnchangedBearerModification(p *PdnConnection) bool {
+	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
+	if p.Deactivating || p.Modifying {
+		return false
+	}
+
+	p.Modifying = true
+	p.PendingDNConfig = p.DnConfig
+	p.PendingSessAmbrDLBps = p.SessAmbrDLBps
+	p.PendingSessAmbrULBps = p.SessAmbrULBps
+	p.PendingQCI = p.Qci
+	p.PendingARP = p.Arp
+
+	return true
+}
+
 // CommitBearerModification commits a PDN connection's pending in-place
 // modification, reporting false (a no-op) if no modification was in flight
 // (TS 24.301 §6.4.2.3).

--- a/internal/mme/nas/bearer_resource.go
+++ b/internal/mme/nas/bearer_resource.go
@@ -30,21 +30,93 @@ func handleBearerResourceAllocationRequest(ctx context.Context, ue *mme.UeContex
 	return nasreply.Handled()
 }
 
-// handleBearerResourceModificationRequest always rejects: the bearer QoS is
-// network-determined, not UE-modifiable (TS 24.301 §6.5.4).
-func handleBearerResourceModificationRequest(ctx context.Context, ue *mme.UeContext, ueConn *mme.UeConn, req *eps.BearerResourceModificationRequest) nasreply.Disposition {
-	pti := req.PTI
+const tftOperationNoOperation uint8 = 0x06
 
-	cause := esmRequestHeaderCause(uint8(pti), uint8(req.EPSBearerIdentity))
-	if cause == 0 {
-		cause = eps.ESMCauseRequestRejectedUnspecified
+func requestsBearerResources(req *eps.BearerResourceModificationRequest) bool {
+	if req.RequiredTrafficFlowQoS != nil {
+		return true
 	}
 
-	logger.From(ctx, logger.MmeLog).Info("bearer resource modification rejected",
-		zap.String("imsi", ue.IMSI()), zap.Uint8("pti", uint8(pti)), zap.Stringer("esm-cause", cause))
-	rejectBearerResourceModification(ctx, ueConn, uint8(pti), cause)
+	if len(req.TrafficFlowAggregate) == 0 {
+		return false
+	}
+
+	return req.TrafficFlowAggregate[0]>>5 != tftOperationNoOperation
+}
+
+func handleBearerResourceModificationRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, req *eps.BearerResourceModificationRequest) nasreply.Disposition {
+	pti := req.PTI
+
+	if cause := esmRequestHeaderCause(uint8(pti), uint8(req.EPSBearerIdentity)); cause != 0 {
+		logger.From(ctx, logger.MmeLog).Info("bearer resource modification rejected",
+			zap.String("imsi", ue.IMSI()), zap.Uint8("pti", uint8(pti)), zap.Stringer("esm-cause", cause))
+		rejectBearerResourceModification(ctx, ueConn, uint8(pti), cause)
+
+		return nasreply.Handled()
+	}
+
+	if requestsBearerResources(req) {
+		cause := eps.ESMCauseEPSQoSNotAccepted
+
+		logger.From(ctx, logger.MmeLog).Info("bearer resource modification rejected",
+			zap.String("imsi", ue.IMSI()), zap.Uint8("pti", uint8(pti)), zap.Stringer("esm-cause", cause))
+		rejectBearerResourceModification(ctx, ueConn, uint8(pti), cause)
+
+		return nasreply.Handled()
+	}
+
+	if !acceptUnchangedBearerModification(ctx, m, ue, ueConn, uint8(req.EPSBearerIdentityForPacketFilter), uint8(pti)) {
+		rejectBearerResourceModification(ctx, ueConn, uint8(pti), eps.ESMCauseInvalidEPSBearerIdentity)
+	}
 
 	return nasreply.Handled()
+}
+
+func acceptUnchangedBearerModification(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, ebi, pti uint8) bool {
+	p := m.LookupPDN(ue, ebi)
+	if p == nil {
+		return false
+	}
+
+	if !ue.BeginUnchangedBearerModification(p) {
+		return false
+	}
+
+	plain, err := (&eps.ModifyEPSBearerContextRequest{
+		EPSBearerIdentity: eps.EPSBearerIdentity(ebi),
+		PTI:               nas.ProcedureTransactionIdentity(pti),
+	}).MarshalBinary()
+	if err != nil {
+		ue.ClearPendingModify(p)
+
+		logger.From(ctx, logger.MmeLog).Error("failed to build Modify EPS Bearer Context Request",
+			zap.String("imsi", ue.IMSI()), zap.Error(err))
+
+		return false
+	}
+
+	write := func(wire []byte) error {
+		ueConn.SendDownlinkNASTransport(ctx, wire)
+
+		return nil
+	}
+
+	if err := ueConn.SendProtected(plain, eps.SHTIntegrityProtectedCiphered, write); err != nil {
+		ue.ClearPendingModify(p)
+
+		mme.ReportProtectFailure(ctx, ueConn, "Modify EPS Bearer Context Request", err)
+
+		return false
+	}
+
+	m.ArmESMGuardAbortOnly(ue, p, "Modify EPS Bearer Context Request", plain, eps.SHTIntegrityProtectedCiphered, func() {
+		ue.ClearPendingModify(p)
+	})
+
+	logger.From(ctx, logger.MmeLog).Info("accepted a UE requested bearer resource modification that asked for no bearer resources",
+		zap.String("imsi", ue.IMSI()), zap.Uint8("pti", pti), zap.String("apn", p.Apn))
+
+	return true
 }
 
 func rejectBearerResourceAllocation(ctx context.Context, ueConn *mme.UeConn, pti uint8, cause eps.ESMCause) {

--- a/internal/mme/nas/bearer_resource.go
+++ b/internal/mme/nas/bearer_resource.go
@@ -30,93 +30,21 @@ func handleBearerResourceAllocationRequest(ctx context.Context, ue *mme.UeContex
 	return nasreply.Handled()
 }
 
-const tftOperationNoOperation uint8 = 0x06
-
-func requestsBearerResources(req *eps.BearerResourceModificationRequest) bool {
-	if req.RequiredTrafficFlowQoS != nil {
-		return true
-	}
-
-	if len(req.TrafficFlowAggregate) == 0 {
-		return false
-	}
-
-	return req.TrafficFlowAggregate[0]>>5 != tftOperationNoOperation
-}
-
-func handleBearerResourceModificationRequest(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, req *eps.BearerResourceModificationRequest) nasreply.Disposition {
+// handleBearerResourceModificationRequest always rejects: the bearer QoS is
+// network-determined, not UE-modifiable (TS 24.301 §6.5.4).
+func handleBearerResourceModificationRequest(ctx context.Context, ue *mme.UeContext, ueConn *mme.UeConn, req *eps.BearerResourceModificationRequest) nasreply.Disposition {
 	pti := req.PTI
 
-	if cause := esmRequestHeaderCause(uint8(pti), uint8(req.EPSBearerIdentity)); cause != 0 {
-		logger.From(ctx, logger.MmeLog).Info("bearer resource modification rejected",
-			zap.String("imsi", ue.IMSI()), zap.Uint8("pti", uint8(pti)), zap.Stringer("esm-cause", cause))
-		rejectBearerResourceModification(ctx, ueConn, uint8(pti), cause)
-
-		return nasreply.Handled()
+	cause := esmRequestHeaderCause(uint8(pti), uint8(req.EPSBearerIdentity))
+	if cause == 0 {
+		cause = eps.ESMCauseEPSQoSNotAccepted
 	}
 
-	if requestsBearerResources(req) {
-		cause := eps.ESMCauseEPSQoSNotAccepted
-
-		logger.From(ctx, logger.MmeLog).Info("bearer resource modification rejected",
-			zap.String("imsi", ue.IMSI()), zap.Uint8("pti", uint8(pti)), zap.Stringer("esm-cause", cause))
-		rejectBearerResourceModification(ctx, ueConn, uint8(pti), cause)
-
-		return nasreply.Handled()
-	}
-
-	if !acceptUnchangedBearerModification(ctx, m, ue, ueConn, uint8(req.EPSBearerIdentityForPacketFilter), uint8(pti)) {
-		rejectBearerResourceModification(ctx, ueConn, uint8(pti), eps.ESMCauseInvalidEPSBearerIdentity)
-	}
+	logger.From(ctx, logger.MmeLog).Info("bearer resource modification rejected",
+		zap.String("imsi", ue.IMSI()), zap.Uint8("pti", uint8(pti)), zap.Stringer("esm-cause", cause))
+	rejectBearerResourceModification(ctx, ueConn, uint8(pti), cause)
 
 	return nasreply.Handled()
-}
-
-func acceptUnchangedBearerModification(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn *mme.UeConn, ebi, pti uint8) bool {
-	p := m.LookupPDN(ue, ebi)
-	if p == nil {
-		return false
-	}
-
-	if !ue.BeginUnchangedBearerModification(p) {
-		return false
-	}
-
-	plain, err := (&eps.ModifyEPSBearerContextRequest{
-		EPSBearerIdentity: eps.EPSBearerIdentity(ebi),
-		PTI:               nas.ProcedureTransactionIdentity(pti),
-	}).MarshalBinary()
-	if err != nil {
-		ue.ClearPendingModify(p)
-
-		logger.From(ctx, logger.MmeLog).Error("failed to build Modify EPS Bearer Context Request",
-			zap.String("imsi", ue.IMSI()), zap.Error(err))
-
-		return false
-	}
-
-	write := func(wire []byte) error {
-		ueConn.SendDownlinkNASTransport(ctx, wire)
-
-		return nil
-	}
-
-	if err := ueConn.SendProtected(plain, eps.SHTIntegrityProtectedCiphered, write); err != nil {
-		ue.ClearPendingModify(p)
-
-		mme.ReportProtectFailure(ctx, ueConn, "Modify EPS Bearer Context Request", err)
-
-		return false
-	}
-
-	m.ArmESMGuardAbortOnly(ue, p, "Modify EPS Bearer Context Request", plain, eps.SHTIntegrityProtectedCiphered, func() {
-		ue.ClearPendingModify(p)
-	})
-
-	logger.From(ctx, logger.MmeLog).Info("accepted a UE requested bearer resource modification that asked for no bearer resources",
-		zap.String("imsi", ue.IMSI()), zap.Uint8("pti", pti), zap.String("apn", p.Apn))
-
-	return true
 }
 
 func rejectBearerResourceAllocation(ctx context.Context, ueConn *mme.UeConn, pti uint8, cause eps.ESMCause) {

--- a/internal/mme/nas/bearer_resource_test.go
+++ b/internal/mme/nas/bearer_resource_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/ellanetworks/core/nas/eps"
 )
@@ -40,17 +39,11 @@ func TestBearerResourceAllocationRejected(t *testing.T) {
 	}
 }
 
-func TestBearerResourceModificationForResourcesRejected(t *testing.T) {
+func TestBearerResourceModificationRejected(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	testPDN(ue)
-
-	req, err := (&eps.BearerResourceModificationRequest{
-		PTI:                              7,
-		EPSBearerIdentityForPacketFilter: eps.EPSBearerIdentity(mme.DefaultERABID),
-		TrafficFlowAggregate:             []byte{0x41, 0x01},
-	}).MarshalBinary()
+	req, err := (&eps.BearerResourceModificationRequest{PTI: 7}).MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,69 +64,6 @@ func TestBearerResourceModificationForResourcesRejected(t *testing.T) {
 
 	if reject.Cause != eps.ESMCauseEPSQoSNotAccepted {
 		t.Fatalf("ESM cause = %d, want %d (EPS QoS not accepted)", reject.Cause, eps.ESMCauseEPSQoSNotAccepted)
-	}
-}
-
-func TestBearerResourceModificationWithoutResourcesAccepted(t *testing.T) {
-	m := newTestMME(t)
-	ue, cc := securedUE(t, m)
-
-	testPDN(ue)
-
-	req, err := (&eps.BearerResourceModificationRequest{
-		PTI:                              7,
-		EPSBearerIdentityForPacketFilter: eps.EPSBearerIdentity(mme.DefaultERABID),
-		TrafficFlowAggregate:             []byte{0xC0},
-	}).MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	d := HandleEmmMessage(context.Background(), m, ue, ue.Conn(), req, true)
-	if d.Action != nasreply.ActionHandled {
-		t.Fatalf("disposition = %+v, want ActionHandled", d)
-	}
-
-	modify, err := eps.ParseModifyEPSBearerContextRequest(lastDownlinkESM(t, ue, cc))
-	if err != nil {
-		t.Fatalf("expected a Modify EPS Bearer Context Request: %v", err)
-	}
-
-	if modify.PTI != 7 {
-		t.Fatalf("PTI = %d, want 7 (echoed from the request, TS 24.301 §6.5.4.3)", modify.PTI)
-	}
-
-	if uint8(modify.EPSBearerIdentity) != mme.DefaultERABID {
-		t.Fatalf("EPS bearer identity = %d, want %d", modify.EPSBearerIdentity, mme.DefaultERABID)
-	}
-
-	if modify.NewEPSQoS != nil || modify.APNAMBR != nil {
-		t.Error("the acceptance changed a bearer parameter the UE did not ask about")
-	}
-}
-
-func TestBearerResourceModificationUnknownBearerRejected(t *testing.T) {
-	m := newTestMME(t)
-	ue, cc := securedUE(t, m)
-
-	req, err := (&eps.BearerResourceModificationRequest{
-		PTI:                              7,
-		EPSBearerIdentityForPacketFilter: 9,
-		TrafficFlowAggregate:             []byte{0xC0},
-	}).MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	HandleEmmMessage(context.Background(), m, ue, ue.Conn(), req, true)
-
-	reject, err := eps.ParseBearerResourceModificationReject(lastDownlinkESM(t, ue, cc))
-	if err != nil {
-		t.Fatalf("expected a Bearer Resource Modification Reject: %v", err)
-	}
-
-	if reject.Cause != eps.ESMCauseInvalidEPSBearerIdentity {
-		t.Fatalf("ESM cause = %d, want %d (invalid EPS bearer identity)", reject.Cause, eps.ESMCauseInvalidEPSBearerIdentity)
 	}
 }
 

--- a/internal/mme/nas/bearer_resource_test.go
+++ b/internal/mme/nas/bearer_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ellanetworks/core/internal/mme"
 	"github.com/ellanetworks/core/internal/nasreply"
 	"github.com/ellanetworks/core/nas/eps"
 )
@@ -39,11 +40,17 @@ func TestBearerResourceAllocationRejected(t *testing.T) {
 	}
 }
 
-func TestBearerResourceModificationRejected(t *testing.T) {
+func TestBearerResourceModificationForResourcesRejected(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	req, err := (&eps.BearerResourceModificationRequest{PTI: 7}).MarshalBinary()
+	testPDN(ue)
+
+	req, err := (&eps.BearerResourceModificationRequest{
+		PTI:                              7,
+		EPSBearerIdentityForPacketFilter: eps.EPSBearerIdentity(mme.DefaultERABID),
+		TrafficFlowAggregate:             []byte{0x41, 0x01},
+	}).MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,8 +69,71 @@ func TestBearerResourceModificationRejected(t *testing.T) {
 		t.Fatalf("PTI = %d, want 7 (echoed from the request)", reject.PTI)
 	}
 
-	if reject.Cause != eps.ESMCauseRequestRejectedUnspecified {
-		t.Fatalf("ESM cause = %d, want %d (request rejected, unspecified)", reject.Cause, eps.ESMCauseRequestRejectedUnspecified)
+	if reject.Cause != eps.ESMCauseEPSQoSNotAccepted {
+		t.Fatalf("ESM cause = %d, want %d (EPS QoS not accepted)", reject.Cause, eps.ESMCauseEPSQoSNotAccepted)
+	}
+}
+
+func TestBearerResourceModificationWithoutResourcesAccepted(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	testPDN(ue)
+
+	req, err := (&eps.BearerResourceModificationRequest{
+		PTI:                              7,
+		EPSBearerIdentityForPacketFilter: eps.EPSBearerIdentity(mme.DefaultERABID),
+		TrafficFlowAggregate:             []byte{0xC0},
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := HandleEmmMessage(context.Background(), m, ue, ue.Conn(), req, true)
+	if d.Action != nasreply.ActionHandled {
+		t.Fatalf("disposition = %+v, want ActionHandled", d)
+	}
+
+	modify, err := eps.ParseModifyEPSBearerContextRequest(lastDownlinkESM(t, ue, cc))
+	if err != nil {
+		t.Fatalf("expected a Modify EPS Bearer Context Request: %v", err)
+	}
+
+	if modify.PTI != 7 {
+		t.Fatalf("PTI = %d, want 7 (echoed from the request, TS 24.301 §6.5.4.3)", modify.PTI)
+	}
+
+	if uint8(modify.EPSBearerIdentity) != mme.DefaultERABID {
+		t.Fatalf("EPS bearer identity = %d, want %d", modify.EPSBearerIdentity, mme.DefaultERABID)
+	}
+
+	if modify.NewEPSQoS != nil || modify.APNAMBR != nil {
+		t.Error("the acceptance changed a bearer parameter the UE did not ask about")
+	}
+}
+
+func TestBearerResourceModificationUnknownBearerRejected(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	req, err := (&eps.BearerResourceModificationRequest{
+		PTI:                              7,
+		EPSBearerIdentityForPacketFilter: 9,
+		TrafficFlowAggregate:             []byte{0xC0},
+	}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	HandleEmmMessage(context.Background(), m, ue, ue.Conn(), req, true)
+
+	reject, err := eps.ParseBearerResourceModificationReject(lastDownlinkESM(t, ue, cc))
+	if err != nil {
+		t.Fatalf("expected a Bearer Resource Modification Reject: %v", err)
+	}
+
+	if reject.Cause != eps.ESMCauseInvalidEPSBearerIdentity {
+		t.Fatalf("ESM cause = %d, want %d (invalid EPS bearer identity)", reject.Cause, eps.ESMCauseInvalidEPSBearerIdentity)
 	}
 }
 

--- a/internal/mme/nas/esm.go
+++ b/internal/mme/nas/esm.go
@@ -30,7 +30,7 @@ func handleESMMessage(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn
 	case *eps.BearerResourceAllocationRequest:
 		return handleBearerResourceAllocationRequest(ctx, ue, ueConn, msg)
 	case *eps.BearerResourceModificationRequest:
-		return handleBearerResourceModificationRequest(ctx, m, ue, ueConn, msg)
+		return handleBearerResourceModificationRequest(ctx, ue, ueConn, msg)
 	case *eps.ActivateDefaultEPSBearerContextAccept:
 		return handleActivateDefaultBearerAccept(ctx, m, ue, msg)
 	case *eps.ActivateDefaultEPSBearerContextReject:

--- a/internal/mme/nas/esm.go
+++ b/internal/mme/nas/esm.go
@@ -30,7 +30,7 @@ func handleESMMessage(ctx context.Context, m *mme.MME, ue *mme.UeContext, ueConn
 	case *eps.BearerResourceAllocationRequest:
 		return handleBearerResourceAllocationRequest(ctx, ue, ueConn, msg)
 	case *eps.BearerResourceModificationRequest:
-		return handleBearerResourceModificationRequest(ctx, ue, ueConn, msg)
+		return handleBearerResourceModificationRequest(ctx, m, ue, ueConn, msg)
 	case *eps.ActivateDefaultEPSBearerContextAccept:
 		return handleActivateDefaultBearerAccept(ctx, m, ue, msg)
 	case *eps.ActivateDefaultEPSBearerContextReject:

--- a/internal/smf/lifecycle_test.go
+++ b/internal/smf/lifecycle_test.go
@@ -996,12 +996,12 @@ func TestReconcileSmContext_UsesNewPolicyForPFCPAndN1N2(t *testing.T) {
 	call := amfCb.modifyCalls[0]
 	amfCb.mu.Unlock()
 
-	oldPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: models.MustParseBitRate("100 Mbps"), Downlink: models.MustParseBitRate("200 Mbps")}, &models.QosData{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 1}, QFI: 1}, nil, 0, nil)
+	oldPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, 0, &models.Ambr{Uplink: models.MustParseBitRate("100 Mbps"), Downlink: models.MustParseBitRate("200 Mbps")}, &models.QosData{Var5qi: 9, Arp: &models.Arp{PriorityLevel: 1}, QFI: 1}, nil, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("build old policy modification command: %v", err)
 	}
 
-	newPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: models.MustParseBitRate("200 Mbps"), Downlink: models.MustParseBitRate("300 Mbps")}, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1}, nil, 0, nil)
+	newPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, 0, &models.Ambr{Uplink: models.MustParseBitRate("200 Mbps"), Downlink: models.MustParseBitRate("300 Mbps")}, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1}, nil, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("build new policy modification command: %v", err)
 	}
@@ -1055,7 +1055,7 @@ func TestReconcileSmContext_AmbrOnly(t *testing.T) {
 		t.Fatalf("QER MBR = %d/%d, want 300000/400000", qer.MBR.ULMBR, qer.MBR.DLMBR)
 	}
 
-	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, &models.Ambr{Uplink: models.MustParseBitRate("300 Mbps"), Downlink: models.MustParseBitRate("400 Mbps")}, nil, nil, 0, nil)
+	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, 0, &models.Ambr{Uplink: models.MustParseBitRate("300 Mbps"), Downlink: models.MustParseBitRate("400 Mbps")}, nil, nil, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("build expected N1: %v", err)
 	}
@@ -1092,7 +1092,7 @@ func TestReconcileSmContext_QoSOnly(t *testing.T) {
 		t.Fatalf("QER MBR = %d/%d, want 100000/200000", qer.MBR.ULMBR, qer.MBR.DLMBR)
 	}
 
-	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, nil, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1}, nil, 0, nil)
+	expectedPayload, err := smfNas.BuildPDUSessionModificationCommand(smCtx.PDUSessionID, 0, nil, &models.QosData{Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}, QFI: 1}, nil, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("build expected N1: %v", err)
 	}
@@ -1988,45 +1988,6 @@ func buildHandoverRequestAcknowledgeTransferWithQFI(teid uint32, ip net.IP, qfi 
 }
 
 // TS 24.501 §6.4.2.4, §7.3.1
-func TestUpdateSmContextN1Msg_ModificationRejected(t *testing.T) {
-	pcf, store, upf, amfCb := defaultFakes()
-	s := newTestSMF(pcf, store, upf, amfCb)
-	ctx := context.Background()
-
-	smCtx, ref := setupSessionWithTunnel(t, s)
-
-	const pti = 7
-
-	n1Msg := buildPDUSessionModificationRequest(smCtx.PDUSessionID, pti)
-
-	rsp, err := s.UpdateSmContextN1Msg(ctx, ref, n1Msg)
-	if err != nil {
-		t.Fatalf("UpdateSmContextN1Msg (modification) failed: %v", err)
-	}
-
-	if rsp == nil || rsp.N1Msg == nil {
-		t.Fatal("expected a Modification Reject N1 message (TS 24.501 §6.4.2.4), got none")
-	}
-
-	if rsp.ReleaseN2 {
-		t.Error("modification reject must not signal N2 release")
-	}
-
-	// PDU SESSION MODIFICATION REJECT: header (EPD, PSI, PTI, type) + mandatory cause.
-	raw := rsp.N1Msg
-	if len(raw) < 5 || raw[3] != uint8(fgs.MsgPDUSessionModificationReject) {
-		t.Fatalf("expected PDUSessionModificationReject, got % x", raw)
-	}
-
-	if got := raw[2]; got != pti {
-		t.Errorf("reject PTI = %d, want %d (echoed from request)", got, pti)
-	}
-
-	if got := raw[4]; fgs.GSMCause(got) != fgs.GSMCauseRequestRejectedUnspecified {
-		t.Errorf("reject cause = %d, want %d (request rejected, unspecified)", got, fgs.GSMCauseRequestRejectedUnspecified)
-	}
-}
-
 // TS 24.501 §7.3.1 b)
 func TestUpdateSmContextN1Msg_AuthenticationCompletePTIPoliced(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()

--- a/internal/smf/nas/build_pdu_session_modification_command.go
+++ b/internal/smf/nas/build_pdu_session_modification_command.go
@@ -17,12 +17,16 @@ type MappedEPSQoS struct {
 	Ambr    models.Ambr
 }
 
-func BuildPDUSessionModificationCommand(pduSessionID uint8, ambr *models.Ambr, qosData *models.QosData, dns net.IP, epsBearerIdentity uint8, mappedEPSQoS *MappedEPSQoS) ([]byte, error) {
-	if ambr == nil && qosData == nil && dns == nil {
-		return nil, fmt.Errorf("at least one of ambr, qosData, or dns must be provided")
+func BuildPDUSessionModificationCommand(pduSessionID uint8, pti uint8, ambr *models.Ambr, qosData *models.QosData, dns net.IP, epsBearerIdentity uint8, mappedEPSQoS *MappedEPSQoS, alwaysOn *bool) ([]byte, error) {
+	if pti == 0 && ambr == nil && qosData == nil && dns == nil && alwaysOn == nil {
+		return nil, fmt.Errorf("at least one of ambr, qosData, dns, or alwaysOn must be provided")
 	}
 
-	m := &fgs.PDUSessionModificationCommand{PDUSessionID: fgs.PDUSessionID(pduSessionID)}
+	m := &fgs.PDUSessionModificationCommand{
+		PDUSessionID: fgs.PDUSessionID(pduSessionID),
+		PTI:          nas.ProcedureTransactionIdentity(pti),
+		AlwaysOn:     alwaysOn,
+	}
 
 	if ambr != nil {
 		sessAMBR, err := ModelsToSessionAMBR(ambr)

--- a/internal/smf/nas/build_pdu_session_modification_command_test.go
+++ b/internal/smf/nas/build_pdu_session_modification_command_test.go
@@ -27,7 +27,7 @@ func TestBuildPDUSessionModificationCommand_AmbrAndQoS(t *testing.T) {
 	ambr := &models.Ambr{Uplink: models.MustParseBitRate("200 Mbps"), Downlink: models.MustParseBitRate("200 Mbps")}
 	qos := &models.QosData{QFI: 1, Var5qi: 8, Arp: &models.Arp{PriorityLevel: 14}}
 
-	encoded, err := smfNas.BuildPDUSessionModificationCommand(1, ambr, qos, nil, 0, nil)
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(1, 0, ambr, qos, nil, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("build failed: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestBuildPDUSessionModificationCommand_WithDNS(t *testing.T) {
 }
 
 func TestBuildPDUSessionModificationCommand_AllNil(t *testing.T) {
-	if _, err := smfNas.BuildPDUSessionModificationCommand(1, nil, nil, nil, 0, nil); err == nil {
+	if _, err := smfNas.BuildPDUSessionModificationCommand(1, 0, nil, nil, nil, 0, nil, nil); err == nil {
 		t.Fatal("expected error when all inputs are nil")
 	}
 }
@@ -97,7 +97,7 @@ func TestBuildPDUSessionModificationCommand_AllNil(t *testing.T) {
 func mustBuildModCmd(t *testing.T, psi uint8, ambr *models.Ambr, qos *models.QosData, dns net.IP) []byte {
 	t.Helper()
 
-	b, err := smfNas.BuildPDUSessionModificationCommand(psi, ambr, qos, dns, 0, nil)
+	b, err := smfNas.BuildPDUSessionModificationCommand(psi, 0, ambr, qos, dns, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("build failed: %v", err)
 	}

--- a/internal/smf/nas/mapped_eps_bearer_refresh_test.go
+++ b/internal/smf/nas/mapped_eps_bearer_refresh_test.go
@@ -18,7 +18,7 @@ func refreshedCommand(t *testing.T, ebi uint8, mapped *smfNas.MappedEPSQoS) *fgs
 	ambr := &models.Ambr{Uplink: models.MustParseBitRate("50 Mbps"), Downlink: models.MustParseBitRate("100 Mbps")}
 	qos := &models.QosData{QFI: 1, Var5qi: 6, Arp: &models.Arp{PriorityLevel: 8}}
 
-	encoded, err := smfNas.BuildPDUSessionModificationCommand(1, ambr, qos, nil, ebi, mapped)
+	encoded, err := smfNas.BuildPDUSessionModificationCommand(1, 0, ambr, qos, nil, ebi, mapped, nil)
 	if err != nil {
 		t.Fatalf("build failed: %v", err)
 	}

--- a/internal/smf/network_requested_procedure.go
+++ b/internal/smf/network_requested_procedure.go
@@ -23,6 +23,14 @@ import (
 // Release Command until the UE replies or the retransmission limit aborts, at which
 // point the SM context is removed from the pool. Caller must hold smContext.Mutex.
 func (s *SMF) startRelease(ctx context.Context, smContext *SMContext, pti uint8, cause fgs.GSMCause) error {
+	if smContext.releasing {
+		logger.WithTrace(ctx, logger.SmfLog).Info("a PDU session release is already outstanding, ignoring the colliding release trigger",
+			zap.Uint8("pti", pti), zap.Stringer("cause", cause),
+			logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+
+		return nil
+	}
+
 	s.releaseUserPlane(ctx, smContext)
 
 	n1Msg, err := nas.BuildGSMPDUSessionReleaseCommand(fgs.PDUSessionID(smContext.PDUSessionID), naslib.ProcedureTransactionIdentity(pti), cause)

--- a/internal/smf/network_requested_procedure_test.go
+++ b/internal/smf/network_requested_procedure_test.go
@@ -320,3 +320,62 @@ func TestT3591StopsOnModificationComplete(t *testing.T) {
 		t.Error("expected PTI 0 cleared after Modification Complete")
 	}
 }
+
+func TestReleaseRequestIgnoredDuringRelease(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := smf.New(pcf, store, upf, amfCb, smf.WithT3592(time.Hour))
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	const firstPTI, secondPTI = 5, 6
+
+	if _, err := s.UpdateSmContextN1Msg(context.Background(), ref, buildPDUSessionReleaseRequest(smCtx.PDUSessionID, firstPTI)); err != nil {
+		t.Fatalf("first release request: %v", err)
+	}
+
+	rsp, err := s.UpdateSmContextN1Msg(context.Background(), ref, buildPDUSessionReleaseRequest(smCtx.PDUSessionID, secondPTI))
+	if err != nil {
+		t.Fatalf("second release request: %v", err)
+	}
+
+	if rsp != nil && rsp.N1Msg != nil {
+		t.Errorf("the colliding request must be ignored, got a 5GSM answer % x", rsp.N1Msg)
+	}
+
+	if got := releaseCallCount(amfCb); got != 1 {
+		t.Errorf("ReleaseSession calls = %d, want 1 (TS 24.501 §6.3.3.5 c): the colliding request sends no second command)", got)
+	}
+
+	if smCtx.IsPTIInUse(secondPTI) {
+		t.Error("an ignored request starts no procedure, so its PTI stays free")
+	}
+
+	if !smCtx.IsPTIInUse(firstPTI) {
+		t.Error("the outstanding release keeps its PTI in use")
+	}
+
+	if s.GetSession(ref) == nil {
+		t.Error("the outstanding release must proceed, not be restarted or abandoned")
+	}
+}
+
+func TestCollidingReleaseRequestDoesNotResetT3592(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := smf.New(pcf, store, upf, amfCb, smf.WithT3592(procedureTimerInterval))
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	if _, err := s.UpdateSmContextN1Msg(context.Background(), ref, buildPDUSessionReleaseRequest(smCtx.PDUSessionID, 5)); err != nil {
+		t.Fatalf("first release request: %v", err)
+	}
+
+	if _, err := s.UpdateSmContextN1Msg(context.Background(), ref, buildPDUSessionReleaseRequest(smCtx.PDUSessionID, 6)); err != nil {
+		t.Fatalf("second release request: %v", err)
+	}
+
+	waitFor(t, "session local release after T3592 expiry", func() bool { return s.GetSession(ref) == nil })
+
+	if got := releaseCallCount(amfCb); got != 5 {
+		t.Errorf("ReleaseSession calls = %d, want 5 (1 initial + 4 retransmissions); the colliding request must not restart the budget", got)
+	}
+}

--- a/internal/smf/reconcile.go
+++ b/internal/smf/reconcile.go
@@ -343,7 +343,7 @@ func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext,
 		mappedEPSQoS = &nas.MappedEPSQoS{QosData: policy.QosData, Ambr: policy.Ambr}
 	}
 
-	n1Msg, err := nas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, n1Ambr, n1QoS, n1DNS, smContext.EBI, mappedEPSQoS)
+	n1Msg, err := nas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, 0, n1Ambr, n1QoS, n1DNS, smContext.EBI, mappedEPSQoS, nil)
 	if err != nil {
 		return fmt.Errorf("build PDU Session Modification Command (N1): %w", err)
 	}

--- a/internal/smf/reconcile.go
+++ b/internal/smf/reconcile.go
@@ -343,7 +343,7 @@ func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext,
 		mappedEPSQoS = &nas.MappedEPSQoS{QosData: policy.QosData, Ambr: policy.Ambr}
 	}
 
-	n1Msg, err := nas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, 0, n1Ambr, n1QoS, n1DNS, smContext.EBI, mappedEPSQoS, nil)
+	n1Msg, err := nas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, networkRequestedPTI, n1Ambr, n1QoS, n1DNS, smContext.EBI, mappedEPSQoS, nil)
 	if err != nil {
 		return fmt.Errorf("build PDU Session Modification Command (N1): %w", err)
 	}
@@ -375,7 +375,7 @@ func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext,
 	// A network-requested modification uses PTI "no procedure transaction
 	// identity assigned" (0) and awaits the UE's Modification Complete or
 	// Command Reject (TS 24.501).
-	smContext.MarkPTIInUse(0)
+	smContext.MarkPTIInUse(networkRequestedPTI)
 
 	// T3591 retransmits the command until the UE replies; on the final expiry
 	// the procedure is aborted and the session stays PDU SESSION ACTIVE
@@ -385,7 +385,7 @@ func (s *SMF) sendSessionModification(ctx context.Context, smContext *SMContext,
 	s.armRetransmit(smContext, s.t3591,
 		func() error { return s.amf.ModifyN1N2(context.Background(), supi, pduSessionID, n1Msg, n2Msg) },
 		func(sc *SMContext) {
-			sc.ClearPTIInUse(0)
+			sc.ClearPTIInUse(networkRequestedPTI)
 			// Discard the uncommitted policy: the UE never confirmed, so the session
 			// keeps its previous configuration and the backstop re-attempts (TS 24.501
 			// §6.3.2.5).

--- a/internal/smf/sm_context.go
+++ b/internal/smf/sm_context.go
@@ -77,8 +77,6 @@ type SMContext struct {
 	// previous configuration (§6.3.2.5). Guarded by Mutex.
 	pendingPolicy *Policy
 
-	ueParams UEIndicatedParams
-
 	releasing                bool // guarded by Mutex
 	n1Released               bool
 	n2Released               bool

--- a/internal/smf/sm_context.go
+++ b/internal/smf/sm_context.go
@@ -100,6 +100,10 @@ func (smContext *SMContext) stopProcedureTimer() {
 	smContext.procedureTimer.Stop()
 }
 
+func (smContext *SMContext) networkProcedureOutstanding() bool {
+	return smContext.releasing || smContext.procedureTimer.Active()
+}
+
 func (smContext *SMContext) upConnectionActive() bool {
 	return smContext.Tunnel != nil && smContext.Tunnel.Downlink == DownlinkForwarding
 }

--- a/internal/smf/sm_context.go
+++ b/internal/smf/sm_context.go
@@ -77,6 +77,8 @@ type SMContext struct {
 	// previous configuration (§6.3.2.5). Guarded by Mutex.
 	pendingPolicy *Policy
 
+	ueParams UEIndicatedParams
+
 	releasing                bool // guarded by Mutex
 	n1Released               bool
 	n2Released               bool

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -161,6 +161,8 @@ type SMF struct {
 // (TS 24.501 §6.3.2.5, §6.3.3).
 const maxSMProcedureRetransmissions = 4
 
+const networkRequestedPTI uint8 = 0
+
 // Option configures an SMF instance.
 type Option func(*SMF)
 

--- a/internal/smf/ue_requested_modification.go
+++ b/internal/smf/ue_requested_modification.go
@@ -15,8 +15,16 @@ import (
 	"go.uber.org/zap"
 )
 
-func requestsQoS(req *fgs.PDUSessionModificationRequest) bool {
-	return len(req.RequestedQoSRules) > 0 || len(req.RequestedQoSFlows) > 0
+func requestsQoSChange(req *fgs.PDUSessionModificationRequest) bool {
+	return len(req.RequestedQoSRules) > 0 || len(req.RequestedQoSFlows) > 0 || len(req.MappedEPSBearerContexts) > 0
+}
+
+func qoSChangeRejectCause(req *fgs.PDUSessionModificationRequest) fgs.GSMCause {
+	if req.Cause != nil {
+		return fgs.GSMCauseRequestRejectedUnspecified
+	}
+
+	return fgs.GSMCauseFiveGSQoSNotAccepted
 }
 
 func requestsDNSServer(req *fgs.PDUSessionModificationRequest) bool {
@@ -43,22 +51,33 @@ func (smContext *SMContext) dnsForModification(req *fgs.PDUSessionModificationRe
 }
 
 func (s *SMF) handleUERequestedModification(ctx context.Context, smContext *SMContext, req *fgs.PDUSessionModificationRequest, pti uint8) (*UpdateResult, error) {
-	if req.Cause == nil && requestsQoS(req) {
-		logger.WithTrace(ctx, logger.SmfLog).Info("rejecting a UE request to set the session's QoS",
+	if smContext.networkProcedureOutstanding() {
+		logger.WithTrace(ctx, logger.SmfLog).Info("ignoring a UE-requested PDU session modification that collided with an outstanding network-requested procedure",
+			zap.Bool("releasing", smContext.releasing),
 			logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
 
-		n1SmMsg, err := smfNas.BuildGSMPDUSessionModificationReject(fgs.PDUSessionID(smContext.PDUSessionID), naslib.ProcedureTransactionIdentity(pti), fgs.GSMCauseFiveGSQoSNotAccepted)
-		if err != nil {
-			return nil, fmt.Errorf("build GSM PDUSessionModificationReject failed: %v", err)
-		}
-
-		return &UpdateResult{N1Msg: n1SmMsg}, nil
+		return nil, nil
 	}
 
 	if req.Cause != nil {
 		logger.WithTrace(ctx, logger.SmfLog).Info("the UE reported an error against its own QoS state",
 			zap.Stringer("cause", *req.Cause),
 			logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+	}
+
+	if requestsQoSChange(req) {
+		cause := qoSChangeRejectCause(req)
+
+		logger.WithTrace(ctx, logger.SmfLog).Info("rejecting a UE request to change the session's QoS",
+			zap.Stringer("cause", cause),
+			logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+
+		n1SmMsg, err := smfNas.BuildGSMPDUSessionModificationReject(fgs.PDUSessionID(smContext.PDUSessionID), naslib.ProcedureTransactionIdentity(pti), cause)
+		if err != nil {
+			return nil, fmt.Errorf("build GSM PDUSessionModificationReject failed: %v", err)
+		}
+
+		return &UpdateResult{N1Msg: n1SmMsg}, nil
 	}
 
 	alwaysOn := alwaysOnIndication(req.AlwaysOnRequested)

--- a/internal/smf/ue_requested_modification.go
+++ b/internal/smf/ue_requested_modification.go
@@ -15,14 +15,6 @@ import (
 	"go.uber.org/zap"
 )
 
-type UEIndicatedParams struct {
-	Capability           *fgs.GSMCapability
-	MaxPacketFilters     *uint16
-	IntegrityMaxDataRate *[2]byte
-	AlwaysOnGranted      bool
-	ModificationDone     bool
-}
-
 func requestsQoS(req *fgs.PDUSessionModificationRequest) bool {
 	return len(req.RequestedQoSRules) > 0 || len(req.RequestedQoSFlows) > 0
 }
@@ -71,8 +63,6 @@ func (s *SMF) handleUERequestedModification(ctx context.Context, smContext *SMCo
 
 	alwaysOn := alwaysOnIndication(req.AlwaysOnRequested)
 
-	smContext.recordUEIndicatedParams(req, alwaysOn)
-
 	dns := smContext.dnsForModification(req)
 
 	n1SmMsg, err := smfNas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, pti, nil, nil, dns, 0, nil, alwaysOn)
@@ -99,27 +89,4 @@ func (s *SMF) handleUERequestedModification(ctx context.Context, smContext *SMCo
 		logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
 
 	return &UpdateResult{N1Msg: n1SmMsg}, nil
-}
-
-func (smContext *SMContext) recordUEIndicatedParams(req *fgs.PDUSessionModificationRequest, alwaysOn *bool) {
-	if req.GSMCapability != nil {
-		smContext.ueParams.Capability = req.GSMCapability
-	}
-
-	if req.MaxPacketFilters != nil {
-		smContext.ueParams.MaxPacketFilters = req.MaxPacketFilters
-	}
-
-	if req.IntegrityProtMaxDataRate != nil {
-		smContext.ueParams.IntegrityMaxDataRate = req.IntegrityProtMaxDataRate
-	}
-
-	smContext.ueParams.AlwaysOnGranted = alwaysOn != nil && *alwaysOn
-}
-
-func (smContext *SMContext) UEIndicatedParams() UEIndicatedParams {
-	smContext.Mutex.Lock()
-	defer smContext.Mutex.Unlock()
-
-	return smContext.ueParams
 }

--- a/internal/smf/ue_requested_modification.go
+++ b/internal/smf/ue_requested_modification.go
@@ -6,6 +6,7 @@ package smf
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/ellanetworks/core/internal/logger"
 	smfNas "github.com/ellanetworks/core/internal/smf/nas"
@@ -24,6 +25,29 @@ type UEIndicatedParams struct {
 
 func requestsQoS(req *fgs.PDUSessionModificationRequest) bool {
 	return len(req.RequestedQoSRules) > 0 || len(req.RequestedQoSFlows) > 0
+}
+
+func requestsDNSServer(req *fgs.PDUSessionModificationRequest) bool {
+	if req.ExtendedPCO == nil {
+		return false
+	}
+
+	for _, id := range req.ExtendedPCO.ContainerIDs() {
+		switch id {
+		case naslib.PCOContainerDNSServerIPv4Address, naslib.PCOContainerDNSServerIPv6Address:
+			return true
+		}
+	}
+
+	return false
+}
+
+func (smContext *SMContext) dnsForModification(req *fgs.PDUSessionModificationRequest) net.IP {
+	if !requestsDNSServer(req) || smContext.PolicyData == nil {
+		return nil
+	}
+
+	return smContext.PolicyData.DNS
 }
 
 func (s *SMF) handleUERequestedModification(ctx context.Context, smContext *SMContext, req *fgs.PDUSessionModificationRequest, pti uint8) (*UpdateResult, error) {
@@ -49,7 +73,9 @@ func (s *SMF) handleUERequestedModification(ctx context.Context, smContext *SMCo
 
 	smContext.recordUEIndicatedParams(req, alwaysOn)
 
-	n1SmMsg, err := smfNas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, pti, nil, nil, nil, 0, nil, alwaysOn)
+	dns := smContext.dnsForModification(req)
+
+	n1SmMsg, err := smfNas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, pti, nil, nil, dns, 0, nil, alwaysOn)
 	if err != nil {
 		return nil, fmt.Errorf("build PDU Session Modification Command (N1): %w", err)
 	}
@@ -69,7 +95,7 @@ func (s *SMF) handleUERequestedModification(ctx context.Context, smContext *SMCo
 		})
 
 	logger.WithTrace(ctx, logger.SmfLog).Info("accepted a UE-requested PDU session modification",
-		zap.Bool("always_on_answered", alwaysOn != nil),
+		zap.Bool("always_on_answered", alwaysOn != nil), zap.Bool("dns_answered", dns != nil),
 		logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
 
 	return &UpdateResult{N1Msg: n1SmMsg}, nil

--- a/internal/smf/ue_requested_modification.go
+++ b/internal/smf/ue_requested_modification.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/logger"
+	smfNas "github.com/ellanetworks/core/internal/smf/nas"
+	naslib "github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+	"go.uber.org/zap"
+)
+
+type UEIndicatedParams struct {
+	Capability           *fgs.GSMCapability
+	MaxPacketFilters     *uint16
+	IntegrityMaxDataRate *[2]byte
+	AlwaysOnGranted      bool
+	ModificationDone     bool
+}
+
+func requestsQoS(req *fgs.PDUSessionModificationRequest) bool {
+	return len(req.RequestedQoSRules) > 0 || len(req.RequestedQoSFlows) > 0
+}
+
+func (s *SMF) handleUERequestedModification(ctx context.Context, smContext *SMContext, req *fgs.PDUSessionModificationRequest, pti uint8) (*UpdateResult, error) {
+	if req.Cause == nil && requestsQoS(req) {
+		logger.WithTrace(ctx, logger.SmfLog).Info("rejecting a UE request to set the session's QoS",
+			logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+
+		n1SmMsg, err := smfNas.BuildGSMPDUSessionModificationReject(fgs.PDUSessionID(smContext.PDUSessionID), naslib.ProcedureTransactionIdentity(pti), fgs.GSMCauseFiveGSQoSNotAccepted)
+		if err != nil {
+			return nil, fmt.Errorf("build GSM PDUSessionModificationReject failed: %v", err)
+		}
+
+		return &UpdateResult{N1Msg: n1SmMsg}, nil
+	}
+
+	if req.Cause != nil {
+		logger.WithTrace(ctx, logger.SmfLog).Info("the UE reported an error against its own QoS state",
+			zap.Stringer("cause", *req.Cause),
+			logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+	}
+
+	alwaysOn := alwaysOnIndication(req.AlwaysOnRequested)
+
+	smContext.recordUEIndicatedParams(req, alwaysOn)
+
+	n1SmMsg, err := smfNas.BuildPDUSessionModificationCommand(smContext.PDUSessionID, pti, nil, nil, nil, 0, nil, alwaysOn)
+	if err != nil {
+		return nil, fmt.Errorf("build PDU Session Modification Command (N1): %w", err)
+	}
+
+	smContext.MarkPTIInUse(pti)
+
+	supi := smContext.Supi
+	pduSessionID := smContext.PDUSessionID
+
+	s.armRetransmit(smContext, s.t3591,
+		func() error { return s.amf.ModifyN1N2(context.Background(), supi, pduSessionID, n1SmMsg, nil) },
+		func(sc *SMContext) {
+			sc.ClearPTIInUse(pti)
+
+			logger.SmfLog.Warn("T3591 expired; UE-requested PDU session modification aborted, session remains active",
+				logger.SUPI(supi.String()), logger.PDUSessionID(pduSessionID))
+		})
+
+	logger.WithTrace(ctx, logger.SmfLog).Info("accepted a UE-requested PDU session modification",
+		zap.Bool("always_on_answered", alwaysOn != nil),
+		logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+
+	return &UpdateResult{N1Msg: n1SmMsg}, nil
+}
+
+func (smContext *SMContext) recordUEIndicatedParams(req *fgs.PDUSessionModificationRequest, alwaysOn *bool) {
+	if req.GSMCapability != nil {
+		smContext.ueParams.Capability = req.GSMCapability
+	}
+
+	if req.MaxPacketFilters != nil {
+		smContext.ueParams.MaxPacketFilters = req.MaxPacketFilters
+	}
+
+	if req.IntegrityProtMaxDataRate != nil {
+		smContext.ueParams.IntegrityMaxDataRate = req.IntegrityProtMaxDataRate
+	}
+
+	smContext.ueParams.AlwaysOnGranted = alwaysOn != nil && *alwaysOn
+}
+
+func (smContext *SMContext) UEIndicatedParams() UEIndicatedParams {
+	smContext.Mutex.Lock()
+	defer smContext.Mutex.Unlock()
+
+	return smContext.ueParams
+}

--- a/internal/smf/ue_requested_modification_test.go
+++ b/internal/smf/ue_requested_modification_test.go
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smf_test
+
+import (
+	"testing"
+
+	naslib "github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func modificationRequest(t *testing.T, pduSessionID, pti uint8, shape func(*fgs.PDUSessionModificationRequest)) []byte {
+	t.Helper()
+
+	req := &fgs.PDUSessionModificationRequest{
+		PDUSessionID: fgs.PDUSessionID(pduSessionID),
+		PTI:          naslib.ProcedureTransactionIdentity(pti),
+	}
+
+	if shape != nil {
+		shape(req)
+	}
+
+	raw, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("build PDU Session Modification Request: %v", err)
+	}
+
+	return raw
+}
+
+func decodeModificationCommand(t *testing.T, raw []byte) *fgs.PDUSessionModificationCommand {
+	t.Helper()
+
+	if raw == nil {
+		t.Fatal("expected a 5GSM message, got none")
+	}
+
+	cmd, err := fgs.ParsePDUSessionModificationCommand(raw)
+	if err != nil {
+		t.Fatalf("expected a PDU Session Modification Command, got % x: %v", raw, err)
+	}
+
+	return cmd
+}
+
+func TestUERequestedModification_CapabilityIndicationAccepted(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	const pti = 7
+
+	n1Msg := modificationRequest(t, smCtx.PDUSessionID, pti, func(req *fgs.PDUSessionModificationRequest) {
+		req.GSMCapability = &fgs.GSMCapability{RqoS: true}
+		req.MaxPacketFilters = ptrTo(uint16(64))
+		req.IntegrityProtMaxDataRate = &[2]byte{0xff, 0xff}
+	})
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, n1Msg)
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg: %v", err)
+	}
+
+	if rsp == nil {
+		t.Fatal("expected a Modification Command, got no result")
+	}
+
+	if rsp.ReleaseN2 {
+		t.Error("a UE-requested modification must not signal N2 release")
+	}
+
+	cmd := decodeModificationCommand(t, rsp.N1Msg)
+
+	if uint8(cmd.PTI) != pti {
+		t.Errorf("command PTI = %d, want %d (echoed from the request, TS 24.501 §6.3.2.2)", cmd.PTI, pti)
+	}
+
+	if uint8(cmd.PDUSessionID) != smCtx.PDUSessionID {
+		t.Errorf("command PDU session ID = %d, want %d", cmd.PDUSessionID, smCtx.PDUSessionID)
+	}
+
+	if cmd.AlwaysOn != nil {
+		t.Error("the UE asked for no always-on session, so TS 24.501 §6.3.2.2 b) 2) leaves the indication out")
+	}
+
+	params := smCtx.UEIndicatedParams()
+	if params.Capability == nil || !params.Capability.RqoS {
+		t.Errorf("5GSM capability = %+v, want reflective QoS recorded", params.Capability)
+	}
+
+	if params.MaxPacketFilters == nil || *params.MaxPacketFilters != 64 {
+		t.Errorf("maximum supported packet filters = %v, want 64", params.MaxPacketFilters)
+	}
+
+	if params.IntegrityMaxDataRate == nil {
+		t.Error("integrity protection maximum data rate was not recorded")
+	}
+
+	if !smCtx.IsPTIInUse(pti) {
+		t.Error("the command is outstanding, so its PTI is in use (TS 24.501 §7.3.1)")
+	}
+}
+
+func TestUERequestedModification_AlwaysOnAnsweredNotAllowed(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	n1Msg := modificationRequest(t, smCtx.PDUSessionID, 3, func(req *fgs.PDUSessionModificationRequest) {
+		req.AlwaysOnRequested = ptrTo(true)
+	})
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, n1Msg)
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg: %v", err)
+	}
+
+	cmd := decodeModificationCommand(t, rsp.N1Msg)
+
+	if cmd.AlwaysOn == nil {
+		t.Fatal("the UE requested an always-on session, so the indication must be present")
+	}
+
+	if *cmd.AlwaysOn {
+		t.Error("always-on indication = required, want not allowed")
+	}
+
+	if smCtx.UEIndicatedParams().AlwaysOnGranted {
+		t.Error("the session was recorded as always-on although the request was refused")
+	}
+}
+
+func TestUERequestedModification_QoSRequestRejected(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	const pti = 9
+
+	n1Msg := modificationRequest(t, smCtx.PDUSessionID, pti, func(req *fgs.PDUSessionModificationRequest) {
+		req.RequestedQoSFlows = fgs.QoSFlowDescriptions{fgs.FiveQIQoSFlow(2, 9, fgs.QoSFlowOpCreate)}
+	})
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, n1Msg)
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg: %v", err)
+	}
+
+	if rsp == nil || rsp.N1Msg == nil {
+		t.Fatal("expected a Modification Reject, got none")
+	}
+
+	rej, err := fgs.ParsePDUSessionModificationReject(rsp.N1Msg)
+	if err != nil {
+		t.Fatalf("expected a PDU Session Modification Reject, got % x: %v", rsp.N1Msg, err)
+	}
+
+	if uint8(rej.PTI) != pti {
+		t.Errorf("reject PTI = %d, want %d (echoed from the request)", rej.PTI, pti)
+	}
+
+	if rej.Cause != fgs.GSMCauseFiveGSQoSNotAccepted {
+		t.Errorf("reject cause = %s, want %s", rej.Cause, fgs.GSMCauseFiveGSQoSNotAccepted)
+	}
+
+	if smCtx.IsPTIInUse(pti) {
+		t.Error("a rejected request starts no procedure, so its PTI stays free")
+	}
+}
+
+func TestUERequestedModification_UEReportedErrorAccepted(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	n1Msg := modificationRequest(t, smCtx.PDUSessionID, 4, func(req *fgs.PDUSessionModificationRequest) {
+		cause := fgs.GSMCauseSemanticErrorsInPacketFilters
+		req.Cause = &cause
+		req.RequestedQoSRules = fgs.QoSRules{fgs.DefaultQoSRule(1, 1)}
+	})
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, n1Msg)
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg: %v", err)
+	}
+
+	decodeModificationCommand(t, rsp.N1Msg)
+}
+
+func TestUERequestedModification_CompleteRecordsSuccess(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	const pti = 5
+
+	if _, err := s.UpdateSmContextN1Msg(t.Context(), ref, modificationRequest(t, smCtx.PDUSessionID, pti, nil)); err != nil {
+		t.Fatalf("UpdateSmContextN1Msg (request): %v", err)
+	}
+
+	if smCtx.UEIndicatedParams().ModificationDone {
+		t.Error("the procedure is recorded as done before the UE completed it")
+	}
+
+	complete := []byte{uint8(fgs.EPD5GSM), smCtx.PDUSessionID, pti, uint8(fgs.MsgPDUSessionModificationComplete)}
+
+	if _, err := s.UpdateSmContextN1Msg(t.Context(), ref, complete); err != nil {
+		t.Fatalf("UpdateSmContextN1Msg (complete): %v", err)
+	}
+
+	if !smCtx.UEIndicatedParams().ModificationDone {
+		t.Error("the UE completed the procedure, but it was not recorded as done")
+	}
+
+	if smCtx.IsPTIInUse(pti) {
+		t.Error("the completed procedure left its PTI in use")
+	}
+}

--- a/internal/smf/ue_requested_modification_test.go
+++ b/internal/smf/ue_requested_modification_test.go
@@ -87,19 +87,6 @@ func TestUERequestedModification_CapabilityIndicationAccepted(t *testing.T) {
 		t.Error("the UE asked for no always-on session, so TS 24.501 §6.3.2.2 b) 2) leaves the indication out")
 	}
 
-	params := smCtx.UEIndicatedParams()
-	if params.Capability == nil || !params.Capability.RqoS {
-		t.Errorf("5GSM capability = %+v, want reflective QoS recorded", params.Capability)
-	}
-
-	if params.MaxPacketFilters == nil || *params.MaxPacketFilters != 64 {
-		t.Errorf("maximum supported packet filters = %v, want 64", params.MaxPacketFilters)
-	}
-
-	if params.IntegrityMaxDataRate == nil {
-		t.Error("integrity protection maximum data rate was not recorded")
-	}
-
 	if !smCtx.IsPTIInUse(pti) {
 		t.Error("the command is outstanding, so its PTI is in use (TS 24.501 §7.3.1)")
 	}
@@ -128,10 +115,6 @@ func TestUERequestedModification_AlwaysOnAnsweredNotAllowed(t *testing.T) {
 
 	if *cmd.AlwaysOn {
 		t.Error("always-on indication = required, want not allowed")
-	}
-
-	if smCtx.UEIndicatedParams().AlwaysOnGranted {
-		t.Error("the session was recorded as always-on although the request was refused")
 	}
 }
 
@@ -194,7 +177,7 @@ func TestUERequestedModification_UEReportedErrorAccepted(t *testing.T) {
 	decodeModificationCommand(t, rsp.N1Msg)
 }
 
-func TestUERequestedModification_CompleteRecordsSuccess(t *testing.T) {
+func TestUERequestedModification_CompleteClearsThePTI(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
 
@@ -206,18 +189,14 @@ func TestUERequestedModification_CompleteRecordsSuccess(t *testing.T) {
 		t.Fatalf("UpdateSmContextN1Msg (request): %v", err)
 	}
 
-	if smCtx.UEIndicatedParams().ModificationDone {
-		t.Error("the procedure is recorded as done before the UE completed it")
+	if !smCtx.IsPTIInUse(pti) {
+		t.Fatal("the outstanding command left its PTI free")
 	}
 
 	complete := []byte{uint8(fgs.EPD5GSM), smCtx.PDUSessionID, pti, uint8(fgs.MsgPDUSessionModificationComplete)}
 
 	if _, err := s.UpdateSmContextN1Msg(t.Context(), ref, complete); err != nil {
 		t.Fatalf("UpdateSmContextN1Msg (complete): %v", err)
-	}
-
-	if !smCtx.UEIndicatedParams().ModificationDone {
-		t.Error("the UE completed the procedure, but it was not recorded as done")
 	}
 
 	if smCtx.IsPTIInUse(pti) {

--- a/internal/smf/ue_requested_modification_test.go
+++ b/internal/smf/ue_requested_modification_test.go
@@ -4,6 +4,7 @@
 package smf_test
 
 import (
+	"net"
 	"testing"
 
 	naslib "github.com/ellanetworks/core/nas"
@@ -221,5 +222,59 @@ func TestUERequestedModification_CompleteRecordsSuccess(t *testing.T) {
 
 	if smCtx.IsPTIInUse(pti) {
 		t.Error("the completed procedure left its PTI in use")
+	}
+}
+
+func TestUERequestedModification_AnswersTheDNSServerRequest(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+	smCtx.PolicyData.DNS = net.ParseIP("8.8.8.8").To4()
+
+	requested := naslib.NewRequestedProtocolConfigurationOptions(naslib.PCOContainerDNSServerIPv4Address)
+
+	n1Msg := modificationRequest(t, smCtx.PDUSessionID, 6, func(req *fgs.PDUSessionModificationRequest) {
+		req.ExtendedPCO = &requested
+	})
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, n1Msg)
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg: %v", err)
+	}
+
+	cmd := decodeModificationCommand(t, rsp.N1Msg)
+
+	if cmd.ExtendedPCO == nil {
+		t.Fatal("the UE asked for a DNS server address, so TS 24.501 §6.3.2.2 requires the extended PCO in the command")
+	}
+
+	for _, c := range cmd.ExtendedPCO.Containers {
+		if c.ID == naslib.PCOContainerDNSServerIPv4Address {
+			if got := net.IP(c.Content).String(); got != "8.8.8.8" {
+				t.Errorf("DNS server = %s, want 8.8.8.8", got)
+			}
+
+			return
+		}
+	}
+
+	t.Errorf("no DNS server IPv4 address container in the command: %+v", cmd.ExtendedPCO.Containers)
+}
+
+func TestUERequestedModification_NoDNSRequestLeavesThePCOOut(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+	smCtx.PolicyData.DNS = net.ParseIP("8.8.8.8").To4()
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, modificationRequest(t, smCtx.PDUSessionID, 6, nil))
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg: %v", err)
+	}
+
+	if cmd := decodeModificationCommand(t, rsp.N1Msg); cmd.ExtendedPCO != nil {
+		t.Errorf("the UE asked for nothing, but the command carried protocol options: %+v", cmd.ExtendedPCO)
 	}
 }

--- a/internal/smf/ue_requested_modification_test.go
+++ b/internal/smf/ue_requested_modification_test.go
@@ -46,6 +46,21 @@ func decodeModificationCommand(t *testing.T, raw []byte) *fgs.PDUSessionModifica
 	return cmd
 }
 
+func decodeModificationReject(t *testing.T, raw []byte) *fgs.PDUSessionModificationReject {
+	t.Helper()
+
+	if raw == nil {
+		t.Fatal("expected a Modification Reject, got none")
+	}
+
+	rej, err := fgs.ParsePDUSessionModificationReject(raw)
+	if err != nil {
+		t.Fatalf("expected a PDU Session Modification Reject, got % x: %v", raw, err)
+	}
+
+	return rej
+}
+
 func TestUERequestedModification_CapabilityIndicationAccepted(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
@@ -135,14 +150,11 @@ func TestUERequestedModification_QoSRequestRejected(t *testing.T) {
 		t.Fatalf("UpdateSmContextN1Msg: %v", err)
 	}
 
-	if rsp == nil || rsp.N1Msg == nil {
-		t.Fatal("expected a Modification Reject, got none")
+	if rsp == nil {
+		t.Fatal("expected a Modification Reject, got no result")
 	}
 
-	rej, err := fgs.ParsePDUSessionModificationReject(rsp.N1Msg)
-	if err != nil {
-		t.Fatalf("expected a PDU Session Modification Reject, got % x: %v", rsp.N1Msg, err)
-	}
+	rej := decodeModificationReject(t, rsp.N1Msg)
 
 	if uint8(rej.PTI) != pti {
 		t.Errorf("reject PTI = %d, want %d (echoed from the request)", rej.PTI, pti)
@@ -157,13 +169,15 @@ func TestUERequestedModification_QoSRequestRejected(t *testing.T) {
 	}
 }
 
-func TestUERequestedModification_UEReportedErrorAccepted(t *testing.T) {
+func TestUERequestedModification_UEReportedErrorDeletionRejected(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
 
 	smCtx, ref := setupSessionWithTunnel(t, s)
 
-	n1Msg := modificationRequest(t, smCtx.PDUSessionID, 4, func(req *fgs.PDUSessionModificationRequest) {
+	const pti = 4
+
+	n1Msg := modificationRequest(t, smCtx.PDUSessionID, pti, func(req *fgs.PDUSessionModificationRequest) {
 		cause := fgs.GSMCauseSemanticErrorsInPacketFilters
 		req.Cause = &cause
 		req.RequestedQoSRules = fgs.QoSRules{fgs.DefaultQoSRule(1, 1)}
@@ -174,7 +188,53 @@ func TestUERequestedModification_UEReportedErrorAccepted(t *testing.T) {
 		t.Fatalf("UpdateSmContextN1Msg: %v", err)
 	}
 
-	decodeModificationCommand(t, rsp.N1Msg)
+	if rsp == nil {
+		t.Fatal("expected a Modification Reject, got no result")
+	}
+
+	rej := decodeModificationReject(t, rsp.N1Msg)
+
+	if rej.Cause != fgs.GSMCauseRequestRejectedUnspecified {
+		t.Errorf("reject cause = %s, want %s (the SMF performs no QoS rule deletion, TS 24.501 §6.4.2.4.1)", rej.Cause, fgs.GSMCauseRequestRejectedUnspecified)
+	}
+
+	if smCtx.IsPTIInUse(pti) {
+		t.Error("a rejected request starts no procedure, so its PTI stays free")
+	}
+}
+
+func TestUERequestedModification_MappedEPSBearerDeletionRejected(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	const pti = 8
+
+	n1Msg := modificationRequest(t, smCtx.PDUSessionID, pti, func(req *fgs.PDUSessionModificationRequest) {
+		cause := fgs.GSMCauseInvalidMappedEPSBearerIdentity
+		req.Cause = &cause
+		req.MappedEPSBearerContexts = fgs.MappedEPSBearerContexts{{EPSBearerIdentity: 5, Operation: fgs.MappedEPSBearerOpDelete}}
+	})
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, n1Msg)
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg: %v", err)
+	}
+
+	if rsp == nil {
+		t.Fatal("expected a Modification Reject, got no result")
+	}
+
+	rej := decodeModificationReject(t, rsp.N1Msg)
+
+	if rej.Cause != fgs.GSMCauseRequestRejectedUnspecified {
+		t.Errorf("reject cause = %s, want %s (TS 24.501 §6.4.2.1 f), §6.4.2.4.1)", rej.Cause, fgs.GSMCauseRequestRejectedUnspecified)
+	}
+
+	if smCtx.IsPTIInUse(pti) {
+		t.Error("a rejected request starts no procedure, so its PTI stays free")
+	}
 }
 
 func TestUERequestedModification_CompleteClearsThePTI(t *testing.T) {
@@ -255,5 +315,73 @@ func TestUERequestedModification_NoDNSRequestLeavesThePCOOut(t *testing.T) {
 
 	if cmd := decodeModificationCommand(t, rsp.N1Msg); cmd.ExtendedPCO != nil {
 		t.Errorf("the UE asked for nothing, but the command carried protocol options: %+v", cmd.ExtendedPCO)
+	}
+}
+
+func TestUERequestedModification_IgnoredDuringRelease(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	const releasePTI, modifyPTI = 5, 6
+
+	if _, err := s.UpdateSmContextN1Msg(t.Context(), ref, buildPDUSessionReleaseRequest(smCtx.PDUSessionID, releasePTI)); err != nil {
+		t.Fatalf("release request: %v", err)
+	}
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, modificationRequest(t, smCtx.PDUSessionID, modifyPTI, nil))
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg (modification): %v", err)
+	}
+
+	if rsp != nil && rsp.N1Msg != nil {
+		t.Errorf("the colliding request must be ignored, got a 5GSM answer % x", rsp.N1Msg)
+	}
+
+	if smCtx.IsPTIInUse(modifyPTI) {
+		t.Error("an ignored request starts no procedure, so its PTI stays free")
+	}
+
+	if !smCtx.IsPTIInUse(releasePTI) {
+		t.Error("the release command is still outstanding, so its PTI stays in use")
+	}
+
+	if s.GetSession(ref) == nil {
+		t.Error("the release must proceed, not be abandoned by the colliding request")
+	}
+}
+
+func TestUERequestedModification_IgnoredDuringNetworkModification(t *testing.T) {
+	pcf, store, upf, amfCb := defaultFakes()
+	s := newTestSMF(pcf, store, upf, amfCb)
+
+	smCtx, ref := setupSessionWithTunnel(t, s)
+
+	const firstPTI, secondPTI = 5, 6
+
+	if _, err := s.UpdateSmContextN1Msg(t.Context(), ref, modificationRequest(t, smCtx.PDUSessionID, firstPTI, nil)); err != nil {
+		t.Fatalf("UpdateSmContextN1Msg (first request): %v", err)
+	}
+
+	if !smCtx.IsPTIInUse(firstPTI) {
+		t.Fatal("the first command left its PTI free")
+	}
+
+	rsp, err := s.UpdateSmContextN1Msg(t.Context(), ref, modificationRequest(t, smCtx.PDUSessionID, secondPTI, nil))
+	if err != nil {
+		t.Fatalf("UpdateSmContextN1Msg (second request): %v", err)
+	}
+
+	if rsp != nil && rsp.N1Msg != nil {
+		t.Errorf("the colliding request must be ignored, got a 5GSM answer % x", rsp.N1Msg)
+	}
+
+	if smCtx.IsPTIInUse(secondPTI) {
+		t.Error("an ignored request starts no procedure, so its PTI stays free")
+	}
+
+	if !smCtx.IsPTIInUse(firstPTI) {
+		t.Error("the outstanding procedure must proceed, keeping its PTI in use")
 	}
 }

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -115,17 +115,9 @@ func (s *SMF) handleUpdateN1Msg(ctx context.Context, n1Msg []byte, smContext *SM
 		return nil, nil
 
 	case *fgs.PDUSessionModificationRequest:
-		logger.WithTrace(ctx, logger.SmfLog).Info("N1 Msg PDU Session Modification Request received; rejecting", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
+		logger.WithTrace(ctx, logger.SmfLog).Info("N1 Msg PDU Session Modification Request received", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
 
-		// The UE cannot set its own QoS; the authorized QoS is network-determined
-		// and not modifiable on UE request, so the request is rejected
-		// (TS 24.501 clause 6.4.2.4).
-		n1SmMsg, err := smfNas.BuildGSMPDUSessionModificationReject(fgs.PDUSessionID(smContext.PDUSessionID), naslib.ProcedureTransactionIdentity(pti), fgs.GSMCauseRequestRejectedUnspecified)
-		if err != nil {
-			return nil, fmt.Errorf("build GSM PDUSessionModificationReject failed: %v", err)
-		}
-
-		return &UpdateResult{N1Msg: n1SmMsg}, nil
+		return s.handleUERequestedModification(ctx, smContext, msg, pti)
 
 	case *fgs.PDUSessionReleaseComplete:
 		logger.WithTrace(ctx, logger.SmfLog).Info("N1 Msg PDU Session Release Complete received", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
@@ -147,6 +139,10 @@ func (s *SMF) handleUpdateN1Msg(ctx context.Context, n1Msg []byte, smContext *SM
 		logger.WithTrace(ctx, logger.SmfLog).Info("N1 Msg PDU Session Modification Complete received", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
 		smContext.stopProcedureTimer()
 		smContext.ClearPTIInUse(pti)
+
+		if pti != 0 {
+			smContext.ueParams.ModificationDone = true
+		}
 
 		if smContext.pendingPolicy != nil {
 			smContext.PolicyData = smContext.pendingPolicy

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -140,10 +140,6 @@ func (s *SMF) handleUpdateN1Msg(ctx context.Context, n1Msg []byte, smContext *SM
 		smContext.stopProcedureTimer()
 		smContext.ClearPTIInUse(pti)
 
-		if pti != 0 {
-			smContext.ueParams.ModificationDone = true
-		}
-
 		if smContext.pendingPolicy != nil {
 			smContext.PolicyData = smContext.pendingPolicy
 			smContext.pendingPolicy = nil

--- a/internal/smf/update.go
+++ b/internal/smf/update.go
@@ -140,7 +140,7 @@ func (s *SMF) handleUpdateN1Msg(ctx context.Context, n1Msg []byte, smContext *SM
 		smContext.stopProcedureTimer()
 		smContext.ClearPTIInUse(pti)
 
-		if smContext.pendingPolicy != nil {
+		if pti == networkRequestedPTI && smContext.pendingPolicy != nil {
 			smContext.PolicyData = smContext.pendingPolicy
 			smContext.pendingPolicy = nil
 		}
@@ -153,7 +153,10 @@ func (s *SMF) handleUpdateN1Msg(ctx context.Context, n1Msg []byte, smContext *SM
 		logger.WithTrace(ctx, logger.SmfLog).Warn("N1 Msg PDU Session Modification Command Reject received", logger.SUPI(smContext.Supi.String()), logger.PDUSessionID(smContext.PDUSessionID))
 		smContext.stopProcedureTimer()
 		smContext.ClearPTIInUse(pti)
-		smContext.pendingPolicy = nil
+
+		if pti == networkRequestedPTI {
+			smContext.pendingPolicy = nil
+		}
 
 		return nil, nil
 

--- a/internal/smf/update_test.go
+++ b/internal/smf/update_test.go
@@ -4,9 +4,11 @@
 package smf
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/fgs"
 	libngap "github.com/ellanetworks/core/ngap"
 )
 
@@ -63,5 +65,45 @@ func TestHandleHandoverRequestAcknowledgeTransfer_BadInput(t *testing.T) {
 
 	if err := handleHandoverRequestAcknowledgeTransfer([]byte{0xff, 0xff}, smContext); err == nil {
 		t.Fatal("expected an error for undecodable transfer, got nil")
+	}
+}
+
+func TestModificationCompleteCommitsOnlyTheNetworkRequestedPolicy(t *testing.T) {
+	const uePTI = 6
+
+	current := &Policy{QosData: models.QosData{Var5qi: 9}}
+	pending := &Policy{QosData: models.QosData{Var5qi: 7}}
+
+	s := &SMF{}
+	smContext := &SMContext{SessionIdentity: SessionIdentity{PDUSessionID: 1}, PolicyData: current, pendingPolicy: pending}
+	smContext.MarkPTIInUse(networkRequestedPTI)
+	smContext.MarkPTIInUse(uePTI)
+
+	complete := func(pti uint8) []byte {
+		return []byte{uint8(fgs.EPD5GSM), smContext.PDUSessionID, pti, uint8(fgs.MsgPDUSessionModificationComplete)}
+	}
+
+	if _, err := s.handleUpdateN1Msg(context.Background(), complete(uePTI), smContext); err != nil {
+		t.Fatalf("handleUpdateN1Msg (UE-requested complete): %v", err)
+	}
+
+	if smContext.PolicyData != current {
+		t.Error("a UE-requested modification must not commit the network-requested policy (TS 24.501 §6.3.2.2)")
+	}
+
+	if smContext.pendingPolicy != pending {
+		t.Error("the network-requested procedure is still outstanding, so its pending policy must be kept")
+	}
+
+	if _, err := s.handleUpdateN1Msg(context.Background(), complete(networkRequestedPTI), smContext); err != nil {
+		t.Fatalf("handleUpdateN1Msg (network-requested complete): %v", err)
+	}
+
+	if smContext.PolicyData != pending {
+		t.Error("the network-requested complete must commit the pending policy")
+	}
+
+	if smContext.pendingPolicy != nil {
+		t.Error("the committed policy must be cleared")
 	}
 }

--- a/internal/tester/gnb/lifecycle.go
+++ b/internal/tester/gnb/lifecycle.go
@@ -192,6 +192,64 @@ func (g *GnodeB) ReleasePDUSession(u *ue.UE, ranUENGAPID int64, pduSessionID uin
 	return nil
 }
 
+func (g *GnodeB) ModifyPDUSession(u *ue.UE, ranUENGAPID int64, opts *ue.PDUSessionModificationRequestOpts, timeout time.Duration) (*fgs.PDUSessionModificationCommand, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("PDUSessionModificationRequestOpts is nil")
+	}
+
+	pti, err := u.SendPDUSessionModificationRequest(g.GetAMFUENGAPID(ranUENGAPID), ranUENGAPID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("send PDU Session Modification Request for session %d: %w", opts.PDUSessionID, err)
+	}
+
+	raw, err := u.WaitForNASGSMMessage(uint8(fgs.MsgPDUSessionModificationCommand), timeout)
+	if err != nil {
+		return nil, fmt.Errorf("await PDU Session Modification Command for session %d: %w", opts.PDUSessionID, err)
+	}
+
+	command, err := fgs.ParsePDUSessionModificationCommand(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse PDU Session Modification Command for session %d: %w", opts.PDUSessionID, err)
+	}
+
+	if uint8(command.PTI) != pti {
+		return nil, fmt.Errorf("PDU Session Modification Command for session %d carries PTI %d, want the requested %d", opts.PDUSessionID, command.PTI, pti)
+	}
+
+	if uint8(command.PDUSessionID) != opts.PDUSessionID {
+		return nil, fmt.Errorf("PDU Session Modification Command carries PDU session %d, want %d", command.PDUSessionID, opts.PDUSessionID)
+	}
+
+	return command, nil
+}
+
+func (g *GnodeB) RefusePDUSessionModification(u *ue.UE, ranUENGAPID int64, opts *ue.PDUSessionModificationRequestOpts, timeout time.Duration) (*fgs.PDUSessionModificationReject, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("PDUSessionModificationRequestOpts is nil")
+	}
+
+	pti, err := u.SendPDUSessionModificationRequest(g.GetAMFUENGAPID(ranUENGAPID), ranUENGAPID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("send PDU Session Modification Request for session %d: %w", opts.PDUSessionID, err)
+	}
+
+	raw, err := u.WaitForNASGSMMessage(uint8(fgs.MsgPDUSessionModificationReject), timeout)
+	if err != nil {
+		return nil, fmt.Errorf("await PDU Session Modification Reject for session %d: %w", opts.PDUSessionID, err)
+	}
+
+	reject, err := fgs.ParsePDUSessionModificationReject(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse PDU Session Modification Reject for session %d: %w", opts.PDUSessionID, err)
+	}
+
+	if uint8(reject.PTI) != pti {
+		return nil, fmt.Errorf("PDU Session Modification Reject for session %d carries PTI %d, want the requested %d", opts.PDUSessionID, reject.PTI, pti)
+	}
+
+	return reject, nil
+}
+
 // MovePDUSessionFromEPS requests an existing EPS PDN connection over NR as a PDU
 // session (TS 23.502 §4.11.2.2), the idle-mode inter-system change without N26.
 // It differs from EstablishPDUSession only in the NAS Request Type.

--- a/internal/tester/scenarios/interworking/idle_session_modification.go
+++ b/internal/tester/scenarios/interworking/idle_session_modification.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package interworking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/ellanetworks/core/internal/tester/gnb"
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/internal/tester/scenarios"
+	"github.com/ellanetworks/core/internal/tester/ue"
+	naslib "github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/eps"
+	"github.com/ellanetworks/core/nas/fgs"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+)
+
+const modificationRANUENGAPID = scenarios.DefaultRANUENGAPID + 1
+
+func init() {
+	scenarios.Register(scenarios.Scenario{
+		Name:      "interworking/idle_eps_to_5gs_session_modification",
+		BindFlags: func(_ *pflag.FlagSet) any { return struct{}{} },
+		Run:       runIdleEPSTo5GSSessionModification,
+		Fixture:   fixture,
+	})
+}
+
+func runIdleEPSTo5GSSessionModification(ctx context.Context, env scenarios.Env, _ any) error {
+	e, err := startENBOnSecondaryN3(env)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = e.Close() }()
+
+	k, opc, err := defaultKeyAndOPc()
+	if err != nil {
+		return err
+	}
+
+	epsUE := e.NewUE(interworkingIMSI, k, opc)
+	epsUE.RequestPDNType(uint8(eps.PDNTypeIPv4v6))
+	epsUE.AnnounceN1Mode(movedPDUSessionID)
+
+	res, err := e.Attach(epsUE, attachTimeout)
+	if err != nil {
+		return fmt.Errorf("attach over E-UTRAN: %w", err)
+	}
+
+	before, err := probeOverEPS(ctx, env, e, res, "before the idle move to 5GS")
+	if err != nil {
+		return err
+	}
+
+	if res.GUTI == nil || res.GUTI.GUTI == nil {
+		return errors.New("the attach accept assigned no GUTI to map into a registration")
+	}
+
+	gNodeB, err := startGNB(env)
+	if err != nil {
+		return err
+	}
+
+	defer gNodeB.Close()
+
+	u, err := newInterworkingUE(gNodeB, false)
+	if err != nil {
+		return err
+	}
+
+	ranUENGAPID := int64(modificationRANUENGAPID)
+
+	if err := arriveOn5GSFromEPS(gNodeB, epsUE, u, *res.GUTI.GUTI, ranUENGAPID, arriveAndResumeUserPlane); err != nil {
+		return err
+	}
+
+	if err := assertSessionOn(ctx, env, "5G", before.addrs); err != nil {
+		return err
+	}
+
+	if err := indicate5GSMParameters(gNodeB, u, ranUENGAPID); err != nil {
+		return err
+	}
+
+	if err := refuseQoSRequest(gNodeB, u, ranUENGAPID); err != nil {
+		return err
+	}
+
+	return assertSessionOn(ctx, env, "5G", before.addrs)
+}
+
+func indicate5GSMParameters(gNodeB *gnb.GnodeB, u *ue.UE, ranUENGAPID int64) error {
+	command, err := gNodeB.ModifyPDUSession(u, ranUENGAPID, &ue.PDUSessionModificationRequestOpts{
+		PDUSessionID:      movedPDUSessionID,
+		ReflectiveQoS:     true,
+		MultiHomedIPv6:    true,
+		MaxPacketFilters:  64,
+		IntegrityMaxRate:  true,
+		AlwaysOnRequested: true,
+		RequestDNSServer:  true,
+	}, registrationTimeout)
+	if err != nil {
+		return fmt.Errorf("indicating the 5GSM parameters after the inter-system change: %w", err)
+	}
+
+	if command.AlwaysOn == nil {
+		return errors.New("the UE requested an always-on PDU session but the modification command carries no " +
+			"always-on indication, which TS 24.501 §6.3.2.2 b) 1) requires")
+	}
+
+	if *command.AlwaysOn {
+		return errors.New("the modification command grants an always-on PDU session, which this core never allows")
+	}
+
+	dns, err := commandDNSServer(command)
+	if err != nil {
+		return err
+	}
+
+	logger.Logger.Info("The network answered the UE's 5GSM parameter indication",
+		zap.Uint8("PDU Session ID", movedPDUSessionID),
+		zap.String("DNS server", dns.String()),
+		zap.Bool("always-on granted", *command.AlwaysOn),
+	)
+
+	return nil
+}
+
+func commandDNSServer(command *fgs.PDUSessionModificationCommand) (net.IP, error) {
+	if command.ExtendedPCO == nil {
+		return nil, errors.New("the UE asked for a DNS server address but the modification command carries no " +
+			"extended protocol configuration options, which TS 24.501 §6.3.2.2 requires")
+	}
+
+	for _, c := range command.ExtendedPCO.Containers {
+		switch c.ID {
+		case naslib.PCOContainerDNSServerIPv4Address, naslib.PCOContainerDNSServerIPv6Address:
+			if addr := net.IP(c.Content); addr.To16() != nil {
+				return addr, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("the modification command carries no DNS server address: %+v", command.ExtendedPCO.Containers)
+}
+
+func refuseQoSRequest(gNodeB *gnb.GnodeB, u *ue.UE, ranUENGAPID int64) error {
+	reject, err := gNodeB.RefusePDUSessionModification(u, ranUENGAPID, &ue.PDUSessionModificationRequestOpts{
+		PDUSessionID:      movedPDUSessionID,
+		RequestedQoSFlows: fgs.QoSFlowDescriptions{fgs.FiveQIQoSFlow(2, 9, fgs.QoSFlowOpCreate)},
+	}, registrationTimeout)
+	if err != nil {
+		return fmt.Errorf("asking the network to set the session QoS: %w", err)
+	}
+
+	if reject.Cause != fgs.GSMCauseFiveGSQoSNotAccepted {
+		return fmt.Errorf("the QoS request was refused with 5GSM cause %s, want %s",
+			reject.Cause, fgs.GSMCauseFiveGSQoSNotAccepted)
+	}
+
+	logger.Logger.Info("The network refused the UE's QoS request with the cause that names the reason",
+		zap.Stringer("cause", reject.Cause),
+	)
+
+	return nil
+}

--- a/internal/tester/ue/build_pdu_session_modification_request.go
+++ b/internal/tester/ue/build_pdu_session_modification_request.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ue
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+type PDUSessionModificationRequestOpts struct {
+	PDUSessionID uint8
+	PTI          uint8
+
+	ReflectiveQoS     bool
+	MultiHomedIPv6    bool
+	MaxPacketFilters  uint16
+	IntegrityMaxRate  bool
+	AlwaysOnRequested bool
+	RequestDNSServer  bool
+
+	RequestedQoSFlows fgs.QoSFlowDescriptions
+}
+
+func BuildPDUSessionModificationRequest(opts *PDUSessionModificationRequestOpts) ([]byte, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("PDUSessionModificationRequestOpts is nil")
+	}
+
+	if opts.PTI == 0 || opts.PTI == 0xff {
+		return nil, fmt.Errorf("PDU Session Modification Request needs an assigned PTI, got %d", opts.PTI)
+	}
+
+	m := &fgs.PDUSessionModificationRequest{
+		PDUSessionID:      fgs.PDUSessionID(opts.PDUSessionID),
+		PTI:               nas.ProcedureTransactionIdentity(opts.PTI),
+		GSMCapability:     &fgs.GSMCapability{RqoS: opts.ReflectiveQoS, MH6PDU: opts.MultiHomedIPv6},
+		RequestedQoSFlows: opts.RequestedQoSFlows,
+	}
+
+	if opts.MaxPacketFilters != 0 {
+		count := opts.MaxPacketFilters
+		m.MaxPacketFilters = &count
+	}
+
+	if opts.IntegrityMaxRate {
+		m.IntegrityProtMaxDataRate = &[2]byte{0xff, 0xff}
+	}
+
+	if opts.AlwaysOnRequested {
+		requested := true
+		m.AlwaysOnRequested = &requested
+	}
+
+	if opts.RequestDNSServer {
+		pco := nas.NewRequestedProtocolConfigurationOptions(
+			nas.PCOContainerDNSServerIPv4Address,
+			nas.PCOContainerDNSServerIPv6Address,
+		)
+		m.ExtendedPCO = &pco
+	}
+
+	return m.MarshalBinary()
+}
+
+type PDUSessionModificationCompleteOpts struct {
+	PDUSessionID uint8
+	PTI          uint8
+}
+
+func BuildPDUSessionModificationComplete(opts *PDUSessionModificationCompleteOpts) ([]byte, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("PDUSessionModificationCompleteOpts is nil")
+	}
+
+	m := &fgs.PDUSessionModificationComplete{
+		PDUSessionID: fgs.PDUSessionID(opts.PDUSessionID),
+		PTI:          nas.ProcedureTransactionIdentity(opts.PTI),
+	}
+
+	return m.MarshalBinary()
+}

--- a/internal/tester/ue/handle_downlink_nas_transport.go
+++ b/internal/tester/ue/handle_downlink_nas_transport.go
@@ -179,6 +179,11 @@ func handle5GSMPayload(ue *UE, payload []byte, amfUENGAPID int64, ranUENGAPID in
 		if err != nil {
 			return fmt.Errorf("could not handle PDU Session Release Command: %v", err)
 		}
+	case fgs.MsgPDUSessionModificationCommand:
+		err := handlePDUSessionModificationCommand(ue, payload, amfUENGAPID, ranUENGAPID)
+		if err != nil {
+			return fmt.Errorf("could not handle PDU Session Modification Command: %v", err)
+		}
 	default:
 		logger.UeLogger.Warn("5GSM message type not implemented", zap.String("Message Type", getGSMMessageName(pcMsgType)))
 	}

--- a/internal/tester/ue/handle_pdu_session_modification_command.go
+++ b/internal/tester/ue/handle_pdu_session_modification_command.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ue
+
+import (
+	"fmt"
+
+	"github.com/ellanetworks/core/internal/tester/logger"
+	"github.com/ellanetworks/core/nas/fgs"
+	"go.uber.org/zap"
+)
+
+func handlePDUSessionModificationCommand(ue *UE, payload []byte, amfUENGAPID int64, ranUENGAPID int64) error {
+	cmd, err := fgs.ParsePDUSessionModificationCommand(payload)
+	if err != nil {
+		return fmt.Errorf("could not parse PDU Session Modification Command: %v", err)
+	}
+
+	pduSessionID := uint8(cmd.PDUSessionID)
+
+	complete, err := BuildPDUSessionModificationComplete(&PDUSessionModificationCompleteOpts{
+		PDUSessionID: pduSessionID,
+		PTI:          uint8(cmd.PTI),
+	})
+	if err != nil {
+		return fmt.Errorf("could not build PDU Session Modification Complete: %v", err)
+	}
+
+	uplink, err := BuildUplinkNasTransportSM(pduSessionID, complete)
+	if err != nil {
+		return fmt.Errorf("could not build Uplink NAS Transport for PDU Session Modification Complete: %v", err)
+	}
+
+	encodedPdu, err := ue.EncodeNasPduWithSecurity(uplink, uint8(fgs.SHTIntegrityProtectedCiphered))
+	if err != nil {
+		return fmt.Errorf("error encoding %s IMSI UE NAS PDU Session Modification Complete Msg", ue.UeSecurity.Supi)
+	}
+
+	if err := ue.Gnb.SendUplinkNAS(encodedPdu, amfUENGAPID, ranUENGAPID); err != nil {
+		return fmt.Errorf("could not send UplinkNASTransport for PDU Session Modification Complete: %v", err)
+	}
+
+	logger.UeLogger.Debug(
+		"Sent PDU Session Modification Complete",
+		zap.String("IMSI", ue.UeSecurity.Supi),
+		zap.Uint8("PDU Session ID", pduSessionID),
+		zap.Uint8("PTI", uint8(cmd.PTI)),
+		zap.Bool("Always-on indication", cmd.AlwaysOn != nil),
+	)
+
+	return nil
+}

--- a/internal/tester/ue/pdu_session_modification_test.go
+++ b/internal/tester/ue/pdu_session_modification_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ue
+
+import (
+	"testing"
+
+	"github.com/ellanetworks/core/nas"
+	"github.com/ellanetworks/core/nas/fgs"
+)
+
+func TestBuildPDUSessionModificationRequestCarriesThe5GSMParameters(t *testing.T) {
+	pdu, err := BuildPDUSessionModificationRequest(&PDUSessionModificationRequestOpts{
+		PDUSessionID:      3,
+		PTI:               9,
+		ReflectiveQoS:     true,
+		MultiHomedIPv6:    true,
+		MaxPacketFilters:  64,
+		IntegrityMaxRate:  true,
+		AlwaysOnRequested: true,
+		RequestDNSServer:  true,
+	})
+	if err != nil {
+		t.Fatalf("BuildPDUSessionModificationRequest: %v", err)
+	}
+
+	req, err := fgs.ParsePDUSessionModificationRequest(pdu)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if uint8(req.PDUSessionID) != 3 || uint8(req.PTI) != 9 {
+		t.Errorf("header = %d/%d, want 3/9", req.PDUSessionID, req.PTI)
+	}
+
+	if req.GSMCapability == nil || !req.GSMCapability.RqoS || !req.GSMCapability.MH6PDU {
+		t.Errorf("5GSM capability = %+v, want reflective QoS and multi-homed IPv6", req.GSMCapability)
+	}
+
+	if req.MaxPacketFilters == nil || *req.MaxPacketFilters != 64 {
+		t.Errorf("maximum supported packet filters = %v, want 64", req.MaxPacketFilters)
+	}
+
+	if req.IntegrityProtMaxDataRate == nil {
+		t.Error("no integrity protection maximum data rate")
+	}
+
+	if req.AlwaysOnRequested == nil || !*req.AlwaysOnRequested {
+		t.Error("the always-on request was dropped")
+	}
+
+	if req.ExtendedPCO == nil {
+		t.Fatal("no extended protocol configuration options carrying the DNS server request")
+	}
+
+	var sawV4 bool
+
+	for _, id := range req.ExtendedPCO.ContainerIDs() {
+		if id == nas.PCOContainerDNSServerIPv4Address {
+			sawV4 = true
+		}
+	}
+
+	if !sawV4 {
+		t.Errorf("no DNS server IPv4 address request: %+v", req.ExtendedPCO.Containers)
+	}
+
+	if len(req.RequestedQoSFlows) != 0 {
+		t.Errorf("requested QoS flows = %+v, want none for a capability indication", req.RequestedQoSFlows)
+	}
+}
+
+func TestBuildPDUSessionModificationRequestRejectsUnusablePTI(t *testing.T) {
+	for _, pti := range []uint8{0, 0xff} {
+		if _, err := BuildPDUSessionModificationRequest(&PDUSessionModificationRequestOpts{
+			PDUSessionID: 1,
+			PTI:          pti,
+		}); err == nil {
+			t.Errorf("PTI %d was accepted, want an error (TS 24.501 §7.3.1 c, d)", pti)
+		}
+	}
+}
+
+func TestBuildPDUSessionModificationCompleteEchoesThePTI(t *testing.T) {
+	pdu, err := BuildPDUSessionModificationComplete(&PDUSessionModificationCompleteOpts{
+		PDUSessionID: 4,
+		PTI:          11,
+	})
+	if err != nil {
+		t.Fatalf("BuildPDUSessionModificationComplete: %v", err)
+	}
+
+	complete, err := fgs.ParsePDUSessionModificationComplete(pdu)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if uint8(complete.PDUSessionID) != 4 || uint8(complete.PTI) != 11 {
+		t.Errorf("header = %d/%d, want 4/11", complete.PDUSessionID, complete.PTI)
+	}
+}

--- a/internal/tester/ue/ue.go
+++ b/internal/tester/ue/ue.go
@@ -995,6 +995,43 @@ func (ue *UE) SendPDUSessionReleaseRequest(amfUENGAPID int64, ranUENGAPID int64,
 	return pti, nil
 }
 
+func (ue *UE) SendPDUSessionModificationRequest(amfUENGAPID int64, ranUENGAPID int64, opts *PDUSessionModificationRequestOpts) (uint8, error) {
+	if opts == nil {
+		return 0, fmt.Errorf("PDUSessionModificationRequestOpts is nil")
+	}
+
+	shaped := *opts
+	shaped.PTI = ue.nextPTI()
+
+	modification, err := BuildPDUSessionModificationRequest(&shaped)
+	if err != nil {
+		return 0, fmt.Errorf("could not build PDU Session Modification Request: %v", err)
+	}
+
+	uplink, err := BuildUplinkNasTransportSM(shaped.PDUSessionID, modification)
+	if err != nil {
+		return 0, fmt.Errorf("could not build Uplink NAS Transport for PDU Session Modification: %v", err)
+	}
+
+	encodedPdu, err := ue.EncodeNasPduWithSecurity(uplink, uint8(fgs.SHTIntegrityProtectedCiphered))
+	if err != nil {
+		return 0, fmt.Errorf("error encoding %s IMSI UE NAS Uplink NAS Transport for PDU Session Modification Msg", ue.UeSecurity.Supi)
+	}
+
+	if err := ue.Gnb.SendUplinkNAS(encodedPdu, amfUENGAPID, ranUENGAPID); err != nil {
+		return 0, fmt.Errorf("could not send UplinkNASTransport for PDU Session Modification: %v", err)
+	}
+
+	logger.UeLogger.Debug(
+		"Sent PDU Session Modification Request",
+		zap.String("IMSI", ue.UeSecurity.Supi),
+		zap.Uint8("PDU Session ID", shaped.PDUSessionID),
+		zap.Uint8("PTI", shaped.PTI),
+	)
+
+	return shaped.PTI, nil
+}
+
 func (ue *UE) sendPDUSessionRequest(amfUENGAPID int64, ranUENGAPID int64, pduSessionID uint8, dnn string, snssai models.Snssai, requestType fgs.RequestType) error {
 	pduReq, err := BuildPduSessionEstablishmentRequest(&PduSessionEstablishmentRequestOpts{
 		PDUSessionID:   pduSessionID,

--- a/nas/fgs/canonical_cases_test.go
+++ b/nas/fgs/canonical_cases_test.go
@@ -35,8 +35,10 @@ var canonicalValues = map[uint8][]byte{
 	ieiGMMCapability:                 {0x00},
 	ieiGUTI5G:                        {0xf2, 0x00, 0xf1, 0x10, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01},
 	ieiIMEISVRequest:                 {0x01},
+	ieiIntegrityProtMaxRate:          {0xff, 0xff},
 	ieiLocalTimeZone:                 {0x00},
 	ieiMICOIndication:                {0x01},
+	ieiMaxPacketFilters:              {0x00, 0x10},
 	ieiNASMessageContainer:           {uint8(EPD5GMM), 0x00, uint8(MsgRegistrationRequest), 0x01, 0x00, 0x01, 0x00},
 	ieiNetworkDaylightSavingTime:     {0x00},
 	ieiNon3GppDeregTimer:             {0x21},
@@ -94,6 +96,11 @@ func canonicalCases(t *testing.T) []canonicalCase {
 		t.Fatalf("encode QoS flow descriptions: %v", err)
 	}
 
+	mappedBearers, err := MappedEPSBearerContexts{{EPSBearerIdentity: 5, Operation: MappedEPSBearerOpDelete}}.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode mapped EPS bearer contexts: %v", err)
+	}
+
 	// An IEI is message-scoped, so an element sharing one with another message's
 	// element needs its own value here (TS 24.501 §8: 0x25 is the allowed PDU
 	// session status in 5GMM and the DNN in 5GSM, 0x77 the 5G-GUTI and the IMEISV).
@@ -107,6 +114,8 @@ func canonicalCases(t *testing.T) []canonicalCase {
 		ieiEAPMessageSession:  {0x01, 0x00, 0x00, 0x04},
 		ieiAlwaysOnIndication: {0x01},
 		ieiAlwaysOnRequested:  {0x01},
+
+		ieiMappedEPSBearerContext: mappedBearers,
 	}
 
 	return []canonicalCase{
@@ -192,13 +201,13 @@ func canonicalCases(t *testing.T) []canonicalCase {
 		{
 			name:   "PDUSessionEstablishmentAccept (TS 24.501 §8.3.2)",
 			bare:   &PDUSessionEstablishmentAccept{},
-			order:  []canonicalIE{{iei5GSMCause, nas.IETV3}, {ieiPDUAddress, nas.IETLV}, {ieiRQTimerValue, nas.IETV3}, {ieiSNSSAI, nas.IETLV}, {ieiAlwaysOnIndication, nas.IETV1}, {ieiEAPMessageSession, nas.IETLVE}, {ieiQoSFlowDescription, nas.IETLVE}, {ieiExtendedPCO, nas.IETLVE}, {ieiDNN, nas.IETLV}},
+			order:  []canonicalIE{{iei5GSMCause, nas.IETV3}, {ieiPDUAddress, nas.IETLV}, {ieiRQTimerValue, nas.IETV3}, {ieiSNSSAI, nas.IETLV}, {ieiAlwaysOnIndication, nas.IETV1}, {ieiMappedEPSBearerContext, nas.IETLVE}, {ieiEAPMessageSession, nas.IETLVE}, {ieiQoSFlowDescription, nas.IETLVE}, {ieiExtendedPCO, nas.IETLVE}, {ieiDNN, nas.IETLV}},
 			values: qos,
 		},
 		{
 			name:   "PDUSessionModificationRequest (TS 24.501 §8.3.7)",
 			bare:   &PDUSessionModificationRequest{},
-			order:  []canonicalIE{{iei5GSMCapability, nas.IETLV}, {iei5GSMCause, nas.IETV3}, {ieiAlwaysOnRequested, nas.IETV1}, {ieiAuthorizedQoSRules, nas.IETLVE}, {ieiQoSFlowDescription, nas.IETLVE}, {ieiExtendedPCO, nas.IETLVE}},
+			order:  []canonicalIE{{iei5GSMCapability, nas.IETLV}, {iei5GSMCause, nas.IETV3}, {ieiMaxPacketFilters, nas.IETV3}, {ieiAlwaysOnRequested, nas.IETV1}, {ieiIntegrityProtMaxRate, nas.IETV3}, {ieiAuthorizedQoSRules, nas.IETLVE}, {ieiQoSFlowDescription, nas.IETLVE}, {ieiMappedEPSBearerContext, nas.IETLVE}, {ieiExtendedPCO, nas.IETLVE}},
 			values: qos,
 		},
 		{
@@ -209,7 +218,7 @@ func canonicalCases(t *testing.T) []canonicalCase {
 		{
 			name:   "PDUSessionModificationCommand (TS 24.501 §8.3.9)",
 			bare:   &PDUSessionModificationCommand{},
-			order:  []canonicalIE{{ieiSessionAMBR, nas.IETLV}, {ieiQoSFlowDescription, nas.IETLVE}, {ieiExtendedPCO, nas.IETLVE}},
+			order:  []canonicalIE{{ieiSessionAMBR, nas.IETLV}, {ieiAlwaysOnIndication, nas.IETV1}, {ieiMappedEPSBearerContext, nas.IETLVE}, {ieiQoSFlowDescription, nas.IETLVE}, {ieiExtendedPCO, nas.IETLVE}},
 			values: qos,
 		},
 		{

--- a/nas/fgs/gsm_modification.go
+++ b/nas/fgs/gsm_modification.go
@@ -342,8 +342,6 @@ type PDUSessionModificationCommand struct {
 
 	AlwaysOn *bool // optional (IEI 0x8), value bit 1
 
-	AuthorizedQoSRules QoSRules // optional (IEI 0x7A)
-
 	// MappedEPSBearerContexts carries the EPS bearer contexts the session's QoS
 	// flows map to (IEI 0x75). TS 24.501 §6.1.4.2 has the SMF provide them only
 	// when the network supports N26; it is also how an EBI revocation strips the
@@ -378,15 +376,6 @@ func (m *PDUSessionModificationCommand) AppendBinary(b []byte) ([]byte, error) {
 
 	if m.AlwaysOn != nil {
 		o.TV1(ieiAlwaysOnIndication, boolBit(*m.AlwaysOn, 0))
-	}
-
-	if m.AuthorizedQoSRules != nil {
-		raw, err := m.AuthorizedQoSRules.MarshalBinary()
-		if err != nil {
-			return b, err
-		}
-
-		o.TLVE(ieiAuthorizedQoSRules, raw)
 	}
 
 	if m.MappedEPSBearerContexts != nil {
@@ -447,13 +436,6 @@ func ParsePDUSessionModificationCommand(b []byte) (*PDUSessionModificationComman
 			out.SessionAMBR = &parsed
 		case ieiAlwaysOnIndication:
 			out.AlwaysOn = tv1Flag(value)
-		case ieiAuthorizedQoSRules:
-			parsed, err := ParseQoSRules(value)
-			if err != nil {
-				return false, err
-			}
-
-			out.AuthorizedQoSRules = parsed
 		case ieiMappedEPSBearerContext:
 			parsed, err := ParseMappedEPSBearerContexts(value)
 			if err != nil {

--- a/nas/fgs/gsm_modification.go
+++ b/nas/fgs/gsm_modification.go
@@ -19,8 +19,8 @@ type PDUSessionModificationRequest struct {
 	GSMCapability            *GSMCapability                    // optional (IEI 0x28)
 	Cause                    *GSMCause                         // optional (IEI 0x59)
 	MaxPacketFilters         *uint16                           // optional (IEI 0x55)
-	IntegrityProtMaxDataRate *[2]byte                          // optional (IEI 0x13)
 	AlwaysOnRequested        *bool                             // optional (IEI 0xB), value bit 1
+	IntegrityProtMaxDataRate *[2]byte                          // optional (IEI 0x13)
 	RequestedQoSRules        QoSRules                          // optional (IEI 0x7A)
 	RequestedQoSFlows        QoSFlowDescriptions               // optional (IEI 0x79)
 	ExtendedPCO              *nas.ProtocolConfigurationOptions // optional (IEI 0x7B)
@@ -81,12 +81,12 @@ func (m *PDUSessionModificationRequest) AppendBinary(b []byte) ([]byte, error) {
 		o.TV3(ieiMaxPacketFilters, []byte{uint8(*m.MaxPacketFilters >> 8), uint8(*m.MaxPacketFilters)})
 	}
 
-	if m.IntegrityProtMaxDataRate != nil {
-		o.TV3(ieiIntegrityProtMaxRate, m.IntegrityProtMaxDataRate[:])
-	}
-
 	if m.AlwaysOnRequested != nil {
 		o.TV1(ieiAlwaysOnRequested, boolBit(*m.AlwaysOnRequested, 0))
+	}
+
+	if m.IntegrityProtMaxDataRate != nil {
+		o.TV3(ieiIntegrityProtMaxRate, m.IntegrityProtMaxDataRate[:])
 	}
 
 	if m.RequestedQoSRules != nil {

--- a/nas/fgs/gsm_modification.go
+++ b/nas/fgs/gsm_modification.go
@@ -16,12 +16,14 @@ type PDUSessionModificationRequest struct {
 	PDUSessionID PDUSessionID
 	PTI          nas.ProcedureTransactionIdentity
 
-	GSMCapability     *GSMCapability                    // optional (IEI 0x28)
-	Cause             *GSMCause                         // optional (IEI 0x59)
-	AlwaysOnRequested *bool                             // optional (IEI 0xB), value bit 1
-	RequestedQoSRules QoSRules                          // optional (IEI 0x7A)
-	RequestedQoSFlows QoSFlowDescriptions               // optional (IEI 0x79)
-	ExtendedPCO       *nas.ProtocolConfigurationOptions // optional (IEI 0x7B)
+	GSMCapability            *GSMCapability                    // optional (IEI 0x28)
+	Cause                    *GSMCause                         // optional (IEI 0x59)
+	MaxPacketFilters         *uint16                           // optional (IEI 0x55)
+	IntegrityProtMaxDataRate *[2]byte                          // optional (IEI 0x13)
+	AlwaysOnRequested        *bool                             // optional (IEI 0xB), value bit 1
+	RequestedQoSRules        QoSRules                          // optional (IEI 0x7A)
+	RequestedQoSFlows        QoSFlowDescriptions               // optional (IEI 0x79)
+	ExtendedPCO              *nas.ProtocolConfigurationOptions // optional (IEI 0x7B)
 
 	// MappedEPSBearerContexts is present when the UE asks to delete one or more
 	// mapped EPS bearer contexts (TS 24.501 §8.3.7.10).
@@ -73,6 +75,14 @@ func (m *PDUSessionModificationRequest) AppendBinary(b []byte) ([]byte, error) {
 
 	if m.Cause != nil {
 		o.TV3(iei5GSMCause, []byte{uint8(*m.Cause)})
+	}
+
+	if m.MaxPacketFilters != nil {
+		o.TV3(ieiMaxPacketFilters, []byte{uint8(*m.MaxPacketFilters >> 8), uint8(*m.MaxPacketFilters)})
+	}
+
+	if m.IntegrityProtMaxDataRate != nil {
+		o.TV3(ieiIntegrityProtMaxRate, m.IntegrityProtMaxDataRate[:])
 	}
 
 	if m.AlwaysOnRequested != nil {
@@ -151,6 +161,20 @@ func ParsePDUSessionModificationRequest(b []byte) (*PDUSessionModificationReques
 
 			cause := GSMCause(value[0])
 			out.Cause = &cause
+		case ieiMaxPacketFilters:
+			if len(value) != 2 {
+				return false, fmt.Errorf("nas/fgs: maximum number of supported packet filters is %d octets, want 2", len(value))
+			}
+
+			count := uint16(value[0])<<8 | uint16(value[1])
+			out.MaxPacketFilters = &count
+		case ieiIntegrityProtMaxRate:
+			if len(value) != 2 {
+				return false, fmt.Errorf("nas/fgs: integrity protection maximum data rate is %d octets, want 2", len(value))
+			}
+
+			rate := [2]byte{value[0], value[1]}
+			out.IntegrityProtMaxDataRate = &rate
 		case ieiAlwaysOnRequested:
 			// TS 24.501 table 9.11.4.4.1 assigns both values — 0 "not requested",
 			// 1 "requested" — so the element carries its own meaning and the field
@@ -316,6 +340,10 @@ type PDUSessionModificationCommand struct {
 	PTI          nas.ProcedureTransactionIdentity
 	SessionAMBR  *SessionAMBR // optional (IEI 0x2A)
 
+	AlwaysOn *bool // optional (IEI 0x8), value bit 1
+
+	AuthorizedQoSRules QoSRules // optional (IEI 0x7A)
+
 	// MappedEPSBearerContexts carries the EPS bearer contexts the session's QoS
 	// flows map to (IEI 0x75). TS 24.501 §6.1.4.2 has the SMF provide them only
 	// when the network supports N26; it is also how an EBI revocation strips the
@@ -346,6 +374,19 @@ func (m *PDUSessionModificationCommand) AppendBinary(b []byte) ([]byte, error) {
 		}
 
 		o.TLV(ieiSessionAMBR, raw)
+	}
+
+	if m.AlwaysOn != nil {
+		o.TV1(ieiAlwaysOnIndication, boolBit(*m.AlwaysOn, 0))
+	}
+
+	if m.AuthorizedQoSRules != nil {
+		raw, err := m.AuthorizedQoSRules.MarshalBinary()
+		if err != nil {
+			return b, err
+		}
+
+		o.TLVE(ieiAuthorizedQoSRules, raw)
 	}
 
 	if m.MappedEPSBearerContexts != nil {
@@ -404,6 +445,15 @@ func ParsePDUSessionModificationCommand(b []byte) (*PDUSessionModificationComman
 			}
 
 			out.SessionAMBR = &parsed
+		case ieiAlwaysOnIndication:
+			out.AlwaysOn = tv1Flag(value)
+		case ieiAuthorizedQoSRules:
+			parsed, err := ParseQoSRules(value)
+			if err != nil {
+				return false, err
+			}
+
+			out.AuthorizedQoSRules = parsed
 		case ieiMappedEPSBearerContext:
 			parsed, err := ParseMappedEPSBearerContexts(value)
 			if err != nil {

--- a/nas/fgs/gsm_modification_test.go
+++ b/nas/fgs/gsm_modification_test.go
@@ -17,15 +17,17 @@ func TestPDUSessionModificationRequestRoundTrip(t *testing.T) {
 	cause := GSMCauseRegularDeactivation
 
 	in := &PDUSessionModificationRequest{
-		PDUSessionID:      5,
-		PTI:               3,
-		GSMCapability:     &GSMCapability{RqoS: true},
-		Cause:             &cause,
-		AlwaysOnRequested: ptr(true),
-		RequestedQoSFlows: QoSFlowDescriptions{FiveQIQoSFlow(1, 9, QoSFlowOpCreate)},
+		PDUSessionID:             5,
+		PTI:                      3,
+		GSMCapability:            &GSMCapability{RqoS: true},
+		Cause:                    &cause,
+		MaxPacketFilters:         ptr(uint16(0x1000)),
+		IntegrityProtMaxDataRate: &[2]byte{0xff, 0xff},
+		AlwaysOnRequested:        ptr(true),
+		RequestedQoSFlows:        QoSFlowDescriptions{FiveQIQoSFlow(1, 9, QoSFlowOpCreate)},
 		Unrecognized: []nas.RawIE{
-			// Maximum number of supported packet filters, a TV the table frames.
-			{IEI: ieiMaxPacketFilters, Format: nas.IETV3, Value: []byte{0x10, 0x00}},
+			// IP header compression configuration, a TLV the table frames.
+			{IEI: ieiIPHeaderCompression, Format: nas.IETLV, Value: []byte{0x00, 0x00}},
 		},
 	}
 
@@ -64,8 +66,16 @@ func TestPDUSessionModificationRequestRoundTrip(t *testing.T) {
 		t.Errorf("requested QoS flow descriptions = %+v", out.RequestedQoSFlows)
 	}
 
+	if out.MaxPacketFilters == nil || *out.MaxPacketFilters != 0x1000 {
+		t.Errorf("maximum number of supported packet filters = %v, want 4096", out.MaxPacketFilters)
+	}
+
+	if out.IntegrityProtMaxDataRate == nil || *out.IntegrityProtMaxDataRate != [2]byte{0xff, 0xff} {
+		t.Errorf("integrity protection maximum data rate = %v, want ff ff", out.IntegrityProtMaxDataRate)
+	}
+
 	if len(out.Unrecognized) != 1 {
-		t.Errorf("unmodelled elements = %+v, want the packet-filter maximum preserved", out.Unrecognized)
+		t.Errorf("unmodelled elements = %+v, want the header-compression element preserved", out.Unrecognized)
 	}
 
 	again, err := out.MarshalBinary()


### PR DESCRIPTION
# Description

The SMF now answers UE-requested PDU session modifications with a modification command instead of rejecting them, fixing the rejection UEs hit after a 4G to 5G idle-mode transfer and aligning always-on and DNS handling with 3GPP; the MME's bearer modification reject now names its cause. Adds tester support and an interworking scenario for the procedure.

## Reference
- TS 24.501 §6.1.4.1, §6.3.2.2, §6.4.2 (primary)
- TS 24.301 §6.5.4 (MME side)
- TS 38.523-1 §10.1.5.1 (conformance reference)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
