### PR TITLE
fix(upf): advertise only configured N3 external addresses

### DIFF
--- a/docs/reference/api/networking.md
+++ b/docs/reference/api/networking.md
@@ -477,7 +477,7 @@ This path updates the N3 interface settings.
 
 ### Parameters
 
-- `external_address` (string): The external address to be used for the N3 / S1-U interface. This address is advertised to the radio in the GTP tunnel Transport Layer Address. The radio uses it to set up the GTP-U tunnel. This setting is useful when Ella Core is behind a proxy or NAT and the N3 / S1-U interface address is not reachable by the radio. Accepts an IPv4 address, an IPv6 address, or one of each separated by a comma. If not set, Ella Core will use the address of the N3 interface as defined in the config file.
+- `external_address` (string): The external address to be used for the N3 / S1-U interface. This address is advertised to the radio in the GTP tunnel Transport Layer Address. The radio uses it to set up the GTP-U tunnel. This setting is useful when Ella Core is behind a proxy or NAT and the N3 / S1-U interface address is not reachable by the radio. If not set, Ella Core will use the address of the N3 interface as defined in the config file.
 
 ### Sample Response
 

--- a/docs/reference/api/networking.md
+++ b/docs/reference/api/networking.md
@@ -477,7 +477,7 @@ This path updates the N3 interface settings.
 
 ### Parameters
 
-- `external_address` (string): The external address to be used for the N3 / S1-U interface. This address is advertised to the radio in the GTP tunnel Transport Layer Address. The radio uses it to set up the GTP-U tunnel. This setting is useful when Ella Core is behind a proxy or NAT and the N3 / S1-U interface address is not reachable by the radio. If not set, Ella Core will use the address of the N3 interface as defined in the config file.
+- `external_address` (string): The external address to be used for the N3 / S1-U interface: an IPv4 address, an IPv6 address, or one of each separated by a comma. This address is advertised to the radio in the GTP tunnel Transport Layer Address. The radio uses it to set up the GTP-U tunnel. This setting is useful when Ella Core is behind a proxy or NAT and the N3 / S1-U interface address is not reachable by the radio. If not set, Ella Core will use the address of the N3 interface as defined in the config file.
 
 ### Sample Response
 

--- a/docs/reference/api/networking.md
+++ b/docs/reference/api/networking.md
@@ -477,7 +477,7 @@ This path updates the N3 interface settings.
 
 ### Parameters
 
-- `external_address` (string): The external address to be used for the N3 / S1-U interface. This address is advertised to the radio in the GTP tunnel Transport Layer Address. The radio uses it to set up the GTP-U tunnel. This setting is useful when Ella Core is behind a proxy or NAT and the N3 / S1-U interface address is not reachable by the radio. If not set, Ella Core will use the address of the N3 interface as defined in the config file.
+- `external_address` (string): The external address to be used for the N3 / S1-U interface. This address is advertised to the radio in the GTP tunnel Transport Layer Address. The radio uses it to set up the GTP-U tunnel. This setting is useful when Ella Core is behind a proxy or NAT and the N3 / S1-U interface address is not reachable by the radio. Accepts an IPv4 address, an IPv6 address, or one of each separated by a comma. If not set, Ella Core will use the address of the N3 interface as defined in the config file.
 
 ### Sample Response
 

--- a/internal/api/server/api_interfaces.go
+++ b/internal/api/server/api_interfaces.go
@@ -175,10 +175,6 @@ func UpdateN3Interface(dbInstance *db.Database) http.Handler {
 			return
 		}
 
-		// Empty means "use the local interface IP"; the upf reconciler
-		// resolves that against each node's local config when applying.
-		// A non-empty value must name one IPv4 address, one IPv6 address,
-		// or one of each separated by a comma.
 		if params.ExternalAddress != "" {
 			if _, _, err := models.ParseN3ExternalAddress(params.ExternalAddress); err != nil {
 				writeError(r.Context(), w, http.StatusBadRequest, "Invalid external address. Must be an IPv4 address, an IPv6 address, or an IPv4 and an IPv6 address separated by a comma", err, logger.APILog)

--- a/internal/api/server/api_interfaces.go
+++ b/internal/api/server/api_interfaces.go
@@ -7,11 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/netip"
 
 	"github.com/ellanetworks/core/internal/config"
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 )
 
 type N2Interface struct {
@@ -177,10 +177,11 @@ func UpdateN3Interface(dbInstance *db.Database) http.Handler {
 
 		// Empty means "use the local interface IP"; the upf reconciler
 		// resolves that against each node's local config when applying.
-		// A non-empty value must be a valid IP.
+		// A non-empty value must name one IPv4 address, one IPv6 address,
+		// or one of each separated by a comma.
 		if params.ExternalAddress != "" {
-			if _, err := netip.ParseAddr(params.ExternalAddress); err != nil {
-				writeError(r.Context(), w, http.StatusBadRequest, "Invalid external address. Must be a valid IP address", err, logger.APILog)
+			if _, _, err := models.ParseN3ExternalAddress(params.ExternalAddress); err != nil {
+				writeError(r.Context(), w, http.StatusBadRequest, "Invalid external address. Must be an IPv4 address, an IPv6 address, or an IPv4 and an IPv6 address separated by a comma", err, logger.APILog)
 				return
 			}
 		}

--- a/internal/api/server/api_interfaces_test.go
+++ b/internal/api/server/api_interfaces_test.go
@@ -185,7 +185,7 @@ func TestNetworkInteraces_EndToEnd(t *testing.T) {
 			t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
 		}
 
-		if updateResponse.Error != "Invalid external address. Must be a valid IP address" {
+		if updateResponse.Error != "Invalid external address. Must be an IPv4 address, an IPv6 address, or an IPv4 and an IPv6 address separated by a comma" {
 			t.Fatalf("expected no error, got %s", updateResponse.Error)
 		}
 	})

--- a/internal/api/server/openapi.yaml
+++ b/internal/api/server/openapi.yaml
@@ -5463,7 +5463,7 @@ components:
       properties:
         external_address:
           type: string
-          description: "External/advertised IP address. Empty string to use default."
+          description: "External/advertised IP address: an IPv4 address, an IPv6 address, or one of each separated by a comma. Empty string to use default."
 
     # -- Radios ----------------------------------------------------------
     PlmnID:

--- a/internal/models/n3_external_address.go
+++ b/internal/models/n3_external_address.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package models
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// ParseN3ExternalAddress parses the operator-configured N3 / S1-U external
+// address into the endpoints to advertise in the Transport Layer Address. It
+// accepts a single IPv4 address, a single IPv6 address, or one of each
+// separated by a comma. A family the operator did not name comes back as the
+// zero Addr, so the advertisement carries exactly the families that were
+// configured and nothing else.
+func ParseN3ExternalAddress(s string) (v4, v6 netip.Addr, err error) {
+	fields := strings.Split(s, ",")
+
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return netip.Addr{}, netip.Addr{}, fmt.Errorf("external address %q: empty address", s)
+		}
+
+		addr, parseErr := netip.ParseAddr(field)
+		if parseErr != nil {
+			return netip.Addr{}, netip.Addr{}, fmt.Errorf("external address %q: %w", s, parseErr)
+		}
+
+		addr = addr.Unmap()
+
+		if addr.Is4() {
+			if v4.IsValid() {
+				return netip.Addr{}, netip.Addr{}, fmt.Errorf("external address %q: more than one IPv4 address", s)
+			}
+
+			v4 = addr
+
+			continue
+		}
+
+		if v6.IsValid() {
+			return netip.Addr{}, netip.Addr{}, fmt.Errorf("external address %q: more than one IPv6 address", s)
+		}
+
+		v6 = addr
+	}
+
+	if !v4.IsValid() && !v6.IsValid() {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("external address %q: no address", s)
+	}
+
+	return v4, v6, nil
+}

--- a/internal/models/n3_external_address.go
+++ b/internal/models/n3_external_address.go
@@ -9,16 +9,10 @@ import (
 	"strings"
 )
 
-// ParseN3ExternalAddress parses the operator-configured N3 / S1-U external
-// address into the endpoints to advertise in the Transport Layer Address. It
-// accepts a single IPv4 address, a single IPv6 address, or one of each
-// separated by a comma. A family the operator did not name comes back as the
-// zero Addr, so the advertisement carries exactly the families that were
-// configured and nothing else.
 func ParseN3ExternalAddress(s string) (v4, v6 netip.Addr, err error) {
-	fields := strings.Split(s, ",")
+	fields := strings.SplitSeq(s, ",")
 
-	for _, field := range fields {
+	for field := range fields {
 		field = strings.TrimSpace(field)
 		if field == "" {
 			return netip.Addr{}, netip.Addr{}, fmt.Errorf("external address %q: empty address", s)

--- a/internal/models/n3_external_address_test.go
+++ b/internal/models/n3_external_address_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package models_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+)
+
+func TestParseN3ExternalAddress(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		v4    string
+		v6    string
+	}{
+		{name: "ipv4 only", input: "33.33.33.5", v4: "33.33.33.5"},
+		{name: "ipv6 only", input: "2001:db8::5", v6: "2001:db8::5"},
+		{name: "dual stack", input: "33.33.33.5,2001:db8::5", v4: "33.33.33.5", v6: "2001:db8::5"},
+		{name: "dual stack ipv6 first", input: "2001:db8::5,33.33.33.5", v4: "33.33.33.5", v6: "2001:db8::5"},
+		{name: "dual stack with spaces", input: " 33.33.33.5 , 2001:db8::5 ", v4: "33.33.33.5", v6: "2001:db8::5"},
+		{name: "ipv4 mapped ipv6 is ipv4", input: "::ffff:33.33.33.5", v4: "33.33.33.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v4, v6, err := models.ParseN3ExternalAddress(tt.input)
+			if err != nil {
+				t.Fatalf("ParseN3ExternalAddress(%q): %v", tt.input, err)
+			}
+
+			if got := addrText(v4); got != tt.v4 {
+				t.Errorf("IPv4: got %q, want %q", got, tt.v4)
+			}
+
+			if got := addrText(v6); got != tt.v6 {
+				t.Errorf("IPv6: got %q, want %q", got, tt.v6)
+			}
+		})
+	}
+}
+
+func TestParseN3ExternalAddressRejects(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty", input: ""},
+		{name: "not an address", input: "not-an-ip"},
+		{name: "two ipv4", input: "33.33.33.5,33.33.33.6"},
+		{name: "two ipv6", input: "2001:db8::5,2001:db8::6"},
+		{name: "trailing comma", input: "33.33.33.5,"},
+		{name: "cidr", input: "33.33.33.5/32"},
+		{name: "three addresses", input: "33.33.33.5,2001:db8::5,2001:db8::6"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := models.ParseN3ExternalAddress(tt.input); err == nil {
+				t.Fatalf("ParseN3ExternalAddress(%q): expected error", tt.input)
+			}
+		})
+	}
+}
+
+func addrText(addr netip.Addr) string {
+	if !addr.IsValid() {
+		return ""
+	}
+
+	return addr.String()
+}

--- a/internal/upf/engine/buffer_test.go
+++ b/internal/upf/engine/buffer_test.go
@@ -152,7 +152,7 @@ func newBufferTestEngine(t *testing.T, buf engine.DownlinkBuffer) *engine.Sessio
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/delete_session_framed_test.go
+++ b/internal/upf/engine/delete_session_framed_test.go
@@ -39,7 +39,7 @@ func TestDeleteSessionRemovesFramedRoutes(t *testing.T) {
 
 	t.Cleanup(func() { _ = obj.Close() })
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, nil)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, nil)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/delete_session_urr_test.go
+++ b/internal/upf/engine/delete_session_urr_test.go
@@ -40,7 +40,7 @@ func TestDeleteSessionRemovesURR(t *testing.T) {
 
 	t.Cleanup(func() { _ = obj.Close() })
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, nil)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, nil)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/establish_session.go
+++ b/internal/upf/engine/establish_session.go
@@ -232,10 +232,12 @@ func (conn *SessionEngine) EstablishSession(ctx context.Context, req *models.Est
 
 	logger.WithTrace(ctx, logger.UpfLog).Debug("Accepted Session Establishment Request")
 
+	advertisedN3IPv4, advertisedN3IPv6 := conn.GetAdvertisedN3Addresses()
+
 	return &models.EstablishResponse{
 		N3TEID: uplinkTEID(createdPDRs),
-		N3IPv4: conn.GetAdvertisedN3Address(),
-		N3IPv6: conn.GetAdvertisedN3AddressIPv6(),
+		N3IPv4: advertisedN3IPv4,
+		N3IPv6: advertisedN3IPv6,
 	}, nil
 }
 

--- a/internal/upf/engine/establish_session_framed_test.go
+++ b/internal/upf/engine/establish_session_framed_test.go
@@ -44,7 +44,7 @@ func TestEstablishSessionSkipsMismatchedFamilyFramedRoute(t *testing.T) {
 		t.Fatalf("fteid manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/establish_session_reestablish_test.go
+++ b/internal/upf/engine/establish_session_reestablish_test.go
@@ -45,7 +45,7 @@ func TestReEstablishTearsDownOldSession(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/establish_session_rollback_test.go
+++ b/internal/upf/engine/establish_session_rollback_test.go
@@ -8,6 +8,7 @@ package engine_test
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"os"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestEstablishSessionRollsBackOnFailure(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/establish_session_spoof_test.go
+++ b/internal/upf/engine/establish_session_spoof_test.go
@@ -43,7 +43,7 @@ func TestEstablishSessionStampsUplinkUEAddresses(t *testing.T) {
 		t.Fatalf("fteid manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/modify_session_imsi_test.go
+++ b/internal/upf/engine/modify_session_imsi_test.go
@@ -45,7 +45,7 @@ func modifyIMSITestEngine(t *testing.T, seid uint64, imsi string) (*engine.Sessi
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/modify_session_policy_test.go
+++ b/internal/upf/engine/modify_session_policy_test.go
@@ -42,7 +42,7 @@ func TestModifySessionPolicyChangeRepointsFilterIndex(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/modify_session_rollback_test.go
+++ b/internal/upf/engine/modify_session_rollback_test.go
@@ -45,7 +45,7 @@ func TestModifySessionRollsBackOnFailure(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestModifySessionUpdatePDRKeyChangeRollback(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestModifySessionUpdatePDRKeyChangeCommit(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/modify_session_teid_test.go
+++ b/internal/upf/engine/modify_session_teid_test.go
@@ -43,7 +43,7 @@ func TestModifySessionFailureKeepsTheLiveUplinkTEID(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/nat_purge_test.go
+++ b/internal/upf/engine/nat_purge_test.go
@@ -58,7 +58,7 @@ func TestDeleteSessionPurgesNATConntrack(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/sdf_filter_reuse_test.go
+++ b/internal/upf/engine/sdf_filter_reuse_test.go
@@ -43,7 +43,7 @@ func TestFilterReleaseVsSessionApplyNoSlotReuse(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/session_concurrency_test.go
+++ b/internal/upf/engine/session_concurrency_test.go
@@ -46,7 +46,7 @@ func TestDeleteVsFilterPropagationNoResurrection(t *testing.T) {
 		t.Fatalf("new fteid resource manager: %v", err)
 	}
 
-	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", "2.3.4.5", "", "2.3.4.5", "", obj, rm)
+	conn, err := engine.NewSessionEngine("1.2.3.4", "nodeId", netip.MustParseAddr("2.3.4.5"), netip.Addr{}, netip.MustParseAddr("2.3.4.5"), netip.Addr{}, obj, rm)
 	if err != nil {
 		t.Fatalf("new session engine: %v", err)
 	}

--- a/internal/upf/engine/session_engine.go
+++ b/internal/upf/engine/session_engine.go
@@ -204,9 +204,6 @@ func (pc *SessionEngine) GetAdvertisedN3AddressIPv6() netip.Addr {
 	return pc.advertisedN3AddressIPv6
 }
 
-// SetAdvertisedN3Addresses replaces both advertised N3 endpoints at once. A
-// zero Addr clears that family, so a configuration naming a single family
-// stops advertising the other one.
 func (pc *SessionEngine) SetAdvertisedN3Addresses(newN3AddrIPv4, newN3AddrIPv6 netip.Addr) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()

--- a/internal/upf/engine/session_engine.go
+++ b/internal/upf/engine/session_engine.go
@@ -190,18 +190,11 @@ func (pc *SessionEngine) InitializeFiltersFromDB(ctx context.Context, dbInstance
 	return nil
 }
 
-func (pc *SessionEngine) GetAdvertisedN3Address() netip.Addr {
+func (pc *SessionEngine) GetAdvertisedN3Addresses() (netip.Addr, netip.Addr) {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
 
-	return pc.advertisedN3AddressIPv4
-}
-
-func (pc *SessionEngine) GetAdvertisedN3AddressIPv6() netip.Addr {
-	pc.mu.RLock()
-	defer pc.mu.RUnlock()
-
-	return pc.advertisedN3AddressIPv6
+	return pc.advertisedN3AddressIPv4, pc.advertisedN3AddressIPv6
 }
 
 func (pc *SessionEngine) SetAdvertisedN3Addresses(newN3AddrIPv4, newN3AddrIPv6 netip.Addr) {

--- a/internal/upf/engine/session_engine.go
+++ b/internal/upf/engine/session_engine.go
@@ -212,54 +212,10 @@ func (pc *SessionEngine) SetAdvertisedN3Addresses(newN3AddrIPv4, newN3AddrIPv6 n
 	pc.advertisedN3AddressIPv6 = newN3AddrIPv6
 }
 
-func NewSessionEngine(addr string, nodeID string, n3IPv4 string, n3IPv6 string, advertisedN3IPv4 string, advertisedN3IPv6 string, bpfObjects *ebpf.BpfObjects, resourceManager *FteIDResourceManager) (*SessionEngine, error) {
+func NewSessionEngine(addr string, nodeID string, n3IPv4 netip.Addr, n3IPv6 netip.Addr, advertisedN3IPv4 netip.Addr, advertisedN3IPv6 netip.Addr, bpfObjects *ebpf.BpfObjects, resourceManager *FteIDResourceManager) (*SessionEngine, error) {
 	addrV4 := net.ParseIP(addr)
 	if addrV4 == nil {
 		return nil, fmt.Errorf("failed to parse IP address ID: %s", addr)
-	}
-
-	var n3AddrIPv4 netip.Addr
-
-	if n3IPv4 != "" {
-		parsed, err := netip.ParseAddr(n3IPv4)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse N3 IPv4 address: %s", n3IPv4)
-		}
-
-		n3AddrIPv4 = parsed
-	}
-
-	var n3AddrIPv6 netip.Addr
-
-	if n3IPv6 != "" {
-		parsed, err := netip.ParseAddr(n3IPv6)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse N3 IPv6 address: %s", n3IPv6)
-		}
-
-		n3AddrIPv6 = parsed
-	}
-
-	var advertisedN3AddrIPv4 netip.Addr
-
-	if advertisedN3IPv4 != "" {
-		parsed, err := netip.ParseAddr(advertisedN3IPv4)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse advertised N3 IPv4 address: %w", err)
-		}
-
-		advertisedN3AddrIPv4 = parsed
-	}
-
-	var advertisedN3AddrIPv6 netip.Addr
-
-	if advertisedN3IPv6 != "" {
-		parsed, err := netip.ParseAddr(advertisedN3IPv6)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse advertised N3 IPv6 address: %w", err)
-		}
-
-		advertisedN3AddrIPv6 = parsed
 	}
 
 	conn := &SessionEngine{
@@ -267,10 +223,10 @@ func NewSessionEngine(addr string, nodeID string, n3IPv4 string, n3IPv6 string, 
 		policyToSEIDs:           make(map[string]map[uint64]struct{}),
 		nodeID:                  nodeID,
 		nodeAddrV4:              addrV4,
-		n3AddressIPv4:           n3AddrIPv4,
-		n3AddressIPv6:           n3AddrIPv6,
-		advertisedN3AddressIPv4: advertisedN3AddrIPv4,
-		advertisedN3AddressIPv6: advertisedN3AddrIPv6,
+		n3AddressIPv4:           n3IPv4,
+		n3AddressIPv6:           n3IPv6,
+		advertisedN3AddressIPv4: advertisedN3IPv4,
+		advertisedN3AddressIPv6: advertisedN3IPv6,
 		BpfObjects:              bpfObjects,
 		FteIDResourceManager:    resourceManager,
 		SdfIndexAllocator:       NewSdfIndexAllocator(ebpf.MaxSdfFilters),

--- a/internal/upf/engine/session_engine.go
+++ b/internal/upf/engine/session_engine.go
@@ -204,18 +204,15 @@ func (pc *SessionEngine) GetAdvertisedN3AddressIPv6() netip.Addr {
 	return pc.advertisedN3AddressIPv6
 }
 
-func (pc *SessionEngine) SetAdvertisedN3Address(newN3Addr netip.Addr) {
+// SetAdvertisedN3Addresses replaces both advertised N3 endpoints at once. A
+// zero Addr clears that family, so a configuration naming a single family
+// stops advertising the other one.
+func (pc *SessionEngine) SetAdvertisedN3Addresses(newN3AddrIPv4, newN3AddrIPv6 netip.Addr) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 
-	pc.advertisedN3AddressIPv4 = newN3Addr
-}
-
-func (pc *SessionEngine) SetAdvertisedN3AddressIPv6(newN3Addr netip.Addr) {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-
-	pc.advertisedN3AddressIPv6 = newN3Addr
+	pc.advertisedN3AddressIPv4 = newN3AddrIPv4
+	pc.advertisedN3AddressIPv6 = newN3AddrIPv6
 }
 
 func NewSessionEngine(addr string, nodeID string, n3IPv4 string, n3IPv6 string, advertisedN3IPv4 string, advertisedN3IPv6 string, bpfObjects *ebpf.BpfObjects, resourceManager *FteIDResourceManager) (*SessionEngine, error) {

--- a/internal/upf/engine/session_handlers_test.go
+++ b/internal/upf/engine/session_handlers_test.go
@@ -5,6 +5,7 @@ package engine_test
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	"github.com/ellanetworks/core/internal/models"
@@ -15,10 +16,10 @@ func TestModifySessionSessionNotFound(t *testing.T) {
 	conn, err := engine.NewSessionEngine(
 		"1.2.3.4",
 		"nodeId",
-		"2.3.4.5",
-		"",
-		"2.3.4.5",
-		"",
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
 		nil,
 		nil,
 	)
@@ -38,10 +39,10 @@ func TestDeleteSessionAccepted(t *testing.T) {
 	conn, err := engine.NewSessionEngine(
 		"1.2.3.4",
 		"nodeId",
-		"2.3.4.5",
-		"",
-		"2.3.4.5",
-		"",
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
 		nil,
 		nil,
 	)
@@ -70,10 +71,10 @@ func TestDeleteSessionNotFound(t *testing.T) {
 	conn, err := engine.NewSessionEngine(
 		"1.2.3.4",
 		"nodeId",
-		"2.3.4.5",
-		"",
-		"2.3.4.5",
-		"",
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
 		nil,
 		nil,
 	)
@@ -91,10 +92,10 @@ func TestModifySessionAccepted(t *testing.T) {
 	conn, err := engine.NewSessionEngine(
 		"1.2.3.4",
 		"nodeId",
-		"2.3.4.5",
-		"",
-		"2.3.4.5",
-		"",
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
+		netip.MustParseAddr("2.3.4.5"),
+		netip.Addr{},
 		nil,
 		nil,
 	)

--- a/internal/upf/reconciler.go
+++ b/internal/upf/reconciler.go
@@ -73,7 +73,7 @@ type SettingsReconciler struct {
 
 	stateMu            sync.Mutex
 	appliedSettings    *DatapathSettings
-	appliedN3Addresses *advertisedN3Addresses
+	appliedN3Addresses advertisedN3Addresses
 	appliedFilters     map[string]filterSnapshot
 }
 
@@ -84,19 +84,6 @@ type advertisedN3Addresses struct {
 
 func (a advertisedN3Addresses) valid() bool {
 	return a.v4.IsValid() || a.v6.IsValid()
-}
-
-func (a advertisedN3Addresses) String() string {
-	switch {
-	case a.v4.IsValid() && a.v6.IsValid():
-		return a.v4.String() + "," + a.v6.String()
-	case a.v6.IsValid():
-		return a.v6.String()
-	case a.v4.IsValid():
-		return a.v4.String()
-	default:
-		return ""
-	}
 }
 
 type filterSnapshot struct {
@@ -323,17 +310,18 @@ func (r *SettingsReconciler) reconcileN3Address(ctx context.Context) error {
 	current := r.appliedN3Addresses
 	r.stateMu.Unlock()
 
-	if current != nil && *current == desired {
+	if current == desired {
 		return nil
 	}
 
 	r.updater.UpdateAdvertisedN3Addresses(desired.v4, desired.v6)
 
 	r.stateMu.Lock()
-	r.appliedN3Addresses = &desired
+	r.appliedN3Addresses = desired
 	r.stateMu.Unlock()
 
-	logger.UpfLog.Info("applied advertised N3 addresses", zap.String("addresses", desired.String()))
+	logger.UpfLog.Info("applied advertised N3 addresses",
+		zap.Stringer("ipv4", desired.v4), zap.Stringer("ipv6", desired.v6))
 
 	return nil
 }

--- a/internal/upf/reconciler.go
+++ b/internal/upf/reconciler.go
@@ -296,7 +296,7 @@ func (r *SettingsReconciler) reconcileN3Address(ctx context.Context) error {
 	if settings.ExternalAddress != "" {
 		v4, v6, err := models.ParseN3ExternalAddress(settings.ExternalAddress)
 		if err != nil {
-			return fmt.Errorf("invalid %w", err)
+			return err
 		}
 
 		desired = advertisedN3Addresses{v4: v4, v6: v6}

--- a/internal/upf/reconciler.go
+++ b/internal/upf/reconciler.go
@@ -77,9 +77,6 @@ type SettingsReconciler struct {
 	appliedFilters     map[string]filterSnapshot
 }
 
-// advertisedN3Addresses is the pair of endpoints signalled to the radio in the
-// Transport Layer Address. Either half may be the zero Addr, meaning that
-// family is not advertised.
 type advertisedN3Addresses struct {
 	v4 netip.Addr
 	v6 netip.Addr
@@ -107,12 +104,6 @@ type filterSnapshot struct {
 	downlink []models.FilterRule
 }
 
-// NewSettingsReconciler wires a reconciler. fallbackN3IPv4 and fallbackN3IPv6
-// are the local node's configured N3 addresses used when
-// n3_settings.external_address is empty; either may be the zero Addr when the
-// N3 interface has no address of that family. changefeed may be nil in tests
-// that drive Reconcile() directly; production callers always pass a non-nil
-// broker.
 func NewSettingsReconciler(updater Updater, store SettingsStore, changefeed *db.Changefeed, fallbackN3IPv4, fallbackN3IPv6 netip.Addr) *SettingsReconciler {
 	return &SettingsReconciler{
 		updater:        updater,

--- a/internal/upf/reconciler.go
+++ b/internal/upf/reconciler.go
@@ -49,7 +49,7 @@ type DatapathSettings struct {
 // *UPF satisfies it.
 type Updater interface {
 	ApplyDatapathSettings(settings DatapathSettings) error
-	UpdateAdvertisedN3Address(addr netip.Addr)
+	UpdateAdvertisedN3Addresses(v4, v6 netip.Addr)
 	UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error
 }
 
@@ -61,20 +61,45 @@ type Updater interface {
 // calls re-attach XDP / re-write eBPF maps, so calling them
 // unconditionally on every tick would disrupt the data plane.
 type SettingsReconciler struct {
-	updater      Updater
-	store        SettingsStore
-	changefeed   *db.Changefeed
-	fallbackN3IP netip.Addr
-	backstop     time.Duration
+	updater    Updater
+	store      SettingsStore
+	changefeed *db.Changefeed
+	fallbackN3 advertisedN3Addresses
+	backstop   time.Duration
 
 	mu     sync.Mutex
 	cancel context.CancelFunc
 	done   chan struct{}
 
-	stateMu          sync.Mutex
-	appliedSettings  *DatapathSettings
-	appliedN3Address netip.Addr
-	appliedFilters   map[string]filterSnapshot
+	stateMu            sync.Mutex
+	appliedSettings    *DatapathSettings
+	appliedN3Addresses *advertisedN3Addresses
+	appliedFilters     map[string]filterSnapshot
+}
+
+// advertisedN3Addresses is the pair of endpoints signalled to the radio in the
+// Transport Layer Address. Either half may be the zero Addr, meaning that
+// family is not advertised.
+type advertisedN3Addresses struct {
+	v4 netip.Addr
+	v6 netip.Addr
+}
+
+func (a advertisedN3Addresses) valid() bool {
+	return a.v4.IsValid() || a.v6.IsValid()
+}
+
+func (a advertisedN3Addresses) String() string {
+	switch {
+	case a.v4.IsValid() && a.v6.IsValid():
+		return a.v4.String() + "," + a.v6.String()
+	case a.v6.IsValid():
+		return a.v6.String()
+	case a.v4.IsValid():
+		return a.v4.String()
+	default:
+		return ""
+	}
 }
 
 type filterSnapshot struct {
@@ -82,16 +107,18 @@ type filterSnapshot struct {
 	downlink []models.FilterRule
 }
 
-// NewSettingsReconciler wires a reconciler. fallbackN3IP is the local
-// node's configured N3 address used when n3_settings.external_address
-// is empty. changefeed may be nil in tests that drive Reconcile()
-// directly; production callers always pass a non-nil broker.
-func NewSettingsReconciler(updater Updater, store SettingsStore, changefeed *db.Changefeed, fallbackN3IP netip.Addr) *SettingsReconciler {
+// NewSettingsReconciler wires a reconciler. fallbackN3IPv4 and fallbackN3IPv6
+// are the local node's configured N3 addresses used when
+// n3_settings.external_address is empty; either may be the zero Addr when the
+// N3 interface has no address of that family. changefeed may be nil in tests
+// that drive Reconcile() directly; production callers always pass a non-nil
+// broker.
+func NewSettingsReconciler(updater Updater, store SettingsStore, changefeed *db.Changefeed, fallbackN3IPv4, fallbackN3IPv6 netip.Addr) *SettingsReconciler {
 	return &SettingsReconciler{
 		updater:        updater,
 		store:          store,
 		changefeed:     changefeed,
-		fallbackN3IP:   fallbackN3IP,
+		fallbackN3:     advertisedN3Addresses{v4: fallbackN3IPv4, v6: fallbackN3IPv6},
 		backstop:       upfReconcileBackstop,
 		appliedFilters: make(map[string]filterSnapshot),
 	}
@@ -286,36 +313,36 @@ func (r *SettingsReconciler) reconcileN3Address(ctx context.Context) error {
 		return err
 	}
 
-	desired := r.fallbackN3IP
+	desired := r.fallbackN3
 
 	if settings.ExternalAddress != "" {
-		parsed, err := netip.ParseAddr(settings.ExternalAddress)
+		v4, v6, err := models.ParseN3ExternalAddress(settings.ExternalAddress)
 		if err != nil {
-			return fmt.Errorf("invalid external address %q: %w", settings.ExternalAddress, err)
+			return fmt.Errorf("invalid %w", err)
 		}
 
-		desired = parsed
+		desired = advertisedN3Addresses{v4: v4, v6: v6}
 	}
 
-	if !desired.IsValid() {
+	if !desired.valid() {
 		return nil
 	}
 
 	r.stateMu.Lock()
-	current := r.appliedN3Address
+	current := r.appliedN3Addresses
 	r.stateMu.Unlock()
 
-	if current == desired {
+	if current != nil && *current == desired {
 		return nil
 	}
 
-	r.updater.UpdateAdvertisedN3Address(desired)
+	r.updater.UpdateAdvertisedN3Addresses(desired.v4, desired.v6)
 
 	r.stateMu.Lock()
-	r.appliedN3Address = desired
+	r.appliedN3Addresses = &desired
 	r.stateMu.Unlock()
 
-	logger.UpfLog.Info("applied advertised N3 address", zap.String("address", desired.String()))
+	logger.UpfLog.Info("applied advertised N3 addresses", zap.String("addresses", desired.String()))
 
 	return nil
 }

--- a/internal/upf/reconciler_test.go
+++ b/internal/upf/reconciler_test.go
@@ -89,7 +89,7 @@ type filterCall struct {
 type fakeUpdater struct {
 	mu                sync.Mutex
 	settingsCalls     []DatapathSettings
-	n3Calls           []netip.Addr
+	n3Calls           []advertisedN3Addresses
 	filterCalls       []filterCall
 	settingsErr       error
 	updateFiltersErr  error
@@ -140,11 +140,11 @@ func (f *fakeUpdater) flowCalls() []bool {
 	return out
 }
 
-func (f *fakeUpdater) UpdateAdvertisedN3Address(addr netip.Addr) {
+func (f *fakeUpdater) UpdateAdvertisedN3Addresses(v4, v6 netip.Addr) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	f.n3Calls = append(f.n3Calls, addr)
+	f.n3Calls = append(f.n3Calls, advertisedN3Addresses{v4: v4, v6: v6})
 }
 
 func (f *fakeUpdater) UpdateFilters(_ context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {
@@ -167,15 +167,15 @@ func (f *fakeUpdater) UpdateFilters(_ context.Context, policyID string, directio
 	return nil
 }
 
-func newReconciler(updater Updater, store SettingsStore, fallback netip.Addr) *SettingsReconciler {
-	return NewSettingsReconciler(updater, store, nil, fallback)
+func newReconciler(updater Updater, store SettingsStore, fallback advertisedN3Addresses) *SettingsReconciler {
+	return NewSettingsReconciler(updater, store, nil, fallback.v4, fallback.v6)
 }
 
 func TestReconcile_NATAppliesOnFirstTickAndSkipsWhenUnchanged(t *testing.T) {
 	store := &fakeStore{natEnabled: true}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("1.2.3.4")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("first reconcile: %v", err)
@@ -198,7 +198,7 @@ func TestReconcile_NATFiresOnChange(t *testing.T) {
 	store := &fakeStore{natEnabled: true}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("1.2.3.4")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("reconcile 1: %v", err)
@@ -221,7 +221,7 @@ func TestReconcile_FlowAccountingDiff(t *testing.T) {
 	store := &fakeStore{flowAccounting: true}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("1.2.3.4")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("first reconcile: %v", err)
@@ -239,7 +239,10 @@ func TestReconcile_FlowAccountingDiff(t *testing.T) {
 func TestReconcile_N3UsesFallbackWhenExternalEmpty(t *testing.T) {
 	store := &fakeStore{n3External: ""}
 	updater := &fakeUpdater{}
-	fallback := netip.MustParseAddr("10.0.0.5")
+	fallback := advertisedN3Addresses{
+		v4: netip.MustParseAddr("10.0.0.5"),
+		v6: netip.MustParseAddr("2001:db8::1"),
+	}
 
 	r := newReconciler(updater, store, fallback)
 
@@ -253,18 +256,21 @@ func TestReconcile_N3UsesFallbackWhenExternalEmpty(t *testing.T) {
 }
 
 func TestReconcile_N3PrefersExternalWhenSet(t *testing.T) {
-	external := "172.16.1.1"
-	store := &fakeStore{n3External: external}
+	store := &fakeStore{n3External: "172.16.1.1"}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{
+		v4: netip.MustParseAddr("10.0.0.5"),
+		v6: netip.MustParseAddr("2001:db8::1"),
+	})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	if got := len(updater.n3Calls); got != 1 || updater.n3Calls[0].String() != external {
-		t.Fatalf("expected N3 call with external %s, got %v", external, updater.n3Calls)
+	want := advertisedN3Addresses{v4: netip.MustParseAddr("172.16.1.1")}
+	if got := len(updater.n3Calls); got != 1 || updater.n3Calls[0] != want {
+		t.Fatalf("expected N3 call with external %s, got %v", want, updater.n3Calls)
 	}
 }
 
@@ -272,7 +278,7 @@ func TestReconcile_N3RejectsInvalidExternal(t *testing.T) {
 	store := &fakeStore{n3External: "not-an-ip"}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("10.0.0.5")})
 
 	err := r.Reconcile(context.Background())
 	if err == nil {
@@ -284,7 +290,7 @@ func TestReconcile_N3HandlesGetN3SettingsNotFound(t *testing.T) {
 	store := &fakeStore{n3GetErr: db.ErrNotFound}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("10.0.0.5")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("ErrNotFound should be tolerated, got %v", err)
@@ -306,7 +312,7 @@ func TestReconcile_FiltersAddRemoveModify(t *testing.T) {
 	}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("10.0.0.5")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("reconcile 1: %v", err)
@@ -388,7 +394,7 @@ func TestReconcile_FilterUpdateFailureRetried(t *testing.T) {
 	}
 	updater := &fakeUpdater{updateFiltersErr: errors.New("map write failed")}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("10.0.0.5")})
 
 	if err := r.Reconcile(context.Background()); err == nil {
 		t.Fatal("expected reconcile to return an error when UpdateFilters fails")
@@ -445,7 +451,7 @@ func TestReconcile_FilterUplinkFailureDoesNotSkipDownlink(t *testing.T) {
 		},
 	}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("10.0.0.5")})
 
 	if err := r.Reconcile(context.Background()); err == nil {
 		t.Fatal("expected error when uplink update fails")
@@ -478,7 +484,7 @@ func TestReconcile_FilterClearFailureRetried(t *testing.T) {
 	}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("10.0.0.5")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("initial apply: %v", err)
@@ -525,7 +531,7 @@ func TestReconcile_LoopWakesOnChangefeedEvent(t *testing.T) {
 	store := &fakeStore{natEnabled: true}
 	updater := &fakeUpdater{}
 
-	r := NewSettingsReconciler(updater, store, feed, netip.MustParseAddr("1.2.3.4"))
+	r := NewSettingsReconciler(updater, store, feed, netip.MustParseAddr("1.2.3.4"), netip.Addr{})
 	r.backstop = time.Hour
 
 	r.Start()
@@ -576,7 +582,7 @@ func TestReconcile_PropagatesNATError(t *testing.T) {
 	store := &fakeStore{natEnabled: true}
 	updater := &fakeUpdater{settingsErr: errors.New("xdp attach failed")}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("10.0.0.5"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("10.0.0.5")})
 
 	err := r.Reconcile(context.Background())
 	if err == nil {
@@ -628,7 +634,7 @@ func TestStart_FiltersDoNotWaitOnASettingsReload(t *testing.T) {
 		},
 	}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("1.2.3.4")})
 	r.Start()
 
 	defer func() {
@@ -647,7 +653,7 @@ func TestReconcile_TogglesShareOneDatapathApply(t *testing.T) {
 	store := &fakeStore{natEnabled: true, flowAccounting: true, localSwitch: true}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("1.2.3.4")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -671,7 +677,7 @@ func TestReconcile_OneChangedToggleReappliesAllOfThem(t *testing.T) {
 	store := &fakeStore{natEnabled: true}
 	updater := &fakeUpdater{}
 
-	r := newReconciler(updater, store, netip.MustParseAddr("1.2.3.4"))
+	r := newReconciler(updater, store, advertisedN3Addresses{v4: netip.MustParseAddr("1.2.3.4")})
 
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("first reconcile: %v", err)

--- a/internal/upf/reconciler_test.go
+++ b/internal/upf/reconciler_test.go
@@ -251,7 +251,7 @@ func TestReconcile_N3UsesFallbackWhenExternalEmpty(t *testing.T) {
 	}
 
 	if got := len(updater.n3Calls); got != 1 || updater.n3Calls[0] != fallback {
-		t.Fatalf("expected N3 call with fallback %s, got %v", fallback, updater.n3Calls)
+		t.Fatalf("expected N3 call with fallback %v, got %v", fallback, updater.n3Calls)
 	}
 }
 
@@ -270,7 +270,7 @@ func TestReconcile_N3PrefersExternalWhenSet(t *testing.T) {
 
 	want := advertisedN3Addresses{v4: netip.MustParseAddr("172.16.1.1")}
 	if got := len(updater.n3Calls); got != 1 || updater.n3Calls[0] != want {
-		t.Fatalf("expected N3 call with external %s, got %v", want, updater.n3Calls)
+		t.Fatalf("expected N3 call with external %v, got %v", want, updater.n3Calls)
 	}
 }
 

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -320,12 +320,8 @@ func (u *UPF) UnregisterIPv6Session(ulTEID uint32) {
 	u.raResponder.UnregisterSession(ulTEID)
 }
 
-func (u *UPF) UpdateAdvertisedN3Address(newN3Addr netip.Addr) {
-	if newN3Addr.Is4() {
-		u.se.SetAdvertisedN3Address(newN3Addr)
-	} else {
-		u.se.SetAdvertisedN3AddressIPv6(newN3Addr)
-	}
+func (u *UPF) UpdateAdvertisedN3Addresses(newN3AddrIPv4, newN3AddrIPv6 netip.Addr) {
+	u.se.SetAdvertisedN3Addresses(newN3AddrIPv4, newN3AddrIPv6)
 }
 
 func (u *UPF) UpdateFilters(ctx context.Context, policyID string, direction models.Direction, rules []models.FilterRule) error {

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -94,7 +94,7 @@ func (u *UPF) DatapathAttachMode() string {
 	return u.attachedMode
 }
 
-func Start(ctx context.Context, smfHandler engine.SMFReportHandler, n3Interface config.N3Interface, n3IPv4 string, n3IPv6 string, advertisedN3IPv4 string, advertisedN3IPv6 string, n6Interface config.N6Interface, attachMode string, masquerade bool, flowact bool, localSwitch bool) (*UPF, error) {
+func Start(ctx context.Context, smfHandler engine.SMFReportHandler, n3Interface config.N3Interface, n3IPv4 netip.Addr, n3IPv6 netip.Addr, advertisedN3IPv4 netip.Addr, advertisedN3IPv6 netip.Addr, n6Interface config.N6Interface, attachMode string, masquerade bool, flowact bool, localSwitch bool) (*UPF, error) {
 	var (
 		n3Vlan uint32
 		n6Vlan uint32
@@ -181,18 +181,8 @@ func Start(ctx context.Context, smfHandler engine.SMFReportHandler, n3Interface 
 	}
 
 	// Start the RA responder for IPv6 prefix delegation (RS → RA via veth).
-	var n3IPv4Addr netip.Addr
-	if parsed, err := netip.ParseAddr(n3IPv4); err == nil && parsed.Is4() {
-		n3IPv4Addr = parsed
-	}
-
-	var n3IPv6Addr netip.Addr
-	if parsed, err := netip.ParseAddr(n3IPv6); err == nil && parsed.Is6() {
-		n3IPv6Addr = parsed
-	}
-
-	if n3IPv4Addr.IsValid() || n3IPv6Addr.IsValid() {
-		raResp, err := NewRAResponder(bpfObjects, n3IPv4Addr, n3IPv6Addr, n3Iface.Index)
+	if n3IPv4.IsValid() || n3IPv6.IsValid() {
+		raResp, err := NewRAResponder(bpfObjects, n3IPv4, n3IPv6, n3Iface.Index)
 		if err != nil {
 			logger.UpfLog.Warn("failed to create RA responder, IPv6 RS/RA will be unavailable", zap.Error(err))
 		} else {
@@ -206,8 +196,8 @@ func Start(ctx context.Context, smfHandler engine.SMFReportHandler, n3Interface 
 		}
 	} else {
 		logger.UpfLog.Warn("skipping RA responder startup because no N3 transport address is available",
-			zap.String("n3_ipv4", n3IPv4),
-			zap.String("n3_ipv6", n3IPv6),
+			zap.Stringer("n3_ipv4", n3IPv4),
+			zap.Stringer("n3_ipv6", n3IPv6),
 			zap.String("n3_interface", n3AttachmentInterface),
 		)
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ellanetworks/core/internal/mme"
 	mmenas "github.com/ellanetworks/core/internal/mme/nas"
 	mmes1ap "github.com/ellanetworks/core/internal/mme/s1ap"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/netutil"
 	ellaraft "github.com/ellanetworks/core/internal/raft"
 	amfsctp "github.com/ellanetworks/core/internal/sctp"
@@ -392,15 +393,15 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 	advertisedN3IPv6 := n3IPv6
 
 	if n3Settings != nil && n3Settings.ExternalAddress != "" {
-		externalAddr, err := netip.ParseAddr(n3Settings.ExternalAddress)
-		if err == nil {
-			if externalAddr.Is4() {
-				advertisedN3IPv4 = n3Settings.ExternalAddress
-				logger.EllaLog.Debug("Using N3 external IPv4 address from N3 settings", zap.String("n3_external_address", advertisedN3IPv4))
-			} else {
-				advertisedN3IPv6 = n3Settings.ExternalAddress
-				logger.EllaLog.Debug("Using N3 external IPv6 address from N3 settings", zap.String("n3_external_address", advertisedN3IPv6))
-			}
+		externalIPv4, externalIPv6, err := models.ParseN3ExternalAddress(n3Settings.ExternalAddress)
+		if err != nil {
+			logger.EllaLog.Warn("Ignoring invalid N3 external address from N3 settings", zap.Error(err))
+		} else {
+			advertisedN3IPv4 = addrString(externalIPv4)
+			advertisedN3IPv6 = addrString(externalIPv6)
+			logger.EllaLog.Debug("Using N3 external address from N3 settings",
+				zap.String("n3_external_ipv4", advertisedN3IPv4),
+				zap.String("n3_external_ipv6", advertisedN3IPv6))
 		}
 	}
 
@@ -416,8 +417,9 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		return fmt.Errorf("couldn't start UPF: %w", err)
 	}
 
-	fallbackN3, _ := netip.ParseAddr(n3IPv4)
-	upfReconciler := upf.NewSettingsReconciler(upfInstance, dbInstance, dbInstance.Changefeed(), fallbackN3)
+	fallbackN3IPv4, _ := netip.ParseAddr(n3IPv4)
+	fallbackN3IPv6, _ := netip.ParseAddr(n3IPv6)
+	upfReconciler := upf.NewSettingsReconciler(upfInstance, dbInstance, dbInstance.Changefeed(), fallbackN3IPv4, fallbackN3IPv6)
 	upfReconciler.Start()
 
 	defer upfReconciler.Stop()
@@ -903,6 +905,14 @@ func (a *bgpLeaseStoreAdapter) ListActiveLeasesByNode(ctx context.Context, nodeI
 	}
 
 	return out, nil
+}
+
+func addrString(addr netip.Addr) string {
+	if !addr.IsValid() {
+		return ""
+	}
+
+	return addr.String()
 }
 
 func resolveN3Addresses(n3Interface config.N3Interface) (n3IPv4, n3IPv6 string) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -397,11 +397,11 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		if err != nil {
 			logger.EllaLog.Warn("Ignoring invalid N3 external address from N3 settings", zap.Error(err))
 		} else {
-			advertisedN3IPv4 = addrString(externalIPv4)
-			advertisedN3IPv6 = addrString(externalIPv6)
+			advertisedN3IPv4 = externalIPv4
+			advertisedN3IPv6 = externalIPv6
 			logger.EllaLog.Debug("Using N3 external address from N3 settings",
-				zap.String("n3_external_ipv4", advertisedN3IPv4),
-				zap.String("n3_external_ipv6", advertisedN3IPv6))
+				zap.Stringer("n3_external_ipv4", advertisedN3IPv4),
+				zap.Stringer("n3_external_ipv6", advertisedN3IPv6))
 		}
 	}
 
@@ -417,9 +417,7 @@ func Start(ctx context.Context, rc RuntimeConfig) error {
 		return fmt.Errorf("couldn't start UPF: %w", err)
 	}
 
-	fallbackN3IPv4, _ := netip.ParseAddr(n3IPv4)
-	fallbackN3IPv6, _ := netip.ParseAddr(n3IPv6)
-	upfReconciler := upf.NewSettingsReconciler(upfInstance, dbInstance, dbInstance.Changefeed(), fallbackN3IPv4, fallbackN3IPv6)
+	upfReconciler := upf.NewSettingsReconciler(upfInstance, dbInstance, dbInstance.Changefeed(), n3IPv4, n3IPv6)
 	upfReconciler.Start()
 
 	defer upfReconciler.Stop()
@@ -907,31 +905,23 @@ func (a *bgpLeaseStoreAdapter) ListActiveLeasesByNode(ctx context.Context, nodeI
 	return out, nil
 }
 
-func addrString(addr netip.Addr) string {
-	if !addr.IsValid() {
-		return ""
-	}
-
-	return addr.String()
-}
-
-func resolveN3Addresses(n3Interface config.N3Interface) (n3IPv4, n3IPv6 string) {
+func resolveN3Addresses(n3Interface config.N3Interface) (n3IPv4, n3IPv6 netip.Addr) {
 	if n3Interface.AddressExplicit && n3Interface.Address != "" {
 		addr, err := netip.ParseAddr(n3Interface.Address)
 		if err != nil {
-			return "", ""
+			return netip.Addr{}, netip.Addr{}
 		}
 
 		if addr.Is4() {
-			return n3Interface.Address, ""
+			return addr, netip.Addr{}
 		}
 
-		return "", n3Interface.Address
+		return netip.Addr{}, addr
 	}
 
 	ips, err := getInterfaceIPs(n3Interface.Name)
 	if err != nil {
-		return "", ""
+		return netip.Addr{}, netip.Addr{}
 	}
 
 	for _, ipStr := range ips {
@@ -940,10 +930,10 @@ func resolveN3Addresses(n3Interface config.N3Interface) (n3IPv4, n3IPv6 string) 
 			continue
 		}
 
-		if addr.Is4() && n3IPv4 == "" {
-			n3IPv4 = ipStr
-		} else if addr.Is6() && n3IPv6 == "" {
-			n3IPv6 = ipStr
+		if addr.Is4() && !n3IPv4.IsValid() {
+			n3IPv4 = addr
+		} else if addr.Is6() && !n3IPv6.IsValid() {
+			n3IPv6 = addr
 		}
 	}
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"net/netip"
 	"reflect"
 	"testing"
 
@@ -29,12 +30,12 @@ func TestResolveN3AddressesConfiguredIPv6IsAuthoritative(t *testing.T) {
 		AddressExplicit: true,
 	})
 
-	if n3IPv4 != "" {
-		t.Fatalf("n3IPv4 = %q, want empty", n3IPv4)
+	if n3IPv4.IsValid() {
+		t.Fatalf("n3IPv4 = %v, want empty", n3IPv4)
 	}
 
-	if got, want := n3IPv6, "2001:db8::1"; got != want {
-		t.Fatalf("n3IPv6 = %q, want %q", got, want)
+	if got, want := n3IPv6, netip.MustParseAddr("2001:db8::1"); got != want {
+		t.Fatalf("n3IPv6 = %v, want %v", got, want)
 	}
 }
 
@@ -57,12 +58,12 @@ func TestResolveN3AddressesConfiguredIPv4IsAuthoritative(t *testing.T) {
 		AddressExplicit: true,
 	})
 
-	if got, want := n3IPv4, "192.0.2.1"; got != want {
-		t.Fatalf("n3IPv4 = %q, want %q", got, want)
+	if got, want := n3IPv4, netip.MustParseAddr("192.0.2.1"); got != want {
+		t.Fatalf("n3IPv4 = %v, want %v", got, want)
 	}
 
-	if n3IPv6 != "" {
-		t.Fatalf("n3IPv6 = %q, want empty", n3IPv6)
+	if n3IPv6.IsValid() {
+		t.Fatalf("n3IPv6 = %v, want empty", n3IPv6)
 	}
 }
 
@@ -82,12 +83,12 @@ func TestResolveN3AddressesDerivedAddressStillScansBothFamilies(t *testing.T) {
 		Address: "2001:db8::20",
 	})
 
-	if got, want := n3IPv4, "192.0.2.20"; got != want {
-		t.Fatalf("n3IPv4 = %q, want %q", got, want)
+	if got, want := n3IPv4, netip.MustParseAddr("192.0.2.20"); got != want {
+		t.Fatalf("n3IPv4 = %v, want %v", got, want)
 	}
 
-	if got, want := n3IPv6, "2001:db8::20"; got != want {
-		t.Fatalf("n3IPv6 = %q, want %q", got, want)
+	if got, want := n3IPv6, netip.MustParseAddr("2001:db8::20"); got != want {
+		t.Fatalf("n3IPv6 = %v, want %v", got, want)
 	}
 }
 
@@ -112,12 +113,12 @@ func TestResolveN3AddressesScansVlanNetdevNotMaster(t *testing.T) {
 		VlanConfig: &config.VlanConfig{MasterInterface: "ens4"},
 	})
 
-	if got, want := n3IPv4, "10.1.1.5"; got != want {
-		t.Fatalf("n3IPv4 = %q, want %q", got, want)
+	if got, want := n3IPv4, netip.MustParseAddr("10.1.1.5"); got != want {
+		t.Fatalf("n3IPv4 = %v, want %v", got, want)
 	}
 
-	if got, want := n3IPv6, "2001:db8::5"; got != want {
-		t.Fatalf("n3IPv6 = %q, want %q", got, want)
+	if got, want := n3IPv6, netip.MustParseAddr("2001:db8::5"); got != want {
+		t.Fatalf("n3IPv6 = %v, want %v", got, want)
 	}
 }
 
@@ -139,7 +140,7 @@ func TestResolveN3AddressesUsesScannedAddressesWhenUnconfigured(t *testing.T) {
 
 	n3IPv4, n3IPv6 := resolveN3Addresses(config.N3Interface{Name: "n3eth0"})
 
-	if got := []string{n3IPv4, n3IPv6}; !reflect.DeepEqual(got, expected) {
+	if got := []string{n3IPv4.String(), n3IPv6.String()}; !reflect.DeepEqual(got, expected) {
 		t.Fatalf("resolved addresses = %v, want %v", got, expected)
 	}
 }

--- a/ui/src/components/EditInterfaceN3Modal.tsx
+++ b/ui/src/components/EditInterfaceN3Modal.tsx
@@ -7,7 +7,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { updateN3Settings } from "@/queries/interfaces";
 import { useAuth } from "@/contexts/AuthContext";
-import { ipv4Regex, ipv6Regex } from "@/utils/ip";
+import { addressFamily } from "@/utils/ip";
 import FormDialog from "@/components/form/FormDialog";
 import TextControl from "@/components/form/TextControl";
 import { PRODUCT } from "@/utils/product";
@@ -35,13 +35,12 @@ const schema = yup.object({
         const parts = value.split(",").map((part) => part.trim());
         if (parts.length > 2) return false;
 
-        const v4 = parts.filter((part) => ipv4Regex.test(part));
-        const v6 = parts.filter((part) => ipv6Regex.test(part));
+        const families = parts.map(addressFamily);
+        if (families.some((family) => family === null)) return false;
 
         return (
-          v4.length + v6.length === parts.length &&
-          v4.length <= 1 &&
-          v6.length <= 1
+          families.filter((family) => family === 4).length <= 1 &&
+          families.filter((family) => family === 6).length <= 1
         );
       },
     ),
@@ -74,7 +73,7 @@ const EditInterfaceN3Modal: React.FC<EditInterfaceN3ModalProps> = ({
       onClose={onClose}
       onSuccess={onSuccess}
       title="Edit N3 Interface"
-      description={`Configure an external address (IPv4 or IPv6) for N3. ${PRODUCT.name} will advertise this address to radios which will use it to establish GTP tunnels. Use this if ${PRODUCT.name} is behind a proxy, NAT, or load-balancer. If not set, ${PRODUCT.name} will use N3's address as defined in the config file.`}
+      description={`Configure an external address for N3: one IPv4 address, one IPv6 address, or one of each separated by a comma. ${PRODUCT.name} will advertise this address to radios which will use it to establish GTP tunnels. Use this if ${PRODUCT.name} is behind a proxy, NAT, or load-balancer. If not set, ${PRODUCT.name} will use N3's address as defined in the config file.`}
       form={form}
       onSubmit={submit}
       errorPrefix="Failed to update N3 external address"
@@ -85,7 +84,7 @@ const EditInterfaceN3Modal: React.FC<EditInterfaceN3ModalProps> = ({
       <TextControl<FormValues>
         name="externalAddress"
         label="External Address"
-        helperText="Leave empty to use N3's configured address. Supports both IPv4 and IPv6."
+        helperText="Leave empty to use N3's configured address. Example: 203.0.113.5, 2001:db8::5"
         showErrorWhileTyping
         autoFocus
       />

--- a/ui/src/components/EditInterfaceN3Modal.tsx
+++ b/ui/src/components/EditInterfaceN3Modal.tsx
@@ -28,10 +28,21 @@ const schema = yup.object({
     .default("")
     .test(
       "empty-or-ipv4-or-ipv6",
-      "External address must be a valid IPv4 or IPv6 address",
+      "External address must be an IPv4 address, an IPv6 address, or one of each separated by a comma",
       (value) => {
         if (!value) return true;
-        return ipv4Regex.test(value) || ipv6Regex.test(value);
+
+        const parts = value.split(",").map((part) => part.trim());
+        if (parts.length > 2) return false;
+
+        const v4 = parts.filter((part) => ipv4Regex.test(part));
+        const v6 = parts.filter((part) => ipv6Regex.test(part));
+
+        return (
+          v4.length + v6.length === parts.length &&
+          v4.length <= 1 &&
+          v6.length <= 1
+        );
       },
     ),
 });

--- a/ui/src/components/MiscModals.test.tsx
+++ b/ui/src/components/MiscModals.test.tsx
@@ -56,7 +56,7 @@ describe("EditInterfaceN3Modal", () => {
     await user.type(field(/External Address/), "not-an-ip");
 
     await screen.findByText(
-      "External address must be a valid IPv4 or IPv6 address",
+      "External address must be an IPv4 address, an IPv6 address, or one of each separated by a comma",
     );
     expect(button(/^Update$/)).toBeDisabled();
   });

--- a/ui/src/utils/ip.test.ts
+++ b/ui/src/utils/ip.test.ts
@@ -9,6 +9,8 @@ import {
   ipRegex,
   ipv4Regex,
   ipv6Regex,
+  addressFamily,
+  unmapIpv4Mapped,
   isValidCidr,
   isValidIpv4Cidr,
   isValidIpv6Cidr,
@@ -149,5 +151,39 @@ describe("address regexes", () => {
   it("ipRegex accepts either family", () => {
     expect(ipRegex.test("10.0.0.1")).toBe(true);
     expect(ipRegex.test("2001:db8::1")).toBe(true);
+  });
+});
+
+describe("unmapIpv4Mapped", () => {
+  it.each([
+    ["::ffff:10.0.0.1", "10.0.0.1"],
+    ["::FFFF:255.255.255.255", "255.255.255.255"],
+    ["::ffff:a00:1", "10.0.0.1"],
+    ["10.0.0.1", "10.0.0.1"],
+    ["2001:db8::1", "2001:db8::1"],
+    ["::1.2.3.4", "::1.2.3.4"],
+    ["::ffff:0:1.2.3.4", "::ffff:0:1.2.3.4"],
+  ])("maps %s to %s", (value, expected) => {
+    expect(unmapIpv4Mapped(value)).toBe(expected);
+  });
+});
+
+describe("addressFamily", () => {
+  it.each(["10.0.0.1", "::ffff:10.0.0.1", "::ffff:a00:1"])(
+    "classifies %s as IPv4",
+    (v) => {
+      expect(addressFamily(v)).toBe(4);
+    },
+  );
+
+  it.each(["2001:db8::1", "::1", "::", "::1.2.3.4"])(
+    "classifies %s as IPv6",
+    (v) => {
+      expect(addressFamily(v)).toBe(6);
+    },
+  );
+
+  it.each(["", "banana", "256.0.0.1", "10.0.0.1/24"])("rejects %s", (v) => {
+    expect(addressFamily(v)).toBeNull();
   });
 });

--- a/ui/src/utils/ip.ts
+++ b/ui/src/utils/ip.ts
@@ -7,6 +7,31 @@ export const ipv4Regex =
 export const ipv6Regex =
   /^((([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,7}:)|(([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2})|(([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3})|(([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4})|(([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5})|([0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}))|(:((:[0-9a-fA-F]{1,4}){1,7}|:))|fe80:(:[0-9a-fA-F]{0,4}){0,4}%?[0-9a-fA-F]{0,4}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/;
 
+const ipv4MappedDottedRegex =
+  /^::ffff:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})$/i;
+
+const ipv4MappedHexRegex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i;
+
+export function unmapIpv4Mapped(value: string): string {
+  const dotted = value.match(ipv4MappedDottedRegex);
+  if (dotted) return dotted[1];
+
+  const hex = value.match(ipv4MappedHexRegex);
+  if (!hex) return value;
+
+  const high = parseInt(hex[1], 16);
+  const low = parseInt(hex[2], 16);
+
+  return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+
+export function addressFamily(value: string): 4 | 6 | null {
+  if (ipv4Regex.test(unmapIpv4Mapped(value))) return 4;
+  if (ipv6Regex.test(value)) return 6;
+
+  return null;
+}
+
 export const ipRegex = new RegExp(
   `(${ipv4Regex.source})|(${ipv6Regex.source})`,
 );


### PR DESCRIPTION
# Description

Respect the user's intent whenever they manually set an N3 external address. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
