### PR TITLE
refactor: model MT delivery procedure on 3GPP

### DIFF
--- a/internal/amf/amf.go
+++ b/internal/amf/amf.go
@@ -89,7 +89,7 @@ type SmfSbi interface {
 	UpdateSmContextXnHandoverFailed(ctx context.Context, smContextRef string, n2Data []byte) error
 	ReconcileSmContext(ctx context.Context, req *models.SessionReconcileRequest) error
 	GetSessionPolicy(ctx context.Context, supi etsi.SUPI, snssai *models.Snssai, dnn string) (*smf.Policy, error)
-	HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
+	HandleN1N2TransferFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, cause models.N1N2MessageTransferCause) error
 	ClearPagingSuppression(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error
 }
 
@@ -803,9 +803,7 @@ func (amf *AMF) StopAllTimers() {
 	amf.mu.Unlock()
 
 	for _, ue := range ues {
-		ue.mu.Lock()
-		ue.stopUeMuTimersLocked()
-		ue.mu.Unlock()
+		ue.PagingFailed(models.N1N2FailureCauseUnspecified)
 	}
 
 	// A UE in CM-IDLE has no connection and a bare connection has no UE, so
@@ -845,8 +843,10 @@ func (amf *AMF) RefreshLocation(ctx context.Context, supi etsi.SUPI) error {
 
 	ueConn := ue.Conn()
 	if ueConn == nil {
-		if err := amf.storeN1N2AndPage(ctx, ue, models.N1N2MessageTransferRequest{}); err != nil {
-			if errors.Is(err, errPagingActive) {
+		var rejected *models.N1N2MessageTransferError
+
+		if _, err := amf.storeN1N2AndPage(ctx, ue, models.N1N2MessageTransferRequest{}); err != nil {
+			if errors.As(err, &rejected) {
 				return nil
 			}
 
@@ -878,7 +878,7 @@ func (amf *AMF) CancelBufferedN1N2(supi etsi.SUPI, n1 models.N1MessageClass, n2 
 		return
 	}
 
-	if req := ue.N1N2Message(); req != nil && req.HasClass(n1, n2) {
-		ue.ClearN1N2Message()
+	if pending := ue.PagingPending(); pending != nil && pending.Req.HasClass(n1, n2) {
+		ue.PagingDelivered()
 	}
 }

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -208,6 +208,7 @@ func (a *AMF) attachUeConnLocked(ue *UeContext, ueConn *UeConn) *UeConn {
 	ue.active.Store(ueConn)
 
 	a.stopIdleTimersLocked(ue)
+	ue.PagingAnswered()
 
 	return displaced
 }

--- a/internal/amf/amf_ue.go
+++ b/internal/amf/amf_ue.go
@@ -113,9 +113,7 @@ type UeContext struct {
 
 	nrppaRoutingIDs map[int64]struct{}
 
-	pagingTimer guard.Guard
-
-	n1n2Message atomic.Pointer[models.N1N2MessageTransferRequest]
+	paging pagingProc
 }
 
 func NewUeContext() *UeContext {
@@ -182,18 +180,6 @@ func (ue *UeContext) Conn() *UeConn {
 	}
 
 	return ue.active.Load()
-}
-
-func (ue *UeContext) N1N2Message() *models.N1N2MessageTransferRequest {
-	return ue.n1n2Message.Load()
-}
-
-func (ue *UeContext) SetN1N2Message(m *models.N1N2MessageTransferRequest) {
-	ue.n1n2Message.Store(m)
-}
-
-func (ue *UeContext) ClearN1N2Message() {
-	ue.n1n2Message.Store(nil)
 }
 
 func (a *AMF) attachUeConnLocked(ue *UeContext, ueConn *UeConn) *UeConn {
@@ -686,36 +672,15 @@ func (a *AMF) detachUeConnLocked(ue *UeContext, target *UeConn) *UeConn {
 	return cur
 }
 
-func (ue *UeContext) stopUeMuTimersLocked() {
-	ue.pagingTimer.Stop()
-}
-
-func (ue *UeContext) StopPaging() {
-	if ue == nil {
-		return
-	}
-
-	ue.pagingTimer.Stop()
-}
-
-func (ue *UeContext) PagingActive() bool {
-	if ue == nil {
-		return false
-	}
-
-	return ue.pagingTimer.Active()
-}
-
 func (ue *UeContext) SuspendRegistration(ctx context.Context) {
 	if conn := ue.Conn(); conn != nil {
 		conn.Release()
 	}
 
 	ue.endKeyChainProcs()
+	ue.PagingFailed(models.N1N2FailureCauseUnspecified)
 
 	ue.mu.Lock()
-
-	ue.stopUeMuTimersLocked()
 
 	ue.transitionToLocked(Registered)
 
@@ -730,10 +695,9 @@ func (ue *UeContext) Deregister(ctx context.Context) {
 	}
 
 	ue.endKeyChainProcs()
+	ue.PagingFailed(models.N1N2FailureCauseUnspecified)
 
 	ue.mu.Lock()
-
-	ue.stopUeMuTimersLocked()
 
 	ue.transitionToLocked(Deregistered)
 

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -19,6 +19,7 @@ type deregisterTestSmf struct {
 	releaseCalls          []string
 	deactivateCalls       []string
 	suppressCalls         int
+	transferFailures      []models.N1N2MessageTransferCause
 	clearSuppressionCalls int
 	onRelease             func(context.Context, string) error
 
@@ -52,8 +53,10 @@ func (s *deregisterTestSmf) DeactivateSmContext(_ context.Context, smContextRef 
 	return nil
 }
 
-func (s *deregisterTestSmf) HandlePagingFailure(_ context.Context, _ etsi.SUPI, _ uint8) error {
+func (s *deregisterTestSmf) HandleN1N2TransferFailure(_ context.Context, _ etsi.SUPI, _ uint8, cause models.N1N2MessageTransferCause) error {
 	s.suppressCalls++
+	s.transferFailures = append(s.transferFailures, cause)
+
 	return nil
 }
 

--- a/internal/amf/amf_ue_deregister_test.go
+++ b/internal/amf/amf_ue_deregister_test.go
@@ -20,6 +20,7 @@ type deregisterTestSmf struct {
 	deactivateCalls       []string
 	suppressCalls         int
 	transferFailures      []models.N1N2MessageTransferCause
+	failedSessions        []uint8
 	clearSuppressionCalls int
 	onRelease             func(context.Context, string) error
 
@@ -53,9 +54,10 @@ func (s *deregisterTestSmf) DeactivateSmContext(_ context.Context, smContextRef 
 	return nil
 }
 
-func (s *deregisterTestSmf) HandleN1N2TransferFailure(_ context.Context, _ etsi.SUPI, _ uint8, cause models.N1N2MessageTransferCause) error {
+func (s *deregisterTestSmf) HandleN1N2TransferFailure(_ context.Context, _ etsi.SUPI, pduSessionID uint8, cause models.N1N2MessageTransferCause) error {
 	s.suppressCalls++
 	s.transferFailures = append(s.transferFailures, cause)
+	s.failedSessions = append(s.failedSessions, pduSessionID)
 
 	return nil
 }

--- a/internal/amf/deferred_release.go
+++ b/internal/amf/deferred_release.go
@@ -36,7 +36,9 @@ func (ueConn *UeConn) DeferRelease(cause ngap.Cause) {
 	}
 
 	held := cause
-	ueConn.deferredCause.Store(&held)
+	if !ueConn.deferredCause.CompareAndSwap(nil, &held) {
+		return
+	}
 
 	ueConn.deferGuard.ArmOnce(deferredReleaseTimeout, func() {
 		logger.From(context.Background(), ueConn.Log()).Warn("deferred UE Context Release deadline reached; releasing the NG connection",
@@ -68,8 +70,12 @@ func (ueConn *UeConn) resumeDeferredRelease(ctx context.Context) {
 
 	logger.From(ctx, ueConn.Log()).Info("resuming the deferred UE Context Release: the pending downlink traffic or signalling has settled")
 
-	ueConn.ReleaseAction = UeContextN2NormalRelease
-	ueConn.SendUEContextReleaseCommand(ctx, *cause)
+	a := ueConn.amf
+	if a == nil {
+		return
+	}
+
+	a.ReleaseOnRANRequest(ctx, ueConn, *cause, nil)
 }
 
 func (ueConn *UeConn) cancelDeferredRelease() {

--- a/internal/amf/deferred_release.go
+++ b/internal/amf/deferred_release.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"context"
+	"time"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/ngap"
+	"go.uber.org/zap"
+)
+
+const deferredReleaseTimeout = 30 * time.Second
+
+func (ueConn *UeConn) MTSignallingPending() bool {
+	if ueConn == nil {
+		return false
+	}
+
+	if ueConn.Parent().MTDeliveryInProgress() {
+		return true
+	}
+
+	if ueConn.N2SetupOpen(N2SetupInitialContext) || ueConn.N2SetupOpen(N2SetupPDUSession) {
+		return true
+	}
+
+	return ueConn.NASGuardActive()
+}
+
+func (ueConn *UeConn) DeferRelease(cause ngap.Cause) {
+	if ueConn == nil {
+		return
+	}
+
+	held := cause
+	ueConn.deferredCause.Store(&held)
+
+	ueConn.deferGuard.ArmOnce(deferredReleaseTimeout, func() {
+		logger.From(context.Background(), ueConn.Log()).Warn("deferred UE Context Release deadline reached; releasing the NG connection",
+			zap.String("cause", cause.String()))
+
+		ueConn.resumeDeferredRelease(context.Background())
+	})
+}
+
+func (ueConn *UeConn) ResumeDeferredReleaseIfSettled() {
+	if ueConn == nil || ueConn.deferredCause.Load() == nil {
+		return
+	}
+
+	if ueConn.MTSignallingPending() {
+		return
+	}
+
+	ueConn.resumeDeferredRelease(context.Background())
+}
+
+func (ueConn *UeConn) resumeDeferredRelease(ctx context.Context) {
+	cause := ueConn.deferredCause.Swap(nil)
+	if cause == nil {
+		return
+	}
+
+	ueConn.deferGuard.Stop()
+
+	logger.From(ctx, ueConn.Log()).Info("resuming the deferred UE Context Release: the pending downlink traffic or signalling has settled")
+
+	ueConn.ReleaseAction = UeContextN2NormalRelease
+	ueConn.SendUEContextReleaseCommand(ctx, *cause)
+}
+
+func (ueConn *UeConn) cancelDeferredRelease() {
+	if ueConn == nil {
+		return
+	}
+
+	ueConn.deferredCause.Store(nil)
+	ueConn.deferGuard.Stop()
+}

--- a/internal/amf/export.go
+++ b/internal/amf/export.go
@@ -376,7 +376,7 @@ func (amf *AMF) collectUeExport(guami *models.Guami, ue *UeContext) (UeContextEx
 		Timers: UETimersExport{
 			T3512ValueSeconds: int64(amf.T3512Value / time.Second),
 			T3502ValueSeconds: int64(amf.T3502Value / time.Second),
-			Paging:            timerStatus(&ue.pagingTimer),
+			Paging:            timerStatus(&ue.paging.guard),
 			NASGuard:          timerStatus(nasGuard),
 			NASGuardProcedure: nasGuardName,
 			MobileReachable:   timerStatus(&ue.mobileReachableTimer),

--- a/internal/amf/export_test.go
+++ b/internal/amf/export_test.go
@@ -227,7 +227,7 @@ func TestExportJSON_FullyPopulatedUE(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		ue.StopPaging()
+		ue.StopPagingForTest()
 	})
 
 	result := exportAndMarshal(t, amfInstance)

--- a/internal/amf/n1n2message.go
+++ b/internal/amf/n1n2message.go
@@ -165,14 +165,16 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 }
 
 // storeN1N2AndPage buffers a downlink request and pages the idle UE
-// (TS 23.502 §4.2.3.3). An earlier request already being paged for is not displaced; the
-// caller is told to retry (HIGHER_PRIORITY_REQUEST_ONGOING, TS 29.518 §6.1.7.3).
+// (TS 23.502 §4.2.3.3). An earlier request already being paged for is displaced only by a
+// higher-priority one, whose consumer is then notified that its transfer failed
+// (TS 29.518 §5.2.2.3.2); otherwise the caller is told to retry
+// (HIGHER_PRIORITY_REQUEST_ONGOING, TS 29.518 §6.1.7.3).
 func (amf *AMF) storeN1N2AndPage(ctx context.Context, ue *UeContext, req models.N1N2MessageTransferRequest) (models.N1N2MessageTransferCause, error) {
 	if err := guardIdlePaging(ue); err != nil {
 		return "", err
 	}
 
-	return amf.pageIdleUE(ctx, ue, &MTRequest{Req: req, Arp: req.Arp, FiveQI: req.FiveQI})
+	return amf.pageIdleUE(ctx, ue, &MTRequest{Req: req})
 }
 
 // ModifyN1N2Message delivers a PDU Session Modification Command (N1) to the
@@ -330,11 +332,11 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 	}
 
 	if ue.State() == RegistrationInitiated {
-		return "", &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectRegistrationOngoing)}
+		return "", &models.N1N2MessageTransferError{Cause: models.N1N2ErrTemporaryRejectRegistrationOngoing}
 	}
 
 	if ue.Procedures().Active(procedure.N2Handover) {
-		return "", &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectHandoverOngoing)}
+		return "", &models.N1N2MessageTransferError{Cause: models.N1N2ErrTemporaryRejectHandoverOngoing}
 	}
 
 	logger.From(ctx, logger.AmfLog).Debug("AMF Transfer NGAP PDU Session Resource Setup Request from SMF")
@@ -346,7 +348,7 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 			logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
 				zap.Uint8("pdu_session_id", req.PduSessionID))
 
-			return models.N1N2N2MsgNotTransferred, nil
+			return "", &models.N1N2MessageTransferError{Cause: models.N1N2ErrTemporaryRejectSROngoing}
 		}
 
 		item, err := PDUSessionSetupItemSUReq(req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
@@ -386,7 +388,7 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 		logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
 			zap.Uint8("pdu_session_id", req.PduSessionID))
 
-		return models.N1N2TransferInitiated, nil
+		return "", &models.N1N2MessageTransferError{Cause: models.N1N2ErrTemporaryRejectSROngoing}
 	}
 
 	item, err := PDUSessionSetupItem(req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)

--- a/internal/amf/n1n2message.go
+++ b/internal/amf/n1n2message.go
@@ -33,7 +33,7 @@ var ErrUENotReachable = errors.New("UE is in CM-IDLE state")
 
 var errNoRANUEContext = errors.New("the NG-RAN node holds no UE context for this connection")
 
-func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req models.N1N2MessageTransferRequest) error {
+func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req models.N1N2MessageTransferRequest) (models.N1N2MessageTransferCause, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		"AMF N1N2 MessageTransfer",
@@ -45,7 +45,7 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 
 	ue, ok := amf.LookupUeBySupi(supi)
 	if !ok {
-		return fmt.Errorf("ue context not found")
+		return "", fmt.Errorf("ue context not found")
 	}
 
 	ueConn := ue.Conn()
@@ -57,7 +57,7 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 
 	plain, err := BuildDLNASTransport(fgs.PayloadContainerTypeN1SMInfo, req.BinaryDataN1Message, new(fgs.PDUSessionID(req.PduSessionID)), nil, nil)
 	if err != nil {
-		return fmt.Errorf("build DL NAS Transport error: %v", err)
+		return "", fmt.Errorf("build DL NAS Transport error: %v", err)
 	}
 
 	sht := uint8(fgs.SHTIntegrityProtectedCiphered)
@@ -66,7 +66,7 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 		// Context already set up (or in progress): deliver the PDU session standalone.
 		n2Setup := ueConn.N2Setup(N2SetupPDUSession)
 
-		return ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
+		if err := ue.SendDownlinkNAS(plain, sht, func(wire []byte) error {
 			if !n2Setup.ClaimSession(req.PduSessionID) {
 				logger.From(ctx, logger.AmfLog).Debug("delivering N1 without a duplicate PDU session setup",
 					zap.Uint8("pdu_session_id", req.PduSessionID))
@@ -94,14 +94,18 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 			logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request to UE")
 
 			return nil
-		})
+		}); err != nil {
+			return "", err
+		}
+
+		return models.N1N2TransferInitiated, nil
 	}
 
 	// Claimed the Initial Context Setup: bundle the PDU session into it.
 	operatorInfo, err := amf.OperatorInfo(ctx)
 	if err != nil {
 		ueConn.ResetICS()
-		return fmt.Errorf("error getting operator info: %v", err)
+		return "", fmt.Errorf("error getting operator info: %v", err)
 	}
 
 	kgnb, ueSecCap := ue.Kgnb(), ue.UESecCap()
@@ -154,25 +158,21 @@ func (amf *AMF) TransferN1N2Message(ctx context.Context, supi etsi.SUPI, req mod
 	if err != nil {
 		ueConn.AbortICS()
 
-		return err
+		return "", err
 	}
 
-	return nil
+	return models.N1N2TransferInitiated, nil
 }
 
 // storeN1N2AndPage buffers a downlink request and pages the idle UE
 // (TS 23.502 §4.2.3.3). An earlier request already being paged for is not displaced; the
 // caller is told to retry (HIGHER_PRIORITY_REQUEST_ONGOING, TS 29.518 §6.1.7.3).
-func (amf *AMF) storeN1N2AndPage(ctx context.Context, ue *UeContext, req models.N1N2MessageTransferRequest) error {
-	if ue.PagingActive() {
-		return errPagingActive
-	}
-
+func (amf *AMF) storeN1N2AndPage(ctx context.Context, ue *UeContext, req models.N1N2MessageTransferRequest) (models.N1N2MessageTransferCause, error) {
 	if err := guardIdlePaging(ue); err != nil {
-		return err
+		return "", err
 	}
 
-	return amf.pageIdleUE(ctx, ue, &req)
+	return amf.pageIdleUE(ctx, ue, &MTRequest{Req: req, Arp: req.Arp, FiveQI: req.FiveQI})
 }
 
 // ModifyN1N2Message delivers a PDU Session Modification Command (N1) to the
@@ -308,7 +308,7 @@ func (amf *AMF) ReleaseSessionMessage(ctx context.Context, supi etsi.SUPI, pduSe
 	})
 }
 
-func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req models.N1N2MessageTransferRequest) error {
+func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req models.N1N2MessageTransferRequest) (models.N1N2MessageTransferCause, error) {
 	ctx, span := tracer.Start(
 		ctx,
 		"AMF N1N2 MessageTransfer",
@@ -320,7 +320,7 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 
 	ue, ok := amf.LookupUeBySupi(supi)
 	if !ok {
-		return fmt.Errorf("ue context not found")
+		return "", fmt.Errorf("ue context not found")
 	}
 
 	ueConn := ue.Conn()
@@ -330,11 +330,11 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 	}
 
 	if ue.State() == RegistrationInitiated {
-		return fmt.Errorf("temporary reject registration ongoing")
+		return "", &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectRegistrationOngoing)}
 	}
 
 	if ue.Procedures().Active(procedure.N2Handover) {
-		return fmt.Errorf("temporary reject handover ongoing")
+		return "", &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectHandoverOngoing)}
 	}
 
 	logger.From(ctx, logger.AmfLog).Debug("AMF Transfer NGAP PDU Session Resource Setup Request from SMF")
@@ -346,14 +346,14 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 			logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
 				zap.Uint8("pdu_session_id", req.PduSessionID))
 
-			return nil
+			return models.N1N2N2MsgNotTransferred, nil
 		}
 
 		item, err := PDUSessionSetupItemSUReq(req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 		if err != nil {
 			n2Setup.End()
 
-			return fmt.Errorf("could not build PDU session setup item: %w", err)
+			return "", fmt.Errorf("could not build PDU session setup item: %w", err)
 		}
 
 		list := ngap.PDUSessionResourceSetupListSUReq{item}
@@ -362,21 +362,21 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 		if err != nil {
 			n2Setup.End()
 
-			return fmt.Errorf("send pdu session resource setup request error: %v", err)
+			return "", fmt.Errorf("send pdu session resource setup request error: %v", err)
 		}
 
 		n2Setup.Arm(amf.N2SetupGuardCfg)
 
 		logger.From(ctx, logger.AmfLog).Info("Sent NGAP pdu session resource setup request to UE")
 
-		return nil
+		return models.N1N2TransferInitiated, nil
 	}
 
 	// Claimed the Initial Context Setup: bundle the PDU session into it.
 	operatorInfo, err := amf.OperatorInfo(ctx)
 	if err != nil {
 		ueConn.ResetICS()
-		return fmt.Errorf("error getting operator info: %v", err)
+		return "", fmt.Errorf("error getting operator info: %v", err)
 	}
 
 	n2Setup := ueConn.N2Setup(N2SetupInitialContext)
@@ -386,14 +386,14 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 		logger.From(ctx, logger.AmfLog).Warn("PDU session already set up on the NG-RAN node; dropping the duplicate N2 transfer",
 			zap.Uint8("pdu_session_id", req.PduSessionID))
 
-		return nil
+		return models.N1N2TransferInitiated, nil
 	}
 
 	item, err := PDUSessionSetupItem(req.PduSessionID, req.SNssai, nil, req.BinaryDataN2Information)
 	if err != nil {
 		ueConn.AbortICS()
 
-		return fmt.Errorf("could not build PDU session setup item: %w", err)
+		return "", fmt.Errorf("could not build PDU session setup item: %w", err)
 	}
 
 	list := ngap.PDUSessionResourceSetupListCxtReq{item}
@@ -414,14 +414,14 @@ func (amf *AMF) N2MessageTransferOrPage(ctx context.Context, supi etsi.SUPI, req
 	if err != nil {
 		ueConn.AbortICS()
 
-		return fmt.Errorf("send initial context setup request error: %v", err)
+		return "", fmt.Errorf("send initial context setup request error: %v", err)
 	}
 
 	n2Setup.Arm(amf.N2SetupGuardCfg)
 
 	logger.From(ctx, logger.AmfLog).Info("Sent NGAP initial context setup request to UE")
 
-	return nil
+	return models.N1N2TransferInitiated, nil
 }
 
 func (amf *AMF) TransferN1Msg(ctx context.Context, supi etsi.SUPI, n1Msg []byte, pduSessionID uint8) error {
@@ -523,7 +523,9 @@ func (amf *AMF) TransferN2NRPPaMsg(ctx context.Context, supi etsi.SUPI, routingI
 func (amf *AMF) transferOrPageStandalone(ctx context.Context, ue *UeContext, req models.N1N2MessageTransferRequest) error {
 	conn := ue.Conn()
 	if conn == nil {
-		return amf.storeN1N2AndPage(ctx, ue, req)
+		_, err := amf.storeN1N2AndPage(ctx, ue, req)
+
+		return err
 	}
 
 	return DeliverStandaloneN1N2(ctx, ue, conn, &req)

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -6,6 +6,7 @@ package amf_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -780,8 +781,11 @@ func TestN2MessageTransferOrPage_DoesNotResetupASessionAlreadyInFlight(t *testin
 		t.Fatalf("PDUSessionResourceSetupRequest count = %d, want 1", sender.pduSessionSetupCalls)
 	}
 
-	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
-		t.Fatalf("second transfer: %v", err)
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
+
+	var rejected *models.N1N2MessageTransferError
+	if !errors.As(err, &rejected) || rejected.Cause != models.N1N2ErrTemporaryRejectSROngoing {
+		t.Fatalf("second transfer = %v, want TEMPORARY_REJECT_SR_ONGOING (TS 29.518 table 6.1.7.3-1)", err)
 	}
 
 	if sender.pduSessionSetupCalls != 1 {

--- a/internal/amf/n1n2message_test.go
+++ b/internal/amf/n1n2message_test.go
@@ -130,7 +130,10 @@ func (f *fakeSmf) DeactivateSmContext(_ context.Context, ref string) error {
 
 	return nil
 }
-func (f *fakeSmf) HandlePagingFailure(context.Context, etsi.SUPI, uint8) error { return nil }
+
+func (f *fakeSmf) HandleN1N2TransferFailure(context.Context, etsi.SUPI, uint8, models.N1N2MessageTransferCause) error {
+	return nil
+}
 
 func (f *fakeSmf) ClearPagingSuppression(context.Context, etsi.SUPI, uint8) error { return nil }
 func (f *fakeSmf) ReleaseSmContext(context.Context, string) error                 { return nil }
@@ -251,7 +254,7 @@ func TestTransferN1N2Message_UENotFound(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	supi := mustSUPIFromIMSI(t, "001010000000001")
 
-	err := amfInstance.TransferN1N2Message(context.Background(), supi, newReq())
+	_, err := amfInstance.TransferN1N2Message(context.Background(), supi, newReq())
 	if err == nil {
 		t.Fatal("expected error for missing UE")
 	}
@@ -262,7 +265,7 @@ func TestTransferN1N2Message_UENotConnected(t *testing.T) {
 
 	ue := addUE(t, amfInstance, "001010000000002", nil)
 
-	err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq())
 	if err == nil {
 		t.Fatal("expected error for UE not connected to RAN")
 	}
@@ -282,7 +285,7 @@ func TestTransferN1N2Message_InitialContextAlreadySent(t *testing.T) {
 	ueConn.MarkICSPending()
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -317,7 +320,7 @@ func TestTransferN1N2Message_InitialContextNotYetSent(t *testing.T) {
 	ueConn.ResetICS()
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -364,7 +367,7 @@ func TestModifyN1N2Message_IdleRegisteredUE_ReturnsNotReachable(t *testing.T) {
 		t.Fatalf("expected 0 paging calls, got %d", sender.pagingCalls)
 	}
 
-	if ue.N1N2Message() != nil {
+	if ue.PagingPending().Request() != nil {
 		t.Fatal("expected no stored N1N2 message")
 	}
 }
@@ -424,7 +427,7 @@ func TestN2MessageTransferOrPage_UENotFound(t *testing.T) {
 	amfInstance := amf.New(nil, nil, nil)
 	supi := mustSUPIFromIMSI(t, "001010000000005")
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), supi, newReq())
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), supi, newReq())
 	if err == nil {
 		t.Fatal("expected error for missing UE")
 	}
@@ -488,7 +491,7 @@ func TestSendPaging_IdleUE_ArmsPersistentTimer(t *testing.T) {
 		t.Fatal("SendPaging must arm the persistent per-UE paging timer")
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 }
 
 func TestN2MessageTransferOrPage_OnGoingPaging(t *testing.T) {
@@ -498,7 +501,7 @@ func TestN2MessageTransferOrPage_OnGoingPaging(t *testing.T) {
 
 	ue.ArmPagingForTest(1*time.Hour, 3)
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
 	if err == nil {
 		t.Fatal("expected error for ongoing paging")
 	}
@@ -511,7 +514,7 @@ func TestN2MessageTransferOrPage_OnGoingRegistration(t *testing.T) {
 
 	ue.ForceStateForTest(amf.RegistrationInitiated)
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
 	if err == nil {
 		t.Fatal("expected error for ongoing registration")
 	}
@@ -526,7 +529,7 @@ func TestN2MessageTransferOrPage_OnGoingN2Handover(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
 	if err == nil {
 		t.Fatal("expected error for ongoing N2 handover")
 	}
@@ -546,7 +549,7 @@ func TestN2MessageTransferOrPage_ConnectedUE_InitialCtxSent(t *testing.T) {
 	ueConn.MarkICSPending()
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -580,7 +583,7 @@ func TestN2MessageTransferOrPage_IdleRegisteredUE_Pages(t *testing.T) {
 
 	req := newReq()
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), req)
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), req)
 	if err != nil {
 		t.Fatalf("expected idle registered UE to be paged, got error: %v", err)
 	}
@@ -593,7 +596,7 @@ func TestN2MessageTransferOrPage_IdleRegisteredUE_Pages(t *testing.T) {
 		t.Fatal("expected the persistent per-UE paging timer to be armed")
 	}
 
-	buffered := ue.N1N2Message()
+	buffered := ue.PagingPending().Request()
 	if buffered == nil {
 		t.Fatal("expected the N1N2 message to be buffered on the persistent UE context")
 	}
@@ -602,7 +605,7 @@ func TestN2MessageTransferOrPage_IdleRegisteredUE_Pages(t *testing.T) {
 		t.Fatalf("buffered PDU session id: expected %d, got %d", req.PduSessionID, buffered.PduSessionID)
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 }
 
 func TestN2MessageTransferOrPage_NotRegistered_NoPaging(t *testing.T) {
@@ -610,7 +613,7 @@ func TestN2MessageTransferOrPage_NotRegistered_NoPaging(t *testing.T) {
 
 	ue := addUE(t, amfInstance, "001010000000010", nil)
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq())
 	if err == nil {
 		t.Fatal("expected error for UE not in registered state")
 	}
@@ -676,7 +679,7 @@ func TestN2MessageTransferOrPage_SetupItemFailureReleasesICSClaim(t *testing.T) 
 	req := newReq()
 	req.SNssai = nil
 
-	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), req); err == nil {
+	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), req); err == nil {
 		t.Fatal("expected an error building the PDU session setup item")
 	}
 
@@ -769,7 +772,7 @@ func TestN2MessageTransferOrPage_DoesNotResetupASessionAlreadyInFlight(t *testin
 	ueConn.MarkICSPending()
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
 		t.Fatalf("first transfer: %v", err)
 	}
 
@@ -777,7 +780,7 @@ func TestN2MessageTransferOrPage_DoesNotResetupASessionAlreadyInFlight(t *testin
 		t.Fatalf("PDUSessionResourceSetupRequest count = %d, want 1", sender.pduSessionSetupCalls)
 	}
 
-	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
 		t.Fatalf("second transfer: %v", err)
 	}
 
@@ -981,7 +984,7 @@ func TestTransferN1N2Message_SessionAlreadySetUp_ReleasesTheICSClaim(t *testing.
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 	ueConn.SetN2SessionActive(1)
 
-	if err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+	if _, err := amfInstance.TransferN1N2Message(context.Background(), ue.SupiForTest(), newReq()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1017,7 +1020,7 @@ func TestStoreN1N2AndPage_RejectsASecondTransferWhilePaging(t *testing.T) {
 	}})
 
 	first := newReq()
-	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), first); err != nil {
+	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), first); err != nil {
 		t.Fatalf("first transfer: %v", err)
 	}
 
@@ -1025,7 +1028,7 @@ func TestStoreN1N2AndPage_RejectsASecondTransferWhilePaging(t *testing.T) {
 		t.Fatal("expected paging supervision to be running")
 	}
 
-	buffered := ue.N1N2Message()
+	buffered := ue.PagingPending().Request()
 	if buffered == nil {
 		t.Fatal("the first transfer was not buffered")
 	}
@@ -1033,12 +1036,12 @@ func TestStoreN1N2AndPage_RejectsASecondTransferWhilePaging(t *testing.T) {
 	second := newReq()
 	second.BinaryDataN2Information = []byte{0xAA, 0xBB}
 
-	err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), second)
+	_, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), second)
 	if err == nil {
 		t.Fatal("a second transfer while paging must be rejected (TS 23.502 4.2.3.3 step 3b)")
 	}
 
-	if got := ue.N1N2Message(); got == nil || !bytes.Equal(got.BinaryDataN2Information, buffered.BinaryDataN2Information) {
+	if got := ue.PagingPending().Request(); got == nil || !bytes.Equal(got.BinaryDataN2Information, buffered.BinaryDataN2Information) {
 		t.Error("the buffered request was displaced; the SMF will never resend the 5GSM message it carried")
 	}
 }
@@ -1178,7 +1181,7 @@ func TestN2MessageTransferOrPage_ReplacedSessionReachesTheRAN(t *testing.T) {
 	ueConn.MarkICSPending()
 	ueConn.AMFForTest().AttachUeConn(ue, ueConn)
 
-	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
 		t.Fatalf("first transfer: %v", err)
 	}
 
@@ -1191,7 +1194,7 @@ func TestN2MessageTransferOrPage_ReplacedSessionReachesTheRAN(t *testing.T) {
 	// context once that transfer has returned.
 	ue.DeleteSmContext(1)
 
-	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
 		t.Fatalf("transfer for the replacement session: %v", err)
 	}
 

--- a/internal/amf/n2_setup_txn.go
+++ b/internal/amf/n2_setup_txn.go
@@ -107,6 +107,7 @@ func (s N2Setup) Arm(cfg guard.TimerValue) {
 
 func (ueConn *UeConn) EndN2Setup(proc N2SetupProcedure) {
 	ueConn.endN2SetupTxn(proc, nil)
+	ueConn.ResumeDeferredReleaseIfSettled()
 }
 
 func (ueConn *UeConn) expireN2Setup(proc N2SetupProcedure, txn *n2SetupTxn) {

--- a/internal/amf/nas/fixtures_test.go
+++ b/internal/amf/nas/fixtures_test.go
@@ -330,7 +330,7 @@ func (s *fakeSmf) DeactivateSmContext(_ context.Context, _ string) error {
 	return s.Error
 }
 
-func (s *fakeSmf) HandlePagingFailure(_ context.Context, _ etsi.SUPI, _ uint8) error {
+func (s *fakeSmf) HandleN1N2TransferFailure(_ context.Context, _ etsi.SUPI, _ uint8, _ models.N1N2MessageTransferCause) error {
 	return s.Error
 }
 

--- a/internal/amf/nas/fixtures_test.go
+++ b/internal/amf/nas/fixtures_test.go
@@ -221,6 +221,12 @@ type fakeSmf struct {
 	DuplicatePDUResponse      []byte
 	DuplicatePDUError         error
 	DuplicatePDUCalls         []SmfDuplicatePDUCall
+	TransferFailures          []SmfTransferFailure
+}
+
+type SmfTransferFailure struct {
+	PDUSessionID uint8
+	Cause        models.N1N2MessageTransferCause
 }
 
 type SmfUpdateN1MsgCall struct {
@@ -330,7 +336,9 @@ func (s *fakeSmf) DeactivateSmContext(_ context.Context, _ string) error {
 	return s.Error
 }
 
-func (s *fakeSmf) HandleN1N2TransferFailure(_ context.Context, _ etsi.SUPI, _ uint8, _ models.N1N2MessageTransferCause) error {
+func (s *fakeSmf) HandleN1N2TransferFailure(_ context.Context, _ etsi.SUPI, pduSessionID uint8, cause models.N1N2MessageTransferCause) error {
+	s.TransferFailures = append(s.TransferFailures, SmfTransferFailure{PDUSessionID: pduSessionID, Cause: cause})
+
 	return s.Error
 }
 

--- a/internal/amf/nas/handle_configuration_update_complete.go
+++ b/internal/amf/nas/handle_configuration_update_complete.go
@@ -18,19 +18,18 @@ func handleConfigurationUpdateComplete(amfInstance *amf.AMF, ue *amf.UeContext) 
 		return nasreply.Silent(nasreply.ReasonOutOfState)
 	}
 
-	if conn := ue.Conn(); conn != nil {
+	conn := ue.Conn()
+	if conn != nil {
 		conn.StopNASGuard()
 	}
 
 	amfInstance.CommitGUTIRealloc(ue)
 
-	if req := ue.N1N2Message(); req != nil && req.Standalone() {
-		ue.ClearN1N2Message()
+	if req := ue.PagingPending().Request(); req != nil && req.Standalone() {
+		ue.PagingDelivered()
 
-		if conn := ue.Conn(); conn != nil {
-			if err := amf.DeliverStandaloneN1N2(context.Background(), ue, conn, req); err != nil {
-				logger.AmfLog.Warn("failed to deliver buffered standalone N1N2 message", zap.Error(err))
-			}
+		if err := amf.DeliverStandaloneN1N2(context.Background(), ue, conn, req); err != nil {
+			logger.AmfLog.Warn("failed to deliver buffered standalone N1N2 message", zap.Error(err))
 		}
 	}
 

--- a/internal/amf/nas/handle_registration_complete_test.go
+++ b/internal/amf/nas/handle_registration_complete_test.go
@@ -298,7 +298,7 @@ func checkUERegistrationDataIsCleared(ue *amf.UeContext) error {
 		return fmt.Errorf("retransmission of initial NAS msg should be false")
 	}
 
-	if ue.PagingActive() {
+	if ue.PagingActiveForTest() {
 		return fmt.Errorf("ongoing should be nothing")
 	}
 

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -64,7 +64,7 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		}
 	}
 
-	ue.StopPaging()
+	ue.PagingAnswered()
 	conn.StopNASGuard()
 
 	// TS 24.501: a present NASMessageContainer holds a ciphered inner

--- a/internal/amf/nas/handle_registration_request.go
+++ b/internal/amf/nas/handle_registration_request.go
@@ -64,7 +64,6 @@ func handleRegistrationRequestMessage(ctx context.Context, amfInstance *amf.AMF,
 		}
 	}
 
-	ue.PagingAnswered()
 	conn.StopNASGuard()
 
 	// TS 24.501: a present NASMessageContainer holds a ciphered inner

--- a/internal/amf/nas/handle_registration_request_test.go
+++ b/internal/amf/nas/handle_registration_request_test.go
@@ -273,6 +273,7 @@ func TestHandleRegistrationRequest_Timers_Stopped(t *testing.T) {
 	}
 
 	ue.ArmPagingForTest(10*time.Minute, 10)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	m, err := buildTestRegistrationRequestMessage(0, nil, 0)
 	if err != nil {

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -276,7 +276,6 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		return nasreply.Silent(nasreply.ReasonNoContext)
 	}
 
-	ue.PagingAnswered()
 	conn.StopNASGuard()
 
 	// TS 24.501: an integrity-protected SERVICE REQUEST carrying a NAS

--- a/internal/amf/nas/handle_service_request.go
+++ b/internal/amf/nas/handle_service_request.go
@@ -37,7 +37,7 @@ type bufferedSM struct {
 }
 
 func resolveBufferedSM(ue *amf.UeContext) bufferedSM {
-	req := ue.N1N2Message()
+	req := ue.PagingPending().Request()
 	if req == nil || req.Standalone() {
 		return bufferedSM{}
 	}
@@ -276,7 +276,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 		return nasreply.Silent(nasreply.ReasonNoContext)
 	}
 
-	ue.StopPaging()
+	ue.PagingAnswered()
 	conn.StopNASGuard()
 
 	// TS 24.501: an integrity-protected SERVICE REQUEST carrying a NAS
@@ -537,7 +537,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 	}
 
 	if buffered.stale && serviceType == fgs.ServiceTypeMobileTerminatedServices {
-		ue.ClearN1N2Message()
+		ue.PagingDelivered()
 
 		if initialContextSetup {
 			ueConn.AbortICS()
@@ -551,7 +551,7 @@ func handleServiceRequest(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeC
 	}
 
 	if buffered.present {
-		ue.ClearN1N2Message()
+		ue.PagingDelivered()
 	}
 
 	if buffered.n1Only != nil {

--- a/internal/amf/nas/handle_service_request_reactivation_test.go
+++ b/internal/amf/nas/handle_service_request_reactivation_test.go
@@ -44,7 +44,7 @@ func TestHandleServiceRequest_BufferedN1N2_DoesNotSuppressReactivation(t *testin
 			f := connectedModeUe(t, &fakeSmf{})
 
 			snssai := models.Snssai{Sst: 1, Sd: "102030"}
-			f.ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+			f.ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 				N1Class:                 models.N1ClassSM,
 				N2Class:                 models.N2ClassSM,
 				PduSessionID:            12,
@@ -69,7 +69,7 @@ func TestHandleServiceRequest_BufferedN1N2_IsConsumed(t *testing.T) {
 	f := connectedModeUe(t, &fakeSmf{})
 
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
-	f.ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	f.ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		N1Class:                 models.N1ClassSM,
 		N2Class:                 models.N2ClassSM,
 		PduSessionID:            12,
@@ -79,7 +79,7 @@ func TestHandleServiceRequest_BufferedN1N2_IsConsumed(t *testing.T) {
 
 	idleToActive(t, f, fgs.ServiceTypeData)
 
-	if f.ue.N1N2Message() != nil {
+	if f.ue.PagingPending().Request() != nil {
 		t.Fatal("buffered N1N2 message still present after the service accept")
 	}
 }
@@ -88,7 +88,7 @@ func TestHandleServiceRequest_SecondRequestAfterBufferedN1N2_StillReactivates(t 
 	f := connectedModeUe(t, &fakeSmf{})
 
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
-	f.ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	f.ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		N1Class:                 models.N1ClassSM,
 		N2Class:                 models.N2ClassSM,
 		PduSessionID:            12,
@@ -245,7 +245,7 @@ func TestHandleServiceRequest_BufferedPayloadForASessionReportedInactive_IsNotSe
 		t.Fatalf("could not create the sm context: %v", err)
 	}
 
-	f.ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	f.ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		N1Class:                 models.N1ClassSM,
 		N2Class:                 models.N2ClassSM,
 		PduSessionID:            9,
@@ -284,7 +284,7 @@ func TestHandleServiceRequest_BufferedPayloadForASessionReportedInactive_IsNotSe
 		t.Error("PDU session 9 is still claimed on the NG-RAN node although it was never set up")
 	}
 
-	if f.ue.N1N2Message() != nil {
+	if f.ue.PagingPending().Request() != nil {
 		t.Error("the buffered downlink payload for the released session must be discarded")
 	}
 }

--- a/internal/amf/nas/handle_service_request_standalone_test.go
+++ b/internal/amf/nas/handle_service_request_standalone_test.go
@@ -82,7 +82,7 @@ func TestHandleServiceRequest_MT_BufferedLPP_Delivered(t *testing.T) {
 	lppMsg := []byte{0x11, 0x22, 0x33}
 	correlID := []byte{0xde, 0xad, 0xbe, 0xef}
 
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		N1Class:             models.N1ClassLPP,
 		BinaryDataN1Message: lppMsg,
 		LCSCorrelationID:    correlID,
@@ -115,7 +115,7 @@ func TestHandleServiceRequest_MT_BufferedLPP_Delivered(t *testing.T) {
 		t.Errorf("additional information = %x, want the correlation id %x", dl.AdditionalInfo, correlID)
 	}
 
-	if ue.N1N2Message() != nil {
+	if ue.PagingPending().Request() != nil {
 		t.Error("expected the buffer to be cleared once delivered")
 	}
 }
@@ -126,7 +126,7 @@ func TestHandleServiceRequest_MT_BufferedNRPPa_Delivered(t *testing.T) {
 
 	nrppaPdu := []byte{0x0a, 0x0b, 0x0c}
 
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		N2Class:                 models.N2ClassNRPPa,
 		BinaryDataN2Information: nrppaPdu,
 		RoutingID:               5,
@@ -147,7 +147,7 @@ func TestHandleServiceRequest_MT_BufferedNRPPa_Delivered(t *testing.T) {
 		t.Error("a positioning buffer must not drive PDU session resource setup")
 	}
 
-	if ue.N1N2Message() != nil {
+	if ue.PagingPending().Request() != nil {
 		t.Error("expected the buffer to be cleared once delivered")
 	}
 }

--- a/internal/amf/nas/handle_service_request_test.go
+++ b/internal/amf/nas/handle_service_request_test.go
@@ -698,7 +698,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_NoPDUSession
 	ue.SetKnasIntForTest(key)
 	ue.SetCipheringAlgForTest(algo)
 	ue.SetIntegrityAlgForTest(nas.IntegrityNull)
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1})
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{PduSessionID: 1})
 
 	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), fgs.ServiceTypeMobileTerminatedServices)
 	if err != nil {
@@ -766,7 +766,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 	ue.AllowedNssai = []models.Snssai{snssai}
 	setTestUESecurityCapability(ue)
 	_ = ue.CreateSmContext(1, "testref", &snssai, "internet")
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai})
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai})
 
 	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), fgs.ServiceTypeMobileTerminatedServices)
 	if err != nil {
@@ -864,7 +864,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	setTestUESecurityCapability(ue)
 	_ = ue.CreateSmContext(1, "testref", &snssai, "internet")
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai, "internet")
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
 
 	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), fgs.ServiceTypeMobileTerminatedServices)
 	if err != nil {
@@ -971,7 +971,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	setTestUESecurityCapability(ue)
 	_ = ue.CreateSmContext(1, "testref", &snssai, "internet")
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai, "internet")
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
 
 	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), fgs.ServiceTypeMobileTerminatedServices)
 	if err != nil {
@@ -1093,7 +1093,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 	ue.Ambr = &models.Ambr{Uplink: models.MustParseBitRate("100 Mbps"), Downlink: models.MustParseBitRate("100 Mbps")}
 	_ = ue.CreateSmContext(1, "testref", &snssai, "internet")
 	_ = ue.CreateSmContext(12, "testrefuplink", &snssai, "internet")
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{PduSessionID: 1, SNssai: &snssai, BinaryDataN2Information: []byte{}})
 	ue.Conn().UeContextRequest = true
 
 	m, err := buildTestServiceRequestCiphered(algo, key, ue.ULCount(), fgs.ServiceTypeMobileTerminatedServices)
@@ -1296,7 +1296,7 @@ func TestHandleServiceRequest_BufferedN1WithN2_ServiceAcceptTakesTheLowerNASCoun
 
 	_ = ue.CreateSmContext(1, "testref", &snssai, "internet")
 
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		PduSessionID:            1,
 		SNssai:                  &snssai,
 		BinaryDataN1Message:     []byte{0x2e, 0x01, 0x01},

--- a/internal/amf/nas/handle_service_request_test.go
+++ b/internal/amf/nas/handle_service_request_test.go
@@ -281,6 +281,7 @@ func TestHandleServiceRequest_ServiceTypeSignaling_ServiceAccept(t *testing.T) {
 	ue.SetSecuredForTest(true)
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	m := buildTestServiceRequest()
 
@@ -538,6 +539,7 @@ func TestHandleServiceRequestMTReadsOperatorOnce(t *testing.T) {
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceStateForTest(amf.Registered)
@@ -606,6 +608,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_ServiceAccept(t *testing
 	oldguti := mustTestGuti("001", "01", "cafe42", 0x00000001)
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceStateForTest(amf.Registered)
@@ -679,6 +682,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_NoPDUSession
 	}
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceStateForTest(amf.Registered)
@@ -743,6 +747,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2Message_ExistingPDUS
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceStateForTest(amf.Registered)
@@ -840,6 +845,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceStateForTest(amf.Registered)
@@ -947,6 +953,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_ExistingPD
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceStateForTest(amf.Registered)
@@ -1071,6 +1078,7 @@ func TestHandleServiceRequest_NASContainerServiceTypeMT_N1N2MessageN2_UeCtxReq_E
 	snssai := models.Snssai{Sst: 1, Sd: "102030"}
 
 	ue.ArmPagingForTest(6*time.Minute, 5)
+	amfInstance.AttachUeConn(ue, ue.Conn())
 
 	ue.PlmnID = models.PlmnID{Mcc: "001", Mnc: "01"}
 	ue.ForceStateForTest(amf.Registered)

--- a/internal/amf/nas/reg_initial.go
+++ b/internal/amf/nas/reg_initial.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ellanetworks/core/internal/amf"
 	"github.com/ellanetworks/core/internal/logger"
 	"github.com/ellanetworks/core/internal/metrics"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas/fgs"
 	"github.com/ellanetworks/core/ngap"
 	"go.uber.org/zap"
@@ -57,6 +58,10 @@ func abortRegistrationRetainingContext(ctx context.Context, amfInstance *amf.AMF
 }
 
 func HandleInitialRegistration(ctx context.Context, amfInstance *amf.AMF, ue *amf.UeContext) {
+	if ue.MTDeliveryInProgress() {
+		ue.PagingFailed(models.N1N2FailureCauseUnspecified)
+	}
+
 	ue.ClearRegistrationData(ctx)
 
 	conn := ue.Conn()

--- a/internal/amf/nas/reg_mobility_paging_disposal_test.go
+++ b/internal/amf/nas/reg_mobility_paging_disposal_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 
 	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/db"
 	"github.com/ellanetworks/core/internal/models"
+	"github.com/ellanetworks/core/nas/fgs"
 )
 
-func TestMobilityReg_PagedRequestDoesNotOutliveTheUEContext(t *testing.T) {
-	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
+func TestMobilityReg_UndeliverablePagedRequestIsFailed(t *testing.T) {
+	ue, _, fakeSmf, amfInstance := buildMobilityRegUeAndAMF(t)
 	setTestUESecurityCapability(ue)
 
 	snssai := &models.Snssai{Sst: 1}
@@ -28,14 +30,118 @@ func TestMobilityReg_PagedRequestDoesNotOutliveTheUEContext(t *testing.T) {
 
 	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
 
-	conn := ue.Conn()
-	if conn == nil {
-		t.Fatal("no connection after the registration")
+	if state := ue.PagingState(); state != amf.PagingIdle {
+		t.Errorf("paging state = %s after a registration that could not deliver the request, want Idle", state)
 	}
 
-	conn.Release()
+	if pending := ue.PagingPending(); pending != nil {
+		t.Errorf("pending = %+v, want the undeliverable request released", pending)
+	}
+
+	if got := fakeSmf.TransferFailures; len(got) != 1 || got[0].PDUSessionID != 5 || got[0].Cause != models.N1N2FailureCauseUnspecified {
+		t.Errorf("transfer failures = %+v, want one FAILURE_CAUSE_UNSPECIFIED for session 5 (TS 29.518 5.2.2.3.2)", got)
+	}
+}
+
+func TestMobilityReg_DeliveredPagedRequestSettlesTheProcedure(t *testing.T) {
+	ue, ngapSender, fakeSmf, amfInstance := buildMobilityRegUeAndAMF(t)
+	ue.AllowedNssai = []models.Snssai{{Sst: 1, Sd: "010203"}}
+	setTestUESecurityCapability(ue)
+
+	snssai := &models.Snssai{Sst: 1}
+	_ = ue.CreateSmContext(3, "ref-3", snssai, "internet")
+
+	ue.Conn().RegistrationRequest.AllowedPDUSessionStatus = mustBitmap([]byte{0x08, 0x00})
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
+		PduSessionID:            3,
+		SNssai:                  snssai,
+		BinaryDataN1Message:     []byte{0x01, 0x02},
+		BinaryDataN2Information: []byte{0x03, 0x04},
+	})
+	ue.PagingAnswered()
+
+	ue.Conn().UeContextRequest = false
+
+	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	if len(ngapSender.SentInitialContextSetupRequest) != 1 {
+		t.Fatalf("initial context setup requests = %d, want 1: the buffered request was not delivered", len(ngapSender.SentInitialContextSetupRequest))
+	}
 
 	if state := ue.PagingState(); state != amf.PagingIdle {
-		t.Fatalf("paging state = %s after the connection carrying the undelivered request was released, want Idle", state)
+		t.Errorf("paging state = %s after the buffered request was delivered, want Idle", state)
+	}
+
+	if pending := ue.PagingPending(); pending != nil {
+		t.Errorf("pending = %+v, want the delivered request released", pending)
+	}
+
+	if got := fakeSmf.TransferFailures; len(got) != 0 {
+		t.Errorf("transfer failures = %+v, want none for a delivered request", got)
+	}
+}
+
+func TestMobilityReg_PagedRequestForUnknownSessionIsFailed(t *testing.T) {
+	ue, _, fakeSmf, amfInstance := buildMobilityRegUeAndAMF(t)
+
+	ue.Conn().RegistrationRequest.AllowedPDUSessionStatus = mustBitmap([]uint8{0x04, 0x00})
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
+		PduSessionID:            3,
+		BinaryDataN1Message:     []byte{0x01, 0x02},
+		BinaryDataN2Information: []byte{0x03, 0x04},
+	})
+	ue.PagingAnswered()
+
+	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	if state := ue.PagingState(); state != amf.PagingIdle {
+		t.Errorf("paging state = %s after the registration was aborted, want Idle", state)
+	}
+
+	if got := fakeSmf.TransferFailures; len(got) != 1 || got[0].PDUSessionID != 3 {
+		t.Errorf("transfer failures = %+v, want one for session 3: the request was never delivered", got)
+	}
+}
+
+func TestInitialReg_PagedRequestIsFailed(t *testing.T) {
+	fakeSmf := &fakeSmf{}
+
+	amfInstance := amf.New(&emptyPolicyDB{fakeDBInstance: &fakeDBInstance{
+		Operator: &db.Operator{
+			Mcc:           "001",
+			Mnc:           "01",
+			SupportedTACs: "[\"000001\"]",
+		},
+	}}, nil, fakeSmf)
+
+	ue, _, err := buildUeAndRadio()
+	if err != nil {
+		t.Fatalf("could not create UE and radio: %v", err)
+	}
+
+	ue.SetSupiForTest(mustSUPIFromPrefixed("imsi-001019756139935"))
+	ue.SetKamfForTest("0000000000000000000000000000000000000000000000000000000000000000")
+
+	ue.Conn().RegistrationRequest = &fgs.RegistrationRequest{}
+	ue.Conn().RegistrationType5GS = fgs.RegistrationTypeInitial
+
+	snssai := &models.Snssai{Sst: 1}
+	_ = ue.CreateSmContext(5, "ref-5", snssai, "internet")
+
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
+		PduSessionID:            5,
+		SNssai:                  snssai,
+		BinaryDataN2Information: []byte{0x01},
+	})
+	ue.PagingAnswered()
+
+	HandleInitialRegistration(context.TODO(), amfInstance, ue)
+
+	if state := ue.PagingState(); state != amf.PagingIdle {
+		t.Errorf("paging state = %s after an initial registration released the UE's sessions, want Idle", state)
+	}
+
+	if pending := ue.PagingPending(); pending != nil {
+		t.Errorf("pending = %+v, want the request released with the registration data", pending)
 	}
 }

--- a/internal/amf/nas/reg_mobility_paging_disposal_test.go
+++ b/internal/amf/nas/reg_mobility_paging_disposal_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/amf"
+	"github.com/ellanetworks/core/internal/models"
+)
+
+func TestMobilityReg_PagedRequestDoesNotOutliveTheUEContext(t *testing.T) {
+	ue, _, _, amfInstance := buildMobilityRegUeAndAMF(t)
+	setTestUESecurityCapability(ue)
+
+	snssai := &models.Snssai{Sst: 1}
+	_ = ue.CreateSmContext(5, "ref-5", snssai, "internet")
+
+	ue.Conn().RegistrationRequest.AllowedPDUSessionStatus = nil
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
+		PduSessionID:            5,
+		SNssai:                  snssai,
+		BinaryDataN2Information: []byte{0x01},
+	})
+	ue.PagingAnswered()
+
+	HandleMobilityAndPeriodicRegistrationUpdating(context.TODO(), amfInstance, ue)
+
+	conn := ue.Conn()
+	if conn == nil {
+		t.Fatal("no connection after the registration")
+	}
+
+	conn.Release()
+
+	if state := ue.PagingState(); state != amf.PagingIdle {
+		t.Fatalf("paging state = %s after the connection carrying the undelivered request was released, want Idle", state)
+	}
+}

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -109,7 +109,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 	appendPendingN1 := func(uint8) error { return nil }
 
-	requestData := ue.N1N2Message()
+	requestData := ue.PagingPending().Request()
 
 	proc, initialContextSetup := ueConn.ClaimN2Setup(n2SessionsRequested(ue, conn.RegistrationRequest, requestData))
 
@@ -238,14 +238,14 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					amf.SendDLNASTransport(ctx, ueConn, fgs.PayloadContainerTypeN1SMInfo, n1Msg, fgs.PDUSessionID(requestData.PduSessionID), 0)
 				}
 
-				ue.ClearN1N2Message()
+				ue.PagingDelivered()
 
 				return
 			}
 
 			_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
 			if !exist {
-				ue.ClearN1N2Message()
+				ue.PagingDelivered()
 				// UE referenced a PDU session id it holds no context for; release the
 				// half-updated registration to avoid leaking it.
 				abortRegistration(ctx, amfInstance, ue, "UE referenced unknown PDU session id", nil)

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating.go
@@ -111,6 +111,22 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 
 	requestData := ue.PagingPending().Request()
 
+	deliveredPending := false
+
+	defer func() {
+		if requestData == nil {
+			return
+		}
+
+		if deliveredPending {
+			ue.PagingDelivered()
+
+			return
+		}
+
+		ue.PagingFailed(models.N1N2FailureCauseUnspecified)
+	}()
+
 	proc, initialContextSetup := ueConn.ClaimN2Setup(n2SessionsRequested(ue, conn.RegistrationRequest, requestData))
 
 	n2Setup := ueConn.N2Setup(proc)
@@ -238,14 +254,13 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					amf.SendDLNASTransport(ctx, ueConn, fgs.PayloadContainerTypeN1SMInfo, n1Msg, fgs.PDUSessionID(requestData.PduSessionID), 0)
 				}
 
-				ue.PagingDelivered()
+				deliveredPending = true
 
 				return
 			}
 
 			_, exist := ue.SmContextFindByPDUSessionID(requestData.PduSessionID)
 			if !exist {
-				ue.PagingDelivered()
 				// UE referenced a PDU session id it holds no context for; release the
 				// half-updated registration to avoid leaking it.
 				abortRegistration(ctx, amfInstance, ue, "UE referenced unknown PDU session id", nil)
@@ -281,7 +296,13 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 				}
 
 				if n1Msg == nil {
-					return stage(nil)
+					if err := stage(nil); err != nil {
+						return err
+					}
+
+					deliveredPending = true
+
+					return nil
 				}
 
 				plain, err := amf.BuildDLNASTransport(fgs.PayloadContainerTypeN1SMInfo, n1Msg, new(fgs.PDUSessionID(requestData.PduSessionID)), nil, nil)
@@ -289,7 +310,13 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ctx context.Context, amfInsta
 					return err
 				}
 
-				return ue.SendDownlinkNAS(plain, sht, stage)
+				if err := ue.SendDownlinkNAS(plain, sht, stage); err != nil {
+					return err
+				}
+
+				deliveredPending = true
+
+				return nil
 			}
 		}
 	}

--- a/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
+++ b/internal/amf/nas/reg_mobility_periodic_registration_updating_test.go
@@ -515,7 +515,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_NonEmptySetupList(t 
 	ue.Conn().UeContextRequest = false
 
 	ue.Conn().RegistrationRequest.AllowedPDUSessionStatus = mustBitmap([]uint8{0x04, 0x00})
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
 		BinaryDataN2Information: nil,
@@ -545,7 +545,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_NonEmptySetupList(t 
 		t.Fatalf("expected DLNASTransport, got %v", nmDL[2])
 	}
 
-	if ue.N1N2Message() != nil {
+	if ue.PagingPending().Request() != nil {
 		t.Fatal("expected N1N2Message to be nil after processing")
 	}
 }
@@ -554,7 +554,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_EmptySuList(t *testi
 	ue, ngapSender, _, amfInstance := buildMobilityRegUeAndAMF(t)
 
 	ue.Conn().RegistrationRequest.AllowedPDUSessionStatus = mustBitmap([]uint8{0x04, 0x00})
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
 		BinaryDataN2Information: nil,
@@ -578,7 +578,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_NilN2Info_EmptySuList(t *testi
 		t.Fatalf("expected DLNASTransport in second DLNASTransport, got %v", nmN1[2])
 	}
 
-	if ue.N1N2Message() != nil {
+	if ue.PagingPending().Request() != nil {
 		t.Fatal("expected N1N2Message to be nil after processing")
 	}
 
@@ -601,7 +601,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_WithN2Info_MissingSmContext(t 
 
 	ue.Conn().RegistrationRequest.AllowedPDUSessionStatus = mustBitmap([]uint8{0x04, 0x00})
 
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
 		BinaryDataN2Information: []byte{0x03, 0x04},
@@ -624,7 +624,7 @@ func TestMobilityReg_AllowedPDUSessionStatus_N1N2_WithN2Info_SmContextExists(t *
 
 	ue.Conn().RegistrationRequest.AllowedPDUSessionStatus = mustBitmap([]byte{0x08, 0x00})
 
-	ue.SetN1N2Message(&models.N1N2MessageTransferRequest{
+	ue.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{
 		PduSessionID:            3,
 		SNssai:                  snssai,
 		BinaryDataN1Message:     []byte{0x01, 0x02},
@@ -1187,7 +1187,7 @@ func TestMobilityReg_AcceptedRegistrationCanReceiveAnN1N2Transfer(t *testing.T) 
 
 	HandleMobilityAndPeriodicRegistrationUpdating(t.Context(), amfInstance, ue)
 
-	err := amfInstance.TransferN1N2Message(t.Context(), ue.Supi(), models.N1N2MessageTransferRequest{
+	_, err := amfInstance.TransferN1N2Message(t.Context(), ue.Supi(), models.N1N2MessageTransferRequest{
 		PduSessionID:        1,
 		BinaryDataN1Message: []byte{0x2e, 0x01, 0x01},
 	})

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -53,8 +53,6 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 		logger.WithTrace(ctx, ueConn.Log()).Info("UE Context Release Cause", fields...)
 	}
 
-	amfUe := ueConn.UeContext()
-
 	if keepsConnectionForPendingDownlink(cause, ueConn) {
 		ueConn.DeferRelease(cause)
 
@@ -63,60 +61,18 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 		return
 	}
 
-	if amfUe != nil {
-		if amfUe.State() == amf.Registered {
-			logger.WithTrace(ctx, ueConn.Log()).Info("Ue Context in GMM-Registered")
+	amfInstance.ReleaseOnRANRequest(ctx, ueConn, cause, reportedSessions(msg))
+}
 
-			if msg.PDUSessionResourceList != nil {
-				for _, item := range msg.PDUSessionResourceList {
-					pduSessionID := uint8(item.PDUSessionID)
-
-					smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
-					if !ok {
-						logger.WithTrace(ctx, ueConn.Log()).Warn("no SM context for a PDU session the NG-RAN node reported as established",
-							zap.Uint8("PduSessionID", pduSessionID))
-
-						continue
-					}
-
-					err := amfInstance.Session.DeactivateSmContext(ctx, smContext.Ref)
-					if err != nil {
-						logger.WithTrace(ctx, ueConn.Log()).Error("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
-					}
-				}
-			} else {
-				logger.WithTrace(ctx, ueConn.Log()).Info("Pdu Session IDs not received from gNB, Releasing the UE Context with SMF using local context")
-
-				for _, sr := range amfUe.SmContextRefs() {
-					if ueConn.N2SessionInactive(sr.PduSessionID) {
-						logger.WithTrace(ctx, ueConn.Log()).Info("Pdu Session is inactive so not sending deactivate to SMF", logger.PDUSessionID(sr.PduSessionID))
-						continue
-					}
-
-					err := amfInstance.Session.DeactivateSmContext(ctx, sr.Ref)
-					if err != nil {
-						logger.WithTrace(ctx, ueConn.Log()).Warn("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
-					}
-				}
-			}
-		} else {
-			logger.WithTrace(ctx, ueConn.Log()).Info("Ue Context in Non GMM-Registered")
-			ueConn.ReleaseAction = amf.UeContextReleaseUeContext
-
-			ueConn.SendUEContextReleaseCommand(ctx, cause)
-
-			for _, sr := range amfUe.SmContextRefs() {
-				err := amfInstance.Session.ReleaseSmContext(ctx, sr.Ref)
-				if err != nil {
-					logger.WithTrace(ctx, ueConn.Log()).Error("error sending release sm context request", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
-				}
-			}
-
-			return
-		}
+func reportedSessions(msg *ngap.UEContextReleaseRequest) []uint8 {
+	if msg.PDUSessionResourceList == nil {
+		return nil
 	}
 
-	ueConn.ReleaseAction = amf.UeContextN2NormalRelease
+	ids := make([]uint8, 0, len(msg.PDUSessionResourceList))
+	for _, item := range msg.PDUSessionResourceList {
+		ids = append(ids, uint8(item.PDUSessionID))
+	}
 
-	ueConn.SendUEContextReleaseCommand(ctx, cause)
+	return ids
 }

--- a/internal/amf/ngap/handle_ue_context_release_request.go
+++ b/internal/amf/ngap/handle_ue_context_release_request.go
@@ -16,20 +16,12 @@ import (
 // CauseRadioNetwork "unspecified").
 var causeReleaseUnspecified = ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUnspecified}
 
-func keepsConnectionForPendingDownlink(cause ngap.Cause, amfUe *amf.UeContext, ueConn *amf.UeConn) bool {
+func keepsConnectionForPendingDownlink(cause ngap.Cause, ueConn *amf.UeConn) bool {
 	if cause.Group != ngap.CauseGroupRadioNetwork || cause.Value != ngap.CauseRadioNetworkUserInactivity {
 		return false
 	}
 
-	if amfUe != nil && amfUe.N1N2Message() != nil {
-		return true
-	}
-
-	if ueConn.N2SetupOpen(amf.N2SetupInitialContext) || ueConn.N2SetupOpen(amf.N2SetupPDUSession) {
-		return true
-	}
-
-	return ueConn.NASGuardActive()
+	return ueConn.MTSignallingPending()
 }
 
 // HandleUEContextReleaseRequest handles an NG-RAN-initiated UE Context Release
@@ -63,7 +55,9 @@ func HandleUEContextReleaseRequest(ctx context.Context, amfInstance *amf.AMF, ra
 
 	amfUe := ueConn.UeContext()
 
-	if keepsConnectionForPendingDownlink(cause, amfUe, ueConn) {
+	if keepsConnectionForPendingDownlink(cause, ueConn) {
+		ueConn.DeferRelease(cause)
+
 		logger.WithTrace(ctx, ueConn.Log()).Info("keeping the NG connection: user inactivity reported while downlink traffic or signalling is pending")
 
 		return

--- a/internal/amf/ngap/handle_ue_context_release_request_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_request_test.go
@@ -95,10 +95,10 @@ func TestHandleUEContextReleaseRequest_UserInactivityWithPendingMTTraffic(t *tes
 
 	amfUe := amf.NewUeContext()
 	amfUe.ForceStateForTest(amf.Registered)
-	amfUe.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1})
 
 	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
 	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+	amfUe.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{PduSessionID: 1})
 
 	msg := &ngap.UEContextReleaseRequest{
 		AMFUENGAPID: 10,
@@ -121,10 +121,10 @@ func TestHandleUEContextReleaseRequest_OtherCauseReleasesDespitePendingMTTraffic
 
 	amfUe := amf.NewUeContext()
 	amfUe.ForceStateForTest(amf.Registered)
-	amfUe.SetN1N2Message(&models.N1N2MessageTransferRequest{PduSessionID: 1})
 
 	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
 	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+	amfUe.SetPagedRequestForTest(&models.N1N2MessageTransferRequest{PduSessionID: 1})
 
 	msg := &ngap.UEContextReleaseRequest{
 		AMFUENGAPID: 10,
@@ -174,5 +174,70 @@ func TestHandleUEContextReleaseRequest_UserInactivityDuringAnN2Setup(t *testing.
 
 	if len(sender.SentUEContextReleaseCommands) != 1 {
 		t.Errorf("UEContextReleaseCommand count = %d, want 1 once the setup has finished", len(sender.SentUEContextReleaseCommands))
+	}
+}
+
+func TestHandleUEContextReleaseRequest_PagedRequestDoesNotFollowTheUEOntoANewConnection(t *testing.T) {
+	amfInstance := newTestAMF()
+	ran := newTestRadio(amfInstance)
+	sender := ran.Conn.(*fakeNGAPSender)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+
+	answered := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	answered.AMFForTest().AttachUeConn(amfUe, answered)
+
+	current := amf.NewUeConnForTest(ran, 2, 11, logger.AmfLog)
+	current.AMFForTest().AttachUeConn(amfUe, current)
+
+	before := len(sender.SentUEContextReleaseCommands)
+
+	msg := &ngap.UEContextReleaseRequest{
+		AMFUENGAPID: 11,
+		RANUENGAPID: 2,
+		Cause:       &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUserInactivity},
+	}
+
+	HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, msg)
+
+	if len(sender.SentUEContextReleaseCommands) != before+1 {
+		t.Errorf("UEContextReleaseCommand count = %d, want %d: a request buffered for an earlier connection pins the current one (TS 23.502 4.2.6 step 1)",
+			len(sender.SentUEContextReleaseCommands)-before, 1)
+	}
+}
+
+func TestHandleUEContextReleaseRequest_DeferredReleaseResumesWhenTheN2SetupEnds(t *testing.T) {
+	amfInstance := newTestAMF()
+	ran := newTestRadio(amfInstance)
+	sender := ran.Conn.(*fakeNGAPSender)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.Registered)
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+
+	if !ueConn.N2Setup(amf.N2SetupPDUSession).ClaimSession(1) {
+		t.Fatal("could not open a PDU session resource setup transaction")
+	}
+
+	msg := &ngap.UEContextReleaseRequest{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 1,
+		Cause:       &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUserInactivity},
+	}
+
+	HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, msg)
+
+	if len(sender.SentUEContextReleaseCommands) != 0 {
+		t.Fatalf("UEContextReleaseCommand count = %d, want 0 while the N2 setup is open", len(sender.SentUEContextReleaseCommands))
+	}
+
+	ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
+	if len(sender.SentUEContextReleaseCommands) != 1 {
+		t.Errorf("UEContextReleaseCommand count = %d, want 1: the deferred AN Release never resumes once the pending signalling settles (TS 23.502 4.2.6 step 1)",
+			len(sender.SentUEContextReleaseCommands))
 	}
 }

--- a/internal/amf/ngap/handle_ue_context_release_request_test.go
+++ b/internal/amf/ngap/handle_ue_context_release_request_test.go
@@ -241,3 +241,53 @@ func TestHandleUEContextReleaseRequest_DeferredReleaseResumesWhenTheN2SetupEnds(
 			len(sender.SentUEContextReleaseCommands))
 	}
 }
+
+// TS 23.502 §4.2.6: a deferred AN Release must complete as the release it deferred, not
+// as a plain N2 release — a UE that never reached 5GMM-REGISTERED has its context and its
+// PDU sessions torn down.
+func TestHandleUEContextReleaseRequest_DeferredReleaseOfANonRegisteredUEStillReleasesTheContext(t *testing.T) {
+	fakeSmf := &fakeSmfSbi{}
+	amfInstance := newTestAMFWithSmf(fakeSmf)
+	ran := newTestRadio(amfInstance)
+	sender := ran.Conn.(*fakeNGAPSender)
+
+	amfUe := amf.NewUeContext()
+	amfUe.ForceStateForTest(amf.RegistrationInitiated)
+
+	ueConn := amf.NewUeConnForTest(ran, 1, 10, logger.AmfLog)
+	ueConn.AMFForTest().AttachUeConn(amfUe, ueConn)
+
+	if err := amfUe.CreateSmContext(1, "ref-1", &models.Snssai{Sst: 1}, "internet"); err != nil {
+		t.Fatalf("CreateSmContext: %v", err)
+	}
+
+	if !ueConn.N2Setup(amf.N2SetupPDUSession).ClaimSession(1) {
+		t.Fatal("could not open a PDU session resource setup transaction")
+	}
+
+	msg := &ngap.UEContextReleaseRequest{
+		AMFUENGAPID: 10,
+		RANUENGAPID: 1,
+		Cause:       &ngap.Cause{Group: ngap.CauseGroupRadioNetwork, Value: ngap.CauseRadioNetworkUserInactivity},
+	}
+
+	HandleUEContextReleaseRequest(context.Background(), amfInstance, ran, msg)
+
+	if len(sender.SentUEContextReleaseCommands) != 0 {
+		t.Fatalf("UEContextReleaseCommand count = %d, want 0 while the N2 setup is open", len(sender.SentUEContextReleaseCommands))
+	}
+
+	ueConn.EndN2Setup(amf.N2SetupPDUSession)
+
+	if len(sender.SentUEContextReleaseCommands) != 1 {
+		t.Fatalf("UEContextReleaseCommand count = %d, want 1 once the pending signalling settles", len(sender.SentUEContextReleaseCommands))
+	}
+
+	if ueConn.ReleaseAction != amf.UeContextReleaseUeContext {
+		t.Errorf("ReleaseAction = %v, want the context-releasing action for a UE that is not registered", ueConn.ReleaseAction)
+	}
+
+	if got := fakeSmf.ReleaseSmContextCalls; len(got) != 1 || got[0] != "ref-1" {
+		t.Errorf("ReleaseSmContext calls = %v, want the PDU session of the unregistered UE released", got)
+	}
+}

--- a/internal/amf/paging.go
+++ b/internal/amf/paging.go
@@ -58,14 +58,14 @@ func (amf *AMF) pageRadios(ctx context.Context, ue *UeContext, ngapBuf []byte) {
 // the UE lock so a second downlink trigger cannot reset an in-flight supervision. No-op when
 // T3513 is disabled.
 func (amf *AMF) armPaging(ue *UeContext, ngapBuf []byte) {
-	ue.mu.Lock()
-	defer ue.mu.Unlock()
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
 
-	if ue.pagingTimer.Active() {
+	if ue.paging.guard.Active() {
 		return
 	}
 
-	ue.pagingTimer.ArmWith(amf.T3513Cfg,
+	ue.paging.guard.ArmWith(amf.T3513Cfg,
 		func(attempt int32) { amf.retransmitPaging(ue, ngapBuf, attempt) },
 		func() { amf.abandonPaging(ue) })
 }
@@ -74,7 +74,7 @@ func (amf *AMF) armPaging(ue *UeContext, ngapBuf []byte) {
 // stops the guard once the UE has answered by re-establishing its connection.
 func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 	if ue.Conn() != nil {
-		ue.pagingTimer.Stop()
+		ue.paging.guard.Stop()
 		return
 	}
 
@@ -88,9 +88,7 @@ func (amf *AMF) abandonPaging(ue *UeContext) {
 	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
 
 	// TS 23.502 4.2.3.3 step 3b: the SMF reissues the N2 payload once the UE is reachable.
-	if ue.Conn() == nil {
-		ue.ClearN1N2Message()
-	}
+	dropped := ue.PagingFailed(models.N1N2UENotResponding)
 
 	if amf.Session == nil {
 		return
@@ -99,7 +97,11 @@ func (amf *AMF) abandonPaging(ue *UeContext) {
 	supi := ue.Supi()
 
 	for id := range ue.SmContextSnapshot() {
-		if err := amf.Session.HandlePagingFailure(context.Background(), supi, id); err != nil {
+		if dropped != nil && !dropped.Req.Standalone() && dropped.Req.PduSessionID == id {
+			continue
+		}
+
+		if err := amf.Session.HandleN1N2TransferFailure(context.Background(), supi, id, models.N1N2UENotResponding); err != nil {
 			logger.AmfLog.Warn("failed to suppress downlink notification after paging failure",
 				logger.SUPI(supi.String()), zap.Error(err))
 		}
@@ -109,45 +111,41 @@ func (amf *AMF) abandonPaging(ue *UeContext) {
 // pageIdleUE pages an idle UE and starts paging supervision (TS 23.502 §4.2.3.3). A
 // non-nil req is buffered for delivery when the UE answers. Callers should guard
 // first, via guardIdlePaging.
-func (amf *AMF) pageIdleUE(ctx context.Context, ue *UeContext, req *models.N1N2MessageTransferRequest) error {
+func (amf *AMF) pageIdleUE(ctx context.Context, ue *UeContext, req *MTRequest) (models.N1N2MessageTransferCause, error) {
 	if amf.DBInstance == nil {
-		return fmt.Errorf("AMF not configured with database, cannot page")
+		return "", fmt.Errorf("AMF not configured with database, cannot page")
 	}
 
 	operatorInfo, err := amf.OperatorInfo(ctx)
 	if err != nil {
-		return fmt.Errorf("get operator info: %w", err)
+		return "", fmt.Errorf("get operator info: %w", err)
 	}
 
 	paging, err := amf.buildPaging(operatorInfo.Guami, ue)
 	if err != nil {
-		return fmt.Errorf("build paging: %w", err)
+		return "", fmt.Errorf("build paging: %w", err)
 	}
 
 	pkg, err := paging.Marshal()
 	if err != nil {
-		return fmt.Errorf("marshal paging: %w", err)
+		return "", fmt.Errorf("marshal paging: %w", err)
 	}
 
 	// Buffer immediately before the send: the UE may answer on another goroutine the
 	// moment the Paging leaves the AMF.
-	if req != nil {
-		ue.SetN1N2Message(req)
+	cause, err := ue.beginPaging(req)
+	if err != nil {
+		return "", err
 	}
 
 	if err := amf.SendPaging(ctx, ue, pkg); err != nil {
-		if req != nil {
-			ue.ClearN1N2Message()
-		}
+		ue.PagingFailed(models.N1N2FailureCauseUnspecified)
 
-		return fmt.Errorf("send paging: %w", err)
+		return "", fmt.Errorf("send paging: %w", err)
 	}
 
-	return nil
+	return cause, nil
 }
-
-// errPagingActive is returned when paging supervision is already in flight for the UE.
-var errPagingActive = fmt.Errorf("paging already in progress")
 
 // guardIdlePaging rejects paging a UE that is already connected, mid-registration,
 // mid-handover, or not registered.
@@ -157,15 +155,15 @@ func guardIdlePaging(ue *UeContext) error {
 	}
 
 	if ue.State() == RegistrationInitiated {
-		return fmt.Errorf("temporary reject: registration ongoing")
+		return &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectRegistrationOngoing)}
 	}
 
 	if ue.Procedures().Active(procedure.N2Handover) {
-		return fmt.Errorf("temporary reject: handover ongoing")
+		return &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectHandoverOngoing)}
 	}
 
 	if ue.State() != Registered {
-		return fmt.Errorf("ue is not in registered state")
+		return &models.N1N2MessageTransferError{Cause: string(models.N1N2FailureCauseUnspecified)}
 	}
 
 	return nil

--- a/internal/amf/paging.go
+++ b/internal/amf/paging.go
@@ -85,10 +85,13 @@ func (amf *AMF) retransmitPaging(ue *UeContext, ngapBuf []byte, attempt int32) {
 // abandonPaging suppresses the anchor's downlink data notification so further
 // downlink packets do not re-page an unreachable UE (TS 23.502 §4.2.3.3).
 func (amf *AMF) abandonPaging(ue *UeContext) {
-	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
-
 	// TS 23.502 4.2.3.3 step 3b: the SMF reissues the N2 payload once the UE is reachable.
-	dropped := ue.PagingFailed(models.N1N2UENotResponding)
+	dropped, abandoned := ue.PagingUnanswered(models.N1N2UENotResponding)
+	if !abandoned {
+		return
+	}
+
+	logger.AmfLog.Info("paging unanswered, abandoning procedure", logger.SUPI(ue.Supi().String()))
 
 	if amf.Session == nil {
 		return
@@ -139,7 +142,7 @@ func (amf *AMF) pageIdleUE(ctx context.Context, ue *UeContext, req *MTRequest) (
 	}
 
 	if err := amf.SendPaging(ctx, ue, pkg); err != nil {
-		ue.PagingFailed(models.N1N2FailureCauseUnspecified)
+		ue.PagingAttemptFailed(req, models.N1N2FailureCauseUnspecified)
 
 		return "", fmt.Errorf("send paging: %w", err)
 	}
@@ -155,15 +158,15 @@ func guardIdlePaging(ue *UeContext) error {
 	}
 
 	if ue.State() == RegistrationInitiated {
-		return &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectRegistrationOngoing)}
+		return &models.N1N2MessageTransferError{Cause: models.N1N2ErrTemporaryRejectRegistrationOngoing}
 	}
 
 	if ue.Procedures().Active(procedure.N2Handover) {
-		return &models.N1N2MessageTransferError{Cause: string(models.N1N2TemporaryRejectHandoverOngoing)}
+		return &models.N1N2MessageTransferError{Cause: models.N1N2ErrTemporaryRejectHandoverOngoing}
 	}
 
 	if ue.State() != Registered {
-		return &models.N1N2MessageTransferError{Cause: string(models.N1N2FailureCauseUnspecified)}
+		return &models.N1N2MessageTransferError{Cause: models.N1N2ErrContextNotFound}
 	}
 
 	return nil

--- a/internal/amf/paging_disposal_test.go
+++ b/internal/amf/paging_disposal_test.go
@@ -12,15 +12,6 @@ import (
 	"github.com/ellanetworks/core/internal/models"
 )
 
-func registeredUEContext(t *testing.T) *UeContext {
-	t.Helper()
-
-	_, ue, _, smf := registeredUE(t)
-	_ = smf
-
-	return ue
-}
-
 func pagedUE(t *testing.T) (*AMF, *UeContext, *deregisterTestSmf) {
 	t.Helper()
 
@@ -123,7 +114,7 @@ func TestConnectionReleaseFailsADeliveringTransfer(t *testing.T) {
 }
 
 func TestSameOrLowerPriorityTransferIsRejectedWhileAttempting(t *testing.T) {
-	ue := registeredUEContext(t)
+	_, ue, _ := pagedUE(t)
 
 	high := &models.Arp{PriorityLevel: 5}
 
@@ -152,7 +143,7 @@ func TestSameOrLowerPriorityTransferIsRejectedWhileAttempting(t *testing.T) {
 }
 
 func TestHigherPriorityTransferReplacesThePendingOne(t *testing.T) {
-	ue := registeredUEContext(t)
+	_, ue, _ := pagedUE(t)
 
 	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}, Arp: &models.Arp{PriorityLevel: 9}}); err != nil {
 		t.Fatalf("beginPaging: %v", err)

--- a/internal/amf/paging_disposal_test.go
+++ b/internal/amf/paging_disposal_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+)
+
+func registeredUEContext(t *testing.T) *UeContext {
+	t.Helper()
+
+	_, ue, _, smf := registeredUE(t)
+	_ = smf
+
+	return ue
+}
+
+func pagedUE(t *testing.T) (*AMF, *UeContext, *deregisterTestSmf) {
+	t.Helper()
+
+	a, ue, _, fakeSmf := registeredUE(t)
+
+	cause, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}})
+	if err != nil {
+		t.Fatalf("beginPaging: %v", err)
+	}
+
+	if cause != models.N1N2AttemptingToReachUE {
+		t.Fatalf("cause = %s, want %s", cause, models.N1N2AttemptingToReachUE)
+	}
+
+	return a, ue, fakeSmf
+}
+
+func TestDeregisterFailsThePendingTransfer(t *testing.T) {
+	_, ue, fakeSmf := pagedUE(t)
+
+	ue.Deregister(context.Background())
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after Deregister, want Idle", state)
+	}
+
+	if got := fakeSmf.transferFailures; len(got) != 1 || got[0] != models.N1N2FailureCauseUnspecified {
+		t.Errorf("transfer failures = %v, want one FAILURE_CAUSE_UNSPECIFIED: the requester is never told the transfer was dropped", got)
+	}
+}
+
+func TestMoveToEPSFailsThePendingTransfer(t *testing.T) {
+	a, ue, _, fakeSmf := registeredUE(t)
+
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}}); err != nil {
+		t.Fatalf("beginPaging: %v", err)
+	}
+
+	a.CancelRegistration(context.Background(), ue.Supi())
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after the move to EPS, want Idle", state)
+	}
+
+	if len(fakeSmf.transferFailures) != 1 {
+		t.Errorf("transfer failures = %v, want one", fakeSmf.transferFailures)
+	}
+}
+
+func TestSuspendRegistrationFailsThePendingTransfer(t *testing.T) {
+	_, ue, _ := pagedUE(t)
+
+	ue.SuspendRegistration(context.Background())
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after SuspendRegistration, want Idle", state)
+	}
+}
+
+func TestPagingAnsweredMovesToDelivering(t *testing.T) {
+	_, ue, _ := pagedUE(t)
+
+	req := ue.PagingAnswered()
+	if req == nil || req.Req.PduSessionID != 5 {
+		t.Fatalf("PagingAnswered returned %+v, want the pending request", req)
+	}
+
+	if state := ue.PagingState(); state != PagingDelivering {
+		t.Errorf("paging state = %s after the UE answered, want Delivering", state)
+	}
+
+	ue.PagingDelivered()
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after delivery, want Idle", state)
+	}
+}
+
+func TestConnectionReleaseFailsADeliveringTransfer(t *testing.T) {
+	a, ue, fakeSmf := pagedUE(t)
+
+	radio := &Radio{Log: logger.AmfLog}
+	radio.BindAMFForTest(a)
+
+	conn := NewUeConnForTest(radio, 1, 10, logger.AmfLog)
+	a.AttachUeConn(ue, conn)
+
+	ue.PagingAnswered()
+
+	conn.Release()
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after the connection was released mid-delivery, want Idle", state)
+	}
+
+	if got := fakeSmf.transferFailures; len(got) != 1 || got[0] != models.N1N2UENotResponding {
+		t.Errorf("transfer failures = %v, want one UE_NOT_RESPONDING", got)
+	}
+}
+
+func TestSameOrLowerPriorityTransferIsRejectedWhileAttempting(t *testing.T) {
+	ue := registeredUEContext(t)
+
+	high := &models.Arp{PriorityLevel: 5}
+
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}, Arp: high}); err != nil {
+		t.Fatalf("beginPaging: %v", err)
+	}
+
+	_, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6}, Arp: &models.Arp{PriorityLevel: 9}})
+
+	var rejected *models.N1N2MessageTransferError
+	if !asTransferError(err, &rejected) {
+		t.Fatalf("err = %v, want a transfer rejection (TS 23.502 4.2.3.3 step 3b)", err)
+	}
+
+	if rejected.Cause != models.N1N2ErrHigherPriorityRequestOngoing {
+		t.Errorf("cause = %s, want %s", rejected.Cause, models.N1N2ErrHigherPriorityRequestOngoing)
+	}
+
+	if rejected.Detail.HighestPrioArp == nil || rejected.Detail.HighestPrioArp.PriorityLevel != 5 {
+		t.Errorf("highestPrioArp = %+v, want the ARP being paged for (TS 29.518 6.1.6.2.32)", rejected.Detail.HighestPrioArp)
+	}
+
+	if pending := ue.PagingPending(); pending == nil || pending.Req.PduSessionID != 5 {
+		t.Errorf("pending = %+v, want the original request undisplaced", pending)
+	}
+}
+
+func TestHigherPriorityTransferReplacesThePendingOne(t *testing.T) {
+	ue := registeredUEContext(t)
+
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}, Arp: &models.Arp{PriorityLevel: 9}}); err != nil {
+		t.Fatalf("beginPaging: %v", err)
+	}
+
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6}, Arp: &models.Arp{PriorityLevel: 2}}); err != nil {
+		t.Fatalf("a higher-priority transfer was rejected: %v", err)
+	}
+
+	if pending := ue.PagingPending(); pending == nil || pending.Req.PduSessionID != 6 {
+		t.Errorf("pending = %+v, want the higher-priority request (TS 23.502 4.2.3.3 step 4b)", pending)
+	}
+}
+
+func asTransferError(err error, target **models.N1N2MessageTransferError) bool {
+	return errors.As(err, target)
+}

--- a/internal/amf/paging_disposal_test.go
+++ b/internal/amf/paging_disposal_test.go
@@ -12,12 +12,30 @@ import (
 	"github.com/ellanetworks/core/internal/models"
 )
 
-func pagedUE(t *testing.T) (*AMF, *UeContext, *deregisterTestSmf) {
+func idleUE(t *testing.T) *UeContext {
+	t.Helper()
+
+	_, ue, _ := idleUEWithSmf(t)
+
+	return ue
+}
+
+func idleUEWithSmf(t *testing.T) (*AMF, *UeContext, *deregisterTestSmf) {
 	t.Helper()
 
 	a, ue, _, fakeSmf := registeredUE(t)
 
-	cause, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}})
+	return a, ue, fakeSmf
+}
+
+func pagedUE(t *testing.T) (*AMF, *UeContext, *deregisterTestSmf) {
+	t.Helper()
+
+	a, ue, fakeSmf := idleUEWithSmf(t)
+
+	cause, err := ue.beginPaging(&MTRequest{
+		Req: models.N1N2MessageTransferRequest{PduSessionID: 5, Arp: &models.Arp{PriorityLevel: 9}},
+	})
 	if err != nil {
 		t.Fatalf("beginPaging: %v", err)
 	}
@@ -114,15 +132,15 @@ func TestConnectionReleaseFailsADeliveringTransfer(t *testing.T) {
 }
 
 func TestSameOrLowerPriorityTransferIsRejectedWhileAttempting(t *testing.T) {
-	_, ue, _ := pagedUE(t)
+	ue := idleUE(t)
 
 	high := &models.Arp{PriorityLevel: 5}
 
-	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}, Arp: high}); err != nil {
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5, Arp: high}}); err != nil {
 		t.Fatalf("beginPaging: %v", err)
 	}
 
-	_, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6}, Arp: &models.Arp{PriorityLevel: 9}})
+	_, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6, Arp: &models.Arp{PriorityLevel: 9}}})
 
 	var rejected *models.N1N2MessageTransferError
 	if !asTransferError(err, &rejected) {
@@ -143,13 +161,13 @@ func TestSameOrLowerPriorityTransferIsRejectedWhileAttempting(t *testing.T) {
 }
 
 func TestHigherPriorityTransferReplacesThePendingOne(t *testing.T) {
-	_, ue, _ := pagedUE(t)
+	ue := idleUE(t)
 
-	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5}, Arp: &models.Arp{PriorityLevel: 9}}); err != nil {
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5, Arp: &models.Arp{PriorityLevel: 9}}}); err != nil {
 		t.Fatalf("beginPaging: %v", err)
 	}
 
-	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6}, Arp: &models.Arp{PriorityLevel: 2}}); err != nil {
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6, Arp: &models.Arp{PriorityLevel: 2}}}); err != nil {
 		t.Fatalf("a higher-priority transfer was rejected: %v", err)
 	}
 
@@ -158,6 +176,132 @@ func TestHigherPriorityTransferReplacesThePendingOne(t *testing.T) {
 	}
 }
 
+func TestAbandonPagingKeepsTheTransferWhenTheUEAnsweredTheLastRetransmission(t *testing.T) {
+	a, ue, fakeSmf := pagedUE(t)
+
+	radio := &Radio{Log: logger.AmfLog}
+	radio.BindAMFForTest(a)
+
+	conn := NewUeConnForTest(radio, 1, 10, logger.AmfLog)
+	a.AttachUeConn(ue, conn)
+
+	ue.PagingAnswered()
+
+	a.abandonPaging(ue)
+
+	if state := ue.PagingState(); state != PagingDelivering {
+		t.Errorf("paging state = %s after an abort that raced the UE answering, want Delivering", state)
+	}
+
+	if pending := ue.PagingPending(); pending == nil || pending.Req.PduSessionID != 5 {
+		t.Errorf("pending = %+v, want the buffered transfer kept for a UE that answered", pending)
+	}
+
+	if got := fakeSmf.transferFailures; len(got) != 0 {
+		t.Errorf("transfer failures = %v, want none: the UE is CM-CONNECTED (TS 23.502 4.2.3.3)", got)
+	}
+}
+
+// TS 29.518 §5.2.2.3.2: the consumer whose transfer the AMF will not deliver is notified.
+func TestDisplacedTransferIsReportedToItsConsumer(t *testing.T) {
+	_, ue, fakeSmf := pagedUE(t)
+
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6, Arp: &models.Arp{PriorityLevel: 2}}}); err != nil {
+		t.Fatalf("a higher-priority transfer was rejected: %v", err)
+	}
+
+	if got := fakeSmf.transferFailures; len(got) != 1 || got[0] != models.N1N2FailureCauseUnspecified {
+		t.Fatalf("transfer failures = %v, want one FAILURE_CAUSE_UNSPECIFIED for the displaced transfer", got)
+	}
+
+	if got := fakeSmf.failedSessions; len(got) != 1 || got[0] != 5 {
+		t.Errorf("failures reported for sessions %v, want the displaced session 5", got)
+	}
+}
+
+// TS 23.502 §4.2.3.3 step 3a: the SMF re-invokes the transfer for the session it is
+// already being paged for, which replaces the request rather than failing it.
+func TestReinvokedTransferForTheSameSessionIsNotAFailure(t *testing.T) {
+	_, ue, fakeSmf := pagedUE(t)
+
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 5, Arp: &models.Arp{PriorityLevel: 2}}}); err != nil {
+		t.Fatalf("a higher-priority transfer was rejected: %v", err)
+	}
+
+	if got := fakeSmf.transferFailures; len(got) != 0 {
+		t.Errorf("transfer failures = %v, want none: the request replaces the one it re-invokes", got)
+	}
+
+	if pending := ue.PagingPending(); pending == nil || pending.Req.Arp == nil || pending.Req.Arp.PriorityLevel != 2 {
+		t.Errorf("pending = %+v, want the re-invoked request with the higher priority", pending)
+	}
+}
+
+func TestPagingAttemptFailedReleasesItsOwnRequest(t *testing.T) {
+	_, ue, fakeSmf := pagedUE(t)
+
+	attempt := ue.PagingPending()
+
+	ue.PagingAttemptFailed(attempt, models.N1N2FailureCauseUnspecified)
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after the paging it buffered for could not be sent, want Idle", state)
+	}
+
+	if pending := ue.PagingPending(); pending != nil {
+		t.Errorf("pending = %+v, want the unpaged request released", pending)
+	}
+
+	if got := fakeSmf.transferFailures; len(got) != 1 || got[0] != models.N1N2FailureCauseUnspecified {
+		t.Errorf("transfer failures = %v, want one FAILURE_CAUSE_UNSPECIFIED for the request that was never paged for", got)
+	}
+}
+
+func TestPagingAttemptFailedLeavesADisplacingRequestAlone(t *testing.T) {
+	_, ue, fakeSmf := pagedUE(t)
+
+	attempt := ue.PagingPending()
+
+	if _, err := ue.beginPaging(&MTRequest{Req: models.N1N2MessageTransferRequest{PduSessionID: 6, Arp: &models.Arp{PriorityLevel: 2}}}); err != nil {
+		t.Fatalf("a higher-priority transfer was rejected: %v", err)
+	}
+
+	fakeSmf.transferFailures = nil
+
+	ue.PagingAttemptFailed(attempt, models.N1N2FailureCauseUnspecified)
+
+	if state := ue.PagingState(); state != PagingAttempting {
+		t.Errorf("paging state = %s, want the displacing procedure still Attempting", state)
+	}
+
+	if pending := ue.PagingPending(); pending == nil || pending.Req.PduSessionID != 6 {
+		t.Errorf("pending = %+v, want the displacing request untouched", pending)
+	}
+
+	if got := fakeSmf.transferFailures; len(got) != 0 {
+		t.Errorf("transfer failures = %v, want none: the displaced request was already reported when it was displaced", got)
+	}
+}
+
 func asTransferError(err error, target **models.N1N2MessageTransferError) bool {
 	return errors.As(err, target)
+}
+
+// TS 23.502 §4.2.3.3: the UE answers the page by establishing a NAS signalling
+// connection, whatever initial NAS message it carries.
+func TestAttachingAConnectionAnswersThePage(t *testing.T) {
+	a, ue, _ := pagedUE(t)
+
+	radio := &Radio{Log: logger.AmfLog}
+	radio.BindAMFForTest(a)
+
+	a.AttachUeConn(ue, NewUeConnForTest(radio, 1, 10, logger.AmfLog))
+
+	if state := ue.PagingState(); state != PagingDelivering {
+		t.Errorf("paging state = %s after the UE re-established its connection, want Delivering", state)
+	}
+
+	if ue.PagingActiveForTest() {
+		t.Error("the paging supervision guard is still armed after the UE answered")
+	}
 }

--- a/internal/amf/paging_disposal_test.go
+++ b/internal/amf/paging_disposal_test.go
@@ -83,9 +83,10 @@ func TestSuspendRegistrationFailsThePendingTransfer(t *testing.T) {
 func TestPagingAnsweredMovesToDelivering(t *testing.T) {
 	_, ue, _ := pagedUE(t)
 
-	req := ue.PagingAnswered()
-	if req == nil || req.Req.PduSessionID != 5 {
-		t.Fatalf("PagingAnswered returned %+v, want the pending request", req)
+	ue.PagingAnswered()
+
+	if req := ue.PagingPending(); req == nil || req.Req.PduSessionID != 5 {
+		t.Fatalf("pending = %+v, want the paged request still held for delivery", req)
 	}
 
 	if state := ue.PagingState(); state != PagingDelivering {

--- a/internal/amf/paging_disposal_test.go
+++ b/internal/amf/paging_disposal_test.go
@@ -89,26 +89,6 @@ func TestSuspendRegistrationFailsThePendingTransfer(t *testing.T) {
 	}
 }
 
-func TestPagingAnsweredMovesToDelivering(t *testing.T) {
-	_, ue, _ := pagedUE(t)
-
-	ue.PagingAnswered()
-
-	if req := ue.PagingPending(); req == nil || req.Req.PduSessionID != 5 {
-		t.Fatalf("pending = %+v, want the paged request still held for delivery", req)
-	}
-
-	if state := ue.PagingState(); state != PagingDelivering {
-		t.Errorf("paging state = %s after the UE answered, want Delivering", state)
-	}
-
-	ue.PagingDelivered()
-
-	if state := ue.PagingState(); state != PagingIdle {
-		t.Errorf("paging state = %s after delivery, want Idle", state)
-	}
-}
-
 func TestConnectionReleaseFailsADeliveringTransfer(t *testing.T) {
 	a, ue, fakeSmf := pagedUE(t)
 
@@ -301,7 +281,17 @@ func TestAttachingAConnectionAnswersThePage(t *testing.T) {
 		t.Errorf("paging state = %s after the UE re-established its connection, want Delivering", state)
 	}
 
+	if req := ue.PagingPending(); req == nil || req.Req.PduSessionID != 5 {
+		t.Fatalf("pending = %+v, want the paged request still held for delivery", req)
+	}
+
 	if ue.PagingActiveForTest() {
 		t.Error("the paging supervision guard is still armed after the UE answered")
+	}
+
+	ue.PagingDelivered()
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after delivery, want Idle", state)
 	}
 }

--- a/internal/amf/paging_proc.go
+++ b/internal/amf/paging_proc.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package amf
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ellanetworks/core/internal/guard"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"go.uber.org/zap"
+)
+
+type PagingState uint8
+
+const (
+	PagingIdle PagingState = iota
+	PagingAttempting
+	PagingDelivering
+)
+
+func (s PagingState) String() string {
+	switch s {
+	case PagingIdle:
+		return "Idle"
+	case PagingAttempting:
+		return "Attempting"
+	case PagingDelivering:
+		return "Delivering"
+	default:
+		return "Unknown"
+	}
+}
+
+type MTRequest struct {
+	Req    models.N1N2MessageTransferRequest
+	Arp    *models.Arp
+	FiveQI int32
+}
+
+func (r *MTRequest) Request() *models.N1N2MessageTransferRequest {
+	if r == nil {
+		return nil
+	}
+
+	return &r.Req
+}
+
+func outranks(candidate, current *models.Arp) bool {
+	if candidate == nil {
+		return false
+	}
+
+	if current == nil {
+		return true
+	}
+
+	return candidate.PriorityLevel < current.PriorityLevel
+}
+
+type pagingProc struct {
+	mu      sync.Mutex
+	state   PagingState
+	pending *MTRequest
+	guard   guard.Guard
+}
+
+func (ue *UeContext) PagingState() PagingState {
+	if ue == nil {
+		return PagingIdle
+	}
+
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	return ue.paging.state
+}
+
+func (ue *UeContext) PagingPending() *MTRequest {
+	if ue == nil {
+		return nil
+	}
+
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	return ue.paging.pending
+}
+
+func (ue *UeContext) MTDeliveryInProgress() bool {
+	return ue.PagingState() != PagingIdle
+}
+
+func (ue *UeContext) beginPaging(req *MTRequest) (models.N1N2MessageTransferCause, error) {
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	if ue.paging.state == PagingAttempting && !outranks(req.Arp, ue.paging.pending.arp()) {
+		return "", &models.N1N2MessageTransferError{
+			Cause:  models.N1N2ErrHigherPriorityRequestOngoing,
+			Detail: models.N1N2MsgTxfrErrDetail{HighestPrioArp: ue.paging.pending.arp()},
+		}
+	}
+
+	ue.paging.pending = req
+	ue.paging.state = PagingAttempting
+
+	return models.N1N2AttemptingToReachUE, nil
+}
+
+func (r *MTRequest) arp() *models.Arp {
+	if r == nil {
+		return nil
+	}
+
+	return r.Arp
+}
+
+func (ue *UeContext) PagingAnswered() *MTRequest {
+	if ue == nil {
+		return nil
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	if ue.paging.pending == nil {
+		ue.paging.state = PagingIdle
+
+		return nil
+	}
+
+	ue.paging.state = PagingDelivering
+
+	return ue.paging.pending
+}
+
+func (ue *UeContext) PagingDelivered() {
+	if ue == nil {
+		return
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+
+	ue.paging.pending = nil
+	ue.paging.state = PagingIdle
+
+	ue.paging.mu.Unlock()
+
+	ue.Conn().ResumeDeferredReleaseIfSettled()
+}
+
+func (ue *UeContext) PagingFailed(cause models.N1N2MessageTransferCause) *MTRequest {
+	if ue == nil {
+		return nil
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+
+	dropped := ue.paging.pending
+	ue.paging.pending = nil
+	ue.paging.state = PagingIdle
+
+	ue.paging.mu.Unlock()
+
+	if dropped != nil {
+		ue.notifyTransferFailure(dropped, cause)
+	}
+
+	ue.Conn().ResumeDeferredReleaseIfSettled()
+
+	return dropped
+}
+
+func (ue *UeContext) PagingActive() bool {
+	return ue.PagingState() == PagingAttempting
+}
+
+func (ue *UeContext) notifyTransferFailure(req *MTRequest, cause models.N1N2MessageTransferCause) {
+	if ue.smf == nil || req == nil || req.Req.Standalone() {
+		return
+	}
+
+	if err := ue.smf.HandleN1N2TransferFailure(context.Background(), ue.Supi(), req.Req.PduSessionID, cause); err != nil {
+		logger.AmfLog.Warn("could not report an N1N2 transfer failure",
+			logger.SUPI(ue.Supi().String()),
+			zap.Uint8("pdu_session_id", req.Req.PduSessionID),
+			zap.String("cause", cause.String()),
+			zap.Error(err))
+	}
+}

--- a/internal/amf/paging_proc.go
+++ b/internal/amf/paging_proc.go
@@ -118,9 +118,9 @@ func (r *MTRequest) arp() *models.Arp {
 	return r.Arp
 }
 
-func (ue *UeContext) PagingAnswered() *MTRequest {
+func (ue *UeContext) PagingAnswered() {
 	if ue == nil {
-		return nil
+		return
 	}
 
 	ue.paging.guard.Stop()
@@ -128,15 +128,9 @@ func (ue *UeContext) PagingAnswered() *MTRequest {
 	ue.paging.mu.Lock()
 	defer ue.paging.mu.Unlock()
 
-	if ue.paging.pending == nil {
-		ue.paging.state = PagingIdle
-
-		return nil
+	if ue.paging.state == PagingAttempting {
+		ue.paging.state = PagingDelivering
 	}
-
-	ue.paging.state = PagingDelivering
-
-	return ue.paging.pending
 }
 
 func (ue *UeContext) PagingDelivered() {
@@ -172,7 +166,7 @@ func (ue *UeContext) PagingFailed(cause models.N1N2MessageTransferCause) *MTRequ
 	ue.paging.mu.Unlock()
 
 	if dropped != nil {
-		ue.notifyTransferFailure(dropped, cause)
+		ue.notifyMTDeliveryFailure(dropped, cause)
 	}
 
 	ue.Conn().ResumeDeferredReleaseIfSettled()
@@ -184,7 +178,7 @@ func (ue *UeContext) PagingActive() bool {
 	return ue.PagingState() == PagingAttempting
 }
 
-func (ue *UeContext) notifyTransferFailure(req *MTRequest, cause models.N1N2MessageTransferCause) {
+func (ue *UeContext) notifyMTDeliveryFailure(req *MTRequest, cause models.N1N2MessageTransferCause) {
 	if ue.smf == nil || req == nil || req.Req.Standalone() {
 		return
 	}

--- a/internal/amf/paging_proc.go
+++ b/internal/amf/paging_proc.go
@@ -35,9 +35,7 @@ func (s PagingState) String() string {
 }
 
 type MTRequest struct {
-	Req    models.N1N2MessageTransferRequest
-	Arp    *models.Arp
-	FiveQI int32
+	Req models.N1N2MessageTransferRequest
 }
 
 func (r *MTRequest) Request() *models.N1N2MessageTransferRequest {
@@ -54,7 +52,7 @@ func outranks(candidate, current *models.Arp) bool {
 	}
 
 	if current == nil {
-		return true
+		return false
 	}
 
 	return candidate.PriorityLevel < current.PriorityLevel
@@ -95,19 +93,37 @@ func (ue *UeContext) MTDeliveryInProgress() bool {
 
 func (ue *UeContext) beginPaging(req *MTRequest) (models.N1N2MessageTransferCause, error) {
 	ue.paging.mu.Lock()
-	defer ue.paging.mu.Unlock()
 
-	if ue.paging.state == PagingAttempting && !outranks(req.Arp, ue.paging.pending.arp()) {
-		return "", &models.N1N2MessageTransferError{
+	if ue.paging.state == PagingAttempting && !outranks(req.arp(), ue.paging.pending.arp()) {
+		rejected := &models.N1N2MessageTransferError{
 			Cause:  models.N1N2ErrHigherPriorityRequestOngoing,
 			Detail: models.N1N2MsgTxfrErrDetail{HighestPrioArp: ue.paging.pending.arp()},
 		}
+
+		ue.paging.mu.Unlock()
+
+		return "", rejected
 	}
 
+	displaced := ue.paging.pending
 	ue.paging.pending = req
 	ue.paging.state = PagingAttempting
 
+	ue.paging.mu.Unlock()
+
+	if displaced != nil && !sameDelivery(displaced, req) {
+		ue.notifyMTDeliveryFailure(displaced, models.N1N2FailureCauseUnspecified)
+	}
+
 	return models.N1N2AttemptingToReachUE, nil
+}
+
+func sameDelivery(a, b *MTRequest) bool {
+	if a.Req.Standalone() || b.Req.Standalone() {
+		return false
+	}
+
+	return a.Req.PduSessionID == b.Req.PduSessionID
 }
 
 func (r *MTRequest) arp() *models.Arp {
@@ -115,7 +131,7 @@ func (r *MTRequest) arp() *models.Arp {
 		return nil
 	}
 
-	return r.Arp
+	return r.Req.Arp
 }
 
 func (ue *UeContext) PagingAnswered() {
@@ -158,11 +174,7 @@ func (ue *UeContext) PagingFailed(cause models.N1N2MessageTransferCause) *MTRequ
 	ue.paging.guard.Stop()
 
 	ue.paging.mu.Lock()
-
-	dropped := ue.paging.pending
-	ue.paging.pending = nil
-	ue.paging.state = PagingIdle
-
+	dropped := ue.takePendingLocked()
 	ue.paging.mu.Unlock()
 
 	if dropped != nil {
@@ -170,6 +182,66 @@ func (ue *UeContext) PagingFailed(cause models.N1N2MessageTransferCause) *MTRequ
 	}
 
 	ue.Conn().ResumeDeferredReleaseIfSettled()
+
+	return dropped
+}
+
+func (ue *UeContext) PagingUnanswered(cause models.N1N2MessageTransferCause) (*MTRequest, bool) {
+	if ue == nil {
+		return nil, false
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+
+	if ue.Conn() != nil {
+		ue.paging.mu.Unlock()
+
+		return nil, false
+	}
+
+	dropped := ue.takePendingLocked()
+
+	ue.paging.mu.Unlock()
+
+	if dropped != nil {
+		ue.notifyMTDeliveryFailure(dropped, cause)
+	}
+
+	return dropped, true
+}
+
+func (ue *UeContext) PagingAttemptFailed(req *MTRequest, cause models.N1N2MessageTransferCause) {
+	if ue == nil {
+		return
+	}
+
+	ue.paging.mu.Lock()
+
+	if ue.paging.pending != req {
+		ue.paging.mu.Unlock()
+
+		return
+	}
+
+	dropped := ue.takePendingLocked()
+
+	ue.paging.mu.Unlock()
+
+	ue.paging.guard.Stop()
+
+	if dropped != nil {
+		ue.notifyMTDeliveryFailure(dropped, cause)
+	}
+
+	ue.Conn().ResumeDeferredReleaseIfSettled()
+}
+
+func (ue *UeContext) takePendingLocked() *MTRequest {
+	dropped := ue.paging.pending
+	ue.paging.pending = nil
+	ue.paging.state = PagingIdle
 
 	return dropped
 }

--- a/internal/amf/paging_proc.go
+++ b/internal/amf/paging_proc.go
@@ -174,10 +174,6 @@ func (ue *UeContext) PagingFailed(cause models.N1N2MessageTransferCause) *MTRequ
 	return dropped
 }
 
-func (ue *UeContext) PagingActive() bool {
-	return ue.PagingState() == PagingAttempting
-}
-
 func (ue *UeContext) notifyMTDeliveryFailure(req *MTRequest, cause models.N1N2MessageTransferCause) {
 	if ue.smf == nil || req == nil || req.Req.Standalone() {
 		return

--- a/internal/amf/positioning_transfer_test.go
+++ b/internal/amf/positioning_transfer_test.go
@@ -56,7 +56,7 @@ func TestTransferN1LPPMsg_IdleUE_BuffersAsN1N2AndPages(t *testing.T) {
 		t.Fatalf("paging calls = %d, want 1", sender.pagingCalls)
 	}
 
-	req := ue.N1N2Message()
+	req := ue.PagingPending().Request()
 	if req == nil {
 		t.Fatal("expected the LPP message buffered as an N1N2 request")
 	}
@@ -77,7 +77,7 @@ func TestTransferN1LPPMsg_IdleUE_BuffersAsN1N2AndPages(t *testing.T) {
 		t.Errorf("buffered correlation id = %x, want %x", req.LCSCorrelationID, correlID)
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 }
 
 // TS 24.501 §5.4.5.3.1
@@ -88,7 +88,7 @@ func TestTransferN1LPPMsg_IdleUE_AssignsCorrelationID(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	req := ue.N1N2Message()
+	req := ue.PagingPending().Request()
 	if req == nil {
 		t.Fatal("expected the LPP message to be buffered")
 	}
@@ -97,7 +97,7 @@ func TestTransferN1LPPMsg_IdleUE_AssignsCorrelationID(t *testing.T) {
 		t.Errorf("correlation id = %x, want a 4-octet AMF-assigned value", req.LCSCorrelationID)
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 }
 
 // TS 23.273 §6.11.2
@@ -114,7 +114,7 @@ func TestTransferN2NRPPaMsg_IdleUE_BuffersAsN1N2AndPages(t *testing.T) {
 		t.Fatalf("paging calls = %d, want 1", sender.pagingCalls)
 	}
 
-	req := ue.N1N2Message()
+	req := ue.PagingPending().Request()
 	if req == nil {
 		t.Fatal("expected the NRPPa message buffered as an N1N2 request")
 	}
@@ -135,23 +135,23 @@ func TestTransferN2NRPPaMsg_IdleUE_BuffersAsN1N2AndPages(t *testing.T) {
 		t.Error("expected no PDU session scoping on a positioning request")
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 }
 
 func TestCancelBufferedN1N2_LeavesOtherClass(t *testing.T) {
 	amfInstance, ue, _ := idlePageableUE(t, "001010000000053")
 
-	if err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
+	if _, err := amfInstance.N2MessageTransferOrPage(context.Background(), ue.SupiForTest(), newReq()); err != nil {
 		t.Fatalf("unexpected error buffering the SM request: %v", err)
 	}
 
 	amfInstance.CancelBufferedN1N2(ue.SupiForTest(), models.N1ClassLPP, models.N2ClassNRPPa)
 
-	if ue.N1N2Message() == nil {
+	if ue.PagingPending().Request() == nil {
 		t.Error("an SM buffer must survive a cancel for other classes")
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 }
 
 func TestTransferN1LPPMsg_ConnectedUE_SendsDLNASTransport(t *testing.T) {
@@ -179,7 +179,7 @@ func TestTransferN1LPPMsg_ConnectedUE_SendsDLNASTransport(t *testing.T) {
 		t.Fatalf("paging calls = %d, want 0 for a connected UE", sender.pagingCalls)
 	}
 
-	if ue.N1N2Message() != nil {
+	if ue.PagingPending().Request() != nil {
 		t.Error("a connected transfer must not buffer anything")
 	}
 }

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -77,8 +77,11 @@ type UeConn struct {
 	n2Setups   n2SetupTxns
 	n2Sessions n2Sessions
 	inboundNAS atomic.Uint32
-	log        atomic.Pointer[zap.Logger]
-	baseLog    atomic.Pointer[zap.Logger]
+
+	deferredCause atomic.Pointer[ngap.Cause]
+	deferGuard    guard.Guard
+	log           atomic.Pointer[zap.Logger]
+	baseLog       atomic.Pointer[zap.Logger]
 	// releasing gates a UE Context Release Command so a second one is not sent for the
 	// same RAN UE. Guarded by AMF.mu, like the conns registry it lives in.
 	releasing bool
@@ -219,6 +222,11 @@ func (ueConn *UeConn) setRanUeNgapID(ranUeNgapID models.RanUeNgapID) {
 // deadline (TS 38.413 handover guard), which runs its cleanup.
 func (ueConn *UeConn) Release() {
 	ueConn.stopTimers()
+	ueConn.cancelDeferredRelease()
+
+	if ue := ueConn.ue.Load(); ue != nil && ue.PagingState() == PagingDelivering {
+		ue.PagingFailed(models.N1N2UENotResponding)
+	}
 
 	a := ueConn.amf
 	if a == nil {
@@ -251,6 +259,7 @@ func (ueConn *UeConn) armNASGuardWith(cfg guard.TimerValue, name string, onRetra
 func (ueConn *UeConn) StopNASGuard() {
 	ueConn.nasGuardName.Store(nil)
 	ueConn.nasGuard.Stop()
+	ueConn.ResumeDeferredReleaseIfSettled()
 }
 
 // nasGuardProcName returns the procedure the NAS guard currently supervises, or ""

--- a/internal/amf/ran_ue.go
+++ b/internal/amf/ran_ue.go
@@ -221,8 +221,8 @@ func (ueConn *UeConn) setRanUeNgapID(ranUeNgapID models.RanUeNgapID) {
 // AttachUeConn. A key-changing procedure still in flight is left to its supervision
 // deadline (TS 38.413 handover guard), which runs its cleanup.
 func (ueConn *UeConn) Release() {
-	ueConn.stopTimers()
 	ueConn.cancelDeferredRelease()
+	ueConn.stopTimers()
 
 	if ue := ueConn.ue.Load(); ue != nil && ue.PagingState() == PagingDelivering {
 		ue.PagingFailed(models.N1N2UENotResponding)
@@ -522,6 +522,70 @@ func (ueConn *UeConn) sendTarget() (*AMF, NGAPWriter, error) {
 // StopReleaseGuard cancels the Release-Complete supervision timer.
 func (ueConn *UeConn) StopReleaseGuard() {
 	ueConn.releaseGuard.Stop()
+}
+
+func (a *AMF) ReleaseOnRANRequest(ctx context.Context, ueConn *UeConn, cause ngap.Cause, reported []uint8) {
+	amfUe := ueConn.UeContext()
+
+	if amfUe != nil && amfUe.State() != Registered {
+		logger.From(ctx, ueConn.Log()).Info("Ue Context in Non GMM-Registered")
+
+		ueConn.ReleaseAction = UeContextReleaseUeContext
+
+		ueConn.SendUEContextReleaseCommand(ctx, cause)
+
+		for _, sr := range amfUe.SmContextRefs() {
+			if err := a.Session.ReleaseSmContext(ctx, sr.Ref); err != nil {
+				logger.From(ctx, ueConn.Log()).Error("error sending release sm context request", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
+			}
+		}
+
+		return
+	}
+
+	if amfUe != nil {
+		logger.From(ctx, ueConn.Log()).Info("Ue Context in GMM-Registered")
+
+		a.deactivateReleasedSessions(ctx, ueConn, amfUe, reported)
+	}
+
+	ueConn.ReleaseAction = UeContextN2NormalRelease
+
+	ueConn.SendUEContextReleaseCommand(ctx, cause)
+}
+
+func (a *AMF) deactivateReleasedSessions(ctx context.Context, ueConn *UeConn, amfUe *UeContext, reported []uint8) {
+	if reported == nil {
+		logger.From(ctx, ueConn.Log()).Info("Pdu Session IDs not received from gNB, Releasing the UE Context with SMF using local context")
+
+		for _, sr := range amfUe.SmContextRefs() {
+			if ueConn.N2SessionInactive(sr.PduSessionID) {
+				logger.From(ctx, ueConn.Log()).Info("Pdu Session is inactive so not sending deactivate to SMF", logger.PDUSessionID(sr.PduSessionID))
+
+				continue
+			}
+
+			if err := a.Session.DeactivateSmContext(ctx, sr.Ref); err != nil {
+				logger.From(ctx, ueConn.Log()).Warn("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", sr.PduSessionID))
+			}
+		}
+
+		return
+	}
+
+	for _, pduSessionID := range reported {
+		smContext, ok := amfUe.SmContextFindByPDUSessionID(pduSessionID)
+		if !ok {
+			logger.From(ctx, ueConn.Log()).Warn("no SM context for a PDU session the NG-RAN node reported as established",
+				zap.Uint8("PduSessionID", pduSessionID))
+
+			continue
+		}
+
+		if err := a.Session.DeactivateSmContext(ctx, smContext.Ref); err != nil {
+			logger.From(ctx, ueConn.Log()).Error("Send Update SmContextDeactivate UpCnxState Error", zap.Error(err), zap.Uint8("PduSessionID", pduSessionID))
+		}
+	}
 }
 
 func (a *AMF) ReleaseUeConn(ctx context.Context, ueConn *UeConn) {

--- a/internal/amf/refresh_location_test.go
+++ b/internal/amf/refresh_location_test.go
@@ -54,7 +54,7 @@ func TestRefreshLocation_IdleRegisteredUE_Pages(t *testing.T) {
 		t.Error("expected paging supervision to be armed for the refresh")
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 }
 
 func TestRefreshLocation_IdleUE_PagingAlreadyInProgress(t *testing.T) {
@@ -80,7 +80,7 @@ func TestRefreshLocation_IdleUE_PagingAlreadyInProgress(t *testing.T) {
 	}})
 
 	ue.ArmPagingForTest(time.Hour, 1)
-	defer ue.StopPaging()
+	defer ue.StopPagingForTest()
 
 	if err := amfInstance.RefreshLocation(context.Background(), ue.SupiForTest()); err != nil {
 		t.Fatalf("expected a deliberate skip reported as success, got error: %v", err)

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -111,11 +111,34 @@ func (a *AMF) SetHandoverGuardTimeoutForTest(d time.Duration) { a.handoverGuardT
 func (a *AMF) FireHandoverGuardForTest(ue *UeContext) bool { return a.abandonHandover(ue) }
 
 func (ue *UeContext) ArmPagingForTest(d time.Duration, maxRetransmit int32) {
-	ue.pagingTimer.Arm(d, maxRetransmit, func(int32) {}, func() {})
+	ue.paging.mu.Lock()
+	ue.paging.state = PagingAttempting
+	ue.paging.mu.Unlock()
+
+	ue.paging.guard.Arm(d, maxRetransmit, func(int32) {}, func() {})
+}
+
+func (ue *UeContext) forcePagingStateForTest(req *MTRequest) {
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	if req == nil {
+		ue.paging.pending = nil
+		ue.paging.state = PagingIdle
+
+		return
+	}
+
+	ue.paging.pending = req
+	ue.paging.state = PagingAttempting
+}
+
+func (ue *UeContext) StopPagingForTest() {
+	ue.PagingDelivered()
 }
 
 func (ue *UeContext) PagingActiveForTest() bool {
-	return ue.pagingTimer.Active()
+	return ue.paging.guard.Active()
 }
 
 func (ue *UeContext) MobileReachableActiveForTest() bool {
@@ -255,4 +278,14 @@ func (ue *UeContext) ForgetS1CapabilityForTest() {
 
 	ue.s1UENetworkCapability = nil
 	ue.epsSecurityCapability = nil
+}
+
+func (ue *UeContext) SetPagedRequestForTest(req *models.N1N2MessageTransferRequest) {
+	if req == nil {
+		ue.forcePagingStateForTest(nil)
+
+		return
+	}
+
+	ue.forcePagingStateForTest(&MTRequest{Req: *req, Arp: req.Arp, FiveQI: req.FiveQI})
 }

--- a/internal/amf/ue_test_support.go
+++ b/internal/amf/ue_test_support.go
@@ -287,5 +287,5 @@ func (ue *UeContext) SetPagedRequestForTest(req *models.N1N2MessageTransferReque
 		return
 	}
 
-	ue.forcePagingStateForTest(&MTRequest{Req: *req, Arp: req.Arp, FiveQI: req.FiveQI})
+	ue.forcePagingStateForTest(&MTRequest{Req: *req})
 }

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -325,8 +325,8 @@ func (f *fakeAMFCallback) TransferN1(ctx context.Context, supi etsi.SUPI, n1Msg 
 	return nil
 }
 
-func (f *fakeAMFCallback) TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) error {
-	return nil
+func (f *fakeAMFCallback) TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) (models.N1N2MessageTransferCause, error) {
+	return models.N1N2TransferInitiated, nil
 }
 
 func (f *fakeAMFCallback) ModifyN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error {
@@ -337,8 +337,8 @@ func (f *fakeAMFCallback) ReleaseSession(ctx context.Context, supi etsi.SUPI, pd
 	return nil
 }
 
-func (f *fakeAMFCallback) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error {
-	return nil
+func (f *fakeAMFCallback) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, _ *models.Arp, _ int32) (models.N1N2MessageTransferCause, error) {
+	return models.N1N2TransferInitiated, nil
 }
 
 func (f *fakeAMFCallback) SessionDropped(_ context.Context, _ etsi.SUPI, _ uint8, _ string, _ []byte) {

--- a/internal/api/server/api_helpers_test.go
+++ b/internal/api/server/api_helpers_test.go
@@ -337,7 +337,7 @@ func (f *fakeAMFCallback) ReleaseSession(ctx context.Context, supi etsi.SUPI, pd
 	return nil
 }
 
-func (f *fakeAMFCallback) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, _ *models.Arp, _ int32) (models.N1N2MessageTransferCause, error) {
+func (f *fakeAMFCallback) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, _ *models.Arp) (models.N1N2MessageTransferCause, error) {
 	return models.N1N2TransferInitiated, nil
 }
 

--- a/internal/lmf/engine_refresh_idle_test.go
+++ b/internal/lmf/engine_refresh_idle_test.go
@@ -132,7 +132,7 @@ func TestDetermineLocation_IdleUE_RefreshUnanswered_ReturnsLastKnownWithAge(t *t
 		t.Error("expected the idle UE to be paged as part of the refresh")
 	}
 
-	ue.StopPaging()
+	ue.StopPagingForTest()
 
 	// The answer must be the stale estimate, carrying its age.
 	if result.AgeOfLocationInfo != ageSeconds {

--- a/internal/mme/credfixture_test.go
+++ b/internal/mme/credfixture_test.go
@@ -149,7 +149,7 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string) e
 	return nil
 }
 
-func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8, _ models.EPSPagingFailureCause) error {
 	f.suppressCalls++
 	return nil
 }

--- a/internal/mme/deferred_release.go
+++ b/internal/mme/deferred_release.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"time"
+
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/s1ap"
+	"go.uber.org/zap"
+)
+
+const deferredReleaseTimeout = 30 * time.Second
+
+func (c *UeConn) MTSignallingPending() bool {
+	if c == nil {
+		return false
+	}
+
+	if c.UeContext().MTDeliveryInProgress() {
+		return true
+	}
+
+	return c.nasGuard.Active() || c.esmInfoGuard.Active()
+}
+
+func (c *UeConn) DeferRelease(cause s1ap.Cause) {
+	if c == nil {
+		return
+	}
+
+	held := cause
+	c.deferredCause.Store(&held)
+
+	c.deferGuard.ArmOnce(deferredReleaseTimeout, func() {
+		logger.MmeLog.Warn("deferred UE Context Release deadline reached; releasing the S1 connection",
+			zap.String("cause", cause.String()))
+
+		c.resumeDeferredRelease(context.Background())
+	})
+}
+
+func (c *UeConn) ResumeDeferredReleaseIfSettled() {
+	if c == nil || c.deferredCause.Load() == nil {
+		return
+	}
+
+	if c.MTSignallingPending() {
+		return
+	}
+
+	c.resumeDeferredRelease(context.Background())
+}
+
+func (c *UeConn) resumeDeferredRelease(ctx context.Context) {
+	cause := c.deferredCause.Swap(nil)
+	if cause == nil {
+		return
+	}
+
+	c.deferGuard.Stop()
+
+	m, ue := c.m, c.UeContext()
+	if m == nil || ue == nil {
+		return
+	}
+
+	logger.From(ctx, logger.MmeLog).Info("resuming the deferred UE Context Release: the pending downlink traffic or signalling has settled")
+
+	m.ReleaseUEContext(ctx, ue, *cause)
+}
+
+func (c *UeConn) cancelDeferredRelease() {
+	if c == nil {
+		return
+	}
+
+	c.deferredCause.Store(nil)
+	c.deferGuard.Stop()
+}

--- a/internal/mme/deferred_release.go
+++ b/internal/mme/deferred_release.go
@@ -23,6 +23,10 @@ func (c *UeConn) MTSignallingPending() bool {
 		return true
 	}
 
+	if c.ICS() == ICSPending {
+		return true
+	}
+
 	return c.nasGuard.Active() || c.esmInfoGuard.Active()
 }
 
@@ -32,7 +36,9 @@ func (c *UeConn) DeferRelease(cause s1ap.Cause) {
 	}
 
 	held := cause
-	c.deferredCause.Store(&held)
+	if !c.deferredCause.CompareAndSwap(nil, &held) {
+		return
+	}
 
 	c.deferGuard.ArmOnce(deferredReleaseTimeout, func() {
 		logger.From(context.Background(), c.Log()).Warn("deferred UE Context Release deadline reached; releasing the S1 connection",

--- a/internal/mme/deferred_release.go
+++ b/internal/mme/deferred_release.go
@@ -35,7 +35,7 @@ func (c *UeConn) DeferRelease(cause s1ap.Cause) {
 	c.deferredCause.Store(&held)
 
 	c.deferGuard.ArmOnce(deferredReleaseTimeout, func() {
-		logger.MmeLog.Warn("deferred UE Context Release deadline reached; releasing the S1 connection",
+		logger.From(context.Background(), c.Log()).Warn("deferred UE Context Release deadline reached; releasing the S1 connection",
 			zap.String("cause", cause.String()))
 
 		c.resumeDeferredRelease(context.Background())

--- a/internal/mme/export.go
+++ b/internal/mme/export.go
@@ -218,7 +218,7 @@ func (m *MME) exportUeContext(plmn models.PlmnID, ue *UeContext) UeContextExport
 			T3402ValueSeconds: int64(T3402Backoff / time.Second),
 			MobileReachable:   timerStatus(&ue.mobileReachableTimer),
 			ImplicitDetach:    timerStatus(&ue.implicitDetachTimer),
-			Paging:            timerStatus(&ue.pagingTimer),
+			Paging:            timerStatus(&ue.paging.guard),
 		},
 		LastActivity: UELastActivityExport{
 			Timestamp: ue.lastSeenTime(),

--- a/internal/mme/handover.go
+++ b/internal/mme/handover.go
@@ -383,7 +383,7 @@ func (m *MME) FinishHandoverCommit(ue *UeContext, conn S1APWriter, notifyENBID s
 
 	target := ho.target
 
-	target.ICS = ICSCompleted
+	target.SetICS(ICSCompleted)
 
 	ue.active.Store(target)
 	m.refreshLastSeenLocked(ue, target)

--- a/internal/mme/lppa_paging_test.go
+++ b/internal/mme/lppa_paging_test.go
@@ -68,7 +68,7 @@ func TestPageAndRetryLPPa_IdleUE_BuffersAndPages(t *testing.T) {
 	}
 
 	m.mu.Lock()
-	m.stopPagingLocked(ue)
+	ue.clearPaging()
 	m.mu.Unlock()
 }
 
@@ -96,7 +96,7 @@ func TestPageAndRetryLPPa_RejectsUEThatNeedsNoPage(t *testing.T) {
 
 		defer func() {
 			m.mu.Lock()
-			m.stopPagingLocked(ue)
+			ue.clearPaging()
 			m.mu.Unlock()
 		}()
 

--- a/internal/mme/mme.go
+++ b/internal/mme/mme.go
@@ -36,7 +36,7 @@ type epsSessionManager interface {
 	ModifyEPSSession(ctx context.Context, ref string, ebi uint8, enb models.FTEID) error
 	UpdateEPSSessionAMBR(ctx context.Context, ref string, ambrUplink, ambrDownlink models.BitRate) error
 	DeactivateEPSSession(ctx context.Context, ref string) error
-	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error
+	HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8, cause models.EPSPagingFailureCause) error
 	ClearEPSPagingSuppression(ctx context.Context, imsi string, ebi uint8) error
 	ReleaseEPSSession(ctx context.Context, ref string) error
 	EPSSubscriptionChanged(ctx context.Context, ref string) (models.SubscriptionDelta, error)

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -193,7 +193,7 @@ type UeContext struct {
 	implicitDetachTimer  guard.Guard
 	idleGen              uint64
 
-	pagingTimer guard.Guard
+	paging pagingProc
 
 	lppaMu            sync.RWMutex
 	lppaMessages      []LPPaMessage
@@ -629,7 +629,7 @@ func (m *MME) NewUe(conn S1APWriter, enbUEID s1ap.ENBUES1APID) *UeContext {
 // carries the message that establishes it).
 func (m *MME) attachUeConnLocked(ue *UeContext, c *UeConn) (superseded *UeConn) {
 	m.stopIdleTimersLocked(ue)
-	m.stopPagingLocked(ue)
+	ue.PagingAnswered()
 
 	// A superseding connection detaches the old one but keeps its MME-UE-S1AP-ID
 	// reserved in m.conns: the eNB can reference it until it is released (TS 36.413 §8.3.3.1).
@@ -760,7 +760,7 @@ func (m *MME) removeContextLocked(ue *UeContext) {
 	ue.clearKeyChainProc()
 
 	m.stopIdleTimersLocked(ue)
-	m.stopPagingLocked(ue)
+	ue.clearPaging()
 	m.releaseMTMSIsLocked(ue)
 	m.freeUeConnLocked(ue)
 	m.endRelocationLocked(ue.supi, ue)

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -141,6 +141,7 @@ type UeContext struct {
 
 	lastSeen atomic.Int64
 
+	session               epsSessionManager
 	Pdns                  map[uint8]*PdnConnection
 	Ambr                  *models.Ambr // UE-AMBR (profile UE-AMBR), shared model; nil until set at attach
 	RequestedPDNType      uint8        // UE-requested PDN type (1 IPv4 / 2 IPv6 / 3 IPv4v6)
@@ -260,6 +261,7 @@ func (m *MME) CommitUEIdentity(ctx context.Context, ue *UeContext, _ AuthProof) 
 	}
 
 	m.UEs[supi] = ue
+	ue.session = m.Session
 	m.recordLastSeenLocked(ue, ue.Conn())
 	m.mu.Unlock()
 

--- a/internal/mme/mme_ue.go
+++ b/internal/mme/mme_ue.go
@@ -740,6 +740,8 @@ func (m *MME) freeUeConnLocked(ue *UeContext) {
 
 // FreeUeConn releases the UE's S1-connection under m.mu, moving it to ECM-IDLE.
 func (m *MME) FreeUeConn(ue *UeContext) {
+	ue.settleDeliveryOnRelease()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/mme/mme_ue_test.go
+++ b/internal/mme/mme_ue_test.go
@@ -72,7 +72,7 @@ func TestAttachUeConn_ClearsEPSPagingSuppression(t *testing.T) {
 
 func TestAbandonPaging_SuppressesAllPDNs(t *testing.T) {
 	m := newTestMME(t)
-	ue, _ := securedUE(t, m)
+	ue := idleRegisteredUE(t, m)
 
 	ue.Pdns = map[uint8]*PdnConnection{
 		5: {Ebi: 5},

--- a/internal/mme/nas/bearer.go
+++ b/internal/mme/nas/bearer.go
@@ -256,7 +256,7 @@ func sendInitialContextSetup(ctx context.Context, ueConn *mme.UeConn, ics *s1ap.
 		return err
 	}
 
-	ueConn.ICS = mme.ICSPending
+	ueConn.SetICS(mme.ICSPending)
 
 	return nil
 }

--- a/internal/mme/nas/fixtures_test.go
+++ b/internal/mme/nas/fixtures_test.go
@@ -151,7 +151,7 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string) e
 	return nil
 }
 
-func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8, _ models.EPSPagingFailureCause) error {
 	return nil
 }
 

--- a/internal/mme/nas/tau.go
+++ b/internal/mme/nas/tau.go
@@ -99,7 +99,7 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 		return nasreply.Handled()
 	}
 
-	reestablish := ueConn.ICS != mme.ICSCompleted && req.ActiveFlag
+	reestablish := ueConn.ICS() != mme.ICSCompleted && req.ActiveFlag
 
 	var qos *mme.EpsQoS
 
@@ -128,7 +128,7 @@ func handleTrackingAreaUpdate(ctx context.Context, m *mme.MME, ue *mme.UeContext
 	var releaseOnComplete bool
 
 	switch {
-	case ueConn.ICS == mme.ICSCompleted:
+	case ueConn.ICS() == mme.ICSCompleted:
 		logger.From(ctx, logger.MmeLog).Info("Tracking Area Update accepted", zap.String("imsi", ue.IMSI()))
 	case reestablish:
 		ics, carrier, ok := buildInitialContextSetup(ctx, m, ue, ueConn, qos)

--- a/internal/mme/nas/tau_test.go
+++ b/internal/mme/nas/tau_test.go
@@ -271,7 +271,7 @@ func TestTrackingAreaUpdateReportsALocalDeactivationOnce(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	ue.Conn().ICS = mme.ICSCompleted
+	ue.Conn().SetICS(mme.ICSCompleted)
 
 	m.AddDefaultPDN(ue)
 

--- a/internal/mme/nas_guard.go
+++ b/internal/mme/nas_guard.go
@@ -137,6 +137,8 @@ func (c *UeConn) StopNASGuard() {
 		return
 	}
 
+	defer c.ResumeDeferredReleaseIfSettled()
+
 	c.m.mu.Lock()
 	defer c.m.mu.Unlock()
 

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -47,7 +47,7 @@ func (m *MME) Page(ctx context.Context, imsi string, ebi uint8, arp *models.Arp)
 func (m *MME) page(ctx context.Context, ue *UeContext, arm func()) error {
 	m.mu.RLock()
 
-	skip := ue.Connected() || ue.PagingActive()
+	skip := ue.Connected() || ue.paging.guard.Active()
 	imsi := ue.imsiOrEmpty()
 
 	m.mu.RUnlock()
@@ -88,8 +88,6 @@ func (m *MME) armPaging(ue *UeContext, pdu []byte) {
 	if ue.paging.guard.Active() {
 		return
 	}
-
-	ue.beginPaging(nil)
 
 	ue.paging.guard.ArmWith(m.pagingCfg,
 		func(attempt int32) { m.retransmitPaging(ue, pdu, attempt) },
@@ -139,7 +137,7 @@ func (m *MME) abandonPaging(ue *UeContext) {
 
 	logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
 
-	dropped := m.PagingFailed(ue, models.EPSPagingUENotResponding)
+	dropped := ue.PagingFailed(models.EPSPagingUENotResponding)
 
 	if m.Session == nil {
 		return
@@ -298,7 +296,12 @@ func (m *MME) PageAndRetryLPPa(ctx context.Context, supi etsi.SUPI, measID int64
 		return fmt.Errorf("UE is not in registered state")
 	}
 
-	if err := m.page(ctx, ue, func() { ue.SetLPPaBuffered(measID, lppaPayload) }); err != nil {
+	arm := func() {
+		ue.beginPaging(&MTRequest{})
+		ue.SetLPPaBuffered(measID, lppaPayload)
+	}
+
+	if err := m.page(ctx, ue, arm); err != nil {
 		return fmt.Errorf("failed to page ECM-IDLE UE: %w", err)
 	}
 

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -26,13 +26,13 @@ var errPagingSkipped = errors.New("paging skipped")
 // retransmitted up to a bound, then abandoned (T3413, TS 24.301 §5.6.2). A nil error
 // covers a deliberate skip (already ECM-CONNECTED, or paging in progress); only a
 // missing context or marshal failure is reported.
-func (m *MME) Page(ctx context.Context, imsi string, ebi uint8, arp *models.Arp) error {
+func (m *MME) Page(ctx context.Context, imsi string, ebi uint8) error {
 	ue, ok := m.LookupUeByIMSI(imsi)
 	if !ok {
 		return fmt.Errorf("paging: no context for imsi %s", imsi)
 	}
 
-	arm := func() { ue.beginPaging(&MTRequest{Ebi: ebi, Arp: arp}) }
+	arm := func() { ue.beginPaging(&MTRequest{Ebi: ebi}) }
 
 	if err := m.page(ctx, ue, arm); err != nil && !errors.Is(err, errPagingSkipped) {
 		return err
@@ -135,9 +135,12 @@ func (m *MME) abandonPaging(ue *UeContext) {
 
 	m.mu.RUnlock()
 
-	logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
+	dropped, abandoned := ue.PagingUnanswered(models.EPSPagingUENotResponding)
+	if !abandoned {
+		return
+	}
 
-	dropped := ue.PagingFailed(models.EPSPagingUENotResponding)
+	logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
 
 	if m.Session == nil {
 		return

--- a/internal/mme/paging.go
+++ b/internal/mme/paging.go
@@ -26,13 +26,15 @@ var errPagingSkipped = errors.New("paging skipped")
 // retransmitted up to a bound, then abandoned (T3413, TS 24.301 §5.6.2). A nil error
 // covers a deliberate skip (already ECM-CONNECTED, or paging in progress); only a
 // missing context or marshal failure is reported.
-func (m *MME) Page(ctx context.Context, imsi string) error {
+func (m *MME) Page(ctx context.Context, imsi string, ebi uint8, arp *models.Arp) error {
 	ue, ok := m.LookupUeByIMSI(imsi)
 	if !ok {
 		return fmt.Errorf("paging: no context for imsi %s", imsi)
 	}
 
-	if err := m.page(ctx, ue, nil); err != nil && !errors.Is(err, errPagingSkipped) {
+	arm := func() { ue.beginPaging(&MTRequest{Ebi: ebi, Arp: arp}) }
+
+	if err := m.page(ctx, ue, arm); err != nil && !errors.Is(err, errPagingSkipped) {
 		return err
 	}
 
@@ -45,7 +47,7 @@ func (m *MME) Page(ctx context.Context, imsi string) error {
 func (m *MME) page(ctx context.Context, ue *UeContext, arm func()) error {
 	m.mu.RLock()
 
-	skip := ue.Connected() || ue.pagingTimer.Active()
+	skip := ue.Connected() || ue.PagingActive()
 	imsi := ue.imsiOrEmpty()
 
 	m.mu.RUnlock()
@@ -83,19 +85,26 @@ func (m *MME) armPaging(ue *UeContext, pdu []byte) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if ue.pagingTimer.Active() {
+	if ue.paging.guard.Active() {
 		return
 	}
 
-	ue.pagingTimer.ArmWith(m.pagingCfg,
+	ue.beginPaging(nil)
+
+	ue.paging.guard.ArmWith(m.pagingCfg,
 		func(attempt int32) { m.retransmitPaging(ue, pdu, attempt) },
 		func() { m.abandonPaging(ue) })
 }
 
-// stopPagingLocked cancels paging supervision. The guard invalidates any
-// in-flight callback. The caller holds m.mu.
-func (m *MME) stopPagingLocked(ue *UeContext) {
-	ue.pagingTimer.Stop()
+func (ue *UeContext) clearPaging() {
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+	ue.paging.pending = nil
+	ue.paging.state = PagingIdle
+	ue.paging.mu.Unlock()
+
+	ue.ClearLPPaBuffered()
 }
 
 // retransmitPaging resends the Paging on each guard interval (T3413, TS 24.301
@@ -109,7 +118,7 @@ func (m *MME) retransmitPaging(ue *UeContext, pdu []byte, attempt int32) {
 	m.mu.RUnlock()
 
 	if connected {
-		ue.pagingTimer.Stop()
+		ue.paging.guard.Stop()
 		return
 	}
 
@@ -130,18 +139,20 @@ func (m *MME) abandonPaging(ue *UeContext) {
 
 	logger.MmeLog.Info("paging unanswered, abandoning procedure", zap.String("imsi", imsi))
 
-	// Backstop for a payload whose requester went away without cancelling.
-	if !ue.Connected() {
-		ue.ClearLPPaBuffered()
-	}
+	dropped := m.PagingFailed(ue, models.EPSPagingUENotResponding)
 
 	if m.Session == nil {
 		return
 	}
 
 	ctx := context.Background()
+
 	for _, p := range m.SnapshotPDNs(ue) {
-		if err := m.Session.HandleEPSPagingFailure(ctx, imsi, p.Ebi); err != nil {
+		if dropped != nil && dropped.Ebi == p.Ebi {
+			continue
+		}
+
+		if err := m.Session.HandleEPSPagingFailure(ctx, imsi, p.Ebi, models.EPSPagingUENotResponding); err != nil {
 			logger.MmeLog.Warn("failed to suppress downlink notification after paging failure",
 				zap.String("imsi", imsi), zap.Uint8("ebi", p.Ebi), zap.Error(err))
 		}

--- a/internal/mme/paging_disposal_test.go
+++ b/internal/mme/paging_disposal_test.go
@@ -22,7 +22,7 @@ func TestPagingFailedReportsTheCauseForThePendingBearer(t *testing.T) {
 		t.Fatalf("paging state = %s after Page, want Attempting", state)
 	}
 
-	dropped := m.PagingFailed(ue, models.EPSPagingUENotResponding)
+	dropped := ue.PagingFailed(models.EPSPagingUENotResponding)
 	if dropped == nil || dropped.Ebi != 5 {
 		t.Fatalf("dropped = %+v, want the pending bearer", dropped)
 	}
@@ -63,7 +63,7 @@ func TestClearPagingDropsTheBufferedLPPa(t *testing.T) {
 		t.Fatalf("Page: %v", err)
 	}
 
-	m.PagingFailed(ue, models.EPSPagingUENotResponding)
+	ue.PagingFailed(models.EPSPagingUENotResponding)
 
 	if ue.PopLPPaBuffered() != nil {
 		t.Error("the buffered LPPa payload survived the failed paging procedure")

--- a/internal/mme/paging_disposal_test.go
+++ b/internal/mme/paging_disposal_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/models"
+)
+
+func TestPagingFailedReportsTheCauseForThePendingBearer(t *testing.T) {
+	m := newTestMME(t)
+	ue := idleRegisteredUE(t, m)
+
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	if state := ue.PagingState(); state != PagingAttempting {
+		t.Fatalf("paging state = %s after Page, want Attempting", state)
+	}
+
+	dropped := m.PagingFailed(ue, models.EPSPagingUENotResponding)
+	if dropped == nil || dropped.Ebi != 5 {
+		t.Fatalf("dropped = %+v, want the pending bearer", dropped)
+	}
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after the failure, want Idle", state)
+	}
+}
+
+func TestPagingAnsweredThenDelivered(t *testing.T) {
+	m := newTestMME(t)
+	ue := idleRegisteredUE(t, m)
+
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	ue.PagingAnswered()
+
+	if state := ue.PagingState(); state != PagingDelivering {
+		t.Errorf("paging state = %s after the UE answered, want Delivering", state)
+	}
+
+	ue.PagingDelivered()
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after delivery, want Idle", state)
+	}
+}
+
+func TestClearPagingDropsTheBufferedLPPa(t *testing.T) {
+	m := newTestMME(t)
+	ue := idleRegisteredUE(t, m)
+
+	ue.SetLPPaBuffered(7, []byte{0x01})
+
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	m.PagingFailed(ue, models.EPSPagingUENotResponding)
+
+	if ue.PopLPPaBuffered() != nil {
+		t.Error("the buffered LPPa payload survived the failed paging procedure")
+	}
+}

--- a/internal/mme/paging_disposal_test.go
+++ b/internal/mme/paging_disposal_test.go
@@ -6,6 +6,7 @@ package mme
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ellanetworks/core/internal/models"
 )
@@ -14,7 +15,7 @@ func TestPagingFailedReportsTheCauseForThePendingBearer(t *testing.T) {
 	m := newTestMME(t)
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -36,7 +37,7 @@ func TestPagingAnsweredThenDelivered(t *testing.T) {
 	m := newTestMME(t)
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -59,7 +60,7 @@ func TestClearPagingDropsTheBufferedLPPa(t *testing.T) {
 
 	ue.SetLPPaBuffered(7, []byte{0x01})
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -74,7 +75,7 @@ func TestDetachFailsThePendingTransfer(t *testing.T) {
 	m := newTestMME(t)
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -89,7 +90,7 @@ func TestConnectionReleaseFailsADeliveringTransfer(t *testing.T) {
 	m := newTestMME(t)
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -99,5 +100,97 @@ func TestConnectionReleaseFailsADeliveringTransfer(t *testing.T) {
 
 	if state := ue.PagingState(); state != PagingIdle {
 		t.Errorf("paging state = %s after the connection carrying the delivery was released, want Idle", state)
+	}
+}
+
+// TS 29.274 §7.2.11.3: no Downlink Data Notification Failure Indication after the
+// MME successfully receives the Service Request from the UE.
+func TestAbandonPagingKeepsTheTransferWhenTheUEAnsweredTheLastRetransmission(t *testing.T) {
+	m := newTestMME(t)
+	m.pagingCfg.ExpireTime = time.Hour
+
+	ue := idleRegisteredUE(t, m)
+
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	ue.SetLPPaBuffered(7, []byte{0x01})
+
+	ue.Pdns = map[uint8]*PdnConnection{
+		5: {Ebi: 5},
+		6: {Ebi: 6},
+	}
+
+	m.AttachUeConn(ue, m.NewUeConn(&captureConn{}, 9))
+
+	m.abandonPaging(ue)
+
+	if state := ue.PagingState(); state != PagingDelivering {
+		t.Errorf("paging state = %s after an abort that raced the UE answering, want Delivering", state)
+	}
+
+	if pending := ue.PagingPending(); pending == nil || pending.Ebi != 5 {
+		t.Errorf("pending = %+v, want the paged bearer kept for delivery", pending)
+	}
+
+	if ue.PopLPPaBuffered() == nil {
+		t.Error("the buffered LPPa payload was discarded although the UE answered the page")
+	}
+
+	if got := m.Session.(*fakeSessionManager).suppressCalls; got != 0 {
+		t.Errorf("downlink data notification failures = %d, want 0 for a UE that answered", got)
+	}
+}
+
+// TS 24.301 §5.5.3.2.2: a UE may answer paging with a tracking area update, which ends
+// without an Initial Context Setup, so the release is what settles the transfer.
+func TestReleaseCompleteFailsADeliveringTransfer(t *testing.T) {
+	m := newTestMME(t)
+	m.pagingCfg.ExpireTime = time.Hour
+
+	ue := idleRegisteredUE(t, m)
+
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	m.AttachUeConn(ue, m.NewUeConn(&captureConn{}, 9))
+
+	if state := ue.PagingState(); state != PagingDelivering {
+		t.Fatalf("paging state = %s after the UE answered, want Delivering", state)
+	}
+
+	m.FreeUeConn(ue)
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after the UE returned to ECM-IDLE, want Idle", state)
+	}
+
+	if pending := ue.PagingPending(); pending != nil {
+		t.Errorf("pending = %+v, want the undelivered transfer released", pending)
+	}
+}
+
+// TS 23.401 §5.3.5: an Initial Context Setup awaiting its response is pending MT
+// signalling, so a user-inactivity release is held until it settles.
+func TestOutstandingInitialContextSetupIsPendingMTSignalling(t *testing.T) {
+	m := newTestMME(t)
+	conn := m.NewUeConn(&captureConn{}, 9)
+
+	if conn.MTSignallingPending() {
+		t.Fatal("a connection with nothing in flight reports pending MT signalling")
+	}
+
+	conn.SetICS(ICSPending)
+
+	if !conn.MTSignallingPending() {
+		t.Error("an Initial Context Setup awaiting its response does not count as pending MT signalling")
+	}
+
+	conn.SetICS(ICSCompleted)
+
+	if conn.MTSignallingPending() {
+		t.Error("a completed Initial Context Setup still counts as pending MT signalling")
 	}
 }

--- a/internal/mme/paging_disposal_test.go
+++ b/internal/mme/paging_disposal_test.go
@@ -69,3 +69,35 @@ func TestClearPagingDropsTheBufferedLPPa(t *testing.T) {
 		t.Error("the buffered LPPa payload survived the failed paging procedure")
 	}
 }
+
+func TestDetachFailsThePendingTransfer(t *testing.T) {
+	m := newTestMME(t)
+	ue := idleRegisteredUE(t, m)
+
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	ue.TransitionTo(EMMDeregistered)
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after the UE was deregistered, want Idle", state)
+	}
+}
+
+func TestConnectionReleaseFailsADeliveringTransfer(t *testing.T) {
+	m := newTestMME(t)
+	ue := idleRegisteredUE(t, m)
+
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	ue.PagingAnswered()
+
+	m.ReleaseUEContextLocally(ue, "test")
+
+	if state := ue.PagingState(); state != PagingIdle {
+		t.Errorf("paging state = %s after the connection carrying the delivery was released, want Idle", state)
+	}
+}

--- a/internal/mme/paging_proc.go
+++ b/internal/mme/paging_proc.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mme
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ellanetworks/core/internal/guard"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"go.uber.org/zap"
+)
+
+type PagingState uint8
+
+const (
+	PagingIdle PagingState = iota
+	PagingAttempting
+	PagingDelivering
+)
+
+func (s PagingState) String() string {
+	switch s {
+	case PagingIdle:
+		return "Idle"
+	case PagingAttempting:
+		return "Attempting"
+	case PagingDelivering:
+		return "Delivering"
+	default:
+		return "Unknown"
+	}
+}
+
+type MTRequest struct {
+	Ebi uint8
+	Arp *models.Arp
+}
+
+type pagingProc struct {
+	mu      sync.Mutex
+	state   PagingState
+	pending *MTRequest
+	guard   guard.Guard
+}
+
+func (ue *UeContext) PagingState() PagingState {
+	if ue == nil {
+		return PagingIdle
+	}
+
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	return ue.paging.state
+}
+
+func (ue *UeContext) PagingPending() *MTRequest {
+	if ue == nil {
+		return nil
+	}
+
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	return ue.paging.pending
+}
+
+func (ue *UeContext) MTDeliveryInProgress() bool {
+	return ue.PagingState() != PagingIdle
+}
+
+func (ue *UeContext) beginPaging(req *MTRequest) {
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	if req != nil {
+		ue.paging.pending = req
+	}
+
+	ue.paging.state = PagingAttempting
+}
+
+func (ue *UeContext) PagingAnswered() {
+	if ue == nil {
+		return
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+	defer ue.paging.mu.Unlock()
+
+	if ue.paging.state == PagingAttempting {
+		ue.paging.state = PagingDelivering
+	}
+}
+
+func (ue *UeContext) PagingDelivered() {
+	if ue == nil {
+		return
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+
+	ue.paging.pending = nil
+	ue.paging.state = PagingIdle
+
+	ue.paging.mu.Unlock()
+
+	ue.Conn().ResumeDeferredReleaseIfSettled()
+}
+
+func (m *MME) PagingFailed(ue *UeContext, cause models.EPSPagingFailureCause) *MTRequest {
+	if ue == nil {
+		return nil
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+
+	dropped := ue.paging.pending
+	ue.paging.pending = nil
+	ue.paging.state = PagingIdle
+
+	ue.paging.mu.Unlock()
+
+	ue.ClearLPPaBuffered()
+
+	if dropped != nil {
+		m.notifyEPSPagingFailure(ue, dropped.Ebi, cause)
+	}
+
+	ue.Conn().ResumeDeferredReleaseIfSettled()
+
+	return dropped
+}
+
+func (m *MME) notifyEPSPagingFailure(ue *UeContext, ebi uint8, cause models.EPSPagingFailureCause) {
+	if m.Session == nil {
+		return
+	}
+
+	imsi := ue.imsiOrEmpty()
+
+	if err := m.Session.HandleEPSPagingFailure(context.Background(), imsi, ebi, cause); err != nil {
+		logger.MmeLog.Warn("could not report an EPS downlink data notification failure",
+			zap.String("imsi", imsi), zap.Uint8("ebi", ebi), zap.String("cause", cause.String()), zap.Error(err))
+	}
+}
+
+func (ue *UeContext) PagingActive() bool {
+	return ue.PagingState() == PagingAttempting
+}

--- a/internal/mme/paging_proc.go
+++ b/internal/mme/paging_proc.go
@@ -130,7 +130,7 @@ func (ue *UeContext) PagingFailed(cause models.EPSPagingFailureCause) *MTRequest
 	ue.ClearLPPaBuffered()
 
 	if dropped != nil {
-		ue.notifyMTDeliveryFailure(dropped.Ebi, cause)
+		ue.notifyMTDeliveryFailure(dropped, cause)
 	}
 
 	ue.Conn().ResumeDeferredReleaseIfSettled()
@@ -138,19 +138,18 @@ func (ue *UeContext) PagingFailed(cause models.EPSPagingFailureCause) *MTRequest
 	return dropped
 }
 
-func (ue *UeContext) PagingActive() bool {
-	return ue.PagingState() == PagingAttempting
-}
-
-func (ue *UeContext) notifyMTDeliveryFailure(ebi uint8, cause models.EPSPagingFailureCause) {
-	if ue.session == nil {
+func (ue *UeContext) notifyMTDeliveryFailure(req *MTRequest, cause models.EPSPagingFailureCause) {
+	if ue.session == nil || req == nil {
 		return
 	}
 
 	imsi := ue.imsiOrEmpty()
 
-	if err := ue.session.HandleEPSPagingFailure(context.Background(), imsi, ebi, cause); err != nil {
+	if err := ue.session.HandleEPSPagingFailure(context.Background(), imsi, req.Ebi, cause); err != nil {
 		logger.MmeLog.Warn("could not report an EPS downlink data notification failure",
-			zap.String("imsi", imsi), zap.Uint8("ebi", ebi), zap.String("cause", cause.String()), zap.Error(err))
+			zap.String("imsi", imsi),
+			zap.Uint8("ebi", req.Ebi),
+			zap.String("cause", cause.String()),
+			zap.Error(err))
 	}
 }

--- a/internal/mme/paging_proc.go
+++ b/internal/mme/paging_proc.go
@@ -36,7 +36,6 @@ func (s PagingState) String() string {
 
 type MTRequest struct {
 	Ebi uint8
-	Arp *models.Arp
 }
 
 type pagingProc struct {
@@ -120,11 +119,7 @@ func (ue *UeContext) PagingFailed(cause models.EPSPagingFailureCause) *MTRequest
 	ue.paging.guard.Stop()
 
 	ue.paging.mu.Lock()
-
-	dropped := ue.paging.pending
-	ue.paging.pending = nil
-	ue.paging.state = PagingIdle
-
+	dropped := ue.takePendingLocked()
 	ue.paging.mu.Unlock()
 
 	ue.ClearLPPaBuffered()
@@ -138,8 +133,50 @@ func (ue *UeContext) PagingFailed(cause models.EPSPagingFailureCause) *MTRequest
 	return dropped
 }
 
+func (ue *UeContext) PagingUnanswered(cause models.EPSPagingFailureCause) (*MTRequest, bool) {
+	if ue == nil {
+		return nil, false
+	}
+
+	ue.paging.guard.Stop()
+
+	ue.paging.mu.Lock()
+
+	if ue.Connected() {
+		ue.paging.mu.Unlock()
+
+		return nil, false
+	}
+
+	dropped := ue.takePendingLocked()
+
+	ue.paging.mu.Unlock()
+
+	ue.ClearLPPaBuffered()
+
+	if dropped != nil {
+		ue.notifyMTDeliveryFailure(dropped, cause)
+	}
+
+	return dropped, true
+}
+
+func (ue *UeContext) settleDeliveryOnRelease() {
+	if ue.PagingState() == PagingDelivering {
+		ue.PagingFailed(models.EPSPagingUENotResponding)
+	}
+}
+
+func (ue *UeContext) takePendingLocked() *MTRequest {
+	dropped := ue.paging.pending
+	ue.paging.pending = nil
+	ue.paging.state = PagingIdle
+
+	return dropped
+}
+
 func (ue *UeContext) notifyMTDeliveryFailure(req *MTRequest, cause models.EPSPagingFailureCause) {
-	if ue.session == nil || req == nil {
+	if ue.session == nil || req == nil || req.Ebi == 0 {
 		return
 	}
 

--- a/internal/mme/paging_proc.go
+++ b/internal/mme/paging_proc.go
@@ -76,10 +76,7 @@ func (ue *UeContext) beginPaging(req *MTRequest) {
 	ue.paging.mu.Lock()
 	defer ue.paging.mu.Unlock()
 
-	if req != nil {
-		ue.paging.pending = req
-	}
-
+	ue.paging.pending = req
 	ue.paging.state = PagingAttempting
 }
 
@@ -115,7 +112,7 @@ func (ue *UeContext) PagingDelivered() {
 	ue.Conn().ResumeDeferredReleaseIfSettled()
 }
 
-func (m *MME) PagingFailed(ue *UeContext, cause models.EPSPagingFailureCause) *MTRequest {
+func (ue *UeContext) PagingFailed(cause models.EPSPagingFailureCause) *MTRequest {
 	if ue == nil {
 		return nil
 	}
@@ -133,7 +130,7 @@ func (m *MME) PagingFailed(ue *UeContext, cause models.EPSPagingFailureCause) *M
 	ue.ClearLPPaBuffered()
 
 	if dropped != nil {
-		m.notifyEPSPagingFailure(ue, dropped.Ebi, cause)
+		ue.notifyMTDeliveryFailure(dropped.Ebi, cause)
 	}
 
 	ue.Conn().ResumeDeferredReleaseIfSettled()
@@ -141,19 +138,19 @@ func (m *MME) PagingFailed(ue *UeContext, cause models.EPSPagingFailureCause) *M
 	return dropped
 }
 
-func (m *MME) notifyEPSPagingFailure(ue *UeContext, ebi uint8, cause models.EPSPagingFailureCause) {
-	if m.Session == nil {
+func (ue *UeContext) PagingActive() bool {
+	return ue.PagingState() == PagingAttempting
+}
+
+func (ue *UeContext) notifyMTDeliveryFailure(ebi uint8, cause models.EPSPagingFailureCause) {
+	if ue.session == nil {
 		return
 	}
 
 	imsi := ue.imsiOrEmpty()
 
-	if err := m.Session.HandleEPSPagingFailure(context.Background(), imsi, ebi, cause); err != nil {
+	if err := ue.session.HandleEPSPagingFailure(context.Background(), imsi, ebi, cause); err != nil {
 		logger.MmeLog.Warn("could not report an EPS downlink data notification failure",
 			zap.String("imsi", imsi), zap.Uint8("ebi", ebi), zap.String("cause", cause.String()), zap.Error(err))
 	}
-}
-
-func (ue *UeContext) PagingActive() bool {
-	return ue.PagingState() == PagingAttempting
 }

--- a/internal/mme/paging_test.go
+++ b/internal/mme/paging_test.go
@@ -108,7 +108,7 @@ func TestPageNoENBs(t *testing.T) {
 	m := newTestMME(t)
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 }
@@ -131,7 +131,7 @@ func TestPageFiltersByServedTAI(t *testing.T) {
 	foreign := &captureConn{}
 	m.IndexRadioForTest(foreign, []SupportedTAI{{Tai: models.Tai{PlmnID: &p, Tac: "0000ff"}}})
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func TestPageFiltersByServedTAI(t *testing.T) {
 func TestPageUnknownIMSI(t *testing.T) {
 	m := newTestMME(t)
 
-	if err := m.Page(context.Background(), "001010000000999", 5, nil); err == nil {
+	if err := m.Page(context.Background(), "001010000000999", 5); err == nil {
 		t.Fatal("Page should error for an unknown IMSI")
 	}
 }
@@ -159,7 +159,7 @@ func TestPagingRetransmitsThenAbandons(t *testing.T) {
 
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -183,7 +183,7 @@ func TestPagingStoppedOnReconnect(t *testing.T) {
 
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 

--- a/internal/mme/paging_test.go
+++ b/internal/mme/paging_test.go
@@ -17,7 +17,7 @@ func (m *MME) pagingActive(ue *UeContext) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return ue.pagingTimer.Active()
+	return ue.PagingActive()
 }
 
 func TestUEIdentityIndex(t *testing.T) {
@@ -108,7 +108,7 @@ func TestPageNoENBs(t *testing.T) {
 	m := newTestMME(t)
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty()); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 }
@@ -131,7 +131,7 @@ func TestPageFiltersByServedTAI(t *testing.T) {
 	foreign := &captureConn{}
 	m.IndexRadioForTest(foreign, []SupportedTAI{{Tai: models.Tai{PlmnID: &p, Tac: "0000ff"}}})
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty()); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func TestPageFiltersByServedTAI(t *testing.T) {
 func TestPageUnknownIMSI(t *testing.T) {
 	m := newTestMME(t)
 
-	if err := m.Page(context.Background(), "001010000000999"); err == nil {
+	if err := m.Page(context.Background(), "001010000000999", 5, nil); err == nil {
 		t.Fatal("Page should error for an unknown IMSI")
 	}
 }
@@ -159,7 +159,7 @@ func TestPagingRetransmitsThenAbandons(t *testing.T) {
 
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty()); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 
@@ -183,7 +183,7 @@ func TestPagingStoppedOnReconnect(t *testing.T) {
 
 	ue := idleRegisteredUE(t, m)
 
-	if err := m.Page(context.Background(), ue.imsiOrEmpty()); err != nil {
+	if err := m.Page(context.Background(), ue.imsiOrEmpty(), 5, nil); err != nil {
 		t.Fatalf("Page: %v", err)
 	}
 

--- a/internal/mme/paging_test.go
+++ b/internal/mme/paging_test.go
@@ -17,7 +17,7 @@ func (m *MME) pagingActive(ue *UeContext) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return ue.PagingActive()
+	return ue.paging.guard.Active()
 }
 
 func TestUEIdentityIndex(t *testing.T) {

--- a/internal/mme/relocation_test.go
+++ b/internal/mme/relocation_test.go
@@ -843,8 +843,8 @@ func TestRelocatedConnectionIsFullyEstablished(t *testing.T) {
 		t.Fatal("the UE holds no connection after the handover")
 	}
 
-	if conn.ICS != ICSCompleted {
-		t.Errorf("connection ICS state = %v, want the bearers the handover established to count as set up", conn.ICS)
+	if conn.ICS() != ICSCompleted {
+		t.Errorf("connection ICS state = %v, want the bearers the handover established to count as set up", conn.ICS())
 	}
 }
 

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -46,7 +46,7 @@ type UeConn struct {
 	ServingTAI                s1ap.TAI
 	Location                  models.UserLocation
 	m                         *MME
-	ICS                       ICSState
+	ics                       atomic.Int32
 	secureExchangeEstablished bool
 	cipheringStarted          atomic.Bool
 	AuthVector                *udm.EPSAV
@@ -181,4 +181,20 @@ func (c *UeConn) MarkCipheringStarted() {
 	if c != nil {
 		c.cipheringStarted.Store(true)
 	}
+}
+
+func (c *UeConn) ICS() ICSState {
+	if c == nil {
+		return ICSNotStarted
+	}
+
+	return ICSState(c.ics.Load())
+}
+
+func (c *UeConn) SetICS(state ICSState) {
+	if c == nil {
+		return
+	}
+
+	c.ics.Store(int32(state))
 }

--- a/internal/mme/s1_conn.go
+++ b/internal/mme/s1_conn.go
@@ -60,6 +60,8 @@ type UeConn struct {
 	FiveGSArrival             *FiveGSArrival
 	DeferredTAUPlain          []byte
 	nasGuard                  guard.Guard
+	deferredCause             atomic.Pointer[s1ap.Cause]
+	deferGuard                guard.Guard
 	nasGuardName              string
 	esmInfoGuard              guard.Guard
 	releaseGuard              guard.Guard

--- a/internal/mme/s1ap/deferred_release_test.go
+++ b/internal/mme/s1ap/deferred_release_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1ap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellanetworks/core/internal/mme"
+	"github.com/ellanetworks/core/s1ap"
+)
+
+func inactivityRelease(ue *mme.UeContext) *s1ap.UEContextReleaseRequest {
+	return &s1ap.UEContextReleaseRequest{
+		MMEUES1APID: ue.Conn().MMEUES1APID,
+		ENBUES1APID: 7,
+		Cause:       s1ap.Ptr(s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkUserInactivity}),
+	}
+}
+
+func deliverReleaseRequest(t *testing.T, m *mme.MME, cc *captureConn, req *s1ap.UEContextReleaseRequest) {
+	t.Helper()
+
+	b, _ := req.Marshal()
+
+	pdu, err := s1ap.Unmarshal(b)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	handleUEContextReleaseRequest(m, context.Background(), mme.NewRadioForTest(cc), pdu.(*s1ap.InitiatingMessage).Value)
+}
+
+func TestUserInactivityIsDeferredWhileAnMTDeliveryIsInProgress(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	ue.SetPagedBearerForTest(5, nil)
+	ue.PagingAnswered()
+
+	deliverReleaseRequest(t, m, cc, inactivityRelease(ue))
+
+	if len(cc.sent) != 0 {
+		t.Fatalf("UE Context Release Commands sent = %d, want 0: the MME is aware of pending MT traffic (TS 23.401 5.3.5)", len(cc.sent))
+	}
+
+	ue.PagingDelivered()
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("UE Context Release Commands sent = %d, want 1: the deferred S1 release never resumes once the MT delivery settles", len(cc.sent))
+	}
+}
+
+func TestOtherCausesReleaseDespiteAnMTDeliveryInProgress(t *testing.T) {
+	m := newTestMME(t)
+	ue, cc := securedUE(t, m)
+
+	ue.SetPagedBearerForTest(5, nil)
+	ue.PagingAnswered()
+
+	req := inactivityRelease(ue)
+	req.Cause = s1ap.Ptr(s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkRadioConnectionWithUELost})
+
+	deliverReleaseRequest(t, m, cc, req)
+
+	if len(cc.sent) != 1 {
+		t.Fatalf("UE Context Release Commands sent = %d, want 1: only user inactivity is conditional on pending MT traffic", len(cc.sent))
+	}
+}

--- a/internal/mme/s1ap/deferred_release_test.go
+++ b/internal/mme/s1ap/deferred_release_test.go
@@ -36,7 +36,7 @@ func TestUserInactivityIsDeferredWhileAnMTDeliveryIsInProgress(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	ue.SetPagedBearerForTest(5, nil)
+	ue.SetPagedBearerForTest(5)
 	ue.PagingAnswered()
 
 	deliverReleaseRequest(t, m, cc, inactivityRelease(ue))
@@ -56,7 +56,7 @@ func TestOtherCausesReleaseDespiteAnMTDeliveryInProgress(t *testing.T) {
 	m := newTestMME(t)
 	ue, cc := securedUE(t, m)
 
-	ue.SetPagedBearerForTest(5, nil)
+	ue.SetPagedBearerForTest(5)
 	ue.PagingAnswered()
 
 	req := inactivityRelease(ue)

--- a/internal/mme/s1ap/fixtures_test.go
+++ b/internal/mme/s1ap/fixtures_test.go
@@ -169,7 +169,7 @@ func (f *fakeSessionManager) DeactivateEPSSession(_ context.Context, _ string) e
 	return nil
 }
 
-func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8) error {
+func (f *fakeSessionManager) HandleEPSPagingFailure(_ context.Context, _ string, _ uint8, _ models.EPSPagingFailureCause) error {
 	return nil
 }
 

--- a/internal/mme/s1ap/handle_initial_context_setup_response.go
+++ b/internal/mme/s1ap/handle_initial_context_setup_response.go
@@ -82,7 +82,7 @@ func handleInitialContextSetupResponse(m *mme.MME, ctx context.Context, radio *m
 	}
 
 	if ueConn != nil {
-		ueConn.ICS = mme.ICSCompleted
+		ueConn.SetICS(mme.ICSCompleted)
 	}
 
 	// With the radio bearers up, a pending data-network change becomes deliverable.

--- a/internal/mme/s1ap/handle_initial_context_setup_response.go
+++ b/internal/mme/s1ap/handle_initial_context_setup_response.go
@@ -65,6 +65,8 @@ func handleInitialContextSetupResponse(m *mme.MME, ctx context.Context, radio *m
 		zap.Int("e-rabs-setup", setup),
 		zap.Int("e-rabs-released", len(result.Released)))
 
+	ue.PagingDelivered()
+
 	// Deliver any LPPa message buffered while the UE was ECM-IDLE.
 	if lppaBuf := ue.PopLPPaBuffered(); lppaBuf != nil {
 		if sendErr := ueConn.SendDownlinkLPPaTransport(ctx, 0, lppaBuf.Payload); sendErr != nil {

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -16,6 +16,14 @@ import (
 // CauseRadioNetwork "unspecified").
 var causeReleaseUnspecified = s1ap.Cause{Group: s1ap.CauseGroupRadioNetwork, Value: s1ap.CauseRadioNetworkUnspecified}
 
+func keepsConnectionForPendingDownlink(cause s1ap.Cause, ueConn *mme.UeConn) bool {
+	if cause.Group != s1ap.CauseGroupRadioNetwork || cause.Value != s1ap.CauseRadioNetworkUserInactivity {
+		return false
+	}
+
+	return ueConn.MTSignallingPending()
+}
+
 // handleUEContextReleaseRequest handles an eNB-initiated UE Context Release
 // Request (inactivity or radio-link failure), starting the S1 release procedure
 // (TS 36.413). Whether the context is deleted or retained in ECM-IDLE is decided
@@ -77,12 +85,4 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 	}
 
 	m.ReleaseUEContext(ctx, ue, cause)
-}
-
-func keepsConnectionForPendingDownlink(cause s1ap.Cause, ueConn *mme.UeConn) bool {
-	if cause.Group != s1ap.CauseGroupRadioNetwork || cause.Value != s1ap.CauseRadioNetworkUserInactivity {
-		return false
-	}
-
-	return ueConn.MTSignallingPending()
 }

--- a/internal/mme/s1ap/handle_ue_context_release_request.go
+++ b/internal/mme/s1ap/handle_ue_context_release_request.go
@@ -68,5 +68,21 @@ func handleUEContextReleaseRequest(m *mme.MME, ctx context.Context, radio *mme.R
 		logger.From(ctx, ueConn.Log()).Info("UE Context Release Request", fields...)
 	}
 
+	if keepsConnectionForPendingDownlink(cause, ueConn) {
+		ueConn.DeferRelease(cause)
+
+		logger.From(ctx, ueConn.Log()).Info("keeping the S1 connection: user inactivity reported while downlink traffic or signalling is pending")
+
+		return
+	}
+
 	m.ReleaseUEContext(ctx, ue, cause)
+}
+
+func keepsConnectionForPendingDownlink(cause s1ap.Cause, ueConn *mme.UeConn) bool {
+	if cause.Group != s1ap.CauseGroupRadioNetwork || cause.Value != s1ap.CauseRadioNetworkUserInactivity {
+		return false
+	}
+
+	return ueConn.MTSignallingPending()
 }

--- a/internal/mme/states.go
+++ b/internal/mme/states.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"go.uber.org/zap"
 )
 
@@ -147,6 +148,10 @@ func (ue *UeContext) EMMState() EMMState {
 // transition graph under ue.mu (TS 24.301 §5.1.3.2); an unexpected transition
 // fails safe to EMM-DEREGISTERED.
 func (ue *UeContext) TransitionTo(s EMMState) {
+	if s == EMMDeregistered {
+		ue.PagingFailed(models.EPSPagingUENotResponding)
+	}
+
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
 

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -105,6 +105,8 @@ func (c *UeConn) SendUEContextReleaseCommand(ctx context.Context, cause s1ap.Cau
 }
 
 func (m *MME) ReleaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Cause) {
+	ue.Conn().cancelDeferredRelease()
+
 	// The idempotency claim is atomic: a NAS guard timeout and an eNB-initiated
 	// release request can race to release the same UE from different goroutines. A
 	// Release Complete in the gap may already have freed the connection, which is

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
 )
@@ -143,6 +144,10 @@ func (m *MME) ReleaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Ca
 // FAILURE, or an eNB/association loss). An incomplete registration is aborted; a
 // registered UE drops to ECM-IDLE.
 func (m *MME) ReleaseUEContextLocally(ue *UeContext, trigger string) {
+	if ue.PagingState() == PagingDelivering {
+		ue.PagingFailed(models.EPSPagingUENotResponding)
+	}
+
 	registered, imsi, mmeUEID := m.releaseContextLockedPart(ue)
 
 	if !registered {

--- a/internal/mme/ue_context_release.go
+++ b/internal/mme/ue_context_release.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ellanetworks/core/internal/logger"
-	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/s1ap"
 	"go.uber.org/zap"
 )
@@ -144,9 +143,7 @@ func (m *MME) ReleaseUEContext(ctx context.Context, ue *UeContext, cause s1ap.Ca
 // FAILURE, or an eNB/association loss). An incomplete registration is aborted; a
 // registered UE drops to ECM-IDLE.
 func (m *MME) ReleaseUEContextLocally(ue *UeContext, trigger string) {
-	if ue.PagingState() == PagingDelivering {
-		ue.PagingFailed(models.EPSPagingUENotResponding)
-	}
+	ue.settleDeliveryOnRelease()
 
 	registered, imsi, mmeUEID := m.releaseContextLockedPart(ue)
 

--- a/internal/mme/ue_test_support.go
+++ b/internal/mme/ue_test_support.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/epskeys"
 	"github.com/ellanetworks/core/internal/mme/procedure"
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/s1ap"
 )
@@ -283,4 +284,8 @@ func (ue *UeContext) ForceStateForTest(s EMMState) {
 
 func (ue *UeContext) NextDownlinkCountForTest() nas.Count {
 	return ue.downlink().Next()
+}
+
+func (ue *UeContext) SetPagedBearerForTest(ebi uint8, arp *models.Arp) {
+	ue.beginPaging(&MTRequest{Ebi: ebi, Arp: arp})
 }

--- a/internal/mme/ue_test_support.go
+++ b/internal/mme/ue_test_support.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ellanetworks/core/etsi"
 	"github.com/ellanetworks/core/internal/epskeys"
 	"github.com/ellanetworks/core/internal/mme/procedure"
-	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/nas"
 	"github.com/ellanetworks/core/s1ap"
 )
@@ -286,6 +285,6 @@ func (ue *UeContext) NextDownlinkCountForTest() nas.Count {
 	return ue.downlink().Next()
 }
 
-func (ue *UeContext) SetPagedBearerForTest(ebi uint8, arp *models.Arp) {
-	ue.beginPaging(&MTRequest{Ebi: ebi, Arp: arp})
+func (ue *UeContext) SetPagedBearerForTest(ebi uint8) {
+	ue.beginPaging(&MTRequest{Ebi: ebi})
 }

--- a/internal/models/eps_paging_failure_cause.go
+++ b/internal/models/eps_paging_failure_cause.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package models
+
+type EPSPagingFailureCause string
+
+const (
+	EPSPagingUENotResponding                 EPSPagingFailureCause = "UE_NOT_RESPONDING"
+	EPSPagingServiceDenied                   EPSPagingFailureCause = "SERVICE_DENIED"
+	EPSPagingUEAlreadyReAttached             EPSPagingFailureCause = "UE_ALREADY_RE_ATTACHED"
+	EPSPagingRejectionDueToPagingRestriction EPSPagingFailureCause = "REJECTION_DUE_TO_PAGING_RESTRICTION"
+)
+
+func (c EPSPagingFailureCause) String() string { return string(c) }

--- a/internal/models/n1n2_message_transfer_cause.go
+++ b/internal/models/n1n2_message_transfer_cause.go
@@ -22,22 +22,11 @@ const (
 
 func (c N1N2MessageTransferCause) String() string { return string(c) }
 
-func (c N1N2MessageTransferCause) Delivered() bool { return c == N1N2TransferInitiated }
-
-type N1N2MessageTransferRspData struct {
-	Cause N1N2MessageTransferCause
-}
+const N1N2ErrHigherPriorityRequestOngoing = "HIGHER_PRIORITY_REQUEST_ONGOING"
 
 type N1N2MsgTxfrErrDetail struct {
 	HighestPrioArp *Arp
 }
-
-type N1N2MsgTxfrFailureNotification struct {
-	Cause        N1N2MessageTransferCause
-	PduSessionID uint8
-}
-
-const N1N2ErrHigherPriorityRequestOngoing = "HIGHER_PRIORITY_REQUEST_ONGOING"
 
 type N1N2MessageTransferError struct {
 	Cause  string

--- a/internal/models/n1n2_message_transfer_cause.go
+++ b/internal/models/n1n2_message_transfer_cause.go
@@ -22,15 +22,27 @@ const (
 
 func (c N1N2MessageTransferCause) String() string { return string(c) }
 
-const N1N2ErrHigherPriorityRequestOngoing = "HIGHER_PRIORITY_REQUEST_ONGOING"
+type N1N2ApplicationError string
+
+const (
+	N1N2ErrContextNotFound                    N1N2ApplicationError = "CONTEXT_NOT_FOUND"
+	N1N2ErrHigherPriorityRequestOngoing       N1N2ApplicationError = "HIGHER_PRIORITY_REQUEST_ONGOING"
+	N1N2ErrTemporaryRejectRegistrationOngoing N1N2ApplicationError = "TEMPORARY_REJECT_REGISTRATION_ONGOING"
+	N1N2ErrTemporaryRejectHandoverOngoing     N1N2ApplicationError = "TEMPORARY_REJECT_HANDOVER_ONGOING"
+	N1N2ErrTemporaryRejectSROngoing           N1N2ApplicationError = "TEMPORARY_REJECT_SR_ONGOING"
+	N1N2ErrUEInCMIdleState                    N1N2ApplicationError = "UE_IN_CM_IDLE_STATE"
+	N1N2ErrUnspecified                        N1N2ApplicationError = "UNSPECIFIED"
+)
+
+func (e N1N2ApplicationError) String() string { return string(e) }
 
 type N1N2MsgTxfrErrDetail struct {
 	HighestPrioArp *Arp
 }
 
 type N1N2MessageTransferError struct {
-	Cause  string
+	Cause  N1N2ApplicationError
 	Detail N1N2MsgTxfrErrDetail
 }
 
-func (e *N1N2MessageTransferError) Error() string { return e.Cause }
+func (e *N1N2MessageTransferError) Error() string { return string(e.Cause) }

--- a/internal/models/n1n2_message_transfer_cause.go
+++ b/internal/models/n1n2_message_transfer_cause.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package models
+
+type N1N2MessageTransferCause string
+
+const (
+	N1N2AttemptingToReachUE                N1N2MessageTransferCause = "ATTEMPTING_TO_REACH_UE"
+	N1N2TransferInitiated                  N1N2MessageTransferCause = "N1_N2_TRANSFER_INITIATED"
+	N1N2WaitingForAsynchronousTransfer     N1N2MessageTransferCause = "WAITING_FOR_ASYNCHRONOUS_TRANSFER"
+	N1N2UENotResponding                    N1N2MessageTransferCause = "UE_NOT_RESPONDING"
+	N1N2N1MsgNotTransferred                N1N2MessageTransferCause = "N1_MSG_NOT_TRANSFERRED"
+	N1N2N2MsgNotTransferred                N1N2MessageTransferCause = "N2_MSG_NOT_TRANSFERRED"
+	N1N2UENotReachableForSession           N1N2MessageTransferCause = "UE_NOT_REACHABLE_FOR_SESSION"
+	N1N2TemporaryRejectRegistrationOngoing N1N2MessageTransferCause = "TEMPORARY_REJECT_REGISTRATION_ONGOING"
+	N1N2TemporaryRejectHandoverOngoing     N1N2MessageTransferCause = "TEMPORARY_REJECT_HANDOVER_ONGOING"
+	N1N2RejectionDueToPagingRestriction    N1N2MessageTransferCause = "REJECTION_DUE_TO_PAGING_RESTRICTION"
+	N1N2ANNotResponding                    N1N2MessageTransferCause = "AN_NOT_RESPONDING"
+	N1N2FailureCauseUnspecified            N1N2MessageTransferCause = "FAILURE_CAUSE_UNSPECIFIED"
+)
+
+func (c N1N2MessageTransferCause) String() string { return string(c) }
+
+func (c N1N2MessageTransferCause) Delivered() bool { return c == N1N2TransferInitiated }
+
+type N1N2MessageTransferRspData struct {
+	Cause N1N2MessageTransferCause
+}
+
+type N1N2MsgTxfrErrDetail struct {
+	HighestPrioArp *Arp
+}
+
+type N1N2MsgTxfrFailureNotification struct {
+	Cause        N1N2MessageTransferCause
+	PduSessionID uint8
+}
+
+const N1N2ErrHigherPriorityRequestOngoing = "HIGHER_PRIORITY_REQUEST_ONGOING"
+
+type N1N2MessageTransferError struct {
+	Cause  string
+	Detail N1N2MsgTxfrErrDetail
+}
+
+func (e *N1N2MessageTransferError) Error() string { return e.Cause }

--- a/internal/models/n1n2_message_transfer_request.go
+++ b/internal/models/n1n2_message_transfer_request.go
@@ -39,6 +39,9 @@ type N1N2MessageTransferRequest struct {
 
 	// RoutingID identifies the LMF handling the LPP or NRPPa data (NGAP Routing ID).
 	RoutingID int64
+
+	Arp    *Arp
+	FiveQI int32
 }
 
 // Standalone reports whether the request is delivered on its own rather than with a PDU

--- a/internal/models/n1n2_message_transfer_request.go
+++ b/internal/models/n1n2_message_transfer_request.go
@@ -40,8 +40,7 @@ type N1N2MessageTransferRequest struct {
 	// RoutingID identifies the LMF handling the LPP or NRPPa data (NGAP Routing ID).
 	RoutingID int64
 
-	Arp    *Arp
-	FiveQI int32
+	Arp *Arp
 }
 
 // Standalone reports whether the request is delivered on its own rather than with a PDU

--- a/internal/smf/create.go
+++ b/internal/smf/create.go
@@ -358,7 +358,7 @@ func (s *SMF) sendPduSessionEstablishmentAccept(
 		return fmt.Errorf("build PDUSessionResourceSetupRequestTransfer failed: %v", err)
 	}
 
-	err = s.amf.TransferN1N2(ctx, smContext.Supi, smContext.PDUSessionID, smContext.Snssai, n1Msg, n2Msg)
+	_, err = s.amf.TransferN1N2(ctx, smContext.Supi, smContext.PDUSessionID, smContext.Snssai, n1Msg, n2Msg)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to transfer N1N2 message")

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -33,7 +33,7 @@ func (s *SMF) HandleN1N2TransferFailure(ctx context.Context, supi etsi.SUPI, pdu
 	return nil
 }
 
-func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8) error {
+func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8, cause models.EPSPagingFailureCause) error {
 	supi, err := etsi.NewSUPIFromIMSI(imsi)
 	if err != nil {
 		return fmt.Errorf("invalid imsi %q: %w", imsi, err)
@@ -42,6 +42,15 @@ func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8
 	smContext := s.currentEPSSession(supi, ebi)
 	if smContext == nil {
 		return fmt.Errorf("no EPS session for %s", imsi)
+	}
+
+	logger.SmfLog.Info("EPS downlink data notification failed",
+		zap.String("imsi", imsi),
+		zap.Uint8("ebi", ebi),
+		zap.String("cause", cause.String()))
+
+	if cause != models.EPSPagingUENotResponding {
+		return nil
 	}
 
 	s.suppressDownlinkDataNotification(ctx, smContext)

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -8,12 +8,24 @@ import (
 	"fmt"
 
 	"github.com/ellanetworks/core/etsi"
+	"github.com/ellanetworks/core/internal/logger"
+	"github.com/ellanetworks/core/internal/models"
+	"go.uber.org/zap"
 )
 
-func (s *SMF) HandlePagingFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8) error {
+func (s *SMF) HandleN1N2TransferFailure(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, cause models.N1N2MessageTransferCause) error {
 	smContext := s.currentPDUSession(supi, pduSessionID)
 	if smContext == nil {
 		return fmt.Errorf("no session for %s pdu %d", supi.String(), pduSessionID)
+	}
+
+	logger.SmfLog.Info("N1N2 message transfer failed",
+		zap.String("supi", supi.String()),
+		zap.Uint8("pdu_session_id", pduSessionID),
+		zap.String("cause", cause.String()))
+
+	if cause != models.N1N2UENotResponding {
+		return nil
 	}
 
 	s.suppressDownlinkDataNotification(ctx, smContext)

--- a/internal/smf/paging_failure.go
+++ b/internal/smf/paging_failure.go
@@ -24,10 +24,6 @@ func (s *SMF) HandleN1N2TransferFailure(ctx context.Context, supi etsi.SUPI, pdu
 		zap.Uint8("pdu_session_id", pduSessionID),
 		zap.String("cause", cause.String()))
 
-	if cause != models.N1N2UENotResponding {
-		return nil
-	}
-
 	s.suppressDownlinkDataNotification(ctx, smContext)
 
 	return nil
@@ -48,10 +44,6 @@ func (s *SMF) HandleEPSPagingFailure(ctx context.Context, imsi string, ebi uint8
 		zap.String("imsi", imsi),
 		zap.Uint8("ebi", ebi),
 		zap.String("cause", cause.String()))
-
-	if cause != models.EPSPagingUENotResponding {
-		return nil
-	}
 
 	s.suppressDownlinkDataNotification(ctx, smContext)
 

--- a/internal/smf/paging_failure_test.go
+++ b/internal/smf/paging_failure_test.go
@@ -23,7 +23,7 @@ func TestHandleEPSPagingFailure_SuppressesDownlinkNotification(t *testing.T) {
 	s.AssignPFCPSession(smCtx, s.AllocateSEID())
 	smCtx.PFCPContext.SEID = 7
 
-	if err := s.HandleEPSPagingFailure(context.Background(), testIMSI, ebi); err != nil {
+	if err := s.HandleEPSPagingFailure(context.Background(), testIMSI, ebi, models.EPSPagingUENotResponding); err != nil {
 		t.Fatalf("HandleEPSPagingFailure: %v", err)
 	}
 

--- a/internal/smf/paging_failure_test.go
+++ b/internal/smf/paging_failure_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ellanetworks/core/internal/models"
 	"github.com/ellanetworks/core/internal/smf"
 )
 
@@ -43,7 +44,7 @@ func TestHandlePagingFailure_SuppressesDownlinkNotification(t *testing.T) {
 	s.AssignPFCPSession(smCtx, s.AllocateSEID())
 	smCtx.PFCPContext.SEID = 4242
 
-	if err := s.HandlePagingFailure(context.Background(), supi, pduSessionID); err != nil {
+	if err := s.HandleN1N2TransferFailure(context.Background(), supi, pduSessionID, models.N1N2UENotResponding); err != nil {
 		t.Fatalf("HandlePagingFailure: %v", err)
 	}
 
@@ -56,7 +57,7 @@ func TestHandlePagingFailure_NoSession(t *testing.T) {
 	pcf, store, upf, amfCb := defaultFakes()
 	s := newTestSMF(pcf, store, upf, amfCb)
 
-	if err := s.HandlePagingFailure(context.Background(), testSUPI(), 1); err == nil {
+	if err := s.HandleN1N2TransferFailure(context.Background(), testSUPI(), 1, models.N1N2UENotResponding); err == nil {
 		t.Fatal("expected error for missing session")
 	}
 

--- a/internal/smf/pfcp_handler.go
+++ b/internal/smf/pfcp_handler.go
@@ -50,9 +50,15 @@ func (s *SMF) HandleDownlinkDataReport(ctx context.Context, report *models.Downl
 		return fmt.Errorf("failed to build PDUSessionResourceSetupRequestTransfer: %v", err)
 	}
 
-	if err := s.amf.N2TransferOrPage(ctx, supi, pduSessionID, snssai, n2Pdu); err != nil {
+	cause, err := s.amf.N2TransferOrPage(ctx, supi, pduSessionID, snssai, n2Pdu, policy.QosData.Arp, policy.QosData.Var5qi)
+	if err != nil {
 		return fmt.Errorf("failed to send N1N2MessageTransfer to AMF: %v", err)
 	}
+
+	logger.SmfLog.Debug("N1N2 message transfer accepted",
+		zap.String("supi", supi.String()),
+		zap.Uint8("pdu_session_id", pduSessionID),
+		zap.String("cause", cause.String()))
 
 	return nil
 }

--- a/internal/smf/pfcp_handler.go
+++ b/internal/smf/pfcp_handler.go
@@ -29,6 +29,7 @@ func (s *SMF) HandleDownlinkDataReport(ctx context.Context, report *models.Downl
 	onEPS := smContext.Access == Access4G
 	policy, tunnel := smContext.PolicyData, smContext.Tunnel
 	pduSessionType, supi, pduSessionID, snssai := smContext.PDUSessionType, smContext.Supi, smContext.PDUSessionID, smContext.Snssai
+	ebi := smContext.EBI
 
 	smContext.Mutex.Unlock()
 
@@ -38,7 +39,7 @@ func (s *SMF) HandleDownlinkDataReport(ctx context.Context, report *models.Downl
 			return fmt.Errorf("no MME registered to page EPS UE %s", supi.IMSI())
 		}
 
-		return s.mme.Page(ctx, supi.IMSI())
+		return s.mme.Page(ctx, supi.IMSI(), ebi, epsArp(policy))
 	}
 
 	if policy == nil || tunnel == nil {
@@ -61,6 +62,14 @@ func (s *SMF) HandleDownlinkDataReport(ctx context.Context, report *models.Downl
 		zap.String("cause", cause.String()))
 
 	return nil
+}
+
+func epsArp(policy *Policy) *models.Arp {
+	if policy == nil {
+		return nil
+	}
+
+	return policy.QosData.Arp
 }
 
 func (s *SMF) SendFlowReports(ctx context.Context, reqs []*models.FlowReportRequest) error {

--- a/internal/smf/pfcp_handler.go
+++ b/internal/smf/pfcp_handler.go
@@ -39,7 +39,7 @@ func (s *SMF) HandleDownlinkDataReport(ctx context.Context, report *models.Downl
 			return fmt.Errorf("no MME registered to page EPS UE %s", supi.IMSI())
 		}
 
-		return s.mme.Page(ctx, supi.IMSI(), ebi, epsArp(policy))
+		return s.mme.Page(ctx, supi.IMSI(), ebi)
 	}
 
 	if policy == nil || tunnel == nil {
@@ -51,7 +51,7 @@ func (s *SMF) HandleDownlinkDataReport(ctx context.Context, report *models.Downl
 		return fmt.Errorf("failed to build PDUSessionResourceSetupRequestTransfer: %v", err)
 	}
 
-	cause, err := s.amf.N2TransferOrPage(ctx, supi, pduSessionID, snssai, n2Pdu, policy.QosData.Arp, policy.QosData.Var5qi)
+	cause, err := s.amf.N2TransferOrPage(ctx, supi, pduSessionID, snssai, n2Pdu, policy.QosData.Arp)
 	if err != nil {
 		return fmt.Errorf("failed to send N1N2MessageTransfer to AMF: %v", err)
 	}
@@ -62,14 +62,6 @@ func (s *SMF) HandleDownlinkDataReport(ctx context.Context, report *models.Downl
 		zap.String("cause", cause.String()))
 
 	return nil
-}
-
-func epsArp(policy *Policy) *models.Arp {
-	if policy == nil {
-		return nil
-	}
-
-	return policy.QosData.Arp
 }
 
 func (s *SMF) SendFlowReports(ctx context.Context, reqs []*models.FlowReportRequest) error {

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -97,10 +97,10 @@ type UPFClient interface {
 // This breaks the circular dependency between the SMF and AMF packages.
 type AMFCallback interface {
 	TransferN1(ctx context.Context, supi etsi.SUPI, n1Msg []byte, pduSessionID uint8) error
-	TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) error
+	TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) (models.N1N2MessageTransferCause, error)
 	ModifyN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error
 	ReleaseSession(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Transfer []byte) error
-	N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error
+	N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, arp *models.Arp, fiveQI int32) (models.N1N2MessageTransferCause, error)
 	SessionDropped(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, ref string, n2Transfer []byte)
 }
 

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -105,7 +105,7 @@ type AMFCallback interface {
 }
 
 type MMECallback interface {
-	Page(ctx context.Context, imsi string) error
+	Page(ctx context.Context, imsi string, ebi uint8, arp *models.Arp) error
 	SessionDropped(ctx context.Context, imsi string, ebi uint8, ref string)
 }
 

--- a/internal/smf/smf.go
+++ b/internal/smf/smf.go
@@ -100,12 +100,12 @@ type AMFCallback interface {
 	TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) (models.N1N2MessageTransferCause, error)
 	ModifyN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error
 	ReleaseSession(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Transfer []byte) error
-	N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, arp *models.Arp, fiveQI int32) (models.N1N2MessageTransferCause, error)
+	N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, arp *models.Arp) (models.N1N2MessageTransferCause, error)
 	SessionDropped(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, ref string, n2Transfer []byte)
 }
 
 type MMECallback interface {
-	Page(ctx context.Context, imsi string, ebi uint8, arp *models.Arp) error
+	Page(ctx context.Context, imsi string, ebi uint8) error
 	SessionDropped(ctx context.Context, imsi string, ebi uint8, ref string)
 }
 

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -371,7 +371,7 @@ func (f *fakeAMF) ReleaseSession(_ context.Context, supi etsi.SUPI, pduSessionID
 	return f.err
 }
 
-func (f *fakeAMF) N2TransferOrPage(_ context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, _ *models.Arp, _ int32) (models.N1N2MessageTransferCause, error) {
+func (f *fakeAMF) N2TransferOrPage(_ context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, _ *models.Arp) (models.N1N2MessageTransferCause, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -408,7 +408,7 @@ func (f *fakeMME) dropped() []mmeTransferredCall {
 	return append([]mmeTransferredCall(nil), f.droppedCalls...)
 }
 
-func (f *fakeMME) Page(_ context.Context, imsi string, _ uint8, _ *models.Arp) error {
+func (f *fakeMME) Page(_ context.Context, imsi string, _ uint8) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -408,7 +408,7 @@ func (f *fakeMME) dropped() []mmeTransferredCall {
 	return append([]mmeTransferredCall(nil), f.droppedCalls...)
 }
 
-func (f *fakeMME) Page(_ context.Context, imsi string) error {
+func (f *fakeMME) Page(_ context.Context, imsi string, _ uint8, _ *models.Arp) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/internal/smf/smf_test.go
+++ b/internal/smf/smf_test.go
@@ -344,13 +344,13 @@ func (f *fakeAMF) TransferN1(_ context.Context, supi etsi.SUPI, n1Msg []byte, pd
 	return f.err
 }
 
-func (f *fakeAMF) TransferN1N2(_ context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) error {
+func (f *fakeAMF) TransferN1N2(_ context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) (models.N1N2MessageTransferCause, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.n1n2Calls = append(f.n1n2Calls, n1n2Call{supi, pduSessionID, snssai, n1Msg, n2Msg})
 
-	return f.err
+	return models.N1N2TransferInitiated, f.err
 }
 
 func (f *fakeAMF) ModifyN1N2(_ context.Context, supi etsi.SUPI, pduSessionID uint8, n1Msg, n2Msg []byte) error {
@@ -371,13 +371,13 @@ func (f *fakeAMF) ReleaseSession(_ context.Context, supi etsi.SUPI, pduSessionID
 	return f.err
 }
 
-func (f *fakeAMF) N2TransferOrPage(_ context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error {
+func (f *fakeAMF) N2TransferOrPage(_ context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, _ *models.Arp, _ int32) (models.N1N2MessageTransferCause, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.pageCalls = append(f.pageCalls, pageCall{supi, pduSessionID, snssai, n2Msg})
 
-	return f.err
+	return models.N1N2AttemptingToReachUE, f.err
 }
 
 // fakeMME records 4G paging calls, standing in for the MME's smf.MMECallback.

--- a/internal/tester/s1enb/guti_realloc.go
+++ b/internal/tester/s1enb/guti_realloc.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Ella Networks Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s1enb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ellanetworks/core/nas/eps"
+)
+
+func (e *ENB) answerGUTIReallocation(ue *UE, mmeUEID, enbUEID int64, timeout time.Duration) (*eps.EPSMobileIdentity, error) {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, fmt.Errorf("s1enb: await GUTI Reallocation Command: timed out")
+		}
+
+		wire, _, err := e.WaitForDownlinkNAS(enbUEID, remaining)
+		if err != nil {
+			return nil, fmt.Errorf("s1enb: await GUTI Reallocation Command: %w", err)
+		}
+
+		plain, err := ue.unprotectDownlink(wire)
+		if err != nil {
+			return nil, fmt.Errorf("s1enb: unprotect downlink NAS: %w", err)
+		}
+
+		mt, err := eps.PeekMessageType(plain)
+		if err != nil {
+			return nil, fmt.Errorf("s1enb: peek downlink NAS: %w", err)
+		}
+
+		if mt != eps.MsgGUTIReallocationCommand {
+			continue
+		}
+
+		cmd, err := eps.ParseGUTIReallocationCommand(plain)
+		if err != nil {
+			return nil, fmt.Errorf("s1enb: parse GUTI Reallocation Command: %w", err)
+		}
+
+		complete, err := (&eps.GUTIReallocationComplete{}).MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("s1enb: build GUTI Reallocation Complete: %w", err)
+		}
+
+		protected, err := ue.protectUplink(complete)
+		if err != nil {
+			return nil, fmt.Errorf("s1enb: protect GUTI Reallocation Complete: %w", err)
+		}
+
+		if err := e.SendUplinkNASTransport(mmeUEID, enbUEID, protected); err != nil {
+			return nil, fmt.Errorf("s1enb: send GUTI Reallocation Complete: %w", err)
+		}
+
+		guti := cmd.GUTI
+
+		return &guti, nil
+	}
+}

--- a/internal/tester/s1enb/lifecycle.go
+++ b/internal/tester/s1enb/lifecycle.go
@@ -73,6 +73,7 @@ func (e *ENB) ReleaseContext(mmeUEID, enbUEID int64, cause s1ap.Cause, timeout t
 type ServiceRequestResult struct {
 	MMEUES1APID int64
 	ENBUES1APID int64
+	GUTI        *eps.EPSMobileIdentity
 	UpfAddress  string // S-GW/UPF S1-U address (uplink target)
 	ULTEID      uint32 // S-GW/UPF uplink TEID
 	DLTEID      uint32 // eNB downlink TEID reported to the MME
@@ -151,7 +152,13 @@ func (e *ENB) serviceRequest(ue *UE, guti *eps.EPSMobileIdentity, answeringPage 
 		return nil, err
 	}
 
+	reallocated, err := e.answerGUTIReallocation(ue, int64(ics.MMEUES1APID), enbUEID, timeout)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ServiceRequestResult{
+		GUTI:              reallocated,
 		UERadioCapability: []byte(ics.UERadioCapability),
 		MMEUES1APID:       int64(ics.MMEUES1APID),
 		ENBUES1APID:       enbUEID,

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -491,14 +491,13 @@ func (a *smfAMFAdapter) ReleaseSession(ctx context.Context, supi etsi.SUPI, pduS
 	return err
 }
 
-func (a *smfAMFAdapter) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, arp *models.Arp, fiveQI int32) (models.N1N2MessageTransferCause, error) {
+func (a *smfAMFAdapter) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, arp *models.Arp) (models.N1N2MessageTransferCause, error) {
 	return a.amf.N2MessageTransferOrPage(ctx, supi, models.N1N2MessageTransferRequest{
 		N2Class:                 models.N2ClassSM,
 		PduSessionID:            pduSessionID,
 		SNssai:                  snssai,
 		BinaryDataN2Information: n2Msg,
 		Arp:                     arp,
-		FiveQI:                  fiveQI,
 	})
 }
 

--- a/pkg/runtime/smf_adapters.go
+++ b/pkg/runtime/smf_adapters.go
@@ -462,7 +462,7 @@ func (a *smfAMFAdapter) TransferN1(ctx context.Context, supi etsi.SUPI, n1Msg []
 	return a.amf.TransferN1Msg(ctx, supi, n1Msg, pduSessionID)
 }
 
-func (a *smfAMFAdapter) TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) error {
+func (a *smfAMFAdapter) TransferN1N2(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n1Msg, n2Msg []byte) (models.N1N2MessageTransferCause, error) {
 	return a.amf.TransferN1N2Message(ctx, supi, models.N1N2MessageTransferRequest{
 		N1Class:                 models.N1ClassSM,
 		N2Class:                 models.N2ClassSM,
@@ -491,12 +491,14 @@ func (a *smfAMFAdapter) ReleaseSession(ctx context.Context, supi etsi.SUPI, pduS
 	return err
 }
 
-func (a *smfAMFAdapter) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte) error {
+func (a *smfAMFAdapter) N2TransferOrPage(ctx context.Context, supi etsi.SUPI, pduSessionID uint8, snssai *models.Snssai, n2Msg []byte, arp *models.Arp, fiveQI int32) (models.N1N2MessageTransferCause, error) {
 	return a.amf.N2MessageTransferOrPage(ctx, supi, models.N1N2MessageTransferRequest{
 		N2Class:                 models.N2ClassSM,
 		PduSessionID:            pduSessionID,
 		SNssai:                  snssai,
 		BinaryDataN2Information: n2Msg,
+		Arp:                     arp,
+		FiveQI:                  fiveQI,
 	})
 }
 

--- a/s1ap/cause.go
+++ b/s1ap/cause.go
@@ -50,6 +50,7 @@ const (
 	CauseRadioNetworkTimeCriticalHandover              = 17 // time-critical-handover
 	CauseRadioNetworkResourceOptimisationHandover      = 18 // resource-optimisation-handover
 	CauseRadioNetworkReduceLoadInServingCell           = 19 // reduce-load-in-serving-cell
+	CauseRadioNetworkUserInactivity                    = 20 // user-inactivity
 	CauseRadioNetworkRadioConnectionWithUELost         = 21 // radio-connection-with-ue-lost
 	CauseRadioNetworkLoadBalancingTAURequired          = 22 // load-balancing-tau-required
 	CauseRadioNetworkRadioResourcesNotAvailable        = 25 // radio-resources-not-available


### PR DESCRIPTION
# Description

Replace ad-hoc paging state with a single mobile-terminated delivery procedure per UE. This fixes an unbounded buffered-request leak and a permanently pinned NG connection.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
