### PR TITLE
perf: resolve gNB neighbours via FIB

### DIFF
--- a/internal/amf/session_reconciler.go
+++ b/internal/amf/session_reconciler.go
@@ -151,7 +151,7 @@ func (amf *AMF) ReconcileSessionsForUE(ctx context.Context, ue *UeContext) {
 			continue
 		}
 
-		policy, reason := amf.fetchSessionPolicy(ref)
+		policy, reason := amf.fetchSessionPolicy(ctx, ref)
 
 		// ReconcileSkip signals a transient error; let the backstop timer retry.
 		if reason == models.ReconcileSkip {
@@ -186,7 +186,7 @@ func permanentPolicyFailure(err error) bool {
 // (the admin changed SST/SD). Returns (nil, ReconcileSkip) when the policy
 // cannot be determined (transient DB error, session gone, nil policy) so the
 // caller skips reconciliation and the backstop retries later.
-func (amf *AMF) fetchSessionPolicy(smContextRef string) (*models.SessionPolicyDelta, models.SessionReconcileReason) {
+func (amf *AMF) fetchSessionPolicy(ctx context.Context, smContextRef string) (*models.SessionPolicyDelta, models.SessionReconcileReason) {
 	sm := amf.Session.GetSession(smContextRef)
 	if sm == nil {
 		// Session already removed from the SMF pool (e.g. after a
@@ -194,7 +194,7 @@ func (amf *AMF) fetchSessionPolicy(smContextRef string) (*models.SessionPolicyDe
 		return nil, models.ReconcileSkip
 	}
 
-	policy, err := amf.Session.GetSessionPolicy(context.Background(), sm.Supi, sm.Snssai, sm.Dnn)
+	policy, err := amf.Session.GetSessionPolicy(ctx, sm.Supi, sm.Snssai, sm.Dnn)
 	if err != nil {
 		if permanentPolicyFailure(err) {
 			logger.AmfLog.Debug("session policy not found, triggering slice mismatch release",

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -286,6 +286,7 @@ type Database struct {
 	deleteSessionByTokenHashStmt *sqlair.Statement
 	deleteExpiredSessionsStmt    *sqlair.Statement
 	countSessionsByUserStmt      *sqlair.Statement
+	countExpiredSessionsStmt     *sqlair.Statement
 	deleteOldestSessionsStmt     *sqlair.Statement
 	deleteAllSessionsForUserStmt *sqlair.Statement
 	deleteAllSessionsStmt        *sqlair.Statement
@@ -1655,6 +1656,7 @@ func (db *Database) PrepareStatements() error {
 		{&db.deleteSessionByTokenHashStmt, fmt.Sprintf(deleteSessionByTokenHashStmt, SessionsTableName), []any{Session{}}},
 		{&db.deleteExpiredSessionsStmt, fmt.Sprintf(deleteExpiredSessionsStmt, SessionsTableName), []any{SessionCutoff{}}},
 		{&db.countSessionsByUserStmt, fmt.Sprintf(countSessionsByUserStmt, SessionsTableName), []any{UserIDArgs{}, NumItems{}}},
+		{&db.countExpiredSessionsStmt, fmt.Sprintf(countExpiredSessionsStmt, SessionsTableName), []any{SessionCutoff{}, NumItems{}}},
 		{&db.deleteOldestSessionsStmt, fmt.Sprintf(deleteOldestSessionsStmt, SessionsTableName, SessionsTableName), []any{DeleteOldestArgs{}}},
 		{&db.deleteAllSessionsForUserStmt, fmt.Sprintf(deleteAllSessionsForUserStmt, SessionsTableName), []any{UserIDArgs{}}},
 		{&db.deleteAllSessionsStmt, fmt.Sprintf(deleteAllSessionsStmt, SessionsTableName), nil},

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -26,6 +26,7 @@ const (
 	deleteSessionByTokenHashStmt = "DELETE FROM %s WHERE token_hash==$Session.token_hash"       // #nosec: G101
 	deleteExpiredSessionsStmt    = "DELETE FROM %s WHERE expires_at <= $SessionCutoff.now_unix" // #nosec: G101
 	countSessionsByUserStmt      = "SELECT COUNT(*) AS &NumItems.count FROM %s WHERE user_id==$UserIDArgs.user_id"
+	countExpiredSessionsStmt     = "SELECT COUNT(*) AS &NumItems.count FROM %s WHERE expires_at <= $SessionCutoff.now_unix" // #nosec: G101
 	deleteOldestSessionsStmt     = "DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE user_id==$DeleteOldestArgs.user_id ORDER BY created_at ASC LIMIT $DeleteOldestArgs.limit)"
 	deleteAllSessionsForUserStmt = "DELETE FROM %s WHERE user_id==$UserIDArgs.user_id"
 	deleteAllSessionsStmt        = "DELETE FROM %s"
@@ -217,6 +218,39 @@ func (db *Database) CountSessionsByUser(ctx context.Context, userID string) (int
 	var result NumItems
 
 	err := db.conn().Query(ctx, db.countSessionsByUserStmt, args).Get(&result)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "query failed")
+
+		return 0, fmt.Errorf("query failed: %w", err)
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	return result.Count, nil
+}
+
+func (db *Database) CountExpiredSessions(ctx context.Context, nowUnix int64) (int, error) {
+	ctx, span := tracer.Start(
+		ctx,
+		fmt.Sprintf("%s %s", "COUNT", SessionsTableName),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			semconv.DBSystemNameSQLite,
+			semconv.DBOperationName("COUNT"),
+			attribute.String("db.collection", SessionsTableName),
+		),
+	)
+	defer span.End()
+
+	timer := prometheus.NewTimer(DBQueryDuration.WithLabelValues(SessionsTableName, "select"))
+	defer timer.ObserveDuration()
+
+	DBQueriesTotal.WithLabelValues(SessionsTableName, "select").Inc()
+
+	var result NumItems
+
+	err := db.conn().Query(ctx, db.countExpiredSessionsStmt, SessionCutoff{NowUnix: nowUnix}).Get(&result)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "query failed")

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -420,3 +420,104 @@ func TestDeleteExpiredSessions_TypedResultSurvivesForwardWire(t *testing.T) {
 		t.Fatalf("typed decode mismatch: got %d, want %d", got, fsmCount)
 	}
 }
+
+func TestCountExpiredSessions(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+
+	userID, err := database.CreateUser(ctx, &db.User{
+		Email:          "countexpired@example.com",
+		HashedPassword: "afewfawe12321",
+	})
+	if err != nil {
+		t.Fatalf("Couldn't complete CreateUser: %s", err)
+	}
+
+	now := time.Now()
+
+	if n, err := database.CountExpiredSessions(ctx, now.Unix()); err != nil || n != 0 {
+		t.Fatalf("CountExpiredSessions on an empty table = (%d, %v), want (0, nil)", n, err)
+	}
+
+	for i, expiresAt := range []int64{
+		now.Add(-time.Hour).Unix(),
+		now.Add(-time.Minute).Unix(),
+		now.Add(time.Hour).Unix(),
+	} {
+		hash := make([]byte, 32)
+		hash[0] = byte(i + 1)
+
+		if err := database.CreateSession(ctx, &db.Session{
+			UserID:    userID,
+			TokenHash: hash,
+			CreatedAt: now.Add(-2 * time.Hour).Unix(),
+			ExpiresAt: expiresAt,
+		}); err != nil {
+			t.Fatalf("Couldn't complete CreateSession: %s", err)
+		}
+	}
+
+	n, err := database.CountExpiredSessions(ctx, now.Unix())
+	if err != nil {
+		t.Fatalf("Couldn't complete CountExpiredSessions: %s", err)
+	}
+
+	if n != 2 {
+		t.Fatalf("CountExpiredSessions = %d, want 2", n)
+	}
+
+	deleted, err := database.DeleteExpiredSessions(ctx)
+	if err != nil {
+		t.Fatalf("Couldn't complete DeleteExpiredSessions: %s", err)
+	}
+
+	if deleted != n {
+		t.Fatalf("DeleteExpiredSessions deleted %d, but CountExpiredSessions reported %d", deleted, n)
+	}
+
+	if after, err := database.CountExpiredSessions(ctx, now.Unix()); err != nil || after != 0 {
+		t.Fatalf("CountExpiredSessions after cleanup = (%d, %v), want (0, nil)", after, err)
+	}
+
+	remaining, err := database.CountSessionsByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("Couldn't complete CountSessionsByUser: %s", err)
+	}
+
+	if remaining != 1 {
+		t.Fatalf("CountSessionsByUser = %d, want 1 (the unexpired session must survive)", remaining)
+	}
+}
+
+func TestCountExpiredSessionsIsInclusiveOfTheCutoff(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+
+	userID, err := database.CreateUser(ctx, &db.User{
+		Email:          "cutoff@example.com",
+		HashedPassword: "afewfawe12321",
+	})
+	if err != nil {
+		t.Fatalf("Couldn't complete CreateUser: %s", err)
+	}
+
+	cutoff := time.Now().Unix()
+
+	if err := database.CreateSession(ctx, &db.Session{
+		UserID:    userID,
+		TokenHash: make([]byte, 32),
+		CreatedAt: cutoff - 3600,
+		ExpiresAt: cutoff,
+	}); err != nil {
+		t.Fatalf("Couldn't complete CreateSession: %s", err)
+	}
+
+	n, err := database.CountExpiredSessions(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("Couldn't complete CountExpiredSessions: %s", err)
+	}
+
+	if n != 1 {
+		t.Fatalf("CountExpiredSessions = %d, want 1: the count must match the DELETE's <= cutoff", n)
+	}
+}

--- a/internal/kernel/neigh.go
+++ b/internal/kernel/neigh.go
@@ -137,7 +137,6 @@ func neighbourFor(ifindex int, ip net.IP) netlink.Neigh {
 	return netlink.Neigh{
 		LinkIndex: ifindex,
 		IP:        ip,
-		Flags:     netlink.NTF_EXT_LEARNED,
 		FlagsExt:  netlink.NTF_EXT_MANAGED,
 	}
 }

--- a/internal/kernel/neigh.go
+++ b/internal/kernel/neigh.go
@@ -19,6 +19,8 @@ import (
 
 var tracer = otel.Tracer("ella-core/kernel")
 
+var errNoRouteToNeighbour = errors.New("no route to neighbour")
+
 // AddNeighbourOnLink adds the provided IP as a neighbour on one specific link.
 func AddNeighbourOnLink(ctx context.Context, neigh netip.Addr, ifindex int) error {
 	_, span := tracer.Start(
@@ -32,8 +34,6 @@ func AddNeighbourOnLink(ctx context.Context, neigh netip.Addr, ifindex int) erro
 
 	return setNeighbour(ifindex, neigh.AsSlice())
 }
-
-var ErrNoRouteToNeighbour = errors.New("no route to neighbour")
 
 func AddNeighbour(ctx context.Context, neigh netip.Addr) error {
 	_, span := tracer.Start(
@@ -53,7 +53,7 @@ func AddNeighbour(ctx context.Context, neigh netip.Addr) error {
 
 	hops := nexthopsFromRoutes(dst, routes)
 	if len(hops) == 0 {
-		return fmt.Errorf("%w: %s", ErrNoRouteToNeighbour, neigh)
+		return fmt.Errorf("%w: %s", errNoRouteToNeighbour, neigh)
 	}
 
 	span.SetAttributes(attribute.Int("nexthops", len(hops)))
@@ -72,27 +72,13 @@ type nexthop struct {
 	ip      net.IP
 }
 
-type nexthopKey struct {
-	ifindex int
-	ip      string
-}
-
 func nexthopsFromRoutes(dst net.IP, routes []netlink.Route) []nexthop {
 	var hops []nexthop
 
-	seen := make(map[nexthopKey]struct{})
-
 	add := func(ifindex int, ip net.IP) {
-		if ifindex <= 0 || ip == nil {
+		if ifindex <= 0 {
 			return
 		}
-
-		key := nexthopKey{ifindex: ifindex, ip: ip.String()}
-		if _, dup := seen[key]; dup {
-			return
-		}
-
-		seen[key] = struct{}{}
 
 		hops = append(hops, nexthop{ifindex: ifindex, ip: ip})
 	}
@@ -128,16 +114,12 @@ func addNeighbourForLink(neigh net.IP, link netlink.Link) error {
 	return setNeighbour(link.Attrs().Index, neigh)
 }
 
-func neighbourFor(ifindex int, ip net.IP) netlink.Neigh {
-	return netlink.Neigh{
+func setNeighbour(ifindex int, ip net.IP) error {
+	nlNeigh := netlink.Neigh{
 		LinkIndex: ifindex,
 		IP:        ip,
 		FlagsExt:  netlink.NTF_EXT_MANAGED,
 	}
-}
-
-func setNeighbour(ifindex int, ip net.IP) error {
-	nlNeigh := neighbourFor(ifindex, ip)
 
 	return netlink.NeighSet(&nlNeigh)
 }

--- a/internal/kernel/neigh.go
+++ b/internal/kernel/neigh.go
@@ -5,6 +5,7 @@ package kernel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -13,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sys/unix"
 )
 
 var tracer = otel.Tracer("ella-core/kernel")
@@ -28,17 +30,16 @@ func AddNeighbourOnLink(ctx context.Context, neigh netip.Addr, ifindex int) erro
 		))
 	defer span.End()
 
-	nlNeigh := netlink.Neigh{
-		LinkIndex: ifindex,
-		IP:        neigh.AsSlice(),
-		FlagsExt:  netlink.NTF_EXT_MANAGED,
-	}
-
-	return netlink.NeighSet(&nlNeigh)
+	return setNeighbour(ifindex, neigh.AsSlice())
 }
 
-// AddNeighbour adds the provided IP as a neighbour
-// on all links that have an address in the same subnet.
+// ErrNoRouteToNeighbour is returned when the kernel has no route to the address,
+// so there is no link on which a neighbour entry would be meaningful.
+var ErrNoRouteToNeighbour = errors.New("no route to neighbour")
+
+// AddNeighbour resolves the address against the kernel routing table and adds a
+// neighbour entry for each nexthop the kernel would forward through: the address
+// itself when it is directly connected, or the gateway when it is not.
 func AddNeighbour(ctx context.Context, neigh netip.Addr) error {
 	_, span := tracer.Start(
 		ctx,
@@ -48,46 +49,101 @@ func AddNeighbour(ctx context.Context, neigh netip.Addr) error {
 		))
 	defer span.End()
 
-	neighIP := neigh.AsSlice()
+	dst := neigh.AsSlice()
 
-	links, err := netlink.LinkList()
-	if err != nil {
-		return fmt.Errorf("could not list network links: %v", err)
+	routes, err := netlink.RouteGetWithOptions(dst, &netlink.RouteGetOptions{FIBMatch: true})
+	if err != nil && !errors.Is(err, unix.EHOSTUNREACH) && !errors.Is(err, unix.ENETUNREACH) {
+		return fmt.Errorf("could not resolve route to %s: %w", neigh, err)
 	}
 
-	added := false
-
-	for _, l := range links {
-		addrs, err := netlink.AddrList(l, netlink.FAMILY_ALL)
-		if err != nil {
-			return fmt.Errorf("could not list addresses for link: %v", err)
-		}
-
-		for _, a := range addrs {
-			if a.Contains(neighIP) {
-				err = addNeighbourForLink(neighIP, l)
-				if err != nil {
-					return fmt.Errorf("could not add neighbour for link: %v", err)
-				}
-
-				added = true
-			}
-		}
+	hops := nexthopsFromRoutes(dst, routes)
+	if len(hops) == 0 {
+		return fmt.Errorf("%w: %s", ErrNoRouteToNeighbour, neigh)
 	}
 
-	if !added {
-		return fmt.Errorf("could not add neighbour")
+	span.SetAttributes(attribute.Int("nexthops", len(hops)))
+
+	for _, h := range hops {
+		if err := setNeighbour(h.ifindex, h.ip); err != nil {
+			return fmt.Errorf("could not add neighbour %s on link %d: %w", h.ip, h.ifindex, err)
+		}
 	}
 
 	return nil
 }
 
+type nexthop struct {
+	ifindex int
+	ip      net.IP
+}
+
+type nexthopKey struct {
+	ifindex int
+	ip      string
+}
+
+func nexthopsFromRoutes(dst net.IP, routes []netlink.Route) []nexthop {
+	var hops []nexthop
+
+	seen := make(map[nexthopKey]struct{})
+
+	add := func(ifindex int, ip net.IP) {
+		if ifindex <= 0 || ip == nil {
+			return
+		}
+
+		key := nexthopKey{ifindex: ifindex, ip: ip.String()}
+		if _, dup := seen[key]; dup {
+			return
+		}
+
+		seen[key] = struct{}{}
+
+		hops = append(hops, nexthop{ifindex: ifindex, ip: ip})
+	}
+
+	for _, r := range routes {
+		if len(r.MultiPath) > 0 {
+			for _, mp := range r.MultiPath {
+				add(mp.LinkIndex, nexthopAddr(dst, mp.Gw, mp.Via))
+			}
+
+			continue
+		}
+
+		add(r.LinkIndex, nexthopAddr(dst, r.Gw, r.Via))
+	}
+
+	return hops
+}
+
+func nexthopAddr(dst net.IP, gw net.IP, via netlink.Destination) net.IP {
+	if gw != nil {
+		return gw
+	}
+
+	if v, ok := via.(*netlink.Via); ok && v != nil && v.Addr != nil {
+		return v.Addr
+	}
+
+	return dst
+}
+
 func addNeighbourForLink(neigh net.IP, link netlink.Link) error {
-	nlNeigh := netlink.Neigh{
-		LinkIndex: link.Attrs().Index,
-		IP:        neigh,
+	return setNeighbour(link.Attrs().Index, neigh)
+}
+
+func neighbourFor(ifindex int, ip net.IP) netlink.Neigh {
+	return netlink.Neigh{
+		LinkIndex: ifindex,
+		IP:        ip,
+		Flags:     netlink.NTF_EXT_LEARNED,
 		FlagsExt:  netlink.NTF_EXT_MANAGED,
 	}
+}
+
+func setNeighbour(ifindex int, ip net.IP) error {
+	nlNeigh := neighbourFor(ifindex, ip)
 
 	return netlink.NeighSet(&nlNeigh)
 }

--- a/internal/kernel/neigh.go
+++ b/internal/kernel/neigh.go
@@ -33,13 +33,8 @@ func AddNeighbourOnLink(ctx context.Context, neigh netip.Addr, ifindex int) erro
 	return setNeighbour(ifindex, neigh.AsSlice())
 }
 
-// ErrNoRouteToNeighbour is returned when the kernel has no route to the address,
-// so there is no link on which a neighbour entry would be meaningful.
 var ErrNoRouteToNeighbour = errors.New("no route to neighbour")
 
-// AddNeighbour resolves the address against the kernel routing table and adds a
-// neighbour entry for each nexthop the kernel would forward through: the address
-// itself when it is directly connected, or the gateway when it is not.
 func AddNeighbour(ctx context.Context, neigh netip.Addr) error {
 	_, span := tracer.Start(
 		ctx,

--- a/internal/kernel/neigh.go
+++ b/internal/kernel/neigh.go
@@ -58,10 +58,26 @@ func AddNeighbour(ctx context.Context, neigh netip.Addr) error {
 
 	span.SetAttributes(attribute.Int("nexthops", len(hops)))
 
+	var firstErr error
+
+	installed := 0
+
 	for _, h := range hops {
 		if err := setNeighbour(h.ifindex, h.ip); err != nil {
-			return fmt.Errorf("could not add neighbour %s on link %d: %w", h.ip, h.ifindex, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("could not add neighbour %s on link %d: %w", h.ip, h.ifindex, err)
+			}
+
+			continue
 		}
+
+		installed++
+	}
+
+	span.SetAttributes(attribute.Int("nexthops.installed", installed))
+
+	if installed == 0 {
+		return firstErr
 	}
 
 	return nil

--- a/internal/kernel/neigh_test.go
+++ b/internal/kernel/neigh_test.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package kernel
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func hopsEqual(got []nexthop, want []nexthop) bool {
+	if len(got) != len(want) {
+		return false
+	}
+
+	for i := range got {
+		if got[i].ifindex != want[i].ifindex || !got[i].ip.Equal(want[i].ip) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestNexthopsFromRoutes_DirectlyConnected(t *testing.T) {
+	dst := net.ParseIP("33.33.33.7")
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 3}})
+
+	want := []nexthop{{ifindex: 3, ip: dst}}
+	if !hopsEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNexthopsFromRoutes_ViaGateway(t *testing.T) {
+	dst := net.ParseIP("10.20.30.40")
+	gw := net.ParseIP("192.168.1.1")
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 2, Gw: gw}})
+
+	want := []nexthop{{ifindex: 2, ip: gw}}
+	if !hopsEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNexthopsFromRoutes_ViaRFC5549(t *testing.T) {
+	dst := net.ParseIP("10.20.30.40")
+	via := &netlink.Via{AddrFamily: netlink.FAMILY_V6, Addr: net.ParseIP("2001:db8::1")}
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 4, Via: via}})
+
+	want := []nexthop{{ifindex: 4, ip: via.Addr}}
+	if !hopsEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNexthopsFromRoutes_GatewayWinsOverVia(t *testing.T) {
+	dst := net.ParseIP("10.20.30.40")
+	gw := net.ParseIP("192.168.1.1")
+	via := &netlink.Via{AddrFamily: netlink.FAMILY_V6, Addr: net.ParseIP("2001:db8::1")}
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 4, Gw: gw, Via: via}})
+
+	want := []nexthop{{ifindex: 4, ip: gw}}
+	if !hopsEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNexthopsFromRoutes_MultiPath(t *testing.T) {
+	dst := net.ParseIP("9.9.9.9")
+	gw1 := net.ParseIP("10.0.1.2")
+	gw2 := net.ParseIP("10.0.2.2")
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{{
+		LinkIndex: 99,
+		MultiPath: []*netlink.NexthopInfo{
+			{LinkIndex: 2, Gw: gw1},
+			{LinkIndex: 3, Gw: gw2},
+		},
+	}})
+
+	want := []nexthop{{ifindex: 2, ip: gw1}, {ifindex: 3, ip: gw2}}
+	if !hopsEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNexthopsFromRoutes_MultiPathDirectlyConnected(t *testing.T) {
+	dst := net.ParseIP("33.33.33.7")
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{{
+		LinkIndex: 99,
+		MultiPath: []*netlink.NexthopInfo{
+			{LinkIndex: 2},
+			{LinkIndex: 3},
+		},
+	}})
+
+	want := []nexthop{{ifindex: 2, ip: dst}, {ifindex: 3, ip: dst}}
+	if !hopsEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNexthopsFromRoutes_DeduplicatesIdenticalHops(t *testing.T) {
+	dst := net.ParseIP("10.20.30.40")
+	gw := net.ParseIP("192.168.1.1")
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{
+		{LinkIndex: 2, Gw: gw},
+		{LinkIndex: 2, Gw: net.ParseIP("192.168.1.1")},
+	})
+
+	want := []nexthop{{ifindex: 2, ip: gw}}
+	if !hopsEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNexthopsFromRoutes_SkipsUnusableLinkIndex(t *testing.T) {
+	dst := net.ParseIP("33.33.33.7")
+
+	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 0}, {LinkIndex: -1}})
+	if len(got) != 0 {
+		t.Fatalf("expected no nexthops, got %v", got)
+	}
+}
+
+func TestNexthopsFromRoutes_NoRoutes(t *testing.T) {
+	got := nexthopsFromRoutes(net.ParseIP("33.33.33.7"), nil)
+	if len(got) != 0 {
+		t.Fatalf("expected no nexthops, got %v", got)
+	}
+}
+
+func TestSetNeighbourFlags(t *testing.T) {
+	n := neighbourFor(7, net.ParseIP("33.33.33.7"))
+
+	if n.Flags&netlink.NTF_EXT_LEARNED == 0 {
+		t.Error("entry must carry NTF_EXT_LEARNED so the kernel exempts it from garbage collection")
+	}
+
+	if n.FlagsExt&netlink.NTF_EXT_MANAGED == 0 {
+		t.Error("entry must carry NTF_EXT_MANAGED so the kernel auto-refreshes it")
+	}
+
+	if n.LinkIndex != 7 {
+		t.Errorf("LinkIndex = %d, want 7", n.LinkIndex)
+	}
+}

--- a/internal/kernel/neigh_test.go
+++ b/internal/kernel/neigh_test.go
@@ -139,12 +139,8 @@ func TestNexthopsFromRoutes_NoRoutes(t *testing.T) {
 	}
 }
 
-func TestSetNeighbourFlags(t *testing.T) {
+func TestNeighbourForIsKernelManaged(t *testing.T) {
 	n := neighbourFor(7, net.ParseIP("33.33.33.7"))
-
-	if n.Flags&netlink.NTF_EXT_LEARNED == 0 {
-		t.Error("entry must carry NTF_EXT_LEARNED so the kernel exempts it from garbage collection")
-	}
 
 	if n.FlagsExt&netlink.NTF_EXT_MANAGED == 0 {
 		t.Error("entry must carry NTF_EXT_MANAGED so the kernel auto-refreshes it")

--- a/internal/kernel/neigh_test.go
+++ b/internal/kernel/neigh_test.go
@@ -10,18 +10,19 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func hopsEqual(got []nexthop, want []nexthop) bool {
+func assertHops(t *testing.T, got []nexthop, want []nexthop) {
+	t.Helper()
+
 	if len(got) != len(want) {
-		return false
+		t.Fatalf("got %d nexthops, want %d: %v", len(got), len(want), got)
 	}
 
 	for i := range got {
 		if got[i].ifindex != want[i].ifindex || !got[i].ip.Equal(want[i].ip) {
-			return false
+			t.Fatalf("nexthop %d = {%d %s}, want {%d %s}",
+				i, got[i].ifindex, got[i].ip, want[i].ifindex, want[i].ip)
 		}
 	}
-
-	return true
 }
 
 func TestNexthopsFromRoutes_DirectlyConnected(t *testing.T) {
@@ -29,10 +30,7 @@ func TestNexthopsFromRoutes_DirectlyConnected(t *testing.T) {
 
 	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 3}})
 
-	want := []nexthop{{ifindex: 3, ip: dst}}
-	if !hopsEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assertHops(t, got, []nexthop{{ifindex: 3, ip: dst}})
 }
 
 func TestNexthopsFromRoutes_ViaGateway(t *testing.T) {
@@ -41,10 +39,7 @@ func TestNexthopsFromRoutes_ViaGateway(t *testing.T) {
 
 	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 2, Gw: gw}})
 
-	want := []nexthop{{ifindex: 2, ip: gw}}
-	if !hopsEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assertHops(t, got, []nexthop{{ifindex: 2, ip: gw}})
 }
 
 func TestNexthopsFromRoutes_ViaRFC5549(t *testing.T) {
@@ -53,23 +48,7 @@ func TestNexthopsFromRoutes_ViaRFC5549(t *testing.T) {
 
 	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 4, Via: via}})
 
-	want := []nexthop{{ifindex: 4, ip: via.Addr}}
-	if !hopsEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-}
-
-func TestNexthopsFromRoutes_GatewayWinsOverVia(t *testing.T) {
-	dst := net.ParseIP("10.20.30.40")
-	gw := net.ParseIP("192.168.1.1")
-	via := &netlink.Via{AddrFamily: netlink.FAMILY_V6, Addr: net.ParseIP("2001:db8::1")}
-
-	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 4, Gw: gw, Via: via}})
-
-	want := []nexthop{{ifindex: 4, ip: gw}}
-	if !hopsEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assertHops(t, got, []nexthop{{ifindex: 4, ip: via.Addr}})
 }
 
 func TestNexthopsFromRoutes_MultiPath(t *testing.T) {
@@ -78,75 +57,23 @@ func TestNexthopsFromRoutes_MultiPath(t *testing.T) {
 	gw2 := net.ParseIP("10.0.2.2")
 
 	got := nexthopsFromRoutes(dst, []netlink.Route{{
-		LinkIndex: 99,
 		MultiPath: []*netlink.NexthopInfo{
 			{LinkIndex: 2, Gw: gw1},
 			{LinkIndex: 3, Gw: gw2},
 		},
 	}})
 
-	want := []nexthop{{ifindex: 2, ip: gw1}, {ifindex: 3, ip: gw2}}
-	if !hopsEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assertHops(t, got, []nexthop{{ifindex: 2, ip: gw1}, {ifindex: 3, ip: gw2}})
 }
 
-func TestNexthopsFromRoutes_MultiPathDirectlyConnected(t *testing.T) {
+func TestNexthopsFromRoutes_NoUsableRoute(t *testing.T) {
 	dst := net.ParseIP("33.33.33.7")
 
-	got := nexthopsFromRoutes(dst, []netlink.Route{{
-		LinkIndex: 99,
-		MultiPath: []*netlink.NexthopInfo{
-			{LinkIndex: 2},
-			{LinkIndex: 3},
-		},
-	}})
-
-	want := []nexthop{{ifindex: 2, ip: dst}, {ifindex: 3, ip: dst}}
-	if !hopsEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-}
-
-func TestNexthopsFromRoutes_DeduplicatesIdenticalHops(t *testing.T) {
-	dst := net.ParseIP("10.20.30.40")
-	gw := net.ParseIP("192.168.1.1")
-
-	got := nexthopsFromRoutes(dst, []netlink.Route{
-		{LinkIndex: 2, Gw: gw},
-		{LinkIndex: 2, Gw: net.ParseIP("192.168.1.1")},
-	})
-
-	want := []nexthop{{ifindex: 2, ip: gw}}
-	if !hopsEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-}
-
-func TestNexthopsFromRoutes_SkipsUnusableLinkIndex(t *testing.T) {
-	dst := net.ParseIP("33.33.33.7")
-
-	got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 0}, {LinkIndex: -1}})
-	if len(got) != 0 {
-		t.Fatalf("expected no nexthops, got %v", got)
-	}
-}
-
-func TestNexthopsFromRoutes_NoRoutes(t *testing.T) {
-	got := nexthopsFromRoutes(net.ParseIP("33.33.33.7"), nil)
-	if len(got) != 0 {
-		t.Fatalf("expected no nexthops, got %v", got)
-	}
-}
-
-func TestNeighbourForIsKernelManaged(t *testing.T) {
-	n := neighbourFor(7, net.ParseIP("33.33.33.7"))
-
-	if n.FlagsExt&netlink.NTF_EXT_MANAGED == 0 {
-		t.Error("entry must carry NTF_EXT_MANAGED so the kernel auto-refreshes it")
+	if got := nexthopsFromRoutes(dst, nil); len(got) != 0 {
+		t.Fatalf("no routes must yield no nexthops, got %v", got)
 	}
 
-	if n.LinkIndex != 7 {
-		t.Errorf("LinkIndex = %d, want 7", n.LinkIndex)
+	if got := nexthopsFromRoutes(dst, []netlink.Route{{LinkIndex: 0}}); len(got) != 0 {
+		t.Fatalf("a route without an output interface must yield no nexthops, got %v", got)
 	}
 }

--- a/internal/sessions/cleanup.go
+++ b/internal/sessions/cleanup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/logger"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -51,6 +52,21 @@ func runCleanupPass(ctx context.Context, dbInstance *db.Database) {
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
+
+	expired, err := dbInstance.CountExpiredSessions(tickCtx, time.Now().Unix())
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to count expired sessions")
+		logger.WithTrace(tickCtx, logger.SessionsLog).Error("error counting expired sessions", zap.Error(err))
+
+		return
+	}
+
+	span.SetAttributes(attribute.Int("sessions.expired", expired))
+
+	if expired == 0 {
+		return
+	}
 
 	numDel, err := dbInstance.DeleteExpiredSessions(tickCtx)
 	if err != nil {

--- a/internal/sessions/cleanup.go
+++ b/internal/sessions/cleanup.go
@@ -56,16 +56,13 @@ func runCleanupPass(ctx context.Context, dbInstance *db.Database) {
 	expired, err := dbInstance.CountExpiredSessions(tickCtx, time.Now().Unix())
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to count expired sessions")
-		logger.WithTrace(tickCtx, logger.SessionsLog).Error("error counting expired sessions", zap.Error(err))
+		logger.WithTrace(tickCtx, logger.SessionsLog).Warn("error counting expired sessions, deleting unconditionally", zap.Error(err))
+	} else {
+		span.SetAttributes(attribute.Int("sessions.expired", expired))
 
-		return
-	}
-
-	span.SetAttributes(attribute.Int("sessions.expired", expired))
-
-	if expired == 0 {
-		return
+		if expired == 0 {
+			return
+		}
 	}
 
 	numDel, err := dbInstance.DeleteExpiredSessions(tickCtx)

--- a/internal/sessions/cleanup_test.go
+++ b/internal/sessions/cleanup_test.go
@@ -97,3 +97,43 @@ func countSessions(t *testing.T, database *db.Database, userID string) int {
 
 	return n
 }
+
+func TestCleanUpLeavesUnexpiredSessionsAlone(t *testing.T) {
+	database := newCleanupTestDB(t)
+	ctx := context.Background()
+
+	userID, err := database.CreateUser(ctx, &db.User{
+		Email:          "unexpired@example.com",
+		RoleID:         db.RoleAdmin,
+		HashedPassword: "not-a-real-hash",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	now := time.Now()
+
+	if err := database.CreateSession(ctx, &db.Session{
+		UserID:    userID,
+		TokenHash: make([]byte, 32),
+		CreatedAt: now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	expired, err := database.CountExpiredSessions(ctx, time.Now().Unix())
+	if err != nil {
+		t.Fatalf("count expired sessions: %v", err)
+	}
+
+	if expired != 0 {
+		t.Fatalf("CountExpiredSessions = %d, want 0: the gate must skip the replicated delete", expired)
+	}
+
+	runCleanupPass(ctx, database)
+
+	if n := countSessions(t, database, userID); n != 1 {
+		t.Fatalf("CountSessionsByUser = %d, want 1: cleanup must not touch an unexpired session", n)
+	}
+}

--- a/internal/upf/upf.go
+++ b/internal/upf/upf.go
@@ -37,6 +37,7 @@ const (
 	ConnTrackTimeout     = 10 * time.Minute
 	natGCInterval        = 10 * time.Second
 	natGCBatchSize       = 4096
+	flowScanBatchSize    = 1024
 	InactiveFlowTimeout  = 30 * time.Second
 	ActiveFlowTimeout    = 30 * time.Minute
 	maxInFlightFlows     = 16384
@@ -901,12 +902,10 @@ func (u *UPF) listenForMissingNeighbours() {
 // after the value has been read but before it is removed. The deleted entry will therefore contain a slightly
 // stale counter. This inaccuracy is accepted as a reasonable trade-off to
 // avoid per-key Lookup+Delete syscall pairs that would double the map load.
-func (u *UPF) scanAndEnqueueExpiredFlows(expiryThreshold int64, flowch chan flowReport) {
-	const scanBatch = 1024
-
+func (u *UPF) scanAndEnqueueExpiredFlows(expiryThreshold int64, flowch chan flowReport,
+	keys []ebpf.N3N6EntrypointFlow, values []ebpf.N3N6EntrypointFlowStats,
+) {
 	var (
-		keys         = make([]ebpf.N3N6EntrypointFlow, scanBatch)
-		values       = make([]ebpf.N3N6EntrypointFlowStats, scanBatch)
 		expiredKeys  []ebpf.N3N6EntrypointFlow
 		expiredFlows []flowReport
 		cursor       bpf.MapBatchCursor
@@ -1010,7 +1009,11 @@ func (u *UPF) deleteFlowKeys(keys []ebpf.N3N6EntrypointFlow) int {
 }
 
 func (u *UPF) collectExpiredFlows(ctx context.Context, flowch chan flowReport) {
-	var ts unix.Timespec
+	var (
+		ts     unix.Timespec
+		keys   = make([]ebpf.N3N6EntrypointFlow, flowScanBatchSize)
+		values = make([]ebpf.N3N6EntrypointFlowStats, flowScanBatchSize)
+	)
 
 	ticker := time.NewTicker(InactiveFlowTimeout / 2)
 	defer ticker.Stop()
@@ -1026,7 +1029,8 @@ func (u *UPF) collectExpiredFlows(ctx context.Context, flowch chan flowReport) {
 				return
 			}
 
-			u.scanAndEnqueueExpiredFlows(ts.Nano()-InactiveFlowTimeout.Nanoseconds(), flowch)
+			u.scanAndEnqueueExpiredFlows(ts.Nano()-InactiveFlowTimeout.Nanoseconds(), flowch,
+				keys, values)
 
 			return
 		case <-ticker.C:
@@ -1037,7 +1041,8 @@ func (u *UPF) collectExpiredFlows(ctx context.Context, flowch chan flowReport) {
 			continue
 		}
 
-		u.scanAndEnqueueExpiredFlows(ts.Nano()-InactiveFlowTimeout.Nanoseconds(), flowch)
+		u.scanAndEnqueueExpiredFlows(ts.Nano()-InactiveFlowTimeout.Nanoseconds(), flowch,
+			keys, values)
 	}
 }
 


### PR DESCRIPTION
# Description

This PR includes performance related improvements observed via profiling and tracing measurements in a live deployment:
- **Resolve gNB neighbours via FIB**: one netlink round trip per call instead of one per network interface. 
- **Reuse flow scan buffers across sweeps**: 88 KB of allocation removed per flow-scan sweep
- **Skip the replicated delete when no session has expired**
- **Thread context through SMF get session policy**: Correctly report Initial Context Setup timing.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
